### PR TITLE
Modify Spyre calculation logic

### DIFF
--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -92,6 +92,12 @@ var createCmd = &cobra.Command{
 			return fmt.Errorf("bootstrap configuration failed: %w", err)
 		}
 
+		// podman connectivity
+		runtime, err := podman.NewPodmanClient()
+		if err != nil {
+			return fmt.Errorf("failed to connect to podman: %w", err)
+		}
+
 		// Proceed to create application
 		logger.Infof("Creating application '%s' using template '%s'\n", appName, templateName)
 
@@ -129,10 +135,10 @@ var createCmd = &cobra.Command{
 
 		// ---- Validate Spyre card Requirements ----
 
-		// calculate the required spyre cards
-		reqSpyreCardsCount, err := calculateReqSpyreCards(tp, utils.ExtractMapKeys(tmpls), templateName, appName)
+		// calculate the required spyre cards of only those pods which are not deployed yet
+		reqSpyreCardsCount, err := calculateReqSpyreCards(runtime, tp, utils.ExtractMapKeys(tmpls), templateName, appName)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to calculateReqSpyreCards: %w", err)
 		}
 
 		var pciAddresses []string
@@ -172,12 +178,6 @@ var createCmd = &cobra.Command{
 		}
 
 		// ---- ! ----
-
-		// podman connectivity
-		runtime, err := podman.NewPodmanClient()
-		if err != nil {
-			return fmt.Errorf("failed to connect to podman: %w", err)
-		}
 
 		// Loop through all pod templates, render and run kube play
 		logger.Infof("Total Pod Templates to be processed: %d\n", len(tmpls))
@@ -478,7 +478,7 @@ func validateSpyreCardRequirements(req int, actual int) error {
 	return nil
 }
 
-func calculateReqSpyreCards(tp templates.Template, podTemplateFileNames []string, appTemplateName, appName string) (int, error) {
+func calculateReqSpyreCards(client *podman.PodmanClient, tp templates.Template, podTemplateFileNames []string, appTemplateName, appName string) (int, error) {
 	totalReqSpyreCounts := 0
 
 	// Calculate Req Spyre Counts
@@ -487,6 +487,17 @@ func calculateReqSpyreCards(tp templates.Template, podTemplateFileNames []string
 		podSpec, err := fetchPodSpec(tp, appTemplateName, podTemplateFileName, appName)
 		if err != nil {
 			return totalReqSpyreCounts, fmt.Errorf("failed to load pod Template: '%s' for appTemplate: '%s' with error: %w", podTemplateFileName, appTemplateName, err)
+		}
+
+		// check if pod already exists and skip counting if it does exists
+		exists, err := client.PodExists(podSpec.Name)
+		if err != nil {
+			return totalReqSpyreCounts, fmt.Errorf("failed to check pod status: %w", err)
+		}
+
+		if exists {
+			logger.Infof("Pod %s already exists, skipping spyre cards calculation", podSpec.Name, 2)
+			continue
 		}
 
 		// fetch the spyreCount for all containers from the annotations


### PR DESCRIPTION
# Description

If we delete the a pod and do retrigger of `application create`, ideally it should create missing pod but it fails with "Insufficent spyre cards" and doesnt allow to recreate that pod, which ideally shouldn't be the case.
Ref: https://jsw.ibm.com/browse/AISERVICES-228

# Fix

We should ignore pods that are already running from the spyre cards calculation logic


# Testing
```
[root@ais-dev-1 ai-services]# ./bin/ai-services application ps
 APPLICATION NAME    POD NAME                 STATUS    
────────────────────────────────────────────────────────
 rag-test            rag-test--milvus         Running   
                     rag-test--vllm-server    Running   
                     rag-test--clean-docs     Exited    
                     rag-test--ingest-docs    Running   
                     
[root@ais-dev-1 ai-services]# ./bin/ai-services application create rag-test -t RAG --skip-validation numa --params UI_PORT=3000 -v=2
Logger initialized (PersistentPreRun)
WARNING: Skipping validation checks (skipped: [numa])
Validating the LPAR environment before creating application 'rag-test'...
WARNING: numa check skipped; Proceeding without validation may result in deployment failure.
Validating operating system...
✔ Operating system is RHEL with version 9.6
Validating IBM Power version...
✔ System is running on IBM Power11 (ppc64le)
Validating RHN registration...
✔ System is registered with RHN
Checking root privileges
✔ Current user is root
Validating Spyre attachment...
✔ IBM Spyre Accelerator is attached to the LPAR
All validations passed
Configuring the LPAR
Checking root privileges
✔ podman already installed
✔ Podman already configured
Validating Spyre attachment...
VFIO kernel modules loaded on the host
⠙ Checking spyre card configurationServiceReport output: servicereport 2.2.5

Spyre configuration checks                          PASS

  VFIO Driver configuration                         PASS
  User memlock configuration                        PASS
  sos config                                        PASS     Auto Fixed
  sos package                                       PASS
  VFIO udev rules configuration                     PASS
  User group configuration                          PASS     Auto Fixed
  VFIO device permission                            PASS
  VFIO kernel module loaded                         PASS
  VFIO module dep configuration                     PASS

Memlock limit is set for the sentient group.
Spyre user must be in the sentient group.
To add run below command:
	sudo usermod -aG sentient <user>
	Example:
	sudo usermod -aG sentient abc
	Re-login as <user>.



✔ Spyre cards configuration validated successfully.
LPAR configured successfully
Creating application 'rag-test' using template 'RAG'
SMT level is already set to %!d(MISSING)
✔ SMT level configured successfully
Pod rag-test--milvus already exists, skipping spyre cards calculation
Pod rag-test--vllm-server already exists, skipping spyre cards calculation
Pod rag-test--clean-docs already exists, skipping spyre cards calculation
Pod rag-test--ingest-docs already exists, skipping spyre cards calculation
Downloading models required for application template RAG:
Downloading model BAAI/bge-reranker-v2-m3 to /var/lib/ai-services/models
Fetching 13 files: 100%|████████████████████████████████████████████████████████████████████████████████████| 13/13 [00:00<00:00, 21199.83it/s]
/models/BAAI/bge-reranker-v2-m3
Model downloaded successfully
Downloading model ibm-granite/granite-embedding-278m-multilingual to /var/lib/ai-services/models
Fetching 13 files: 100%|█████████████████████████████████████████████████████████████████████████████████████| 13/13 [00:00<00:00, 8948.95it/s]
/models/ibm-granite/granite-embedding-278m-multilingual
Model downloaded successfully
Downloading model ibm-granite/granite-3.3-8b-instruct to /var/lib/ai-services/models
Fetching 15 files: 100%|█████████████████████████████████████████████████████████████████████████████████████| 15/15 [00:00<00:00, 6935.79it/s]
/models/ibm-granite/granite-3.3-8b-instruct
⠋ Downloading model: ibm-granite/granite-3.3-8b-instruct...Model downloaded successfully
✔ Model download completed.
Checking status of existing pods...
Existing pod found: rag-test--milvus with status: Running
Existing pod found: rag-test--vllm-server with status: Running
Existing pod found: rag-test--clean-docs with status: Exited
Existing pod found: rag-test--ingest-docs with status: Running

 Executing Layer 1: [milvus.yaml.tmpl vllm-server.yaml.tmpl]
-------
Processing template: vllm-server.yaml.tmpl...
Processing template: milvus.yaml.tmpl...
Skipping pod: rag-test--vllm-server as it already exists
Skipping pod: rag-test--milvus as it already exists
Layer %!d(MISSING) completed

 Executing Layer 2: [clean-docs.yaml.tmpl]
-------
Processing template: clean-docs.yaml.tmpl...
Skipping pod: rag-test--clean-docs as it already exists
Layer %!d(MISSING) completed

 Executing Layer 3: [ingest-docs.yaml.tmpl chat-bot.yaml.tmpl]
-------
Processing template: chat-bot.yaml.tmpl...
Processing template: ingest-docs.yaml.tmpl...
Skipping pod: rag-test--ingest-docs as it already exists
⠸ Deploying application 'rag-test'...Successfully ran podman kube play for chat-bot.yaml.tmpl
Performing Pod Readiness check...: 885bbce7373e6464523ea86e752421106a101c6cf37fa375c6205173262802e2
Doing Container Readiness check...: e28daa0375fb7b3c9ea17f5e1c2beb3b2196cd7aa4af24b3ef45d8ffcaba2ccd
No container health check is set. Hence skipping readiness check
Doing Container Readiness check...: 060873b771783abc3057a662c432382c3f7d9cb26ed179c5fe4cf739f110ccc6
No container health check is set. Hence skipping readiness check
Doing Container Readiness check...: fb313014170fd694d255ca01748004db39e4ae6114c6da2d441358b44cd23a12
No container health check is set. Hence skipping readiness check
Pod: 885bbce7373e6464523ea86e752421106a101c6cf37fa375c6205173262802e2 has been successfully deployed and ready!
-------
-------
-------
✔ Application 'rag-test' deployed successfully
-------
Next Steps: 
-------
1. Move the documents that you want to serve via this RAG application inside "/var/lib/ai-services/rag-test/docs" directory

2. Start the ingestion with below command to feed the documents placed in previous step into the DB
`ai-services application start rag-test --pod=rag-test--ingest-docs`

3. Chatbot is available to use at http://10.20.178.231:3000
```