### PR TITLE
feat(catalog-ui): Reusable Architecture card & Solution Card

### DIFF
--- a/catalog-ui/src/App.tsx
+++ b/catalog-ui/src/App.tsx
@@ -6,6 +6,7 @@ import AuthLayout from "./layouts/AuthLayout";
 import Login from "./pages/Login";
 import Logout from "./pages/Logout";
 import ApplicationsListPage from "./pages/AiDeployments";
+import CardsDemo from "./pages/CardsDemo";
 import { ProtectedRoute } from "@/components";
 
 function App() {
@@ -21,6 +22,7 @@ function App() {
               path={ROUTES.AI_DEPLOYMENTS}
               element={<ApplicationsListPage />}
             />
+            <Route path={ROUTES.CARDS_DEMO} element={<CardsDemo />} />
           </Route>
         </Route>
 

--- a/catalog-ui/src/components/ArchitectureCard/ArchitectureCard.module.scss
+++ b/catalog-ui/src/components/ArchitectureCard/ArchitectureCard.module.scss
@@ -1,0 +1,86 @@
+@use "@carbon/react/scss/spacing";
+@use "@carbon/react/scss/type";
+
+.card {
+  background-color: var(--cds-layer);
+  border: 1px solid var(--cds-border-subtle);
+  padding: spacing.$spacing-05;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: spacing.$spacing-03;
+  margin-bottom: spacing.$spacing-05;
+}
+
+.cardTitle {
+  @include type.type-style("heading-compact-02");
+  color: var(--cds-text-primary);
+  margin: 0;
+  flex: 1;
+}
+
+.headerRight {
+  display: flex;
+  align-items: center;
+  gap: spacing.$spacing-02;
+}
+
+.certifiedBadge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--cds-support-success);
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  svg {
+    fill: var(--cds-support-success);
+  }
+}
+
+.cardDescription {
+  @include type.type-style("body-compact-01");
+  color: var(--cds-text-secondary);
+  margin: 0 0 spacing.$spacing-05 0;
+  min-height: 100px;
+}
+
+.tagsSection {
+  display: flex;
+  flex-direction: column;
+  gap: spacing.$spacing-03;
+  margin-bottom: spacing.$spacing-06;
+}
+
+.tagsHeading {
+  @include type.type-style("label-01");
+  font-weight: 600;
+  color: var(--cds-text-secondary);
+  margin: 0;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: spacing.$spacing-02;
+  max-height: calc(2 * 1.5rem + spacing.$spacing-02);
+  overflow: hidden;
+}
+
+.cardActions {
+  display: flex;
+  gap: spacing.$spacing-03;
+  margin-top: auto;
+}

--- a/catalog-ui/src/components/ArchitectureCard/ArchitectureCard.tsx
+++ b/catalog-ui/src/components/ArchitectureCard/ArchitectureCard.tsx
@@ -1,0 +1,95 @@
+import { Button, Tag, Tooltip } from "@carbon/react";
+import { ArrowRight, Badge, Deploy } from "@carbon/icons-react";
+import styles from "./ArchitectureCard.module.scss";
+
+export interface ArchitectureCardProps {
+  id: string;
+  title: string;
+  description: string;
+  tags: string[];
+  isCertified?: boolean;
+  tagsHeading?: string;
+  onDeploy?: (id: string) => void;
+  onLearnMore?: (id: string) => void;
+}
+
+const ArchitectureCard = ({
+  id,
+  title,
+  description,
+  tags,
+  isCertified,
+  tagsHeading = "Services",
+  onDeploy,
+  onLearnMore,
+}: ArchitectureCardProps) => {
+  const maxVisibleTags = 4;
+  const visibleTags = tags.slice(0, maxVisibleTags);
+  const remainingCount = Math.max(0, tags.length - maxVisibleTags);
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.cardHeader}>
+        <h3 className={styles.cardTitle}>{title}</h3>
+        <div className={styles.headerRight}>
+          {isCertified && (
+            <Tooltip align="top" label="IBM certified">
+              <button
+                className={styles.certifiedBadge}
+                type="button"
+                aria-label="IBM certified"
+              >
+                <Badge size={16} />
+              </button>
+            </Tooltip>
+          )}
+        </div>
+      </div>
+
+      <p className={styles.cardDescription}>{description}</p>
+
+      {tags.length > 0 && (
+        <div className={styles.tagsSection}>
+          <h4 className={styles.tagsHeading}>{tagsHeading}</h4>
+          <div className={styles.tags}>
+            {visibleTags.map((tag) => (
+              <Tag key={tag} type="blue" size="md">
+                {tag}
+              </Tag>
+            ))}
+            {remainingCount > 0 && (
+              <Tag type="blue" size="md">
+                +{remainingCount}
+              </Tag>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className={styles.cardActions}>
+        {onDeploy && (
+          <Button
+            kind="tertiary"
+            size="sm"
+            renderIcon={Deploy}
+            onClick={() => onDeploy(id)}
+          >
+            Deploy
+          </Button>
+        )}
+        {onLearnMore && (
+          <Button
+            kind="tertiary"
+            size="sm"
+            renderIcon={ArrowRight}
+            onClick={() => onLearnMore(id)}
+          >
+            Learn more
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ArchitectureCard;

--- a/catalog-ui/src/components/ArchitectureCard/index.ts
+++ b/catalog-ui/src/components/ArchitectureCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ArchitectureCard";
+export type { ArchitectureCardProps } from "./ArchitectureCard";

--- a/catalog-ui/src/components/SolutionCard/SolutionCard.module.scss
+++ b/catalog-ui/src/components/SolutionCard/SolutionCard.module.scss
@@ -1,0 +1,82 @@
+@use "@carbon/react/scss/spacing";
+@use "@carbon/react/scss/type";
+@use "@carbon/react/scss/motion";
+
+.card {
+  background-color: var(--cds-layer);
+  border: 1px solid var(--cds-border-subtle);
+  padding: spacing.$spacing-05;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  position: relative;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: spacing.$spacing-05;
+}
+
+.iconContainer {
+  flex-shrink: 0;
+  color: var(--cds-icon-primary);
+
+  svg {
+    display: block;
+  }
+}
+
+.indicatorIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--cds-support-success);
+  position: relative;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  svg {
+    fill: var(--cds-support-success);
+  }
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.category {
+  @include type.type-style("label-01");
+  color: var(--cds-text-secondary);
+  margin: 0;
+  margin-bottom: spacing.$spacing-02;
+}
+
+.title {
+  @include type.type-style("heading-03");
+  color: var(--cds-text-primary);
+  margin: 0;
+  margin-bottom: spacing.$spacing-03;
+}
+
+.description {
+  @include type.type-style("body-compact-01");
+  color: var(--cds-text-secondary);
+  margin: 0 0 spacing.$spacing-05 0;
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: auto;
+}

--- a/catalog-ui/src/components/SolutionCard/SolutionCard.tsx
+++ b/catalog-ui/src/components/SolutionCard/SolutionCard.tsx
@@ -1,0 +1,85 @@
+import { Tag, IconButton, Tooltip } from "@carbon/react";
+import {
+  ArrowRight,
+  AgricultureAnalytics,
+  PiggyBank,
+  IbmPlanningAnalytics,
+  Umbrella,
+  Help,
+  Badge,
+} from "@carbon/icons-react";
+import styles from "./SolutionCard.module.scss";
+
+export interface SolutionCardProps {
+  id: string;
+  title: string;
+  description: string;
+  tags: string[];
+  category: string;
+  onViewDetails?: (id: string) => void;
+}
+
+const categoryIcons: Record<
+  string,
+  React.ComponentType<{ size?: string | number }>
+> = {
+  Agriculture: AgricultureAnalytics,
+  "Banking and Finance": PiggyBank,
+  "Dev operations": Help,
+  "Enterprise resource planning": IbmPlanningAnalytics,
+  Healthcare: Help,
+  Insurance: Umbrella,
+  "IT operations": Help,
+  "Professional services": Help,
+  "Public sector": Help,
+  "Real estates": Help,
+};
+
+const SolutionCard = ({
+  id,
+  title,
+  description,
+  tags,
+  category,
+  onViewDetails,
+}: SolutionCardProps) => {
+  const IconComponent = categoryIcons[category] || AgricultureAnalytics;
+  const primaryTag = tags[0] || "Digital assistant";
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.cardHeader}>
+        <div className={styles.iconContainer}>
+          <IconComponent size={32} />
+        </div>
+        <Tooltip align="top" label="IBM certified">
+          <button className={styles.indicatorIcon} type="button">
+            <Badge size={16} />
+          </button>
+        </Tooltip>
+      </div>
+
+      <div className={styles.content}>
+        <p className={styles.category}>{category}</p>
+        <h3 className={styles.title}>{title}</h3>
+        <p className={styles.description}>{description}</p>
+      </div>
+
+      <div className={styles.footer}>
+        <Tag type="gray" size="sm">
+          {primaryTag}
+        </Tag>
+        <IconButton
+          kind="ghost"
+          size="sm"
+          label="View details"
+          onClick={() => onViewDetails?.(id)}
+        >
+          <ArrowRight size={20} />
+        </IconButton>
+      </div>
+    </div>
+  );
+};
+
+export default SolutionCard;

--- a/catalog-ui/src/components/SolutionCard/index.ts
+++ b/catalog-ui/src/components/SolutionCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./SolutionCard";
+export type { SolutionCardProps } from "./SolutionCard";

--- a/catalog-ui/src/components/index.ts
+++ b/catalog-ui/src/components/index.ts
@@ -1,3 +1,7 @@
 export { default as Header } from "./AppHeader";
 export { default as Navbar } from "./Navbar";
 export { default as ProtectedRoute } from "./ProtectedRoute";
+export { default as ArchitectureCard } from "./ArchitectureCard";
+export { default as SolutionCard } from "./SolutionCard";
+export type { ArchitectureCardProps } from "./ArchitectureCard";
+export type { SolutionCardProps } from "./SolutionCard";

--- a/catalog-ui/src/constants/endpoints.constants.ts
+++ b/catalog-ui/src/constants/endpoints.constants.ts
@@ -5,4 +5,5 @@ export const ROUTES = {
   ARCHITECTURES: "/architectures",
   SERVICES: "/services",
   SOLUTIONS_AND_USE_CASES: "/solutions-and-use-cases",
+  CARDS_DEMO: "/cards-demo",
 } as const;

--- a/catalog-ui/src/pages/CardsDemo/CardsDemo.module.scss
+++ b/catalog-ui/src/pages/CardsDemo/CardsDemo.module.scss
@@ -1,0 +1,28 @@
+@use "@carbon/react/scss/spacing";
+@use "@carbon/react/scss/type";
+
+.container {
+  padding: spacing.$spacing-07;
+  max-width: 1584px;
+  margin: 0 auto;
+}
+
+.pageTitle {
+  @include type.type-style("heading-05");
+  color: var(--cds-text-primary);
+  margin: 0 0 spacing.$spacing-07 0;
+}
+
+.section {
+  margin-bottom: spacing.$spacing-09;
+}
+
+.sectionTitle {
+  @include type.type-style("heading-03");
+  color: var(--cds-text-primary);
+  margin: 0 0 spacing.$spacing-06 0;
+}
+
+.solutionCardColumn {
+  height: 272px;
+}

--- a/catalog-ui/src/pages/CardsDemo/CardsDemo.tsx
+++ b/catalog-ui/src/pages/CardsDemo/CardsDemo.tsx
@@ -1,0 +1,110 @@
+import { Grid, Column } from "@carbon/react";
+import { ArchitectureCard, SolutionCard } from "@/components";
+import styles from "./CardsDemo.module.scss";
+
+const CardsDemo = () => {
+  const handleDeploy = (id: string) => {
+    console.log("Deploy clicked:", id);
+  };
+
+  const handleLearnMore = (id: string) => {
+    console.log("Learn more clicked:", id);
+  };
+
+  const handleViewDetails = (id: string) => {
+    console.log("View details clicked:", id);
+  };
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.pageTitle}>Card Components Demo</h1>
+
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>ArchitectureCard Examples</h2>
+        <Grid>
+          <Column sm={4} md={4} lg={5}>
+            <ArchitectureCard
+              id="catalog-1"
+              title="Digital assistant"
+              description="Enable digital assistants using Retrieval-Augmented Generation (RAG) so AI services can query a managed knowledge base to answer questions from custom documents and data."
+              tags={[
+                "Q&A",
+                "Find similar items",
+                "Translation",
+                "Digitize documents",
+                "Summarization",
+                "Reranking",
+              ]}
+              isCertified={true}
+              tagsHeading="Services"
+              onDeploy={handleDeploy}
+              onLearnMore={handleLearnMore}
+            />
+          </Column>
+          <Column sm={4} md={4} lg={5}>
+            <ArchitectureCard
+              id="catalog-2"
+              title="Document processing"
+              description="Process and analyze documents using advanced AI capabilities for extraction, classification, and insights generation."
+              tags={["OCR", "Classification", "Extraction", "Analysis"]}
+              isCertified={false}
+              tagsHeading="Services"
+              onDeploy={handleDeploy}
+              onLearnMore={handleLearnMore}
+            />
+          </Column>
+          <Column sm={4} md={4} lg={6}>
+            <ArchitectureCard
+              id="catalog-3"
+              title="Data analytics platform"
+              description="Comprehensive analytics solution for processing large datasets and generating actionable insights with machine learning."
+              tags={[]}
+              isCertified={true}
+              tagsHeading="Services"
+              onDeploy={handleDeploy}
+              onLearnMore={handleLearnMore}
+            />
+          </Column>
+        </Grid>
+      </section>
+
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>SolutionCard Examples</h2>
+        <Grid>
+          <Column sm={4} md={4} lg={5} className={styles.solutionCardColumn}>
+            <SolutionCard
+              id="solution-1"
+              title="Agriculture assistant"
+              description="Provides farmers with accurate, validated crop‑growing guidance tailored to their region and preferred language."
+              tags={["Digital assistant", "Crop guidance"]}
+              category="Agriculture"
+              onViewDetails={handleViewDetails}
+            />
+          </Column>
+          <Column sm={4} md={4} lg={5} className={styles.solutionCardColumn}>
+            <SolutionCard
+              id="solution-2"
+              title="Banking advisor"
+              description="AI-powered financial advisory system providing personalized banking recommendations and insights."
+              tags={["Financial services", "Advisory"]}
+              category="Banking and Finance"
+              onViewDetails={handleViewDetails}
+            />
+          </Column>
+          <Column sm={4} md={4} lg={6} className={styles.solutionCardColumn}>
+            <SolutionCard
+              id="solution-3"
+              title="Healthcare diagnostics"
+              description="Advanced diagnostic support system for healthcare professionals using AI-powered analysis."
+              tags={["Diagnostics", "Healthcare AI"]}
+              category="Healthcare"
+              onViewDetails={handleViewDetails}
+            />
+          </Column>
+        </Grid>
+      </section>
+    </div>
+  );
+};
+
+export default CardsDemo;

--- a/catalog-ui/src/pages/CardsDemo/index.ts
+++ b/catalog-ui/src/pages/CardsDemo/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CardsDemo";


### PR DESCRIPTION
Architecture Card to be placed in Architectures page
<img width="412" height="398" alt="image" src="https://github.com/user-attachments/assets/a5c0686c-e907-467a-af51-f94757eeea37" />

Solution Card to be placed in Solution and use cases page
<img width="413" height="340" alt="image" src="https://github.com/user-attachments/assets/886c8510-0f19-4516-a877-e979a4ecb252" />

Cards Demo page is just to render and verify the cards. Will be removed in the next PR.