### PR TITLE
UI- fix AI label

### DIFF
--- a/spyre-rag/ui/src/components/App.jsx
+++ b/spyre-rag/ui/src/components/App.jsx
@@ -32,6 +32,10 @@ function App() {
   function onAfterRender(instance) {
 
     instance.updateMainHeaderTitle("DocuAssistant");
+    instance.updateLanguagePack({
+      ai_slug_title: undefined,
+      ai_slug_description: undefined,
+    })
     instance.on({ type: BusEventType.FEEDBACK, handler: feedbackHandler });
 
     instance.messaging.addMessage({


### PR DESCRIPTION
Remove Watsonx reference in AI label.
<img width="1896" height="1094" alt="Screenshot 2025-11-13 at 9 59 21 AM" src="https://github.com/user-attachments/assets/6e098fad-03d4-4ad6-a68a-4332ca2b40b7" />



Currently its empty. But we can fill in our own appropriate description if needed.