### PR TITLE
remove invalid aria-label from Carbon Header

### DIFF
--- a/spyre-rag/ui/src/components/Header.jsx
+++ b/spyre-rag/ui/src/components/Header.jsx
@@ -2,7 +2,7 @@ import { Header, HeaderName } from '@carbon/react';
 
 const HeaderNav = () => {
   return (
-    <Header aria-label="">
+    <Header>
       <HeaderName to="/" prefix="">
         DigitalAssistant
       </HeaderName>


### PR DESCRIPTION
Removed the empty aria-label from the Carbon `<Header>` component to resolve the aria_attribute_valid accessibility violation.
The header already contains visible text (DigitalAssistant), so an explicit ARIA label was unnecessary.
No functional or UI changes.

Report before code change:
<img width="1850" height="178" alt="image" src="https://github.com/user-attachments/assets/5a2f5b4e-758c-4fff-b4cc-007ebef336d3" />
 
 Report after code change:
 <img width="1850" height="143" alt="image" src="https://github.com/user-attachments/assets/29e17771-a696-4fc8-aeff-d61efaf11d41" />
 Issue ID `2624070542` is no longer present
