### PR TITLE
Fix CVES: Bumping up version of tools and rag-ui

### DIFF
--- a/ai-services/assets/applications/RAG/values.yaml
+++ b/ai-services/assets/applications/RAG/values.yaml
@@ -2,7 +2,7 @@ ui:
   # @description The host port on which the RAG UI will run
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag-ui:v0.0.7
+  image: icr.io/ai-services-cicd/rag-ui:v0.0.8
 
 backend:
   # @hidden

--- a/ai-services/internal/pkg/vars/var.go
+++ b/ai-services/internal/pkg/vars/var.go
@@ -5,7 +5,7 @@ import "regexp"
 var (
 	// SpyreCardAnnotationRegex -> ai-services.io/<containerName>--spyre-cards
 	SpyreCardAnnotationRegex = regexp.MustCompile(`^ai-services\.io\/([A-Za-z0-9][-A-Za-z0-9_.]*)--spyre-cards$`)
-	ToolImage                = "icr.io/ai-services-cicd/tools:0.3"
+	ToolImage                = "icr.io/ai-services-cicd/tools:0.4"
 	ModelDirectory           = "/var/lib/ai-services/models"
 )
 

--- a/images/tools/Makefile
+++ b/images/tools/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=tools
-TAG?=0.3
+TAG?=0.4
 SR_VERSION=2.2.5-2
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/spyre-rag/ui/Makefile
+++ b/spyre-rag/ui/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=rag-ui
-TAG?=v0.0.7
+TAG?=v0.0.8
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman


### PR DESCRIPTION
By rebuilding `Tools` and the `Rag-ui` image, the latest version of the `expat` package will be installed, helping to resolve the high-severity CVEs.