### PR TITLE
Add ContainerNames col to 'application ps'

### DIFF
--- a/ai-services/cmd/ai-services/cmd/application/ps.go
+++ b/ai-services/cmd/ai-services/cmd/application/ps.go
@@ -57,13 +57,13 @@ var psCmd = &cobra.Command{
 	},
 }
 
-func runPsCmd(client *podman.PodmanClient, appName string) error {
+func runPsCmd(runtimeClient *podman.PodmanClient, appName string) error {
 	listFilters := map[string][]string{}
 	if appName != "" {
 		listFilters["label"] = []string{fmt.Sprintf("ai-services.io/application=%s", appName)}
 	}
 
-	resp, err := client.ListPods(listFilters)
+	resp, err := runtimeClient.ListPods(listFilters)
 	if err != nil {
 		return fmt.Errorf("failed to list pods: %w", err)
 	}
@@ -84,7 +84,7 @@ func runPsCmd(client *podman.PodmanClient, appName string) error {
 	defer p.CloseTableWriter()
 
 	if isOutputWide() {
-		p.SetHeaders("APPLICATION NAME", "POD ID", "POD NAME", "STATUS", "EXPOSED")
+		p.SetHeaders("APPLICATION NAME", "POD ID", "POD NAME", "STATUS", "EXPOSED", "CONTAINERS")
 	} else {
 		p.SetHeaders("APPLICATION NAME", "POD NAME", "STATUS")
 	}
@@ -94,31 +94,21 @@ func runPsCmd(client *podman.PodmanClient, appName string) error {
 			//Skip pods which are not linked to ai-services
 			continue
 		}
-		podPorts := []string{}
-		pInfo, err := client.InspectPod(pod.Id)
-		if err != nil {
-			continue
-		}
-
-		if pInfo.InfraConfig != nil && pInfo.InfraConfig.PortBindings != nil {
-			for _, ports := range pInfo.InfraConfig.PortBindings {
-				for _, port := range ports {
-					podPorts = append(podPorts, port.HostPort)
-				}
-			}
-		}
-
-		if len(podPorts) == 0 {
-			podPorts = []string{"none"}
-		}
 
 		if isOutputWide() {
+			podPorts, err := getPodPorts(runtimeClient, pod.Id)
+			if err != nil {
+				// if failed to fetch ports for pod, then set podPorts to none
+				podPorts = []string{"none"}
+			}
+			containerNames := getContainerNames(runtimeClient, pod)
 			p.AppendRow(
 				fetchPodNameFromLabels(pod.Labels),
 				pod.Id[:12],
 				pod.Name,
 				pod.Status,
 				strings.Join(podPorts, ", "),
+				strings.Join(containerNames, ", "),
 			)
 		} else {
 			p.AppendRow(
@@ -133,4 +123,51 @@ func runPsCmd(client *podman.PodmanClient, appName string) error {
 
 func fetchPodNameFromLabels(labels map[string]string) string {
 	return labels["ai-services.io/application"]
+}
+
+func getPodPorts(runtimeClient *podman.PodmanClient, podID string) ([]string, error) {
+	podPorts := []string{}
+	pInfo, err := runtimeClient.InspectPod(podID)
+	if err != nil {
+		return podPorts, err
+	}
+
+	if pInfo.InfraConfig != nil && pInfo.InfraConfig.PortBindings != nil {
+		for _, ports := range pInfo.InfraConfig.PortBindings {
+			for _, port := range ports {
+				podPorts = append(podPorts, port.HostPort)
+			}
+		}
+	}
+
+	if len(podPorts) == 0 {
+		podPorts = []string{"none"}
+	}
+
+	return podPorts, nil
+}
+
+func getContainerNames(runtimeClient *podman.PodmanClient, pod *types.ListPodsReport) []string {
+	containerNames := []string{}
+
+	for _, container := range pod.Containers {
+		cInfo, err := runtimeClient.InspectContainer(container.Id)
+		if err != nil {
+			// skip container if inspect failed
+			continue
+		}
+
+		if cInfo.IsInfra {
+			// skip infra container
+			continue
+		}
+
+		containerNames = append(containerNames, cInfo.Name)
+	}
+
+	if len(containerNames) == 0 {
+		containerNames = []string{"none"}
+	}
+
+	return containerNames
 }

--- a/ai-services/internal/pkg/utils/printer.go
+++ b/ai-services/internal/pkg/utils/printer.go
@@ -92,19 +92,14 @@ func (p *Printer) CloseTableWriter() {
 			}
 		}
 
-		// truncate at 30 chars max
-		if maxLen+2 <= 30 {
-			cols[colIdx].Width = maxLen + 2
-		} else {
-			cols[colIdx].Width = 30
-		}
+		cols[colIdx].Width = maxLen + 2
 	}
 
 	p.model.SetColumns(cols)
 
 	out := p.model.View()
 
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		if strings.TrimSpace(line) != "" {
 			logger.Infoln(line)
 		}


### PR DESCRIPTION
- Add a new column 'containers' in application ps which will show the container names for respective pod.
- The above is visible only when using '-o wide'.
- This would be mainly used for troubleshooting (helps us to know what and how many container is running with respective to each pod)
- Currently fetching pod port is done inspite of not using '-o wide', so have moved this along with containerNames only when '-o wide' flag is set.
- Remove max length chars set for each column in table and let it stretch and wrap around if the terminal size is reduced (same behavior as podman ps)

<img width="1320" height="155" alt="image" src="https://github.com/user-attachments/assets/eb104e22-8898-4bab-93a8-66675f8ad422" />
