### PR TITLE
Move SMT configuration to bootstrap configure

### DIFF
--- a/ai-services/assets/applications/rag-dev/metadata.yaml
+++ b/ai-services/assets/applications/rag-dev/metadata.yaml
@@ -2,6 +2,5 @@ name: rag-dev
 description: "Retrieval Augmented Generation (RAG) application that combines a vector database, a large language model, 
               and a retrieval mechanism to provide accurate and context-aware responses based on ingested documents."
 hidden: true
-smtLevel: 2
 openshift:
   timeout: 20m

--- a/ai-services/assets/applications/rag/metadata.yaml
+++ b/ai-services/assets/applications/rag/metadata.yaml
@@ -1,6 +1,5 @@
 name: rag
 description: "Retrieval Augmented Generation (RAG) application that combines a vector database, a large language model, 
               and a retrieval mechanism to provide accurate and context-aware responses based on ingested documents."
-smtLevel: 2
 openshift:
   timeout: 30m

--- a/ai-services/internal/pkg/application/podman/create.go
+++ b/ai-services/internal/pkg/application/podman/create.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os/exec"
 	"slices"
 	"strconv"
 	"strings"
@@ -38,18 +37,6 @@ var (
 func (p *PodmanApplication) Create(ctx context.Context, opts types.CreateOptions) error {
 	// Proceed to create application
 	logger.Infof("Creating application '%s' using template '%s'\n", opts.Name, opts.TemplateName)
-
-	// set SMT level to target value
-	s := spinner.New("Checking SMT level")
-	s.Start(ctx)
-	err := p.setSMTLevel(opts.TemplateName)
-	if err != nil {
-		s.Fail("failed to set SMT level")
-
-		return fmt.Errorf("failed to set SMT level: %w", err)
-	}
-	s.Stop("SMT level configured successfully")
-
 	tp := templates.NewEmbedTemplateProvider(templates.EmbedOptions{})
 
 	// validate whether the provided template name is correct
@@ -206,100 +193,6 @@ func (p *PodmanApplication) downloadModels(ctx context.Context, templateName, ap
 	s.Stop("Model download completed.")
 
 	return nil
-}
-
-func (p *PodmanApplication) setSMTLevel(templateName string) error {
-	// 1. Fetch Current SMT level
-	cmd := exec.Command("ppc64_cpu", "--smt")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to check current SMT level: %v, output: %s", err, string(out))
-	}
-
-	currentSMTlevel, err := p.getSMTLevel(string(out))
-	if err != nil {
-		return fmt.Errorf("failed to get current SMT level: %w", err)
-	}
-
-	// 2. Fetch the target SMT level
-	targetSMTLevel, err := p.getTargetSMTLevel(templateName)
-	if err != nil {
-		return fmt.Errorf("failed to get target SMT level: %w", err)
-	}
-
-	if targetSMTLevel == nil {
-		// No SMT level specified in metadata.yaml
-		logger.Infof("No SMT level specified in metadata.yaml. Keeping it to current level: %d\n", currentSMTlevel)
-
-		return nil
-	}
-
-	// 3. Check if SMT level is already set to target value
-	if currentSMTlevel == *targetSMTLevel {
-		// already set
-		logger.Infof("SMT level is already set to %d\n", *targetSMTLevel)
-
-		return nil
-	}
-
-	// 4. Set SMT level to target value
-	arg := "--smt=" + strconv.Itoa(*targetSMTLevel)
-	cmd = exec.Command("ppc64_cpu", arg)
-	out, err = cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to set SMT level: %v, output: %s", err, string(out))
-	}
-
-	// 5. Verify again
-	cmd = exec.Command("ppc64_cpu", "--smt")
-	out, err = cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to verify SMT level: %v, output: %s", err, string(out))
-	}
-
-	currentSMTlevel, err = p.getSMTLevel(string(out))
-	if err != nil {
-		return fmt.Errorf("failed to get SMT level after updating: %w", err)
-	}
-
-	if currentSMTlevel != *targetSMTLevel {
-		return fmt.Errorf("SMT level verification failed: expected %d, got %d", targetSMTLevel, currentSMTlevel)
-	}
-
-	return nil
-}
-
-func (p *PodmanApplication) getSMTLevel(output string) (int, error) {
-	out := strings.TrimSpace(output)
-
-	if !strings.HasPrefix(out, "SMT=") {
-		return 0, fmt.Errorf("unexpected output: %s", out)
-	}
-
-	SMTLevelStr := strings.TrimPrefix(out, "SMT=")
-	SMTlevel, err := strconv.Atoi(SMTLevelStr)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse SMT level: %w", err)
-	}
-
-	return SMTlevel, nil
-}
-
-func (p *PodmanApplication) getTargetSMTLevel(templateName string) (*int, error) {
-	tp := templates.NewEmbedTemplateProvider(templates.EmbedOptions{})
-
-	// validate whether the provided template name is correct
-	if err := validators.ValidateAppTemplateExist(tp, templateName); err != nil {
-		return nil, err
-	}
-
-	// load metadata.yml to read the app metadata
-	appMetadata, err := tp.LoadMetadata(templateName, false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read the app metadata: %w", err)
-	}
-
-	return appMetadata.SMTLevel, nil
 }
 
 func (p *PodmanApplication) verifyPodTemplateExists(tmpls map[string]*template.Template, appMetadata *templates.AppMetadata) error {

--- a/ai-services/internal/pkg/bootstrap/podman/configure.go
+++ b/ai-services/internal/pkg/bootstrap/podman/configure.go
@@ -55,7 +55,7 @@ func (p *PodmanBootstrap) Configure() error {
 		s.Stop("Podman already configured")
 	}
 
-	s = spinner.New("Configuring SMT level")
+	s = spinner.New("Configuring SMT level to 2")
 	s.Start(ctx)
 	// 2. Configure SMT level to 2 and persist via systemd
 	if err := setupSMTLevel(); err != nil {

--- a/ai-services/internal/pkg/bootstrap/podman/configure.go
+++ b/ai-services/internal/pkg/bootstrap/podman/configure.go
@@ -55,9 +55,19 @@ func (p *PodmanBootstrap) Configure() error {
 		s.Stop("Podman already configured")
 	}
 
+	s = spinner.New("Configuring SMT level")
+	s.Start(ctx)
+	// 2. Configure SMT level to 2 and persist via systemd
+	if err := setupSMTLevel(); err != nil {
+		s.Fail("failed to configure SMT level")
+
+		return err
+	}
+	s.Stop("SMT level configured successfully (set to 2)")
+
 	s = spinner.New("Checking spyre card configuration")
 	s.Start(ctx)
-	// 2. Spyre cards – run servicereport tool to validate and repair spyre configurations
+	// 3. Spyre cards – run servicereport tool to validate and repair spyre configurations
 	if err := runServiceReport(); err != nil {
 		s.Fail("failed to configure spyre card")
 

--- a/ai-services/internal/pkg/bootstrap/podman/helper.go
+++ b/ai-services/internal/pkg/bootstrap/podman/helper.go
@@ -9,12 +9,11 @@ import (
 	"time"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/validators"
 	"github.com/project-ai-services/ai-services/internal/pkg/validators/podman/spyre"
 )
-
-const smtLevel = 2
 
 func runServiceReport() error {
 	// validate spyre attachment first before running servicereport
@@ -170,14 +169,7 @@ func setupSMTLevel() error {
 		return fmt.Errorf("failed to get current SMT level: %w", err)
 	}
 
-	// Skip setup if SMT is already set to 2
-	if currentSMTLevel == smtLevel {
-		logger.Infof("SMT level is already set to %d, skipping setup", smtLevel, logger.VerbosityLevelDebug)
-
-		return nil
-	}
-
-	logger.Infof("Current SMT level is %d, setting to %d", currentSMTLevel, smtLevel, logger.VerbosityLevelDebug)
+	logger.Infof("Current SMT level is %d", currentSMTLevel, logger.VerbosityLevelDebug)
 
 	// 1. Enable smtstate.service
 	if err := systemctl("enable", "smtstate.service"); err != nil {
@@ -192,12 +184,17 @@ func setupSMTLevel() error {
 	logger.Infoln("smtstate.service started successfully", logger.VerbosityLevelDebug)
 
 	// 3. Set SMT level to 2
-	cmd = exec.Command("ppc64_cpu", fmt.Sprintf("--smt=%d", smtLevel))
-	out, err = cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to set SMT level to %d: %v, output: %s", smtLevel, err, string(out))
+	if currentSMTLevel != constants.SMTLevel {
+		logger.Infof("Setting SMT level from %d to %d", currentSMTLevel, constants.SMTLevel, logger.VerbosityLevelDebug)
+		cmd = exec.Command("ppc64_cpu", fmt.Sprintf("--smt=%d", constants.SMTLevel))
+		out, err = cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to set SMT level to %d: %v, output: %s", constants.SMTLevel, err, string(out))
+		}
+		logger.Infof("SMT level set to %d", constants.SMTLevel, logger.VerbosityLevelDebug)
+	} else {
+		logger.Infof("SMT level is already set to %d", constants.SMTLevel, logger.VerbosityLevelDebug)
 	}
-	logger.Infof("SMT level set to %d", smtLevel, logger.VerbosityLevelDebug)
 
 	// 4. Restart smtstate.service to persist the setting
 	if err := systemctl("restart", "smtstate.service"); err != nil {

--- a/ai-services/internal/pkg/bootstrap/podman/helper.go
+++ b/ai-services/internal/pkg/bootstrap/podman/helper.go
@@ -158,6 +158,27 @@ func systemctl(action, unit string) error {
 }
 
 func setupSMTLevel() error {
+	// Check current SMT level first
+	cmd := exec.Command("ppc64_cpu", "--smt")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to check current SMT level: %v, output: %s", err, string(out))
+	}
+
+	currentSMTLevel, err := getSMTLevel(string(out))
+	if err != nil {
+		return fmt.Errorf("failed to get current SMT level: %w", err)
+	}
+
+	// Skip setup if SMT is already set to 2
+	if currentSMTLevel == smtLevel {
+		logger.Infoln("SMT level is already set to %d, skipping setup", smtLevel, logger.VerbosityLevelDebug)
+
+		return nil
+	}
+
+	logger.Infoln("Current SMT level is %d, setting to %d", currentSMTLevel, smtLevel, logger.VerbosityLevelDebug)
+
 	// 1. Enable smtstate.service
 	if err := systemctl("enable", "smtstate.service"); err != nil {
 		return fmt.Errorf("failed to enable smtstate.service: %w", err)
@@ -171,12 +192,12 @@ func setupSMTLevel() error {
 	logger.Infoln("smtstate.service started successfully", logger.VerbosityLevelDebug)
 
 	// 3. Set SMT level to 2
-	cmd := exec.Command("ppc64_cpu", fmt.Sprintf("--smt=%d", smtLevel))
-	out, err := cmd.CombinedOutput()
+	cmd = exec.Command("ppc64_cpu", fmt.Sprintf("--smt=%d", smtLevel))
+	out, err = cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to set SMT level to %d: %v, output: %s", smtLevel, err, string(out))
 	}
-	logger.Infoln(fmt.Sprintf("SMT level set to %d", smtLevel), logger.VerbosityLevelDebug)
+	logger.Infoln("SMT level set to %d", smtLevel, logger.VerbosityLevelDebug)
 
 	// 4. Restart smtstate.service to persist the setting
 	if err := systemctl("restart", "smtstate.service"); err != nil {
@@ -195,7 +216,7 @@ func setupSMTLevel() error {
 	if err != nil {
 		return fmt.Errorf("failed to get current SMT level: %w", err)
 	}
-	logger.Infof("SMT level verified: %s", smtLevel, logger.VerbosityLevelDebug)
+	logger.Infof("SMT level verified: %d", smtLevel, logger.VerbosityLevelDebug)
 
 	return nil
 }

--- a/ai-services/internal/pkg/bootstrap/podman/helper.go
+++ b/ai-services/internal/pkg/bootstrap/podman/helper.go
@@ -172,12 +172,12 @@ func setupSMTLevel() error {
 
 	// Skip setup if SMT is already set to 2
 	if currentSMTLevel == smtLevel {
-		logger.Infoln("SMT level is already set to %d, skipping setup", smtLevel, logger.VerbosityLevelDebug)
+		logger.Infof("SMT level is already set to %d, skipping setup", smtLevel, logger.VerbosityLevelDebug)
 
 		return nil
 	}
 
-	logger.Infoln("Current SMT level is %d, setting to %d", currentSMTLevel, smtLevel, logger.VerbosityLevelDebug)
+	logger.Infof("Current SMT level is %d, setting to %d", currentSMTLevel, smtLevel, logger.VerbosityLevelDebug)
 
 	// 1. Enable smtstate.service
 	if err := systemctl("enable", "smtstate.service"); err != nil {
@@ -197,7 +197,7 @@ func setupSMTLevel() error {
 	if err != nil {
 		return fmt.Errorf("failed to set SMT level to %d: %v, output: %s", smtLevel, err, string(out))
 	}
-	logger.Infoln("SMT level set to %d", smtLevel, logger.VerbosityLevelDebug)
+	logger.Infof("SMT level set to %d", smtLevel, logger.VerbosityLevelDebug)
 
 	// 4. Restart smtstate.service to persist the setting
 	if err := systemctl("restart", "smtstate.service"); err != nil {

--- a/ai-services/internal/pkg/bootstrap/podman/helper.go
+++ b/ai-services/internal/pkg/bootstrap/podman/helper.go
@@ -14,6 +14,8 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/validators/podman/spyre"
 )
 
+const smtLevel = 2
+
 func runServiceReport() error {
 	// validate spyre attachment first before running servicereport
 	spyreCheck := spyre.NewSpyreRule()
@@ -169,12 +171,12 @@ func setupSMTLevel() error {
 	logger.Infoln("smtstate.service started successfully", logger.VerbosityLevelDebug)
 
 	// 3. Set SMT level to 2
-	cmd := exec.Command("ppc64_cpu", "--smt=2")
+	cmd := exec.Command("ppc64_cpu", fmt.Sprintf("--smt=%d", smtLevel))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to set SMT level to 2: %v, output: %s", err, string(out))
+		return fmt.Errorf("failed to set SMT level to %d: %v, output: %s", smtLevel, err, string(out))
 	}
-	logger.Infoln("SMT level set to 2", logger.VerbosityLevelDebug)
+	logger.Infoln(fmt.Sprintf("SMT level set to %d", smtLevel), logger.VerbosityLevelDebug)
 
 	// 4. Restart smtstate.service to persist the setting
 	if err := systemctl("restart", "smtstate.service"); err != nil {

--- a/ai-services/internal/pkg/bootstrap/podman/helper.go
+++ b/ai-services/internal/pkg/bootstrap/podman/helper.go
@@ -154,3 +154,62 @@ func systemctl(action, unit string) error {
 
 	return nil
 }
+
+func setupSMTLevel() error {
+	// 1. Enable smtstate.service
+	if err := systemctl("enable", "smtstate.service"); err != nil {
+		return fmt.Errorf("failed to enable smtstate.service: %w", err)
+	}
+	logger.Infoln("smtstate.service enabled successfully", logger.VerbosityLevelDebug)
+
+	// 2. Start smtstate.service
+	if err := systemctl("start", "smtstate.service"); err != nil {
+		return fmt.Errorf("failed to start smtstate.service: %w", err)
+	}
+	logger.Infoln("smtstate.service started successfully", logger.VerbosityLevelDebug)
+
+	// 3. Set SMT level to 2
+	cmd := exec.Command("ppc64_cpu", "--smt=2")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to set SMT level to 2: %v, output: %s", err, string(out))
+	}
+	logger.Infoln("SMT level set to 2", logger.VerbosityLevelDebug)
+
+	// 4. Restart smtstate.service to persist the setting
+	if err := systemctl("restart", "smtstate.service"); err != nil {
+		return fmt.Errorf("failed to restart smtstate.service: %w", err)
+	}
+	logger.Infoln("smtstate.service restarted successfully", logger.VerbosityLevelDebug)
+
+	// 5. Verify the SMT level is set correctly
+	cmd = exec.Command("ppc64_cpu", "--smt")
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to check current SMT level: %v, output: %s", err, string(out))
+	}
+
+	smtLevel, err := getSMTLevel(string(out))
+	if err != nil {
+		return fmt.Errorf("failed to get current SMT level: %w", err)
+	}
+	logger.Infof("SMT level verified: %s", smtLevel, logger.VerbosityLevelDebug)
+
+	return nil
+}
+
+func getSMTLevel(output string) (int, error) {
+	out := strings.TrimSpace(output)
+
+	if !strings.HasPrefix(out, "SMT=") {
+		return 0, fmt.Errorf("unexpected output: %s", out)
+	}
+
+	SMTLevelStr := strings.TrimPrefix(out, "SMT=")
+	SMTlevel, err := strconv.Atoi(SMTLevelStr)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse SMT level: %w", err)
+	}
+
+	return SMTlevel, nil
+}

--- a/ai-services/internal/pkg/cli/templates/templates.go
+++ b/ai-services/internal/pkg/cli/templates/templates.go
@@ -14,7 +14,6 @@ type AppMetadata struct {
 	Description           string           `yaml:"description,omitempty"`
 	Hidden                bool             `yaml:"hidden,omitempty"`
 	Version               string           `yaml:"version,omitempty"`
-	SMTLevel              *int             `yaml:"smtLevel,omitempty"`
 	PodTemplateExecutions [][]string       `yaml:"podTemplateExecutions"`
 	Openshift             OpenshiftRuntime `yaml:"openshift,omitempty"`
 }

--- a/ai-services/internal/pkg/constants/common.go
+++ b/ai-services/internal/pkg/constants/common.go
@@ -12,6 +12,7 @@ const (
 	VersionV2            = "v2"
 	DSCKind              = "DataScienceCluster"
 	DSCIKind             = "DSCInitialization"
+	SMTLevel             = 2
 )
 
 // OperatorConfig defines configuration for an operator.


### PR DESCRIPTION
Planning to move SMT configuration out of application metadata so that deploying multiple application would not make sense having different SMT as it is a machine wide setting.

Default value is going to be 2 for LPAR