### PR TITLE
fix: reorder bootstrap configuration steps

### DIFF
--- a/ai-services/internal/pkg/bootstrap/podman/configure.go
+++ b/ai-services/internal/pkg/bootstrap/podman/configure.go
@@ -2,7 +2,6 @@ package podman
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/bootstrap/spyreconfig/utils"
@@ -24,20 +23,10 @@ func (p *PodmanBootstrap) Configure() error {
 	}
 	ctx := context.Background()
 
-	s := spinner.New("Checking spyre card configuration")
+	s := spinner.New("Checking podman installation")
 	s.Start(ctx)
-	// 1. Spyre cards – validate and repair spyre configurations
-	if err := configureSpyre(); err != nil {
-		s.Fail("failed to configure spyre card")
-
-		return err
-	}
-	s.Stop("Spyre cards configuration validated successfully.")
-
-	s = spinner.New("Checking podman installation")
-	s.Start(ctx)
-	// 2. Install and configure Podman if not done
-	// 2.1 Install Podman
+	// 1. Install and configure Podman if not done
+	// 1.1 Install Podman
 	if _, err := utils.Podman(); err != nil {
 		s.UpdateMessage("Installing podman")
 		// setup podman socket and enable service
@@ -53,7 +42,7 @@ func (p *PodmanBootstrap) Configure() error {
 
 	s = spinner.New("Verifying podman configuration")
 	s.Start(ctx)
-	// 2.2 Configure Podman
+	// 1.2 Configure Podman
 	if err := utils.PodmanHealthCheck(); err != nil {
 		s.UpdateMessage("Configuring podman")
 		if err := setupPodman(); err != nil {
@@ -66,9 +55,16 @@ func (p *PodmanBootstrap) Configure() error {
 		s.Stop("Podman already configured")
 	}
 
-	if err := configurePodmanGroups(); err != nil {
-		return fmt.Errorf("failed to configure podman service supplementary groups: %w", err)
+	s = spinner.New("Checking spyre card configuration")
+	s.Start(ctx)
+	// 2. Spyre cards – validate and repair spyre configurations
+	if err := configureSpyre(); err != nil {
+		s.Fail("failed to configure spyre card")
+
+		return err
 	}
+	s.Stop("Spyre cards configuration validated successfully.")
+
 	s = spinner.New("Configuring SMT level to 2")
 	s.Start(ctx)
 	// 3. Configure SMT level to 2 and persist via systemd

--- a/ai-services/internal/pkg/bootstrap/podman/helper.go
+++ b/ai-services/internal/pkg/bootstrap/podman/helper.go
@@ -3,7 +3,6 @@ package podman
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -14,11 +13,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/bootstrap/spyreconfig/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-)
-
-const (
-	// dirPermissions is the default permission for creating directories.
-	dirPermissions = 0755
 )
 
 // configureSpyre validates and repairs Spyre card configuration.
@@ -159,98 +153,6 @@ func setupPodman() error {
 	}
 
 	logger.Infof("Podman configured successfully.")
-
-	return nil
-}
-
-func configurePodmanGroups() error {
-	logger.Infoln("Configuring podman service supplementary groups...", logger.VerbosityLevelDebug)
-
-	// Check if Spyre cards are present - only needed if Spyre cards exist
-	if !spyre.IsApplicable() {
-		logger.Infoln("No Spyre cards detected. Skipping podman service supplementary groups configuration.", logger.VerbosityLevelDebug)
-
-		return nil
-	}
-
-	// Run the check
-	checkResult := spyre.CheckPodmanServiceSupplementaryGroups()
-	if checkResult.GetStatus() {
-		logger.Infoln("✓ Podman service supplementary groups already configured", logger.VerbosityLevelDebug)
-
-		return nil
-	}
-
-	// Attempt repair
-	logger.Infoln("Fixing podman service supplementary groups configuration...", logger.VerbosityLevelDebug)
-	if err := fixPodmanServiceSupplementaryGroups(); err != nil {
-		return fmt.Errorf("failed to configure podman service supplementary groups: %w", err)
-	}
-
-	logger.Infof("✓ Podman service supplementary groups configured successfully")
-
-	return nil
-}
-
-// fixPodmanServiceSupplementaryGroups repairs the podman service SupplementaryGroups configuration.
-//
-// This function addresses the issue where Podman operations invoked via the socket (e.g., through
-// systemd or remote API calls) lack access to VFIO devices because the service doesn't inherit
-// the user's supplementary groups. While shell-based Podman commands work fine (inheriting the
-// user's 'sentient' group), socket-based operations fail without explicit configuration.
-//
-// The repair process:
-//  1. Creates a systemd drop-in file at /etc/systemd/system/podman.service.d/override.conf
-//     containing: [Service]\nSupplementaryGroups=sentient
-//  2. Reloads the systemd daemon to pick up the new configuration
-//  3. Restarts both podman.service and podman.socket to apply the changes
-//
-// This ensures that all Podman operations, regardless of invocation method, have the necessary
-// permissions to access VFIO devices (/dev/vfio/*) required for Spyre card functionality.
-func fixPodmanServiceSupplementaryGroups() error {
-	if err := createPodmanServiceDropIn(); err != nil {
-		return err
-	}
-
-	if err := reloadAndRestartPodmanServices(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func createPodmanServiceDropIn() error {
-	dropInDir := "/etc/systemd/system/podman.service.d"
-	if err := os.MkdirAll(dropInDir, dirPermissions); err != nil {
-		return err
-	}
-
-	dropInFile := dropInDir + "/override.conf"
-	dropInContent := `[Service]
-SupplementaryGroups=sentient
-`
-
-	return os.WriteFile(dropInFile, []byte(dropInContent), utils.FilePermissions)
-}
-
-func reloadAndRestartPodmanServices() error {
-	// Reload systemd daemon
-	cmd := exec.Command("systemctl", "daemon-reload")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to reload systemd daemon: %v, output: %s", err, string(out))
-	}
-
-	// Restart podman service
-	cmd = exec.Command("systemctl", "restart", "podman.service")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to restart podman.service: %v, output: %s", err, string(out))
-	}
-
-	// Restart podman socket
-	cmd = exec.Command("systemctl", "restart", "podman.socket")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to restart podman.socket: %v, output: %s", err, string(out))
-	}
 
 	return nil
 }

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
@@ -25,6 +25,8 @@ const (
 	expectedKeyValueParts = 2
 	// maxVfioRuleParts is the maximum number of comma-separated parts in a valid VFIO rule.
 	maxVfioRuleParts = 3
+	// dirPermissions is the default permission for creating directories.
+	dirPermissions = 0755
 )
 
 // RepairResult represents the result of a repair operation.
@@ -54,6 +56,7 @@ func Repair(checks []check.CheckResult) []RepairResult {
 	results = append(results, userGroupResult)
 	results = append(results, fixVFIOModule(checkMap))
 	results = append(results, fixVFIOPermissions(checkMap, userGroupResult))
+	results = append(results, fixPodmanServiceSupplementaryGroups(checkMap))
 
 	return results
 }
@@ -345,6 +348,100 @@ func fixVFIOPermissions(checkMap map[string]check.CheckResult, userGroupResult R
 	}
 
 	return RepairResult{CheckName: checkName, Status: StatusFixed}
+}
+
+// fixPodmanServiceSupplementaryGroups repairs the podman service SupplementaryGroups configuration.
+//
+// This function addresses the issue where Podman operations invoked via the socket (e.g., through
+// systemd or remote API calls) lack access to VFIO devices because the service doesn't inherit
+// the user's supplementary groups. While shell-based Podman commands work fine (inheriting the
+// user's 'sentient' group), socket-based operations fail without explicit configuration.
+//
+// The repair process:
+//  1. Creates a systemd drop-in file at /etc/systemd/system/podman.service.d/override.conf
+//     containing: [Service]\nSupplementaryGroups=sentient
+//  2. Reloads the systemd daemon to pick up the new configuration
+//  3. Restarts both podman.service and podman.socket to apply the changes
+//
+// This ensures that all Podman operations, regardless of invocation method, have the necessary
+// permissions to access VFIO devices (/dev/vfio/*) required for Spyre card functionality.
+func fixPodmanServiceSupplementaryGroups(checkMap map[string]check.CheckResult) RepairResult {
+	checkName := "Podman service SupplementaryGroups configuration"
+	_, ok := getCheckFromMap(checkMap, checkName)
+	if !ok {
+		return RepairResult{CheckName: checkName, Status: StatusSkipped}
+	}
+
+	if err := createPodmanServiceDropIn(); err != nil {
+		return RepairResult{
+			CheckName: checkName,
+			Status:    StatusFailedToFix,
+			Error:     err,
+			Message:   err.Error(),
+		}
+	}
+
+	if err := reloadAndRestartPodmanServices(); err != nil {
+		return RepairResult{
+			CheckName: checkName,
+			Status:    StatusFailedToFix,
+			Error:     err,
+			Message:   err.Error(),
+		}
+	}
+
+	return RepairResult{
+		CheckName: checkName,
+		Status:    StatusFixed,
+	}
+}
+
+func createPodmanServiceDropIn() error {
+	dropInDir := "/etc/systemd/system/podman.service.d"
+	if err := os.MkdirAll(dropInDir, dirPermissions); err != nil {
+		return err
+	}
+
+	dropInFile := dropInDir + "/override.conf"
+	dropInContent := `[Service]
+SupplementaryGroups=sentient
+`
+
+	return utils.WriteToFile(dropInFile, dropInContent)
+}
+
+func reloadAndRestartPodmanServices() error {
+	// Reload systemd daemon
+	exitCode, _, _, err := utils.ExecuteCommand("systemctl", "daemon-reload")
+	if err != nil || exitCode != 0 {
+		if err == nil {
+			err = os.ErrInvalid
+		}
+
+		return err
+	}
+
+	// Restart podman service
+	exitCode, _, _, err = utils.ExecuteCommand("systemctl", "restart", "podman.service")
+	if err != nil || exitCode != 0 {
+		if err == nil {
+			err = os.ErrInvalid
+		}
+
+		return err
+	}
+
+	// Restart podman socket
+	exitCode, _, _, err = utils.ExecuteCommand("systemctl", "restart", "podman.socket")
+	if err != nil || exitCode != 0 {
+		if err == nil {
+			err = os.ErrInvalid
+		}
+
+		return err
+	}
+
+	return nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
@@ -67,7 +67,7 @@ func IsApplicable() bool {
 
 // RunChecks executes all Spyre validation checks.
 func RunChecks() []check.CheckResult {
-	checks := []check.CheckResult{
+	return []check.CheckResult{
 		checkDriverConfig(),
 		checkUdevRule(),
 		checkMemlockConf(),
@@ -75,14 +75,8 @@ func RunChecks() []check.CheckResult {
 		checkUserGroup(),
 		checkVfioModule(),
 		checkVfioAccessPermission(),
+		checkPodmanServiceSupplementaryGroups(),
 	}
-
-	// Only check podman service configuration if podman is installed
-	if _, err := utils.Podman(); err == nil {
-		checks = append(checks, CheckPodmanServiceSupplementaryGroups())
-	}
-
-	return checks
 }
 
 // parseVfioConfigLine parses a single VFIO configuration line and returns the module name
@@ -448,7 +442,7 @@ func checkVfioDevicePermission(path string, expectedGid int) (bool, error) {
 	return fileGid == expectedGid && utils.IsReadWriteToOwnerGroupUsers(path), nil
 }
 
-// CheckPodmanServiceSupplementaryGroups validates that the podman.service has SupplementaryGroups=sentient configured.
+// checkPodmanServiceSupplementaryGroups validates that the podman.service has SupplementaryGroups=sentient configured.
 //
 // Background:
 // When Podman commands are executed directly from the shell, they inherit the user's supplementary groups,
@@ -464,7 +458,7 @@ func checkVfioDevicePermission(path string, expectedGid int) (bool, error) {
 //	SupplementaryGroups=sentient
 //
 // in the [Service] section, allowing socket-based Podman operations to access VFIO devices properly.
-func CheckPodmanServiceSupplementaryGroups() *check.ConfigurationFileCheck {
+func checkPodmanServiceSupplementaryGroups() *check.ConfigurationFileCheck {
 	serviceName := "podman.service"
 	confCheck := check.NewConfigurationFileCheck("Podman service SupplementaryGroups configuration", serviceName)
 


### PR DESCRIPTION
Found issue while running `boostrap configure` on a fresh setup:

Supplementary groups are added after Spyre and Podman configuration. Unlike other Spyre checks which follow a check-and-repair pattern, this particular check is validate only, repair is not possible here because repair itself requires Podman.
Also in that validation, we verify if podman is installed or not, if not, we skip that check and then proceed to install podman, and then add supplementary group, refer: https://github.com/IBM/project-ai-services/blob/main/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go#L82
Since podman was already installed, it went ahead and started validating.



This PR fixes the order of execution of configuration steps.