### PR TITLE
Support standalone golden dataset validation

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -17,7 +17,6 @@ BUILD_CMD = CGO_ENABLED=0 $(GO) build $(BUILDFLAGS) \
      " \
      ./cmd/ai-services
 
-TEST_CMD = ginkgo $(TEST_ARGS) -r ./tests/e2e
 REPORT_DIR := tests/e2e/reports
 RUN_ID := $(shell date +%s)
 export RUN_ID
@@ -27,12 +26,13 @@ TEST_PKG = ./tests/e2e
 TEST_ARGS ?=
 JUNIT_FLAG = --junit-report=report-$(RUN_ID).xml --output-dir=$(REPORT_DIR)
 
-
+TEST_CMD = $(TEST_BASE) $(TEST_ARGS) $(TEST_PKG) \
+	-- $(if $(APP_NAME),--app-name=$(APP_NAME),)
 
 .PHONY: default
 default:
 ifdef TEST
-    $(TEST_CMD)
+	$(TEST_CMD)
 else
 	$(BUILD_CMD)
 endif
@@ -41,11 +41,9 @@ endif
 build:
 	$(BUILD_CMD)
 
-.PHONY: test
 test:
-	$(TEST_BASE) $(TEST_ARGS) $(TEST_PKG)
+	$(TEST_CMD)
 
-.PHONY: test-generate-report
 test-generate-report:
 	@echo "Using RUN_ID=$(RUN_ID)"
 	$(TEST_BASE) $(TEST_ARGS) $(JUNIT_FLAG) $(TEST_PKG)

--- a/ai-services/tests/e2e/bootstrap/env.go
+++ b/ai-services/tests/e2e/bootstrap/env.go
@@ -52,3 +52,8 @@ func GetLLMasJudgeModelDetails() (downloadPath string, modelName string) {
 func GetLLMasJudgePodDetails() (portNumber string, llmImage string) {
 	return os.Getenv("LLM_JUDGE_PORT"), os.Getenv("LLM_JUDGE_IMAGE")
 }
+
+// GetGoldenDatasetFile returns the name of the golden dataset file.
+func GetGoldenDatasetFile() string {
+	return os.Getenv("GOLDEN_DATASET_FILE")
+}

--- a/ai-services/tests/e2e/e2e_suite_test.go
+++ b/ai-services/tests/e2e/e2e_suite_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"flag"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -28,6 +29,7 @@ var (
 	cfg                         *config.Config
 	runID                       string
 	appName                     string
+	providedAppName			    string
 	tempDir                     string
 	tempBinDir                  string
 	aiServiceBin                string
@@ -41,11 +43,15 @@ var (
 	backendPort                 string
 	uiPort                      string
 	judgePort                   string
+	goldenDatasetFile           string
 	mainPodsByTemplate          map[string][]string
 	defaultRagAccuracyThreshold = 0.70
 	defaultMaxRetries           = 2
 )
 
+func init() {
+	flag.StringVar(&providedAppName, "app-name", "", "Use existing application instead of creating one")
+}
 func TestE2E(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t, "AI Services E2E Suite")
@@ -86,8 +92,14 @@ var _ = ginkgo.BeforeSuite(func() {
 	ginkgo.By("Setting template name")
 	templateName = "rag"
 
-	ginkgo.By("Setting application name")
-	appName = fmt.Sprintf("%s-app-%s", templateName, runID)
+	ginkgo.By("Resolving application name")
+	if providedAppName != "" {
+		appName = providedAppName
+		logger.Infof("[SETUP] Using provided application name: %s", appName)
+	} else {
+		appName = fmt.Sprintf("%s-app-%s", templateName, runID)
+		logger.Infof("[SETUP] Generated application name: %s", appName)
+	}
 
 	ginkgo.By("Setting main pods by template")
 	mainPodsByTemplate = map[string][]string{
@@ -101,7 +113,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	ginkgo.By("Resolving application ports from environment")
 	backendPort = getEnvWithDefault("RAG_BACKEND_PORT", "5100")
 	uiPort = getEnvWithDefault("RAG_UI_PORT", "3100")
-	judgePort = getEnvWithDefault("LLM_JUDGE_PORT", "8011")
+	judgePort = getEnvWithDefault("LLM_JUDGE_PORT", "8000")
 	if ragAccuracyThreshold, err := strconv.ParseFloat(
 		getEnvWithDefault("RAG_ACCURACY_THRESHOLD", "0.70"),
 		64,
@@ -111,17 +123,6 @@ var _ = ginkgo.BeforeSuite(func() {
 		logger.Warningf("[SETUP][WARN] Invalid RAG_ACCURACY_THRESHOLD, using default %.2f", defaultRagAccuracyThreshold)
 	}
 	logger.Infof("[SETUP] Ports: backend=%s ui=%s judge=%s | accuracy=%.2f", backendPort, uiPort, judgePort, defaultRagAccuracyThreshold)
-
-	ginkgo.By("Setting golden dataset path")
-	_, filename, _, _ := runtime.Caller(0)                        // returns the file path of this test file (e2e_suite_test.go)
-	e2eDir := filepath.Dir(filename)                              // resolves ai-services/tests/e2e
-	repoRoot := filepath.Clean(filepath.Join(e2eDir, "../../..")) // navigates to the workspace root
-	goldenPath = filepath.Join(
-		repoRoot,
-		"test",
-		"golden",
-		"golden1.csv",
-	)
 
 	ginkgo.By("Building or verifying ai-services CLI")
 	var err error
@@ -245,6 +246,10 @@ var _ = ginkgo.Describe("AI Services End-to-End Tests", ginkgo.Ordered, func() {
 	})
 	ginkgo.Context("Application Creation", func() {
 		ginkgo.It("creates rag application, runs health checks and validates RAG endpoints", ginkgo.Label("spyre-dependent"), func() {
+			if providedAppName != "" {
+				ginkgo.Skip("Skipping creation — using existing application")
+			}
+
 			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Minute)
 			defer cancel()
 
@@ -374,10 +379,50 @@ var _ = ginkgo.Describe("AI Services End-to-End Tests", ginkgo.Ordered, func() {
 			logger.Infof("[TEST] Ingestion completed successfully for application %s", appName)
 		})
 	})
-	ginkgo.Context("RAG Golden Dataset Validation", func() {
+	ginkgo.Context("RAG Golden Dataset Validation", ginkgo.Label("golden-dataset-validation"), func() {
 		ginkgo.BeforeAll(func() {
-			logger.Infof("[RAG] Setting up LLM-as-Judge")
+			if appName == "" {
+				ginkgo.Fail("Application name is not set")
+			}
 
+			logger.Infof("[RAG] Setting golden dataset path")
+			goldenDatasetFile = bootstrap.GetGoldenDatasetFile()
+			if goldenDatasetFile == "" {
+				ginkgo.Fail("GOLDEN_DATASET_FILE environment variable is not set")
+			}
+
+			_, filename, _, _ := runtime.Caller(0)                        // returns the file path of this test file (e2e_suite_test.go)
+			e2eDir := filepath.Dir(filename)                              // resolves ai-services/tests/e2e
+			repoRoot := filepath.Clean(filepath.Join(e2eDir, "../../..")) // navigates to the workspace root
+
+			goldenPath = filepath.Join(
+				repoRoot,
+				"test",
+				"golden",
+				goldenDatasetFile,
+			)
+			logger.Infof("[RAG] Golden dataset file: %s", goldenPath)
+
+			logger.Infof("[RAG] Fetching application info to derive RAG and Judge URLs")
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+			infoOutput, err := cli.ApplicationInfo(ctx, cfg, appName)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			if err := cli.ValidateApplicationInfo(infoOutput, appName, templateName); err != nil {
+				ginkgo.Fail(fmt.Sprintf("Golden dataset validation requires a valid running application: %v", err))
+			}
+
+			ragBaseURL, err = cli.GetBaseURL(infoOutput, backendPort)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			judgeBaseURL, err = cli.GetBaseURL(infoOutput, judgePort)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			logger.Infof("[RAG] RAG Base URL: %s", ragBaseURL)
+			logger.Infof("[RAG] Judge Base URL: %s", judgeBaseURL)
+
+			logger.Infof("[RAG] Setting up LLM-as-Judge")
 			if err := rag.SetupLLMAsJudge(ctx, cfg, runID); err != nil {
 				ginkgo.Fail(fmt.Sprintf("failed to setup LLM-as-Judge: %v", err))
 			}
@@ -388,6 +433,7 @@ var _ = ginkgo.Describe("AI Services End-to-End Tests", ginkgo.Ordered, func() {
 				logger.Warningf("[RAG][WARN] Judge cleanup failed: %v", err)
 			}
 		})
+		
 		ginkgo.It("validates RAG answers against golden dataset", ginkgo.Label("spyre-dependent"), func() {
 			logger.Infof("[RAG] Starting golden dataset validation")
 			cases, err := rag.LoadGoldenCSV(goldenPath)


### PR DESCRIPTION
- Add --app-name flag to reuse existing application
- Skip app creation when app name is provided
- Allow golden validation to run independently via label filter
- Update Makefile to support standalone execution
- Document standalone flow in E2E README