### PR TITLE
helm style of values 

### DIFF
--- a/ai-services/assets/applications/RAG/metadata.yaml
+++ b/ai-services/assets/applications/RAG/metadata.yaml
@@ -6,3 +6,4 @@ podTemplateExecutions:
   - [milvus.yaml.tmpl, vllm-server.yaml.tmpl]
   - [clean-docs.yaml.tmpl]
   - [ingest-docs.yaml.tmpl, chat-bot.yaml.tmpl]
+

--- a/ai-services/assets/applications/RAG/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/applications/RAG/templates/chat-bot.yaml.tmpl
@@ -12,7 +12,7 @@ metadata:
 spec:
   containers:
     - name: ui
-      image: icr.io/ai-services-private/rag-ui:v0.0.3
+      image: "{{ .Values.ui.image }}"
       resources:
         requests:
           memory: "1Gi"
@@ -28,7 +28,7 @@ spec:
           containerPort: 3000
           protocol: TCP
     - name: backend-server
-      image: icr.io/ai-services-private/rag:v0.0.4
+      image: "{{ .Values.backend.image }}"
       command:
         - "/var/venv/bin/python"
         - "-m"

--- a/ai-services/assets/applications/RAG/templates/clean-docs.yaml.tmpl
+++ b/ai-services/assets/applications/RAG/templates/clean-docs.yaml.tmpl
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
     - name: clean-docs
-      image: icr.io/ai-services-private/rag:v0.0.4
+      image: "{{ .Values.backend.image }}"
       command:
         - "/var/venv/bin/python"
         - "-m"

--- a/ai-services/assets/applications/RAG/templates/ingest-docs.yaml.tmpl
+++ b/ai-services/assets/applications/RAG/templates/ingest-docs.yaml.tmpl
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
     - name: ingest-docs
-      image: icr.io/ai-services-private/rag:v0.0.4
+      image: "{{ .Values.backend.image }}"
       command:
         - "/var/venv/bin/python"
         - "-m"

--- a/ai-services/assets/applications/RAG/templates/milvus.yaml.tmpl
+++ b/ai-services/assets/applications/RAG/templates/milvus.yaml.tmpl
@@ -10,7 +10,7 @@ spec:
   containers:
      # Etcd sidecar
     - name: etcd
-      image: icr.io/ai-services/etcd:3.6.5
+      image: "{{ .Values.etcd.image }}"
       command:
         - etcd
         - --data-dir=/etcd
@@ -52,7 +52,7 @@ spec:
     
     # MinIO sidecar
     - name: minio
-      image: icr.io/ai-services-private/minio:RELEASE.2025-10-15T17-29-55Z
+      image: "{{ .Values.minio.image }}"
       command: ["minio", "server", "/minio_data", "--console-address", ":9001"]
       env:
         - name: MINIO_ROOT_USER
@@ -78,7 +78,7 @@ spec:
 
     # Milvus main container
     - name: milvus
-      image: icr.io/ppc64le-oss/milvus-ppc64le:v2.5.3
+      image: "{{ .Values.milvus.image }}"
       command: ["milvus", "run", "standalone"]
       env:
         - name: ETCD_ENDPOINTS

--- a/ai-services/assets/applications/RAG/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/applications/RAG/templates/vllm-server.yaml.tmpl
@@ -28,7 +28,7 @@ spec:
         type: Directory
   containers:
     - name: instruct
-      image: icr.io/ibmaiu_internal/ppc64le/dd2/rhaiis:3.2.5-ci_236
+      image: "{{ .Values.instruct.image }}"
       command: ["/bin/bash"]
       args:
         - "-c"
@@ -83,7 +83,7 @@ spec:
         - mountPath: /dev/shm
           name: dshm
     - name: embedding
-      image: icr.io/ppc64le-oss/vllm-ppc64le:0.9.1
+      image: "{{ .Values.embedding.image }}"
       command: ["/bin/sh", "-c"]
       args: [
           "vllm serve /models/ibm-granite/granite-embedding-278m-multilingual --served-model-name ibm-granite/granite-embedding-278m-multilingual --port 8001"
@@ -108,7 +108,7 @@ spec:
           name: models
           readOnly: true
     - name: reranker
-      image: icr.io/ibmaiu_internal/ppc64le/dd2/rhaiis:3.2.5-ci_236
+      image: "{{ .Values.reranker.image }}"
       command: ["/bin/bash"]
       args:
         - "-c"

--- a/ai-services/assets/applications/RAG/values.yaml
+++ b/ai-services/assets/applications/RAG/values.yaml
@@ -1,0 +1,32 @@
+ui:
+  port: 3000
+  # @hidden
+  image: icr.io/ai-services-private/rag-ui:v0.0.3
+
+backend:
+  # @hidden
+  image: icr.io/ai-services-private/rag:v0.0.4 
+
+etcd:
+  # @hidden
+  image: icr.io/ai-services/etcd:3.6.5 
+
+minio:
+  # @hidden
+  image: icr.io/ai-services-private/minio:RELEASE.2025-10-15T17-29-55Z 
+
+milvus:
+  # @hidden
+  image: icr.io/ppc64le-oss/milvus-ppc64le:v2.5.3 
+
+instruct:
+  # @hidden
+  image: icr.io/ibmaiu_internal/ppc64le/dd2/rhaiis:3.2.5-ci_236 
+
+embedding:
+  # @hidden
+  image: icr.io/ppc64le-oss/vllm-ppc64le:0.9.1 
+
+reranker:
+  # @hidden
+  image: icr.io/ibmaiu_internal/ppc64le/dd2/rhaiis:3.2.5-ci_236

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -530,7 +530,7 @@ func fetchSpyreCardsFromPodAnnotations(annotations map[string]string) (int, map[
 }
 
 func fetchPodSpec(tp templates.Template, appTemplateName, podTemplateFileName, appName string) (*models.PodSpec, error) {
-	podSpec, err := tp.LoadPodTemplateWithDummyParams(appTemplateName, podTemplateFileName, appName)
+	podSpec, err := tp.LoadPodTemplateWithValues(appTemplateName, podTemplateFileName, appName, argParams)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load pod Template: '%s' for appTemplate: '%s' with error: %w", podTemplateFileName, appTemplateName, err)
 	}

--- a/ai-services/cmd/ai-services/cmd/application/info.go
+++ b/ai-services/cmd/ai-services/cmd/application/info.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/containers/podman/v5/pkg/domain/entities/types"
 	"github.com/spf13/cobra"
-	"k8s.io/klog/v2"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
@@ -68,7 +67,7 @@ var infoCmd = &cobra.Command{
 
 		if err := helpers.PrintInfo(runtimeClient, applicationName, appTemplate); err != nil {
 			// not failing if overall info command, if we cannot display Info
-			klog.Errorf("failed to display info: %v\n", err)
+			logger.Errorf("failed to display info: %v\n", err)
 			return nil
 		}
 

--- a/ai-services/cmd/ai-services/cmd/application/model/list.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/list.go
@@ -29,7 +29,7 @@ func list(cmd *cobra.Command) error {
 	if err != nil {
 		return fmt.Errorf("failed to list the models, err: %w", err)
 	}
-	logger.Infoln("Models in application template" + templateName + ":")
+	logger.Infoln("Models in application template " + templateName + ":")
 	for _, model := range models {
 		logger.Infoln("-" + model)
 	}

--- a/ai-services/cmd/ai-services/cmd/application/templates.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates.go
@@ -32,7 +32,14 @@ var templatesCmd = &cobra.Command{
 
 		logger.Infoln("Available Application Templates:")
 		for _, name := range appTemplateNames {
-			logger.Infoln("- " + name)
+			appTemplatesValues, err := tp.ListApplicationTemplateValues(name)
+			if err != nil {
+				return fmt.Errorf("failed to list application template values: %w", err)
+			}
+			logger.Infof("- %s\n  Parameters supported:\n", name)
+			for _, v := range appTemplatesValues {
+				logger.Infoln("    " + v)
+			}
 		}
 		return nil
 	},

--- a/ai-services/go.mod
+++ b/ai-services/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/containers/podman/v5 v5.6.2
 	github.com/spf13/cobra v1.9.1
 	github.com/yarlson/pin v0.9.1
+	go.yaml.in/yaml/v3 v3.0.4
 	k8s.io/klog/v2 v2.130.1
-	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -132,7 +132,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
@@ -147,6 +146,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	sigs.k8s.io/yaml v1.6.0 // indirect
 	tags.cncf.io/container-device-interface v1.0.1 // indirect
 )
 

--- a/ai-services/internal/pkg/cli/helpers/images.go
+++ b/ai-services/internal/pkg/cli/helpers/images.go
@@ -29,7 +29,7 @@ func ListImages(template, appName string) ([]string, error) {
 	}
 
 	for _, tmpl := range tmpls {
-		ps, err := tp.LoadPodTemplateWithDummyParams(template, tmpl.Name(), appName)
+		ps, err := tp.LoadPodTemplateWithValues(template, tmpl.Name(), appName, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error loading pod template: %w", err)
 		}

--- a/ai-services/internal/pkg/cli/helpers/models.go
+++ b/ai-services/internal/pkg/cli/helpers/models.go
@@ -32,7 +32,7 @@ func ListModels(template, appName string) ([]string, error) {
 
 	modelList := []string{}
 	for _, tmpl := range tmpls {
-		ps, err := tp.LoadPodTemplateWithDummyParams(template, tmpl.Name(), appName)
+		ps, err := tp.LoadPodTemplateWithValues(template, tmpl.Name(), appName, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error loading pod template: %w", err)
 		}

--- a/ai-services/internal/pkg/cli/templates/embed.go
+++ b/ai-services/internal/pkg/cli/templates/embed.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 	"io/fs"
 	"slices"
+	"sort"
 	"strings"
 	"text/template"
 
-	"sigs.k8s.io/yaml"
-
 	"github.com/project-ai-services/ai-services/assets"
 	"github.com/project-ai-services/ai-services/internal/pkg/models"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	"go.yaml.in/yaml/v3"
 )
 
 type embedTemplateProvider struct {
@@ -49,6 +50,28 @@ func (e *embedTemplateProvider) ListApplications() ([]string, error) {
 	}
 
 	return apps, nil
+}
+
+// ListApplicationTemplateValues lists all available template value keys for a single application.
+func (e *embedTemplateProvider) ListApplicationTemplateValues(app string) ([]string, error) {
+	valuesPath := fmt.Sprintf("%s/%s/values.yaml", e.root, app)
+	valuesData, err := e.fs.ReadFile(valuesPath)
+	if err != nil {
+		return nil, fmt.Errorf("read values.yaml: %w", err)
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(valuesData, &root); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal yaml.Node: %w", err)
+	}
+
+	var keys []string
+	if len(root.Content) > 0 {
+		utils.FlattenNode("", root.Content[0], &keys)
+	}
+
+	sort.Strings(keys)
+	return keys, nil
 }
 
 // LoadAllTemplates loads all templates for a given application
@@ -100,40 +123,35 @@ func (e *embedTemplateProvider) LoadPodTemplate(app, file string, params any) (*
 	return &spec, nil
 }
 
-// LoadPodTemplate loads and renders a pod template with the dummy parameters
-func (e *embedTemplateProvider) LoadPodTemplateWithDummyParams(app, file, appName string) (*models.PodSpec, error) {
-	dummyParams := map[string]any{
+func (e *embedTemplateProvider) LoadPodTemplateWithValues(app, file, appName string, overrides map[string]string) (*models.PodSpec, error) {
+	valuesPath := fmt.Sprintf("%s/%s/values.yaml", e.root, app)
+	valuesData, err := e.fs.ReadFile(valuesPath)
+	if err != nil {
+		return nil, fmt.Errorf("read values.yaml: %w", err)
+	}
+
+	var values map[string]any
+	if err := yaml.Unmarshal(valuesData, &values); err != nil {
+		return nil, fmt.Errorf("parse values.yaml: %w", err)
+	}
+
+	for key, val := range overrides {
+		utils.SetNestedValue(values, key, val)
+	}
+
+	// Build full params directly
+	params := map[string]any{
+		"Values":          values,
 		"AppName":         appName,
 		"AppTemplateName": "",
 		"Version":         "",
 	}
-
-	path := fmt.Sprintf("%s/%s/templates/%s", e.root, app, file)
-	data, err := e.fs.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("read metadata: %w", err)
-	}
-
-	var rendered bytes.Buffer
-	tmpl, err := template.New("podTemplate").Parse(string(data))
-	if err != nil {
-		return nil, fmt.Errorf("parse template %s: %w", file, err)
-	}
-	if err := tmpl.Execute(&rendered, dummyParams); err != nil {
-		return nil, fmt.Errorf("failed to execute template %s: %v", path, err)
-	}
-
-	var spec models.PodSpec
-	if err := yaml.Unmarshal(rendered.Bytes(), &spec); err != nil {
-		return nil, fmt.Errorf("unable to read YAML as Kube Pod: %w", err)
-	}
-
-	return &spec, nil
+	return e.LoadPodTemplate(app, file, params)
 }
 
 // LoadMetadata loads the metadata for a given application template
-func (e *embedTemplateProvider) LoadMetadata(template string) (*AppMetadata, error) {
-	path := fmt.Sprintf("%s/%s/metadata.yaml", e.root, template)
+func (e *embedTemplateProvider) LoadMetadata(appTemplateName string) (*AppMetadata, error) {
+	path := fmt.Sprintf("%s/%s/metadata.yaml", e.root, appTemplateName)
 	data, err := e.fs.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read metadata: %w", err)

--- a/ai-services/internal/pkg/cli/templates/templates.go
+++ b/ai-services/internal/pkg/cli/templates/templates.go
@@ -32,12 +32,14 @@ type HostVar struct {
 type Template interface {
 	// ListApplications lists all available application templates
 	ListApplications() ([]string, error)
+	// ListApplicationTemplateValues lists all available template value keys for a single application.
+	ListApplicationTemplateValues(app string) ([]string, error)
 	// LoadAllTemplates loads all templates for a given application
 	LoadAllTemplates(path string) (map[string]*template.Template, error)
 	// LoadPodTemplate loads and renders a pod template with the given parameters
 	LoadPodTemplate(app, file string, params any) (*models.PodSpec, error)
-	// LoadPodTemplateWithDummyParams loads and renders a pod template with the dummy parameters
-	LoadPodTemplateWithDummyParams(app, file, appName string) (*models.PodSpec, error)
+	// LoadPodTemplateWithValues loads and renders a pod template with values from application
+	LoadPodTemplateWithValues(app, file, appName string, overrides map[string]string) (*models.PodSpec, error)
 	// LoadMetadata loads the metadata for a given application template
 	LoadMetadata(app string) (*AppMetadata, error)
 	// LoadMdFiles loads all md files for a given application


### PR DESCRIPTION
What's done?
-Introduced values file, extracted parametrizable vars (currently ui-port and images) to it
-`ListApplicationTemplateValues` that lists individual application template's values
-`LoadPodTemplateWithValues` that merges both default values and command line overrides into one single map and internally calls `LoadPodTemplate`
-Headline comment with `@hidden` - includes `FlattenNode` and `SetNestedValue` logic
-Tiny nits

What's pending?
-Complete usage of ui-port via values (replace vars_file and usages in steps dir)

Sample `application template` output
<img width="1042" height="138" alt="image" src="https://github.com/user-attachments/assets/20f8778c-c6c2-4060-adb9-9594a0f17cec" />
