### PR TITLE
Bug fix - Include tokenize/detokenize APIs to call via request SESSION to avoid ephemeral port exhaustion issue

### DIFF
--- a/ai-services/assets/applications/rag/values.yaml
+++ b/ai-services/assets/applications/rag/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.19
+  image: icr.io/ai-services-cicd/rag:v0.0.20
 
 ingest:
   # @hidden

--- a/spyre-rag/src/Makefile
+++ b/spyre-rag/src/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=rag
-TAG?=v0.0.19
+TAG?=v0.0.20
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman

--- a/spyre-rag/src/common/emb_utils.py
+++ b/spyre-rag/src/common/emb_utils.py
@@ -42,8 +42,11 @@ class Embedding:
             embeddings = [data['embedding'] for data in r['data']]
             return [np.array(embed, dtype=np.float32) for embed in embeddings]
         except requests.exceptions.RequestException as e:
-            logger.error(f"Error while calling embedding API: {e}, {e.response.text}")
+            error_details = str(e)
+            if e.response is not None:
+                error_details += f", Response Text: {e.response.text}"
+            logger.error(f"Error calling embedding API: {error_details}")
             raise e
         except Exception as e:
-            logger.error(f"Error while calling embedding API: {e}")
+            logger.error(f"Error calling embedding API: {e}")
             raise e


### PR DESCRIPTION
- Fix error log for vllm calls
- Add clear comment on the reasoning behind SESSION usage
```
# SESSION object will be used by instruct and embedding endpoints. Hence keeping pool_connections = 2
    # Need to use SESSION object for following reasons:
    # - To limit the number of concurrent requests getting created to instruct vLLM's API to 32
    # - To fix the ephemeral port exhaustion issue during chunking, since numerous tokenize calls are made to embedding server
```