### PR TITLE
Use 32 as connection size for backend server

### DIFF
--- a/spyre-rag/src/retrieve/backend_server.py
+++ b/spyre-rag/src/retrieve/backend_server.py
@@ -5,7 +5,7 @@ import os
 import time
 
 from common.db_utils import MilvusVectorStore, MilvusNotReadyError
-from common.llm_utils import query_vllm_stream, query_vllm_models
+from common.llm_utils import create_llm_session, query_vllm_stream, query_vllm_models
 from common.misc_utils import get_model_endpoints, set_log_level
 from retrieve.backend_utils import search_and_answer_backend, search_only
 
@@ -26,6 +26,11 @@ def initialize_vectorstore():
     vectorstore = MilvusVectorStore()
 
 app = Flask(__name__)
+
+# Setting 32 to fully utilse the vLLM's Max Batch Size
+POOL_SIZE = 32
+
+create_llm_session(pool_maxsize=POOL_SIZE)
 
 @app.post("/generate")
 def generate():


### PR DESCRIPTION
- Reserved the SESSION usage for instruct vllm APIs by removing the SESSION for tokenize & detokenize APIs since its called to embedding vllm.
- To keep things clear, renamed the llm_endpoint to emb_endpoint.
- Removed unused code - filter_with_llm