### PR TITLE
Catalog Configure command Implementation - 1

### DIFF
--- a/ai-services/assets/catalog/podman/metadata.yaml
+++ b/ai-services/assets/catalog/podman/metadata.yaml
@@ -2,4 +2,5 @@ name: ai-services-catalog
 version: 0.0.1
 description: "Catalog Services for Project AI-Service"
 podTemplateExecutions:
+  - [password.yaml.tmpl]
   - [catalog.yaml.tmpl]

--- a/ai-services/assets/catalog/podman/steps/next.md
+++ b/ai-services/assets/catalog/podman/steps/next.md
@@ -1,0 +1,1 @@
+- Access the Catalog UI at http://{{ .HOST_IP }}:{{ .UI_PORT }}

--- a/ai-services/assets/catalog/podman/steps/vars_file.yaml
+++ b/ai-services/assets/catalog/podman/steps/vars_file.yaml
@@ -1,0 +1,9 @@
+pods:
+  - name: "{{ .AppName }}--catalog"
+    format: "index .Ports \"3000/tcp\" 0"
+    default: ""
+    alias: UI_PORT
+
+hosts:
+  - fetch: HOST_IP
+    type: ip

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -1,11 +1,13 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "ai-services-catalog"
+  name: "{{ .AppName }}--catalog"
   labels:
+    ai-services.io/application: "{{ .AppName }}"
+    ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:8080"
+    ai-services.io/ports: "{{ .Values.ui.port }}:3000"
 spec:
   containers:
     - name: ui
@@ -17,7 +19,7 @@ spec:
           memory: "512Mi"
       env:
         - name: BACKEND_HOST
-          value: "ai-services-catalog"
+          value: "{{ .AppName }}--catalog"
         - name: BACKEND_PORT
           value: "8080" 
       ports:
@@ -40,14 +42,15 @@ spec:
         seLinuxOptions:
           type: "spc_t"
       env:
-        - name: AUTH_JWT_SECRET
-          value: "{{ .Values.backend.jwtSecret }}"
         - name: CONTAINER_HOST
           value: "unix://{{ .Values.backend.podman.uri }}"
         - name: RUNTIME
           value: "{{ .Values.backend.runtime }}"
         - name: ADMIN_PASSWORD
-          value: "{{ .Values.backend.adminPasswordHash }}"
+          valueFrom:
+            secretKeyRef:
+              name: catalog-secret
+              key: admin-password
       ports:
         - containerPort: 8080
           protocol: TCP

--- a/ai-services/assets/catalog/podman/templates/password.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/password.yaml.tmpl
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: catalog-secret
+type: Opaque
+data:
+  admin-password: {{ .Values.backend.adminPasswordHash }}

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,11 +1,10 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/catalog-ui:0.0.1
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.1
 
 backend:
   port: ""
   image: icr.io/ai-services-cicd/ai-services:0.0.2
-  jwtSecret: ""
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/catalog/catalog.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/catalog.go
@@ -15,6 +15,7 @@ deploying services, and managing service metadata`,
 	}
 
 	catalogCMD.AddCommand(NewAPIServerCmd())
+	catalogCMD.AddCommand(NewConfigureCmd())
 	catalogCMD.AddCommand(NewHashpwCmd())
 	catalogCMD.AddCommand(NewLoginCmd())
 	catalogCMD.AddCommand(NewLogoutCmd())

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -1,0 +1,151 @@
+package catalog
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
+)
+
+var (
+	// Runtime type flag for catalog configure command.
+	runtimeType string
+)
+
+// NewConfigureCmd creates a new configure command for the catalog service.
+func NewConfigureCmd() *cobra.Command {
+	var (
+		rawArgParams []string
+		argParams    map[string]string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "configure",
+		Short: "Configure the catalog service with initial configuration",
+		Long: `Deploys the catalog service with the provided configuration.
+
+Examples:
+	 # Configure catalog service for podman
+	 ai-services catalog configure --runtime podman
+	 
+	 # Configure with custom UI port
+	 ai-services catalog configure --runtime podman --params ui.port=3000`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+
+			var err error
+			argParams, err = validateConfigureFlags(rawArgParams)
+			_ = argParams
+
+			return err
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Prompt for admin password
+			adminPassword, err := promptForPassword()
+			if err != nil {
+				return fmt.Errorf("failed to read admin password: %w", err)
+			}
+
+			_ = adminPassword
+
+			return nil
+
+			// return bootstrap.Run(bootstrap.BootstrapOptions{
+			// 	AdminPassword: adminPassword,
+			// 	Runtime:       vars.RuntimeFactory.GetRuntimeType(),
+			// 	ArgParams:     argParams,
+			// })
+		},
+	}
+
+	configureConfigureFlags(cmd, &rawArgParams)
+
+	return cmd
+}
+
+// validateConfigureFlags validates the configure command flags and initializes runtime.
+func validateConfigureFlags(rawArgParams []string) (map[string]string, error) {
+	// Initialize runtime factory based on flag
+	rt := types.RuntimeType(runtimeType)
+	if !rt.Valid() {
+		return nil, fmt.Errorf("invalid runtime type: %s (must be 'podman' or 'openshift'). Please specify runtime using --runtime flag", runtimeType)
+	}
+
+	vars.RuntimeFactory = runtime.NewRuntimeFactory(rt)
+	logger.Infof("Using runtime: %s\n", rt, logger.VerbosityLevelDebug)
+
+	// Check if podman runtime is being used on unsupported platform
+	if err := utils.CheckPodmanPlatformSupport(vars.RuntimeFactory.GetRuntimeType()); err != nil {
+		return nil, err
+	}
+
+	// Parse params if provided
+	var argParams map[string]string
+	if len(rawArgParams) > 0 {
+		var err error
+		argParams, err = utils.ParseKeyValues(rawArgParams)
+		if err != nil {
+			return nil, fmt.Errorf("invalid params format: %w", err)
+		}
+	}
+
+	return argParams, nil
+}
+
+// configureConfigureFlags configures the flags for the configure command.
+func configureConfigureFlags(cmd *cobra.Command, rawArgParams *[]string) {
+	// Add runtime flag as required
+	cmd.Flags().StringVarP(&runtimeType, "runtime", "r", "", fmt.Sprintf("runtime to use (options: %s, %s) (required)", types.RuntimeTypePodman, types.RuntimeTypeOpenShift))
+	_ = cmd.MarkFlagRequired("runtime")
+
+	cmd.Flags().StringSliceVar(
+		rawArgParams,
+		"params",
+		[]string{},
+		"Inline parameters to configure the catalog service.\n\n"+
+			"Format:\n"+
+			"- Comma-separated key=value pairs\n"+
+			"- Example: --params ui.port=3000\n\n"+
+			"Available parameters:\n"+
+			"- ui.port: Port for the catalog UI (default: random available port)\n",
+	)
+}
+
+// promptForPassword prompts the user to enter a password securely.
+func promptForPassword() (string, error) {
+	fmt.Print("Enter admin password: ")
+	passwordBytes, err := term.ReadPassword(int(syscall.Stdin))
+	fmt.Println() // Print newline after password input
+	if err != nil {
+		return "", err
+	}
+
+	password := string(passwordBytes)
+	if password == "" {
+		return "", fmt.Errorf("password cannot be empty")
+	}
+
+	// Prompt for confirmation
+	fmt.Print("Confirm admin password: ")
+	confirmBytes, err := term.ReadPassword(int(syscall.Stdin))
+	fmt.Println() // Print newline after password input
+	if err != nil {
+		return "", err
+	}
+
+	confirm := string(confirmBytes)
+	if password != confirm {
+		return "", fmt.Errorf("passwords do not match")
+	}
+
+	return password, nil
+}
+
+// Made with Bob


### PR DESCRIPTION
- Asset updates.
- Introduce new Catalog configure sub command.
- Read the admin Password as Prompt.

This is actually broken down/ subset of this PR: https://github.com/IBM/project-ai-services/pull/627 as suggested by @yussufsh to have smaller PRs for better reviewing.

Will be raising subsequent changes in multiple smaller parts.