### PR TITLE
Fix sos config issue in bootstrap configure

### DIFF
--- a/ai-services/internal/pkg/cli/helpers/helper.go
+++ b/ai-services/internal/pkg/cli/helpers/helper.go
@@ -173,6 +173,7 @@ func RunServiceReportContainer(runCmd string, mode string) error {
 			"-v", "/etc/modules-load.d/:/etc/modules-load.d/",
 			"-v", "/etc/udev/rules.d/:/etc/udev/rules.d/",
 			"-v", "/etc/security/limits.d/:/etc/security/limits.d/",
+			"-v", "/etc/sos:/etc/sos",
 			vars.ToolImage,
 			"bash", "-c", runCmd,
 		)


### PR DESCRIPTION
Servicereport tool when run in repair mode, adds below 2 lines to `/etc/sos/sos.conf`. Hence its required to volume mount `/etc/sos` host directory during `ai-services bootstrap configure` as well.
```
podman.logs = true
podman.all = true
```