### PR TITLE
stop containers before stopping pods

### DIFF
--- a/ai-services/cmd/ai-services/cmd/application/stop.go
+++ b/ai-services/cmd/ai-services/cmd/application/stop.go
@@ -44,7 +44,7 @@ Arguments
 			return fmt.Errorf("failed to connect to podman: %w", err)
 		}
 
-		return stopApplication(cmd, runtimeClient, applicationName, stopPodNames)
+		return stopApplication(runtimeClient, applicationName, stopPodNames)
 	},
 }
 
@@ -53,7 +53,7 @@ func init() {
 }
 
 // stopApplication stops all pods associated with the given application name
-func stopApplication(cmd *cobra.Command, client *podman.PodmanClient, appName string, podNames []string) error {
+func stopApplication(client *podman.PodmanClient, appName string, podNames []string) error {
 	resp, err := client.ListPods(map[string][]string{
 		"label": {fmt.Sprintf("ai-services.io/application=%s", appName)},
 	})


### PR DESCRIPTION
# Description
While starting the pod, below errors were seen:
```
Error: unable to create pod cgroup for pod...: Unit machine-libpod_pod_...slice was already loaded or has a fragment file
Error: container state improper
```

This is because podman creates an infra container as well. Now when `pods.Stop()` is directly called, the shutdown cannot be guaranteed. Few stale resources were observed:

1. stale systemd cgroups
2. stale container state references

A [suggestion](https://github.com/containers/podman/discussions/10036#discussioncomment-629380) was made in podman open issues, saying all container must be stopped in correct order before stopping the pod, to ensure graceful shutdown.

# Fix
Stopping all container before stopping the pod

# Testing
```
[root@temp ai-services]# podman pod ps
POD ID        NAME         STATUS      CREATED            INFRA ID      # OF CONTAINERS
86605dfd2dcb  temp--pod-2  Running     About an hour ago  b2ce9037425c  3
0ce86fea2705  temp--pod-3  Running     About an hour ago  3ce446276650  3
981da829d040  temp--pod-1  Running     About an hour ago  b425f263b0f4  3

[root@temp ai-services]# ./bin/ai-services application stop temp
Found 3 pods for given applicationName: temp.
Below pods will be stopped:
	-> temp--pod-1
	-> temp--pod-3
	-> temp--pod-2
Are you sure you want to stop the above pods?  true
Proceeding to stop pods...
Stopping the pod: temp--pod-1
Successfully stopped the pod: temp--pod-1
Stopping the pod: temp--pod-3
Successfully stopped the pod: temp--pod-3
Stopping the pod: temp--pod-2
Successfully stopped the pod: temp--pod-2

[root@temp ai-services]# podman pod ps
POD ID        NAME         STATUS      CREATED            INFRA ID      # OF CONTAINERS
86605dfd2dcb  temp--pod-2  Exited      About an hour ago  b2ce9037425c  3
0ce86fea2705  temp--pod-3  Exited      About an hour ago  3ce446276650  3
981da829d040  temp--pod-1  Exited      About an hour ago  b425f263b0f4  3

[root@temp ai-services]# ./bin/ai-services application start temp
Found 3 pods for given applicationName: temp.
Below pods will be started:
	-> temp--pod-1
	-> temp--pod-3
	-> temp--pod-2
Are you sure you want to start above pods?  true
Proceeding to start pods...
Starting the pod: temp--pod-1
Successfully started the pod: temp--pod-1
Starting the pod: temp--pod-3
Successfully started the pod: temp--pod-3
Starting the pod: temp--pod-2
Successfully started the pod: temp--pod-2
[root@temp ai-services]# podman pod ps
POD ID        NAME         STATUS      CREATED            INFRA ID      # OF CONTAINERS
86605dfd2dcb  temp--pod-2  Running     About an hour ago  b2ce9037425c  3
0ce86fea2705  temp--pod-3  Running     About an hour ago  3ce446276650  3
981da829d040  temp--pod-1  Running     About an hour ago  b425f263b0f4  3
```