### PR TITLE
stop the spinner when numa check failed

### DIFF
--- a/ai-services/cmd/ai-services/cmd/bootstrap/validate.go
+++ b/ai-services/cmd/ai-services/cmd/bootstrap/validate.go
@@ -125,7 +125,7 @@ func RunValidateCmd(skip map[string]bool) error {
 				s.Fail(err.Error())
 				validationErrors = append(validationErrors, fmt.Errorf("%s: %w", ruleName, err))
 			case constants.ValidationLevelWarning:
-				logger.Warningf(err.Error())
+				s.Stop("Warning: " + err.Error())
 			}
 		} else {
 			s.Stop(rule.Message())


### PR DESCRIPTION
This will ensure that stop is called when there is even a warning, this was missing and spinner was getting called forever.