### PR TITLE
Add subcommand for application logs

### DIFF
--- a/ai-services/cmd/ai-services/cmd/application/application.go
+++ b/ai-services/cmd/ai-services/cmd/application/application.go
@@ -24,6 +24,7 @@ func init() {
 	ApplicationCmd.AddCommand(stopCmd)
 	ApplicationCmd.AddCommand(startCmd)
 	ApplicationCmd.AddCommand(infoCmd)
+	ApplicationCmd.AddCommand(logsCmd)
 	ApplicationCmd.AddCommand(model.ModelCmd)
 	ApplicationCmd.PersistentFlags().StringVar(&vars.ToolImage, "tool-image", vars.ToolImage, "Tool image to use for downloading the model(only for the development purpose)")
 	ApplicationCmd.PersistentFlags().MarkHidden("tool-image")

--- a/ai-services/cmd/ai-services/cmd/application/logs.go
+++ b/ai-services/cmd/ai-services/cmd/application/logs.go
@@ -1,0 +1,73 @@
+package application
+
+import (
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
+	"github.com/spf13/cobra"
+)
+
+var (
+	podName           string
+	containerNameOrID string
+)
+
+var logsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "shows application pod logs",
+	Long: `show application pod logs based on pod name		
+Flags
+- [pod]: Pod name (Required)
+- [containter]: Container name (Optional)
+Specify container name or ID to show logs of a specific container
+	`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if podName == "" {
+			return fmt.Errorf("pod name must be specified using --pod flag")
+		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		runtimeClient, err := podman.NewPodmanClient()
+		if err != nil {
+			return fmt.Errorf("failed to connect to podman: %w", err)
+		}
+
+		return showLogs(runtimeClient, podName, containerNameOrID)
+	},
+}
+
+func init() {
+	logsCmd.Flags().StringVar(&podName, "pod", "", "Pod name to show logs from (required)")
+	logsCmd.Flags().StringVar(&containerNameOrID, "container", "", "Container logs to show logs from (Optional)")
+	logsCmd.MarkFlagRequired("pod")
+}
+
+func showLogs(client *podman.PodmanClient, podName string, containerNameOrID string) error {
+	logger.Warningln("Press Ctrl+C to exit the logs and return to the terminal.")
+	logger.Infof("Fetching logs for application pod: %s", podName)
+
+	if containerNameOrID != "" {
+		exists, err := client.ContainerExists(containerNameOrID)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("container %s doesn't exists", containerNameOrID)
+		}
+		logger.Infof("Fetching logs for container: %s", containerNameOrID)
+		err = client.ContainerLogs(containerNameOrID)
+		if err != nil {
+			return fmt.Errorf("failed to fetch container: %s logs; err: %w", containerNameOrID, err)
+		}
+	} else {
+		err := client.PodLogs(podName)
+		if err != nil {
+			return fmt.Errorf("failed to fetch pod: %s logs; err: %w", podName, err)
+		}
+	}
+
+	return nil
+}

--- a/ai-services/internal/pkg/runtime/interface.go
+++ b/ai-services/internal/pkg/runtime/interface.go
@@ -20,4 +20,7 @@ type Runtime interface {
 	ListContainers(filters map[string][]string) (any, error)
 	InspectPod(nameOrId string) (*types.PodInspectReport, error)
 	PodExists(nameOrID string) (bool, error)
+	PodLogs(nameOrID string) error
+	ContainerLogs(containerNameOrID string) error
+	ContainerExists(nameOrID string) (bool, error)
 }


### PR DESCRIPTION
# Testing

- Case 1:

```
[root@temp ai-services]# ./bin/ai-services application logs
Error: required flag(s) "pod" not set
Usage:
  ai-services application logs [flags]

Flags:
      --container string   Container logs to show logs from (Optional)
  -h, --help               help for logs
      --pod string         Pod name to show logs from (required)
```
---
- Case 2:

```
[root@temp ai-services]# ./bin/ai-services application logs --pod temp--pod3
⚠️ Press Ctrl+C to exit the logs and return to the terminal.
Fetching logs for application pod	{"pod": "temp--pod3"}
4166daebd7a0 /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
4166daebd7a0 /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
4166daebd7a0 /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
4166daebd7a0 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
4166daebd7a0 10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
4166daebd7a0 /docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
4166daebd7a0 /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
4166daebd7a0 /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
4166daebd7a0 /docker-entrypoint.sh: Configuration complete; ready for start up
4166daebd7a0 2025/11/11 15:21:16 [notice] 1#1: using the "epoll" event method
4166daebd7a0 2025/11/11 15:21:16 [notice] 1#1: nginx/1.29.3
4166daebd7a0 2025/11/11 15:21:16 [notice] 1#1: built by gcc 14.2.0 (Debian 14.2.0-19) 
4166daebd7a0 2025/11/11 15:21:16 [notice] 1#1: OS: Linux 5.14.0-570.24.1.el9_6.ppc64le
4166daebd7a0 2025/11/11 15:21:16 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1048576:1048576
4166daebd7a0 2025/11/11 15:21:16 [notice] 1#1: start worker processes
4166daebd7a0 2025/11/11 15:21:16 [notice] 1#1: start worker process 24
4166daebd7a0 2025/11/11 15:21:16 [notice] 1#1: start worker process 25
```
---
- Case 3:
```
[root@temp ai-services]# ./bin/ai-services application logs --pod temp--pod3 --container 4166daebd7a0
⚠️ Press Ctrl+C to exit the logs and return to the terminal.
Fetching logs for application pod	{"pod": "temp--pod3"}
Fetching logs for container	{"container": "4166daebd7a0"}
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration

/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/

/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh

10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf

10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf

/docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh

/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh

/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh

/docker-entrypoint.sh: Configuration complete; ready for start up

2025/11/11 15:21:16 [notice] 1#1: using the "epoll" event method

2025/11/11 15:21:16 [notice] 1#1: nginx/1.29.3

2025/11/11 15:21:16 [notice] 1#1: built by gcc 14.2.0 (Debian 14.2.0-19) 

2025/11/11 15:21:16 [notice] 1#1: OS: Linux 5.14.0-570.24.1.el9_6.ppc64le

2025/11/11 15:21:16 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1048576:1048576

2025/11/11 15:21:16 [notice] 1#1: start worker processes

2025/11/11 15:21:16 [notice] 1#1: start worker process 24

2025/11/11 15:21:16 [notice] 1#1: start worker process 25

^C
```