### PR TITLE
Implement --params flag and expose UI Port config

### DIFF
--- a/ai-services/assets/applications/RAG/chat-bot.yaml.tmpl
+++ b/ai-services/assets/applications/RAG/chat-bot.yaml.tmpl
@@ -4,6 +4,8 @@ metadata:
   name: "{{ .AppName }}--chat-bot"
   labels:
     ai-services.io/application: "{{ .AppName }}"
+  annotations:
+    ai-services.io/ui--UI_PORT-expose: "3000" # containerPort
 spec:
   containers:
     - name: ui
@@ -19,8 +21,8 @@ spec:
         - name: BACKEND_PORT
           value: "5000" 
       ports:
-        - containerPort: 3000
-          hostPort: 3000
+        - name: UI_PORT
+          containerPort: 3000
           protocol: TCP
     - name: backend-server
       image: icr.io/ai-services-private/rag:v0.0.3

--- a/ai-services/internal/pkg/runtime/podman/cli.go
+++ b/ai-services/internal/pkg/runtime/podman/cli.go
@@ -16,6 +16,10 @@ const (
 	startFlagFalse = "--start=false"
 )
 
+var (
+	publishFlag = "--publish=%s"
+)
+
 func RunPodmanKubePlay(body io.Reader, opts map[string]string) (*KubePlayOutput, error) {
 	cmdName := "podman"
 
@@ -92,6 +96,15 @@ func buildCmdArgs(opts map[string]string) []string {
 		default:
 			// by default go with start set to true
 			cmdArgs = append(cmdArgs, startFlagTrue)
+		}
+	}
+
+	if v, ok := opts["publish"]; ok {
+		portMappings := strings.Split(v, ",")
+		for _, portMapping := range portMappings {
+			if portMapping != "" {
+				cmdArgs = append(cmdArgs, fmt.Sprintf(publishFlag, portMapping))
+			}
 		}
 	}
 

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"maps"
 	"strings"
 )
@@ -64,4 +65,21 @@ func UniqueSlice[T comparable](slice []T) []T {
 		}
 	}
 	return result
+}
+
+func ParseKeyValues(pairs []string) (map[string]string, error) {
+	out := map[string]string{}
+
+	for _, pair := range pairs {
+		if pair == "" {
+			continue
+		}
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("invalid format: %s (expected key=value)", pair)
+		}
+		out[kv[0]] = kv[1]
+	}
+
+	return out, nil
 }

--- a/ai-services/internal/pkg/vars/var.go
+++ b/ai-services/internal/pkg/vars/var.go
@@ -3,7 +3,10 @@ package vars
 import "regexp"
 
 var (
+	// SpyreCardAnnotationRegex -> ai-services.io/<containerName>--spyre-cards
 	SpyreCardAnnotationRegex = regexp.MustCompile(`^ai-services\.io\/([A-Za-z0-9][-A-Za-z0-9_.]*)--sypre-cards$`)
-	ToolImage                = "icr.io/ai-services-private/tools:latest"
-	ModelDirectory           = "/var/lib/ai-services/models"
+	// ContainerPortExposeAnnotationRegex -> ai-services.io/<containerName>--<PortName>-expose
+	ContainerPortExposeAnnotationRegex = regexp.MustCompile(`^ai-services\.io\/([A-Za-z0-9][-A-Za-z0-9_.]*)--([A-Za-z0-9][-A-Za-z0-9_.]*)-expose$`)
+	ToolImage                          = "icr.io/ai-services-private/tools:latest"
+	ModelDirectory                     = "/var/lib/ai-services/models"
 )


### PR DESCRIPTION
Implementation design
---
- Expose a new annotation which controls whether the `--publish` flag needs to be set while using `podman kube play`.
- If the UI_Port is set by the user then use that value or else dynamically generate a new value. Inorder to do this `--publish` flag needs to set hostPort dynamically.


Output
---
Default Port
--
<img width="812" height="316" alt="image" src="https://github.com/user-attachments/assets/9327463f-4bb5-4381-ac35-7b3809ce3fb8" />

Port value overriden
--
<img width="808" height="322" alt="image" src="https://github.com/user-attachments/assets/a85a4bd0-6b5b-4ea9-b75d-fcb028f69d74" />
