### PR TITLE
build: Migration to UBI Minimal for rag-base

### DIFF
--- a/images/rag-base/Containerfile
+++ b/images/rag-base/Containerfile
@@ -1,12 +1,14 @@
 FROM localhost/prebuilder as prebuilder
 
-FROM registry.access.redhat.com/ubi9/ubi:9.7
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 
-RUN yum install -y --setopt=tsflags=nodocs python3.12-devel python3.12-pip \
+RUN microdnf install -y python3.12-devel python3.12-pip \
         lcms2-devel openblas-devel freetype libicu libjpeg-turbo && \
-    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
-    yum install -y spatialindex-devel && \
-    yum clean all && rm -rf /var/cache/yum && \
+    curl -o /tmp/epel-release.rpm https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    rpm -ivh /tmp/epel-release.rpm && \
+    rm -f /tmp/epel-release.rpm && \
+    microdnf install -y spatialindex-devel && \
+    microdnf clean all && \
     rm -rf /usr/bin/python && rm -rf /usr/bin/python3 && \
     ln -s /usr/bin/pip3.12 /usr/bin/pip && ln -s /usr/bin/pip3.12 /usr/bin/pip3 && \
     ln -s /usr/bin/python3.12 /usr/bin/python && ln -s /usr/bin/python3.12 /usr/bin/python3

--- a/images/rag-base/Makefile
+++ b/images/rag-base/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=rag-base
-TAG?=v0.0.21
+TAG?=v0.0.22
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman


### PR DESCRIPTION
This change will:
1. Reduce the image size for base and other rag images
2. Limit the number of vulnerable packages. Eg: `vim-minimal` currently has no fix.