### PR TITLE
validate params from values.yaml

### DIFF
--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -47,6 +47,7 @@ var (
 	rawArgParams      []string
 	argParams         map[string]string
 	valuesFiles       []string
+	values            map[string]any
 )
 
 var createCmd = &cobra.Command{
@@ -69,13 +70,9 @@ var createCmd = &cobra.Command{
 			if err := validators.ValidateAppTemplateExist(tp, templateName); err != nil {
 				return err
 			}
-			supportedParams, err := tp.ListApplicationTemplateValues(templateName)
+			values, err = tp.LoadValues(templateName, valuesFiles, argParams)
 			if err != nil {
-				return fmt.Errorf("failed to list application template values: %w", err)
-			}
-			err = utils.ValidateParams(argParams, supportedParams)
-			if err != nil {
-				return fmt.Errorf("error validating params: %w", err)
+				return fmt.Errorf("failed to load params for application: %w", err)
 			}
 		}
 
@@ -471,10 +468,6 @@ func verifyPodTemplateExists(tmpls map[string]*template.Template, appMetadata *t
 
 func executePodTemplates(runtime runtime.Runtime, tp templates.Template, appName string, appMetadata *templates.AppMetadata,
 	tmpls map[string]*template.Template, pciAddresses []string, existingPods []string) error {
-	values, err := tp.LoadValues(templateName, valuesFiles, argParams)
-	if err != nil {
-		return fmt.Errorf("failed to load params for application: %w", err)
-	}
 	globalParams := map[string]any{
 		"AppName":         appName,
 		"AppTemplateName": appMetadata.Name,

--- a/ai-services/internal/pkg/cli/templates/embed.go
+++ b/ai-services/internal/pkg/cli/templates/embed.go
@@ -166,6 +166,11 @@ func (e *embedTemplateProvider) LoadValues(app string, valuesFileOverrides []str
 		}
 	}
 
+	// validate CLI Overrides before applying since we are adding them directly
+	if err := utils.ValidateParams(cliOverrides, values); err != nil {
+		return nil, err
+	}
+
 	// Load user provided CLI overides
 	for key, val := range cliOverrides {
 		utils.SetNestedValue(values, key, val)


### PR DESCRIPTION
# Description
We were only validation params which are present as part of description (Exposed to user). As a result, params that are hidden but can be overridden, was not working

# Fix
Validate all params instead of what is exposed

# Testing

Case 1: valid param
```
[root@sagarwal ai-services]# ./bin/ai-services application create temp --template rag --params "ingest.log_level=DEBUG"
Validating the LPAR environment before creating application 'temp'...
Creating application 'temp' using template 'rag'
✔ SMT level configured successfully
No existing pods found for application: temp
Downloading container images required for application template rag:
Downloading image: icr.io/ai-services/tools:0.5...
Pulling image icr.io/ai-services/tools:0.5...
Trying to pull icr.io/ai-services/tools:0.5...
^C

[root@sagarwal ai-services]# ./bin/ai-services application create temp --template rag --params "ui.port=12312"
Validating the LPAR environment before creating application 'temp'...
Creating application 'temp' using template 'rag'
✔ SMT level configured successfully
No existing pods found for application: temp
Downloading container images required for application template rag:
Downloading image: icr.io/ai-services/tools:0.5...
Pulling image icr.io/ai-services/tools:0.5...
^C
```

Case 2: Invalid param
```
[root@sagarwal ai-services]# ./bin/ai-services application create temp --template rag --params "u.port=12312"
Error: failed to load params for application: unsupported parameter: u.port

[root@sagarwal ai-services]# ./bin/ai-services application create temp --template rag --params "ui.ort=12312"
Error: failed to load params for application: unsupported parameter: ui.ort
```