### PR TITLE
Use GAed Spyre vLLM image

### DIFF
--- a/ai-services/assets/applications/rag/values.yaml
+++ b/ai-services/assets/applications/rag/values.yaml
@@ -30,7 +30,7 @@ milvus:
 
 instruct:
   # @hidden
-  image: icr.io/ibmaiu_internal/ppc64le/dd2/rhaiis:3.2.5-1764891918
+  image: registry.redhat.io/rhaiis/vllm-spyre-rhel9@sha256:8a0588fec105f2a950705391093a7a813ccdf457042a621bf4b1b5d9e1df96d6
 
 embedding:
   # @hidden
@@ -38,4 +38,4 @@ embedding:
 
 reranker:
   # @hidden
-  image: icr.io/ibmaiu_internal/ppc64le/dd2/rhaiis:3.2.5-1764891918
+  image: registry.redhat.io/rhaiis/vllm-spyre-rhel9@sha256:8a0588fec105f2a950705391093a7a813ccdf457042a621bf4b1b5d9e1df96d6


### PR DESCRIPTION
Since version is not part of the image `registry.redhat.io/rhaiis/vllm-spyre-rhel9` and it is getting updated every month, want to avoid untested image getting pulled. Hence using sha.