### PR TITLE
[WIP] Add TLS/HTTPS support for externally exposed services

### DIFF
--- a/ai-services/assets/catalog/podman/metadata.yaml
+++ b/ai-services/assets/catalog/podman/metadata.yaml
@@ -4,4 +4,5 @@ description: "Catalog Services for Project AI-Service"
 podTemplateExecutions:
   - [catalog-secret.yaml.tmpl]
   - [catalog-db.yaml.tmpl]
+  - [caddy.yaml.tmpl]
   - [catalog.yaml.tmpl]

--- a/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .AppName }}--caddy"
+  labels:
+    ai-services.io/application: "{{ .AppName }}"
+    ai-services.io/template: "{{ .AppTemplateName }}"
+    ai-services.io/version: "{{ .Version }}"
+    ai-services.io/component: "proxy"
+spec:
+  containers:
+    - name: caddy
+      image: "{{ .Values.caddy.image }}"
+      command: ["caddy", "run", "--config", "/data/Caddyfile", "--adapter", "caddyfile"]
+      ports:
+        - containerPort: {{ .Values.caddy.httpsPort }}
+          hostPort: {{ .Values.caddy.httpsPort }}
+          protocol: TCP
+        - containerPort: 2019
+          hostPort: 2019
+          protocol: TCP
+      volumeMounts:
+        - name: caddy-data
+          mountPath: /data:z
+      resources:
+        requests:
+          memory: "256Mi"
+        limits:
+          memory: "512Mi"
+      livenessProbe:
+        tcpSocket:
+          port: 2019
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+      readinessProbe:
+        tcpSocket:
+          port: 2019
+        initialDelaySeconds: 30
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+  volumes:
+    - name: caddy-data
+      hostPath:
+        path: {{ .Values.caddy.dataPath }}
+        type: DirectoryOrCreate

--- a/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
@@ -11,7 +11,7 @@ spec:
   containers:
     - name: caddy
       image: "{{ .Values.caddy.image }}"
-      command: ["caddy", "run", "--config", "/data/Caddyfile", "--adapter", "caddyfile"]
+      command: ["caddy", "run", "--config", "/data/caddy/Caddyfile", "--adapter", "caddyfile"]
       ports:
         - containerPort: {{ .Values.caddy.httpsPort }}
           hostPort: {{ .Values.caddy.httpsPort }}
@@ -21,7 +21,7 @@ spec:
           protocol: TCP
       volumeMounts:
         - name: caddy-data
-          mountPath: /data:z
+          mountPath: /data/caddy:z
       resources:
         requests:
           memory: "256Mi"

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -22,3 +22,11 @@ db:
       memory: "512Mi"
     limits:
       memory: "1Gi"
+
+caddy:
+  image: "docker.io/library/caddy:2.8-alpine"
+  httpsPort: 443
+  serverName: "ai_services_server"
+  dataPath: "/var/lib/ai-services/catalog/caddy"
+  domain: ""  # Will be set by configure command
+  externalPort: 443  # Will be set by configure command

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -18,6 +18,8 @@ import (
 var (
 	// Runtime type flag for catalog configure command.
 	runtimeType string
+	// Custom domain name for HTTPS
+	domainName string
 )
 
 // NewConfigureCmd creates a new configure command for the catalog service.
@@ -35,7 +37,7 @@ func NewConfigureCmd() *cobra.Command {
 Examples:
 	 # Configure catalog service for podman
 	 ai-services catalog configure --runtime podman
-	 
+
 	 # Configure with custom UI port
 	 ai-services catalog configure --runtime podman --params ui.port=8081`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -57,6 +59,7 @@ Examples:
 				AdminPassword: adminPassword,
 				Runtime:       vars.RuntimeFactory.GetRuntimeType(),
 				ArgParams:     argParams,
+				DomainName:    domainName,
 			})
 		},
 	}
@@ -80,6 +83,13 @@ func validateConfigureFlags(rawArgParams []string) (map[string]string, error) {
 	// Check if podman runtime is being used on unsupported platform
 	if err := utils.CheckPodmanPlatformSupport(vars.RuntimeFactory.GetRuntimeType()); err != nil {
 		return nil, err
+	}
+
+	// Validate domain name if provided
+	if domainName != "" {
+		if err := utils.ValidateDomainName(domainName); err != nil {
+			return nil, fmt.Errorf("invalid domain name: %w", err)
+		}
 	}
 
 	// Parse params if provided
@@ -111,6 +121,16 @@ func configureConfigureFlags(cmd *cobra.Command, rawArgParams *[]string) {
 			"- Example: --params ui.port=8081\n\n"+
 			"Available parameters:\n"+
 			"- ui.port: Port for the catalog UI (default: random available port)\n",
+	)
+
+	cmd.Flags().StringVar(
+		&domainName,
+		"domain-name",
+		"",
+		"Custom domain name for HTTPS access.\n"+
+			"If not provided, uses nip.io format: <service>.<ip>.nip.io\n"+
+			"Example: --domain-name example.com\n"+
+			"Note: Requires DNS configuration to point domain to host IP.",
 	)
 }
 

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -20,6 +20,10 @@ var (
 	runtimeType string
 	// Custom domain name for HTTPS
 	domainName string
+	// SSL certificate file path
+	sslCertPath string
+	// SSL key file path
+	sslKeyPath string
 )
 
 // NewConfigureCmd creates a new configure command for the catalog service.
@@ -60,6 +64,8 @@ Examples:
 				Runtime:       vars.RuntimeFactory.GetRuntimeType(),
 				ArgParams:     argParams,
 				DomainName:    domainName,
+				SSLCertPath:   sslCertPath,
+				SSLKeyPath:    sslKeyPath,
 			})
 		},
 	}
@@ -85,8 +91,34 @@ func validateConfigureFlags(rawArgParams []string) (map[string]string, error) {
 		return nil, err
 	}
 
-	// Validate domain name if provided
-	if domainName != "" {
+	// Validate SSL certificate files if provided
+	if sslCertPath != "" || sslKeyPath != "" {
+		// Both cert and key must be provided together
+		if sslCertPath == "" || sslKeyPath == "" {
+			return nil, fmt.Errorf("both --ssl-cert and --ssl-key must be provided together")
+		}
+
+		// Validate certificate files exist and are readable
+		if err := utils.ValidateCertificateFiles(sslCertPath, sslKeyPath); err != nil {
+			return nil, fmt.Errorf("invalid SSL certificate files: %w", err)
+		}
+
+		// Extract domain from certificate
+		extractedDomain, err := utils.ExtractDomainFromCertificate(sslCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract domain from certificate: %w", err)
+		}
+
+		// If user also provided --domain-name, warn that certificate domain takes precedence
+		if domainName != "" && domainName != extractedDomain {
+			logger.Infof("Warning: Ignoring --domain-name '%s', using domain from certificate: %s", domainName, extractedDomain)
+		}
+
+		// Override domainName with extracted domain
+		domainName = extractedDomain
+		logger.Infof("Extracted domain from certificate: %s", extractedDomain)
+	} else if domainName != "" {
+		// Validate domain name only if no certificates provided
 		if err := utils.ValidateDomainName(domainName); err != nil {
 			return nil, fmt.Errorf("invalid domain name: %w", err)
 		}
@@ -131,6 +163,25 @@ func configureConfigureFlags(cmd *cobra.Command, rawArgParams *[]string) {
 			"If not provided, uses nip.io format: <service>.<ip>.nip.io\n"+
 			"Example: --domain-name example.com\n"+
 			"Note: Requires DNS configuration to point domain to host IP.",
+	)
+
+	cmd.Flags().StringVar(
+		&sslCertPath,
+		"ssl-cert",
+		"",
+		"Path to SSL certificate file (PEM format).\n"+
+			"Must be used together with --ssl-key.\n"+
+			"If not provided, self-signed certificates will be generated.\n"+
+			"Example: --ssl-cert /path/to/cert.pem",
+	)
+
+	cmd.Flags().StringVar(
+		&sslKeyPath,
+		"ssl-key",
+		"",
+		"Path to SSL private key file (PEM format).\n"+
+			"Must be used together with --ssl-cert.\n"+
+			"Example: --ssl-key /path/to/key.pem",
 	)
 }
 

--- a/ai-services/internal/pkg/catalog/cli/configure/common.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/common.go
@@ -23,6 +23,8 @@ type ConfigureOptions struct {
 	Runtime       types.RuntimeType
 	ArgParams     map[string]string
 	DomainName    string
+	SSLCertPath   string
+	SSLKeyPath    string
 }
 
 // Run executes the configure process for the catalog service.
@@ -44,7 +46,7 @@ func Run(opts ConfigureOptions) error {
 		// Determine Podman URI
 		podmanURI := getPodmanURI()
 
-		return catalogPodman.DeployCatalog(ctx, podmanURI, passwordHashBase64, opts.ArgParams, opts.DomainName)
+		return catalogPodman.DeployCatalog(ctx, podmanURI, passwordHashBase64, opts.ArgParams, opts.DomainName, opts.SSLCertPath, opts.SSLKeyPath)
 
 	case types.RuntimeTypeOpenShift:
 		return fmt.Errorf("openshift runtime is not yet supported for catalog configure")

--- a/ai-services/internal/pkg/catalog/cli/configure/common.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/common.go
@@ -22,6 +22,7 @@ type ConfigureOptions struct {
 	AdminPassword string
 	Runtime       types.RuntimeType
 	ArgParams     map[string]string
+	DomainName    string
 }
 
 // Run executes the configure process for the catalog service.
@@ -43,7 +44,7 @@ func Run(opts ConfigureOptions) error {
 		// Determine Podman URI
 		podmanURI := getPodmanURI()
 
-		return catalogPodman.DeployCatalog(ctx, podmanURI, passwordHashBase64, opts.ArgParams)
+		return catalogPodman.DeployCatalog(ctx, podmanURI, passwordHashBase64, opts.ArgParams, opts.DomainName)
 
 	case types.RuntimeTypeOpenShift:
 		return fmt.Errorf("openshift runtime is not yet supported for catalog configure")

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -30,7 +30,7 @@ const (
 )
 
 // DeployCatalog deploys the catalog service using the assets/catalog template for podman runtime.
-func DeployCatalog(ctx context.Context, podmanURI, passwordHash string, argParams map[string]string) error {
+func DeployCatalog(ctx context.Context, podmanURI, passwordHash string, argParams map[string]string, domainName string) error {
 	s := spinner.New("Deploying catalog service...")
 	s.Start(ctx)
 
@@ -62,7 +62,7 @@ func DeployCatalog(ctx context.Context, podmanURI, passwordHash string, argParam
 	}
 
 	// Setup HTTPS configuration
-	httpsConfig, err := setupHTTPSConfig(s)
+	httpsConfig, err := setupHTTPSConfig(domainName, s)
 	if err != nil {
 		s.Fail("failed to setup HTTPS configuration")
 		return fmt.Errorf("failed to setup HTTPS configuration: %w", err)
@@ -104,7 +104,7 @@ type HTTPSConfig struct {
 }
 
 // setupHTTPSConfig prepares HTTPS configuration
-func setupHTTPSConfig(s *spinner.Spinner) (*HTTPSConfig, error) {
+func setupHTTPSConfig(domainName string, s *spinner.Spinner) (*HTTPSConfig, error) {
 	config := &HTTPSConfig{}
 
 	// Get host IP
@@ -114,9 +114,16 @@ func setupHTTPSConfig(s *spinner.Spinner) (*HTTPSConfig, error) {
 	}
 	config.HostIP = hostIP
 
-	// Use nip.io with host IP
-	config.Domain = fmt.Sprintf("%s.nip.io", hostIP)
-	logger.Infof("Using nip.io domain: %s", config.Domain)
+	// Determine domain name
+	if domainName != "" {
+		// Use custom domain name
+		config.Domain = domainName
+		logger.Infof("Using custom domain: %s", domainName)
+	} else {
+		// Use nip.io with host IP
+		config.Domain = fmt.Sprintf("%s.nip.io", hostIP)
+		logger.Infof("Using nip.io domain: %s", config.Domain)
+	}
 
 	// Create Caddy configuration directory and Caddyfile
 	if err := createCaddyConfig(config); err != nil {
@@ -205,6 +212,13 @@ func printNextSteps(tp templates.Template, rt *podman.PodmanClient, config *HTTP
 	logger.Infoln("")
 	logger.Infof("   Note: Using self-signed certificate for %s.\n", config.Domain)
 	logger.Infof("         Your browser may show a security warning.\n")
+
+	// Show DNS configuration note for custom domains
+	if config.Domain != fmt.Sprintf("%s.nip.io", config.HostIP) {
+		logger.Infoln("")
+		logger.Infof("   IMPORTANT: Ensure DNS is configured to point %s to %s\n", config.Domain, config.HostIP)
+	}
+
 	logger.Infoln("")
 	logger.Infoln("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -6,6 +6,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"text/template"
 
@@ -14,6 +16,7 @@ import (
 	clipodman "github.com/project-ai-services/ai-services/internal/pkg/cli/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/proxy"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/specs"
 	"github.com/project-ai-services/ai-services/internal/pkg/spinner"
@@ -21,8 +24,9 @@ import (
 )
 
 const (
-	catalogAppName     = "ai-services"
+	catalogAppName  = "ai-services"
 	catalogAppTemplate = "catalog"
+	caddyDataDir    = "/var/lib/ai-services/catalog/caddy"
 )
 
 // DeployCatalog deploys the catalog service using the assets/catalog template for podman runtime.
@@ -34,7 +38,6 @@ func DeployCatalog(ctx context.Context, podmanURI, passwordHash string, argParam
 	rt, err := podman.NewPodmanClient()
 	if err != nil {
 		s.Fail("failed to initialize podman client")
-
 		return fmt.Errorf("failed to initialize podman client: %w", err)
 	}
 
@@ -42,7 +45,6 @@ func DeployCatalog(ctx context.Context, podmanURI, passwordHash string, argParam
 	tp, appMetadata, tmpls, err := loadCatalogTemplates(s)
 	if err != nil {
 		s.Fail("failed to load catalog templates")
-
 		return fmt.Errorf("failed to load catalog templates: %w", err)
 	}
 
@@ -50,22 +52,26 @@ func DeployCatalog(ctx context.Context, podmanURI, passwordHash string, argParam
 	existingPods, err := helpers.CheckExistingPodsForApplication(rt, catalogAppName)
 	if err != nil {
 		s.Fail("failed to check existing pods")
-
 		return fmt.Errorf("failed to check existing pods: %w", err)
 	}
 
 	if len(existingPods) == len(tmpls) {
 		s.Stop("Catalog service already deployed")
 		logger.Infof("Catalog pod already exists: %v\n", existingPods)
-
 		return nil
 	}
 
+	// Setup HTTPS configuration
+	httpsConfig, err := setupHTTPSConfig(s)
+	if err != nil {
+		s.Fail("failed to setup HTTPS configuration")
+		return fmt.Errorf("failed to setup HTTPS configuration: %w", err)
+	}
+
 	// Prepare values with configure-specific configuration
-	values, err := prepareCatalogValues(tp, podmanURI, passwordHash, argParams)
+	values, err := prepareCatalogValues(tp, podmanURI, passwordHash, argParams, httpsConfig)
 	if err != nil {
 		s.Fail("failed to load values")
-
 		return fmt.Errorf("failed to load values: %w", err)
 	}
 
@@ -75,13 +81,132 @@ func DeployCatalog(ctx context.Context, podmanURI, passwordHash string, argParam
 	}
 
 	s.Stop("Catalog service deployed successfully")
+
+	// Register catalog routes with Caddy
+	if err := registerCatalogRoutes(rt, httpsConfig); err != nil {
+		logger.Infof("Warning: Failed to register catalog routes with Caddy: %v", err)
+	}
+
 	logger.Infoln("-------")
 
-	// Print next steps similar to application create
-	if err := helpers.PrintNextSteps(tp, rt, catalogAppName, catalogAppTemplate); err != nil {
-		// do not want to fail the overall configure if we cannot print next steps
+	// Print next steps
+	if err := printNextSteps(tp, rt, httpsConfig); err != nil {
 		logger.Infof("failed to display next steps: %v\n", err)
 	}
+
+	return nil
+}
+
+// HTTPSConfig contains HTTPS configuration
+type HTTPSConfig struct {
+	Domain string
+	HostIP string
+}
+
+// setupHTTPSConfig prepares HTTPS configuration
+func setupHTTPSConfig(s *spinner.Spinner) (*HTTPSConfig, error) {
+	config := &HTTPSConfig{}
+
+	// Get host IP
+	hostIP, err := utils.GetHostIP()
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect host IP: %w", err)
+	}
+	config.HostIP = hostIP
+
+	// Use nip.io with host IP
+	config.Domain = fmt.Sprintf("%s.nip.io", hostIP)
+	logger.Infof("Using nip.io domain: %s", config.Domain)
+
+	// Create Caddy configuration directory and Caddyfile
+	if err := createCaddyConfig(config); err != nil {
+		return nil, fmt.Errorf("failed to create Caddy configuration: %w", err)
+	}
+
+	return config, nil
+}
+
+// createCaddyConfig creates the Caddy data directory and Caddyfile
+func createCaddyConfig(config *HTTPSConfig) error {
+	// Create data directory
+	if err := os.MkdirAll(caddyDataDir, 0755); err != nil {
+		return fmt.Errorf("failed to create Caddy data directory: %w", err)
+	}
+
+	// Create Caddyfile in /data/caddy directory (Caddy's default location)
+	caddyfilePath := filepath.Join(caddyDataDir, "Caddyfile")
+	caddyfileContent := `{
+	# Admin API - accessible from host
+	admin 0.0.0.0:2019
+
+	# Configure HTTPS server
+	servers :443 {
+		name ai_services_server
+	}
+}
+
+# Default HTTPS configuration with self-signed certificates
+:443 {
+	tls internal
+}
+
+# Routes will be dynamically added via Caddy Admin API
+`
+
+	if err := os.WriteFile(caddyfilePath, []byte(caddyfileContent), 0644); err != nil {
+		return fmt.Errorf("failed to write Caddyfile: %w", err)
+	}
+
+	logger.Infof("Created Caddyfile at %s", caddyfilePath)
+	return nil
+}
+
+// registerCatalogRoutes registers catalog service routes with Caddy
+func registerCatalogRoutes(rt *podman.PodmanClient, config *HTTPSConfig) error {
+	logger.Infof("Registering catalog routes with Caddy...")
+
+	// Wait for Caddy to be ready
+	caddyClient := proxy.NewCaddyClient()
+	if err := caddyClient.HealthCheck(); err != nil {
+		return fmt.Errorf("caddy is not available: %w", err)
+	}
+
+	// Register route for catalog UI
+	catalogUIRoute := proxy.Route{
+		ID:              "route-ai-services--catalog-ui",
+		Host:            utils.ConstructServiceDomain(catalogAppName, "catalog", config.Domain),
+		UpstreamAddress: fmt.Sprintf("%s--catalog:8081", catalogAppName),
+		Terminal:        true,
+	}
+
+	if err := caddyClient.RegisterRoute(catalogUIRoute); err != nil {
+		return fmt.Errorf("failed to register catalog UI route: %w", err)
+	}
+
+	logger.Infof("Successfully registered catalog routes")
+	return nil
+}
+
+// printNextSteps prints the next steps after deployment
+func printNextSteps(tp templates.Template, rt *podman.PodmanClient, config *HTTPSConfig) error {
+	// Construct catalog URL (port 443 is default for HTTPS, so omit it)
+	catalogURL := utils.ConstructServiceURL(
+		"https",
+		utils.ConstructServiceDomain(catalogAppName, "catalog", config.Domain),
+		443,
+	)
+
+	// Print custom next steps
+	logger.Infoln("Next Steps:")
+	logger.Infoln("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	logger.Infoln("")
+	logger.Infof("1. Access the Catalog UI via HTTPS:\n")
+	logger.Infof("   %s\n", catalogURL)
+	logger.Infoln("")
+	logger.Infof("   Note: Using self-signed certificate for %s.\n", config.Domain)
+	logger.Infof("         Your browser may show a security warning.\n")
+	logger.Infoln("")
+	logger.Infoln("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 
 	return nil
 }
@@ -94,7 +219,6 @@ func loadCatalogTemplates(s *spinner.Spinner) (templates.Template, *templates.Ap
 	appMetadata, err := tp.LoadMetadata(catalogAppTemplate, true)
 	if err != nil {
 		s.Fail("failed to load catalog metadata")
-
 		return nil, nil, nil, fmt.Errorf("failed to load catalog metadata: %w", err)
 	}
 
@@ -102,7 +226,6 @@ func loadCatalogTemplates(s *spinner.Spinner) (templates.Template, *templates.Ap
 	tmpls, err := tp.LoadAllTemplates(catalogAppTemplate)
 	if err != nil {
 		s.Fail("failed to load catalog templates")
-
 		return nil, nil, nil, fmt.Errorf("failed to load catalog templates: %w", err)
 	}
 
@@ -110,7 +233,7 @@ func loadCatalogTemplates(s *spinner.Spinner) (templates.Template, *templates.Ap
 }
 
 // prepareCatalogValues prepares the values map with configure-specific configuration.
-func prepareCatalogValues(tp templates.Template, podmanURI, passwordHash string, argParams map[string]string) (map[string]any, error) {
+func prepareCatalogValues(tp templates.Template, podmanURI, passwordHash string, argParams map[string]string, httpsConfig *HTTPSConfig) (map[string]any, error) {
 	if argParams == nil {
 		argParams = make(map[string]string)
 	}
@@ -130,6 +253,11 @@ func prepareCatalogValues(tp templates.Template, podmanURI, passwordHash string,
 	argParams["backend.podman.uri"] = podmanURI
 	argParams["db.password"] = dbPasswordBase64
 
+	// Set Caddy configuration
+	argParams["caddy.httpsPort"] = "443"
+	argParams["caddy.domain"] = httpsConfig.Domain
+	argParams["caddy.externalPort"] = "443"
+
 	// Load values from catalog
 	return tp.LoadValues(catalogAppTemplate, nil, argParams)
 }
@@ -143,7 +271,6 @@ func executePodLayers(rt *podman.PodmanClient, tp templates.Template, tmpls map[
 
 		if err := executeLayer(rt, tp, tmpls, layer, appMetadata.Version, values, argParams, i); err != nil {
 			s.Fail("failed to deploy catalog pod")
-
 			return err
 		}
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -30,7 +30,7 @@ const (
 )
 
 // DeployCatalog deploys the catalog service using the assets/catalog template for podman runtime.
-func DeployCatalog(ctx context.Context, podmanURI, passwordHash string, argParams map[string]string, domainName string) error {
+func DeployCatalog(ctx context.Context, podmanURI, passwordHash string, argParams map[string]string, domainName, sslCertPath, sslKeyPath string) error {
 	s := spinner.New("Deploying catalog service...")
 	s.Start(ctx)
 
@@ -62,7 +62,7 @@ func DeployCatalog(ctx context.Context, podmanURI, passwordHash string, argParam
 	}
 
 	// Setup HTTPS configuration
-	httpsConfig, err := setupHTTPSConfig(domainName, s)
+	httpsConfig, err := setupHTTPSConfig(domainName, sslCertPath, sslKeyPath, s)
 	if err != nil {
 		s.Fail("failed to setup HTTPS configuration")
 		return fmt.Errorf("failed to setup HTTPS configuration: %w", err)
@@ -99,12 +99,15 @@ func DeployCatalog(ctx context.Context, podmanURI, passwordHash string, argParam
 
 // HTTPSConfig contains HTTPS configuration
 type HTTPSConfig struct {
-	Domain string
-	HostIP string
+	Domain         string
+	HostIP         string
+	UseUserCerts   bool
+	UserCertPath   string
+	UserKeyPath    string
 }
 
 // setupHTTPSConfig prepares HTTPS configuration
-func setupHTTPSConfig(domainName string, s *spinner.Spinner) (*HTTPSConfig, error) {
+func setupHTTPSConfig(domainName, sslCertPath, sslKeyPath string, s *spinner.Spinner) (*HTTPSConfig, error) {
 	config := &HTTPSConfig{}
 
 	// Get host IP
@@ -125,6 +128,14 @@ func setupHTTPSConfig(domainName string, s *spinner.Spinner) (*HTTPSConfig, erro
 		logger.Infof("Using nip.io domain: %s", config.Domain)
 	}
 
+	// Check if user provided certificates
+	if sslCertPath != "" && sslKeyPath != "" {
+		config.UseUserCerts = true
+		config.UserCertPath = sslCertPath
+		config.UserKeyPath = sslKeyPath
+		logger.Infof("Using user-provided SSL certificates")
+	}
+
 	// Create Caddy configuration directory and Caddyfile
 	if err := createCaddyConfig(config); err != nil {
 		return nil, fmt.Errorf("failed to create Caddy configuration: %w", err)
@@ -140,9 +151,40 @@ func createCaddyConfig(config *HTTPSConfig) error {
 		return fmt.Errorf("failed to create Caddy data directory: %w", err)
 	}
 
+	// If user provided certificates, copy them to Caddy directory
+	var tlsConfig string
+	if config.UseUserCerts {
+		// Copy certificate files to Caddy directory
+		certDestPath := filepath.Join(caddyDataDir, "cert.pem")
+		keyDestPath := filepath.Join(caddyDataDir, "key.pem")
+
+		// Read and write certificate
+		certData, err := os.ReadFile(config.UserCertPath)
+		if err != nil {
+			return fmt.Errorf("failed to read certificate file: %w", err)
+		}
+		if err := os.WriteFile(certDestPath, certData, 0644); err != nil {
+			return fmt.Errorf("failed to write certificate to Caddy directory: %w", err)
+		}
+
+		// Read and write key
+		keyData, err := os.ReadFile(config.UserKeyPath)
+		if err != nil {
+			return fmt.Errorf("failed to read key file: %w", err)
+		}
+		if err := os.WriteFile(keyDestPath, keyData, 0600); err != nil {
+			return fmt.Errorf("failed to write key to Caddy directory: %w", err)
+		}
+
+		logger.Infof("Copied user certificates to %s", caddyDataDir)
+		tlsConfig = "\ttls /data/caddy/cert.pem /data/caddy/key.pem"
+	} else {
+		tlsConfig = "\ttls internal"
+	}
+
 	// Create Caddyfile in /data/caddy directory (Caddy's default location)
 	caddyfilePath := filepath.Join(caddyDataDir, "Caddyfile")
-	caddyfileContent := `{
+	caddyfileContent := fmt.Sprintf(`{
 	# Admin API - accessible from host
 	admin 0.0.0.0:2019
 
@@ -152,13 +194,13 @@ func createCaddyConfig(config *HTTPSConfig) error {
 	}
 }
 
-# Default HTTPS configuration with self-signed certificates
+# Default HTTPS configuration
 :443 {
-	tls internal
+%s
 }
 
 # Routes will be dynamically added via Caddy Admin API
-`
+`, tlsConfig)
 
 	if err := os.WriteFile(caddyfilePath, []byte(caddyfileContent), 0644); err != nil {
 		return fmt.Errorf("failed to write Caddyfile: %w", err)
@@ -210,8 +252,14 @@ func printNextSteps(tp templates.Template, rt *podman.PodmanClient, config *HTTP
 	logger.Infof("1. Access the Catalog UI via HTTPS:\n")
 	logger.Infof("   %s\n", catalogURL)
 	logger.Infoln("")
-	logger.Infof("   Note: Using self-signed certificate for %s.\n", config.Domain)
-	logger.Infof("         Your browser may show a security warning.\n")
+
+	// Show certificate information
+	if config.UseUserCerts {
+		logger.Infof("   Note: Using user-provided SSL certificate for %s.\n", config.Domain)
+	} else {
+		logger.Infof("   Note: Using self-signed certificate for %s.\n", config.Domain)
+		logger.Infof("         Your browser may show a security warning.\n")
+	}
 
 	// Show DNS configuration note for custom domains
 	if config.Domain != fmt.Sprintf("%s.nip.io", config.HostIP) {

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -1,0 +1,208 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+)
+
+const (
+	// DefaultAdminURL is the default Caddy Admin API URL (localhost only for security)
+	DefaultAdminURL = "http://127.0.0.1:2019"
+	// DefaultServerName is the default server name in Caddy config
+	DefaultServerName = "ai_services_server"
+	// DefaultRequestTimeout is the default HTTP request timeout
+	DefaultRequestTimeout = 30 * time.Second
+)
+
+// CaddyClient implements ProxyManager for Caddy server
+type CaddyClient struct {
+	config CaddyConfig
+	client *http.Client
+	mu     sync.Mutex // Protects concurrent API calls
+}
+
+// NewCaddyClient creates a new Caddy client with default configuration
+func NewCaddyClient() *CaddyClient {
+	return &CaddyClient{
+		config: CaddyConfig{
+			AdminURL:       DefaultAdminURL,
+			ServerName:     DefaultServerName,
+			HTTPSPort:      443,
+			RequestTimeout: DefaultRequestTimeout,
+		},
+		client: &http.Client{
+			Timeout: DefaultRequestTimeout,
+		},
+	}
+}
+
+// NewCaddyClientWithConfig creates a new Caddy client with custom configuration
+func NewCaddyClientWithConfig(config CaddyConfig) *CaddyClient {
+	if config.RequestTimeout == 0 {
+		config.RequestTimeout = DefaultRequestTimeout
+	}
+	if config.AdminURL == "" {
+		config.AdminURL = DefaultAdminURL
+	}
+	if config.ServerName == "" {
+		config.ServerName = DefaultServerName
+	}
+	if config.HTTPSPort == 0 {
+		config.HTTPSPort = 443
+	}
+
+	return &CaddyClient{
+		config: config,
+		client: &http.Client{
+			Timeout: config.RequestTimeout,
+		},
+	}
+}
+
+// HealthCheck verifies Caddy is available and responding
+func (c *CaddyClient) HealthCheck() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	url := fmt.Sprintf("%s/config/", c.config.AdminURL)
+	resp, err := c.client.Get(url)
+	if err != nil {
+		return fmt.Errorf("caddy health check failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("caddy health check failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	logger.Infof("Caddy health check passed", logger.VerbosityLevelDebug)
+	return nil
+}
+
+// RegisterRoute registers a new route with Caddy
+func (c *CaddyClient) RegisterRoute(route Route) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	logger.Infof("Registering route: %s -> %s", route.Host, route.UpstreamAddress)
+
+	// Construct route configuration
+	routeConfig := map[string]interface{}{
+		"@id": route.ID,
+		"match": []map[string]interface{}{
+			{
+				"host": []string{route.Host},
+			},
+		},
+		"handle": []map[string]interface{}{
+			{
+				"handler": "reverse_proxy",
+				"upstreams": []map[string]string{
+					{
+						"dial": route.UpstreamAddress,
+					},
+				},
+			},
+		},
+		"terminal": route.Terminal,
+	}
+
+	// Check if routes array exists, initialize if needed
+	checkURL := fmt.Sprintf("%s/config/apps/http/servers/%s/routes", c.config.AdminURL, c.config.ServerName)
+	checkResp, err := c.client.Get(checkURL)
+	if err != nil {
+		return fmt.Errorf("failed to check routes: %w", err)
+	}
+	defer checkResp.Body.Close()
+
+	body, _ := io.ReadAll(checkResp.Body)
+	if string(body) == "null\n" || string(body) == "null" {
+		// Initialize empty routes array
+		logger.Infof("Initializing routes array", logger.VerbosityLevelDebug)
+		initReq, _ := http.NewRequest(http.MethodPost, checkURL, bytes.NewBufferString("[]"))
+		initReq.Header.Set("Content-Type", "application/json")
+		initResp, err := c.client.Do(initReq)
+		if err != nil {
+			return fmt.Errorf("failed to initialize routes: %w", err)
+		}
+		initResp.Body.Close()
+	}
+
+	// Append route to array using /-
+	url := fmt.Sprintf("%s/config/apps/http/servers/%s/routes/-", c.config.AdminURL, c.config.ServerName)
+	data, err := json.Marshal(routeConfig)
+	if err != nil {
+		return fmt.Errorf("failed to marshal route config: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(data))
+	if err != nil {
+		return fmt.Errorf("failed to create post request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to register route: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("caddy returned error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	logger.Infof("Successfully registered route: %s", route.ID)
+	return nil
+}
+
+// UnregisterRoute removes a route from Caddy
+func (c *CaddyClient) UnregisterRoute(routeID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	logger.Infof("Unregistering route: %s", routeID)
+
+	// Send DELETE request to Caddy Admin API
+	url := fmt.Sprintf("%s/id/%s", c.config.AdminURL, routeID)
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to unregister route: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("caddy returned error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	logger.Infof("Successfully unregistered route: %s", routeID)
+	return nil
+}
+
+// LoadCertificates loads user-provided certificates into Caddy
+// TODO: Implement in future commit for user-provided certificates
+func (c *CaddyClient) LoadCertificates(config TLSConfig) error {
+	return fmt.Errorf("user-provided certificates not yet implemented")
+}
+
+// GetRoutes retrieves all registered routes from Caddy
+func (c *CaddyClient) GetRoutes() ([]Route, error) {
+	// TODO: Implement when needed for route listing
+	return nil, fmt.Errorf("not implemented yet")
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/proxy/interface.go
+++ b/ai-services/internal/pkg/proxy/interface.go
@@ -1,0 +1,21 @@
+package proxy
+
+// ProxyManager defines the interface for managing reverse proxy routes
+type ProxyManager interface {
+	// RegisterRoute registers a new route with the proxy
+	RegisterRoute(route Route) error
+
+	// UnregisterRoute removes a route from the proxy
+	UnregisterRoute(routeID string) error
+
+	// LoadCertificates loads user-provided certificates into the proxy
+	LoadCertificates(config TLSConfig) error
+
+	// HealthCheck verifies the proxy is available and responding
+	HealthCheck() error
+
+	// GetRoutes retrieves all registered routes
+	GetRoutes() ([]Route, error)
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/proxy/types.go
+++ b/ai-services/internal/pkg/proxy/types.go
@@ -1,0 +1,36 @@
+package proxy
+
+import "time"
+
+// Route represents a service route configuration
+type Route struct {
+	ID              string // Unique route identifier (e.g., "route-ai-services--catalog-ui")
+	Host            string // Domain name (e.g., "ai-services--catalog-ui.example.com")
+	UpstreamAddress string // Backend service address (e.g., "ai-services--catalog:8081")
+	Terminal        bool   // Stop route matching after this route
+}
+
+// TLSConfig represents TLS configuration
+type TLSConfig struct {
+	CertPath string // Path to certificate file
+	KeyPath  string // Path to private key file
+	Domain   string // Domain name extracted from certificate
+}
+
+// CaddyConfig represents Caddy server configuration
+type CaddyConfig struct {
+	AdminURL       string        // Caddy Admin API URL (e.g., "http://127.0.0.1:2019")
+	ServerName     string        // Server name in Caddy config
+	HTTPSPort      int           // HTTPS port (default: 443)
+	RequestTimeout time.Duration // HTTP request timeout
+}
+
+// RouteRegistrationResult contains the result of route registration
+type RouteRegistrationResult struct {
+	RouteID string
+	URL     string
+	Success bool
+	Error   error
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -375,6 +375,67 @@ func FlattenMapToKeys(m map[string]any, prefix string) map[string]string {
 	return result
 }
 
+// ValidateDomainName validates a domain name according to RFC 1035
+func ValidateDomainName(domain string) error {
+	if domain == "" {
+		return fmt.Errorf("domain name cannot be empty")
+	}
+
+	// Maximum length is 253 characters
+	if len(domain) > 253 {
+		return fmt.Errorf("domain name exceeds maximum length of 253 characters")
+	}
+
+	// Split into labels
+	labels := strings.Split(domain, ".")
+	if len(labels) < 2 {
+		return fmt.Errorf("domain name must have at least two labels (e.g., example.com)")
+	}
+
+	for _, label := range labels {
+		if err := validateDomainLabel(label); err != nil {
+			return fmt.Errorf("invalid label '%s': %w", label, err)
+		}
+	}
+
+	return nil
+}
+
+// validateDomainLabel validates a single domain label
+func validateDomainLabel(label string) error {
+	if label == "" {
+		return fmt.Errorf("label cannot be empty")
+	}
+
+	if len(label) > 63 {
+		return fmt.Errorf("label exceeds maximum length of 63 characters")
+	}
+
+	// Label must start with alphanumeric
+	if !isAlphanumeric(rune(label[0])) {
+		return fmt.Errorf("label must start with alphanumeric character")
+	}
+
+	// Label must end with alphanumeric
+	if !isAlphanumeric(rune(label[len(label)-1])) {
+		return fmt.Errorf("label must end with alphanumeric character")
+	}
+
+	// Check all characters
+	for _, ch := range label {
+		if !isAlphanumeric(ch) && ch != '-' {
+			return fmt.Errorf("label contains invalid character '%c'", ch)
+		}
+	}
+
+	return nil
+}
+
+// isAlphanumeric checks if a character is alphanumeric
+func isAlphanumeric(ch rune) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9')
+}
+
 // ConstructServiceDomain constructs a service domain name
 // Format: <podName>-<containerName>.<domain>
 func ConstructServiceDomain(podName, containerName, domain string) string {

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -374,3 +374,20 @@ func FlattenMapToKeys(m map[string]any, prefix string) map[string]string {
 
 	return result
 }
+
+// ConstructServiceDomain constructs a service domain name
+// Format: <podName>-<containerName>.<domain>
+func ConstructServiceDomain(podName, containerName, domain string) string {
+	return fmt.Sprintf("%s-%s.%s", podName, containerName, domain)
+}
+
+// ConstructServiceURL constructs a full service URL
+func ConstructServiceURL(protocol, domain string, port int) string {
+	if port == 443 && protocol == "https" {
+		return fmt.Sprintf("%s://%s", protocol, domain)
+	}
+	if port == 80 && protocol == "http" {
+		return fmt.Sprintf("%s://%s", protocol, domain)
+	}
+	return fmt.Sprintf("%s://%s:%d", protocol, domain, port)
+}

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"maps"
 	"net"
@@ -451,4 +453,94 @@ func ConstructServiceURL(protocol, domain string, port int) string {
 		return fmt.Sprintf("%s://%s", protocol, domain)
 	}
 	return fmt.Sprintf("%s://%s:%d", protocol, domain, port)
+}
+
+// ValidateCertificateFiles validates that SSL certificate and key files exist and are readable
+func ValidateCertificateFiles(certPath, keyPath string) error {
+	// Check certificate file
+	certInfo, err := os.Stat(certPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("certificate file does not exist: %s", certPath)
+		}
+		return fmt.Errorf("cannot access certificate file: %w", err)
+	}
+	if certInfo.IsDir() {
+		return fmt.Errorf("certificate path is a directory, not a file: %s", certPath)
+	}
+
+	// Check key file
+	keyInfo, err := os.Stat(keyPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("key file does not exist: %s", keyPath)
+		}
+		return fmt.Errorf("cannot access key file: %w", err)
+	}
+	if keyInfo.IsDir() {
+		return fmt.Errorf("key path is a directory, not a file: %s", keyPath)
+	}
+
+	// Try to read the files to ensure they're readable
+	if _, err := os.ReadFile(certPath); err != nil {
+		return fmt.Errorf("cannot read certificate file: %w", err)
+	}
+	if _, err := os.ReadFile(keyPath); err != nil {
+		return fmt.Errorf("cannot read key file: %w", err)
+	}
+
+	return nil
+}
+
+// ExtractDomainFromCertificate extracts the base domain from a certificate file
+// It looks for wildcard domains in CN or SANs (e.g., *.example.com -> example.com)
+// Returns the base domain or error if extraction fails
+func ExtractDomainFromCertificate(certPath string) (string, error) {
+	// Read certificate file
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read certificate: %w", err)
+	}
+
+	// Decode PEM block
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return "", fmt.Errorf("failed to decode PEM block from certificate")
+	}
+
+	// Parse certificate
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	// Try to extract domain from SANs first (preferred)
+	for _, dnsName := range cert.DNSNames {
+		if domain := extractBaseDomain(dnsName); domain != "" {
+			return domain, nil
+		}
+	}
+
+	// Fallback to Common Name
+	if domain := extractBaseDomain(cert.Subject.CommonName); domain != "" {
+		return domain, nil
+	}
+
+	return "", fmt.Errorf("no valid domain found in certificate (CN: %s, SANs: %v)",
+		cert.Subject.CommonName, cert.DNSNames)
+}
+
+// extractBaseDomain extracts base domain from a DNS name
+// Examples: *.example.com -> example.com, example.com -> example.com
+func extractBaseDomain(dnsName string) string {
+	if dnsName == "" {
+		return ""
+	}
+
+	// Remove wildcard prefix if present
+	if strings.HasPrefix(dnsName, "*.") {
+		return dnsName[2:] // Remove "*."
+	}
+
+	return dnsName
 }


### PR DESCRIPTION
This PR adds HTTPS (secure connections) support for external services using a tool called Caddy, which works like a traffic manager between users and your services. It currently shows this setup using the catalog service, but it can be reused for other services too.

- Automatically enables HTTPS for services (no manual setup needed)
- Works in local development using fake/test domains (nip.io)
- Supports real production domains using --domain-name
- Lets users provide their own SSL certificates if they already have them
- Automatically figures out the correct domain from certificates (even for wildcard domains like *.example.com)
- If a certificate already defines a domain, it takes priority to avoid conflicts
- Designed so more services can easily be added later without changing the core setup


Note: Using docker image now.Need to build UBI based image.