### PR TITLE
enable ai-services to run as non-root-user

### DIFF
--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -375,15 +375,28 @@ func getSMTLevel(output string) (int, error) {
 
 func setSMTLevel() error {
 	/*
-		1. Fetch current SMT level
-		2. Fetch the target SMT level
+		1. Fetch the target SMT level
+		2. Fetch current SMT level
 		3. Check if SMT level is already set to target value
 		4. If not, set it to target value
 		5. Verify again
 	*/
 
-	// 1. Fetch Current SMT level
-	cmd := exec.Command("ppc64_cpu", "--smt")
+	// 1. Fetch the target SMT level
+	targetSMTLevel, err := getTargetSMTLevel()
+	if err != nil {
+		return fmt.Errorf("failed to get target SMT level: %w", err)
+	}
+
+	if targetSMTLevel == nil {
+		// No SMT level specified in metadata.yaml
+		logger.Infof("No SMT level specified in metadata.yaml. Keeping it to current level")
+
+		return nil
+	}
+
+	// 2. Fetch Current SMT level
+	cmd := exec.Command("sudo", "ppc64_cpu", "--smt")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to check current SMT level: %v, output: %s", err, string(out))
@@ -392,19 +405,6 @@ func setSMTLevel() error {
 	currentSMTlevel, err := getSMTLevel(string(out))
 	if err != nil {
 		return fmt.Errorf("failed to get current SMT level: %w", err)
-	}
-
-	// 2. Fetch the target SMT level
-	targetSMTLevel, err := getTargetSMTLevel()
-	if err != nil {
-		return fmt.Errorf("failed to get target SMT level: %w", err)
-	}
-
-	if targetSMTLevel == nil {
-		// No SMT level specified in metadata.yaml
-		logger.Infof("No SMT level specified in metadata.yaml. Keeping it to current level: %d\n", currentSMTlevel)
-
-		return nil
 	}
 
 	// 3. Check if SMT level is already set to target value
@@ -417,14 +417,14 @@ func setSMTLevel() error {
 
 	// 4. Set SMT level to target value
 	arg := "--smt=" + strconv.Itoa(*targetSMTLevel)
-	cmd = exec.Command("ppc64_cpu", arg)
+	cmd = exec.Command("sudo", "ppc64_cpu", arg)
 	out, err = cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to set SMT level: %v, output: %s", err, string(out))
 	}
 
 	// 5. Verify again
-	cmd = exec.Command("ppc64_cpu", "--smt")
+	cmd = exec.Command("sudo", "ppc64_cpu", "--smt")
 	out, err = cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to verify SMT level: %v, output: %s", err, string(out))

--- a/ai-services/internal/pkg/cli/helpers/models.go
+++ b/ai-services/internal/pkg/cli/helpers/models.go
@@ -46,10 +46,7 @@ func ListModels(template, appName string) ([]string, error) {
 func DownloadModel(model, targetDir string) error {
 	// check for target model directory, if not present create it
 	if _, err := os.Stat(targetDir); os.IsNotExist(err) {
-		err := os.MkdirAll(targetDir, os.ModePerm)
-		if err != nil {
-			return fmt.Errorf("failed to create target model directory: %w", err)
-		}
+		return fmt.Errorf("failed to validate model path, please run `ai-services bootstrap` command to setup directories: %w", err)
 	}
 	logger.Infof("Downloading model %s to %s\n", model, targetDir)
 	command := "podman"

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -300,3 +300,11 @@ func checkParamsInValues(param string, values map[string]any) bool {
 
 	return false
 }
+
+func RequiredDirs() []string {
+	return []string{
+		"/var/lib/ai-services",
+		"/var/lib/ai-services/models",
+		"/var/lib/ai-services/applications",
+	}
+}

--- a/ai-services/internal/pkg/validators/directory/directory.go
+++ b/ai-services/internal/pkg/validators/directory/directory.go
@@ -1,0 +1,51 @@
+package directory
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+)
+
+type DirectoryRule struct{}
+
+func NewDirectoryRule() *DirectoryRule {
+	return &DirectoryRule{}
+}
+
+func (r *DirectoryRule) Name() string {
+	return "directory"
+}
+
+func (r *DirectoryRule) Verify() error {
+	dirs := utils.RequiredDirs()
+	for _, dir := range dirs {
+		_, err := os.Stat(dir)
+		if err != nil {
+			if err == os.ErrNotExist {
+				return fmt.Errorf("dir %s does not exist", dir)
+			}
+
+			return fmt.Errorf("failed to access dir %s: %w", dir, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *DirectoryRule) Description() string {
+	return "Checks if all required directories are present"
+}
+
+func (r *DirectoryRule) Message() string {
+	return "All required directories are present"
+}
+
+func (r *DirectoryRule) Level() constants.ValidationLevel {
+	return constants.ValidationLevelError
+}
+
+func (r *DirectoryRule) Hint() string {
+	return "Ensure that all required directories are created and accessible, run `ai-services bootstrap` to configure"
+}

--- a/ai-services/internal/pkg/validators/root/root.go
+++ b/ai-services/internal/pkg/validators/root/root.go
@@ -33,7 +33,9 @@ func (r *RootRule) Verify() error {
 	if euid != 0 && os.Getenv("XDG_RUNTIME_DIR") == "" {
 		uid := os.Getuid()
 		logger.Infoln("running command as %s", uid, logger.VerbosityLevelDebug)
-		os.Setenv("XDG_RUNTIME_DIR", fmt.Sprintf("/run/user/%d", uid))
+		if err := os.Setenv("XDG_RUNTIME_DIR", fmt.Sprintf("/run/user/%d", uid)); err != nil {
+			return fmt.Errorf("failed to set XDG_RUNTIME_DIR: %w", err)
+		}
 	}
 
 	return nil

--- a/ai-services/internal/pkg/validators/root/root.go
+++ b/ai-services/internal/pkg/validators/root/root.go
@@ -24,11 +24,16 @@ func (r *RootRule) Description() string {
 
 func (r *RootRule) Verify() error {
 	euid := os.Geteuid()
+	if euid == 0 {
+		logger.Infoln("running command as root", logger.VerbosityLevelDebug)
 
-	logger.Infoln("Checking root privileges", logger.VerbosityLevelDebug)
+		return nil
+	}
 
-	if euid != 0 {
-		return fmt.Errorf("current user is not root (EUID: %d)", euid)
+	if euid != 0 && os.Getenv("XDG_RUNTIME_DIR") == "" {
+		uid := os.Getuid()
+		logger.Infoln("running command as %s", uid, logger.VerbosityLevelDebug)
+		os.Setenv("XDG_RUNTIME_DIR", fmt.Sprintf("/run/user/%d", uid))
 	}
 
 	return nil

--- a/ai-services/internal/pkg/validators/validators.go
+++ b/ai-services/internal/pkg/validators/validators.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/validators/directory"
 	"github.com/project-ai-services/ai-services/internal/pkg/validators/numa"
 	"github.com/project-ai-services/ai-services/internal/pkg/validators/platform"
 	"github.com/project-ai-services/ai-services/internal/pkg/validators/power"
@@ -23,6 +24,7 @@ func init() {
 	DefaultRegistry.Register(rhn.NewRHNRule())
 	DefaultRegistry.Register(spyre.NewSpyreRule())
 	DefaultRegistry.Register(servicereport.NewServiceReportRule())
+	DefaultRegistry.Register(directory.NewDirectoryRule())
 }
 
 // Rule defines the interface for validation rules.


### PR DESCRIPTION
Context: https://ibm.ent.box.com/file/2102027246213

# Description
## Problem Statement
Currently, ai-services only supports execution as the root user. 

## Solution
This PR enables ai-services to run as a non-root user. The tool now supports a hybrid approach:
- **bootstrap (validate/configure)**: Runs with `sudo` for one-time system setup
- **runtime operations (application commands)**: Run as a regular user without elevated privileges

## User Setup Requirements

To use ai-services as a non-root user, the following one-time setup is required:

### 1. Add user to sudo group (wheel)
```bash
sudo usermod -aG wheel <username>
```
This grants the user permission to execute specific commands with sudo when needed.

### 2. Enable systemd user session persistence
```bash
sudo loginctl enable-linger <username>
```
This ensures the user's systemd instance persists even when not logged in, which is required for:
- Rootless podman socket to remain active
- User services to run in the background

## Implementation Details

### Rootless Podman
- Containers run as the regular user on the host (not root)
- Uses user namespaces: processes appear as "root" inside containers but are actually the user's UID on the host
- Podman socket created at `/run/user/<UID>/podman/podman.sock` (user-specific, not system-wide)

### Directory Permissions
- Bootstrap creates directories with ownership set to `$SUDO_USER`
- Regular user has full read/write access to application directories
- No root privileges required for runtime operations

### Environment Variables
- `XDG_RUNTIME_DIR`: Automatically set if missing (required for user systemd operations)
- `SUDO_USER`: Used during bootstrap to determine the actual user for ownership settings

## Q&A

Q: Why do we need to add the non-root user to the sudo group?
A: We still need certain commands to be executed with sudo, like `ai-services bootstrap`, as it configures and modifies the env which requires root permissions. 

Q: Which commands would be run without sudo?
A: Except `bootstrap`, every other command would be run without sudo.