### PR TITLE
Run go mod tidy to fix a dependency

### DIFF
--- a/ai-services/go.mod
+++ b/ai-services/go.mod
@@ -4,6 +4,7 @@ go 1.24.1
 
 require (
 	github.com/containers/podman/v5 v5.6.2
+	github.com/jedib0t/go-pretty/v6 v6.7.1
 	github.com/spf13/cobra v1.9.1
 	github.com/yarlson/pin v0.9.1
 	k8s.io/klog/v2 v2.130.1
@@ -61,7 +62,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jedib0t/go-pretty/v6 v6.7.1 // indirect
 	github.com/jinzhu/copier v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect


### PR DESCRIPTION
Rerunning go mod tidy as one of the dependency that was used here: https://github.com/IBM/project-ai-services/pull/47 was marked as indirect but rather should be a direct dependency.

Reran `go mod tidy` to resolve