### PR TITLE
Add headcomment description parsing for template parameters

### DIFF
--- a/ai-services/assets/applications/RAG/values.yaml
+++ b/ai-services/assets/applications/RAG/values.yaml
@@ -1,4 +1,5 @@
 ui:
+  # @description The host port on which the RAG UI will run
   port: 3000
   # @hidden
   image: icr.io/ai-services-cicd/rag-ui:v0.0.5

--- a/ai-services/cmd/ai-services/cmd/application/templates.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates.go
@@ -40,13 +40,13 @@ var templatesCmd = &cobra.Command{
 
 		logger.Infoln("Available Application Templates:")
 		for _, name := range appTemplateNames {
-			appTemplatesValues, err := tp.ListApplicationTemplateValues(name)
+			appTemplatesParametersWithDescription, err := tp.ListApplicationTemplateValues(name)
 			if err != nil {
 				return fmt.Errorf("failed to list application template values: %w", err)
 			}
-			logger.Infof("- %s\n  Parameters supported:\n", name)
-			for _, v := range appTemplatesValues {
-				logger.Infoln("    " + v)
+			logger.Infof("- %s\n    Supported Parameters:\n", name)
+			for k, v := range appTemplatesParametersWithDescription {
+				logger.Infoln("\t" + k + "\t\t-- " + v)
 			}
 		}
 		return nil

--- a/ai-services/internal/pkg/cli/templates/embed.go
+++ b/ai-services/internal/pkg/cli/templates/embed.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/fs"
 	"slices"
-	"sort"
 	"strings"
 	"text/template"
 
@@ -54,7 +53,7 @@ func (e *embedTemplateProvider) ListApplications() ([]string, error) {
 }
 
 // ListApplicationTemplateValues lists all available template value keys for a single application.
-func (e *embedTemplateProvider) ListApplicationTemplateValues(app string) ([]string, error) {
+func (e *embedTemplateProvider) ListApplicationTemplateValues(app string) (map[string]string, error) {
 	valuesPath := fmt.Sprintf("%s/%s/values.yaml", e.root, app)
 	valuesData, err := e.fs.ReadFile(valuesPath)
 	if err != nil {
@@ -66,13 +65,13 @@ func (e *embedTemplateProvider) ListApplicationTemplateValues(app string) ([]str
 		return nil, fmt.Errorf("failed to unmarshal yaml.Node: %w", err)
 	}
 
-	var keys []string
+	parametersWithDescription := make(map[string]string)
+
 	if len(root.Content) > 0 {
-		utils.FlattenNode("", root.Content[0], &keys)
+		utils.FlattenNode("", root.Content[0], parametersWithDescription)
 	}
 
-	sort.Strings(keys)
-	return keys, nil
+	return parametersWithDescription, nil
 }
 
 // LoadAllTemplates loads all templates for a given application

--- a/ai-services/internal/pkg/cli/templates/templates.go
+++ b/ai-services/internal/pkg/cli/templates/templates.go
@@ -32,8 +32,8 @@ type HostVar struct {
 type Template interface {
 	// ListApplications lists all available application templates
 	ListApplications() ([]string, error)
-	// ListApplicationTemplateValues lists all available template value keys for a single application.
-	ListApplicationTemplateValues(app string) ([]string, error)
+	// ListApplicationTemplateValues lists all available template parameters with description for a single application.
+	ListApplicationTemplateValues(app string) (map[string]string, error)
 	// LoadAllTemplates loads all templates for a given application
 	LoadAllTemplates(path string) (map[string]*template.Template, error)
 	// LoadPodTemplate loads and renders a pod template with the given parameters


### PR DESCRIPTION
The values file now supports head comment style description like this:

<img width="1513" height="227" alt="image" src="https://github.com/user-attachments/assets/ed23d49d-c823-4b80-b7f9-5600d9fb1722" />
