### PR TITLE
Restrict query_length in backend - chat

### DIFF
--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -1,16 +1,16 @@
 ui:
   # @hidden
-  image: icr.io/ai-services-cicd/rag-ui:v0.0.21
+  image: icr.io/ai-services-cicd/rag-ui:v0.0.22
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.49
+  image: icr.io/ai-services-cicd/rag:v0.0.50
   # @hidden
   log_level: "INFO"
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.49
+  image: icr.io/ai-services-cicd/rag:v0.0.50
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -2,13 +2,13 @@ ui:
   # @description Host port for the RAG UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag-ui:v0.0.21
+  image: icr.io/ai-services-cicd/rag-ui:v0.0.22
 
 backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.49
+  image: icr.io/ai-services-cicd/rag:v0.0.50
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.49
+  image: icr.io/ai-services-cicd/rag:v0.0.50
   # @hidden
   log_level: "INFO"
 
@@ -49,6 +49,6 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: "6000"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.49
+  image: icr.io/ai-services-cicd/rag:v0.0.50
   # @hidden
   log_level: "INFO"

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -2,13 +2,13 @@ ui:
   # @description Host port for the RAG UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag-ui:v0.0.21
+  image: icr.io/ai-services-cicd/rag-ui:v0.0.22
 
 backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.49
+  image: icr.io/ai-services-cicd/rag:v0.0.50
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.49
+  image: icr.io/ai-services-cicd/rag:v0.0.50
   # @hidden
   log_level: "INFO"
 
@@ -49,6 +49,6 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: "6000"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.49
+  image: icr.io/ai-services-cicd/rag:v0.0.50
   # @hidden
   log_level: "INFO"

--- a/spyre-rag/src/Makefile
+++ b/spyre-rag/src/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=rag
-TAG?=v0.0.49
+TAG?=v0.0.50
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman

--- a/spyre-rag/src/common/settings.py
+++ b/spyre-rag/src/common/settings.py
@@ -111,6 +111,7 @@ class Settings:
     temperature: float
     max_input_length: int
     prompt_template_token_count: int
+    max_query_token_length: int
     summarization_coefficient: float
     summarization_prompt_token_count: int
     summarization_temperature: float
@@ -126,6 +127,7 @@ class Settings:
         default_temperature = 0.0
         default_max_input_length = 6000
         default_prompt_template_token_count = 250
+        default_max_query_token_length = 512
         default_summarization_coefficient = 0.2
         default_summarization_prompt_token_count = 100
         default_summarization_temperature = 0.2
@@ -167,6 +169,10 @@ class Settings:
             object.__setattr__(self, "prompt_template_token_count", default_prompt_template_token_count)
             logger.warning(f"Setting prompt_template_token_count to default '{default_prompt_template_token_count}' as it is missing in the settings")
 
+        if not (isinstance(self.max_query_token_length, int) and self.max_query_token_length > 0):
+            object.__setattr__(self, "max_query_token_length", default_max_query_token_length)
+            logger.warning(f"Setting max_query_token_length to default '{default_max_query_token_length}' as it is missing or malformed in the settings")
+
         if not isinstance(self.summarization_coefficient, float):
             object.__setattr__(self, "summarization_coefficient", default_summarization_coefficient)
             logger.warning(f"Setting summarization_coefficient to default '{default_summarization_coefficient}' as it is missing in the settings")
@@ -206,6 +212,7 @@ class Settings:
             temperature = data.get("temperature", None),  # type: ignore[arg-type]
             max_input_length = data.get("max_input_length", None),  # type: ignore[arg-type]
             prompt_template_token_count = data.get("prompt_template_token_count", None),  # type: ignore[arg-type]
+            max_query_token_length = data.get("max_query_token_length", None),  # type: ignore[arg-type]
             summarization_coefficient = data.get("summarization_coefficient", None),  # type: ignore[arg-type]
             summarization_prompt_token_count = data.get("summarization_prompt_token_count", None),  # type: ignore[arg-type]
             summarization_temperature = data.get("summarization_temperature", None),  # type: ignore[arg-type]

--- a/spyre-rag/src/retrieve/app.py
+++ b/spyre-rag/src/retrieve/app.py
@@ -15,7 +15,7 @@ from common.llm_utils import create_llm_session, query_vllm_stream, query_vllm_n
 from common.misc_utils import get_model_endpoints, set_log_level, set_request_id
 from common.settings import get_settings
 from common.perf_utils import perf_registry
-from retrieve.backend_utils import search_only
+from retrieve.backend_utils import search_only, validate_query_length
 from retrieve.response_utils import (
     ReferenceRequest,
     ReferenceResponse,
@@ -111,12 +111,26 @@ def limit_concurrency(f):
     description="Search the vector store using the prompt, rerank results, and return relevant document chunks with performance metrics."
 )
 async def get_reference_docs(req: ReferenceRequest) -> ReferenceResponse:
+    # Validate query is not empty
+    if not req.prompt or not req.prompt.strip():
+        raise HTTPException(status_code=400, detail="Query cannot be empty")
+    
     try:
         emb_model = emb_model_dict['emb_model']
         emb_endpoint = emb_model_dict['emb_endpoint']
         emb_max_tokens = emb_model_dict['max_tokens']
         reranker_model = reranker_model_dict['reranker_model']
         reranker_endpoint = reranker_model_dict['reranker_endpoint']
+        
+        # Validate query length
+        is_valid, token_count, error_msg = await asyncio.to_thread(
+            validate_query_length, req.prompt, emb_endpoint
+        )
+        if not is_valid:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{error_msg}. Query has {token_count} tokens, maximum allowed is {settings.max_query_token_length} tokens."
+            )
 
         docs, perf_stat_dict = await asyncio.to_thread(
             search_only,
@@ -131,6 +145,9 @@ async def get_reference_docs(req: ReferenceRequest) -> ReferenceResponse:
         # Store metrics in registry for reference endpoint
         perf_registry.add_metric(perf_stat_dict)
         
+    except HTTPException:
+        # Re-raise HTTPException without modification
+        raise
     except db.VectorStoreNotReadyError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
@@ -203,6 +220,10 @@ async def chat_completion(req: ChatCompletionRequest) -> ChatCompletionResponse 
         raise HTTPException(status_code=400, detail="messages can't be empty")
 
     query = req.messages[0].content
+    
+    # Validate query is not empty
+    if not query or not query.strip():
+        raise HTTPException(status_code=400, detail="Query cannot be empty")
 
     try:
         emb_model = emb_model_dict['emb_model']
@@ -212,6 +233,16 @@ async def chat_completion(req: ChatCompletionRequest) -> ChatCompletionResponse 
         llm_endpoint = llm_model_dict['llm_endpoint']
         reranker_model = reranker_model_dict['reranker_model']
         reranker_endpoint = reranker_model_dict['reranker_endpoint']
+        
+        # Validate query length
+        is_valid, token_count, error_msg = await asyncio.to_thread(
+            validate_query_length, query, emb_endpoint
+        )
+        if not is_valid:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{error_msg}. Query has {token_count} tokens, maximum allowed is {settings.max_query_token_length} tokens."
+            )
         
         docs, perf_stat_dict = await asyncio.to_thread(
             search_only,
@@ -223,6 +254,9 @@ async def chat_completion(req: ChatCompletionRequest) -> ChatCompletionResponse 
             settings.num_chunks_post_reranker,
             vectorstore=vectorstore
         )
+    except HTTPException:
+        # Re-raise HTTPException without modification
+        raise
     except db.VectorStoreNotReadyError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:

--- a/spyre-rag/src/retrieve/app.py
+++ b/spyre-rag/src/retrieve/app.py
@@ -239,7 +239,8 @@ async def chat_completion(req: ChatCompletionRequest) -> ChatCompletionResponse 
             # Return streaming error response for consistency
             if req.stream:
                 async def stream_query_length_error():
-                    yield f"data: {json.dumps({'choices': [{'delta': {'content': error_msg}}]})}\n\n"
+                    message = f"Your query is too long. Please shorten it and try again."
+                    yield f"data: {json.dumps({'choices': [{'delta': {'content': message}}]})}\n\n"
                 return StreamingResponse(stream_query_length_error(), media_type="text/event-stream")
             else:
                 return JSONResponse(

--- a/spyre-rag/src/retrieve/app.py
+++ b/spyre-rag/src/retrieve/app.py
@@ -123,14 +123,14 @@ async def get_reference_docs(req: ReferenceRequest) -> ReferenceResponse:
         reranker_endpoint = reranker_model_dict['reranker_endpoint']
         
         # Validate query length
-        is_valid, token_count, error_msg = await asyncio.to_thread(
+        is_valid, error_msg = await asyncio.to_thread(
             validate_query_length, req.prompt, emb_endpoint
         )
         if not is_valid:
-            raise HTTPException(
-                status_code=400,
-                detail=f"{error_msg}. Query has {token_count} tokens, maximum allowed is {settings.max_query_token_length} tokens."
-            )
+            return JSONResponse(
+                    status_code=400,
+                    content={"error": error_msg}
+                )
 
         docs, perf_stat_dict = await asyncio.to_thread(
             search_only,
@@ -145,9 +145,6 @@ async def get_reference_docs(req: ReferenceRequest) -> ReferenceResponse:
         # Store metrics in registry for reference endpoint
         perf_registry.add_metric(perf_stat_dict)
         
-    except HTTPException:
-        # Re-raise HTTPException without modification
-        raise
     except db.VectorStoreNotReadyError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
@@ -235,14 +232,20 @@ async def chat_completion(req: ChatCompletionRequest) -> ChatCompletionResponse 
         reranker_endpoint = reranker_model_dict['reranker_endpoint']
         
         # Validate query length
-        is_valid, token_count, error_msg = await asyncio.to_thread(
+        is_valid, error_msg = await asyncio.to_thread(
             validate_query_length, query, emb_endpoint
         )
         if not is_valid:
-            raise HTTPException(
-                status_code=400,
-                detail=f"{error_msg}. Query has {token_count} tokens, maximum allowed is {settings.max_query_token_length} tokens."
-            )
+            # Return streaming error response for consistency
+            if req.stream:
+                async def stream_query_length_error():
+                    yield f"data: {json.dumps({'choices': [{'delta': {'content': error_msg}}]})}\n\n"
+                return StreamingResponse(stream_query_length_error(), media_type="text/event-stream")
+            else:
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": error_msg}
+                )
         
         docs, perf_stat_dict = await asyncio.to_thread(
             search_only,
@@ -254,9 +257,7 @@ async def chat_completion(req: ChatCompletionRequest) -> ChatCompletionResponse 
             settings.num_chunks_post_reranker,
             vectorstore=vectorstore
         )
-    except HTTPException:
-        # Re-raise HTTPException without modification
-        raise
+        
     except db.VectorStoreNotReadyError as e:
         raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:

--- a/spyre-rag/src/retrieve/backend_utils.py
+++ b/spyre-rag/src/retrieve/backend_utils.py
@@ -1,11 +1,31 @@
 from common.misc_utils import get_logger
 from common.settings import get_settings
+from common.llm_utils import tokenize_with_llm
 from retrieve.reranker_utils import rerank_documents
 from retrieve.retrieval_utils import retrieve_documents
 import time
 
 logger = get_logger("backend_utils")
 settings = get_settings()
+
+def validate_query_length(query, emb_endpoint):
+    
+    #Validate that the query length does not exceed the maximum allowed tokens.
+    try:
+        tokens = tokenize_with_llm(query, emb_endpoint)
+        token_count = len(tokens)
+        
+        if token_count > settings.max_query_token_length:
+            error_msg = f"Query length ({token_count} tokens) exceeds maximum allowed length of {settings.max_query_token_length} tokens"
+            logger.warning(error_msg)
+            return False, token_count, error_msg
+        
+        return True, token_count, None
+    except Exception as e:
+        logger.error(f"Error validating query length: {e}")
+        # If tokenization fails, we'll allow the request to proceed
+        # to avoid blocking legitimate requests due to tokenization issues
+        return True, 0, None
 
 def search_only(question, emb_model, emb_endpoint, max_tokens, reranker_model, reranker_endpoint, top_k, top_r, vectorstore):
     # Perform retrieval

--- a/spyre-rag/src/retrieve/backend_utils.py
+++ b/spyre-rag/src/retrieve/backend_utils.py
@@ -10,7 +10,8 @@ settings = get_settings()
 
 def validate_query_length(query, emb_endpoint):
     
-    #Validate that the query length does not exceed the maximum allowed tokens.
+    # Validate that the query length does not exceed the maximum allowed tokens.
+
     try:
         tokens = tokenize_with_llm(query, emb_endpoint)
         token_count = len(tokens)
@@ -18,14 +19,14 @@ def validate_query_length(query, emb_endpoint):
         if token_count > settings.max_query_token_length:
             error_msg = f"Query length ({token_count} tokens) exceeds maximum allowed length of {settings.max_query_token_length} tokens"
             logger.warning(error_msg)
-            return False, token_count, error_msg
+            return False, error_msg
         
-        return True, token_count, None
+        return True, None
     except Exception as e:
         logger.error(f"Error validating query length: {e}")
         # If tokenization fails, we'll allow the request to proceed
         # to avoid blocking legitimate requests due to tokenization issues
-        return True, 0, None
+        return True, None
 
 def search_only(question, emb_model, emb_endpoint, max_tokens, reranker_model, reranker_endpoint, top_k, top_r, vectorstore):
     # Perform retrieval

--- a/spyre-rag/src/settings.json
+++ b/spyre-rag/src/settings.json
@@ -20,6 +20,7 @@
   "temperature": 0.0,
   "max_input_length": 6000,
   "prompt_template_token_count": 250,
+  "max_query_token_length": 512,
   "summarization_coefficient": 0.2,
   "summarization_prompt_token_count": 100,
   "summarization_temperature": 0.2,

--- a/spyre-rag/ui/Makefile
+++ b/spyre-rag/ui/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=rag-ui
-TAG?=v0.0.21
+TAG?=v0.0.22
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman

--- a/spyre-rag/ui/src/components/customSendMessage.jsx
+++ b/spyre-rag/ui/src/components/customSendMessage.jsx
@@ -177,7 +177,10 @@ async function customSendMessage(request, _options, instance) {
     } catch (refError) {
       // If reference call fails (e.g., query too long), continue without docs
       // The chat response has already been streamed successfully
-      console.warn('Reference document retrieval failed:', refError.response?.data?.detail || refError.message);
+      console.warn(
+        'Reference document retrieval failed:',
+        refError.response?.data?.detail || refError.message,
+      );
     }
 
     const responseBlocks = [

--- a/spyre-rag/ui/src/components/customSendMessage.jsx
+++ b/spyre-rag/ui/src/components/customSendMessage.jsx
@@ -169,9 +169,16 @@ async function customSendMessage(request, _options, instance) {
     });
 
     // await for the reference promise to finish
-    const context_response = await referencePromise;
-    // get docs out of context_response
-    const docs = context_response.data?.documents || [];
+    let docs = [];
+    try {
+      const context_response = await referencePromise;
+      // get docs out of context_response
+      docs = context_response.data?.documents || [];
+    } catch (refError) {
+      // If reference call fails (e.g., query too long), continue without docs
+      // The chat response has already been streamed successfully
+      console.warn('Reference document retrieval failed:', refError.response?.data?.detail || refError.message);
+    }
 
     const responseBlocks = [
       {
@@ -184,7 +191,7 @@ async function customSendMessage(request, _options, instance) {
       },
     ];
 
-    if (docs.length > 0) {
+    if (docs?.length > 0) {
       responseBlocks.push({
         response_type: 'user_defined',
         user_defined: {


### PR DESCRIPTION
What does this PR do?
- Keeps a check on the query_length in the chat app, and returns appropriate errors on  respective cases.

( inherently, there are already exceptions by 
 1. reranker -> to restrict query + doc to 1024 tokens
 2. opensearch in case of sparse mode of search to 1024 tokens ) 
  
  But in order to catch it gracefully, and use a more realistic limit - we have restricted the query_length to 512 tokens.
  


