### PR TITLE
AISERVICES-975 bugfix for insertion issue in opensearch 

### DIFF
--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 
@@ -56,7 +56,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 
@@ -64,6 +64,6 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -4,25 +4,25 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 
 similarity:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 
@@ -56,7 +56,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 
@@ -64,6 +64,6 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -4,25 +4,25 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 
 similarity:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 
@@ -56,7 +56,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"
 
@@ -64,6 +64,6 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.93
+  image: icr.io/ai-services-cicd/rag:v0.0.94
   # @hidden
   log_level: "INFO"

--- a/spyre-rag/src/Makefile
+++ b/spyre-rag/src/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=rag
-TAG?=v0.0.93
+TAG?=v0.0.94
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman

--- a/spyre-rag/src/digitize/doc_utils.py
+++ b/spyre-rag/src/digitize/doc_utils.py
@@ -337,7 +337,6 @@ def process_table(converted_doc, pdf_path, out_path, gen_model, gen_endpoint):
 
     filtered_table_dicts = {
         idx: {
-            'markdown': markdown,
             'summary': summary,
             'caption': caption,
             'page_number': page_num
@@ -912,7 +911,6 @@ def chunk_tables(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None
             for block in tqdm_wrapper(tab_data_list, desc=f"Chunking tables of '{input_path}'"):
                 caption = block.get('caption', '')
                 summary = block.get("summary", '')
-                markdown_source = block.get("markdown", '')
                 page_number = block.get('page_number')
 
                 # Use summary for chunking - summaries are more concise and meaningful for RAG
@@ -929,14 +927,12 @@ def chunk_tables(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None
                         chunked_tables.append({
                             "content": chunk,
                             "caption": caption,
-                            "markdown_source": markdown_source,
                             "page_number": page_number,
                         })
                 else:
                     chunked_tables.append({
                         "content": summary,
                         "caption": caption,
-                        "markdown_source": markdown_source,
                         "page_number": page_number,
                     })
 
@@ -1016,7 +1012,6 @@ def merge_chunked_documents(in_txt_chunk_f, in_tab_chunk_f, orig_fn):
             caption = block.get("caption", "")
             page_number = block.get("page_number")
             content = block.get("content", "")
-            md_source = block.get("markdown_source")
 
             # Smart caption prefixing: only add if caption not already in content
             def _normalize(text: str) -> str:
@@ -1035,7 +1030,7 @@ def merge_chunked_documents(in_txt_chunk_f, in_tab_chunk_f, orig_fn):
                 "page_content": page_content,
                 "filename": orig_fn,
                 "type": "table",
-                "source": md_source,
+                "source": caption,
                 "page_number": page_number,
                 "language": "en",
                 "chunk_index": txt_count + tab_idx,


### PR DESCRIPTION
bug: whenever the source metadata for chunked table contents is larger than 32766, opensearch fails the request due to illegal_argument_exception.

fix: now instead of sending full markdown of table as source metadata, we are sending caption to ensure proper searchability for table contents. 