### PR TITLE
[AISERVICES-883] Address stuck ingestion job during ligomp thread crash

### DIFF
--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.85
+  image: icr.io/ai-services-cicd/rag:v0.0.86
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.85
+  image: icr.io/ai-services-cicd/rag:v0.0.86
   # @hidden
   log_level: "INFO"
 
@@ -56,6 +56,6 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.85
+  image: icr.io/ai-services-cicd/rag:v0.0.86
   # @hidden
   log_level: "INFO"

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -4,19 +4,19 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.85
+  image: icr.io/ai-services-cicd/rag:v0.0.86
   # @hidden
   log_level: "INFO"
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.85
+  image: icr.io/ai-services-cicd/rag:v0.0.86
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.85
+  image: icr.io/ai-services-cicd/rag:v0.0.86
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.85
+  image: icr.io/ai-services-cicd/rag:v0.0.86
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.85
+  image: icr.io/ai-services-cicd/rag:v0.0.86
   # @hidden
   log_level: "INFO"
 
@@ -56,6 +56,6 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.85
+  image: icr.io/ai-services-cicd/rag:v0.0.86
   # @hidden
   log_level: "INFO"

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -4,19 +4,19 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.85
+  image: icr.io/ai-services-cicd/rag:v0.0.86
   # @hidden
   log_level: "INFO"
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.85
+  image: icr.io/ai-services-cicd/rag:v0.0.86
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.85
+  image: icr.io/ai-services-cicd/rag:v0.0.86
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.85
+  image: icr.io/ai-services-cicd/rag:v0.0.86
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.85
+  image: icr.io/ai-services-cicd/rag:v0.0.86
   # @hidden
   log_level: "INFO"
 
@@ -56,6 +56,6 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.85
+  image: icr.io/ai-services-cicd/rag:v0.0.86
   # @hidden
   log_level: "INFO"

--- a/spyre-rag/src/Makefile
+++ b/spyre-rag/src/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=rag
-TAG?=v0.0.85
+TAG?=v0.0.86
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman

--- a/spyre-rag/src/digitize/doc_utils.py
+++ b/spyre-rag/src/digitize/doc_utils.py
@@ -204,21 +204,25 @@ def process_converted_document(converted_json_path, pdf_path, out_path, gen_mode
 
 def convert_document(pdf_path, out_path, file_name):
     """
-    Worker function for document conversion.
+    Convert a single document to JSON format.
     This function runs in a separate process via ProcessPoolExecutor.
     """
-    logger.info(f"Processing '{pdf_path}'")
-    converted_json = (Path(out_path) / f"{file_name}.json")
-    converted_json_f = str(converted_json)
-    logger.debug(f"Converting '{pdf_path}'")
-    t0 = time.time()
+    try:
+        logger.info(f"Processing '{pdf_path}'")
+        converted_json = (Path(out_path) / f"{file_name}.json")
+        converted_json_f = str(converted_json)
+        logger.debug(f"Converting '{pdf_path}'")
+        t0 = time.time()
 
-    converted_doc: DoclingDocument = convert_doc(pdf_path, cache_dir=out_path / file_name)
-    converted_doc.save_as_json(str(converted_json_f))
+        converted_doc: DoclingDocument = convert_doc(pdf_path, cache_dir=out_path / file_name)
+        converted_doc.save_as_json(str(converted_json_f))
 
-    conversion_time = time.time() - t0
-    logger.debug(f"'{pdf_path}' converted")
-    return converted_json_f, conversion_time
+        conversion_time = time.time() - t0
+        logger.debug(f"'{pdf_path}' converted")
+        return converted_json_f, conversion_time
+    except Exception as e:
+        logger.error(f"Error converting '{pdf_path}': {e}")
+    return None, None
 
 def clean_intermediate_files(doc_id, out_path):
     # Remove intermediate files but keep <doc_id>.json
@@ -266,33 +270,33 @@ def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoi
              ContextAwareThreadPoolExecutor(max_workers=max_worker) as chunker_executor:
 
             # A. Submit Conversions
-                conversion_futures = {}
-                for path in batch_paths:
-                    file_name = ""
-                    doc_id = doc_id_dict.get(Path(path).name)
-                    if doc_id is None:
-                        file_name = path
-                    else:
-                        file_name = doc_id
+            conversion_futures = {}
+            for path in batch_paths:
+                file_name = ""
+                doc_id = doc_id_dict.get(Path(path).name)
+                if doc_id is None:
+                    file_name = path
+                else:
+                    file_name = doc_id
 
-                    try:
-                        future = converter_executor.submit(convert_document, path, out_path, file_name)
-                        conversion_futures[future] = path
-                        # Update status to IN_PROGRESS as soon as document is submitted for conversion
-                        if doc_id is not None:
-                            logger.debug(f"Submitted for conversion: updating job & doc metadata to IN_PROGRESS for document: {doc_id}")
-                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.IN_PROGRESS})
-                            status_mgr.update_job_progress(doc_id, DocStatus.IN_PROGRESS, JobStatus.IN_PROGRESS)
-                    except (BrokenExecutor, RuntimeError) as e:
-                        # Pool is broken, cannot submit more documents
-                        logger.error(f"Cannot submit document {path} - pool is broken: {e}")
-                        if doc_id:
-                            error_msg = f"Process pool broken before submission: {str(e)}"
-                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
-                            status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
-                            processed_doc_ids.add(doc_id)
-                        # Stop trying to submit more documents
-                        break
+                try:
+                    future = converter_executor.submit(convert_document, path, out_path, file_name)
+                    conversion_futures[future] = path
+                    # Update status to IN_PROGRESS as soon as document is submitted for conversion
+                    if doc_id is not None:
+                        logger.debug(f"Submitted for conversion: updating job & doc metadata to IN_PROGRESS for document: {doc_id}")
+                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.IN_PROGRESS})
+                        status_mgr.update_job_progress(doc_id, DocStatus.IN_PROGRESS, JobStatus.IN_PROGRESS)
+                except (BrokenExecutor, RuntimeError) as e:
+                    # Pool is broken, cannot submit more documents
+                    logger.error(f"Cannot submit document {path} - pool is broken: {e}")
+                    if doc_id:
+                        error_msg = f"Process pool broken before submission: {str(e)}"
+                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                        status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                        processed_doc_ids.add(doc_id)
+                    # Stop trying to submit more documents
+                    break
 
                 process_futures = {}
                 chunk_futures = {}

--- a/spyre-rag/src/digitize/doc_utils.py
+++ b/spyre-rag/src/digitize/doc_utils.py
@@ -11,7 +11,7 @@ os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 from tqdm import tqdm
 from pathlib import Path
 from docling_core.types.doc.document import DoclingDocument
-from concurrent.futures import as_completed, ProcessPoolExecutor, BrokenExecutor, TimeoutError as FuturesTimeoutError
+from concurrent.futures import as_completed, ProcessPoolExecutor, BrokenExecutor
 from sentence_splitter import SentenceSplitter
 
 # Set third-party library log levels before importing project modules
@@ -202,10 +202,10 @@ def process_converted_document(converted_json_path, pdf_path, out_path, gen_mode
 
         return None, None, None, None, None
 
-def _safe_convert_document(pdf_path, out_path, file_name):
+def convert_document(pdf_path, out_path, file_name):
     """
-    Internal conversion function that can raise exceptions.
-    This is the actual worker logic without exception handling.
+    Worker function for document conversion.
+    This function runs in a separate process via ProcessPoolExecutor.
     """
     logger.info(f"Processing '{pdf_path}'")
     converted_json = (Path(out_path) / f"{file_name}.json")
@@ -219,42 +219,6 @@ def _safe_convert_document(pdf_path, out_path, file_name):
     conversion_time = time.time() - t0
     logger.debug(f"'{pdf_path}' converted")
     return converted_json_f, conversion_time
-
-
-def convert_document(pdf_path, out_path, file_name):
-    """
-    Guarded worker wrapper for document conversion.
-    This function runs in a separate process via ProcessPoolExecutor.
-
-    Returns a structured result dict with success/failure information.
-    The parent process is responsible for updating document status based on this result.
-    """
-    result = {
-        "success": False,
-        "converted_json": None,
-        "conversion_time": None,
-        "error": None,
-        "error_type": None
-    }
-
-    try:
-        converted_json, conversion_time = _safe_convert_document(pdf_path, out_path, file_name)
-        result["success"] = True
-        result["converted_json"] = converted_json
-        result["conversion_time"] = conversion_time
-        return result
-    except MemoryError as e:
-        # OOM - process will likely be killed soon
-        result["error"] = f"Out of memory: {str(e)}"
-        result["error_type"] = "OOM"
-        logger.error(f"OOM error converting '{pdf_path}': {e}")
-        return result
-    except Exception as e:
-        # Catch all other exceptions to return structured error
-        result["error"] = str(e)
-        result["error_type"] = type(e).__name__
-        logger.error(f"Error converting '{pdf_path}': {e}", exc_info=True)
-        return result
 
 def clean_intermediate_files(doc_id, out_path):
     # Remove intermediate files but keep <doc_id>.json
@@ -293,193 +257,189 @@ def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoi
         if not batch_paths:
             return batch_stats, batch_chunk_paths, batch_table_paths
 
+        # Track all documents in this batch for cleanup
+        batch_doc_ids = {doc_id_dict.get(Path(path).name) for path in batch_paths if doc_id_dict.get(Path(path).name)}
+        processed_doc_ids = set()  # Track which documents completed processing
+
         with ProcessPoolExecutor(max_workers=convert_worker) as converter_executor, \
              ContextAwareThreadPoolExecutor(max_workers=max_worker) as processor_executor, \
              ContextAwareThreadPoolExecutor(max_workers=max_worker) as chunker_executor:
 
             # A. Submit Conversions
-            conversion_futures = {}
-            for path in batch_paths:
-                file_name = ""
-                doc_id = doc_id_dict.get(Path(path).name)
-                if doc_id is None:
-                    file_name = path
-                else:
-                    file_name = doc_id
-                future = converter_executor.submit(convert_document, path, out_path, file_name)
-                conversion_futures[future] = path
-                # Update status to IN_PROGRESS as soon as document is submitted for conversion
-                if doc_id is not None:
-                    logger.debug(f"Submitted for conversion: updating job & doc metadata to IN_PROGRESS for document: {doc_id}")
-                    status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.IN_PROGRESS})
-                    status_mgr.update_job_progress(doc_id, DocStatus.IN_PROGRESS, JobStatus.IN_PROGRESS)
+                conversion_futures = {}
+                for path in batch_paths:
+                    file_name = ""
+                    doc_id = doc_id_dict.get(Path(path).name)
+                    if doc_id is None:
+                        file_name = path
+                    else:
+                        file_name = doc_id
 
-            process_futures = {}
-            chunk_futures = {}
-
-            # B. Handle Conversions -> Submit Processing
-            # Per-file timeout to prevent single document from blocking entire batch
-            per_file_timeout = 3600  # 1 hour per document
-
-            for fut in as_completed(conversion_futures, timeout=per_file_timeout * len(conversion_futures)):
-                path = conversion_futures[fut]
-                doc_id = doc_id_dict.get(Path(path).name)
-                try:
-                    # Get structured result from guarded worker with per-file timeout
-                    result = fut.result(timeout=per_file_timeout)
-
-                    # Parent-side state management: Check worker result structure
-                    if not result or not isinstance(result, dict):
-                        # Worker crashed or returned invalid result
+                    try:
+                        future = converter_executor.submit(convert_document, path, out_path, file_name)
+                        conversion_futures[future] = path
+                        # Update status to IN_PROGRESS as soon as document is submitted for conversion
                         if doc_id is not None:
-                            error_msg = "Worker process crashed or returned invalid result"
-                            logger.error(f"Conversion failed for {path}: {error_msg}")
+                            logger.debug(f"Submitted for conversion: updating job & doc metadata to IN_PROGRESS for document: {doc_id}")
+                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.IN_PROGRESS})
+                            status_mgr.update_job_progress(doc_id, DocStatus.IN_PROGRESS, JobStatus.IN_PROGRESS)
+                    except (BrokenExecutor, RuntimeError) as e:
+                        # Pool is broken, cannot submit more documents
+                        logger.error(f"Cannot submit document {path} - pool is broken: {e}")
+                        if doc_id:
+                            error_msg = f"Process pool broken before submission: {str(e)}"
                             status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
                             status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
-                        continue
+                            processed_doc_ids.add(doc_id)
+                        # Stop trying to submit more documents
+                        break
 
-                    # Check if worker reported failure
-                    if not result.get("success"):
+                process_futures = {}
+                chunk_futures = {}
+
+                # B. Handle Conversions -> Submit Processing
+                for fut in as_completed(conversion_futures):
+                    path = conversion_futures[fut]
+                    doc_id = doc_id_dict.get(Path(path).name)
+                    try:
+                        converted_json, conv_time = fut.result()
+
+                        if not converted_json:
+                            if doc_id is not None:
+                                logger.error(f"Conversion failed for {path}: converted_json is None")
+                                status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error="Failed to convert document: conversion returned None")
+                                status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                                processed_doc_ids.add(doc_id)
+                            continue
+
+                        # Update persistence and session stats
+                        batch_stats[path] = {"timings": {"digitizing": round(float(conv_time or 0), 2)}}
+
                         if doc_id is not None:
-                            error_type = result.get("error_type", "Unknown")
-                            error_msg = result.get("error", "Conversion failed")
+                            logger.debug(f"Conversion Done: updating doc & job metadata for document: {doc_id}")
+                            status_mgr.update_doc_metadata(doc_id, {
+                                "status": DocStatus.DIGITIZED,
+                                "timing_in_secs": {**batch_stats[path]["timings"]}
+                            })
+                            status_mgr.update_job_progress(doc_id, DocStatus.DIGITIZED, JobStatus.IN_PROGRESS)
+                            processed_doc_ids.add(doc_id)
 
-                            # Provide specific error message for OOM
-                            if error_type == "OOM":
-                                error_msg = f"Out of memory during conversion: {error_msg}"
-
-                            logger.error(f"Conversion failed for {path}: {error_msg}")
-                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
-                            status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
-                        continue
-
-                    # Extract successful results
-                    converted_json = result.get("converted_json")
-                    conv_time = result.get("conversion_time")
-
-                    if not converted_json:
-                        if doc_id is not None:
-                            logger.error(f"Conversion failed for {path}: converted_json is None")
-                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error="Failed to convert document: conversion returned None")
-                            status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
-                        continue
-
-                    # Update persistence and session stats
-                    batch_stats[path] = {"timings": {"digitizing": round(float(conv_time or 0), 2)}}
-
-                    if doc_id is not None:
-                        logger.debug(f"Conversion Done: updating doc & job metadata for document: {doc_id}")
-                        status_mgr.update_doc_metadata(doc_id, {
-                            "status": DocStatus.DIGITIZED,
-                            "timing_in_secs": {**batch_stats[path]["timings"]}
-                        })
-                        status_mgr.update_job_progress(doc_id, DocStatus.DIGITIZED, JobStatus.IN_PROGRESS)
-
-                    p_future = processor_executor.submit(
-                        process_converted_document, converted_json, path, out_path,
-                        llm_model, llm_endpoint, emb_endpoint, max_tokens, doc_id=doc_id
-                    )
-                    process_futures[p_future] = str(path)
-                except FuturesTimeoutError:
-                    # Per-file timeout exceeded
-                    if doc_id is not None:
-                        error_msg = f"Conversion timed out after {per_file_timeout} seconds"
-                        logger.error(f"{error_msg} for {path}")
-                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
-                        status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
-                except (BrokenExecutor, RuntimeError, Exception) as e:
-                    # Handle pool crashes and other errors
-                    error_type = "Process pool crashed" if isinstance(e, (BrokenExecutor, RuntimeError)) else "Conversion error"
-                    logger.error(f"{error_type} for {path}: {str(e)}", exc_info=True)
-                    batch_stats.pop(path, {})
-                    if doc_id is not None:
-                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"{error_type}: {str(e)}")
-                        status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
-
-            # C. Handle Processing -> Submit Chunking
-            for fut in as_completed(process_futures):
-                path = process_futures[fut]
-                doc_id = doc_id_dict.get(Path(path).name)
-                try:
-                    txt_json, tab_json, pgs, tabs, timings = fut.result()
-
-                    if not txt_json or not tab_json:
-                        if doc_id is not None:
-                            logger.error(f"Processing failed for {path}: txt_json or tab_json is None")
-                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"Failed to process document {doc_id}: processing returned None")
-                            status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                        p_future = processor_executor.submit(
+                            process_converted_document, converted_json, path, out_path,
+                            llm_model, llm_endpoint, emb_endpoint, max_tokens, doc_id=doc_id
+                        )
+                        process_futures[p_future] = str(path)
+                    except (BrokenExecutor, RuntimeError, Exception) as e:
+                        # Handle pool crashes and other errors
+                        error_type = "Process pool crashed" if isinstance(e, (BrokenExecutor, RuntimeError)) else "Conversion error"
+                        logger.error(f"{error_type} for {path}: {str(e)}", exc_info=True)
                         batch_stats.pop(path, {})
-                        continue
-
-                    total_processing_time = timings["process_text"] + timings["process_tables"]
-                    batch_stats[path].update({
-                        "page_count": pgs,
-                        "table_count": tabs
-                    })
-                    batch_stats[path]["timings"]["processing"] = round(float(total_processing_time or 0), 2)
-                    batch_table_paths.append(tab_json)
-
-                    if doc_id is not None:
-                        logger.debug(f"Processing Done: updating doc & job metadata for document: {doc_id}")
-                        status_mgr.update_doc_metadata(doc_id, {
-                            "status": DocStatus.PROCESSED,
-                            "pages": pgs,
-                            "tables": tabs,
-                            "timing_in_secs": {**batch_stats[path]["timings"]}
-                        })
-                        status_mgr.update_job_progress(
-                            doc_id=doc_id,
-                            doc_status=DocStatus.PROCESSED,  # Transitioning within processing
-                            job_status=JobStatus.IN_PROGRESS
-                    )
-
-                    c_future = chunker_executor.submit(
-                        chunk_single_file, txt_json, path, out_path,
-                        emb_endpoint, max_tokens, doc_id=doc_id
-                    )
-                    chunk_futures[c_future] = (str(path), tab_json)
-                except Exception as e:
-                    if doc_id is not None:
-                        logger.error(f"Error from processing for {path}: {str(e)}", exc_info=True)
-                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"failed to process document: {str(e)}")
-                        status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
-                    batch_stats.pop(path, {})
-
-            # D. Handle Chunking
-            for fut in as_completed(chunk_futures):
-                path, tab_json = chunk_futures[fut]
-                doc_id = doc_id_dict.get(Path(path).name)
-                try:
-                    chunk_json, _, chunk_time = fut.result()
-
-                    if not chunk_json:
                         if doc_id is not None:
-                            logger.error(f"Chunking failed for {path}: chunk_json is None")
-                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"failed to chunk document {doc_id}: chunk_json returned is None")
+                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"{error_type}: {str(e)}")
                             status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
-                        batch_stats.pop(path, {})
-                        continue
+                            processed_doc_ids.add(doc_id)
 
-                    batch_stats[path]["timings"]["chunking"] = round(float(chunk_time or 0), 2)
-                    batch_chunk_paths.append(chunk_json)
-                    # Capture chunk counts in real time and update <doc_id>_metadata.json
-                    chunk_count = count_chunks(chunk_json, tab_json)
-                    batch_stats[path]["chunk_count"] = chunk_count
+                # C. Handle Processing -> Submit Chunking
+                for fut in as_completed(process_futures):
+                    path = process_futures[fut]
+                    doc_id = doc_id_dict.get(Path(path).name)
+                    try:
+                        txt_json, tab_json, pgs, tabs, timings = fut.result()
 
-                    if doc_id is not None:
-                        logger.debug(f"Chunking Done: updating doc & job metadata for document: {doc_id}")
-                        status_mgr.update_doc_metadata(doc_id, {
-                            "status": DocStatus.CHUNKED,
-                            "chunks": chunk_count,
-                            "timing_in_secs": {**batch_stats[path]["timings"]}
+                        if not txt_json or not tab_json:
+                            if doc_id is not None:
+                                logger.error(f"Processing failed for {path}: txt_json or tab_json is None")
+                                status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"Failed to process document {doc_id}: processing returned None")
+                                status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                                processed_doc_ids.add(doc_id)
+                            batch_stats.pop(path, {})
+                            continue
+
+                        total_processing_time = timings["process_text"] + timings["process_tables"]
+                        batch_stats[path].update({
+                            "page_count": pgs,
+                            "table_count": tabs
                         })
-                        status_mgr.update_job_progress(doc_id, DocStatus.CHUNKED, JobStatus.IN_PROGRESS)
-                except Exception as e:
-                    if doc_id is not None:
-                        logger.error(f"Error from chunking for {path}: {str(e)}", exc_info=True)
-                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"failed to chunk document: {str(e)}")
-                        status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
-                    batch_stats.pop(path, {})
+                        batch_stats[path]["timings"]["processing"] = round(float(total_processing_time or 0), 2)
+                        batch_table_paths.append(tab_json)
+
+                        if doc_id is not None:
+                            logger.debug(f"Processing Done: updating doc & job metadata for document: {doc_id}")
+                            status_mgr.update_doc_metadata(doc_id, {
+                                "status": DocStatus.PROCESSED,
+                                "pages": pgs,
+                                "tables": tabs,
+                                "timing_in_secs": {**batch_stats[path]["timings"]}
+                            })
+                            status_mgr.update_job_progress(
+                                doc_id=doc_id,
+                                doc_status=DocStatus.PROCESSED,  # Transitioning within processing
+                                job_status=JobStatus.IN_PROGRESS
+                        )
+                            processed_doc_ids.add(doc_id)
+
+                        c_future = chunker_executor.submit(
+                            chunk_single_file, txt_json, path, out_path,
+                            emb_endpoint, max_tokens, doc_id=doc_id
+                        )
+                        chunk_futures[c_future] = (str(path), tab_json)
+                    except Exception as e:
+                        if doc_id is not None:
+                            logger.error(f"Error from processing for {path}: {str(e)}", exc_info=True)
+                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"failed to process document: {str(e)}")
+                            status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                            processed_doc_ids.add(doc_id)
+                        batch_stats.pop(path, {})
+
+                # D. Handle Chunking
+                for fut in as_completed(chunk_futures):
+                    path, tab_json = chunk_futures[fut]
+                    doc_id = doc_id_dict.get(Path(path).name)
+                    try:
+                        chunk_json, _, chunk_time = fut.result()
+
+                        if not chunk_json:
+                            if doc_id is not None:
+                                logger.error(f"Chunking failed for {path}: chunk_json is None")
+                                status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"failed to chunk document {doc_id}: chunk_json returned is None")
+                                status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                                processed_doc_ids.add(doc_id)
+                            batch_stats.pop(path, {})
+                            continue
+
+                        batch_stats[path]["timings"]["chunking"] = round(float(chunk_time or 0), 2)
+                        batch_chunk_paths.append(chunk_json)
+                        # Capture chunk counts in real time and update <doc_id>_metadata.json
+                        chunk_count = count_chunks(chunk_json, tab_json)
+                        batch_stats[path]["chunk_count"] = chunk_count
+
+                        if doc_id is not None:
+                            logger.debug(f"Chunking Done: updating doc & job metadata for document: {doc_id}")
+                            status_mgr.update_doc_metadata(doc_id, {
+                                "status": DocStatus.CHUNKED,
+                                "chunks": chunk_count,
+                                "timing_in_secs": {**batch_stats[path]["timings"]}
+                            })
+                            status_mgr.update_job_progress(doc_id, DocStatus.CHUNKED, JobStatus.IN_PROGRESS)
+                            processed_doc_ids.add(doc_id)
+                    except Exception as e:
+                        if doc_id is not None:
+                            logger.error(f"Error from chunking for {path}: {str(e)}", exc_info=True)
+                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"failed to chunk document: {str(e)}")
+                            status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                            processed_doc_ids.add(doc_id)
+                        batch_stats.pop(path, {})
+
+        # CRITICAL: Mark any documents that were never processed as FAILED
+        # This handles the case where pool crashes before all documents are submitted/processed
+        orphaned_doc_ids = batch_doc_ids - processed_doc_ids
+        if orphaned_doc_ids:
+            logger.warning(f"Found {len(orphaned_doc_ids)} orphaned document(s) in batch that were never processed")
+            for orphan_doc_id in orphaned_doc_ids:
+                error_msg = "Document was never processed - pool may have crashed or been exhausted"
+                logger.warning(f"Marking orphaned document {orphan_doc_id} as FAILED")
+                status_mgr.update_doc_metadata(orphan_doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                status_mgr.update_job_progress(orphan_doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
 
         return batch_stats, batch_chunk_paths, batch_table_paths
 

--- a/spyre-rag/src/digitize/doc_utils.py
+++ b/spyre-rag/src/digitize/doc_utils.py
@@ -11,7 +11,7 @@ os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 from tqdm import tqdm
 from pathlib import Path
 from docling_core.types.doc.document import DoclingDocument
-from concurrent.futures import as_completed, ProcessPoolExecutor
+from concurrent.futures import as_completed, ProcessPoolExecutor, BrokenExecutor, TimeoutError as FuturesTimeoutError
 from sentence_splitter import SentenceSplitter
 
 # Set third-party library log levels before importing project modules
@@ -202,27 +202,59 @@ def process_converted_document(converted_json_path, pdf_path, out_path, gen_mode
 
         return None, None, None, None, None
 
+def _safe_convert_document(pdf_path, out_path, file_name):
+    """
+    Internal conversion function that can raise exceptions.
+    This is the actual worker logic without exception handling.
+    """
+    logger.info(f"Processing '{pdf_path}'")
+    converted_json = (Path(out_path) / f"{file_name}.json")
+    converted_json_f = str(converted_json)
+    logger.debug(f"Converting '{pdf_path}'")
+    t0 = time.time()
+
+    converted_doc: DoclingDocument = convert_doc(pdf_path, cache_dir=out_path / file_name)
+    converted_doc.save_as_json(str(converted_json_f))
+
+    conversion_time = time.time() - t0
+    logger.debug(f"'{pdf_path}' converted")
+    return converted_json_f, conversion_time
+
+
 def convert_document(pdf_path, out_path, file_name):
     """
-    Convert a single document to JSON format.
+    Guarded worker wrapper for document conversion.
     This function runs in a separate process via ProcessPoolExecutor.
+
+    Returns a structured result dict with success/failure information.
+    The parent process is responsible for updating document status based on this result.
     """
+    result = {
+        "success": False,
+        "converted_json": None,
+        "conversion_time": None,
+        "error": None,
+        "error_type": None
+    }
+
     try:
-        logger.info(f"Processing '{pdf_path}'")
-        converted_json = (Path(out_path) / f"{file_name}.json")
-        converted_json_f = str(converted_json)
-        logger.debug(f"Converting '{pdf_path}'")
-        t0 = time.time()
-
-        converted_doc: DoclingDocument = convert_doc(pdf_path, cache_dir=out_path / file_name)
-        converted_doc.save_as_json(str(converted_json_f))
-
-        conversion_time = time.time() - t0
-        logger.debug(f"'{pdf_path}' converted")
-        return converted_json_f, conversion_time
+        converted_json, conversion_time = _safe_convert_document(pdf_path, out_path, file_name)
+        result["success"] = True
+        result["converted_json"] = converted_json
+        result["conversion_time"] = conversion_time
+        return result
+    except MemoryError as e:
+        # OOM - process will likely be killed soon
+        result["error"] = f"Out of memory: {str(e)}"
+        result["error_type"] = "OOM"
+        logger.error(f"OOM error converting '{pdf_path}': {e}")
+        return result
     except Exception as e:
-        logger.error(f"Error converting '{pdf_path}': {e}")
-    return None, None
+        # Catch all other exceptions to return structured error
+        result["error"] = str(e)
+        result["error_type"] = type(e).__name__
+        logger.error(f"Error converting '{pdf_path}': {e}", exc_info=True)
+        return result
 
 def clean_intermediate_files(doc_id, out_path):
     # Remove intermediate files but keep <doc_id>.json
@@ -286,16 +318,50 @@ def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoi
             chunk_futures = {}
 
             # B. Handle Conversions -> Submit Processing
-            for fut in as_completed(conversion_futures):
+            # Per-file timeout to prevent single document from blocking entire batch
+            per_file_timeout = 3600  # 1 hour per document
+
+            for fut in as_completed(conversion_futures, timeout=per_file_timeout * len(conversion_futures)):
                 path = conversion_futures[fut]
                 doc_id = doc_id_dict.get(Path(path).name)
                 try:
-                    converted_json, conv_time = fut.result()
+                    # Get structured result from guarded worker with per-file timeout
+                    result = fut.result(timeout=per_file_timeout)
+
+                    # Parent-side state management: Check worker result structure
+                    if not result or not isinstance(result, dict):
+                        # Worker crashed or returned invalid result
+                        if doc_id is not None:
+                            error_msg = "Worker process crashed or returned invalid result"
+                            logger.error(f"Conversion failed for {path}: {error_msg}")
+                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                            status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                        continue
+
+                    # Check if worker reported failure
+                    if not result.get("success"):
+                        if doc_id is not None:
+                            error_type = result.get("error_type", "Unknown")
+                            error_msg = result.get("error", "Conversion failed")
+
+                            # Provide specific error message for OOM
+                            if error_type == "OOM":
+                                error_msg = f"Out of memory during conversion: {error_msg}"
+
+                            logger.error(f"Conversion failed for {path}: {error_msg}")
+                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                            status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                        continue
+
+                    # Extract successful results
+                    converted_json = result.get("converted_json")
+                    conv_time = result.get("conversion_time")
+
                     if not converted_json:
                         if doc_id is not None:
                             logger.error(f"Conversion failed for {path}: converted_json is None")
                             status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error="Failed to convert document: conversion returned None")
-                            status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.FAILED, error="Failed to convert document: conversion returned None")
+                            status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
                         continue
 
                     # Update persistence and session stats
@@ -314,11 +380,20 @@ def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoi
                         llm_model, llm_endpoint, emb_endpoint, max_tokens, doc_id=doc_id
                     )
                     process_futures[p_future] = str(path)
-                except Exception as e:
-                    logger.error(f"Error from conversion for {path}: {str(e)}", exc_info=True)
+                except FuturesTimeoutError:
+                    # Per-file timeout exceeded
+                    if doc_id is not None:
+                        error_msg = f"Conversion timed out after {per_file_timeout} seconds"
+                        logger.error(f"{error_msg} for {path}")
+                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                        status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                except (BrokenExecutor, RuntimeError, Exception) as e:
+                    # Handle pool crashes and other errors
+                    error_type = "Process pool crashed" if isinstance(e, (BrokenExecutor, RuntimeError)) else "Conversion error"
+                    logger.error(f"{error_type} for {path}: {str(e)}", exc_info=True)
                     batch_stats.pop(path, {})
                     if doc_id is not None:
-                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"failed to convert document: {str(e)}")
+                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"{error_type}: {str(e)}")
                         status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
 
             # C. Handle Processing -> Submit Chunking

--- a/spyre-rag/src/digitize/doc_utils.py
+++ b/spyre-rag/src/digitize/doc_utils.py
@@ -297,6 +297,17 @@ def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoi
                         processed_doc_ids.add(doc_id)
                     # Stop trying to submit more documents
                     break
+                except Exception as e:
+                    # Handle any other unexpected failures during document submission
+                    logger.error(f"Unexpected error submitting document {path} for conversion: {e}", exc_info=True)
+                    if doc_id:
+                        error_msg = f"Failed to submit document for conversion: {str(e)}"
+                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                        status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                        processed_doc_ids.add(doc_id)
+                    # Continue processing other documents
+                    continue
+                
 
                 process_futures = {}
                 chunk_futures = {}
@@ -333,15 +344,28 @@ def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoi
                             llm_model, llm_endpoint, emb_endpoint, max_tokens, doc_id=doc_id
                         )
                         process_futures[p_future] = str(path)
-                    except (BrokenExecutor, RuntimeError, Exception) as e:
-                        # Handle pool crashes and other errors
-                        error_type = "Process pool crashed" if isinstance(e, (BrokenExecutor, RuntimeError)) else "Conversion error"
-                        logger.error(f"{error_type} for {path}: {str(e)}", exc_info=True)
+                    except (BrokenExecutor, RuntimeError) as e:
+                        # Pool is broken, cannot submit more documents
+                        logger.error(f"Cannot submit document {path} for processing - pool is broken: {e}")
                         batch_stats.pop(path, {})
-                        if doc_id is not None:
-                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"{error_type}: {str(e)}")
+                        if doc_id:
+                            error_msg = f"Process pool broken during conversion: {str(e)}"
+                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
                             status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
                             processed_doc_ids.add(doc_id)
+                        # Stop trying to process more documents
+                        break
+                    except Exception as e:
+                        # Handle any other unexpected failures during conversion
+                        logger.error(f"Unexpected error during conversion for {path}: {e}", exc_info=True)
+                        batch_stats.pop(path, {})
+                        if doc_id:
+                            error_msg = f"Failed during conversion: {str(e)}"
+                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                            status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                            processed_doc_ids.add(doc_id)
+                        # Continue processing other documents
+                        continue
 
                 # C. Handle Processing -> Submit Chunking
                 for fut in as_completed(process_futures):
@@ -387,13 +411,28 @@ def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoi
                             emb_endpoint, max_tokens, doc_id=doc_id
                         )
                         chunk_futures[c_future] = (str(path), tab_json)
-                    except Exception as e:
-                        if doc_id is not None:
-                            logger.error(f"Error from processing for {path}: {str(e)}", exc_info=True)
-                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"failed to process document: {str(e)}")
+                    except (BrokenExecutor, RuntimeError) as e:
+                        # Pool is broken, cannot submit more documents
+                        logger.error(f"Cannot submit document {path} for chunking - pool is broken: {e}")
+                        batch_stats.pop(path, {})
+                        if doc_id:
+                            error_msg = f"Process pool broken during processing: {str(e)}"
+                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
                             status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
                             processed_doc_ids.add(doc_id)
+                        # Stop trying to process more documents
+                        break
+                    except Exception as e:
+                        # Handle any other unexpected failures during processing
+                        logger.error(f"Unexpected error during processing for {path}: {e}", exc_info=True)
                         batch_stats.pop(path, {})
+                        if doc_id:
+                            error_msg = f"Failed during processing: {str(e)}"
+                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                            status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                            processed_doc_ids.add(doc_id)
+                        # Continue processing other documents
+                        continue
 
                 # D. Handle Chunking
                 for fut in as_completed(chunk_futures):
@@ -427,12 +466,16 @@ def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoi
                             status_mgr.update_job_progress(doc_id, DocStatus.CHUNKED, JobStatus.IN_PROGRESS)
                             processed_doc_ids.add(doc_id)
                     except Exception as e:
-                        if doc_id is not None:
-                            logger.error(f"Error from chunking for {path}: {str(e)}", exc_info=True)
-                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"failed to chunk document: {str(e)}")
+                        # Handle any unexpected failures during chunking
+                        logger.error(f"Unexpected error during chunking for {path}: {e}", exc_info=True)
+                        batch_stats.pop(path, {})
+                        if doc_id:
+                            error_msg = f"Failed during chunking: {str(e)}"
+                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
                             status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
                             processed_doc_ids.add(doc_id)
-                        batch_stats.pop(path, {})
+                        # Continue processing other documents
+                        continue
 
         # CRITICAL: Mark any documents that were never processed as FAILED
         # This handles the case where pool crashes before all documents are submitted/processed

--- a/spyre-rag/src/digitize/doc_utils.py
+++ b/spyre-rag/src/digitize/doc_utils.py
@@ -271,6 +271,9 @@ def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoi
 
             # A. Submit Conversions
             conversion_futures = {}
+            process_futures = {}
+            chunk_futures = {}
+
             for path in batch_paths:
                 file_name = ""
                 doc_id = doc_id_dict.get(Path(path).name)
@@ -307,175 +310,171 @@ def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoi
                         processed_doc_ids.add(doc_id)
                     # Continue processing other documents
                     continue
-                
 
-                process_futures = {}
-                chunk_futures = {}
+            # B. Handle Conversions -> Submit Processing
+            for fut in as_completed(conversion_futures):
+                path = conversion_futures[fut]
+                doc_id = doc_id_dict.get(Path(path).name)
+                try:
+                    converted_json, conv_time = fut.result()
 
-                # B. Handle Conversions -> Submit Processing
-                for fut in as_completed(conversion_futures):
-                    path = conversion_futures[fut]
-                    doc_id = doc_id_dict.get(Path(path).name)
-                    try:
-                        converted_json, conv_time = fut.result()
-
-                        if not converted_json:
-                            if doc_id is not None:
-                                logger.error(f"Conversion failed for {path}: converted_json is None")
-                                status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error="Failed to convert document: conversion returned None")
-                                status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
-                                processed_doc_ids.add(doc_id)
-                            continue
-
-                        # Update persistence and session stats
-                        batch_stats[path] = {"timings": {"digitizing": round(float(conv_time or 0), 2)}}
-
+                    if not converted_json:
                         if doc_id is not None:
-                            logger.debug(f"Conversion Done: updating doc & job metadata for document: {doc_id}")
-                            status_mgr.update_doc_metadata(doc_id, {
-                                "status": DocStatus.DIGITIZED,
-                                "timing_in_secs": {**batch_stats[path]["timings"]}
-                            })
-                            status_mgr.update_job_progress(doc_id, DocStatus.DIGITIZED, JobStatus.IN_PROGRESS)
-                            processed_doc_ids.add(doc_id)
-
-                        p_future = processor_executor.submit(
-                            process_converted_document, converted_json, path, out_path,
-                            llm_model, llm_endpoint, emb_endpoint, max_tokens, doc_id=doc_id
-                        )
-                        process_futures[p_future] = str(path)
-                    except (BrokenExecutor, RuntimeError) as e:
-                        # Pool is broken, cannot submit more documents
-                        logger.error(f"Cannot submit document {path} for processing - pool is broken: {e}")
-                        batch_stats.pop(path, {})
-                        if doc_id:
-                            error_msg = f"Process pool broken during conversion: {str(e)}"
-                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                            logger.error(f"Conversion failed for {path}: converted_json is None")
+                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error="Failed to convert document: conversion returned None")
                             status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
                             processed_doc_ids.add(doc_id)
-                        # Stop trying to process more documents
-                        break
-                    except Exception as e:
-                        # Handle any other unexpected failures during conversion
-                        logger.error(f"Unexpected error during conversion for {path}: {e}", exc_info=True)
-                        batch_stats.pop(path, {})
-                        if doc_id:
-                            error_msg = f"Failed during conversion: {str(e)}"
-                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
-                            status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
-                            processed_doc_ids.add(doc_id)
-                        # Continue processing other documents
                         continue
 
-                # C. Handle Processing -> Submit Chunking
-                for fut in as_completed(process_futures):
-                    path = process_futures[fut]
-                    doc_id = doc_id_dict.get(Path(path).name)
-                    try:
-                        txt_json, tab_json, pgs, tabs, timings = fut.result()
+                    # Update persistence and session stats
+                    batch_stats[path] = {"timings": {"digitizing": round(float(conv_time or 0), 2)}}
 
-                        if not txt_json or not tab_json:
-                            if doc_id is not None:
-                                logger.error(f"Processing failed for {path}: txt_json or tab_json is None")
-                                status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"Failed to process document {doc_id}: processing returned None")
-                                status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
-                                processed_doc_ids.add(doc_id)
-                            batch_stats.pop(path, {})
-                            continue
-
-                        total_processing_time = timings["process_text"] + timings["process_tables"]
-                        batch_stats[path].update({
-                            "page_count": pgs,
-                            "table_count": tabs
+                    if doc_id is not None:
+                        logger.debug(f"Conversion Done: updating doc & job metadata for document: {doc_id}")
+                        status_mgr.update_doc_metadata(doc_id, {
+                            "status": DocStatus.DIGITIZED,
+                            "timing_in_secs": {**batch_stats[path]["timings"]}
                         })
-                        batch_stats[path]["timings"]["processing"] = round(float(total_processing_time or 0), 2)
-                        batch_table_paths.append(tab_json)
+                        status_mgr.update_job_progress(doc_id, DocStatus.DIGITIZED, JobStatus.IN_PROGRESS)
+                        processed_doc_ids.add(doc_id)
 
+                    p_future = processor_executor.submit(
+                        process_converted_document, converted_json, path, out_path,
+                        llm_model, llm_endpoint, emb_endpoint, max_tokens, doc_id=doc_id
+                    )
+                    process_futures[p_future] = str(path)
+                except (BrokenExecutor, RuntimeError) as e:
+                    # Pool is broken, cannot submit more documents
+                    logger.error(f"Cannot submit document {path} for processing - pool is broken: {e}")
+                    batch_stats.pop(path, {})
+                    if doc_id:
+                        error_msg = f"Process pool broken during conversion: {str(e)}"
+                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                        status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                        processed_doc_ids.add(doc_id)
+                    # Stop trying to process more documents
+                    break
+                except Exception as e:
+                    # Handle any other unexpected failures during conversion
+                    logger.error(f"Unexpected error during conversion for {path}: {e}", exc_info=True)
+                    batch_stats.pop(path, {})
+                    if doc_id:
+                        error_msg = f"Failed during conversion: {str(e)}"
+                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                        status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                        processed_doc_ids.add(doc_id)
+                    # Continue processing other documents
+                    continue
+
+            # C. Handle Processing -> Submit Chunking
+            for fut in as_completed(process_futures):
+                path = process_futures[fut]
+                doc_id = doc_id_dict.get(Path(path).name)
+                try:
+                    txt_json, tab_json, pgs, tabs, timings = fut.result()
+
+                    if not txt_json or not tab_json:
                         if doc_id is not None:
-                            logger.debug(f"Processing Done: updating doc & job metadata for document: {doc_id}")
-                            status_mgr.update_doc_metadata(doc_id, {
-                                "status": DocStatus.PROCESSED,
-                                "pages": pgs,
-                                "tables": tabs,
-                                "timing_in_secs": {**batch_stats[path]["timings"]}
-                            })
-                            status_mgr.update_job_progress(
-                                doc_id=doc_id,
-                                doc_status=DocStatus.PROCESSED,  # Transitioning within processing
-                                job_status=JobStatus.IN_PROGRESS
-                        )
-                            processed_doc_ids.add(doc_id)
-
-                        c_future = chunker_executor.submit(
-                            chunk_single_file, txt_json, path, out_path,
-                            emb_endpoint, max_tokens, doc_id=doc_id
-                        )
-                        chunk_futures[c_future] = (str(path), tab_json)
-                    except (BrokenExecutor, RuntimeError) as e:
-                        # Pool is broken, cannot submit more documents
-                        logger.error(f"Cannot submit document {path} for chunking - pool is broken: {e}")
-                        batch_stats.pop(path, {})
-                        if doc_id:
-                            error_msg = f"Process pool broken during processing: {str(e)}"
-                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                            logger.error(f"Processing failed for {path}: txt_json or tab_json is None")
+                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"Failed to process document {doc_id}: processing returned None")
                             status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
                             processed_doc_ids.add(doc_id)
-                        # Stop trying to process more documents
-                        break
-                    except Exception as e:
-                        # Handle any other unexpected failures during processing
-                        logger.error(f"Unexpected error during processing for {path}: {e}", exc_info=True)
                         batch_stats.pop(path, {})
-                        if doc_id:
-                            error_msg = f"Failed during processing: {str(e)}"
-                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
-                            status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
-                            processed_doc_ids.add(doc_id)
-                        # Continue processing other documents
                         continue
 
-                # D. Handle Chunking
-                for fut in as_completed(chunk_futures):
-                    path, tab_json = chunk_futures[fut]
-                    doc_id = doc_id_dict.get(Path(path).name)
-                    try:
-                        chunk_json, _, chunk_time = fut.result()
+                    total_processing_time = timings["process_text"] + timings["process_tables"]
+                    batch_stats[path].update({
+                        "page_count": pgs,
+                        "table_count": tabs
+                    })
+                    batch_stats[path]["timings"]["processing"] = round(float(total_processing_time or 0), 2)
+                    batch_table_paths.append(tab_json)
 
-                        if not chunk_json:
-                            if doc_id is not None:
-                                logger.error(f"Chunking failed for {path}: chunk_json is None")
-                                status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"failed to chunk document {doc_id}: chunk_json returned is None")
-                                status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
-                                processed_doc_ids.add(doc_id)
-                            batch_stats.pop(path, {})
-                            continue
+                    if doc_id is not None:
+                        logger.debug(f"Processing Done: updating doc & job metadata for document: {doc_id}")
+                        status_mgr.update_doc_metadata(doc_id, {
+                            "status": DocStatus.PROCESSED,
+                            "pages": pgs,
+                            "tables": tabs,
+                            "timing_in_secs": {**batch_stats[path]["timings"]}
+                        })
+                        status_mgr.update_job_progress(
+                            doc_id=doc_id,
+                            doc_status=DocStatus.PROCESSED,  # Transitioning within processing
+                            job_status=JobStatus.IN_PROGRESS
+                    )
+                        processed_doc_ids.add(doc_id)
 
-                        batch_stats[path]["timings"]["chunking"] = round(float(chunk_time or 0), 2)
-                        batch_chunk_paths.append(chunk_json)
-                        # Capture chunk counts in real time and update <doc_id>_metadata.json
-                        chunk_count = count_chunks(chunk_json, tab_json)
-                        batch_stats[path]["chunk_count"] = chunk_count
+                    c_future = chunker_executor.submit(
+                        chunk_single_file, txt_json, path, out_path,
+                        emb_endpoint, max_tokens, doc_id=doc_id
+                    )
+                    chunk_futures[c_future] = (str(path), tab_json)
+                except (BrokenExecutor, RuntimeError) as e:
+                    # Pool is broken, cannot submit more documents
+                    logger.error(f"Cannot submit document {path} for chunking - pool is broken: {e}")
+                    batch_stats.pop(path, {})
+                    if doc_id:
+                        error_msg = f"Process pool broken during processing: {str(e)}"
+                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                        status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                        processed_doc_ids.add(doc_id)
+                    # Stop trying to process more documents
+                    break
+                except Exception as e:
+                    # Handle any other unexpected failures during processing
+                    logger.error(f"Unexpected error during processing for {path}: {e}", exc_info=True)
+                    batch_stats.pop(path, {})
+                    if doc_id:
+                        error_msg = f"Failed during processing: {str(e)}"
+                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                        status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                        processed_doc_ids.add(doc_id)
+                    # Continue processing other documents
+                    continue
 
+            # D. Handle Chunking
+            for fut in as_completed(chunk_futures):
+                path, tab_json = chunk_futures[fut]
+                doc_id = doc_id_dict.get(Path(path).name)
+                try:
+                    chunk_json, _, chunk_time = fut.result()
+
+                    if not chunk_json:
                         if doc_id is not None:
-                            logger.debug(f"Chunking Done: updating doc & job metadata for document: {doc_id}")
-                            status_mgr.update_doc_metadata(doc_id, {
-                                "status": DocStatus.CHUNKED,
-                                "chunks": chunk_count,
-                                "timing_in_secs": {**batch_stats[path]["timings"]}
-                            })
-                            status_mgr.update_job_progress(doc_id, DocStatus.CHUNKED, JobStatus.IN_PROGRESS)
-                            processed_doc_ids.add(doc_id)
-                    except Exception as e:
-                        # Handle any unexpected failures during chunking
-                        logger.error(f"Unexpected error during chunking for {path}: {e}", exc_info=True)
-                        batch_stats.pop(path, {})
-                        if doc_id:
-                            error_msg = f"Failed during chunking: {str(e)}"
-                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                            logger.error(f"Chunking failed for {path}: chunk_json is None")
+                            status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=f"failed to chunk document {doc_id}: chunk_json returned is None")
                             status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
                             processed_doc_ids.add(doc_id)
-                        # Continue processing other documents
+                        batch_stats.pop(path, {})
                         continue
+
+                    batch_stats[path]["timings"]["chunking"] = round(float(chunk_time or 0), 2)
+                    batch_chunk_paths.append(chunk_json)
+                    # Capture chunk counts in real time and update <doc_id>_metadata.json
+                    chunk_count = count_chunks(chunk_json, tab_json)
+                    batch_stats[path]["chunk_count"] = chunk_count
+
+                    if doc_id is not None:
+                        logger.debug(f"Chunking Done: updating doc & job metadata for document: {doc_id}")
+                        status_mgr.update_doc_metadata(doc_id, {
+                            "status": DocStatus.CHUNKED,
+                            "chunks": chunk_count,
+                            "timing_in_secs": {**batch_stats[path]["timings"]}
+                        })
+                        status_mgr.update_job_progress(doc_id, DocStatus.CHUNKED, JobStatus.IN_PROGRESS)
+                        processed_doc_ids.add(doc_id)
+                except Exception as e:
+                    # Handle any unexpected failures during chunking
+                    logger.error(f"Unexpected error during chunking for {path}: {e}", exc_info=True)
+                    batch_stats.pop(path, {})
+                    if doc_id:
+                        error_msg = f"Failed during chunking: {str(e)}"
+                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                        status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+                        processed_doc_ids.add(doc_id)
+                    # Continue processing other documents
+                    continue
 
         # CRITICAL: Mark any documents that were never processed as FAILED
         # This handles the case where pool crashes before all documents are submitted/processed

--- a/spyre-rag/src/digitize/ingest.py
+++ b/spyre-rag/src/digitize/ingest.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import time
+import json
 from typing import Optional
 
 import common.db_utils as db
@@ -16,6 +17,43 @@ def ingest(directory_path: Path, job_id: Optional[str] = None, doc_id_dict: Opti
 
     def ingestion_failed():
         logger.info("❌ Ingestion failed, please re-run the ingestion again, If the issue still persists, please report an issue in https://github.com/IBM/project-ai-services/issues")
+
+    def finalize_orphaned_documents(status_mgr, job_id, doc_id_dict):
+        """
+        Job Reaper/Finalizer: Ensures all documents reach a terminal state (COMPLETED or FAILED).
+        This prevents job deadlock by marking any stuck documents as FAILED.
+        Called in the finally block to guarantee execution even on catastrophic failures.
+        """
+        if not status_mgr or not job_id or not doc_id_dict:
+            return
+
+        try:
+            doc_stats = get_job_document_stats(job_id)
+            total_docs = doc_stats["total_docs"]
+            completed_count = doc_stats["completed_count"]
+            failed_count = doc_stats["failed_count"]
+
+            # Check if there are orphaned documents (not in terminal state)
+            terminal_count = completed_count + failed_count
+            if terminal_count < total_docs:
+                orphaned_count = total_docs - terminal_count
+                logger.warning(f"Job Reaper: Found {orphaned_count} orphaned document(s) in job {job_id}")
+
+                # Mark all orphaned documents as FAILED
+                for filename, doc_id in doc_id_dict.items():
+                    # Check if document is in terminal state
+                    is_completed = any(doc["id"] == doc_id for doc in doc_stats["completed_docs"])
+                    is_failed = any(doc["id"] == doc_id for doc in doc_stats["failed_docs"])
+
+                    if not is_completed and not is_failed:
+                        error_msg = "Document processing incomplete - marked as failed during job finalization"
+                        logger.warning(f"Job Reaper: Finalizing orphaned document {doc_id} as FAILED")
+                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
+                        status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
+
+                logger.info(f"Job Reaper: Marked {orphaned_count} orphaned document(s) as FAILED")
+        except Exception as e:
+            logger.error(f"Job Reaper: Error during job finalization for {job_id}: {e}", exc_info=True)
 
     logger.info(f"Ingestion started from dir '{directory_path}'")
     
@@ -185,3 +223,41 @@ def ingest(directory_path: Path, job_id: Optional[str] = None, doc_id_dict: Opti
                 raise fnf_error
 
         return None
+
+    finally:
+        # Job Reaper: ALWAYS run finalization to ensure no orphaned documents
+        # This critical section prevents job deadlock
+        if status_mgr and job_id and doc_id_dict:
+            logger.debug(f"Running job finalizer for job {job_id}")
+            finalize_orphaned_documents(status_mgr, job_id, doc_id_dict)
+
+            # After finalization, ensure job reaches terminal state
+            try:
+                doc_stats = get_job_document_stats(job_id)
+                total_docs = doc_stats["total_docs"]
+                completed_count = doc_stats["completed_count"]
+                failed_count = doc_stats["failed_count"]
+                terminal_count = completed_count + failed_count
+
+                # If all documents are in terminal state, finalize the job
+                if terminal_count == total_docs:
+                    # Read current job status to avoid overwriting
+                    job_file = config.JOBS_DIR / f"{job_id}_status.json"
+                    if job_file.exists():
+                        with open(job_file, "r") as f:
+                            job_data = json.load(f)
+                        current_status = job_data.get("status")
+
+                        # Only update if job is still IN_PROGRESS
+                        if current_status == JobStatus.IN_PROGRESS.value:
+                            if failed_count > 0:
+                                error_msg = f"{failed_count} of {total_docs} document(s) failed"
+                                status_mgr.update_job_progress("", DocStatus.FAILED, JobStatus.FAILED, error=error_msg)
+                                logger.info(f"Job {job_id} finalized as FAILED ({failed_count} failures)")
+                            else:
+                                status_mgr.update_job_progress("", DocStatus.COMPLETED, JobStatus.COMPLETED)
+                                logger.info(f"Job {job_id} finalized as COMPLETED")
+                else:
+                    logger.warning(f"Job {job_id} has {total_docs - terminal_count} documents not in terminal state after finalization")
+            except Exception as final_error:
+                logger.error(f"Error during final job status update for {job_id}: {final_error}", exc_info=True)

--- a/spyre-rag/src/digitize/ingest.py
+++ b/spyre-rag/src/digitize/ingest.py
@@ -18,42 +18,6 @@ def ingest(directory_path: Path, job_id: Optional[str] = None, doc_id_dict: Opti
     def ingestion_failed():
         logger.info("❌ Ingestion failed, please re-run the ingestion again, If the issue still persists, please report an issue in https://github.com/IBM/project-ai-services/issues")
 
-    def finalize_orphaned_documents(status_mgr, job_id, doc_id_dict):
-        """
-        Job Reaper/Finalizer: Ensures all documents reach a terminal state (COMPLETED or FAILED).
-        This prevents job deadlock by marking any stuck documents as FAILED.
-        Called in the finally block to guarantee execution even on catastrophic failures.
-        """
-        if not status_mgr or not job_id or not doc_id_dict:
-            return
-
-        try:
-            doc_stats = get_job_document_stats(job_id)
-            total_docs = doc_stats["total_docs"]
-            completed_count = doc_stats["completed_count"]
-            failed_count = doc_stats["failed_count"]
-
-            # Check if there are orphaned documents (not in terminal state)
-            terminal_count = completed_count + failed_count
-            if terminal_count < total_docs:
-                orphaned_count = total_docs - terminal_count
-                logger.warning(f"Job Reaper: Found {orphaned_count} orphaned document(s) in job {job_id}")
-
-                # Mark all orphaned documents as FAILED
-                for filename, doc_id in doc_id_dict.items():
-                    # Check if document is in terminal state
-                    is_completed = any(doc["id"] == doc_id for doc in doc_stats["completed_docs"])
-                    is_failed = any(doc["id"] == doc_id for doc in doc_stats["failed_docs"])
-
-                    if not is_completed and not is_failed:
-                        error_msg = "Document processing incomplete - marked as failed during job finalization"
-                        logger.warning(f"Job Reaper: Finalizing orphaned document {doc_id} as FAILED")
-                        status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.FAILED}, error=error_msg)
-                        status_mgr.update_job_progress(doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS)
-
-                logger.info(f"Job Reaper: Marked {orphaned_count} orphaned document(s) as FAILED")
-        except Exception as e:
-            logger.error(f"Job Reaper: Error during job finalization for {job_id}: {e}", exc_info=True)
 
     logger.info(f"Ingestion started from dir '{directory_path}'")
     
@@ -224,40 +188,3 @@ def ingest(directory_path: Path, job_id: Optional[str] = None, doc_id_dict: Opti
 
         return None
 
-    finally:
-        # Job Reaper: ALWAYS run finalization to ensure no orphaned documents
-        # This critical section prevents job deadlock
-        if status_mgr and job_id and doc_id_dict:
-            logger.debug(f"Running job finalizer for job {job_id}")
-            finalize_orphaned_documents(status_mgr, job_id, doc_id_dict)
-
-            # After finalization, ensure job reaches terminal state
-            try:
-                doc_stats = get_job_document_stats(job_id)
-                total_docs = doc_stats["total_docs"]
-                completed_count = doc_stats["completed_count"]
-                failed_count = doc_stats["failed_count"]
-                terminal_count = completed_count + failed_count
-
-                # If all documents are in terminal state, finalize the job
-                if terminal_count == total_docs:
-                    # Read current job status to avoid overwriting
-                    job_file = config.JOBS_DIR / f"{job_id}_status.json"
-                    if job_file.exists():
-                        with open(job_file, "r") as f:
-                            job_data = json.load(f)
-                        current_status = job_data.get("status")
-
-                        # Only update if job is still IN_PROGRESS
-                        if current_status == JobStatus.IN_PROGRESS.value:
-                            if failed_count > 0:
-                                error_msg = f"{failed_count} of {total_docs} document(s) failed"
-                                status_mgr.update_job_progress("", DocStatus.FAILED, JobStatus.FAILED, error=error_msg)
-                                logger.info(f"Job {job_id} finalized as FAILED ({failed_count} failures)")
-                            else:
-                                status_mgr.update_job_progress("", DocStatus.COMPLETED, JobStatus.COMPLETED)
-                                logger.info(f"Job {job_id} finalized as COMPLETED")
-                else:
-                    logger.warning(f"Job {job_id} has {total_docs - terminal_count} documents not in terminal state after finalization")
-            except Exception as final_error:
-                logger.error(f"Error during final job status update for {job_id}: {final_error}", exc_info=True)

--- a/spyre-rag/src/digitize/ingest.py
+++ b/spyre-rag/src/digitize/ingest.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import time
-import json
 from typing import Optional
 
 import common.db_utils as db
@@ -17,7 +16,6 @@ def ingest(directory_path: Path, job_id: Optional[str] = None, doc_id_dict: Opti
 
     def ingestion_failed():
         logger.info("❌ Ingestion failed, please re-run the ingestion again, If the issue still persists, please report an issue in https://github.com/IBM/project-ai-services/issues")
-
 
     logger.info(f"Ingestion started from dir '{directory_path}'")
     
@@ -187,4 +185,3 @@ def ingest(directory_path: Path, job_id: Optional[str] = None, doc_id_dict: Opti
                 raise fnf_error
 
         return None
-


### PR DESCRIPTION
- Tracking the documents which are being handled in each phase of ingestion to handle final cleanup if they get stuck in case of process pool crashes.
- Implemented ingestion job reaper that runs cleanup of stuck documents to move to terminal state in process crash scenario which helps processing of future ingestion requests to be processed

With these changes, now all docs are marked to failed in case of process crash and job is marked with failure
<img width="612" height="1650" alt="image" src="https://github.com/user-attachments/assets/5ddeabd0-e75a-4a4a-acf3-9d107150d0cf" />



Addresses the issue [AISERVICES-883](https://jsw.ibm.com/browse/AISERVICES-883)