### PR TITLE
Reduce memory limits for vllm and ingest

### DIFF
--- a/ai-services/assets/applications/rag/templates/clean-docs.yaml.tmpl
+++ b/ai-services/assets/applications/rag/templates/clean-docs.yaml.tmpl
@@ -34,7 +34,7 @@ spec:
       volumeMounts:
         - mountPath: /var/cache:z
           name: cache
-  restartPolicy: OnFailure
+  restartPolicy: Never
   volumes:
     - name: cache
       hostPath:

--- a/ai-services/assets/applications/rag/templates/ingest-docs.yaml.tmpl
+++ b/ai-services/assets/applications/rag/templates/ingest-docs.yaml.tmpl
@@ -19,9 +19,9 @@ spec:
         - "ingest"
       resources:
         requests:
-          memory: "128Gi"
+          memory: "40Gi"
         limits:
-          memory: "128Gi"
+          memory: "40Gi"
       env:
         - name: EMB_ENDPOINT
           value: "http://{{ .AppName  }}--vllm-server:8001"
@@ -47,7 +47,7 @@ spec:
           readOnly: true
         - mountPath: /var/cache:z
           name: cache
-  restartPolicy: OnFailure
+  restartPolicy: Never
   volumes:
     - name: docs
       hostPath:

--- a/ai-services/assets/applications/rag/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/applications/rag/templates/vllm-server.yaml.tmpl
@@ -71,9 +71,9 @@ spec:
       resources:
         requests:
           podman.io/device=/dev/vfio: 4
-          memory: "200Gi"
+          memory: "150Gi"
         limits:
-          memory: "200Gi"
+          memory: "150Gi"
       ports:
         - containerPort: 8000
       volumeMounts:


### PR DESCRIPTION
Set restartPolicy to Never for ingest-docs & clean-docs, since these are not meant to be restarted on failure