### PR TITLE
Improve bootstrap command depiction

### DIFF
--- a/ai-services/cmd/ai-services/cmd/bootstrap/bootstrap.go
+++ b/ai-services/cmd/ai-services/cmd/bootstrap/bootstrap.go
@@ -3,6 +3,7 @@ package bootstrap
 import (
 	"fmt"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/validators/root"
 	"github.com/spf13/cobra"
@@ -15,13 +16,23 @@ func BootstrapCmd() *cobra.Command {
 		Short: "Initializes AI services infrastructure",
 		Long: `Bootstrap and configure the infrastructure required for AI services.
 
-The bootstrap command prepares and validates the environment needed
+The bootstrap command configures and validates the environment needed
 to run AI services on Power11 systems, ensuring prerequisites are met
 and initial configuration is completed.
 
 Available subcommands:
-  validate   - Check system prerequisites and configuration
-  configure  - Configure and initialize the AI services infrastructure`,
+  configure - Configure performs below actions
+  • Installs podman on host if not installed
+  • Runs servicereport tool to configure required spyre cards
+  • Initializes the AI services infrastructure
+
+  validate - Checks below system prerequisites
+  • Root user
+  • Power11 server
+  • RHEL OS
+  • LPAR affinity
+  • Spyre cards availability
+  • ServiceReport validation`,
 		Example: `  # Validate the environment
   ai-services bootstrap validate
 
@@ -46,6 +57,10 @@ Available subcommands:
 			}
 
 			logger.Infoln("LPAR boostrapped successfully")
+			logger.Infoln("----------------------------------------------------------------------------")
+			style := lipgloss.NewStyle().Foreground(lipgloss.Color("#32BD27"))
+			message := style.Render("Re-login to the shell to reflect necessary permissions assigned to vfio cards")
+			logger.Infoln(message)
 			return nil
 		},
 	}

--- a/ai-services/cmd/ai-services/cmd/bootstrap/configure.go
+++ b/ai-services/cmd/ai-services/cmd/bootstrap/configure.go
@@ -90,8 +90,6 @@ func RunConfigureCmd() error {
 	s.Stop("Spyre cards configuration validated successfully.")
 
 	logger.Infoln("LPAR configured successfully")
-	logger.Infoln("-------------------------------------------------------------------")
-	logger.Infoln("Re-login to the shell to relect necessary permissions assigned to vfio cards")
 
 	return nil
 }


### PR DESCRIPTION
- Added description for bootstrap validate and configure
- Moved the message `Re-login to the shell to relect necessary permissions assigned to vfio cards` from end of configure flow to end of bootstrap flow

Updated bootstrap help message:
```
[root@onprem133727026 ai-services]# ./bin/ai-services bootstrap --help
Bootstrap and configure the infrastructure required for AI services.

The bootstrap command configures and validates the environment needed
to run AI services on Power11 systems, ensuring prerequisites are met
and initial configuration is completed.

Available subcommands:
  configure - Configure performs below actions
  • Installs podman on host if not installed
  • Runs servicereport tool to configure required spyre cards
  • Initializes the AI services infrastructure

  validate - Checks below system prerequisites
  • root user
  • Power11 server
  • RHEL OS
  • LPAR affinity
  • Spyre cards availability
  • ServiceReport validation

Usage:
  ai-services bootstrap [flags]

Examples:
  # Validate the environment
  aiservices bootstrap validate

  # Configure the infrastructure
  aiservices bootstrap configure

  # Get help on a specific subcommand
  aiservices bootstrap validate --help

Flags:
  -h, --help   help for bootstrap
```
