### PR TITLE
Show Chatbot not available when pod is not running in info command

### DIFF
--- a/ai-services/assets/applications/RAG/steps/info.md
+++ b/ai-services/assets/applications/RAG/steps/info.md
@@ -1,6 +1,9 @@
 Day N:
-
+{{ if eq .UI_STATUS "running" }}
 1. Chatbot is available to use at http://{{ .HOST_IP }}:{{ .UI_PORT }}
+{{ else }}
+1. Chatbot is unavailable to use. Please make sure '{{ .AppName }}--chat-bot' pod is running.
+{{ end }}
 
 2. If you want to serve any more new documents via this RAG application, add them inside "/var/lib/ai-services/applications/{{ .AppName }}/docs" directory
 

--- a/ai-services/assets/applications/RAG/steps/next.md
+++ b/ai-services/assets/applications/RAG/steps/next.md
@@ -3,4 +3,4 @@
 2. Start the ingestion with below command to feed the documents placed in previous step into the DB
 `ai-services application start {{ .AppName }} --pod={{ .AppName }}--ingest-docs`
 
-3. Chatbot is available to use at http://{{ .HOST_IP }}:{{ .UI_PORT }}
+3. Chatbot is available to use at http://{{ .HOST_IP }}:{{ .UI_PORT }}.

--- a/ai-services/assets/applications/RAG/steps/vars_file.yaml
+++ b/ai-services/assets/applications/RAG/steps/vars_file.yaml
@@ -1,8 +1,12 @@
 pods:
   - name: "{{ .AppName }}--chat-bot"
-    fetch: "3000"
+    format: "(index (index .InfraConfig.PortBindings \"3000/tcp\") 0).HostPort"
     alias: UI_PORT
-    type: port
+
+containers:
+  - name: "{{ .AppName }}--chat-bot-ui"
+    format: ".State.Status"
+    alias: UI_STATUS
 
 hosts:
   - fetch: HOST_IP

--- a/ai-services/internal/pkg/cli/templates/templates.go
+++ b/ai-services/internal/pkg/cli/templates/templates.go
@@ -14,15 +14,21 @@ type AppMetadata struct {
 }
 
 type Vars struct {
-	Pods  []PodVar  `yaml:"pods,omitempty"`
-	Hosts []HostVar `yaml:"hosts,omitempty"`
+	Pods       []PodVar       `yaml:"pods,omitempty"`
+	Containers []ContainerVar `yaml:"containers,omitempty"`
+	Hosts      []HostVar      `yaml:"hosts,omitempty"`
 }
 
 type PodVar struct {
-	Name  string `yaml:"name,omitempty"`
-	Fetch string `yaml:"fetch,omitempty"`
-	Alias string `yaml:"alias,omitempty"`
-	Type  string `yaml:"type,omitempty"`
+	Name   string `yaml:"name,omitempty"`
+	Format string `yaml:"format,omitempty"`
+	Alias  string `yaml:"alias,omitempty"`
+}
+
+type ContainerVar struct {
+	Name   string `yaml:"name,omitempty"`
+	Format string `yaml:"format,omitempty"`
+	Alias  string `yaml:"alias,omitempty"`
 }
 
 type HostVar struct {


### PR DESCRIPTION
@manalilatkar Based on the bug raised, PTAL at below screenshots if this is what you wanted.

Technical details
---
- Added a new output var type "stats" which fetches the pod info.
- Based on the `fetch` populate the params map.
- Currently from the stats only pod status is fetched. But this can be extended in future to fetch any pod related info.
- Do conditional rendenering based on `status` in info.md.

**Output**

Pod stopped
---
<img width="1317" height="577" alt="image" src="https://github.com/user-attachments/assets/d73b30e9-1684-4044-8ce7-d9c3849cc19f" />

Pod running
---
<img width="1297" height="566" alt="image" src="https://github.com/user-attachments/assets/16ef7f15-f938-4b2f-ad06-1f6391009b2e" />
