### PR TITLE
Validate params while creating application

### DIFF
--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -63,7 +63,19 @@ var createCmd = &cobra.Command{
 		if len(rawArgParams) > 0 {
 			argParams, err = utils.ParseKeyValues(rawArgParams)
 			if err != nil {
-				return fmt.Errorf("error validating params flag: %v", err)
+				return fmt.Errorf("error validating params flag: %w", err)
+			}
+			tp := templates.NewEmbedTemplateProvider(templates.EmbedOptions{})
+			if err := validators.ValidateAppTemplateExist(tp, templateName); err != nil {
+				return err
+			}
+			supportedParams, err := tp.ListApplicationTemplateValues(templateName)
+			if err != nil {
+				return fmt.Errorf("failed to list application template values: %w", err)
+			}
+			err = utils.ValidateParams(argParams, supportedParams)
+			if err != nil {
+				return fmt.Errorf("error validating params: %w", err)
 			}
 		}
 

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -229,3 +229,12 @@ func VerifyAppName(appName string) error {
 	}
 	return nil
 }
+
+func ValidateParams(params, supportedParams map[string]string) error {
+	for param := range params {
+		if _, ok := supportedParams[param]; !ok {
+			return fmt.Errorf("unsupported parameter: %s, run 'ai-services application templates' for more help", param)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
# Description
This PR adds validation level to the params flag, i.e., passing unsupported parameters would abort the create operation.

# Testing
```
[root@sagarwal ai-services]# ./bin/ai-services application create temp --template rag --params "ui.port=3000"
Validating the LPAR environment before creating application 'temp'...
✔ Current user is root
✔ LPAR affinity score is above the threshold: 70
✔ Operating system is RHEL with version 9.6
✖ unsupported IBM Power version: Power11 is required
HINT: This tools requires IBM Power11 (ppc64le)
✔ System is registered with RHN
✖ IBM Spyre Accelerator is not attached to the LPAR
HINT: IBM Spyre Accelerator hardware is required but not detected.
⠹ Validating servicereport ...servicereport 2.2.5

Warning: spyre plugin is either invalid or not applicable to this system.

✔ ServiceReport tool has successfully run on the LPAR
Error: bootstrap validation failed: 2 validation check(s) failed
```

```
[root@sagarwal ai-services]# ./bin/ai-services application create temp --template rag --params "ui.prt=3000"
Error: error validating params: unsupported parameter: ui.prt, run 'ai-services application templates' for more help
Usage:
  ai-services application create [name] [flags]
  ```