### PR TITLE
upgrade carbon-ai-chat library to 0.5.1

### DIFF
--- a/spyre-rag/ui/package-lock.json
+++ b/spyre-rag/ui/package-lock.json
@@ -1,14 +1,14 @@
 {
-    "name": "itops-chatbot",
+    "name": "chatbot",
     "version": "0.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "itops-chatbot",
+            "name": "chatbot",
             "version": "0.1.0",
             "dependencies": {
-                "@carbon/ai-chat": "^0.3.2",
+                "@carbon/ai-chat": "^0.5.1",
                 "@carbon/react": "^1.31.3",
                 "@testing-library/jest-dom": "^5.16.5",
                 "@testing-library/react": "^13.4.0",
@@ -2034,55 +2034,43 @@
             }
         },
         "node_modules/@carbon/ai-chat": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@carbon/ai-chat/-/ai-chat-0.3.3.tgz",
-            "integrity": "sha512-4M2Kk0ceeForKxwvzs406WQji1VekiVsCr2pj1jnRd7bSVzoo5NCf7j/lf5bNTtiZcPm6bD9cWMdsDG3RiMr4A==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@carbon/ai-chat/-/ai-chat-0.5.2.tgz",
+            "integrity": "sha512-d0W5FsDMGLDbCdi+EaMU0gtvYI2XY1RMdBMGS8GHUleNDCS9035mqEW4I1/HJUNdNyXBsMY2g6n0ll5RjChTnw==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@ibm/telemetry-js": "^1.9.1",
                 "@lit/react": "^1.0.6",
-                "@microsoft/fetch-event-source": "^2.0.1",
-                "@nice-devone/nice-cxone-chat-web-sdk": "^1.18.0",
                 "color": "^4.2.3",
                 "compute-scroll-into-view": "^3.1.0",
                 "csv-stringify": "^6.5.2",
                 "dayjs": "^1.11.10",
-                "detect-browser": "^5.3.0",
                 "dompurify": "^3.1.6",
                 "focus-trap-react": "^10.2.3",
                 "highlight.js": "^11.9.0",
-                "html-tags": "^3.3.1",
-                "http-status-codes": "^2.3.0",
                 "intl-messageformat": "^10.7.15",
                 "intl-pluralrules": "^2.0.1",
-                "js-cookie": "^3.0.5",
-                "jwt-decode": "^4.0.0",
-                "lodash-es": "^4.17.21",
                 "markdown-it": "^14.1.0",
                 "markdown-it-attrs": "^4.1.6",
-                "markdown-it-sub": "^2.0.0",
-                "markdown-it-sup": "^2.0.0",
-                "memoize-one": "^6.0.0",
-                "pdfjs-dist": "4.3.136",
                 "react-intl": "^7.1.6",
-                "react-player": "^2.15.1",
-                "react-redux": "^8.1.3",
-                "redux": "^4.2.1",
-                "reselect": "^4.1.8",
-                "swiper": "^11.1.1",
-                "ts-essentials": "^9.4.1",
-                "utility-types": "^3.10.0",
-                "uuid": "^9.0.1"
+                "react-player": "2.15.1",
+                "swiper": "^11.1.1"
             },
             "peerDependencies": {
                 "@carbon/icon-helpers": ">=10.53.0 <11.0.0",
                 "@carbon/icons": ">=11.53.0 <12.0.0",
                 "@carbon/react": ">=1.68.0 <2.0.0",
                 "@carbon/web-components": ">=2.25.0 <3.0.0",
+                "@floating-ui/react": ">=0.25.0 <1.0.0",
+                "classnames": ">=2.5.0 <3.0.0",
                 "lit": ">=3.1.0 <4.0.0",
+                "lodash-es": ">=4.17.0 <5.0.0",
                 "react": ">=17.0.0 <20.0.0",
-                "react-dom": ">=17.0.0 <20.0.0"
+                "react-dom": ">=17.0.0 <20.0.0",
+                "react-redux": ">=8.0.0 <10.0.0",
+                "redux": ">=4.0.0 <6.0.0",
+                "tabbable": ">=6.2.0 <7.0.0"
             }
         },
         "node_modules/@carbon/ai-chat/node_modules/@formatjs/intl": {
@@ -3301,55 +3289,6 @@
                 "@lit-labs/ssr-dom-shim": "^1.4.0"
             }
         },
-        "node_modules/@mapbox/node-pre-gyp": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
-            "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "dependencies": {
-                "detect-libc": "^2.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "make-dir": "^3.1.0",
-                "node-fetch": "^2.6.7",
-                "nopt": "^5.0.0",
-                "npmlog": "^5.0.1",
-                "rimraf": "^3.0.2",
-                "semver": "^7.3.5",
-                "tar": "^6.1.11"
-            },
-            "bin": {
-                "node-pre-gyp": "bin/node-pre-gyp"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
-            "version": "7.7.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-            "license": "ISC",
-            "optional": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@microsoft/fetch-event-source": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
-            "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
-            "license": "MIT"
-        },
-        "node_modules/@nice-devone/nice-cxone-chat-web-sdk": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/@nice-devone/nice-cxone-chat-web-sdk/-/nice-cxone-chat-web-sdk-1.20.0.tgz",
-            "integrity": "sha512-l5kkkwQ6B42V0Rafx1qAPpvr4SgAWFqWcFNrK097P3aIl0wfK6Or5lsg+H+4nbsPr2sqRX/wmbI61alqqrIK4g==",
-            "license": "UNLICENSED",
-            "dependencies": {
-                "ua-parser-js": "1.0.37"
-            }
-        },
         "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
             "version": "5.1.1-v1",
             "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -4391,7 +4330,8 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
             "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/yargs": {
             "version": "17.0.34",
@@ -4716,13 +4656,6 @@
                 "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
             }
         },
-        "node_modules/abbrev": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-            "license": "ISC",
-            "optional": true
-        },
         "node_modules/accepts": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -4759,19 +4692,6 @@
             "peer": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6.0.0"
             }
         },
         "node_modules/ajv": {
@@ -4814,28 +4734,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/aproba": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
-            "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/are-we-there-yet": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-            "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-            "deprecated": "This package is no longer supported.",
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^3.6.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/argparse": {
@@ -5192,7 +5090,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
@@ -5248,7 +5146,7 @@
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
             "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -5388,22 +5286,6 @@
             ],
             "license": "CC-BY-4.0"
         },
-        "node_modules/canvas": {
-            "version": "2.11.2",
-            "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
-            "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@mapbox/node-pre-gyp": "^1.0.0",
-                "nan": "^2.17.0",
-                "simple-get": "^3.0.3"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/chalk": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -5430,16 +5312,6 @@
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/chownr": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-            "license": "ISC",
-            "optional": true,
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/ci-info": {
@@ -5504,16 +5376,6 @@
                 "simple-swizzle": "^0.2.2"
             }
         },
-        "node_modules/color-support": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-            "license": "ISC",
-            "optional": true,
-            "bin": {
-                "color-support": "bin.js"
-            }
-        },
         "node_modules/combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -5545,7 +5407,7 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/confusing-browser-globals": {
@@ -5554,13 +5416,6 @@
             "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-            "license": "ISC",
-            "optional": true
         },
         "node_modules/content-disposition": {
             "version": "0.5.4",
@@ -5771,7 +5626,7 @@
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -5790,19 +5645,6 @@
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
             "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
             "license": "MIT"
-        },
-        "node_modules/decompress-response": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-            "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "mimic-response": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/deep-equal": {
             "version": "2.2.3",
@@ -5896,13 +5738,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-            "license": "MIT",
-            "optional": true
-        },
         "node_modules/depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5920,22 +5755,6 @@
             "engines": {
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
-        "node_modules/detect-browser": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
-            "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
-            "license": "MIT"
-        },
-        "node_modules/detect-libc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-            "license": "Apache-2.0",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/dir-glob": {
@@ -7204,45 +7023,13 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/fs-minipass": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/fs-minipass/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/fs-minipass/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "license": "ISC",
-            "optional": true
-        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "devOptional": true,
-            "license": "ISC"
+            "dev": true,
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
@@ -7296,28 +7083,6 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/gauge": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
-            "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-            "deprecated": "This package is no longer supported.",
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "aproba": "^1.0.3 || ^2.0.0",
-                "color-support": "^1.1.2",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.1",
-                "object-assign": "^4.1.1",
-                "signal-exit": "^3.0.0",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1",
-                "wide-align": "^1.1.2"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/generator-function": {
@@ -7400,8 +7165,9 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "deprecated": "Glob versions prior to v9 are no longer supported",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -7587,13 +7353,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-            "license": "ISC",
-            "optional": true
-        },
         "node_modules/hasown": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -7630,18 +7389,6 @@
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
             "license": "MIT"
         },
-        "node_modules/html-tags": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
-            "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/http-errors": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -7656,26 +7403,6 @@
             },
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/http-status-codes": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
-            "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
-            "license": "MIT"
-        },
-        "node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "agent-base": "6",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/iconv-lite": {
@@ -7748,8 +7475,9 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
             "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -7988,16 +7716,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/is-generator-function": {
@@ -8512,15 +8230,6 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "node_modules/js-cookie": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-            "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8612,15 +8321,6 @@
             },
             "engines": {
                 "node": ">=4.0"
-            }
-        },
-        "node_modules/jwt-decode": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
-            "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/keyv": {
@@ -8752,7 +8452,8 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
             "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
@@ -8800,22 +8501,6 @@
                 "lz-string": "bin/bin.js"
             }
         },
-        "node_modules/make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "semver": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/markdown-it": {
             "version": "14.1.0",
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
@@ -8845,18 +8530,6 @@
                 "markdown-it": ">= 9.0.0"
             }
         },
-        "node_modules/markdown-it-sub": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/markdown-it-sub/-/markdown-it-sub-2.0.0.tgz",
-            "integrity": "sha512-iCBKgwCkfQBRg2vApy9vx1C1Tu6D8XYo8NvevI3OlwzBRmiMtsJ2sXupBgEA7PPxiDwNni3qIUkhZ6j5wofDUA==",
-            "license": "MIT"
-        },
-        "node_modules/markdown-it-sup": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/markdown-it-sup/-/markdown-it-sup-2.0.0.tgz",
-            "integrity": "sha512-5VgmdKlkBd8sgXuoDoxMpiU+BiEt3I49GItBzzw7Mxq9CxvnhE/k09HFli09zgfFDRixDQDfDxi0mgBCXtaTvA==",
-            "license": "MIT"
-        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -8882,9 +8555,9 @@
             }
         },
         "node_modules/memoize-one": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
-            "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+            "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
             "license": "MIT"
         },
         "node_modules/merge-descriptors": {
@@ -8973,19 +8646,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/mimic-response": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-            "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/min-indent": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -8999,7 +8659,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
             "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -9018,75 +8678,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/minipass": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-            "license": "ISC",
-            "optional": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/minizlib": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/minizlib/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/minizlib/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/mkdirp": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-            "license": "MIT",
-            "optional": true,
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
-        },
-        "node_modules/nan": {
-            "version": "2.23.1",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.1.tgz",
-            "integrity": "sha512-r7bBUGKzlqk8oPBDYxt6Z0aEdF1G1rwlMcLk8LCOMbOzf0mG+JUfUzG4fIMWwHWP0iyaLWEQZJmtB7nOHEm/qw==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/nanoid": {
             "version": "3.3.11",
@@ -9138,63 +8734,12 @@
             "license": "MIT",
             "optional": true
         },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/node-releases": {
             "version": "2.0.27",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
             "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/nopt": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-            "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "abbrev": "1"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/npmlog": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
-            "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-            "deprecated": "This package is no longer supported.",
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "are-we-there-yet": "^2.0.0",
-                "console-control-strings": "^1.1.0",
-                "gauge": "^3.0.0",
-                "set-blocking": "^2.0.0"
-            }
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
@@ -9347,8 +8892,9 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -9480,8 +9026,9 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9516,29 +9063,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/path2d": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.2.2.tgz",
-            "integrity": "sha512-+vnG6S4dYcYxZd+CZxzXCNKdELYZSKfohrk98yajCo1PtRoDgCTrrwOvK1GT0UoAdVszagDVllQc0U1vaX4NUQ==",
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/pdfjs-dist": {
-            "version": "4.3.136",
-            "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.3.136.tgz",
-            "integrity": "sha512-gzfnt1qc4yA+U46golPGYtU4WM2ssqP2MvFjKga8GEKOrEnzRPrA/9jogLLPYHiA3sGBPJ+p7BdAq+ytmw3jEg==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "canvas": "^2.11.2",
-                "path2d": "^0.2.0"
             }
         },
         "node_modules/picocolors": {
@@ -9795,9 +9319,9 @@
             "peer": true
         },
         "node_modules/react-player": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.16.1.tgz",
-            "integrity": "sha512-mxP6CqjSWjidtyDoMOSHVPdhX0pY16aSvw5fVr44EMaT7X5Xz46uQ4b/YBm1v2x+3hHkB9PmjEEkmbHb9PXQ4w==",
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.15.1.tgz",
+            "integrity": "sha512-ni1XFuYZuhIKKdeFII+KRLmIPcvCYlyXvtSMhNOgssdfnSovmakBtBTW2bxowPvmpKy5BTR4jC4CF79ucgHT+g==",
             "license": "MIT",
             "dependencies": {
                 "deepmerge": "^4.0.0",
@@ -9810,17 +9334,12 @@
                 "react": ">=16.6.0"
             }
         },
-        "node_modules/react-player/node_modules/memoize-one": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-            "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-            "license": "MIT"
-        },
         "node_modules/react-redux": {
             "version": "8.1.3",
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
             "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.1",
                 "@types/hoist-non-react-statics": "^3.3.1",
@@ -9859,7 +9378,8 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
             "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/react-refresh": {
             "version": "0.18.0",
@@ -9903,21 +9423,6 @@
                 "react-dom": ">=16.8"
             }
         },
-        "node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/readdirp": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -9949,6 +9454,7 @@
             "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
             "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.9.2"
             }
@@ -10054,12 +9560,6 @@
                 "regjsparser": "bin/parser"
             }
         },
-        "node_modules/reselect": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
-            "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
-            "license": "MIT"
-        },
         "node_modules/resolve": {
             "version": "1.22.11",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -10107,8 +9607,9 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
             "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
             "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -10298,7 +9799,7 @@
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "devOptional": true,
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -10366,13 +9867,6 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
-        },
-        "node_modules/set-blocking": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-            "license": "ISC",
-            "optional": true
         },
         "node_modules/set-function-length": {
             "version": "1.2.2",
@@ -10520,46 +10014,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "license": "ISC",
-            "optional": true
-        },
-        "node_modules/simple-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/simple-get": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-            "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "decompress-response": "^4.2.0",
-                "once": "^1.3.1",
-                "simple-concat": "^1.0.0"
-            }
-        },
         "node_modules/simple-swizzle": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
@@ -10636,44 +10090,12 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/string_decoder": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "safe-buffer": "~5.2.0"
-            }
-        },
         "node_modules/string-natural-compare": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/string-natural-compare/-/string-natural-compare-3.0.1.tgz",
             "integrity": "sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/string-width/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "license": "MIT",
-            "optional": true
         },
         "node_modules/string.prototype.includes": {
             "version": "2.0.1",
@@ -10792,8 +10214,9 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -10887,31 +10310,6 @@
             "integrity": "sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==",
             "license": "MIT"
         },
-        "node_modules/tar": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^5.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/tar/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "license": "ISC",
-            "optional": true
-        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -10962,27 +10360,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.6"
-            }
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/ts-essentials": {
-            "version": "9.4.2",
-            "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.4.2.tgz",
-            "integrity": "sha512-mB/cDhOvD7pg3YCLk2rOtejHjjdSi9in/IBYE13S+8WA5FBSraYf4V/ws55uvs0IvQ/l0wBOlXy5yBNZ9Bl8ZQ==",
-            "license": "MIT",
-            "peerDependencies": {
-                "typescript": ">=4.1.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
             }
         },
         "node_modules/tsconfig-paths": {
@@ -11163,7 +10540,7 @@
             "version": "4.9.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -11171,29 +10548,6 @@
             },
             "engines": {
                 "node": ">=4.2.0"
-            }
-        },
-        "node_modules/ua-parser-js": {
-            "version": "1.0.37",
-            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
-            "integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/ua-parser-js"
-                },
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/faisalman"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/faisalman"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/uc.micro": {
@@ -11327,24 +10681,9 @@
             "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
             "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-            }
-        },
-        "node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "license": "MIT",
-            "optional": true
-        },
-        "node_modules/utility-types": {
-            "version": "3.11.0",
-            "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
-            "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
             }
         },
         "node_modules/utils-merge": {
@@ -11354,19 +10693,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/vary": {
@@ -11458,24 +10784,6 @@
             "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
             "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg==",
             "license": "Apache-2.0"
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "license": "BSD-2-Clause",
-            "optional": true
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -11578,16 +10886,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/wide-align": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-            "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-            "license": "ISC",
-            "optional": true,
-            "dependencies": {
-                "string-width": "^1.0.2 || 2 || 3 || 4"
-            }
-        },
         "node_modules/window-or-global": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/window-or-global/-/window-or-global-1.0.1.tgz",
@@ -11609,8 +10907,9 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "devOptional": true,
-            "license": "ISC"
+            "dev": true,
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/yallist": {
             "version": "3.1.1",

--- a/spyre-rag/ui/package.json
+++ b/spyre-rag/ui/package.json
@@ -1,9 +1,9 @@
 {
-    "name": "itops-chatbot",
+    "name": "chatbot",
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@carbon/ai-chat": "^0.3.2",
+        "@carbon/ai-chat": "^0.5.1",
         "@carbon/react": "^1.31.3",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",

--- a/spyre-rag/ui/src/components/App.jsx
+++ b/spyre-rag/ui/src/components/App.jsx
@@ -1,12 +1,10 @@
 import React, { useState } from "react";
-import { createRoot } from "react-dom/client";
 import {
-  ChatContainer,
   ChatCustomElement,
   BusEventType,
   FeedbackInteractionType,
   CornersType,
-  MinimizeButtonIconType,
+  UserType,
 } from "@carbon/ai-chat";
 import "./App.scss"
 import HeaderNav from "./Header.jsx"
@@ -36,25 +34,30 @@ function App() {
 
   function onBeforeRender(instance) {
 
-    instance.updateMainHeaderAvatar({
-      source: 'https://isv-graphics.s3.us-south.cloud-object-storage.appdomain.cloud/PAC-background-new.jpg',
-      corners: 'round',
-    });
-    instance.updateMainHeaderTitle('DocuAssist');
-
+    instance.updateMainHeaderTitle("DocuAssistant");
     instance.on({ type: BusEventType.FEEDBACK, handler: feedbackHandler });
     setChatInstance(instance);
 
-    instance.messaging.addMessage({
-      output: {
-        generic: [
-          {
-            response_type: "text",
-            text: `Hi, I'm your assistant! You can ask me anything related to your documents`,
+    // Delay welcome message to avoid triggering initial loading indicator
+    setTimeout(() => {
+      instance.messaging.addMessage({
+        output: {
+          generic: [
+            {
+              response_type: "text",
+              text: `Hi, I'm your assistant! You can ask me anything related to your documents`,
+            },
+          ],
+        },
+        message_options: {
+          response_user_profile: {
+            id: "assistant",
+            nickname: "DocuAgent",
+            user_type: UserType.BOT,
           },
-        ],
-      },
-    });
+        },
+      });
+    }, 300);
   }
 
   function feedbackHandler(event) {

--- a/spyre-rag/ui/src/components/Header.jsx
+++ b/spyre-rag/ui/src/components/Header.jsx
@@ -8,7 +8,7 @@ const HeaderNav = () => {
   return (
     <Header aria-label="">
     <HeaderName to="/" prefix="">
-        DocuAssist &#8482;
+        DocuAssistant &#8482;
     </HeaderName>
     </Header>
   );

--- a/spyre-rag/ui/src/components/customSendMessage.jsx
+++ b/spyre-rag/ui/src/components/customSendMessage.jsx
@@ -1,7 +1,14 @@
 import axios from "axios";
+import { UserType } from "@carbon/ai-chat";
 
 async function customSendMessage(request, _options, instance) {
   const userInput = request.input.text;
+
+  const ResponseUserProfile = {
+    id: "assistant",
+    nickname: "DocuAgent",
+    user_type: UserType.BOT,
+  }
 
   function finalizeResponse(fullText) {
     let trimmed = fullText.trim(); // to remove trailing white-space
@@ -35,6 +42,11 @@ async function customSendMessage(request, _options, instance) {
     },
     streaming_metadata: {
       response_id: responseId,
+    },
+    partial_response: {
+      message_options: {
+        response_user_profile: ResponseUserProfile,
+      },
     },
   });
 
@@ -85,6 +97,11 @@ async function customSendMessage(request, _options, instance) {
           streaming_metadata: {
             response_id: responseId,
           },
+          partial_response: {
+            message_options: {
+              response_user_profile: ResponseUserProfile,
+            },
+          },
         });
       }
     }
@@ -102,6 +119,11 @@ async function customSendMessage(request, _options, instance) {
       },
       streaming_metadata: {
         response_id: responseId,
+      },
+      partial_response: {
+        message_options: {
+          response_user_profile: ResponseUserProfile,
+        },
       },
     });
 
@@ -133,6 +155,9 @@ async function customSendMessage(request, _options, instance) {
             },
           ],
         },
+        message_options: {
+          response_user_profile: ResponseUserProfile
+        },
       },
     });
 
@@ -153,6 +178,9 @@ async function customSendMessage(request, _options, instance) {
               },
             },
           ],
+        },
+        message_options: {
+          response_user_profile: ResponseUserProfile
         },
       },
     });


### PR DESCRIPTION
- upgrade carbon-ai-chat library to 0.5.1 version
- replace default watsonx references
- adapt streaming changes as part of migration

<img width="2598" height="1756" alt="Screenshot 2025-11-11 at 12 30 05 PM" src="https://github.com/user-attachments/assets/44239439-8a9c-4bae-bbf0-1285db057f4e" />
