### PR TITLE
Add more packages from devpi

### DIFF
--- a/images/rag-base/Makefile
+++ b/images/rag-base/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=rag-base
-TAG?=v0.0.10
+TAG?=v0.0.11
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman

--- a/images/rag-base/docling/Containerfile
+++ b/images/rag-base/docling/Containerfile
@@ -113,8 +113,8 @@ RUN wget ${PATCH_FILE} && \
     cd /tmp && rm -rf /tmp/"${PACKAGE_NAME}"
 
 #Install docling wheel and its dependencies
-RUN pip install wheel==0.45.1 hf_xet==1.2.0 huggingface_hub==1.1.4 && \
-    pip install --prefer-binary --extra-index-url=https://wheels.developerfirst.ibm.com/ppc64le/linux/ \
+RUN pip install --prefer-binary --extra-index-url=https://wheels.developerfirst.ibm.com/ppc64le/linux/ \
+        wheel==0.45.1 hf-xet==1.1.1 huggingface-hub==0.36.0 \
         tree_sitter_c==0.23.2 tree-sitter-python==0.23.2 tesserocr==2.9.1 rapidocr==3.4.2 \
         docling-parse==4.7.1 pylatexenc==2.10 rtree==1.4.1 pyclipper==1.4.0 antlr4-python3-runtime==4.9.3 \
         fastavro==1.12.1 uvloop==0.22.1 /tmp/*.whl

--- a/images/rag-base/requirements.txt
+++ b/images/rag-base/requirements.txt
@@ -6,11 +6,12 @@ fastapi[all]==0.121.0
 fastavro==1.12.1
 Flask==3.1.2
 grpcio==1.67.1
-hf_xet==1.2.0
+hf-xet==1.1.1
 huggingface-hub==0.36.0
 httptools==0.6.4
 joblib==1.5.2
 lxml==5.4.0
+markupsafe==3.0.2
 numpy==2.3.1
 openai==2.6.0
 opencv-python==4.10.0.84
@@ -23,6 +24,7 @@ pyclipper==1.4.0
 pylatexenc==2.10
 pymilvus==2.6.2
 pywavelets==1.8.0
+pyyaml==6.0.2
 rapidfuzz==3.13.0
 rapidocr==3.4.2
 regex==2025.10.23


### PR DESCRIPTION
1. Picking up `hf-xet` version available from pyeco.
2. Correcting the version of `huggingface-hub` which was getting replaced during the build.
3. Added `markupsafe` and `pyyaml` in base image requirements.txt to match available versions from pyeco.