### PR TITLE
feat: Add runtime param to catalog apiserver

### DIFF
--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -37,15 +37,13 @@ spec:
       image: "{{ .Values.backend.image }}"
       command: ["/bin/sh", "-c"]
       args:
-        - "/usr/bin/ai-services catalog apiserver --port=8080 --admin-username=admin --admin-password-hash=${ADMIN_PASSWORD}"
+        - "/usr/bin/ai-services catalog apiserver --port=8080 --admin-username=admin --admin-password-hash=${ADMIN_PASSWORD} --runtime={{ .Values.backend.runtime }}"
       securityContext:
         seLinuxOptions:
           type: "spc_t"
       env:
         - name: CONTAINER_HOST
           value: "unix://{{ .Values.backend.podman.uri }}"
-        - name: RUNTIME
-          value: "{{ .Values.backend.runtime }}"
         - name: ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -8,6 +8,10 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	"github.com/spf13/cobra"
 )
 
@@ -21,11 +25,24 @@ func NewAPIServerCmd() *cobra.Command {
 		defaultRefreshTokenTTL = time.Hour * 24 * 7
 		adminUserName          string
 		adminPasswordHash      string
+		runtimeType            string
 	)
 	apiserverCmd := &cobra.Command{
 		Use:   "apiserver",
 		Short: "Manage AI Services API server",
 		Long:  `The apiserver command allows you to manage the AI Services API server, including starting, stopping, and checking the status of the server.`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Validate and set runtime
+			rt := types.RuntimeType(runtimeType)
+			if !rt.Valid() {
+				return fmt.Errorf("invalid runtime type: %s (must be '%s' or '%s')", runtimeType, types.RuntimeTypePodman, types.RuntimeTypeOpenShift)
+			}
+
+			vars.RuntimeFactory = runtime.NewRuntimeFactory(rt)
+			logger.Infof("Using runtime: %s\n", rt, logger.VerbosityLevelDebug)
+
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			secretKey := os.Getenv("AUTH_JWT_SECRET")
 			if len(secretKey) == 0 {
@@ -54,6 +71,7 @@ func NewAPIServerCmd() *cobra.Command {
 	apiserverCmd.Flags().DurationVarP(&defaultRefreshTokenTTL, "refresh-token-ttl", "", defaultRefreshTokenTTL, "Time-to-live for refresh tokens")
 	apiserverCmd.Flags().StringVar(&adminUserName, "admin-username", "admin", "Username for the default admin user")
 	apiserverCmd.Flags().StringVar(&adminPasswordHash, "admin-password-hash", "", "Precomputed hash of the password for the default admin user")
+	apiserverCmd.Flags().StringVar(&runtimeType, "runtime", string(types.RuntimeTypePodman), fmt.Sprintf("Runtime to use (options: %s, %s)", types.RuntimeTypePodman, types.RuntimeTypeOpenShift))
 
 	return apiserverCmd
 }


### PR DESCRIPTION
A runtime flag will be needed per runtime so the APIs can resolve proper manifest files.