### PR TITLE
Increase spyre-reranker WARMUP_PROMPT_LENS

### DIFF
--- a/ai-services/assets/applications/RAG/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/applications/RAG/templates/vllm-server.yaml.tmpl
@@ -133,7 +133,7 @@ spec:
         - name: VLLM_SPYRE_WARMUP_BATCH_SIZES
           value: "4"
         - name: VLLM_SPYRE_WARMUP_PROMPT_LENS
-          value: "512"
+          value: "1024"
         - name: MASTER_PORT
           value: "12356"
         {{- /* Check if .env.reranker exists and is a non-empty map */}}


### PR DESCRIPTION
In our use-case, while the process of ingestion, we have created chunks with max-tokens = 512 ( and along with some heuristic approaches to improve accuracy- there are some chunks > 512 to preserve important context).

Now, currently the VLLM_SPYRE_WARMUP_PROMPT_LENS for reranker is set to 512, to accomodate ( query + doc) . But. there are a lot of cases , where our ingested chunks + query exceed this limit. Hence we were seeing this issues in the reranker logs on such docs:
<img width="844" height="260" alt="Screenshot 2025-11-27 at 6 41 51 AM" src="https://github.com/user-attachments/assets/d5e62e2b-8593-40d8-a23b-02b07014aa8a" />

we were handling the errors by adding the doc with score 0.0 , due to which it was missed out of relevant context - even when it was relevant. 
Hence based on the dimensions used in our usecase - increasing the VLLM_SPYRE_WARMUP_PROMPT_LENS to 1024

Testing:

I have tested couple of queries , as well as a tester utility to check some docs. It is working as expected now:
<img width="1580" height="603" alt="Screenshot 2025-11-27 at 7 00 18 AM" src="https://github.com/user-attachments/assets/2dd35c31-b961-48f0-a799-7f1008251884" />
