### PR TITLE
Application Create for Openshift - 2

### DIFF
--- a/ai-services/assets/applications/rag-dev/metadata.yaml
+++ b/ai-services/assets/applications/rag-dev/metadata.yaml
@@ -3,6 +3,5 @@ description: "Retrieval Augmented Generation (RAG) application that combines a v
               and a retrieval mechanism to provide accurate and context-aware responses based on ingested documents."
 hidden: true
 smtLevel: 2
-runtimes:
-  - name: openshift
-    timeout: 30m
+openshift:
+  timeout: 20m

--- a/ai-services/assets/applications/rag-dev/metadata.yaml
+++ b/ai-services/assets/applications/rag-dev/metadata.yaml
@@ -3,3 +3,6 @@ description: "Retrieval Augmented Generation (RAG) application that combines a v
               and a retrieval mechanism to provide accurate and context-aware responses based on ingested documents."
 hidden: true
 smtLevel: 2
+runtimes:
+  - name: openshift
+    timeout: 30m

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -223,7 +223,7 @@ func initOpenShiftFlags() {
 		&timeout,
 		"timeout",
 		0, // default
-		"Timeout for the operation (e.g. 10s, 2m, 1h)",
+		"Timeout for the operation (e.g. 10s, 2m, 1h). Supported for runtime set to openshift only.",
 	)
 }
 

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -23,12 +23,12 @@ import (
 
 // Variables for flags placeholder.
 var (
-	// common flags
+	// common flags.
 	templateName string
 	rawArgParams []string
 	argParams    map[string]string
 
-	// podman flags
+	// podman flags.
 	skipModelDownload     bool
 	skipImageDownload     bool
 	skipChecks            []string
@@ -36,7 +36,7 @@ var (
 	rawArgImagePullPolicy string
 	imagePullPolicy       image.ImagePullPolicy
 
-	// openshift flags
+	// openshift flags.
 	timeout time.Duration
 )
 

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -22,15 +23,21 @@ import (
 
 // Variables for flags placeholder.
 var (
-	templateName          string
+	// common flags
+	templateName string
+	rawArgParams []string
+	argParams    map[string]string
+
+	// podman flags
 	skipModelDownload     bool
 	skipImageDownload     bool
 	skipChecks            []string
-	rawArgParams          []string
-	argParams             map[string]string
 	valuesFiles           []string
 	rawArgImagePullPolicy string
 	imagePullPolicy       image.ImagePullPolicy
+
+	// openshift flags
+	timeout time.Duration
 )
 
 var createCmd = &cobra.Command{
@@ -91,9 +98,7 @@ var createCmd = &cobra.Command{
 
 		//nolint:godox
 		// TODO: Integrate Bootstrap validate for Openshift in create flow once ready. For now skipping it for Openshift runtime.
-		if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypeOpenShift {
-			return nil
-		} else {
+		if vars.RuntimeFactory.GetRuntimeType() != types.RuntimeTypeOpenShift {
 			if err := doBootstrapValidate(); err != nil {
 				return err
 			}
@@ -114,6 +119,7 @@ var createCmd = &cobra.Command{
 			ArgParams:         argParams,
 			ValuesFiles:       valuesFiles,
 			ImagePullPolicy:   imagePullPolicy,
+			Timeout:           timeout,
 		}
 
 		return app.Create(ctx, opts)
@@ -141,11 +147,33 @@ func doBootstrapValidate() error {
 }
 
 func init() {
+	initCommonFlags()
+	initPodmanFlags()
+	initOpenShiftFlags()
+}
+
+func initCommonFlags() {
 	skipCheckDesc := appBootstrap.BuildSkipFlagDescription()
 	createCmd.Flags().StringSliceVar(&skipChecks, "skip-validation", []string{}, skipCheckDesc)
+
 	createCmd.Flags().StringVarP(&templateName, "template", "t", "", "Application template to use (required)")
 	_ = createCmd.MarkFlagRequired("template")
-	// Add a flag for skipping image download
+
+	createCmd.Flags().StringSliceVar(
+		&rawArgParams,
+		"params",
+		[]string{},
+		"Inline parameters to configure the application.\n\n"+
+			"Format:\n"+
+			"- Comma-separated key=value pairs\n"+
+			"- Example: --params key1=value1,key2=value2\n\n"+
+			"- Use \"ai-services application templates\" to view the list of supported parameters\n\n"+
+			"Precedence:\n"+
+			"- When both --values and --params are provided, --params overrides --values\n",
+	)
+}
+
+func initPodmanFlags() {
 	createCmd.Flags().BoolVar(
 		&skipImageDownload,
 		"skip-image-download",
@@ -168,6 +196,7 @@ func init() {
 			"- If set to true and models are missing → command will fail\n"+
 			"- If left false in air-gapped environments → download attempt will fail\n",
 	)
+
 	createCmd.Flags().StringArrayVarP(
 		&valuesFiles,
 		"values",
@@ -182,23 +211,20 @@ func init() {
 			"- Files are applied in the order provided\n"+
 			"- Later files override earlier ones\n",
 	)
-	createCmd.Flags().StringSliceVar(
-		&rawArgParams,
-		"params",
-		[]string{},
-		"Inline parameters to configure the application.\n\n"+
-			"Format:\n"+
-			"- Comma-separated key=value pairs\n"+
-			"- Example: --params key1=value1,key2=value2\n\n"+
-			"- Use \"ai-services application templates\" to view the list of supported parameters\n\n"+
-			"Precedence:\n"+
-			"- When both --values and --params are provided, --params overrides --values\n",
-	)
 
 	initializeImagePullPolicyFlag()
 
 	// deprecated flags
-	deprecatedFlags()
+	deprecatedPodmanFlags()
+}
+
+func initOpenShiftFlags() {
+	createCmd.Flags().DurationVar(
+		&timeout,
+		"timeout",
+		0, // default
+		"Timeout for the operation (e.g. 10s, 2m, 1h)",
+	)
 }
 
 func initializeImagePullPolicyFlag() {
@@ -216,7 +242,7 @@ func initializeImagePullPolicyFlag() {
 	)
 }
 
-func deprecatedFlags() {
+func deprecatedPodmanFlags() {
 	if err := createCmd.Flags().MarkDeprecated("skip-image-download", "use --image-pull-policy instead"); err != nil {
 		panic(fmt.Sprintf("Failed to mark 'skip-image-download' flag deprecated. Err: %v", err))
 	}

--- a/ai-services/internal/pkg/application/openshift/create.go
+++ b/ai-services/internal/pkg/application/openshift/create.go
@@ -8,17 +8,36 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
 	"github.com/project-ai-services/ai-services/internal/pkg/helm"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // Create deploys a new application based on a template.
 func (o *OpenshiftApplication) Create(_ context.Context, opts types.CreateOptions) error {
-	// fetch app and namespace from opts
+	// fetch app, namespace and timeout from opts
 	app := opts.Name
 	namespace := app
+	timeout := opts.Timeout
+
+	tp := templates.NewEmbedTemplateProvider(templates.EmbedOptions{Runtime: vars.RuntimeFactory.GetRuntimeType()})
+
+	// populate the operation timeout
+	if timeout == 0 {
+		// load metadata.yml to read the app metadata
+		appMetadata, err := tp.LoadMetadata(opts.TemplateName, false)
+		if err != nil {
+			return fmt.Errorf("failed to read the app metadata: %w", err)
+		}
+
+		// means timeout is not set, then read from the app metadata
+		for _, runtime := range appMetadata.Runtimes {
+			if runtime.Name == string(runtimeTypes.RuntimeTypeOpenShift) {
+				timeout = runtime.Timeout
+			}
+		}
+	}
 
 	// Load the Chart from assets
-	tp := templates.NewEmbedTemplateProvider(templates.EmbedOptions{Runtime: vars.RuntimeFactory.GetRuntimeType()})
 	chart, err := tp.LoadChart(opts.TemplateName)
 	if err != nil {
 		return fmt.Errorf("failed to load chart: %w", err)
@@ -38,10 +57,10 @@ func (o *OpenshiftApplication) Create(_ context.Context, opts types.CreateOption
 
 	if !isAppExist {
 		// if App does not exist then perform install
-		err = helmClient.Install(app, chart, nil)
+		err = helmClient.Install(app, chart, &helm.InstallOpts{Timeout: timeout})
 	} else {
 		// if App exists, perform upgrade
-		err = helmClient.Upgrade(app, chart, nil)
+		err = helmClient.Upgrade(app, chart, &helm.UpgradeOpts{Timeout: timeout})
 	}
 
 	if err != nil {

--- a/ai-services/internal/pkg/application/openshift/create.go
+++ b/ai-services/internal/pkg/application/openshift/create.go
@@ -48,7 +48,7 @@ func getOperationTimeout(ctx context.Context, tp templates.Template, opts types.
 
 	s.Start(ctx)
 	timeout := opts.Timeout
-	// populate the operation timeout
+	// populate the operation timeout if its either not set or set negatively
 	if timeout == 0 {
 		// load metadata.yml to read the app metadata
 		appMetadata, err := tp.LoadMetadata(opts.TemplateName, false)
@@ -109,7 +109,7 @@ func deployApp(ctx context.Context, chart chart.Charter, timeout time.Duration, 
 		logger.Infof("App: %s does not exist, proceeding with install...", app)
 		err = helmClient.Install(app, chart, &helm.InstallOpts{Timeout: timeout})
 	} else {
-		// if App exists, perform upgrade
+		// if App exists, perform upgrade so that the actual state of the app meets the desired state
 		logger.Infof("App: %s already exist, proceeding with reconciling...", app)
 		err = helmClient.Upgrade(app, chart, &helm.UpgradeOpts{Timeout: timeout})
 	}

--- a/ai-services/internal/pkg/application/openshift/create.go
+++ b/ai-services/internal/pkg/application/openshift/create.go
@@ -49,7 +49,7 @@ func getOperationTimeout(ctx context.Context, tp templates.Template, opts types.
 	s.Start(ctx)
 	timeout := opts.Timeout
 	// populate the operation timeout if its either not set or set negatively
-	if timeout == 0 {
+	if timeout <= 0 {
 		// load metadata.yml to read the app metadata
 		appMetadata, err := tp.LoadMetadata(opts.TemplateName, false)
 		if err != nil {

--- a/ai-services/internal/pkg/application/openshift/create.go
+++ b/ai-services/internal/pkg/application/openshift/create.go
@@ -14,6 +14,8 @@ import (
 )
 
 func (o *OpenshiftApplication) Create(ctx context.Context, opts types.CreateOptions) error {
+	logger.Infof("Creating application '%s' using template '%s'\n", opts.Name, opts.TemplateName)
+
 	// fetch app, namespace and timeout from opts
 	app := opts.Name
 	namespace := app

--- a/ai-services/internal/pkg/application/openshift/create.go
+++ b/ai-services/internal/pkg/application/openshift/create.go
@@ -65,11 +65,11 @@ func (o *OpenshiftApplication) Create(ctx context.Context, opts types.CreateOpti
 
 	if !isAppExist {
 		// if App does not exist then perform install
-		logger.Infof("App: %s does not exist, proceeding with install...")
+		logger.Infof("App: %s does not exist, proceeding with install...", app)
 		err = helmClient.Install(app, chart, &helm.InstallOpts{Timeout: timeout})
 	} else {
 		// if App exists, perform upgrade
-		logger.Infof("App: %s already exist, proceeding with reconciling...")
+		logger.Infof("App: %s already exist, proceeding with reconciling...", app)
 		err = helmClient.Upgrade(app, chart, &helm.UpgradeOpts{Timeout: timeout})
 	}
 

--- a/ai-services/internal/pkg/application/types/types.go
+++ b/ai-services/internal/pkg/application/types/types.go
@@ -1,19 +1,29 @@
 package types
 
-import "github.com/project-ai-services/ai-services/internal/pkg/image"
+import (
+	"time"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/image"
+)
 
 // CreateOptions contains parameters for creating an application.
 type CreateOptions struct {
-	Name              string
-	TemplateName      string
+	// Common
+	Name         string
+	TemplateName string
+	SkipChecks   []string
+	ArgParams    map[string]string
+
+	// Podman
 	SkipModelDownload bool
 	SkipImageDownload bool
-	SkipChecks        []string
-	ArgParams         map[string]string
 	ValuesFiles       []string
 	Values            map[string]any
 	ImagePullPolicy   image.ImagePullPolicy
 	AutoYes           bool
+
+	// Openshift
+	Timeout time.Duration
 }
 
 // DeleteOptions contains parameters for deleting an application.

--- a/ai-services/internal/pkg/cli/templates/templates.go
+++ b/ai-services/internal/pkg/cli/templates/templates.go
@@ -10,17 +10,16 @@ import (
 )
 
 type AppMetadata struct {
-	Name                  string     `yaml:"name,omitempty"`
-	Description           string     `yaml:"description,omitempty"`
-	Hidden                bool       `yaml:"hidden,omitempty"`
-	Version               string     `yaml:"version,omitempty"`
-	SMTLevel              *int       `yaml:"smtLevel,omitempty"`
-	PodTemplateExecutions [][]string `yaml:"podTemplateExecutions"`
-	Runtimes              []Runtime  `yaml:"runtimes,omitempty"`
+	Name                  string           `yaml:"name,omitempty"`
+	Description           string           `yaml:"description,omitempty"`
+	Hidden                bool             `yaml:"hidden,omitempty"`
+	Version               string           `yaml:"version,omitempty"`
+	SMTLevel              *int             `yaml:"smtLevel,omitempty"`
+	PodTemplateExecutions [][]string       `yaml:"podTemplateExecutions"`
+	Openshift             OpenshiftRuntime `yaml:"openshift,omitempty"`
 }
 
-type Runtime struct {
-	Name    string        `yaml:"name,omitempty"`
+type OpenshiftRuntime struct {
 	Timeout time.Duration `yaml:"timeout,omitempty"`
 }
 

--- a/ai-services/internal/pkg/cli/templates/templates.go
+++ b/ai-services/internal/pkg/cli/templates/templates.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"text/template"
+	"time"
 
 	"helm.sh/helm/v4/pkg/chart"
 
@@ -15,6 +16,12 @@ type AppMetadata struct {
 	Version               string     `yaml:"version,omitempty"`
 	SMTLevel              *int       `yaml:"smtLevel,omitempty"`
 	PodTemplateExecutions [][]string `yaml:"podTemplateExecutions"`
+	Runtimes              []Runtime  `yaml:"runtimes,omitempty"`
+}
+
+type Runtime struct {
+	Name    string        `yaml:"name,omitempty"`
+	Timeout time.Duration `yaml:"timeout,omitempty"`
 }
 
 type Vars struct {

--- a/ai-services/internal/pkg/helm/helm.go
+++ b/ai-services/internal/pkg/helm/helm.go
@@ -14,6 +14,10 @@ import (
 	"helm.sh/helm/v4/pkg/storage/driver"
 )
 
+var (
+	defaultWaitingTimeout = 10 * time.Minute
+)
+
 type Helm struct {
 	namespace    string
 	actionConfig *action.Configuration
@@ -60,7 +64,7 @@ func (h *Helm) Install(release string, chart chart.Charter, opts *InstallOpts) e
 	installClient.Timeout = opts.Timeout
 	if installClient.Timeout == 0 {
 		// use 30 minutes as default timeout if not set
-		installClient.Timeout = 30 * time.Minute
+		installClient.Timeout = defaultWaitingTimeout
 	}
 
 	// Perform helm install
@@ -87,7 +91,7 @@ func (h *Helm) Upgrade(release string, chart chart.Charter, opts *UpgradeOpts) e
 	upgradeClient.Timeout = opts.Timeout
 	if upgradeClient.Timeout == 0 {
 		// use 30 minutes as default timeout if not set
-		upgradeClient.Timeout = 30 * time.Minute
+		upgradeClient.Timeout = defaultWaitingTimeout
 	}
 
 	// Perform helm upgrade

--- a/ai-services/internal/pkg/helm/helm.go
+++ b/ai-services/internal/pkg/helm/helm.go
@@ -62,8 +62,8 @@ func (h *Helm) Install(release string, chart chart.Charter, opts *InstallOpts) e
 	installClient.WaitStrategy = kube.StatusWatcherStrategy
 
 	installClient.Timeout = opts.Timeout
-	if installClient.Timeout == 0 {
-		// use default timeout if not set
+	if installClient.Timeout <= 0 {
+		// use default timeout if set to 0 or negative
 		installClient.Timeout = defaultWaitingTimeout
 	}
 
@@ -89,8 +89,8 @@ func (h *Helm) Upgrade(release string, chart chart.Charter, opts *UpgradeOpts) e
 	upgradeClient.WaitStrategy = kube.StatusWatcherStrategy
 
 	upgradeClient.Timeout = opts.Timeout
-	if upgradeClient.Timeout == 0 {
-		// use default timeout if not set
+	if upgradeClient.Timeout <= 0 {
+		// use default timeout if set to 0 or negative
 		upgradeClient.Timeout = defaultWaitingTimeout
 	}
 

--- a/ai-services/internal/pkg/helm/helm.go
+++ b/ai-services/internal/pkg/helm/helm.go
@@ -14,10 +14,6 @@ import (
 	"helm.sh/helm/v4/pkg/storage/driver"
 )
 
-var (
-	defaultWaitingTimeout = 10 * time.Minute
-)
-
 type Helm struct {
 	namespace    string
 	actionConfig *action.Configuration
@@ -60,12 +56,7 @@ func (h *Helm) Install(release string, chart chart.Charter, opts *InstallOpts) e
 	installClient.Namespace = h.namespace
 	installClient.CreateNamespace = true
 	installClient.WaitStrategy = kube.StatusWatcherStrategy
-
 	installClient.Timeout = opts.Timeout
-	if installClient.Timeout <= 0 {
-		// use default timeout if set to 0 or negative
-		installClient.Timeout = defaultWaitingTimeout
-	}
 
 	// Perform helm install
 	_, err := installClient.Run(chart, opts.Values)
@@ -87,12 +78,7 @@ func (h *Helm) Upgrade(release string, chart chart.Charter, opts *UpgradeOpts) e
 	upgradeClient.Namespace = h.namespace
 	upgradeClient.ServerSideApply = "true"
 	upgradeClient.WaitStrategy = kube.StatusWatcherStrategy
-
 	upgradeClient.Timeout = opts.Timeout
-	if upgradeClient.Timeout <= 0 {
-		// use default timeout if set to 0 or negative
-		upgradeClient.Timeout = defaultWaitingTimeout
-	}
 
 	// Perform helm upgrade
 	_, err := upgradeClient.Run(release, chart, opts.Values)

--- a/ai-services/internal/pkg/helm/helm.go
+++ b/ai-services/internal/pkg/helm/helm.go
@@ -63,7 +63,7 @@ func (h *Helm) Install(release string, chart chart.Charter, opts *InstallOpts) e
 
 	installClient.Timeout = opts.Timeout
 	if installClient.Timeout == 0 {
-		// use 30 minutes as default timeout if not set
+		// use default timeout if not set
 		installClient.Timeout = defaultWaitingTimeout
 	}
 
@@ -90,7 +90,7 @@ func (h *Helm) Upgrade(release string, chart chart.Charter, opts *UpgradeOpts) e
 
 	upgradeClient.Timeout = opts.Timeout
 	if upgradeClient.Timeout == 0 {
-		// use 30 minutes as default timeout if not set
+		// use default timeout if not set
 		upgradeClient.Timeout = defaultWaitingTimeout
 	}
 


### PR DESCRIPTION
- Use Helm Wait strategy: Watcher
- Add default timeout in app metadata.yml
- Support `timeout` flag as part of application creation to override the default timeout.
- Add spinner