### PR TITLE
 Bump Go version to fix CVE-2026-32280 (stdlib)

### DIFF
--- a/ai-services/Containerfile
+++ b/ai-services/Containerfile
@@ -4,7 +4,7 @@ ARG CMD_VERSION
 ARG GITCOMMIT
 ARG BUILDDATE
 ARG BUILDTAGS
-ARG GO_VERSION=1.25.8
+ARG GO_VERSION=1.25.9
 
 WORKDIR /go/src/github.com/project-ai-services/ai-services
 

--- a/ai-services/go.mod
+++ b/ai-services/go.mod
@@ -1,6 +1,6 @@
 module github.com/project-ai-services/ai-services
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/charmbracelet/bubbles v0.21.0


### PR DESCRIPTION
There is a High CVE found in stdlib, so updating the go version to remediate cve
[CVE-2026-32280](https://nvd.nist.gov/vuln/detail/CVE-2026-32280)

