### PR TITLE
Use :z for shared context for SELinux labeling

### DIFF
--- a/ai-services/assets/applications/RAG/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/applications/RAG/templates/chat-bot.yaml.tmpl
@@ -62,7 +62,7 @@ spec:
         limits:
           memory: "5Gi"
       volumeMounts:
-        - mountPath: /var/cache:Z
+        - mountPath: /var/cache:z
           name: cache
           readOnly: true
   volumes:

--- a/ai-services/assets/applications/RAG/templates/clean-docs.yaml.tmpl
+++ b/ai-services/assets/applications/RAG/templates/clean-docs.yaml.tmpl
@@ -32,7 +32,7 @@ spec:
         - name: MILVUS_COLLECTION_NAME
           value: "{{ .AppName  }}"
       volumeMounts:
-        - mountPath: /var/cache:Z
+        - mountPath: /var/cache:z
           name: cache
   restartPolicy: OnFailure
   volumes:

--- a/ai-services/assets/applications/RAG/templates/ingest-docs.yaml.tmpl
+++ b/ai-services/assets/applications/RAG/templates/ingest-docs.yaml.tmpl
@@ -42,10 +42,10 @@ spec:
         - name: MILVUS_COLLECTION_NAME
           value: "{{ .AppName  }}"
       volumeMounts:
-        - mountPath: /var/docs:Z
+        - mountPath: /var/docs:z
           name: docs
           readOnly: true
-        - mountPath: /var/cache:Z
+        - mountPath: /var/cache:z
           name: cache
   restartPolicy: OnFailure
   volumes:

--- a/ai-services/assets/applications/RAG/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/applications/RAG/templates/vllm-server.yaml.tmpl
@@ -66,7 +66,7 @@ spec:
       ports:
         - containerPort: 8000
       volumeMounts:
-        - mountPath: /models:Z
+        - mountPath: /models:z
           name: models
           readOnly: true
         - mountPath: /dev/shm
@@ -93,7 +93,7 @@ spec:
       ports:
         - containerPort: 8001
       volumeMounts:
-        - mountPath: /models:Z
+        - mountPath: /models:z
           name: models
           readOnly: true
     - name: reranker
@@ -118,6 +118,6 @@ spec:
       ports:
         - containerPort: 8002
       volumeMounts:
-        - mountPath: /models:Z
+        - mountPath: /models:z
           name: models
           readOnly: true


### PR DESCRIPTION
Need to use :z for shared context, :Z is for private context. For our use case we should be using shared context between ingestion and chatbot.
https://docs.podman.io/en/latest/markdown/podman-run.1.html#volume-v-source-volume-host-dir-container-dir-options
