### PR TITLE
feat: add support for local tokenization with downloaded models for podman runtime

### DIFF
--- a/ai-services/assets/applications/rag-cpu/podman/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/applications/rag-cpu/podman/templates/chat-bot.yaml.tmpl
@@ -83,9 +83,15 @@ spec:
           value: "1"
         - name: LOG_LEVEL
           value: "{{ .Values.backend.log_level}}"
+        - name: TOKENIZER_MODEL_PATH
+          value: "/models/{{ .Values.instruct.model }}"
       ports:
         - containerPort: 5000
           protocol: TCP
+      volumeMounts:
+        - mountPath: /models/{{ .Values.instruct.model }}:z
+          name: chat-model
+          readOnly: true
       livenessProbe:
         httpGet:
           path: /health
@@ -99,3 +105,8 @@ spec:
           memory: "1Gi"
         limits:
           memory: "1Gi"
+  volumes:
+    - name: chat-model
+      hostPath:
+        path: "/var/lib/ai-services/models/{{ .Values.instruct.model }}"
+        type: Directory

--- a/ai-services/assets/applications/rag-cpu/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/applications/rag-cpu/podman/templates/digitize.yaml.tmpl
@@ -96,12 +96,21 @@ spec:
         - name: VLLM_API_KEY
           value: "{{ .Values.instruct.apiKey }}"
         {{- end }}
+        - name: TOKENIZER_MODEL_PATH
+          value: "/models/{{ .Values.embedding.model }}"
       volumeMounts:
         - mountPath: /var/cache:z
           name: cache
+        - mountPath: /models/{{ .Values.embedding.model }}:z
+          name: embedding-model
+          readOnly: true
   restartPolicy: Always
   volumes:
     - name: cache
       hostPath:
         path: "/var/lib/ai-services/applications/{{ .AppName }}/cache"
         type: DirectoryOrCreate
+    - name: embedding-model
+      hostPath:
+        path: "/var/lib/ai-services/models/{{ .Values.embedding.model }}"
+        type: Directory

--- a/ai-services/assets/applications/rag-cpu/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/applications/rag-cpu/podman/templates/vllm-server.yaml.tmpl
@@ -8,9 +8,9 @@ metadata:
     ai-services.io/version: "{{ .Version }}"
   annotations:
     io.podman.annotations.ulimit: "nofile=134217728:134217728,memlock=-1:-1"
-    ai-services.io/model1: BAAI/bge-reranker-v2-m3
-    ai-services.io/model2: ibm-granite/granite-embedding-278m-multilingual
-    ai-services.io/model3: ibm-granite/granite-3.3-8b-instruct
+    ai-services.io/model1: {{ .Values.reranker.model }}
+    ai-services.io/model2: {{ .Values.embedding.model }}
+    ai-services.io/model3: {{ .Values.instruct.model }}
 spec:
   volumes:
     - name: models
@@ -22,9 +22,9 @@ spec:
       image: "{{ .Values.instruct.image }}"
       args:
       - --model
-      - /models/ibm-granite/granite-3.3-8b-instruct
+      - /models/{{ .Values.instruct.model }}
       - --served-model-name
-      - ibm-granite/granite-3.3-8b-instruct
+      - {{ .Values.instruct.model }}
       - --max-num-batched-tokens=26208
       - --max-model-len=26208
       - --port=8000
@@ -60,9 +60,9 @@ spec:
       image: "{{ .Values.embedding.image }}"
       args:
       - --model
-      - /models/ibm-granite/granite-embedding-278m-multilingual
+      - /models/{{ .Values.embedding.model }}
       - --served-model-name
-      - ibm-granite/granite-embedding-278m-multilingual
+      - {{ .Values.embedding.model }}
       - --port=8001
       livenessProbe:
         httpGet:
@@ -90,9 +90,9 @@ spec:
       image: "{{ .Values.reranker.image }}"
       args:
       - --model
-      - /models/BAAI/bge-reranker-v2-m3
+      - /models/{{ .Values.reranker.model }}
       - --served-model-name
-      - BAAI/bge-reranker-v2-m3
+      - {{ .Values.reranker.model }}
       - --port=8002
       livenessProbe:
         httpGet:

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -45,14 +45,17 @@ instruct:
   image: icr.io/ppc64le-oss/vllm-ppc64le:0.18.0
   # @description API key for vLLM instruct service authentication. If empty, authentication is disabled. Provide a key to enable authentication.
   apiKey: ""
+  model: ibm-granite/granite-3.3-8b-instruct
 
 embedding:
   # @hidden
   image: icr.io/ppc64le-oss/vllm-ppc64le:0.18.0
+  model: ibm-granite/granite-embedding-278m-multilingual
 
 reranker:
   # @hidden
   image: icr.io/ppc64le-oss/vllm-ppc64le:0.18.0
+  model: BAAI/bge-reranker-v2-m3
 
 summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 
@@ -61,7 +61,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 
@@ -69,6 +69,6 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -4,25 +4,25 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 
 similarity:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag-dev/podman/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/applications/rag-dev/podman/templates/chat-bot.yaml.tmpl
@@ -83,9 +83,15 @@ spec:
           value: "1"
         - name: LOG_LEVEL
           value: "{{ .Values.backend.log_level}}"
+        - name: TOKENIZER_MODEL_PATH
+          value: "/models/{{ .Values.instruct.model }}"
       ports:
         - containerPort: 5000
           protocol: TCP
+      volumeMounts:
+        - mountPath: /models/{{ .Values.instruct.model }}:z
+          name: chat-model
+          readOnly: true
       livenessProbe:
         httpGet:
           path: /health
@@ -99,3 +105,8 @@ spec:
           memory: "1Gi"
         limits:
           memory: "1Gi"
+  volumes:
+    - name: chat-model
+      hostPath:
+        path: "/var/lib/ai-services/models/{{ .Values.instruct.model }}"
+        type: Directory

--- a/ai-services/assets/applications/rag-dev/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/applications/rag-dev/podman/templates/digitize.yaml.tmpl
@@ -96,12 +96,21 @@ spec:
         - name: VLLM_API_KEY
           value: "{{ .Values.instruct.apiKey }}"
         {{- end }}
+        - name: TOKENIZER_MODEL_PATH
+          value: "/models/{{ .Values.embedding.model }}"
       volumeMounts:
         - mountPath: /var/cache:z
           name: cache
+        - mountPath: /models/{{ .Values.embedding.model }}:z
+          name: embedding-model
+          readOnly: true
   restartPolicy: Always
   volumes:
     - name: cache
       hostPath:
         path: "/var/lib/ai-services/applications/{{ .AppName }}/cache"
         type: DirectoryOrCreate
+    - name: embedding-model
+      hostPath:
+        path: "/var/lib/ai-services/models/{{ .Values.embedding.model }}"
+        type: Directory

--- a/ai-services/assets/applications/rag-dev/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/applications/rag-dev/podman/templates/vllm-server.yaml.tmpl
@@ -10,9 +10,9 @@ metadata:
     io.podman.annotations.ulimit: "nofile=134217728:134217728,memlock=-1:-1"
     io.podman.annotations.userns: "keep-id"
     run.oci.keep_original_groups: "1"
-    ai-services.io/model1: BAAI/bge-reranker-v2-m3
-    ai-services.io/model2: ibm-granite/granite-embedding-278m-multilingual
-    ai-services.io/model3: ibm-granite/granite-3.3-8b-instruct
+    ai-services.io/model1: {{ .Values.reranker.model }}
+    ai-services.io/model2: {{ .Values.embedding.model }}
+    ai-services.io/model3: {{ .Values.instruct.model }}
     ai-services.io/instruct--spyre-cards: "4"
 spec:
   volumes:
@@ -40,7 +40,7 @@ spec:
           -tp ${AIU_WORLD_SIZE} \
           --max-model-len ${MAX_MODEL_LEN} \
           --max-num-seqs ${MAX_BATCH_SIZE} \
-          --served-model-name ibm-granite/granite-3.3-8b-instruct --port 8000
+          --served-model-name {{ .Values.instruct.model }} --port 8000
       livenessProbe:
         httpGet:
           path: /health
@@ -51,7 +51,7 @@ spec:
         failureThreshold: 3
       env:
         - name: VLLM_MODEL_PATH
-          value: "/models/ibm-granite/granite-3.3-8b-instruct"
+          value: "/models/{{ .Values.instruct.model }}"
         - name: AIU_WORLD_SIZE
           value: "4"
         - name: VLLM_SPYRE_USE_CB
@@ -92,7 +92,7 @@ spec:
       image: "{{ .Values.embedding.image }}"
       command: ["/bin/sh", "-c"]
       args: [
-          "vllm serve /models/ibm-granite/granite-embedding-278m-multilingual --served-model-name ibm-granite/granite-embedding-278m-multilingual --port 8001"
+          "vllm serve /models/{{ .Values.embedding.model }} --served-model-name {{ .Values.embedding.model }} --port 8001"
       ]
       livenessProbe:
         httpGet:
@@ -117,7 +117,7 @@ spec:
       image: "{{ .Values.reranker.image }}"
       command: ["/bin/sh", "-c"]
       args: [
-          "vllm serve /models/BAAI/bge-reranker-v2-m3 --served-model-name BAAI/bge-reranker-v2-m3 --port 8002"
+          "vllm serve /models/{{ .Values.reranker.model }} --served-model-name {{ .Values.reranker.model }} --port 8002"
       ]
       livenessProbe:
         httpGet:

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -45,14 +45,15 @@ instruct:
   apiKey: ""
   # @hidden
   image: registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.3.0
-
+  model: ibm-granite/granite-3.3-8b-instruct
 embedding:
   # @hidden
   image: icr.io/ppc64le-oss/vllm-ppc64le:0.9.1
-
+  model: ibm-granite/granite-embedding-278m-multilingual
 reranker:
   # @hidden
   image: icr.io/ppc64le-oss/vllm-ppc64le:0.9.1
+  model: BAAI/bge-reranker-v2-m3
 
 summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 
@@ -59,7 +59,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 
@@ -67,6 +67,6 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -4,25 +4,25 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 
 similarity:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag/podman/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/chat-bot.yaml.tmpl
@@ -83,9 +83,15 @@ spec:
           value: "1"
         - name: LOG_LEVEL
           value: "{{ .Values.backend.log_level}}"
+        - name: TOKENIZER_MODEL_PATH
+          value: "/models/{{ .Values.instruct.model }}"
       ports:
         - containerPort: 5000
           protocol: TCP
+      volumeMounts:
+        - mountPath: /models/{{ .Values.instruct.model }}:z
+          name: chat-model
+          readOnly: true
       livenessProbe:
         httpGet:
           path: /health
@@ -99,3 +105,8 @@ spec:
           memory: "1Gi"
         limits:
           memory: "1Gi"
+  volumes:
+    - name: chat-model
+      hostPath:
+        path: "/var/lib/ai-services/models/{{ .Values.instruct.model }}"
+        type: Directory

--- a/ai-services/assets/applications/rag/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/digitize.yaml.tmpl
@@ -96,12 +96,21 @@ spec:
         - name: VLLM_API_KEY
           value: "{{ .Values.instruct.apiKey }}"
         {{- end }}
+        - name: TOKENIZER_MODEL_PATH
+          value: "/models/{{ .Values.embedding.model }}"
       volumeMounts:
         - mountPath: /var/cache:z
           name: cache
+        - mountPath: /models/{{ .Values.embedding.model }}:z
+          name: embedding-model
+          readOnly: true
   restartPolicy: Always
   volumes:
     - name: cache
       hostPath:
         path: "/var/lib/ai-services/applications/{{ .AppName }}/cache"
         type: DirectoryOrCreate
+    - name: embedding-model
+      hostPath:
+        path: "/var/lib/ai-services/models/{{ .Values.embedding.model }}"
+        type: Directory

--- a/ai-services/assets/applications/rag/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/vllm-server.yaml.tmpl
@@ -10,9 +10,9 @@ metadata:
     io.podman.annotations.ulimit: "nofile=134217728:134217728,memlock=-1:-1"
     io.podman.annotations.userns: "keep-id"
     run.oci.keep_original_groups: "1"
-    ai-services.io/model1: BAAI/bge-reranker-v2-m3
-    ai-services.io/model2: ibm-granite/granite-embedding-278m-multilingual
-    ai-services.io/model3: ibm-granite/granite-3.3-8b-instruct
+    ai-services.io/model1: {{ .Values.reranker.model }}
+    ai-services.io/model2: {{ .Values.embedding.model }}
+    ai-services.io/model3: {{ .Values.instruct.model }}
     ai-services.io/instruct--spyre-cards: "4"
     ai-services.io/reranker--spyre-cards: "1"
 spec:
@@ -41,7 +41,7 @@ spec:
           -tp ${AIU_WORLD_SIZE} \
           --max-model-len ${MAX_MODEL_LEN} \
           --max-num-seqs ${MAX_BATCH_SIZE} \
-          --served-model-name ibm-granite/granite-3.3-8b-instruct --port 8000
+          --served-model-name {{ .Values.instruct.model }} --port 8000
       livenessProbe:
         httpGet:
           path: /health
@@ -52,7 +52,7 @@ spec:
         failureThreshold: 3
       env:
         - name: VLLM_MODEL_PATH
-          value: "/models/ibm-granite/granite-3.3-8b-instruct"
+          value: "/models/{{ .Values.instruct.model }}"
         - name: AIU_WORLD_SIZE
           value: "4"
         - name: VLLM_SPYRE_USE_CB
@@ -93,7 +93,7 @@ spec:
       image: "{{ .Values.embedding.image }}"
       command: ["/bin/sh", "-c"]
       args: [
-          "vllm serve /models/ibm-granite/granite-embedding-278m-multilingual --served-model-name ibm-granite/granite-embedding-278m-multilingual --port 8001"
+          "vllm serve /models/{{ .Values.embedding.model }} --served-model-name {{ .Values.embedding.model }} --port 8001"
       ]
       livenessProbe:
         httpGet:
@@ -123,7 +123,7 @@ spec:
           /opt/app-root/spyre_entrypoint.sh \
           --model ${VLLM_MODEL_PATH} \
           -tp ${AIU_WORLD_SIZE} \
-          --served-model-name BAAI/bge-reranker-v2-m3 --port 8002
+          --served-model-name {{ .Values.reranker.model }} --port 8002
       livenessProbe:
         httpGet:
           path: /health
@@ -134,7 +134,7 @@ spec:
         failureThreshold: 3
       env:
         - name: VLLM_MODEL_PATH
-          value: "/models/BAAI/bge-reranker-v2-m3"
+          value: "/models/{{ .Values.reranker.model }}"
         - name: AIU_WORLD_SIZE
           value: "1"
         - name: VLLM_SPYRE_WARMUP_BATCH_SIZES

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -45,14 +45,17 @@ instruct:
   image: registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.3.0
   # @description API key for vLLM instruct service authentication. If empty, authentication is disabled. Provide a key to enable authentication.
   apiKey: ""
+  model: ibm-granite/granite-3.3-8b-instruct
 
 embedding:
   # @hidden
   image: icr.io/ppc64le-oss/vllm-ppc64le:0.9.1
+  model: ibm-granite/granite-embedding-278m-multilingual
 
 reranker:
   # @hidden
   image: registry.redhat.io/rhaiis/vllm-spyre-rhel9:3.3.0
+  model: BAAI/bge-reranker-v2-m3
 
 summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 
@@ -61,7 +61,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"
 
@@ -69,6 +69,6 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/rag:v0.0.101
+  image: icr.io/ai-services-cicd/rag:v0.0.102
   # @hidden
   log_level: "INFO"

--- a/spyre-rag/src/Makefile
+++ b/spyre-rag/src/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=rag
-TAG?=v0.0.101
+TAG?=v0.0.102
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman

--- a/spyre-rag/src/chatbot/app.py
+++ b/spyre-rag/src/chatbot/app.py
@@ -25,6 +25,7 @@ import common.db_utils as db
 from common.lang_utils import setup_language_detector, detect_language, lang_de, max_tokens_map
 from common.misc_utils import get_model_endpoints, set_request_id, create_llm_session, configure_uvicorn_logging
 from common.llm_utils import query_vllm_stream, query_vllm_non_stream, query_vllm_models
+from common.tokenizer_utils import initialize_tokenizer
 from common.perf_utils import perf_registry
 from common.error_utils import APIError, ErrorCode, http_error_responses, http_exception_handler
 from chatbot.backend_utils import search_only, validate_query_length
@@ -83,6 +84,17 @@ diagnostic_logger, stderr_monitor, signal_handler = setup_comprehensive_crash_ha
 async def lifespan(app):
     filtered_paths = ['/health']
     configure_uvicorn_logging(settings.common.app.log_level, filtered_paths)
+    
+    # Initialize tokenizer
+    if settings.common.app.tokenizer_model_path:
+        try:
+            initialize_tokenizer(settings.common.app.tokenizer_model_path)
+            logging.info(f"Tokenizer initialized from {settings.common.app.tokenizer_model_path}")
+        except Exception as e:
+            logging.error(f"Failed to initialize tokenizer: {e}", exc_info=True)
+    else:
+        logging.warning("tokenizer_model_path not set in settings, tokenizer not initialized")
+    
     initialize_models()
     setup_language_detector([Language.ENGLISH, Language.GERMAN])
     create_llm_session(pool_maxsize=settings.common.llm.llm_max_batch_size)

--- a/spyre-rag/src/chatbot/app.py
+++ b/spyre-rag/src/chatbot/app.py
@@ -25,7 +25,7 @@ import common.db_utils as db
 from common.lang_utils import setup_language_detector, detect_language, lang_de, max_tokens_map
 from common.misc_utils import get_model_endpoints, set_request_id, create_llm_session, configure_uvicorn_logging
 from common.llm_utils import query_vllm_stream, query_vllm_non_stream, query_vllm_models
-from common.tokenizer_utils import initialize_tokenizer
+from common.tokenizer_utils import initialize_local_tokenizer
 from common.perf_utils import perf_registry
 from common.error_utils import APIError, ErrorCode, http_error_responses, http_exception_handler
 from chatbot.backend_utils import search_only, validate_query_length
@@ -85,15 +85,16 @@ async def lifespan(app):
     filtered_paths = ['/health']
     configure_uvicorn_logging(settings.common.app.log_level, filtered_paths)
     
-    # Initialize tokenizer
+    # Initialize local tokenizer for offline tokenization (optional)
     if settings.common.app.tokenizer_model_path:
         try:
-            initialize_tokenizer(settings.common.app.tokenizer_model_path)
-            logging.info(f"Tokenizer initialized from {settings.common.app.tokenizer_model_path}")
+            initialize_local_tokenizer(settings.common.app.tokenizer_model_path)
+            logging.info(f"Local tokenizer initialized from {settings.common.app.tokenizer_model_path}")
         except Exception as e:
-            logging.error(f"Failed to initialize tokenizer: {e}", exc_info=True)
+            logging.error(f"Failed to initialize local tokenizer: {e}", exc_info=True)
+            logging.info("Will fall back to LLM-based tokenization via API")
     else:
-        logging.warning("tokenizer_model_path not set in settings, tokenizer not initialized")
+        logging.info("TOKENIZER_MODEL_PATH not set, will use LLM-based tokenization via API")
     
     initialize_models()
     setup_language_detector([Language.ENGLISH, Language.GERMAN])

--- a/spyre-rag/src/chatbot/backend_utils.py
+++ b/spyre-rag/src/chatbot/backend_utils.py
@@ -1,5 +1,5 @@
 from common.misc_utils import get_logger
-from common.llm_utils import tokenize_with_llm
+from common.tokenizer_utils import tokenize
 from chatbot.reranker_utils import rerank_documents
 from chatbot.retrieval_utils import retrieve_documents
 from chatbot.settings import settings
@@ -12,7 +12,7 @@ def validate_query_length(query, emb_endpoint):
     # Validate that the query length does not exceed the maximum allowed tokens.
 
     try:
-        tokens = tokenize_with_llm(query, emb_endpoint)
+        tokens = tokenize(query)
         token_count = len(tokens)
         
         if token_count > settings.chatbot.max_query_token_length:

--- a/spyre-rag/src/common/llm_utils.py
+++ b/spyre-rag/src/common/llm_utils.py
@@ -14,6 +14,7 @@ from chatbot.settings import settings as chatbot_settings
 from summarize.settings import settings as summarize_settings
 from digitize.settings import settings as digitize_settings
 import common.misc_utils as misc_utils
+from common.tokenizer_utils import tokenize, detokenize
 
 logger = get_logger("LLM")
 
@@ -169,11 +170,11 @@ def query_vllm_payload(question, documents, llm_endpoint, llm_model, stop_words,
     logger.debug(f'Original Context: {context}')
 
     # dynamic chunk truncation: truncates the context, if doesn't fit in the sequence length
-    question_token_count = len(tokenize_with_llm(question, llm_endpoint))
+    question_token_count = len(tokenize(question))
     reamining_tokens = settings.llm.max_input_length - (
         chatbot_settings.chatbot.prompt_template_token_count + question_token_count
     )
-    context = detokenize_with_llm(tokenize_with_llm(context, llm_endpoint)[:reamining_tokens], llm_endpoint)
+    context = detokenize(tokenize(context)[:reamining_tokens])
     logger.debug(f"Truncated Context: {context}")
 
     # Get the appropriate prompt template based on language and format it
@@ -365,64 +366,3 @@ def query_vllm_summarize_stream(
         yield f"data: {json.dumps({'error': str(e)})}\n\n"
         yield "data: [DONE]\n\n"
 
-@retry_on_transient_error(max_retries=3, initial_delay=1.0, backoff_multiplier=2.0)
-def tokenize_with_llm(prompt, emb_endpoint, max_retries=3):
-    """
-    Tokenize text using the LLM embedding endpoint with retry logic.
-
-    Args:
-        prompt: Text to tokenize
-        emb_endpoint: Embedding endpoint URL
-        max_retries: Maximum number of retry attempts (default: 3)
-
-    Returns:
-        List of tokens
-
-    Raises:
-        RuntimeError: If SESSION is not initialized
-        requests.exceptions.RequestException: If all retries fail
-    """
-    if misc_utils.SESSION is None:
-        raise RuntimeError("LLM session not initialized. Call create_llm_session() first.")
-
-    payload = {
-        "prompt": prompt
-    }
-
-    response = misc_utils.SESSION.post(f"{emb_endpoint}/tokenize", json=payload)
-    response.raise_for_status()
-    result = response.json()
-    tokens = result.get("tokens", [])
-
-    return tokens
-
-@retry_on_transient_error(max_retries=3, initial_delay=1.0, backoff_multiplier=2.0)
-def detokenize_with_llm(tokens, emb_endpoint, max_retries=3):
-    """
-    Detokenize tokens using the LLM embedding endpoint with retry logic.
-
-    Args:
-        tokens: List of tokens to detokenize
-        emb_endpoint: Embedding endpoint URL
-        max_retries: Maximum number of retry attempts (default: 3)
-
-    Returns:
-        Detokenized text string
-
-    Raises:
-        RuntimeError: If SESSION is not initialized
-        requests.exceptions.RequestException: If all retries fail
-    """
-    if misc_utils.SESSION is None:
-        raise RuntimeError("LLM session not initialized. Call create_llm_session() first.")
-
-    payload = {
-        "tokens": tokens
-    }
-
-    response = misc_utils.SESSION.post(f"{emb_endpoint}/detokenize", json=payload)
-    response.raise_for_status()
-    result = response.json()
-    prompt = result.get("prompt", "")
-
-    return prompt

--- a/spyre-rag/src/common/settings.py
+++ b/spyre-rag/src/common/settings.py
@@ -134,6 +134,11 @@ class AppConfig(BaseSettings):
         description="Application port number",
     )
 
+    tokenizer_model_path: str = Field(
+        default="",
+        description="Path to the tokenizer model directory",
+    )
+
     @field_validator('log_level')
     @classmethod
     def validate_log_level(cls, v):

--- a/spyre-rag/src/common/tokenizer_utils.py
+++ b/spyre-rag/src/common/tokenizer_utils.py
@@ -1,0 +1,74 @@
+"""Local tokenization utilities using HuggingFace transformers."""
+
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
+from typing import List, Optional
+import threading
+from common.misc_utils import get_logger
+
+logger = get_logger("tokenizer")
+
+_tokenizer: Optional[PreTrainedTokenizerBase] = None
+_tokenizer_lock = threading.Lock()
+
+
+def initialize_tokenizer(model_path: str) -> None:
+    """
+    Initialize the tokenizer from a local model path.
+    
+    Args:
+        model_path: Path to the local model directory
+        
+    Raises:
+        Exception: If tokenizer fails to load
+    """
+    global _tokenizer
+    with _tokenizer_lock:
+        if _tokenizer is None:
+            logger.info(f"Loading tokenizer from {model_path}")
+            _tokenizer = AutoTokenizer.from_pretrained(
+                model_path, 
+                local_files_only=True
+            )
+            logger.info("Tokenizer loaded successfully")
+
+
+def tokenize(text: str) -> List[int]:
+    """
+    Tokenize text and return token IDs.
+    
+    Args:
+        text: Text to tokenize
+        
+    Returns:
+        List of token IDs
+        
+    Raises:
+        RuntimeError: If tokenizer not initialized
+    """
+    if _tokenizer is None:
+        raise RuntimeError(
+            "Tokenizer not initialized. Call initialize_tokenizer() first."
+        )
+    return _tokenizer.encode(text, add_special_tokens=False)
+
+
+def detokenize(tokens: List[int]) -> str:
+    """
+    Detokenize token IDs and return text.
+    
+    Args:
+        tokens: List of token IDs to detokenize
+        
+    Returns:
+        Detokenized text string
+        
+    Raises:
+        RuntimeError: If tokenizer not initialized
+    """
+    if _tokenizer is None:
+        raise RuntimeError(
+            "Tokenizer not initialized. Call initialize_tokenizer() first."
+        )
+    return _tokenizer.decode(tokens, skip_special_tokens=True)
+
+# Made with Bob

--- a/spyre-rag/src/common/tokenizer_utils.py
+++ b/spyre-rag/src/common/tokenizer_utils.py
@@ -1,9 +1,10 @@
-"""Local tokenization utilities using HuggingFace transformers."""
+"""Tokenization utilities supporting both local and LLM-based tokenization."""
 
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 from typing import List, Optional
 import threading
 from common.misc_utils import get_logger
+from common.settings import settings
 
 logger = get_logger("tokenizer")
 
@@ -11,9 +12,10 @@ _tokenizer: Optional[PreTrainedTokenizerBase] = None
 _tokenizer_lock = threading.Lock()
 
 
-def initialize_tokenizer(model_path: str) -> None:
+def initialize_local_tokenizer(model_path: str) -> None:
     """
-    Initialize the tokenizer from a local model path.
+    Initialize the local tokenizer from a model path for offline tokenization.
+    If not initialized, the system will fall back to LLM-based tokenization via API.
     
     Args:
         model_path: Path to the local model directory
@@ -26,35 +28,48 @@ def initialize_tokenizer(model_path: str) -> None:
         if _tokenizer is None:
             logger.info(f"Loading tokenizer from {model_path}")
             _tokenizer = AutoTokenizer.from_pretrained(
-                model_path, 
+                model_path,
                 local_files_only=True
             )
             logger.info("Tokenizer loaded successfully")
 
 
-def tokenize(text: str) -> List[int]:
+def _tokenize_with_llm(prompt: str) -> List[int]:
     """
-    Tokenize text and return token IDs.
+    Tokenize text using the LLM embedding endpoint.
     
     Args:
-        text: Text to tokenize
+        prompt: Text to tokenize
         
     Returns:
         List of token IDs
         
     Raises:
-        RuntimeError: If tokenizer not initialized
+        RuntimeError: If SESSION is not initialized
+        requests.exceptions.RequestException: If request fails
     """
-    if _tokenizer is None:
-        raise RuntimeError(
-            "Tokenizer not initialized. Call initialize_tokenizer() first."
-        )
-    return _tokenizer.encode(text, add_special_tokens=False)
+    import common.misc_utils as misc_utils
+    from common.retry_utils import retry_on_transient_error
+    
+    emb_endpoint = settings.model_endpoints.emb_endpoint
+    
+    @retry_on_transient_error(max_retries=3, initial_delay=1.0, backoff_multiplier=2.0)
+    def _tokenize_request():
+        if misc_utils.SESSION is None:
+            raise RuntimeError("LLM session not initialized. Call create_llm_session() first.")
+        
+        payload = {"prompt": prompt}
+        response = misc_utils.SESSION.post(f"{emb_endpoint}/tokenize", json=payload)
+        response.raise_for_status()
+        result = response.json()
+        return result.get("tokens", [])
+    
+    return _tokenize_request()
 
 
-def detokenize(tokens: List[int]) -> str:
+def _detokenize_with_llm(tokens: List[int]) -> str:
     """
-    Detokenize token IDs and return text.
+    Detokenize tokens using the LLM embedding endpoint.
     
     Args:
         tokens: List of token IDs to detokenize
@@ -63,12 +78,71 @@ def detokenize(tokens: List[int]) -> str:
         Detokenized text string
         
     Raises:
-        RuntimeError: If tokenizer not initialized
+        RuntimeError: If SESSION is not initialized
+        requests.exceptions.RequestException: If request fails
     """
-    if _tokenizer is None:
-        raise RuntimeError(
-            "Tokenizer not initialized. Call initialize_tokenizer() first."
-        )
-    return _tokenizer.decode(tokens, skip_special_tokens=True)
+    import common.misc_utils as misc_utils
+    from common.retry_utils import retry_on_transient_error
+    
+    emb_endpoint = settings.model_endpoints.emb_endpoint
+    
+    @retry_on_transient_error(max_retries=3, initial_delay=1.0, backoff_multiplier=2.0)
+    def _detokenize_request():
+        if misc_utils.SESSION is None:
+            raise RuntimeError("LLM session not initialized. Call create_llm_session() first.")
+        
+        payload = {"tokens": tokens}
+        response = misc_utils.SESSION.post(f"{emb_endpoint}/detokenize", json=payload)
+        response.raise_for_status()
+        result = response.json()
+        return result.get("prompt", "")
+    
+    return _detokenize_request()
+
+
+def tokenize(text: str) -> List[int]:
+    """
+    Tokenize text and return token IDs.
+    Uses local tokenizer if TOKENIZER_MODEL_PATH is set, otherwise falls back to LLM-based tokenization.
+    
+    Args:
+        text: Text to tokenize
+        
+    Returns:
+        List of token IDs
+        
+    Raises:
+        RuntimeError: If tokenizer not initialized and settings not available
+    """
+    # Use local tokenizer if available
+    if _tokenizer is not None:
+        return _tokenizer.encode(text, add_special_tokens=False)
+    
+    # Fall back to LLM-based tokenization
+    logger.debug("Using LLM-based tokenization")
+    return _tokenize_with_llm(text)
+
+
+def detokenize(tokens: List[int]) -> str:
+    """
+    Detokenize token IDs and return text.
+    Uses local tokenizer if TOKENIZER_MODEL_PATH is set, otherwise falls back to LLM-based tokenization.
+    
+    Args:
+        tokens: List of token IDs to detokenize
+        
+    Returns:
+        Detokenized text string
+        
+    Raises:
+        RuntimeError: If tokenizer not initialized and settings not available
+    """
+    # Use local tokenizer if available
+    if _tokenizer is not None:
+        return _tokenizer.decode(tokens, skip_special_tokens=True)
+    
+    # Fall back to LLM-based tokenization
+    logger.debug("Using LLM-based detokenization")
+    return _detokenize_with_llm(tokens)
 
 # Made with Bob

--- a/spyre-rag/src/digitize/app.py
+++ b/spyre-rag/src/digitize/app.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import uuid
+import os
 from typing import List, Optional
 from contextlib import asynccontextmanager
 import uvicorn
@@ -15,6 +16,7 @@ from digitize.settings import settings
 set_log_level(settings.common.app.log_level)
 
 from common.misc_utils import validate_pdf_file, set_request_id, configure_uvicorn_logging
+from common.tokenizer_utils import initialize_tokenizer
 from common.error_utils import APIError, ErrorCode, http_error_responses, http_exception_handler
 import digitize.digitize_utils as dg_util
 import digitize.types as types
@@ -38,6 +40,16 @@ async def lifespan(app: FastAPI):
     filtered_paths = ['/health', '/v1/jobs']
     configure_uvicorn_logging(settings.common.app.log_level, filtered_paths)
     logger.info("Application starting up...")
+
+    # Initialize tokenizer
+    if settings.common.app.tokenizer_model_path:
+        try:
+            initialize_tokenizer(settings.common.app.tokenizer_model_path)
+            logger.info(f"Tokenizer initialized from {settings.common.app.tokenizer_model_path}")
+        except Exception as e:
+            logger.error(f"Failed to initialize tokenizer: {e}", exc_info=True)
+    else:
+        logger.warning("tokenizer_model_path not set in settings, tokenizer not initialized")
 
     # Scan for orphan jobs and mark them as failed
     try:

--- a/spyre-rag/src/digitize/app.py
+++ b/spyre-rag/src/digitize/app.py
@@ -16,7 +16,7 @@ from digitize.settings import settings
 set_log_level(settings.common.app.log_level)
 
 from common.misc_utils import validate_pdf_file, set_request_id, configure_uvicorn_logging
-from common.tokenizer_utils import initialize_tokenizer
+from common.tokenizer_utils import initialize_local_tokenizer
 from common.error_utils import APIError, ErrorCode, http_error_responses, http_exception_handler
 import digitize.digitize_utils as dg_util
 import digitize.types as types
@@ -41,15 +41,16 @@ async def lifespan(app: FastAPI):
     configure_uvicorn_logging(settings.common.app.log_level, filtered_paths)
     logger.info("Application starting up...")
 
-    # Initialize tokenizer
+    # Initialize local tokenizer for offline tokenization (optional)
     if settings.common.app.tokenizer_model_path:
         try:
-            initialize_tokenizer(settings.common.app.tokenizer_model_path)
-            logger.info(f"Tokenizer initialized from {settings.common.app.tokenizer_model_path}")
+            initialize_local_tokenizer(settings.common.app.tokenizer_model_path)
+            logger.info(f"Local tokenizer initialized from {settings.common.app.tokenizer_model_path}")
         except Exception as e:
-            logger.error(f"Failed to initialize tokenizer: {e}", exc_info=True)
+            logger.error(f"Failed to initialize local tokenizer: {e}", exc_info=True)
+            logger.info("Will fall back to LLM-based tokenization via API")
     else:
-        logger.warning("tokenizer_model_path not set in settings, tokenizer not initialized")
+        logger.info("TOKENIZER_MODEL_PATH not set, will use LLM-based tokenization via API")
 
     # Scan for orphan jobs and mark them as failed
     try:

--- a/spyre-rag/src/digitize/doc_utils.py
+++ b/spyre-rag/src/digitize/doc_utils.py
@@ -19,7 +19,8 @@ logging.getLogger('docling').setLevel(logging.CRITICAL)
 
 # Import project modules after setting log levels
 from common.thread_utils import ContextAwareThreadPoolExecutor
-from common.llm_utils import summarize_and_classify_tables, tokenize_with_llm
+from common.llm_utils import summarize_and_classify_tables
+from common.tokenizer_utils import tokenize
 from common.misc_utils import get_logger, text_suffix, table_suffix, text_chunk_suffix, table_chunk_suffix
 from digitize.pdf_utils import get_toc, get_matching_header_lvl, load_pdf_pages, find_text_font_size, get_pdf_page_count, convert_doc
 from digitize.status import (
@@ -708,7 +709,7 @@ def get_header_level(text, font_size, sorted_font_sizes):
 
 
 def count_tokens(text, emb_endpoint):
-    token_len = len(tokenize_with_llm(text, emb_endpoint))
+    token_len = len(tokenize(text))
     return token_len
 
 def split_text_into_token_chunks(text, emb_endpoint, max_tokens=512, overlap=50):

--- a/spyre-rag/src/digitize/doc_utils.py
+++ b/spyre-rag/src/digitize/doc_utils.py
@@ -350,7 +350,7 @@ def process_table(converted_doc, pdf_path, out_path, gen_model, gen_endpoint):
 
     return table_count, process_time
 
-def process_converted_document(converted_json_path, pdf_path, out_path, gen_model, gen_endpoint, emb_endpoint, max_tokens, doc_id):
+def process_converted_document(converted_json_path, pdf_path, out_path, gen_model, gen_endpoint, doc_id):
     """
     Process converted document to extract text and tables.
     No caching - always process fresh.
@@ -418,7 +418,7 @@ def clean_intermediate_files(doc_id, out_path):
             except Exception as e:
                 logger.warning(f"Failed to clean up {file_path}: {e}")
 
-def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoint, max_tokens, job_id, doc_id_dict, indexing_callback=None):
+def process_documents(input_paths, out_path, llm_model, llm_endpoint, max_tokens, job_id, doc_id_dict, indexing_callback=None):
     """
     Process documents for ingestion pipeline.
     Each request is treated as fresh.
@@ -507,7 +507,7 @@ def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoi
 
                     p_future = processor_executor.submit(
                         process_converted_document, converted_json, path, out_path,
-                        llm_model, llm_endpoint, emb_endpoint, max_tokens, doc_id=doc_id
+                        llm_model, llm_endpoint, doc_id=doc_id
                     )
                     process_futures[p_future] = str(path)
                 except Exception as e:
@@ -555,7 +555,7 @@ def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoi
 
                     c_future = chunker_executor.submit(
                         chunk_single_file, txt_json, tab_json, out_path,
-                        emb_endpoint, max_tokens, doc_id=doc_id
+                        max_tokens, doc_id=doc_id
                     )
                     chunk_futures[c_future] = str(path)
                 except Exception as e:
@@ -708,18 +708,18 @@ def get_header_level(text, font_size, sorted_font_sizes):
     return level, text
 
 
-def count_tokens(text, emb_endpoint):
+def count_tokens(text):
     token_len = len(tokenize(text))
     return token_len
 
-def split_text_into_token_chunks(text, emb_endpoint, max_tokens=512, overlap=50):
+def split_text_into_token_chunks(text, max_tokens=512, overlap=50):
     sentences = SentenceSplitter(language='en').split(text)
     chunks = []
     current_chunk = []
     current_token_count = 0
 
     for sentence in sentences:
-        token_len = count_tokens(sentence, emb_endpoint)
+        token_len = count_tokens(sentence)
 
         if current_token_count + token_len > max_tokens:
             # save current chunk
@@ -729,7 +729,7 @@ def split_text_into_token_chunks(text, emb_endpoint, max_tokens=512, overlap=50)
             if overlap > 0 and len(current_chunk) > 0:
                 overlap_text = current_chunk[-1]
                 current_chunk = [overlap_text]
-                current_token_count = count_tokens(overlap_text, emb_endpoint)
+                current_token_count = count_tokens(overlap_text)
             else:
                 current_chunk = []
                 current_token_count = 0
@@ -745,13 +745,13 @@ def split_text_into_token_chunks(text, emb_endpoint, max_tokens=512, overlap=50)
     return chunks
 
 
-def flush_chunk(current_chunk, chunks, emb_endpoint, max_tokens):
+def flush_chunk(current_chunk, chunks, max_tokens):
     content = current_chunk["content"].strip()
     if not content:
         return
 
     # Split content into token chunks
-    token_chunks = split_text_into_token_chunks(content, emb_endpoint, max_tokens=max_tokens)
+    token_chunks = split_text_into_token_chunks(content, max_tokens=max_tokens)
 
     for i, part in enumerate(token_chunks):
         chunk = {
@@ -777,7 +777,7 @@ def flush_chunk(current_chunk, chunks, emb_endpoint, max_tokens):
     current_chunk["source_nodes"] = []
 
 
-def chunk_text(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None):
+def chunk_text(input_path, out_path, max_tokens=512, doc_id=None):
     """
     Chunk text content from a document into smaller pieces based on token limits.
     """
@@ -830,7 +830,7 @@ def chunk_text(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None):
                         current_subsubsection = full_title
 
                     # Flush current chunk and update
-                    flush_chunk(current_chunk, chunks, emb_endpoint, max_tokens)
+                    flush_chunk(current_chunk, chunks, max_tokens)
                     current_chunk["chapter_title"] = current_chapter
                     current_chunk["section_title"] = current_section
                     current_chunk["subsection_title"] = current_subsection
@@ -859,7 +859,7 @@ def chunk_text(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None):
                     logger.debug(f'Skipping adding "{label}".')
 
             # Flush any remaining content
-            flush_chunk(current_chunk, chunks, emb_endpoint, max_tokens)
+            flush_chunk(current_chunk, chunks, max_tokens)
 
         # Save the processed chunks to the output file
         with open(processed_chunk_json_path, "w") as f:
@@ -872,7 +872,7 @@ def chunk_text(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None):
         logger.error(f"Error chunking text from '{input_path}': {e}")
         return None, None
 
-def chunk_single_file(input_path, table_json_path, out_path, emb_endpoint, max_tokens=512, doc_id=None):
+def chunk_single_file(input_path, table_json_path, out_path, max_tokens=512, doc_id=None):
     """
     Orchestrates chunking of both text and tables for a single document.
     """
@@ -880,10 +880,10 @@ def chunk_single_file(input_path, table_json_path, out_path, emb_endpoint, max_t
 
     try:
         # Chunk text content
-        text_chunk_json, text_chunk_time = chunk_text(input_path, out_path, emb_endpoint, max_tokens, doc_id)
+        text_chunk_json, text_chunk_time = chunk_text(input_path, out_path, max_tokens, doc_id)
 
         # Chunk tables
-        table_chunk_json, table_chunk_time = chunk_tables(table_json_path, out_path, emb_endpoint, max_tokens, doc_id)
+        table_chunk_json, table_chunk_time = chunk_tables(table_json_path, out_path, max_tokens, doc_id)
 
         total_time = time.time() - t0
         return text_chunk_json, table_chunk_json, total_time
@@ -891,7 +891,7 @@ def chunk_single_file(input_path, table_json_path, out_path, emb_endpoint, max_t
         logger.error(f"Error chunking document '{input_path}': {e}")
         return None, None, None
 
-def chunk_tables(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None):
+def chunk_tables(input_path, out_path, max_tokens=512, doc_id=None):
     """
     Chunk table summaries into smaller pieces if they exceed token limits.
     Called internally by chunk_single_file() for sequential processing.
@@ -915,12 +915,12 @@ def chunk_tables(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None
                 page_number = block.get('page_number')
 
                 # Use summary for chunking - summaries are more concise and meaningful for RAG
-                summary_token_count = count_tokens(summary, emb_endpoint)
+                summary_token_count = count_tokens(summary)
 
                 if summary_token_count > max_tokens:
                     tables_chunked_count += 1
                     # Chunk the summary
-                    chunks = split_text_into_token_chunks(summary, emb_endpoint, max_tokens=max_tokens, overlap=50)
+                    chunks = split_text_into_token_chunks(summary, max_tokens=max_tokens, overlap=50)
 
                     for chunk_part_idx, chunk in enumerate(chunks):
                         # TODO: Consider adding chunking properties ("is_chunked", "chunk_part", "total_parts")

--- a/spyre-rag/src/digitize/ingest.py
+++ b/spyre-rag/src/digitize/ingest.py
@@ -151,7 +151,7 @@ def ingest(directory_path: Path, job_id: Optional[str] = None, doc_id_dict: Opti
         # Reserve 100 tokens from embedding model's max_tokens to account for metadata
         # that will be prepended to content during final merge, ensuring total tokens stay within embedding model limits
         _, converted_pdf_stats = process_documents(
-            input_file_paths, out_path, llm_model_dict['llm_model'], llm_model_dict['llm_endpoint'],  emb_model_dict["emb_endpoint"],
+            input_file_paths, out_path, llm_model_dict['llm_model'], llm_model_dict['llm_endpoint'],
             max_tokens=emb_model_dict['max_tokens'] - 100, job_id=job_id, doc_id_dict=doc_id_dict,
             indexing_callback=indexing_handler)
         # converted_pdf_stats holds { file_name: {page_count: int, table_count: int, timings: {conversion: time_in_secs, process_text: time_in_secs, process_tables: time_in_secs, chunking: time_in_secs}} }

--- a/spyre-rag/src/summarize/app.py
+++ b/spyre-rag/src/summarize/app.py
@@ -16,9 +16,10 @@ from summarize.settings import settings
 
 set_log_level(settings.common.app.log_level)
 
-from common.llm_utils import query_vllm_summarize, query_vllm_summarize_stream, tokenize_with_llm
+from common.llm_utils import query_vllm_summarize, query_vllm_summarize_stream
 from common.misc_utils import get_model_endpoints, set_request_id, configure_uvicorn_logging, create_llm_session
 from common.diagnostic_logger import setup_comprehensive_crash_handler
+from common.tokenizer_utils import tokenize
 
 from common.error_utils import http_error_responses
 from summarize.summ_utils import (
@@ -131,7 +132,7 @@ async def handle_summarize(
     
     # Get actual token count from the input text
     input_tokens = await asyncio.to_thread(
-        lambda: len(tokenize_with_llm(content_text, llm_endpoint))
+        lambda: len(tokenize(content_text))
     )
     
     # Validate that both parameters are not provided simultaneously


### PR DESCRIPTION
- Add new tokenizer_utils.py module for local tokenization functionality
- Update podman templates (chat-bot, digitize, vllm-server) to mount model cache volumes
- Configure TOKENIZER_MODEL_PATH environment variable in podman values.yaml files
- Integrate local tokenizer in chatbot and digitize applications
- Refactor llm_utils.py to use centralized tokenizer utilities
- Add tokenizer dependencies to Makefile
- Enable offline tokenization using locally downloaded models

This change allows podman deployments to perform tokenization locally
using downloaded models instead of relying on remote API calls,
improving performance and enabling offline operation.