### PR TITLE
Disable automountServiceAccounToken for services which do not need to talk to cluster

### DIFF
--- a/ai-services/assets/applications/rag-dev/openshift/templates/backend-deployment.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/templates/backend-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         ai-services.io/component: backend
         ai-services.io/version: {{ default .Chart.AppVersion | quote }}
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: server
           image: "{{ .Values.backend.image }}"

--- a/ai-services/assets/applications/rag-dev/openshift/templates/ui-deployment.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/templates/ui-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         ai-services.io/component: ui
         ai-services.io/version: {{ default .Chart.AppVersion | quote }}
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: ui
           image: "{{ .Values.ui.image }}"


### PR DESCRIPTION
- Disabling mounting SA token for services which do not require.
- This is considered to be best security practice if the services doesnt talk to kube server.