### PR TITLE
AI-Services 878: fixes to support concurrency

### DIFF
--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.84
+  image: icr.io/ai-services-cicd/rag:v0.0.85
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.84
+  image: icr.io/ai-services-cicd/rag:v0.0.85
   # @hidden
   log_level: "INFO"
 
@@ -56,6 +56,6 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.84
+  image: icr.io/ai-services-cicd/rag:v0.0.85
   # @hidden
   log_level: "INFO"

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -4,19 +4,19 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.84
+  image: icr.io/ai-services-cicd/rag:v0.0.85
   # @hidden
   log_level: "INFO"
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.84
+  image: icr.io/ai-services-cicd/rag:v0.0.85
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.84
+  image: icr.io/ai-services-cicd/rag:v0.0.85
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.84
+  image: icr.io/ai-services-cicd/rag:v0.0.85
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.84
+  image: icr.io/ai-services-cicd/rag:v0.0.85
   # @hidden
   log_level: "INFO"
 
@@ -56,6 +56,6 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.84
+  image: icr.io/ai-services-cicd/rag:v0.0.85
   # @hidden
   log_level: "INFO"

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -4,19 +4,19 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.84
+  image: icr.io/ai-services-cicd/rag:v0.0.85
   # @hidden
   log_level: "INFO"
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.84
+  image: icr.io/ai-services-cicd/rag:v0.0.85
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.84
+  image: icr.io/ai-services-cicd/rag:v0.0.85
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.84
+  image: icr.io/ai-services-cicd/rag:v0.0.85
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.84
+  image: icr.io/ai-services-cicd/rag:v0.0.85
   # @hidden
   log_level: "INFO"
 
@@ -56,6 +56,6 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.84
+  image: icr.io/ai-services-cicd/rag:v0.0.85
   # @hidden
   log_level: "INFO"

--- a/spyre-rag/src/Makefile
+++ b/spyre-rag/src/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=rag
-TAG?=v0.0.84
+TAG?=v0.0.85
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman

--- a/spyre-rag/src/summarize/summ_utils.py
+++ b/spyre-rag/src/summarize/summ_utils.py
@@ -4,6 +4,7 @@ import re
 from typing import Optional
 import pypdfium2 as pdfium
 from pydantic import BaseModel, Field
+import threading
 
 from common.settings import get_settings
 from common.misc_utils import set_log_level, get_logger
@@ -20,6 +21,7 @@ set_log_level(log_level)
 logger = get_logger("summarize")
 
 settings = get_settings()
+_pdf_lock = threading.Lock()
 
 # Pre-compute max input word count from context length at startup
 # input_words/ratio + buf + (input_words/ratio)*coeff < max_model_len
@@ -45,16 +47,17 @@ def compute_target_and_max_tokens(input_word_count: int, summary_length: Optiona
     return target_word_count, max_tokens
 
 def extract_text_from_pdf(content: bytes) -> str:
-    pdf = pdfium.PdfDocument(content)
-    text_parts = []
-    for page_index in range(len(pdf)):
-        page = pdf[page_index]
-        textpage = page.get_textpage()
-        text_parts.append(textpage.get_text_range())
-        textpage.close()
-        page.close()
-    pdf.close()
-    return "\n".join(text_parts)
+    with _pdf_lock:
+        pdf = pdfium.PdfDocument(content)
+        text_parts = []
+        for page_index in range(len(pdf)):
+            page = pdf[page_index]
+            textpage = page.get_textpage()
+            text_parts.append(textpage.get_text_range())
+            textpage.close()
+            page.close()
+        pdf.close()
+        return "\n".join(text_parts)
 
 def trim_to_last_sentence(text: str) -> str:
     """Remove any trailing incomplete sentence."""


### PR DESCRIPTION
- run pdf extraction under a thread lock
- one non-async call fix which is pushed already



concurrency test with pdf:
<img width="417" height="546" alt="Screenshot 2026-04-09 at 9 28 15 AM" src="https://github.com/user-attachments/assets/fafd83b3-88de-4d31-8d15-55cdfe918240" />

concurrency test with txt file:
<img width="417" height="546" alt="Screenshot 2026-04-09 at 9 44 37 AM" src="https://github.com/user-attachments/assets/3366b648-821f-4784-b11f-7f894f45c34c" />
