### PR TITLE
Fix OpenAI API compatibility for litellm

### DIFF
--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 
@@ -56,7 +56,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 
@@ -64,6 +64,6 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -4,25 +4,25 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 
 similarity:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 
@@ -56,7 +56,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 
@@ -64,6 +64,6 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -4,25 +4,25 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 
 similarity:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 
@@ -56,7 +56,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"
 
@@ -64,6 +64,6 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.95
+  image: icr.io/ai-services-cicd/rag:v0.0.96
   # @hidden
   log_level: "INFO"

--- a/spyre-rag/src/Makefile
+++ b/spyre-rag/src/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=rag
-TAG?=v0.0.95
+TAG?=v0.0.96
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman

--- a/spyre-rag/src/common/llm_utils.py
+++ b/spyre-rag/src/common/llm_utils.py
@@ -161,7 +161,7 @@ def query_vllm_payload(question, documents, llm_endpoint, llm_model, stop_words,
         "messages": [{"role": "user", "content": prompt}],
         "model": llm_model,
         "max_tokens": max_new_tokens,
-        "repetition_penalty": 1.1,
+        "frequency_penalty": 1.1,
         "temperature": temperature,
         "stop": stop_words,
         "stream": stream


### PR DESCRIPTION
Replace repetition_penalty with frequency_penalty
- The repetition_penalty parameter is not supported by OpenAI's Chat Completions API.
    Replaced it with frequency_penalty which is the correct OpenAI API parameter for
    controlling token repetition based on their frequency in the generated text.