### PR TITLE
Fix: Change log level for container logs

### DIFF
--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -220,7 +220,7 @@ func (pc *PodmanClient) streamContainerLogs(ctx context.Context, containerNameOr
 				if !ok {
 					return
 				}
-				logger.Errorln(line)
+				logger.Infoln(line)
 			}
 		}
 	}()


### PR DESCRIPTION
JIRA: https://jsw.ibm.com/browse/AISERVICES-932

Changed logging in container logs from logger.Errorln(line) to logger.Infoln(line) so that stderr output is displayed as-is without the ERROR prefix. This may be because many containers write all their logs to stderr regardless of the actual log level.