### PR TITLE
build: Clean up hf cache from rag-base

### DIFF
--- a/images/rag-base/Containerfile
+++ b/images/rag-base/Containerfile
@@ -23,4 +23,5 @@ RUN --mount=type=bind,from=prebuilder,source=/wheels,target=/wheels,ro \
         --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux \
         --prefer-binary && \
     pip cache purge && \
-    python download_docling_models.py
+    python download_docling_models.py && \
+    rm -rf ~/.cache/huggingface

--- a/images/rag-base/Makefile
+++ b/images/rag-base/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=rag-base
-TAG?=v0.0.20
+TAG?=v0.0.21
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman


### PR DESCRIPTION
1. Cleans up 500MB worth of cache from the image
```
[root@4e079a8c423e /]# du -sh /root/.cache/huggingface/
506M    /root/.cache/huggingface/
```
2. Also, rag-base update is needed to fix the High sev python version issues.