### PR TITLE
[Digitize-UI] Proper Error Handling in Jobs and Docs Page

### DIFF
--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -22,7 +22,7 @@ digitize:
 
 digitizeUi:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.6
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.7
 
 instruct:
   # @hidden

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -24,7 +24,7 @@ digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.6
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.7
 
 ingest:
   # @hidden

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -22,7 +22,7 @@ digitize:
 
 digitizeUi:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.6
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.7
 
 instruct:
   # @hidden

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -24,7 +24,7 @@ digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.6
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.7
 
 ingest:
   # @hidden

--- a/digitize-ui/Makefile
+++ b/digitize-ui/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= digitize-ui
-TAG ?= v0.0.6
+TAG ?= v0.0.7
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/digitize-ui/src/pages/DocumentListPage/DocumentListPage.module.scss
+++ b/digitize-ui/src/pages/DocumentListPage/DocumentListPage.module.scss
@@ -131,6 +131,67 @@
   fill: var(--cds-support-info);
 }
 
+.errorInfoButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  margin-left: 0.25rem;
+  cursor: pointer;
+  outline: none;
+  
+  &:hover .errorInfoIcon {
+    fill: var(--cds-icon-primary);
+  }
+  
+  &:focus {
+    outline: 2px solid var(--cds-focus);
+    outline-offset: 2px;
+  }
+}
+
+.errorInfoIcon {
+  fill: var(--cds-icon-secondary);
+  flex-shrink: 0;
+  transition: fill 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.errorTooltip {
+  :global {
+    .cds--tooltip-content {
+      max-width: 18rem;
+      max-height: 12rem;
+      overflow-y: auto;
+      word-wrap: break-word;
+      
+      /* Custom scrollbar styling */
+      &::-webkit-scrollbar {
+        width: 6px;
+      }
+      
+      &::-webkit-scrollbar-track {
+        background: var(--cds-layer-02);
+        border-radius: 3px;
+      }
+      
+      &::-webkit-scrollbar-thumb {
+        background: var(--cds-border-subtle-01);
+        border-radius: 3px;
+        
+        &:hover {
+          background: var(--cds-border-strong-01);
+        }
+      }
+      
+      /* Firefox scrollbar styling */
+      scrollbar-width: thin;
+      scrollbar-color: var(--cds-border-subtle-01) var(--cds-layer-02);
+    }
+  }
+}
+
 .emptyStateCell {
   padding: $spacing-09 $spacing-05 !important;
   border-bottom: none !important;

--- a/digitize-ui/src/pages/DocumentListPage/DocumentListPage.tsx
+++ b/digitize-ui/src/pages/DocumentListPage/DocumentListPage.tsx
@@ -303,8 +303,29 @@ const DocumentListPage = () => {
           totalItems: response.pagination?.total || 0,
         },
       });
-    } catch (error) {
-      console.error('Error fetching documents:', error);
+    } catch (error: any) {
+      
+      // Handle 5xx server errors with appropriate user-facing messages
+      if (error.response && error.response.status >= 500 && error.response.status < 600) {
+        const errorMessage = error.response.status === 503
+          ? 'The service is temporarily unavailable. Please try again in a few moments.'
+          : 'A server error occurred while fetching documents. Please try again later.';
+        
+        dispatch({
+          type: 'SHOW_ERROR',
+          payload: {
+            message: errorMessage,
+          },
+        });
+      } else if (error.code === 'ECONNABORTED' || error.message === 'Network Error') {
+        // Handle network/timeout errors
+        dispatch({
+          type: 'SHOW_ERROR',
+          payload: {
+            message: 'Unable to connect to the server. Please check your network connection and try again.',
+          },
+        });
+      }
     } finally {
       dispatch({ type: 'SET_LOADING', payload: false });
     }
@@ -565,8 +586,12 @@ const DocumentListPage = () => {
             aria-label="close notification"
             kind="error"
             closeOnEscape
-            title={`Delete document ${state.errorDocName} failed`}
+            title={state.errorDocName ? `Delete document ${state.errorDocName} failed` : 'Error loading documents'}
             subtitle={state.errorMessage}
+            onActionButtonClick={() => {
+              dispatch({ type: 'HIDE_ERROR' });
+              fetchDocuments();
+            }}
             onCloseButtonClick={() => {
               dispatch({ type: 'HIDE_ERROR' });
             }}

--- a/digitize-ui/src/pages/DocumentListPage/DocumentListPage.tsx
+++ b/digitize-ui/src/pages/DocumentListPage/DocumentListPage.tsx
@@ -24,6 +24,7 @@ import {
   ActionableNotification,
   TextInput,
   InlineLoading,
+  Tooltip,
 } from '@carbon/react';
 import { Renew, TrashCan, Download, CheckmarkFilled, ErrorFilled, InProgress } from '@carbon/icons-react';
 import { useTheme } from '../../contexts/useTheme';
@@ -535,45 +536,64 @@ const DocumentListPage = () => {
     }
   };
 
-  const rows = state.documents.map((doc) => ({
-    id: doc.id,
-    name: doc.name || doc.filename || 'N/A',
-    status: (
-      <div className={styles.statusCell}>
-        {getStatusIcon(doc.status)}
-        <span className={styles.statusText}>{doc.status}</span>
-      </div>
-    ),
-    submitted_at: doc.submitted_at
-      ? new Date(doc.submitted_at).toLocaleString('en-US', {
-          month: 'short',
-          day: 'numeric',
-          year: 'numeric',
-          hour: 'numeric',
-          minute: '2-digit',
-          hour12: true,
-        })
-      : 'N/A',
-    view_action: (
-      <Button
-        kind="ghost"
-        size="sm"
-        onClick={() => handleViewContent(doc)}
-      >
-        View content
-      </Button>
-    ),
-    delete_action: (
-      <Button
-        hasIconOnly
-        kind="ghost"
-        size="sm"
-        renderIcon={TrashCan}
-        iconDescription="Delete"
-        onClick={() => dispatch({ type: 'OPEN_DELETE_MODAL', payload: doc.id })}
-      />
-    ),
-  }));
+  const rows = state.documents.map((doc) => {
+    const hasError = doc.status === 'failed';
+    
+    return {
+      id: doc.id,
+      name: doc.name || doc.filename || 'N/A',
+      status: (
+        <div className={styles.statusCell}>
+          {getStatusIcon(doc.status)}
+          <span className={styles.statusText}>{doc.status}</span>
+          {hasError && (
+            <Tooltip
+              align="top"
+              label="Document processing failed. Please try re-uploading the document."
+              className={styles.errorTooltip}
+            >
+              <button
+                type="button"
+                className={styles.errorInfoButton}
+                aria-label="Error details"
+              >
+                <ErrorFilled size={16} className={styles.errorInfoIcon} />
+              </button>
+            </Tooltip>
+          )}
+        </div>
+      ),
+      submitted_at: doc.submitted_at
+        ? new Date(doc.submitted_at).toLocaleString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true,
+          })
+        : 'N/A',
+      view_action: (
+        <Button
+          kind="ghost"
+          size="sm"
+          onClick={() => handleViewContent(doc)}
+        >
+          View content
+        </Button>
+      ),
+      delete_action: (
+        <Button
+          hasIconOnly
+          kind="ghost"
+          size="sm"
+          renderIcon={TrashCan}
+          iconDescription="Delete"
+          onClick={() => dispatch({ type: 'OPEN_DELETE_MODAL', payload: doc.id })}
+        />
+      ),
+    };
+  });
 
   const noSearchResults = state.documents.length === 0 && state.search;
 

--- a/digitize-ui/src/pages/DocumentListPage/DocumentListPage.tsx
+++ b/digitize-ui/src/pages/DocumentListPage/DocumentListPage.tsx
@@ -270,12 +270,14 @@ const headers = [
 
 const getStatusIcon = (status: string) => {
   switch (status) {
+    case 'accepted':
     case 'chunked':
     case 'completed':
+    case 'digitized':
+    case 'processed':
       return <CheckmarkFilled size={16} className={styles.statusIconSuccess} />;
     case 'failed':
       return <ErrorFilled size={16} className={styles.statusIconError} />;
-    case 'processing':
     case 'in_progress':
       return <InProgress size={16} className={styles.statusIconProgress} />;
     default:

--- a/digitize-ui/src/pages/JobMonitorPage/JobMonitorPage.module.scss
+++ b/digitize-ui/src/pages/JobMonitorPage/JobMonitorPage.module.scss
@@ -158,6 +158,67 @@
   flex-shrink: 0;
 }
 
+.errorInfoButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  margin-left: 0.25rem;
+  cursor: pointer;
+  outline: none;
+  
+  &:hover .errorInfoIcon {
+    fill: var(--cds-icon-primary);
+  }
+  
+  &:focus {
+    outline: 2px solid var(--cds-focus);
+    outline-offset: 2px;
+  }
+}
+
+.errorInfoIcon {
+  fill: var(--cds-icon-secondary);
+  flex-shrink: 0;
+  transition: fill 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
+}
+
+.errorTooltip {
+  :global {
+    .cds--tooltip-content {
+      max-width: 18rem;
+      max-height: 12rem;
+      overflow-y: auto;
+      word-wrap: break-word;
+      
+      /* Custom scrollbar styling */
+      &::-webkit-scrollbar {
+        width: 6px;
+      }
+      
+      &::-webkit-scrollbar-track {
+        background: var(--cds-layer-02);
+        border-radius: 3px;
+      }
+      
+      &::-webkit-scrollbar-thumb {
+        background: var(--cds-border-subtle-01);
+        border-radius: 3px;
+        
+        &:hover {
+          background: var(--cds-border-strong-01);
+        }
+      }
+      
+      /* Firefox scrollbar styling */
+      scrollbar-width: thin;
+      scrollbar-color: var(--cds-border-subtle-01) var(--cds-layer-02);
+    }
+  }
+}
+
 .modalContent {
   padding: 1rem 0;
 }

--- a/digitize-ui/src/pages/JobMonitorPage/JobMonitorPage.tsx
+++ b/digitize-ui/src/pages/JobMonitorPage/JobMonitorPage.tsx
@@ -24,6 +24,7 @@ import {
   ActionableNotification,
   TextInput,
   InlineLoading,
+  Tooltip,
 } from '@carbon/react';
 import { SidePanel, NoDataEmptyState } from '@carbon/ibm-products';
 import { Download, Renew, Add, CheckmarkFilled, InProgress, ErrorFilled, TrashCan } from '@carbon/icons-react';
@@ -583,6 +584,21 @@ const JobMonitorPage = () => {
         <div className={styles.statusCell}>
           {getStatusIcon(jobStatus)}
           <span className={styles.statusText}>{jobStatus}</span>
+          {hasError && (
+            <Tooltip
+              align="top"
+              label={getErrorMessage(job)}
+              className={styles.errorTooltip}
+            >
+              <button
+                type="button"
+                className={styles.errorInfoButton}
+                aria-label="Error details"
+              >
+                <ErrorFilled size={16} className={styles.errorInfoIcon} />
+              </button>
+            </Tooltip>
+          )}
         </div>
       ),
       started: job.submitted_at
@@ -596,12 +612,7 @@ const JobMonitorPage = () => {
           })
         : 'N/A',
       duration: calculateDuration(job.submitted_at, job.completed_at),
-      view_action: hasError ? (
-        <div className={styles.errorMessage}>
-          <ErrorFilled size={16} className={styles.errorIcon} />
-          <span>{getErrorMessage(job)}</span>
-        </div>
-      ) : (
+      view_action: (
         <Button
           kind="ghost"
           size="sm"

--- a/digitize-ui/src/pages/JobMonitorPage/JobMonitorPage.tsx
+++ b/digitize-ui/src/pages/JobMonitorPage/JobMonitorPage.tsx
@@ -316,8 +316,28 @@ const JobMonitorPage = () => {
           totalItems: response.pagination?.total || 0,
         },
       });
-    } catch (error) {
-      console.error('Error fetching jobs:', error);
+    } catch (error: any) {
+      // Handle 5xx server errors with appropriate user-facing messages
+      if (error.response && error.response.status >= 500 && error.response.status < 600) {
+        const errorMessage = error.response.status === 503
+          ? 'The service is temporarily unavailable. Please try again in a few moments.'
+          : 'A server error occurred while fetching jobs. Please try again later.';
+
+        dispatch({
+          type: 'SHOW_ERROR',
+          payload: {
+            message: errorMessage,
+          },
+        });
+      } else if (error.code === 'ECONNABORTED' || error.message === 'Network Error') {
+        // Handle network/timeout errors
+        dispatch({
+          type: 'SHOW_ERROR',
+          payload: {
+            message: 'Unable to connect to the server. Please check your network connection and try again.',
+          },
+        });
+      }
     } finally {
       dispatch({ type: 'SET_LOADING', payload: false });
     }
@@ -612,8 +632,12 @@ const JobMonitorPage = () => {
             aria-label="close notification"
             kind="error"
             closeOnEscape
-            title={`Delete job ${state.errorJobName} failed`}
+            title={state.errorJobName ? `Delete job ${state.errorJobName} failed` : 'Error loading jobs'}
             subtitle={state.errorMessage}
+            onActionButtonClick={() => {
+              dispatch({ type: 'HIDE_ERROR' });
+              fetchJobs();
+            }}
             onCloseButtonClick={() => {
               dispatch({ type: 'HIDE_ERROR' });
             }}


### PR DESCRIPTION
- Error Handling for 5xx errors in Jobs and Docs Page.
- Handle individual job/ doc errors by using a tip next to status which shows the detailed information about the error. Also adds overflow with scrollable y-axis if error message is too big.
- Also added status icon checks based on all the enums defined for digitize.

Made With Bob