### PR TITLE
Add LPAR affinity score as part of numa check in bootstrap

### DIFF
--- a/ai-services/internal/pkg/vars/var.go
+++ b/ai-services/internal/pkg/vars/var.go
@@ -15,3 +15,7 @@ var (
 	TemplateLabel Label = "ai-services.io/template"
 	VersionLabel  Label = "ai-services.io/version"
 )
+
+var (
+	LparAffinityThreshold = 70
+)


### PR DESCRIPTION
```
[root@onprem133727026 ai-services]# ./bin/ai-services bootstrap validate
Running bootstrap validation...
✔ Current user is root
✔ LPAR affinity score is above the threshold: 70
✔ Operating system is RHEL with version 9.6
✔ System is running on IBM Power11 (ppc64le)
✔ System is registered with RHN
✔ IBM Spyre Accelerator is attached to the LPAR
⠙ Validating servicereport ...servicereport 2.2.5

Spyre configuration checks                          PASS

  VFIO Driver configuration                         PASS
  User memlock configuration                        PASS
  sos config                                        PASS
  sos package                                       PASS
  VFIO udev rules configuration                     PASS
  User group configuration                          PASS
  VFIO device permission                            PASS
  VFIO kernel module loaded                         PASS
  VFIO module dep configuration                     PASS


✔ ServiceReport tool has successfully run on the LPAR
All validations passed
```