### PR TITLE
bump the memory limit for the doc ingestion

### DIFF
--- a/ai-services/assets/applications/RAG/templates/ingest-docs.yaml.tmpl
+++ b/ai-services/assets/applications/RAG/templates/ingest-docs.yaml.tmpl
@@ -19,9 +19,9 @@ spec:
         - "ingest"
       resources:
         requests:
-          memory: "10Gi"
+          memory: "128Gi"
         limits:
-          memory: "10Gi"
+          memory: "128Gi"
       env:
         - name: EMB_ENDPOINT
           value: "http://{{ .AppName  }}--vllm-server:8001"


### PR DESCRIPTION
for now we are bumping this to 128GB, we will correct it when we get the right sizing for the pod