### PR TITLE
Implement API functions for architecture and services

### DIFF
--- a/ai-services/cmd/ai-services/cmd/application/templates.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates.go
@@ -51,8 +51,8 @@ var templatesCmd = &cobra.Command{
 			}
 
 			logger.Infof("- %s\n", name)
-			metadata, err := tp.LoadMetadata(name, false)
-			if err != nil {
+			var metadata templates.AppMetadata
+			if err := tp.LoadMetadata(name, false, &metadata); err != nil {
 				logger.Errorf("failed to load application metadata: %v", err)
 
 				continue

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -893,7 +893,29 @@ const docTemplate = `{
                 }
             }
         }
-    }
+    },
+    "securityDefinitions": {
+        "BearerAuth": {
+            "description": "Type \"Bearer\" followed by a space and JWT token.",
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
+        }
+    },
+    "tags": [
+        {
+            "description": "Authentication and authorization endpoints",
+            "name": "Authentication"
+        },
+        {
+            "description": "Application management endpoints",
+            "name": "Applications"
+        },
+        {
+            "description": "Catalog endpoints for architectures and services",
+            "name": "Catalog"
+        }
+    ]
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -332,6 +332,98 @@ const docTemplate = `{
                 }
             }
         },
+        "/architectures": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieves a list of all available architecture templates with summary information",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Catalog"
+                ],
+                "summary": "List available architectures",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ArchitectureSummary"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - Invalid or missing access token",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/architectures/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieves detailed information about a specific architecture template",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Catalog"
+                ],
+                "summary": "Get architecture details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Architecture template ID (e.g., 'rag')",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - Invalid or missing access token",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Architecture not found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/login": {
             "post": {
                 "description": "Authenticate user and return access and refresh tokens",
@@ -512,9 +604,269 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/services": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieves a list of all deployable service templates. Dependency-only services are excluded from this list. Returns service summaries without endpoints and pod templates.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Catalog"
+                ],
+                "summary": "List available services",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceSummary"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - Invalid or missing access token",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/services/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieves detailed information about a specific service template",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Catalog"
+                ],
+                "summary": "Get service details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Service template ID (e.g., 'summarize')",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Service"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - Invalid or missing access token",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Service not found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture": {
+            "type": "object",
+            "properties": {
+                "certified_by": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "links": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ArchitectureLinks"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "runtimes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "services": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceReference"
+                    }
+                },
+                "type": {
+                    "description": "\"architecture\"",
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ArchitectureLinks": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "demo": {
+                    "type": "string"
+                },
+                "documentation": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ArchitectureSummary": {
+            "type": "object",
+            "properties": {
+                "certified_by": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "services": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.DependencyReference": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Service": {
+            "type": "object",
+            "properties": {
+                "architectures": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "certified_by": {
+                    "type": "string"
+                },
+                "dependencies": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.DependencyReference"
+                    }
+                },
+                "dependency_only": {
+                    "type": "boolean"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "description": "\"service\"",
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceReference": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "optional": {
+                    "type": "boolean"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceSummary": {
+            "type": "object",
+            "properties": {
+                "architectures": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "certified_by": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_pkg_catalog_apiserver_handlers.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_pkg_catalog_apiserver_handlers.loginReq": {
             "type": "object",
             "required": [
@@ -541,25 +893,7 @@ const docTemplate = `{
                 }
             }
         }
-    },
-    "securityDefinitions": {
-        "BearerAuth": {
-            "description": "Type \"Bearer\" followed by a space and JWT token.",
-            "type": "apiKey",
-            "name": "Authorization",
-            "in": "header"
-        }
-    },
-    "tags": [
-        {
-            "description": "Authentication and authorization endpoints",
-            "name": "Authentication"
-        },
-        {
-            "description": "Application management endpoints",
-            "name": "Applications"
-        }
-    ]
+    }
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -887,5 +887,27 @@
                 }
             }
         }
-    }
+    },
+    "securityDefinitions": {
+        "BearerAuth": {
+            "description": "Type \"Bearer\" followed by a space and JWT token.",
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header"
+        }
+    },
+    "tags": [
+        {
+            "description": "Authentication and authorization endpoints",
+            "name": "Authentication"
+        },
+        {
+            "description": "Application management endpoints",
+            "name": "Applications"
+        },
+        {
+            "description": "Catalog endpoints for architectures and services",
+            "name": "Catalog"
+        }
+    ]
 }

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -326,6 +326,98 @@
                 }
             }
         },
+        "/architectures": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieves a list of all available architecture templates with summary information",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Catalog"
+                ],
+                "summary": "List available architectures",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ArchitectureSummary"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - Invalid or missing access token",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/architectures/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieves detailed information about a specific architecture template",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Catalog"
+                ],
+                "summary": "Get architecture details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Architecture template ID (e.g., 'rag')",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - Invalid or missing access token",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Architecture not found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/login": {
             "post": {
                 "description": "Authenticate user and return access and refresh tokens",
@@ -506,9 +598,269 @@
                     }
                 }
             }
+        },
+        "/services": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieves a list of all deployable service templates. Dependency-only services are excluded from this list. Returns service summaries without endpoints and pod templates.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Catalog"
+                ],
+                "summary": "List available services",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceSummary"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - Invalid or missing access token",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/services/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieves detailed information about a specific service template",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Catalog"
+                ],
+                "summary": "Get service details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Service template ID (e.g., 'summarize')",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Service"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - Invalid or missing access token",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Service not found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture": {
+            "type": "object",
+            "properties": {
+                "certified_by": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "links": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ArchitectureLinks"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "runtimes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "services": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceReference"
+                    }
+                },
+                "type": {
+                    "description": "\"architecture\"",
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ArchitectureLinks": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "demo": {
+                    "type": "string"
+                },
+                "documentation": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ArchitectureSummary": {
+            "type": "object",
+            "properties": {
+                "certified_by": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "services": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.DependencyReference": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Service": {
+            "type": "object",
+            "properties": {
+                "architectures": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "certified_by": {
+                    "type": "string"
+                },
+                "dependencies": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.DependencyReference"
+                    }
+                },
+                "dependency_only": {
+                    "type": "boolean"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "description": "\"service\"",
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceReference": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "optional": {
+                    "type": "boolean"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceSummary": {
+            "type": "object",
+            "properties": {
+                "architectures": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "certified_by": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_pkg_catalog_apiserver_handlers.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_pkg_catalog_apiserver_handlers.loginReq": {
             "type": "object",
             "required": [
@@ -535,23 +887,5 @@
                 }
             }
         }
-    },
-    "securityDefinitions": {
-        "BearerAuth": {
-            "description": "Type \"Bearer\" followed by a space and JWT token.",
-            "type": "apiKey",
-            "name": "Authorization",
-            "in": "header"
-        }
-    },
-    "tags": [
-        {
-            "description": "Authentication and authorization endpoints",
-            "name": "Authentication"
-        },
-        {
-            "description": "Application management endpoints",
-            "name": "Applications"
-        }
-    ]
+    }
 }

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -1,5 +1,114 @@
-basePath: /api/v1
 definitions:
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture:
+    properties:
+      certified_by:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      links:
+        $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ArchitectureLinks'
+      name:
+        type: string
+      runtimes:
+        items:
+          type: string
+        type: array
+      services:
+        items:
+          $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceReference'
+        type: array
+      type:
+        description: '"architecture"'
+        type: string
+      version:
+        type: string
+    type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ArchitectureLinks:
+    properties:
+      code:
+        type: string
+      demo:
+        type: string
+      documentation:
+        type: string
+    type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ArchitectureSummary:
+    properties:
+      certified_by:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      services:
+        items:
+          type: string
+        type: array
+    type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.DependencyReference:
+    properties:
+      id:
+        type: string
+      version:
+        type: string
+    type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Service:
+    properties:
+      architectures:
+        items:
+          type: string
+        type: array
+      certified_by:
+        type: string
+      dependencies:
+        items:
+          $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.DependencyReference'
+        type: array
+      dependency_only:
+        type: boolean
+      description:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      type:
+        description: '"service"'
+        type: string
+    type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceReference:
+    properties:
+      id:
+        type: string
+      optional:
+        type: boolean
+      version:
+        type: string
+    type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceSummary:
+    properties:
+      architectures:
+        items:
+          type: string
+        type: array
+      certified_by:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  internal_pkg_catalog_apiserver_handlers.ErrorResponse:
+    properties:
+      error:
+        type: string
+    type: object
   internal_pkg_catalog_apiserver_handlers.loginReq:
     properties:
       password:
@@ -17,19 +126,8 @@ definitions:
     required:
     - refresh_token
     type: object
-host: localhost:8080
 info:
-  contact:
-    email: support@example.com
-    name: API Support
-    url: https://github.com/project-ai-services/ai-services
-  description: API server for managing AI Services catalog, applications, and authentication
-  license:
-    name: Apache 2.0
-    url: http://www.apache.org/licenses/LICENSE-2.0.html
-  termsOfService: http://swagger.io/terms/
-  title: AI Services Catalog API
-  version: "1.0"
+  contact: {}
 paths:
   /applications:
     post:
@@ -228,6 +326,65 @@ paths:
       summary: List application templates
       tags:
       - Applications
+  /architectures:
+    get:
+      description: Retrieves a list of all available architecture templates with summary
+        information
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ArchitectureSummary'
+            type: array
+        "401":
+          description: Unauthorized - Invalid or missing access token
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: List available architectures
+      tags:
+      - Catalog
+  /architectures/{id}:
+    get:
+      description: Retrieves detailed information about a specific architecture template
+      parameters:
+      - description: Architecture template ID (e.g., 'rag')
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture'
+        "401":
+          description: Unauthorized - Invalid or missing access token
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "404":
+          description: Architecture not found
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get architecture details
+      tags:
+      - Catalog
   /auth/login:
     post:
       consumes:
@@ -348,15 +505,64 @@ paths:
       summary: Refresh access token
       tags:
       - Authentication
-securityDefinitions:
-  BearerAuth:
-    description: Type "Bearer" followed by a space and JWT token.
-    in: header
-    name: Authorization
-    type: apiKey
+  /services:
+    get:
+      description: Retrieves a list of all deployable service templates. Dependency-only
+        services are excluded from this list. Returns service summaries without endpoints
+        and pod templates.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceSummary'
+            type: array
+        "401":
+          description: Unauthorized - Invalid or missing access token
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: List available services
+      tags:
+      - Catalog
+  /services/{id}:
+    get:
+      description: Retrieves detailed information about a specific service template
+      parameters:
+      - description: Service template ID (e.g., 'summarize')
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Service'
+        "401":
+          description: Unauthorized - Invalid or missing access token
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "404":
+          description: Service not found
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get service details
+      tags:
+      - Catalog
 swagger: "2.0"
-tags:
-- description: Authentication and authorization endpoints
-  name: Authentication
-- description: Application management endpoints
-  name: Applications

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -1,3 +1,4 @@
+basePath: /api/v1
 definitions:
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture:
     properties:
@@ -126,8 +127,19 @@ definitions:
     required:
     - refresh_token
     type: object
+host: localhost:8080
 info:
-  contact: {}
+  contact:
+    email: support@example.com
+    name: API Support
+    url: https://github.com/project-ai-services/ai-services
+  description: API server for managing AI Services catalog, applications, and authentication
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  termsOfService: http://swagger.io/terms/
+  title: AI Services Catalog API
+  version: "1.0"
 paths:
   /applications:
     post:
@@ -565,4 +577,17 @@ paths:
       summary: Get service details
       tags:
       - Catalog
+securityDefinitions:
+  BearerAuth:
+    description: Type "Bearer" followed by a space and JWT token.
+    in: header
+    name: Authorization
+    type: apiKey
 swagger: "2.0"
+tags:
+- description: Authentication and authorization endpoints
+  name: Authentication
+- description: Application management endpoints
+  name: Applications
+- description: Catalog endpoints for architectures and services
+  name: Catalog

--- a/ai-services/go.mod
+++ b/ai-services/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20260213141500-06efc6dce93b
 	github.com/operator-framework/api v0.39.0
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.16.3

--- a/ai-services/internal/pkg/application/openshift/create.go
+++ b/ai-services/internal/pkg/application/openshift/create.go
@@ -65,8 +65,8 @@ func getOperationTimeout(ctx context.Context, tp templates.Template, opts types.
 	// populate the operation timeout if its either not set or set negatively
 	if timeout <= 0 {
 		// load metadata.yml to read the app metadata
-		appMetadata, err := tp.LoadMetadata(opts.TemplateName, false)
-		if err != nil {
+		var appMetadata templates.AppMetadata
+		if err := tp.LoadMetadata(opts.TemplateName, false, &appMetadata); err != nil {
 			s.Fail("failed to read the app metadata")
 
 			return 0, fmt.Errorf("failed to read the app metadata: %w", err)

--- a/ai-services/internal/pkg/application/podman/create.go
+++ b/ai-services/internal/pkg/application/podman/create.go
@@ -46,12 +46,12 @@ func (p *PodmanApplication) Create(ctx context.Context, opts types.CreateOptions
 	}
 
 	// load metadata.yml to read the app metadata
-	appMetadata, err := tp.LoadMetadata(opts.TemplateName, true)
-	if err != nil {
+	var appMetadata templates.AppMetadata
+	if err := tp.LoadMetadata(opts.TemplateName, true, &appMetadata); err != nil {
 		return fmt.Errorf("failed to read the app metadata: %w", err)
 	}
 
-	if err := p.verifyPodTemplateExists(tmpls, appMetadata); err != nil {
+	if err := p.verifyPodTemplateExists(tmpls, &appMetadata); err != nil {
 		return fmt.Errorf("failed to verify pod template: %w", err)
 	}
 
@@ -81,7 +81,7 @@ func (p *PodmanApplication) Create(ctx context.Context, opts types.CreateOptions
 	// Loop through all pod templates, render and run kube play
 	logger.Infof("Total Pod Templates to be processed: %d\n", len(tmpls))
 
-	return p.deployApplication(ctx, opts, tmpls, appMetadata, pciAddresses)
+	return p.deployApplication(ctx, opts, tmpls, &appMetadata, pciAddresses)
 }
 
 func (p *PodmanApplication) validateAndAllocateSpyreCards(templateName, appName string, tmpls map[string]*template.Template) ([]string, error) {

--- a/ai-services/internal/pkg/catalog/apiserver/apiserver.go
+++ b/ai-services/internal/pkg/catalog/apiserver/apiserver.go
@@ -22,6 +22,9 @@
 //	@tag.name					Applications
 //	@tag.description			Application management endpoints
 //
+//	@tag.name					Catalog
+//	@tag.description			Catalog endpoints for architectures and services
+//
 //	@securityDefinitions.apikey	BearerAuth
 //	@in							header
 //	@name						Authorization

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
@@ -10,10 +10,10 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
-// CatalogHandler handles catalog-related HTTP requests
+// CatalogHandler handles catalog-related HTTP requests.
 type CatalogHandler struct{}
 
-// NewCatalogHandler creates a new catalog handler
+// NewCatalogHandler creates a new catalog handler.
 func NewCatalogHandler() *CatalogHandler {
 	return &CatalogHandler{}
 }
@@ -35,6 +35,7 @@ func (h *CatalogHandler) ListArchitectures(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{
 			Error: fmt.Sprintf("Failed to list architectures: %v", err),
 		})
+
 		return
 	}
 
@@ -68,6 +69,7 @@ func (h *CatalogHandler) GetArchitectureDetails(c *gin.Context) {
 		c.JSON(http.StatusNotFound, ErrorResponse{
 			Error: fmt.Sprintf("Architecture '%s' not found: %v", id, err),
 		})
+
 		return
 	}
 
@@ -94,6 +96,7 @@ func (h *CatalogHandler) ListServices(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{
 			Error: fmt.Sprintf("Failed to list services: %v", err),
 		})
+
 		return
 	}
 
@@ -127,13 +130,14 @@ func (h *CatalogHandler) GetServiceDetails(c *gin.Context) {
 		c.JSON(http.StatusNotFound, ErrorResponse{
 			Error: fmt.Sprintf("Service '%s' not found: %v", id, err),
 		})
+
 		return
 	}
 
 	c.JSON(http.StatusOK, service)
 }
 
-// ErrorResponse represents an error response
+// ErrorResponse represents an error response.
 type ErrorResponse struct {
 	Error string `json:"error"`
 }

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
+)
+
+// CatalogHandler handles catalog-related HTTP requests
+type CatalogHandler struct{}
+
+// NewCatalogHandler creates a new catalog handler
+func NewCatalogHandler() *CatalogHandler {
+	return &CatalogHandler{}
+}
+
+// ListArchitectures godoc
+//
+//	@Summary		List available architectures
+//	@Description	Retrieves a list of all available architecture templates with summary information
+//	@Tags			Catalog
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Success		200	{array}		types.ArchitectureSummary
+//	@Failure		401	{object}	ErrorResponse	"Unauthorized - Invalid or missing access token"
+//	@Failure		500	{object}	ErrorResponse	"Internal Server Error"
+//	@Router			/architectures [get]
+func (h *CatalogHandler) ListArchitectures(c *gin.Context) {
+	architectures, err := catalog.ListArchitectures()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: fmt.Sprintf("Failed to list architectures: %v", err),
+		})
+		return
+	}
+
+	// Convert to summaries
+	summaries := make([]types.ArchitectureSummary, len(architectures))
+	for i, arch := range architectures {
+		summaries[i] = catalog.ToArchitectureSummary(&arch)
+	}
+
+	c.JSON(http.StatusOK, summaries)
+}
+
+// GetArchitectureDetails godoc
+//
+//	@Summary		Get architecture details
+//	@Description	Retrieves detailed information about a specific architecture template
+//	@Tags			Catalog
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id	path		string	true	"Architecture template ID (e.g., 'rag')"
+//	@Success		200	{object}	types.Architecture
+//	@Failure		401	{object}	ErrorResponse	"Unauthorized - Invalid or missing access token"
+//	@Failure		404	{object}	ErrorResponse	"Architecture not found"
+//	@Failure		500	{object}	ErrorResponse	"Internal Server Error"
+//	@Router			/architectures/{id} [get]
+func (h *CatalogHandler) GetArchitectureDetails(c *gin.Context) {
+	id := c.Param("id")
+
+	architecture, err := catalog.LoadArchitecture(id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, ErrorResponse{
+			Error: fmt.Sprintf("Architecture '%s' not found: %v", id, err),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, architecture)
+}
+
+// ListServices godoc
+//
+//	@Summary		List available services
+//	@Description	Retrieves a list of all deployable service templates. Dependency-only services are excluded from this list. Returns service summaries without endpoints and pod templates.
+//	@Tags			Catalog
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Success		200	{array}		types.ServiceSummary
+//	@Failure		401	{object}	ErrorResponse	"Unauthorized - Invalid or missing access token"
+//	@Failure		500	{object}	ErrorResponse	"Internal Server Error"
+//	@Router			/services [get]
+func (h *CatalogHandler) ListServices(c *gin.Context) {
+	// Get runtime from global factory
+	runtime := vars.RuntimeFactory.GetRuntimeType()
+
+	servicesList, err := catalog.ListServicesWithRuntime(runtime)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: fmt.Sprintf("Failed to list services: %v", err),
+		})
+		return
+	}
+
+	// Convert to summaries (exclude endpoints and pod_templates)
+	summaries := make([]types.ServiceSummary, len(servicesList))
+	for i, svc := range servicesList {
+		summaries[i] = catalog.ToServiceSummary(&svc)
+	}
+
+	c.JSON(http.StatusOK, summaries)
+}
+
+// GetServiceDetails godoc
+//
+//	@Summary		Get service details
+//	@Description	Retrieves detailed information about a specific service template
+//	@Tags			Catalog
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id	path		string	true	"Service template ID (e.g., 'summarize')"
+//	@Success		200	{object}	types.Service
+//	@Failure		401	{object}	ErrorResponse	"Unauthorized - Invalid or missing access token"
+//	@Failure		404	{object}	ErrorResponse	"Service not found"
+//	@Failure		500	{object}	ErrorResponse	"Internal Server Error"
+//	@Router			/services/{id} [get]
+func (h *CatalogHandler) GetServiceDetails(c *gin.Context) {
+	id := c.Param("id")
+
+	service, err := catalog.LoadService(id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, ErrorResponse{
+			Error: fmt.Sprintf("Service '%s' not found: %v", id, err),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, service)
+}
+
+// ErrorResponse represents an error response
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/catalog_test.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/catalog_test.go
@@ -1,0 +1,287 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	// Initialize runtime factory for tests
+	if vars.RuntimeFactory == nil {
+		vars.RuntimeFactory = runtime.NewRuntimeFactory(runtimeTypes.RuntimeTypePodman)
+	}
+
+	return router
+}
+
+func TestListArchitectures(t *testing.T) {
+	router := setupTestRouter()
+	handler := NewCatalogHandler()
+	router.GET("/api/v1/architectures", handler.ListArchitectures)
+
+	tests := []struct {
+		name           string
+		expectedStatus int
+		validateBody   func(t *testing.T, body []byte)
+	}{
+		{
+			name:           "Successfully list architectures",
+			expectedStatus: http.StatusOK,
+			validateBody: func(t *testing.T, body []byte) {
+				var architectures []types.ArchitectureSummary
+				err := json.Unmarshal(body, &architectures)
+				require.NoError(t, err)
+
+				// Should have at least one architecture (rag)
+				assert.NotEmpty(t, architectures)
+
+				// Verify structure of first architecture
+				if len(architectures) > 0 {
+					arch := architectures[0]
+					assert.NotEmpty(t, arch.ID)
+					assert.NotEmpty(t, arch.Name)
+					assert.NotEmpty(t, arch.Description)
+					assert.NotEmpty(t, arch.CertifiedBy)
+					assert.NotEmpty(t, arch.Services)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/api/v1/architectures", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.validateBody != nil {
+				tt.validateBody(t, w.Body.Bytes())
+			}
+		})
+	}
+}
+
+func TestGetArchitecture(t *testing.T) {
+	router := setupTestRouter()
+	handler := NewCatalogHandler()
+	router.GET("/api/v1/architectures/:id", handler.GetArchitectureDetails)
+
+	tests := []struct {
+		name           string
+		archID         string
+		expectedStatus int
+		validateBody   func(t *testing.T, body []byte)
+	}{
+		{
+			name:           "Successfully get rag architecture",
+			archID:         "rag",
+			expectedStatus: http.StatusOK,
+			validateBody: func(t *testing.T, body []byte) {
+				var arch types.Architecture
+				err := json.Unmarshal(body, &arch)
+				require.NoError(t, err)
+
+				assert.Equal(t, "rag", arch.ID)
+				assert.Equal(t, "Digital Assistant", arch.Name)
+				assert.NotEmpty(t, arch.Description)
+				assert.Equal(t, "1.0.0", arch.Version)
+				assert.Equal(t, "architecture", arch.Type)
+				assert.Equal(t, "IBM", arch.CertifiedBy)
+				assert.Contains(t, arch.Runtimes, "podman")
+
+				// Verify services
+				assert.NotEmpty(t, arch.Services)
+				serviceIDs := make(map[string]bool)
+				for _, svc := range arch.Services {
+					serviceIDs[svc.ID] = true
+				}
+				assert.True(t, serviceIDs["chat"])
+				assert.True(t, serviceIDs["digitize"])
+				assert.True(t, serviceIDs["summarize"])
+			},
+		},
+		{
+			name:           "Architecture not found",
+			archID:         "nonexistent",
+			expectedStatus: http.StatusNotFound,
+			validateBody: func(t *testing.T, body []byte) {
+				var errResp map[string]string
+				err := json.Unmarshal(body, &errResp)
+				require.NoError(t, err)
+				assert.Contains(t, errResp["error"], "not found")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/api/v1/architectures/"+tt.archID, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.validateBody != nil {
+				tt.validateBody(t, w.Body.Bytes())
+			}
+		})
+	}
+}
+
+func TestListServices(t *testing.T) {
+	router := setupTestRouter()
+	handler := NewCatalogHandler()
+	router.GET("/api/v1/services", handler.ListServices)
+
+	tests := []struct {
+		name           string
+		expectedStatus int
+		validateBody   func(t *testing.T, body []byte)
+	}{
+		{
+			name:           "Successfully list services (excludes dependency-only)",
+			expectedStatus: http.StatusOK,
+			validateBody: func(t *testing.T, body []byte) {
+				var services []types.ServiceSummary
+				err := json.Unmarshal(body, &services)
+				require.NoError(t, err)
+
+				// Should have deployable services only
+				assert.NotEmpty(t, services)
+
+				// Verify dependency-only services are excluded
+				serviceIDs := make(map[string]bool)
+				for _, svc := range services {
+					serviceIDs[svc.ID] = true
+					// Verify structure
+					assert.NotEmpty(t, svc.ID)
+					assert.NotEmpty(t, svc.Name)
+					assert.NotEmpty(t, svc.Description)
+					assert.NotEmpty(t, svc.CertifiedBy)
+					assert.NotEmpty(t, svc.Architectures)
+				}
+
+				// Should include deployable services
+				assert.True(t, serviceIDs["chat"])
+				assert.True(t, serviceIDs["digitize"])
+				assert.True(t, serviceIDs["summarize"])
+
+				// Should NOT include dependency-only services
+				assert.False(t, serviceIDs["opensearch"])
+				assert.False(t, serviceIDs["embedding"])
+				assert.False(t, serviceIDs["instruct"])
+				assert.False(t, serviceIDs["reranker"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/api/v1/services", nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.validateBody != nil {
+				tt.validateBody(t, w.Body.Bytes())
+			}
+		})
+	}
+}
+
+func TestGetService(t *testing.T) {
+	router := setupTestRouter()
+	handler := NewCatalogHandler()
+	router.GET("/api/v1/services/:id", handler.GetServiceDetails)
+
+	tests := []struct {
+		name           string
+		serviceID      string
+		expectedStatus int
+		validateBody   func(t *testing.T, body []byte)
+	}{
+		{
+			name:           "Successfully get chat service",
+			serviceID:      "chat",
+			expectedStatus: http.StatusOK,
+			validateBody: func(t *testing.T, body []byte) {
+				var svc types.Service
+				err := json.Unmarshal(body, &svc)
+				require.NoError(t, err)
+
+				assert.Equal(t, "chat", svc.ID)
+				assert.Equal(t, "Question and Answer", svc.Name)
+				assert.Equal(t, "service", svc.Type)
+				assert.Equal(t, "IBM", svc.CertifiedBy)
+				assert.Contains(t, svc.Architectures, "rag")
+
+				// Verify dependencies
+				assert.NotEmpty(t, svc.Dependencies)
+				depIDs := make(map[string]bool)
+				for _, dep := range svc.Dependencies {
+					depIDs[dep.ID] = true
+				}
+				assert.True(t, depIDs["opensearch"])
+				assert.True(t, depIDs["embedding"])
+				assert.True(t, depIDs["instruct"])
+				assert.True(t, depIDs["reranker"])
+
+				assert.NotEmpty(t, svc.Architectures)
+			},
+		},
+		{
+			name:           "Successfully get dependency-only service (opensearch)",
+			serviceID:      "opensearch",
+			expectedStatus: http.StatusOK,
+			validateBody: func(t *testing.T, body []byte) {
+				var svc types.Service
+				err := json.Unmarshal(body, &svc)
+				require.NoError(t, err)
+
+				assert.Equal(t, "opensearch", svc.ID)
+				assert.Equal(t, "OpenSearch", svc.Name)
+				assert.True(t, svc.DependencyOnly)
+				assert.Empty(t, svc.Dependencies) // Dependency-only services have no dependencies
+			},
+		},
+		{
+			name:           "Service not found",
+			serviceID:      "nonexistent",
+			expectedStatus: http.StatusNotFound,
+			validateBody: func(t *testing.T, body []byte) {
+				var errResp map[string]string
+				err := json.Unmarshal(body, &errResp)
+				require.NoError(t, err)
+				assert.Contains(t, errResp["error"], "not found")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "/api/v1/services/"+tt.serviceID, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.validateBody != nil {
+				tt.validateBody(t, w.Body.Bytes())
+			}
+		})
+	}
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/catalog_test.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/catalog_test.go
@@ -90,40 +90,13 @@ func TestGetArchitecture(t *testing.T) {
 			name:           "Successfully get rag architecture",
 			archID:         "rag",
 			expectedStatus: http.StatusOK,
-			validateBody: func(t *testing.T, body []byte) {
-				var arch types.Architecture
-				err := json.Unmarshal(body, &arch)
-				require.NoError(t, err)
-
-				assert.Equal(t, "rag", arch.ID)
-				assert.Equal(t, "Digital Assistant", arch.Name)
-				assert.NotEmpty(t, arch.Description)
-				assert.Equal(t, "1.0.0", arch.Version)
-				assert.Equal(t, "architecture", arch.Type)
-				assert.Equal(t, "IBM", arch.CertifiedBy)
-				assert.Contains(t, arch.Runtimes, "podman")
-
-				// Verify services
-				assert.NotEmpty(t, arch.Services)
-				serviceIDs := make(map[string]bool)
-				for _, svc := range arch.Services {
-					serviceIDs[svc.ID] = true
-				}
-				assert.True(t, serviceIDs["chat"])
-				assert.True(t, serviceIDs["digitize"])
-				assert.True(t, serviceIDs["summarize"])
-			},
+			validateBody:   validateRagArchitecture,
 		},
 		{
 			name:           "Architecture not found",
 			archID:         "nonexistent",
 			expectedStatus: http.StatusNotFound,
-			validateBody: func(t *testing.T, body []byte) {
-				var errResp map[string]string
-				err := json.Unmarshal(body, &errResp)
-				require.NoError(t, err)
-				assert.Contains(t, errResp["error"], "not found")
-			},
+			validateBody:   validateArchitectureNotFound,
 		},
 	}
 
@@ -139,6 +112,36 @@ func TestGetArchitecture(t *testing.T) {
 			}
 		})
 	}
+}
+
+func validateRagArchitecture(t *testing.T, body []byte) {
+	var arch types.Architecture
+	err := json.Unmarshal(body, &arch)
+	require.NoError(t, err)
+
+	assert.Equal(t, "rag", arch.ID)
+	assert.Equal(t, "Digital Assistant", arch.Name)
+	assert.NotEmpty(t, arch.Description)
+	assert.Equal(t, "1.0.0", arch.Version)
+	assert.Equal(t, "architecture", arch.Type)
+	assert.Equal(t, "IBM", arch.CertifiedBy)
+	assert.Contains(t, arch.Runtimes, "podman")
+
+	assert.NotEmpty(t, arch.Services)
+	serviceIDs := make(map[string]bool)
+	for _, svc := range arch.Services {
+		serviceIDs[svc.ID] = true
+	}
+	assert.True(t, serviceIDs["chat"])
+	assert.True(t, serviceIDs["digitize"])
+	assert.True(t, serviceIDs["summarize"])
+}
+
+func validateArchitectureNotFound(t *testing.T, body []byte) {
+	var errResp map[string]string
+	err := json.Unmarshal(body, &errResp)
+	require.NoError(t, err)
+	assert.Contains(t, errResp["error"], "not found")
 }
 
 func TestListServices(t *testing.T) {
@@ -217,56 +220,19 @@ func TestGetService(t *testing.T) {
 			name:           "Successfully get chat service",
 			serviceID:      "chat",
 			expectedStatus: http.StatusOK,
-			validateBody: func(t *testing.T, body []byte) {
-				var svc types.Service
-				err := json.Unmarshal(body, &svc)
-				require.NoError(t, err)
-
-				assert.Equal(t, "chat", svc.ID)
-				assert.Equal(t, "Question and Answer", svc.Name)
-				assert.Equal(t, "service", svc.Type)
-				assert.Equal(t, "IBM", svc.CertifiedBy)
-				assert.Contains(t, svc.Architectures, "rag")
-
-				// Verify dependencies
-				assert.NotEmpty(t, svc.Dependencies)
-				depIDs := make(map[string]bool)
-				for _, dep := range svc.Dependencies {
-					depIDs[dep.ID] = true
-				}
-				assert.True(t, depIDs["opensearch"])
-				assert.True(t, depIDs["embedding"])
-				assert.True(t, depIDs["instruct"])
-				assert.True(t, depIDs["reranker"])
-
-				assert.NotEmpty(t, svc.Architectures)
-			},
+			validateBody:   validateChatService,
 		},
 		{
 			name:           "Successfully get dependency-only service (opensearch)",
 			serviceID:      "opensearch",
 			expectedStatus: http.StatusOK,
-			validateBody: func(t *testing.T, body []byte) {
-				var svc types.Service
-				err := json.Unmarshal(body, &svc)
-				require.NoError(t, err)
-
-				assert.Equal(t, "opensearch", svc.ID)
-				assert.Equal(t, "OpenSearch", svc.Name)
-				assert.True(t, svc.DependencyOnly)
-				assert.Empty(t, svc.Dependencies) // Dependency-only services have no dependencies
-			},
+			validateBody:   validateOpensearchService,
 		},
 		{
 			name:           "Service not found",
 			serviceID:      "nonexistent",
 			expectedStatus: http.StatusNotFound,
-			validateBody: func(t *testing.T, body []byte) {
-				var errResp map[string]string
-				err := json.Unmarshal(body, &errResp)
-				require.NoError(t, err)
-				assert.Contains(t, errResp["error"], "not found")
-			},
+			validateBody:   validateServiceNotFound,
 		},
 	}
 
@@ -282,6 +248,47 @@ func TestGetService(t *testing.T) {
 			}
 		})
 	}
+}
+
+func validateChatService(t *testing.T, body []byte) {
+	var svc types.Service
+	err := json.Unmarshal(body, &svc)
+	require.NoError(t, err)
+
+	assert.Equal(t, "chat", svc.ID)
+	assert.Equal(t, "Question and Answer", svc.Name)
+	assert.Equal(t, "service", svc.Type)
+	assert.Equal(t, "IBM", svc.CertifiedBy)
+	assert.Contains(t, svc.Architectures, "rag")
+
+	assert.NotEmpty(t, svc.Dependencies)
+	depIDs := make(map[string]bool)
+	for _, dep := range svc.Dependencies {
+		depIDs[dep.ID] = true
+	}
+	assert.True(t, depIDs["opensearch"])
+	assert.True(t, depIDs["embedding"])
+	assert.True(t, depIDs["instruct"])
+	assert.True(t, depIDs["reranker"])
+	assert.NotEmpty(t, svc.Architectures)
+}
+
+func validateOpensearchService(t *testing.T, body []byte) {
+	var svc types.Service
+	err := json.Unmarshal(body, &svc)
+	require.NoError(t, err)
+
+	assert.Equal(t, "opensearch", svc.ID)
+	assert.Equal(t, "OpenSearch", svc.Name)
+	assert.True(t, svc.DependencyOnly)
+	assert.Empty(t, svc.Dependencies)
+}
+
+func validateServiceNotFound(t *testing.T, body []byte) {
+	var errResp map[string]string
+	err := json.Unmarshal(body, &errResp)
+	require.NoError(t, err)
+	assert.Contains(t, errResp["error"], "not found")
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/router.go
+++ b/ai-services/internal/pkg/catalog/apiserver/router.go
@@ -26,12 +26,24 @@ func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist r
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
 	authHandler := handlers.NewAuthHandler(authSvc)
+	catalogHandler := handlers.NewCatalogHandler()
+
 	v1 := router.Group("/api/v1")
 	{
 		v1.POST("/auth/login", authHandler.Login)
 		v1.POST("/auth/logout", middleware.AuthMiddleware(tokenMgr, blacklist), authHandler.Logout)
 		v1.POST("/auth/refresh", authHandler.Refresh)
 		v1.GET("/auth/me", middleware.AuthMiddleware(tokenMgr, blacklist), authHandler.Me)
+	}
+
+	// Catalog endpoints
+	catalog := v1.Group("")
+	catalog.Use(middleware.AuthMiddleware(tokenMgr, blacklist))
+	{
+		catalog.GET("/architectures", catalogHandler.ListArchitectures)
+		catalog.GET("/architectures/:id", catalogHandler.GetArchitectureDetails)
+		catalog.GET("/services", catalogHandler.ListServices)
+		catalog.GET("/services/:id", catalogHandler.GetServiceDetails)
 	}
 
 	applications := v1.Group("applications")

--- a/ai-services/internal/pkg/catalog/catalog.go
+++ b/ai-services/internal/pkg/catalog/catalog.go
@@ -1,0 +1,277 @@
+package catalog
+
+import (
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/assets"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
+	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+)
+
+var (
+	// architectureProvider handles architecture catalog operations
+	architectureProvider = templates.NewEmbedTemplateProvider(&assets.CatalogFS, "architectures")
+	// serviceProvider handles service catalog operations
+	serviceProvider = templates.NewEmbedTemplateProvider(&assets.CatalogFS, "services")
+)
+
+// LoadArchitecture loads an architecture by ID
+func LoadArchitecture(id string) (*types.Architecture, error) {
+	var arch types.Architecture
+	if err := architectureProvider.LoadMetadata(id, false, &arch); err != nil {
+		return nil, fmt.Errorf("failed to load architecture '%s': %w", id, err)
+	}
+	return &arch, nil
+}
+
+// LoadService loads a service by ID (base metadata only)
+func LoadService(id string) (*types.Service, error) {
+	var service types.Service
+	if err := serviceProvider.LoadMetadata(id, false, &service); err != nil {
+		return nil, fmt.Errorf("failed to load service '%s': %w", id, err)
+	}
+	return &service, nil
+}
+
+// ToServiceSummary converts a Service to ServiceSummary
+func ToServiceSummary(service *types.Service) types.ServiceSummary {
+	return types.ServiceSummary{
+		ID:            service.ID,
+		Name:          service.Name,
+		Description:   service.Description,
+		CertifiedBy:   service.CertifiedBy,
+		Architectures: service.Architectures,
+	}
+}
+
+// ToArchitectureSummary converts an Architecture to ArchitectureSummary
+func ToArchitectureSummary(arch *types.Architecture) types.ArchitectureSummary {
+	// Extract just the service IDs as strings
+	services := make([]string, len(arch.Services))
+	for i, svc := range arch.Services {
+		services[i] = svc.ID
+	}
+
+	return types.ArchitectureSummary{
+		ID:          arch.ID,
+		Name:        arch.Name,
+		Description: arch.Description,
+		CertifiedBy: arch.CertifiedBy,
+		Services:    services,
+	}
+}
+
+// ListArchitectures lists all available architectures
+func ListArchitectures() ([]types.Architecture, error) {
+	archIDs, err := architectureProvider.ListApplications(true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list architectures: %w", err)
+	}
+
+	var architectures []types.Architecture
+	for _, id := range archIDs {
+		arch, err := LoadArchitecture(id)
+		if err != nil {
+			// Log error but continue with other architectures
+			continue
+		}
+		architectures = append(architectures, *arch)
+	}
+
+	return architectures, nil
+}
+
+// ListServices lists all available deployable services
+// Only returns services where DependencyOnly is false (default)
+func ListServices() ([]types.Service, error) {
+	serviceIDs, err := serviceProvider.ListApplications(true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list services: %w", err)
+	}
+
+	var services []types.Service
+	for _, id := range serviceIDs {
+		service, err := LoadService(id)
+		if err != nil {
+			// Log error but continue with other services
+			continue
+		}
+
+		// Only include services that are not dependency-only
+		if !service.DependencyOnly {
+			services = append(services, *service)
+		}
+	}
+
+	return services, nil
+}
+
+// ListServicesWithRuntime lists all available deployable services
+// Runtime parameter kept for API compatibility but not used
+// Only returns services where DependencyOnly is false (default)
+func ListServicesWithRuntime(runtime runtimeTypes.RuntimeType) ([]types.Service, error) {
+	return ListServices()
+}
+
+// ArchitectureExists checks if an architecture exists
+func ArchitectureExists(id string) bool {
+	_, err := LoadArchitecture(id)
+	return err == nil
+}
+
+// ServiceExists checks if a service exists
+func ServiceExists(id string) bool {
+	_, err := LoadService(id)
+	return err == nil
+}
+
+// ResolveServiceDependencies resolves all dependencies for one or more services recursively
+// Returns a flat list of all unique service IDs needed (including the services themselves)
+// Accepts either service IDs (strings) or ServiceReferences
+func ResolveServiceDependencies(services ...interface{}) ([]string, error) {
+	visited := make(map[string]bool)
+	var result []string
+
+	for _, svc := range services {
+		var serviceID string
+		switch v := svc.(type) {
+		case string:
+			serviceID = v
+		case types.ServiceReference:
+			serviceID = v.ID
+		default:
+			return nil, fmt.Errorf("invalid service type: %T", svc)
+		}
+
+		if err := resolveDependenciesRecursive(serviceID, visited, &result); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}
+
+// resolveDependenciesRecursive performs depth-first traversal of dependencies
+func resolveDependenciesRecursive(serviceID string, visited map[string]bool, result *[]string) error {
+	// Check for circular dependencies
+	if visited[serviceID] {
+		return nil
+	}
+
+	// Load service metadata
+	service, err := LoadService(serviceID)
+	if err != nil {
+		return fmt.Errorf("failed to load service '%s': %w", serviceID, err)
+	}
+
+	// Mark as visited
+	visited[serviceID] = true
+
+	// Recursively resolve all dependencies (all are required)
+	for _, dep := range service.Dependencies {
+		if err := resolveDependenciesRecursive(dep.ID, visited, result); err != nil {
+			return err
+		}
+	}
+
+	// Add current service to result
+	*result = append(*result, serviceID)
+
+	return nil
+}
+
+// GetDeploymentOrder returns services grouped into deployment layers
+// Services in the same layer can be deployed in parallel
+func GetDeploymentOrder(serviceIDs []string) ([][]string, error) {
+	// Build dependency graph
+	graph := make(map[string][]string)
+	inDegree := make(map[string]int)
+
+	// Initialize all services
+	for _, svcID := range serviceIDs {
+		if _, exists := graph[svcID]; !exists {
+			graph[svcID] = []string{}
+			inDegree[svcID] = 0
+		}
+	}
+
+	// Build edges (dependencies)
+	for _, svcID := range serviceIDs {
+		service, err := LoadService(svcID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load service '%s': %w", svcID, err)
+		}
+
+		for _, dep := range service.Dependencies {
+			// Only add edge if dependency is in our service list
+			if _, exists := graph[dep.ID]; exists {
+				graph[dep.ID] = append(graph[dep.ID], svcID)
+				inDegree[svcID]++
+			}
+		}
+	}
+
+	// Topological sort using Kahn's algorithm
+	var layers [][]string
+	queue := []string{}
+
+	// Find all services with no dependencies (in-degree = 0)
+	for svcID, degree := range inDegree {
+		if degree == 0 {
+			queue = append(queue, svcID)
+		}
+	}
+
+	for len(queue) > 0 {
+		// Current layer contains all services with no remaining dependencies
+		currentLayer := make([]string, len(queue))
+		copy(currentLayer, queue)
+		layers = append(layers, currentLayer)
+
+		// Process current layer
+		nextQueue := []string{}
+		for _, svcID := range queue {
+			// Reduce in-degree for all dependent services
+			for _, dependent := range graph[svcID] {
+				inDegree[dependent]--
+				if inDegree[dependent] == 0 {
+					nextQueue = append(nextQueue, dependent)
+				}
+			}
+		}
+		queue = nextQueue
+	}
+
+	// Check for circular dependencies
+	processedCount := 0
+	for _, layer := range layers {
+		processedCount += len(layer)
+	}
+	if processedCount != len(serviceIDs) {
+		return nil, fmt.Errorf("circular dependency detected in services")
+	}
+
+	return layers, nil
+}
+
+// ValidateDependencies checks if all dependencies for given services exist
+func ValidateDependencies(serviceIDs []string) error {
+	for _, svcID := range serviceIDs {
+		service, err := LoadService(svcID)
+		if err != nil {
+			return fmt.Errorf("service '%s' not found: %w", svcID, err)
+		}
+
+		// Check all dependencies (all are required)
+		for _, dep := range service.Dependencies {
+			if !ServiceExists(dep.ID) {
+				return fmt.Errorf("service '%s' requires dependency '%s' which does not exist", svcID, dep.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/catalog.go
+++ b/ai-services/internal/pkg/catalog/catalog.go
@@ -6,6 +6,7 @@ import (
 	"github.com/project-ai-services/ai-services/assets"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 )
 
@@ -96,7 +97,8 @@ func ListServices() ([]types.Service, error) {
 	for _, id := range serviceIDs {
 		service, err := LoadService(id)
 		if err != nil {
-			// Log error but continue with other services
+			logger.Infof("service %s loading failed with: %w", id, err, logger.VerbosityLevelDebug)
+
 			continue
 		}
 

--- a/ai-services/internal/pkg/catalog/catalog.go
+++ b/ai-services/internal/pkg/catalog/catalog.go
@@ -10,31 +10,33 @@ import (
 )
 
 var (
-	// architectureProvider handles architecture catalog operations
+	// architectureProvider handles architecture catalog operations.
 	architectureProvider = templates.NewEmbedTemplateProvider(&assets.CatalogFS, "architectures")
-	// serviceProvider handles service catalog operations
+	// serviceProvider handles service catalog operations.
 	serviceProvider = templates.NewEmbedTemplateProvider(&assets.CatalogFS, "services")
 )
 
-// LoadArchitecture loads an architecture by ID
+// LoadArchitecture loads an architecture by ID.
 func LoadArchitecture(id string) (*types.Architecture, error) {
 	var arch types.Architecture
 	if err := architectureProvider.LoadMetadata(id, false, &arch); err != nil {
 		return nil, fmt.Errorf("failed to load architecture '%s': %w", id, err)
 	}
+
 	return &arch, nil
 }
 
-// LoadService loads a service by ID (base metadata only)
+// LoadService loads a service by ID (base metadata only).
 func LoadService(id string) (*types.Service, error) {
 	var service types.Service
 	if err := serviceProvider.LoadMetadata(id, false, &service); err != nil {
 		return nil, fmt.Errorf("failed to load service '%s': %w", id, err)
 	}
+
 	return &service, nil
 }
 
-// ToServiceSummary converts a Service to ServiceSummary
+// ToServiceSummary converts a Service to ServiceSummary.
 func ToServiceSummary(service *types.Service) types.ServiceSummary {
 	return types.ServiceSummary{
 		ID:            service.ID,
@@ -45,7 +47,7 @@ func ToServiceSummary(service *types.Service) types.ServiceSummary {
 	}
 }
 
-// ToArchitectureSummary converts an Architecture to ArchitectureSummary
+// ToArchitectureSummary converts an Architecture to ArchitectureSummary.
 func ToArchitectureSummary(arch *types.Architecture) types.ArchitectureSummary {
 	// Extract just the service IDs as strings
 	services := make([]string, len(arch.Services))
@@ -62,14 +64,14 @@ func ToArchitectureSummary(arch *types.Architecture) types.ArchitectureSummary {
 	}
 }
 
-// ListArchitectures lists all available architectures
+// ListArchitectures lists all available architectures.
 func ListArchitectures() ([]types.Architecture, error) {
 	archIDs, err := architectureProvider.ListApplications(true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list architectures: %w", err)
 	}
 
-	var architectures []types.Architecture
+	architectures := make([]types.Architecture, 0, len(archIDs))
 	for _, id := range archIDs {
 		arch, err := LoadArchitecture(id)
 		if err != nil {
@@ -83,7 +85,7 @@ func ListArchitectures() ([]types.Architecture, error) {
 }
 
 // ListServices lists all available deployable services
-// Only returns services where DependencyOnly is false (default)
+// Only returns services where DependencyOnly is false (default).
 func ListServices() ([]types.Service, error) {
 	serviceIDs, err := serviceProvider.ListApplications(true)
 	if err != nil {
@@ -109,26 +111,28 @@ func ListServices() ([]types.Service, error) {
 
 // ListServicesWithRuntime lists all available deployable services
 // Runtime parameter kept for API compatibility but not used
-// Only returns services where DependencyOnly is false (default)
+// Only returns services where DependencyOnly is false (default).
 func ListServicesWithRuntime(runtime runtimeTypes.RuntimeType) ([]types.Service, error) {
 	return ListServices()
 }
 
-// ArchitectureExists checks if an architecture exists
+// ArchitectureExists checks if an architecture exists.
 func ArchitectureExists(id string) bool {
 	_, err := LoadArchitecture(id)
+
 	return err == nil
 }
 
-// ServiceExists checks if a service exists
+// ServiceExists checks if a service exists.
 func ServiceExists(id string) bool {
 	_, err := LoadService(id)
+
 	return err == nil
 }
 
 // ResolveServiceDependencies resolves all dependencies for one or more services recursively
 // Returns a flat list of all unique service IDs needed (including the services themselves)
-// Accepts either service IDs (strings) or ServiceReferences
+// Accepts either service IDs (strings) or ServiceReferences.
 func ResolveServiceDependencies(services ...interface{}) ([]string, error) {
 	visited := make(map[string]bool)
 	var result []string
@@ -152,7 +156,7 @@ func ResolveServiceDependencies(services ...interface{}) ([]string, error) {
 	return result, nil
 }
 
-// resolveDependenciesRecursive performs depth-first traversal of dependencies
+// resolveDependenciesRecursive performs depth-first traversal of dependencies.
 func resolveDependenciesRecursive(serviceID string, visited map[string]bool, result *[]string) error {
 	// Check for circular dependencies
 	if visited[serviceID] {
@@ -181,10 +185,25 @@ func resolveDependenciesRecursive(serviceID string, visited map[string]bool, res
 	return nil
 }
 
-// GetDeploymentOrder returns services grouped into deployment layers
-// Services in the same layer can be deployed in parallel
+// GetDeploymentOrder returns services grouped into deployment layers.
+// Services in the same layer can be deployed in parallel.
 func GetDeploymentOrder(serviceIDs []string) ([][]string, error) {
-	// Build dependency graph
+	graph, inDegree, err := buildDependencyGraph(serviceIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	layers := performTopologicalSort(graph, inDegree)
+
+	if err := validateNoCircularDependencies(layers, serviceIDs); err != nil {
+		return nil, err
+	}
+
+	return layers, nil
+}
+
+// buildDependencyGraph creates a dependency graph for the given services.
+func buildDependencyGraph(serviceIDs []string) (map[string][]string, map[string]int, error) {
 	graph := make(map[string][]string)
 	inDegree := make(map[string]int)
 
@@ -200,7 +219,7 @@ func GetDeploymentOrder(serviceIDs []string) ([][]string, error) {
 	for _, svcID := range serviceIDs {
 		service, err := LoadService(svcID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load service '%s': %w", svcID, err)
+			return nil, nil, fmt.Errorf("failed to load service '%s': %w", svcID, err)
 		}
 
 		for _, dep := range service.Dependencies {
@@ -212,50 +231,66 @@ func GetDeploymentOrder(serviceIDs []string) ([][]string, error) {
 		}
 	}
 
-	// Topological sort using Kahn's algorithm
-	var layers [][]string
-	queue := []string{}
+	return graph, inDegree, nil
+}
 
-	// Find all services with no dependencies (in-degree = 0)
+// performTopologicalSort performs Kahn's algorithm for topological sorting.
+func performTopologicalSort(graph map[string][]string, inDegree map[string]int) [][]string {
+	var layers [][]string
+	queue := getServicesWithNoDependencies(inDegree)
+
+	for len(queue) > 0 {
+		currentLayer := make([]string, len(queue))
+		copy(currentLayer, queue)
+		layers = append(layers, currentLayer)
+
+		queue = processLayer(queue, graph, inDegree)
+	}
+
+	return layers
+}
+
+// getServicesWithNoDependencies returns services with no dependencies.
+func getServicesWithNoDependencies(inDegree map[string]int) []string {
+	var queue []string
 	for svcID, degree := range inDegree {
 		if degree == 0 {
 			queue = append(queue, svcID)
 		}
 	}
 
-	for len(queue) > 0 {
-		// Current layer contains all services with no remaining dependencies
-		currentLayer := make([]string, len(queue))
-		copy(currentLayer, queue)
-		layers = append(layers, currentLayer)
+	return queue
+}
 
-		// Process current layer
-		nextQueue := []string{}
-		for _, svcID := range queue {
-			// Reduce in-degree for all dependent services
-			for _, dependent := range graph[svcID] {
-				inDegree[dependent]--
-				if inDegree[dependent] == 0 {
-					nextQueue = append(nextQueue, dependent)
-				}
+// processLayer processes a layer and returns the next queue.
+func processLayer(queue []string, graph map[string][]string, inDegree map[string]int) []string {
+	var nextQueue []string
+	for _, svcID := range queue {
+		for _, dependent := range graph[svcID] {
+			inDegree[dependent]--
+			if inDegree[dependent] == 0 {
+				nextQueue = append(nextQueue, dependent)
 			}
 		}
-		queue = nextQueue
 	}
 
-	// Check for circular dependencies
+	return nextQueue
+}
+
+// validateNoCircularDependencies checks for circular dependencies.
+func validateNoCircularDependencies(layers [][]string, serviceIDs []string) error {
 	processedCount := 0
 	for _, layer := range layers {
 		processedCount += len(layer)
 	}
 	if processedCount != len(serviceIDs) {
-		return nil, fmt.Errorf("circular dependency detected in services")
+		return fmt.Errorf("circular dependency detected in services")
 	}
 
-	return layers, nil
+	return nil
 }
 
-// ValidateDependencies checks if all dependencies for given services exist
+// ValidateDependencies checks if all dependencies for given services exist.
 func ValidateDependencies(serviceIDs []string) error {
 	for _, svcID := range serviceIDs {
 		service, err := LoadService(svcID)

--- a/ai-services/internal/pkg/catalog/catalog_test.go
+++ b/ai-services/internal/pkg/catalog/catalog_test.go
@@ -1,0 +1,503 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Architecture Tests
+// ============================================================================
+
+func TestLoadArchitecture(t *testing.T) {
+	t.Run("Load existing architecture", func(t *testing.T) {
+		arch, err := LoadArchitecture("rag")
+		require.NoError(t, err, "Should load existing architecture without error")
+		require.NotNil(t, arch, "Architecture should not be nil")
+
+		assert.Equal(t, "rag", arch.ID, "Architecture ID should match")
+		assert.NotEmpty(t, arch.Name, "Architecture name should not be empty")
+		assert.NotEmpty(t, arch.Description, "Architecture description should not be empty")
+		assert.NotEmpty(t, arch.Version, "Architecture version should not be empty")
+		assert.NotNil(t, arch.Services, "Architecture services should not be nil")
+		assert.NotEmpty(t, arch.Services, "Architecture should have services")
+	})
+
+	t.Run("Load non-existent architecture", func(t *testing.T) {
+		arch, err := LoadArchitecture("non-existent")
+		assert.Error(t, err, "Should return error for non-existent architecture")
+		assert.Nil(t, arch, "Architecture should be nil on error")
+		assert.Contains(t, err.Error(), "failed to load architecture", "Error should mention loading architecture")
+	})
+
+	t.Run("Validate architecture structure", func(t *testing.T) {
+		arch, err := LoadArchitecture("rag")
+		require.NoError(t, err)
+
+		// Validate services
+		assert.Greater(t, len(arch.Services), 0, "Should have at least one service")
+
+		// Check all services have IDs and track if at least one is required
+		hasRequiredService := false
+		for _, svc := range arch.Services {
+			assert.NotEmpty(t, svc.ID, "Service should have an ID")
+			// Verify the service exists
+			assert.True(t, ServiceExists(svc.ID), "Service '%s' should exist", svc.ID)
+			if !svc.Optional {
+				hasRequiredService = true
+			}
+		}
+
+		assert.True(t, hasRequiredService, "Should have at least one required service")
+	})
+}
+
+func TestListArchitectures(t *testing.T) {
+	t.Run("List all architectures", func(t *testing.T) {
+		architectures, err := ListArchitectures()
+		require.NoError(t, err, "Should list architectures without error")
+		assert.NotEmpty(t, architectures, "Should have at least one architecture")
+
+		// Verify each architecture has required fields
+		for _, arch := range architectures {
+			assert.NotEmpty(t, arch.ID, "Architecture ID should not be empty")
+			assert.NotEmpty(t, arch.Name, "Architecture name should not be empty")
+			assert.NotEmpty(t, arch.Version, "Architecture version should not be empty")
+		}
+	})
+
+	t.Run("Verify rag architecture is in list", func(t *testing.T) {
+		architectures, err := ListArchitectures()
+		require.NoError(t, err)
+
+		found := false
+		for _, arch := range architectures {
+			if arch.ID == "rag" {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "RAG architecture should be in the list")
+	})
+}
+
+func TestArchitectureExists(t *testing.T) {
+	testCases := []struct {
+		name     string
+		archID   string
+		expected bool
+	}{
+		{
+			name:     "Existing architecture",
+			archID:   "rag",
+			expected: true,
+		},
+		{
+			name:     "Non-existent architecture",
+			archID:   "non-existent",
+			expected: false,
+		},
+		{
+			name:     "Empty architecture ID",
+			archID:   "",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			exists := ArchitectureExists(tc.archID)
+			assert.Equal(t, tc.expected, exists, "ArchitectureExists should return %v for '%s'", tc.expected, tc.archID)
+		})
+	}
+}
+
+// ============================================================================
+// Service Tests
+// ============================================================================
+
+func TestLoadService(t *testing.T) {
+	testCases := []struct {
+		name      string
+		serviceID string
+		wantError bool
+	}{
+		{
+			name:      "Load opensearch service",
+			serviceID: "opensearch",
+			wantError: false,
+		},
+		{
+			name:      "Load chat service",
+			serviceID: "chat",
+			wantError: false,
+		},
+		{
+			name:      "Load digitize service",
+			serviceID: "digitize",
+			wantError: false,
+		},
+		{
+			name:      "Load summarize service",
+			serviceID: "summarize",
+			wantError: false,
+		},
+		{
+			name:      "Load non-existent service",
+			serviceID: "non-existent",
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			service, err := LoadService(tc.serviceID)
+
+			if tc.wantError {
+				assert.Error(t, err, "Should return error for non-existent service")
+				assert.Nil(t, service, "Service should be nil on error")
+				assert.Contains(t, err.Error(), "failed to load service", "Error should mention loading service")
+			} else {
+				require.NoError(t, err, "Should load existing service without error")
+				require.NotNil(t, service, "Service should not be nil")
+
+				assert.Equal(t, tc.serviceID, service.ID, "Service ID should match")
+				assert.NotEmpty(t, service.Name, "Service name should not be empty")
+				assert.NotEmpty(t, service.Description, "Service description should not be empty")
+				assert.NotEmpty(t, service.Type, "Service type should not be empty")
+			}
+		})
+	}
+}
+
+func TestListServices(t *testing.T) {
+	t.Run("List all services", func(t *testing.T) {
+		services, err := ListServices()
+		require.NoError(t, err, "Should list services without error")
+		assert.NotEmpty(t, services, "Should have at least one service")
+
+		// Verify each service has required fields
+		for _, svc := range services {
+			assert.NotEmpty(t, svc.ID, "Service ID should not be empty")
+			assert.NotEmpty(t, svc.Name, "Service name should not be empty")
+			assert.NotEmpty(t, svc.Type, "Service type should not be empty")
+		}
+	})
+
+	t.Run("Verify expected deployable services are in list", func(t *testing.T) {
+		services, err := ListServices()
+		require.NoError(t, err)
+
+		// Only deployable services (not dependency-only)
+		expectedServices := []string{
+			"chat",
+			"digitize",
+			"summarize",
+		}
+
+		serviceMap := make(map[string]bool)
+		for _, svc := range services {
+			serviceMap[svc.ID] = true
+		}
+
+		for _, expected := range expectedServices {
+			assert.True(t, serviceMap[expected], "Service '%s' should be in the list", expected)
+		}
+	})
+
+	t.Run("Verify dependency-only services are not in list", func(t *testing.T) {
+		services, err := ListServices()
+		require.NoError(t, err)
+
+		// These services should NOT be in the list (dependency-only)
+		dependencyOnlyServices := []string{
+			"opensearch",
+			"instruct",
+			"embedding",
+		}
+
+		serviceMap := make(map[string]bool)
+		for _, svc := range services {
+			serviceMap[svc.ID] = true
+		}
+
+		for _, depOnly := range dependencyOnlyServices {
+			assert.False(t, serviceMap[depOnly], "Dependency-only service '%s' should not be in the list", depOnly)
+		}
+	})
+
+	t.Run("Verify service count", func(t *testing.T) {
+		services, err := ListServices()
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(services), 3, "Should have at least 3 deployable services")
+	})
+}
+
+func TestServiceExists(t *testing.T) {
+	testCases := []struct {
+		name      string
+		serviceID string
+		expected  bool
+	}{
+		{
+			name:      "Existing service - opensearch",
+			serviceID: "opensearch",
+			expected:  true,
+		},
+		{
+			name:      "Existing service - chat",
+			serviceID: "chat",
+			expected:  true,
+		},
+		{
+			name:      "Non-existent service",
+			serviceID: "non-existent",
+			expected:  false,
+		},
+		{
+			name:      "Empty service ID",
+			serviceID: "",
+			expected:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			exists := ServiceExists(tc.serviceID)
+			assert.Equal(t, tc.expected, exists, "ServiceExists should return %v for '%s'", tc.expected, tc.serviceID)
+		})
+	}
+}
+
+// ============================================================================
+// Dependency Resolution Tests
+// ============================================================================
+
+func TestResolveServiceDependencies(t *testing.T) {
+	t.Run("Resolve service with no dependencies", func(t *testing.T) {
+		// OpenSearch has no dependencies
+		deps, err := ResolveServiceDependencies("opensearch")
+		require.NoError(t, err, "Should resolve opensearch without error")
+		require.NotNil(t, deps, "Dependencies should not be nil")
+
+		assert.Contains(t, deps, "opensearch", "Should include the service itself")
+		assert.Equal(t, 1, len(deps), "OpenSearch should have only itself")
+	})
+
+	t.Run("Resolve service with dependencies", func(t *testing.T) {
+		// Chat depends on opensearch, embedding, instruct, reranker
+		deps, err := ResolveServiceDependencies("chat")
+		require.NoError(t, err, "Should resolve chat without error")
+		require.NotNil(t, deps, "Dependencies should not be nil")
+
+		assert.Contains(t, deps, "chat", "Should include the service itself")
+		assert.Contains(t, deps, "opensearch", "Should include opensearch dependency")
+		assert.Contains(t, deps, "embedding", "Should include embedding dependency")
+		assert.Contains(t, deps, "instruct", "Should include instruct dependency")
+
+		// Verify dependencies come before the service
+		chatIdx := indexOf(deps, "chat")
+		opensearchIdx := indexOf(deps, "opensearch")
+		assert.Less(t, opensearchIdx, chatIdx, "Dependencies should come before the service")
+	})
+
+	t.Run("Resolve service with transitive dependencies", func(t *testing.T) {
+		// Digitize depends on opensearch
+		deps, err := ResolveServiceDependencies("digitize")
+		require.NoError(t, err, "Should resolve digitize without error")
+		require.NotNil(t, deps, "Dependencies should not be nil")
+
+		assert.Contains(t, deps, "digitize", "Should include the service itself")
+		assert.Contains(t, deps, "opensearch", "Should include transitive dependency")
+	})
+
+	t.Run("Resolve non-existent service", func(t *testing.T) {
+		deps, err := ResolveServiceDependencies("non-existent")
+		assert.Error(t, err, "Should return error for non-existent service")
+		assert.Nil(t, deps, "Dependencies should be nil on error")
+		assert.Contains(t, err.Error(), "failed to load service", "Error should mention loading service")
+	})
+
+	t.Run("Handle circular dependencies gracefully", func(t *testing.T) {
+		// Even if there were circular dependencies, the visited map should prevent infinite loops
+		// This test verifies the algorithm doesn't hang
+		deps, err := ResolveServiceDependencies("chat")
+		require.NoError(t, err, "Should handle dependencies without hanging")
+		assert.NotNil(t, deps, "Should return dependencies")
+	})
+
+	t.Run("Resolve multiple services at once", func(t *testing.T) {
+		deps, err := ResolveServiceDependencies("chat", "digitize")
+		require.NoError(t, err, "Should resolve multiple services")
+		require.NotNil(t, deps, "Dependencies should not be nil")
+
+		assert.Contains(t, deps, "chat", "Should include chat")
+		assert.Contains(t, deps, "digitize", "Should include digitize")
+		assert.Contains(t, deps, "opensearch", "Should include shared dependency")
+	})
+}
+
+func TestGetDeploymentOrder(t *testing.T) {
+	t.Run("Get deployment order for single service", func(t *testing.T) {
+		layers, err := GetDeploymentOrder([]string{"opensearch"})
+		require.NoError(t, err, "Should get deployment order without error")
+		require.NotNil(t, layers, "Layers should not be nil")
+
+		assert.Equal(t, 1, len(layers), "Should have one layer")
+		assert.Contains(t, layers[0], "opensearch", "First layer should contain opensearch")
+	})
+
+	t.Run("Get deployment order for services with dependencies", func(t *testing.T) {
+		// Chat depends on opensearch, embedding, instruct
+		services := []string{"opensearch", "embedding", "instruct", "chat"}
+		layers, err := GetDeploymentOrder(services)
+		require.NoError(t, err, "Should get deployment order without error")
+		require.NotNil(t, layers, "Layers should not be nil")
+
+		assert.Greater(t, len(layers), 1, "Should have multiple layers")
+
+		// OpenSearch should be in first layer (no dependencies)
+		assert.Contains(t, layers[0], "opensearch", "First layer should contain opensearch")
+
+		// Chat should be in last layer (depends on others)
+		lastLayer := layers[len(layers)-1]
+		assert.Contains(t, lastLayer, "chat", "Last layer should contain chat")
+
+		// Verify all services are included
+		allServices := flattenLayers(layers)
+		for _, svc := range services {
+			assert.Contains(t, allServices, svc, "All services should be in deployment order")
+		}
+	})
+
+	t.Run("Get deployment order for complex architecture", func(t *testing.T) {
+		// Get all services for RAG architecture manually
+		services := []string{"opensearch", "embedding", "instruct", "chat", "digitize"}
+
+		layers, err := GetDeploymentOrder(services)
+		require.NoError(t, err, "Should get deployment order without error")
+		require.NotNil(t, layers, "Layers should not be nil")
+
+		assert.Greater(t, len(layers), 0, "Should have at least one layer")
+
+		// Verify all services are included
+		allServices := flattenLayers(layers)
+		assert.Equal(t, len(services), len(allServices), "All services should be in deployment order")
+	})
+
+	t.Run("Handle empty service list", func(t *testing.T) {
+		layers, err := GetDeploymentOrder([]string{})
+		require.NoError(t, err, "Should handle empty list without error")
+		assert.Empty(t, layers, "Layers should be empty for empty input")
+	})
+
+	t.Run("Detect circular dependencies", func(t *testing.T) {
+		// This test would require creating services with circular dependencies
+		// Since our current services don't have circular deps, we just verify
+		// the algorithm completes without hanging
+		services := []string{"chat", "opensearch", "embedding", "instruct"}
+		layers, err := GetDeploymentOrder(services)
+		require.NoError(t, err, "Should complete without hanging")
+		assert.NotNil(t, layers, "Should return layers")
+	})
+}
+
+func TestValidateDependencies(t *testing.T) {
+	t.Run("Validate services with valid dependencies", func(t *testing.T) {
+		services := []string{"opensearch", "chat"}
+		err := ValidateDependencies(services)
+		assert.NoError(t, err, "Should validate without error for valid dependencies")
+	})
+
+	t.Run("Validate service with missing dependency in catalog", func(t *testing.T) {
+		// This test would require a service that depends on a non-existent service
+		// Since all our services have valid dependencies, we test with a non-existent service
+		services := []string{"chat", "opensearch", "embedding", "instruct"}
+		err := ValidateDependencies(services)
+		assert.NoError(t, err, "Should validate successfully when all dependencies exist in catalog")
+	})
+
+	t.Run("Validate non-existent service", func(t *testing.T) {
+		services := []string{"non-existent"}
+		err := ValidateDependencies(services)
+		assert.Error(t, err, "Should return error for non-existent service")
+		assert.Contains(t, err.Error(), "not found", "Error should mention service not found")
+	})
+
+	t.Run("Validate empty service list", func(t *testing.T) {
+		err := ValidateDependencies([]string{})
+		assert.NoError(t, err, "Should handle empty list without error")
+	})
+
+	t.Run("Validate all RAG services", func(t *testing.T) {
+		// Get all services for RAG manually
+		services := []string{"opensearch", "embedding", "instruct", "chat", "digitize"}
+
+		err := ValidateDependencies(services)
+		assert.NoError(t, err, "All RAG services should have valid dependencies")
+	})
+}
+
+// ============================================================================
+// Concurrency Tests
+// ============================================================================
+
+func TestConcurrency(t *testing.T) {
+	t.Run("Concurrent architecture loads", func(t *testing.T) {
+		done := make(chan bool, 10)
+
+		for i := 0; i < 10; i++ {
+			go func() {
+				_, err := LoadArchitecture("rag")
+				assert.NoError(t, err, "Concurrent load should not error")
+				done <- true
+			}()
+		}
+
+		for i := 0; i < 10; i++ {
+			<-done
+		}
+	})
+
+	t.Run("Concurrent service loads", func(t *testing.T) {
+		services := []string{"opensearch", "chat", "instruct", "embedding"}
+		done := make(chan bool, len(services))
+
+		for _, svc := range services {
+			go func(serviceID string) {
+				_, err := LoadService(serviceID)
+				assert.NoError(t, err, "Concurrent load should not error for %s", serviceID)
+				done <- true
+			}(svc)
+		}
+
+		for i := 0; i < len(services); i++ {
+			<-done
+		}
+	})
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+func indexOf(slice []string, value string) int {
+	for i, v := range slice {
+		if v == value {
+			return i
+		}
+	}
+	return -1
+}
+
+func flattenLayers(layers [][]string) []string {
+	var result []string
+	for _, layer := range layers {
+		result = append(result, layer...)
+	}
+	return result
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/catalog_test.go
+++ b/ai-services/internal/pkg/catalog/catalog_test.go
@@ -76,6 +76,7 @@ func TestListArchitectures(t *testing.T) {
 		for _, arch := range architectures {
 			if arch.ID == "rag" {
 				found = true
+
 				break
 			}
 		}
@@ -489,6 +490,7 @@ func indexOf(slice []string, value string) int {
 			return i
 		}
 	}
+
 	return -1
 }
 
@@ -497,6 +499,7 @@ func flattenLayers(layers [][]string) []string {
 	for _, layer := range layers {
 		result = append(result, layer...)
 	}
+
 	return result
 }
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -91,8 +91,8 @@ func loadCatalogTemplates(s *spinner.Spinner) (templates.Template, *templates.Ap
 	tp := templates.NewEmbedTemplateProvider(&assets.CatalogFS, "")
 
 	// Load metadata from catalog/podman
-	appMetadata, err := tp.LoadMetadata(catalogAppTemplate, true)
-	if err != nil {
+	var appMetadata templates.AppMetadata
+	if err := tp.LoadMetadata(catalogAppTemplate, true, &appMetadata); err != nil {
 		s.Fail("failed to load catalog metadata")
 
 		return nil, nil, nil, fmt.Errorf("failed to load catalog metadata: %w", err)
@@ -106,7 +106,7 @@ func loadCatalogTemplates(s *spinner.Spinner) (templates.Template, *templates.Ap
 		return nil, nil, nil, fmt.Errorf("failed to load catalog templates: %w", err)
 	}
 
-	return tp, appMetadata, tmpls, nil
+	return tp, &appMetadata, tmpls, nil
 }
 
 // prepareCatalogValues prepares the values map with configure-specific configuration.

--- a/ai-services/internal/pkg/catalog/types/types.go
+++ b/ai-services/internal/pkg/catalog/types/types.go
@@ -1,6 +1,6 @@
 package types
 
-// Architecture represents a complete AI solution template
+// Architecture represents a complete AI solution template.
 type Architecture struct {
 	ID          string             `yaml:"id" json:"id"`
 	Name        string             `yaml:"name" json:"name"`
@@ -13,7 +13,7 @@ type Architecture struct {
 	Links       *ArchitectureLinks `yaml:"links,omitempty" json:"links,omitempty"`
 }
 
-// ArchitectureSummary represents an architecture for list API responses
+// ArchitectureSummary represents an architecture for list API responses.
 type ArchitectureSummary struct {
 	ID          string   `json:"id"`
 	Name        string   `json:"name"`
@@ -22,27 +22,27 @@ type ArchitectureSummary struct {
 	Services    []string `json:"services"`
 }
 
-// ArchitectureLinks contains links related to an architecture
+// ArchitectureLinks contains links related to an architecture.
 type ArchitectureLinks struct {
 	Demo          string `yaml:"demo,omitempty" json:"demo,omitempty"`
 	Code          string `yaml:"code,omitempty" json:"code,omitempty"`
 	Documentation string `yaml:"documentation,omitempty" json:"documentation,omitempty"`
 }
 
-// ServiceReference represents a reference to a service in an architecture
+// ServiceReference represents a reference to a service in an architecture.
 type ServiceReference struct {
 	ID       string `yaml:"id" json:"id"`
 	Version  string `yaml:"version,omitempty" json:"version,omitempty"`
 	Optional bool   `yaml:"optional,omitempty" json:"optional,omitempty"`
 }
 
-// DependencyReference represents a reference to a dependency service
+// DependencyReference represents a reference to a dependency service.
 type DependencyReference struct {
 	ID      string `yaml:"id" json:"id"`
 	Version string `yaml:"version,omitempty" json:"version,omitempty"`
 }
 
-// Service represents a deployable AI service
+// Service represents a deployable AI service.
 type Service struct {
 	ID             string                `yaml:"id" json:"id"`
 	Name           string                `yaml:"name" json:"name"`
@@ -54,7 +54,7 @@ type Service struct {
 	Dependencies   []DependencyReference `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
 }
 
-// ServiceSummary represents a service for list API responses
+// ServiceSummary represents a service for list API responses.
 type ServiceSummary struct {
 	ID            string   `json:"id"`
 	Name          string   `json:"name"`
@@ -63,7 +63,7 @@ type ServiceSummary struct {
 	Architectures []string `json:"architectures"`
 }
 
-// RuntimeMetadata contains runtime-specific metadata
+// RuntimeMetadata contains runtime-specific metadata.
 type RuntimeMetadata struct {
 	Name    string `yaml:"name" json:"name"`
 	Version string `yaml:"version" json:"version"`

--- a/ai-services/internal/pkg/catalog/types/types.go
+++ b/ai-services/internal/pkg/catalog/types/types.go
@@ -1,0 +1,72 @@
+package types
+
+// Architecture represents a complete AI solution template
+type Architecture struct {
+	ID          string             `yaml:"id" json:"id"`
+	Name        string             `yaml:"name" json:"name"`
+	Description string             `yaml:"description" json:"description"`
+	Version     string             `yaml:"version" json:"version"`
+	Type        string             `yaml:"type" json:"type"` // "architecture"
+	CertifiedBy string             `yaml:"certified_by" json:"certified_by"`
+	Runtimes    []string           `yaml:"runtimes" json:"runtimes"`
+	Services    []ServiceReference `yaml:"services" json:"services"`
+	Links       *ArchitectureLinks `yaml:"links,omitempty" json:"links,omitempty"`
+}
+
+// ArchitectureSummary represents an architecture for list API responses
+type ArchitectureSummary struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	CertifiedBy string   `json:"certified_by"`
+	Services    []string `json:"services"`
+}
+
+// ArchitectureLinks contains links related to an architecture
+type ArchitectureLinks struct {
+	Demo          string `yaml:"demo,omitempty" json:"demo,omitempty"`
+	Code          string `yaml:"code,omitempty" json:"code,omitempty"`
+	Documentation string `yaml:"documentation,omitempty" json:"documentation,omitempty"`
+}
+
+// ServiceReference represents a reference to a service in an architecture
+type ServiceReference struct {
+	ID       string `yaml:"id" json:"id"`
+	Version  string `yaml:"version,omitempty" json:"version,omitempty"`
+	Optional bool   `yaml:"optional,omitempty" json:"optional,omitempty"`
+}
+
+// DependencyReference represents a reference to a dependency service
+type DependencyReference struct {
+	ID      string `yaml:"id" json:"id"`
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
+}
+
+// Service represents a deployable AI service
+type Service struct {
+	ID             string                `yaml:"id" json:"id"`
+	Name           string                `yaml:"name" json:"name"`
+	Description    string                `yaml:"description" json:"description"`
+	Type           string                `yaml:"type" json:"type"` // "service"
+	CertifiedBy    string                `yaml:"certified_by" json:"certified_by"`
+	DependencyOnly bool                  `yaml:"dependency_only,omitempty" json:"dependency_only,omitempty"`
+	Architectures  []string              `yaml:"architectures" json:"architectures"`
+	Dependencies   []DependencyReference `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
+}
+
+// ServiceSummary represents a service for list API responses
+type ServiceSummary struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	Description   string   `json:"description"`
+	CertifiedBy   string   `json:"certified_by"`
+	Architectures []string `json:"architectures"`
+}
+
+// RuntimeMetadata contains runtime-specific metadata
+type RuntimeMetadata struct {
+	Name    string `yaml:"name" json:"name"`
+	Version string `yaml:"version" json:"version"`
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/cli/templates/embed.go
+++ b/ai-services/internal/pkg/cli/templates/embed.go
@@ -102,8 +102,9 @@ func (e *embedTemplateProvider) ListApplications(hidden bool) ([]string, error) 
 		parts := strings.Split(filepath.ToSlash(path), "/")
 		if len(parts) == minPathPartsForAppName && filepath.Base(path) == "metadata.yaml" {
 			appName := parts[1]
-			md, err := e.LoadMetadata(appName, false)
-			if err != nil {
+			var md AppMetadata
+
+			if err := e.LoadMetadata(appName, false, &md); err != nil {
 				return err
 			}
 			if !md.Hidden || hidden {
@@ -193,7 +194,7 @@ func (e *embedTemplateProvider) LoadAllTemplates(app string) (map[string]*templa
 }
 
 // LoadPodTemplate loads and renders a pod template with the given parameters.
-func (e *embedTemplateProvider) LoadPodTemplate(app, file string, params any) (*models.PodSpec, error) {
+func (e *embedTemplateProvider) loadPodTemplate(app, file string, params any) (*models.PodSpec, error) {
 	path := e.buildPath(app, getRuntime(), "templates", file)
 	data, err := e.fs.ReadFile(path)
 	if err != nil {
@@ -230,7 +231,7 @@ func (e *embedTemplateProvider) LoadPodTemplateWithValues(app, file, appName str
 		"Version":         "",
 	}
 
-	return e.LoadPodTemplate(app, file, params)
+	return e.loadPodTemplate(app, file, params)
 }
 
 func (e *embedTemplateProvider) LoadValues(app string, valuesFileOverrides []string, cliOverrides map[string]string) (map[string]interface{}, error) {
@@ -283,7 +284,8 @@ func (e *embedTemplateProvider) LoadValues(app string, valuesFileOverrides []str
 // LoadMetadata loads the metadata for a given application template.
 // if runtime is empty then it loads the app Metadata.
 // if set it loads the runtime specific metadata.
-func (e *embedTemplateProvider) LoadMetadata(app string, isRuntime bool) (*AppMetadata, error) {
+// target: pointer to the struct where metadata should be unmarshaled (e.g., *AppMetadata, *types.Service, *types.Architecture)
+func (e *embedTemplateProvider) LoadMetadata(app string, isRuntime bool, target interface{}) error {
 	// construct metadata.yaml path
 	var p string
 	if isRuntime {
@@ -294,15 +296,14 @@ func (e *embedTemplateProvider) LoadMetadata(app string, isRuntime bool) (*AppMe
 
 	data, err := e.fs.ReadFile(p)
 	if err != nil {
-		return nil, fmt.Errorf("read metadata: %w", err)
+		return fmt.Errorf("read metadata: %w", err)
 	}
 
-	var appMetadata AppMetadata
-	if err := yaml.Unmarshal(data, &appMetadata); err != nil {
-		return nil, err
+	if err := yaml.Unmarshal(data, target); err != nil {
+		return err
 	}
 
-	return &appMetadata, nil
+	return nil
 }
 
 // LoadMdFiles loads all md files for a given application.

--- a/ai-services/internal/pkg/cli/templates/templates.go
+++ b/ai-services/internal/pkg/cli/templates/templates.go
@@ -56,13 +56,13 @@ type Template interface {
 	ListApplicationTemplateValues(app string) (map[string]string, error)
 	// LoadAllTemplates loads all templates for a given application
 	LoadAllTemplates(app string) (map[string]*template.Template, error)
-	// LoadPodTemplate loads and renders a pod template with the given parameters
-	LoadPodTemplate(app, file string, params any) (*models.PodSpec, error)
 	// LoadPodTemplateWithValues loads and renders a pod template with values from application
 	LoadPodTemplateWithValues(app, file, appName string, valuesFileOverrides []string, cliOverrides map[string]string) (*models.PodSpec, error)
+	// LoadValues loads the values for a given template
 	LoadValues(app string, valuesFileOverrides []string, cliOverrides map[string]string) (map[string]interface{}, error)
 	// LoadMetadata loads the metadata for a given application template
-	LoadMetadata(app string, isRuntime bool) (*AppMetadata, error)
+	// target: pointer to the struct where metadata should be unmarshaled (e.g., *AppMetadata, *types.Service, *types.Architecture)
+	LoadMetadata(app string, isRuntime bool, target interface{}) error
 	// LoadMdFiles loads all md files for a given application
 	LoadMdFiles(app string) (map[string]*template.Template, error)
 	// LoadVarsFile loads the var template file


### PR DESCRIPTION
This implements catalog API system for managing AI service architectures and services. The following APIs are implemented with swagger docs.
```
GET /architectures - List all architectures (summary view)
GET /architectures/:id - Get architecture details
GET /services - List deployable services (excludes dependency-only)
GET /services/:id - Get service details
```

Key Changes:
1. New Core Catalog functions - catalog.go
2. API Server Implementation
3. Type Definitions - Architecture and Service types for detail views
4. Swagger Documentation (Auto-generated by Bob)
5. Template Provider Enhancements