### PR TITLE
hide klog flags

### DIFF
--- a/ai-services/internal/pkg/logger/logger.go
+++ b/ai-services/internal/pkg/logger/logger.go
@@ -7,11 +7,12 @@ import (
 )
 
 func Init() {
-	klog.InitFlags(nil)
-	_ = flag.Set("alsologtostderr", "true")
-	_ = flag.Set("skip_headers", "true")
-	_ = flag.Set("skip_log_headers", "true")
-	flag.Parse()
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+	_ = klogFlags.Set("alsologtostderr", "true")
+	_ = klogFlags.Set("skip_headers", "true")
+	_ = klogFlags.Set("skip_log_headers", "true")
+	_ = klogFlags.Parse([]string{})
 }
 
 func Flush() {


### PR DESCRIPTION
```
[root@temp ai-services]# ./bin/ai-services application create temp --template "RAG"
Validating the LPAR environment before creating application 'temp'...
✔ NUMA node alignment on LPAR: 1
✔ Operating system is RHEL with version 9.6
✖ unsupported IBM Power version: Power11 is required
✖ system is not registered with RHN
✔ Current user is root
✖ IBM Spyre Accelerator is not attached to the LPAR
Error: bootstrap validation failed: 3 validation check(s) failed
Usage:
  ai-services application create [name] [flags]

Flags:
  -h, --help                      help for create
      --params strings            Parameters required to configure the application. Takes Comma-separated key=value pairs. Values Supported: UI_PORT=8000
      --skip-model-download       Set to true to skip model download during application creation. This assumes local models are already available at /var/lib/ai-services/models/ and is particularly beneficial for air-gapped networks with limited internet access. If not set correctly (e.g., set to true when models are missing, or left false in an air-gapped environment), the create command may fail.
      --skip-validation strings   Skip specific validation checks (comma-separated: root,rhel,rhn,power,rhaiis,numa)
  -t, --template string           Template name to use (required)
  ```