### PR TITLE
fix linting

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -34,9 +34,9 @@ jobs:
           git diff --exit-code go.mod go.sum
  
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.59.0
+          version: v2.6
           working-directory: ai-services
 
       - name: Build Go binary

--- a/ai-services/.golangci.yml
+++ b/ai-services/.golangci.yml
@@ -1,0 +1,4 @@
+version: "2"
+run:
+  build-tags:
+    - exclude_graphdriver_btrfs containers_image_openpgp remote

--- a/ai-services/cmd/ai-services/cmd/application/application.go
+++ b/ai-services/cmd/ai-services/cmd/application/application.go
@@ -27,5 +27,5 @@ func init() {
 	ApplicationCmd.AddCommand(logsCmd)
 	ApplicationCmd.AddCommand(model.ModelCmd)
 	ApplicationCmd.PersistentFlags().StringVar(&vars.ToolImage, "tool-image", vars.ToolImage, "Tool image to use for downloading the model(only for the development purpose)")
-	ApplicationCmd.PersistentFlags().MarkHidden("tool-image")
+	_ = ApplicationCmd.PersistentFlags().MarkHidden("tool-image")
 }

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -219,7 +219,7 @@ func init() {
 	createCmd.Flags().StringSliceVar(&skipChecks, "skip-validation", []string{},
 		"Skip specific validation checks (comma-separated: root,rhel,rhn,power,rhaiis,numa)")
 	createCmd.Flags().StringVarP(&templateName, "template", "t", "", "Template name to use (required)")
-	createCmd.MarkFlagRequired("template")
+	_ = createCmd.MarkFlagRequired("template")
 	createCmd.Flags().BoolVar(&skipModelDownload, "skip-model-download", false, "Set to true to skip model download during application creation. This assumes local models are already available at /var/lib/ai-services/models/ and is particularly beneficial for air-gapped networks with limited internet access. If not set correctly (e.g., set to true when models are missing, or left false in an air-gapped environment), the create command may fail.")
 	createCmd.Flags().StringSliceVar(&rawArgParams, "params", []string{}, "Parameters required to configure the application. Takes Comma-separated key=value pairs. Values Supported: UI_PORT=8000")
 }

--- a/ai-services/cmd/ai-services/cmd/application/image/image.go
+++ b/ai-services/cmd/ai-services/cmd/application/image/image.go
@@ -20,5 +20,5 @@ func init() {
 	ImageCmd.AddCommand(listCmd)
 	ImageCmd.AddCommand(pullCmd)
 	ImageCmd.PersistentFlags().StringVarP(&templateName, "template", "t", "", "Application template name (Required)")
-	ImageCmd.MarkPersistentFlagRequired("template")
+	_ = ImageCmd.MarkPersistentFlagRequired("template")
 }

--- a/ai-services/cmd/ai-services/cmd/application/logs.go
+++ b/ai-services/cmd/ai-services/cmd/application/logs.go
@@ -42,7 +42,7 @@ Specify container name or ID to show logs of a specific container
 func init() {
 	logsCmd.Flags().StringVar(&podName, "pod", "", "Pod name to show logs from (required)")
 	logsCmd.Flags().StringVar(&containerNameOrID, "container", "", "Container logs to show logs from (Optional)")
-	logsCmd.MarkFlagRequired("pod")
+	_ = logsCmd.MarkFlagRequired("pod")
 }
 
 func showLogs(client *podman.PodmanClient, podName string, containerNameOrID string) error {

--- a/ai-services/cmd/ai-services/cmd/application/model/download.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/download.go
@@ -21,9 +21,9 @@ var downloadCmd = &cobra.Command{
 
 func init() {
 	downloadCmd.Flags().StringVarP(&templateName, "template", "t", "", "Application template name(Required)")
-	downloadCmd.MarkFlagRequired("template")
+	_ = downloadCmd.MarkFlagRequired("template")
 	downloadCmd.Flags().StringVar(&vars.ToolImage, "tool-image", vars.ToolImage, "Tool image to use for downloading the model(only for the development purpose)")
-	downloadCmd.Flags().MarkHidden("tool-image")
+	_ = downloadCmd.Flags().MarkHidden("tool-image")
 	downloadCmd.Flags().StringVar(&vars.ModelDirectory, "dir", vars.ModelDirectory, "Directory to download the model files")
 }
 

--- a/ai-services/cmd/ai-services/cmd/application/model/list.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/list.go
@@ -21,7 +21,7 @@ var listCmd = &cobra.Command{
 
 func init() {
 	listCmd.Flags().StringVarP(&templateName, "template", "t", "", "Application template name (Required)")
-	listCmd.MarkFlagRequired("template")
+	_ = listCmd.MarkFlagRequired("template")
 }
 
 func list(cmd *cobra.Command) error {

--- a/ai-services/cmd/ai-services/cmd/bootstrap/configure.go
+++ b/ai-services/cmd/ai-services/cmd/bootstrap/configure.go
@@ -144,7 +144,7 @@ func configureUsergroup() error {
 	cmd := exec.Command("bash", "-c", cmd_str)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("❌ failed to create sentient group and add current user to the sentient group. Error: %w, output: %w", err, string(out))
+		return fmt.Errorf("❌ failed to create sentient group and add current user to the sentient group. Error: %w, output: %s", err, string(out))
 	}
 
 	return nil

--- a/ai-services/cmd/ai-services/main.go
+++ b/ai-services/cmd/ai-services/main.go
@@ -5,7 +5,6 @@ import "github.com/project-ai-services/ai-services/cmd/ai-services/cmd"
 // ai-services completion bash|zsh|fish|powershell
 // ai-services --version
 
-// Needs implementation
 // ai-services --help
 
 // ai-services application templates (Multiple application templates Eg:- RAG)

--- a/ai-services/internal/pkg/cli/helpers/helper.go
+++ b/ai-services/internal/pkg/cli/helpers/helper.go
@@ -111,7 +111,9 @@ func FindFreeSpyreCards() ([]string, error) {
 			logger.Infoln("Device or resource busy, skipping..", 1)
 			continue
 		}
-		f.Close()
+		if err := f.Close(); err != nil {
+			logger.Infoln("Failed to close the device file handle", 1)
+		}
 
 		// free card available to use
 		dev_pci_path := fmt.Sprintf("/sys/kernel/iommu_groups/%s/devices", dev_file.Name())


### PR DESCRIPTION
This PR fixes:
- updated `golangci/golangci-lint-action` to v6
- Created .golangci.yml with additional build tags which are required to build
- fixed the following issues
```shell
cmd/ai-services/cmd/application/application.go:30:45: Error return value of `(*github.com/spf13/pflag.FlagSet).MarkHidden` is not checked (errcheck)
        ApplicationCmd.PersistentFlags().MarkHidden("tool-image")
                                                   ^
cmd/ai-services/cmd/application/create.go:222:28: Error return value of `createCmd.MarkFlagRequired` is not checked (errcheck)
        createCmd.MarkFlagRequired("template")
                                  ^
cmd/ai-services/cmd/application/image/image.go:23:37: Error return value of `ImageCmd.MarkPersistentFlagRequired` is not checked (errcheck)
        ImageCmd.MarkPersistentFlagRequired("template")
                                           ^
cmd/ai-services/cmd/application/logs.go:45:26: Error return value of `logsCmd.MarkFlagRequired` is not checked (errcheck)
        logsCmd.MarkFlagRequired("pod")
                                ^
cmd/ai-services/cmd/application/model/download.go:24:30: Error return value of `downloadCmd.MarkFlagRequired` is not checked (errcheck)
        downloadCmd.MarkFlagRequired("template")
                                    ^
cmd/ai-services/cmd/application/model/download.go:26:32: Error return value of `(*github.com/spf13/pflag.FlagSet).MarkHidden` is not checked (errcheck)
        downloadCmd.Flags().MarkHidden("tool-image")
                                      ^
cmd/ai-services/cmd/application/model/list.go:24:26: Error return value of `listCmd.MarkFlagRequired` is not checked (errcheck)
        listCmd.MarkFlagRequired("template")
                                ^
internal/pkg/cli/helpers/helper.go:114:10: Error return value of `f.Close` is not checked (errcheck)
                f.Close()
                       ^
cmd/ai-services/cmd/bootstrap/configure.go:147:121: printf: fmt.Errorf format %w has arg string(out) of wrong type string (govet)
                return fmt.Errorf("❌ failed to create sentient group and add current user to the sentient group. Error: %w, output: %w", err, string(out))
                                                                                                                                      ^
9 issues:
* errcheck: 8
* govet: 1
```