### PR TITLE
Token Management in Catalog

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.3
+TAG?=0.0.4
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -75,6 +75,10 @@ spec:
             secretKeyRef:
               name: catalog-secret
               key: admin-password
+        - name: DB_HOST
+          value: {{ .AppName }}--db
+        - name: DB_PORT
+          value: 5432
         - name: DB_USER
           value: "{{ .Values.db.user }}"
         - name: DB_PASSWORD

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -78,7 +78,7 @@ spec:
         - name: DB_HOST
           value: {{ .AppName }}--db
         - name: DB_PORT
-          value: 5432
+          value: "5432"
         - name: DB_USER
           value: "{{ .Values.db.user }}"
         - name: DB_PASSWORD

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.3
+  image: icr.io/ai-services-cicd/ai-services:0.0.4
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -20,10 +20,48 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const defaultRandomSecretKeyLength = 32
+
+// loadDBConfig loads database configuration from environment variables.
+func loadDBConfig() (db.Config, error) {
+	portStr := utils.GetEnv("DB_PORT", strconv.Itoa(db.DefaultDBPort))
+	dbPort, err := strconv.Atoi(portStr)
+	if err != nil {
+		return db.Config{}, fmt.Errorf("invalid DB_PORT value '%s': %w", portStr, err)
+	}
+
+	dbConfig := db.Config{
+		Host:     utils.GetEnv("DB_HOST", db.DefaultDBHost),
+		Port:     dbPort,
+		User:     utils.GetEnv("DB_USER", db.DefaultDBUser),
+		Password: os.Getenv("DB_PASSWORD"),
+		DBName:   utils.GetEnv("DB_NAME", db.DefaultDBName),
+		SSLMode:  utils.GetEnv("DB_SSLMODE", db.DefaultSSLMode),
+	}
+
+	if dbConfig.Password == "" {
+		return db.Config{}, fmt.Errorf("DB_PASSWORD environment variable is required")
+	}
+
+	return dbConfig, nil
+}
+
+// getOrGenerateSecretKey retrieves the JWT secret key from environment or generates a random one.
+func getOrGenerateSecretKey() (string, error) {
+	secretKey := os.Getenv("AUTH_JWT_SECRET")
+	if len(secretKey) == 0 {
+		fmt.Println("** WARNING: AUTH_JWT_SECRET environment variable not set. This is not recommended for production use. **")
+		byteSecretKey, err := auth.GenerateRandomSecretKey(defaultRandomSecretKeyLength)
+		if err != nil {
+			return "", err
+		}
+		secretKey = string(byteSecretKey)
+	}
+
+	return secretKey, nil
+}
+
 func NewAPIServerCmd() *cobra.Command {
-	const (
-		defaultRandomSecretKeyLength int = 32
-	)
 	var (
 		port                   = 8080
 		defaultAccessTokenTTL  = time.Minute * 15
@@ -32,12 +70,12 @@ func NewAPIServerCmd() *cobra.Command {
 		adminPasswordHash      string
 		runtimeType            string
 	)
+
 	apiserverCmd := &cobra.Command{
 		Use:   "apiserver",
 		Short: "Manage AI Services API server",
 		Long:  `The apiserver command allows you to manage the AI Services API server, including starting, stopping, and checking the status of the server.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			// Validate and set runtime
 			rt := types.RuntimeType(runtimeType)
 			if !rt.Valid() {
 				return fmt.Errorf("invalid runtime type: %s (must be '%s' or '%s')", runtimeType, types.RuntimeTypePodman, types.RuntimeTypeOpenShift)
@@ -49,39 +87,16 @@ func NewAPIServerCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			secretKey := os.Getenv("AUTH_JWT_SECRET")
-			if len(secretKey) == 0 {
-				fmt.Println("** WARNING: AUTH_JWT_SECRET environment variable not set. This is not recommended for production use. **")
-				// generate a random secret key if not provided via environment variable
-				byteSecretKey, err := auth.GenerateRandomSecretKey(defaultRandomSecretKeyLength)
-				if err != nil {
-					return err
-				}
-				secretKey = string(byteSecretKey)
-			}
-
-			// Load database configuration from environment variables
-			portStr := utils.GetEnv("DB_PORT", strconv.Itoa(db.DefaultDBPort))
-			dbPort, err := strconv.Atoi(portStr)
+			secretKey, err := getOrGenerateSecretKey()
 			if err != nil {
-				return fmt.Errorf("invalid DB_PORT value '%s': %w", portStr, err)
+				return err
 			}
 
-			dbConfig := db.Config{
-				Host:     utils.GetEnv("DB_HOST", db.DefaultDBHost),
-				Port:     dbPort,
-				User:     utils.GetEnv("DB_USER", db.DefaultDBUser),
-				Password: os.Getenv("DB_PASSWORD"),
-				DBName:   utils.GetEnv("DB_NAME", db.DefaultDBName),
-				SSLMode:  utils.GetEnv("DB_SSLMODE", db.DefaultSSLMode),
+			dbConfig, err := loadDBConfig()
+			if err != nil {
+				return err
 			}
 
-			// Validate required password
-			if dbConfig.Password == "" {
-				return fmt.Errorf("DB_PASSWORD environment variable is required")
-			}
-
-			// Connect to database
 			ctx := context.Background()
 			pool, err := db.ConnectPool(ctx, dbConfig)
 			if err != nil {
@@ -91,19 +106,23 @@ func NewAPIServerCmd() *cobra.Command {
 
 			logger.Infoln("Connected to database successfully")
 
-			// Repositories
 			userRepo := apirepository.NewInMemoryUserRepoWithAdminHash("uid_1", adminUserName, "Admin", adminPasswordHash)
 			tokenBlacklistRepo := repository.NewTokenBlacklistRepository(pool)
 			blacklist := apirepository.NewDBTokenBlacklist(tokenBlacklistRepo)
 			defer blacklist.Stop()
 
-			// JWT manager
 			tokenMgr := auth.NewTokenManager(secretKey, defaultAccessTokenTTL, defaultRefreshTokenTTL)
 			authSvc := auth.NewAuthService(userRepo, tokenMgr, blacklist)
 
-			return apiserver.NewAPIserver(apiserver.APIServerOptions{Port: port, AuthService: authSvc, TokenManager: tokenMgr, Blacklist: blacklist}).Start()
+			return apiserver.NewAPIserver(apiserver.APIServerOptions{
+				Port:         port,
+				AuthService:  authSvc,
+				TokenManager: tokenMgr,
+				Blacklist:    blacklist,
+			}).Start()
 		},
 	}
+
 	apiserverCmd.Flags().IntVarP(&port, "port", "p", port, "Port for the API server to listen on")
 	apiserverCmd.Flags().DurationVarP(&defaultAccessTokenTTL, "access-token-ttl", "", defaultAccessTokenTTL, "Time-to-live for access tokens")
 	apiserverCmd.Flags().DurationVarP(&defaultRefreshTokenTTL, "refresh-token-ttl", "", defaultRefreshTokenTTL, "Time-to-live for refresh tokens")

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -1,16 +1,21 @@
 package catalog
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver"
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
+	apirepository "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	"github.com/spf13/cobra"
 )
@@ -22,7 +27,7 @@ func NewAPIServerCmd() *cobra.Command {
 	var (
 		port                   = 8080
 		defaultAccessTokenTTL  = time.Minute * 15
-		defaultRefreshTokenTTL = time.Hour * 24 * 7
+		defaultRefreshTokenTTL = time.Hour * 24 * 1
 		adminUserName          string
 		adminPasswordHash      string
 		runtimeType            string
@@ -55,9 +60,42 @@ func NewAPIServerCmd() *cobra.Command {
 				secretKey = string(byteSecretKey)
 			}
 
+			// Load database configuration from environment variables
+			portStr := utils.GetEnv("DB_PORT", strconv.Itoa(db.DefaultDBPort))
+			dbPort, err := strconv.Atoi(portStr)
+			if err != nil {
+				return fmt.Errorf("invalid DB_PORT value '%s': %w", portStr, err)
+			}
+
+			dbConfig := db.Config{
+				Host:     utils.GetEnv("DB_HOST", db.DefaultDBHost),
+				Port:     dbPort,
+				User:     utils.GetEnv("DB_USER", db.DefaultDBUser),
+				Password: os.Getenv("DB_PASSWORD"),
+				DBName:   utils.GetEnv("DB_NAME", db.DefaultDBName),
+				SSLMode:  utils.GetEnv("DB_SSLMODE", db.DefaultSSLMode),
+			}
+
+			// Validate required password
+			if dbConfig.Password == "" {
+				return fmt.Errorf("DB_PASSWORD environment variable is required")
+			}
+
+			// Connect to database
+			ctx := context.Background()
+			pool, err := db.ConnectPool(ctx, dbConfig)
+			if err != nil {
+				return fmt.Errorf("failed to connect to database: %w", err)
+			}
+			defer pool.Close()
+
+			logger.Infoln("Connected to database successfully")
+
 			// Repositories
-			userRepo := repository.NewInMemoryUserRepoWithAdminHash("uid_1", adminUserName, "Admin", adminPasswordHash)
-			blacklist := repository.NewInMemoryTokenBlacklist()
+			userRepo := apirepository.NewInMemoryUserRepoWithAdminHash("uid_1", adminUserName, "Admin", adminPasswordHash)
+			tokenBlacklistRepo := repository.NewTokenBlacklistRepository(pool)
+			blacklist := apirepository.NewDBTokenBlacklist(tokenBlacklistRepo)
+			defer blacklist.Stop()
 
 			// JWT manager
 			tokenMgr := auth.NewTokenManager(secretKey, defaultAccessTokenTTL, defaultRefreshTokenTTL)

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -61,6 +61,43 @@ func getOrGenerateSecretKey() (string, error) {
 	return secretKey, nil
 }
 
+// runAPIServer initializes and starts the API server with the provided configuration.
+func runAPIServer(port int, accessTTL, refreshTTL time.Duration, adminUser, adminPassHash string) error {
+	secretKey, err := getOrGenerateSecretKey()
+	if err != nil {
+		return err
+	}
+
+	dbConfig, err := loadDBConfig()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	pool, err := db.ConnectPool(ctx, dbConfig)
+	if err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+	defer pool.Close()
+
+	logger.Infoln("Connected to database successfully")
+
+	userRepo := apirepository.NewInMemoryUserRepoWithAdminHash("uid_1", adminUser, "Admin", adminPassHash)
+	tokenBlacklistRepo := repository.NewTokenBlacklistRepository(pool)
+	blacklist := apirepository.NewDBTokenBlacklist(tokenBlacklistRepo)
+	defer blacklist.Stop()
+
+	tokenMgr := auth.NewTokenManager(secretKey, accessTTL, refreshTTL)
+	authSvc := auth.NewAuthService(userRepo, tokenMgr, blacklist)
+
+	return apiserver.NewAPIserver(apiserver.APIServerOptions{
+		Port:         port,
+		AuthService:  authSvc,
+		TokenManager: tokenMgr,
+		Blacklist:    blacklist,
+	}).Start()
+}
+
 func NewAPIServerCmd() *cobra.Command {
 	var (
 		port                   = 8080
@@ -87,39 +124,7 @@ func NewAPIServerCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			secretKey, err := getOrGenerateSecretKey()
-			if err != nil {
-				return err
-			}
-
-			dbConfig, err := loadDBConfig()
-			if err != nil {
-				return err
-			}
-
-			ctx := context.Background()
-			pool, err := db.ConnectPool(ctx, dbConfig)
-			if err != nil {
-				return fmt.Errorf("failed to connect to database: %w", err)
-			}
-			defer pool.Close()
-
-			logger.Infoln("Connected to database successfully")
-
-			userRepo := apirepository.NewInMemoryUserRepoWithAdminHash("uid_1", adminUserName, "Admin", adminPasswordHash)
-			tokenBlacklistRepo := repository.NewTokenBlacklistRepository(pool)
-			blacklist := apirepository.NewDBTokenBlacklist(tokenBlacklistRepo)
-			defer blacklist.Stop()
-
-			tokenMgr := auth.NewTokenManager(secretKey, defaultAccessTokenTTL, defaultRefreshTokenTTL)
-			authSvc := auth.NewAuthService(userRepo, tokenMgr, blacklist)
-
-			return apiserver.NewAPIserver(apiserver.APIServerOptions{
-				Port:         port,
-				AuthService:  authSvc,
-				TokenManager: tokenMgr,
-				Blacklist:    blacklist,
-			}).Start()
+			return runAPIServer(port, defaultAccessTokenTTL, defaultRefreshTokenTTL, adminUserName, adminPasswordHash)
 		},
 	}
 

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver"
 	apirepository "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
@@ -24,19 +25,19 @@ const defaultRandomSecretKeyLength = 32
 
 // loadDBConfig loads database configuration from environment variables.
 func loadDBConfig() (db.Config, error) {
-	portStr := utils.GetEnv("DB_PORT", strconv.Itoa(db.DefaultDBPort))
+	portStr := utils.GetEnv("DB_PORT", strconv.Itoa(constants.DefaultDBPort))
 	dbPort, err := strconv.Atoi(portStr)
 	if err != nil {
 		return db.Config{}, fmt.Errorf("invalid DB_PORT value '%s': %w", portStr, err)
 	}
 
 	dbConfig := db.Config{
-		Host:     utils.GetEnv("DB_HOST", db.DefaultDBHost),
+		Host:     utils.GetEnv("DB_HOST", constants.DefaultDBHost),
 		Port:     dbPort,
-		User:     utils.GetEnv("DB_USER", db.DefaultDBUser),
+		User:     utils.GetEnv("DB_USER", constants.DefaultDBUser),
 		Password: os.Getenv("DB_PASSWORD"),
-		DBName:   utils.GetEnv("DB_NAME", db.DefaultDBName),
-		SSLMode:  utils.GetEnv("DB_SSLMODE", db.DefaultSSLMode),
+		DBName:   utils.GetEnv("DB_NAME", constants.DefaultDBName),
+		SSLMode:  utils.GetEnv("DB_SSLMODE", constants.DefaultSSLMode),
 	}
 
 	if dbConfig.Password == "" {

--- a/ai-services/cmd/ai-services/cmd/catalog/migrate.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/migrate.go
@@ -33,12 +33,12 @@ check migration status, and rollback migrations.`,
 	}
 
 	// Add persistent flags for database connection
-	migrateCmd.PersistentFlags().StringVar(&dbHost, "db-host", "localhost", "Database host")
+	migrateCmd.PersistentFlags().StringVar(&dbHost, "db-host", db.DefaultDBHost, "Database host")
 	migrateCmd.PersistentFlags().IntVar(&dbPort, "db-port", db.DefaultDBPort, "Database port")
-	migrateCmd.PersistentFlags().StringVar(&dbUser, "db-user", "admin", "Database user")
+	migrateCmd.PersistentFlags().StringVar(&dbUser, "db-user", db.DefaultDBUser, "Database user")
 	migrateCmd.PersistentFlags().StringVar(&dbPassword, "db-password", "", "Database password")
 	migrateCmd.PersistentFlags().StringVar(&dbName, "db-name", db.DefaultDBName, "Database name")
-	migrateCmd.PersistentFlags().StringVar(&dbSSLMode, "db-sslmode", "disable", "Database SSL mode (disable, require, verify-ca, verify-full)")
+	migrateCmd.PersistentFlags().StringVar(&dbSSLMode, "db-sslmode", db.DefaultSSLMode, "Database SSL mode (disable, require, verify-ca, verify-full)")
 
 	// Helper function to get database config from flags
 	getDBConfig := func() db.Config {

--- a/ai-services/cmd/ai-services/cmd/catalog/migrate.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/migrate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/migrations"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
@@ -33,12 +34,12 @@ check migration status, and rollback migrations.`,
 	}
 
 	// Add persistent flags for database connection
-	migrateCmd.PersistentFlags().StringVar(&dbHost, "db-host", db.DefaultDBHost, "Database host")
-	migrateCmd.PersistentFlags().IntVar(&dbPort, "db-port", db.DefaultDBPort, "Database port")
-	migrateCmd.PersistentFlags().StringVar(&dbUser, "db-user", db.DefaultDBUser, "Database user")
+	migrateCmd.PersistentFlags().StringVar(&dbHost, "db-host", constants.DefaultDBHost, "Database host")
+	migrateCmd.PersistentFlags().IntVar(&dbPort, "db-port", constants.DefaultDBPort, "Database port")
+	migrateCmd.PersistentFlags().StringVar(&dbUser, "db-user", constants.DefaultDBUser, "Database user")
 	migrateCmd.PersistentFlags().StringVar(&dbPassword, "db-password", "", "Database password")
-	migrateCmd.PersistentFlags().StringVar(&dbName, "db-name", db.DefaultDBName, "Database name")
-	migrateCmd.PersistentFlags().StringVar(&dbSSLMode, "db-sslmode", db.DefaultSSLMode, "Database SSL mode (disable, require, verify-ca, verify-full)")
+	migrateCmd.PersistentFlags().StringVar(&dbName, "db-name", constants.DefaultDBName, "Database name")
+	migrateCmd.PersistentFlags().StringVar(&dbSSLMode, "db-sslmode", constants.DefaultSSLMode, "Database SSL mode (disable, require, verify-ca, verify-full)")
 
 	// Helper function to get database config from flags
 	getDBConfig := func() db.Config {

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/auth_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/auth_handler.go
@@ -104,13 +104,17 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 //	@Failure		500	{object}	map[string]interface{}	"Failed to logout"
 //	@Router			/auth/logout [post]
 func (h *AuthHandler) Logout(c *gin.Context) {
-	token := c.GetString(middleware.CtxRawTokenKey)
-	if token == "" {
+	accessToken := c.GetString(middleware.CtxRawTokenKey)
+	if accessToken == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "missing token"})
 
 		return
 	}
-	if err := h.svc.Logout(c.Request.Context(), token); err != nil {
+
+	// Get refresh token from X-Refresh-Token header
+	refreshToken := c.GetHeader("X-Refresh-Token")
+
+	if err := h.svc.Logout(c.Request.Context(), accessToken, refreshToken); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to logout"})
 
 		return

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/auth_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/auth_handler.go
@@ -112,6 +112,7 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 	}
 
 	// Get refresh token from X-Refresh-Token header
+	// TODO: Once the consumers starts providing refreshToken in the header, make it mandatory
 	refreshToken := c.GetHeader("X-Refresh-Token")
 
 	if err := h.svc.Logout(c.Request.Context(), accessToken, refreshToken); err != nil {

--- a/ai-services/internal/pkg/catalog/apiserver/middleware/auth.go
+++ b/ai-services/internal/pkg/catalog/apiserver/middleware/auth.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 )
 
 const (
@@ -34,7 +35,7 @@ func AuthMiddleware(tokenMgr *auth.TokenManager, blacklist repository.TokenBlack
 
 			return
 		}
-		if blacklist.Contains(raw) {
+		if blacklist.Contains(raw, constants.TokenTypeAccess) {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "token revoked"})
 
 			return

--- a/ai-services/internal/pkg/catalog/apiserver/repository/token_store.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/token_store.go
@@ -22,6 +22,7 @@ type TokenBlacklist interface {
 // HashToken creates a SHA-256 hash of the token for secure storage.
 func HashToken(token string) string {
 	hash := sha256.Sum256([]byte(token))
+
 	return hex.EncodeToString(hash[:])
 }
 
@@ -74,7 +75,8 @@ func (b *DBTokenBlacklist) Stop() {
 
 // gc runs periodically to clean up expired tokens from the database.
 func (b *DBTokenBlacklist) gc() {
-	ticker := time.NewTicker(5 * time.Minute)
+	const cleanupInterval = 5 * time.Minute
+	ticker := time.NewTicker(cleanupInterval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/ai-services/internal/pkg/catalog/apiserver/repository/token_store.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/token_store.go
@@ -1,99 +1,92 @@
 package repository
 
 import (
-	"sync"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"time"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 )
 
 // TokenBlacklist defines the interface for managing revoked tokens. It allows adding tokens to the blacklist
 // with their expiry times and checking if a token is currently blacklisted.
 type TokenBlacklist interface {
-	Add(token string, exp time.Time)
-	Contains(token string) bool
+	Add(token string, tokenType string, exp time.Time)
+	Contains(token string, tokenType string) bool
 	Stop()
 }
 
-// InMemoryTokenBlacklist is a simple in-memory implementation of a token blacklist.
-// It stores revoked tokens along with their expiry times and provides methods to add tokens,
-// check for their presence, and clean up expired tokens.
-type InMemoryTokenBlacklist struct {
-	mu     sync.RWMutex
-	tokens map[string]time.Time // token -> expiry
+// HashToken creates a SHA-256 hash of the token for secure storage.
+func HashToken(token string) string {
+	hash := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(hash[:])
+}
+
+// DBTokenBlacklist is a database-backed implementation of TokenBlacklist.
+// It stores revoked tokens in PostgreSQL with SHA-256 hashing for security.
+// Suitable for multi-instance deployments.
+type DBTokenBlacklist struct {
+	repo   repository.TokenBlacklistRepository
 	stopCh chan struct{}
 }
 
-// TODO: Use a more robust for multi-instance deployments, e.g. Redis with TTL or a distributed cache like Memcached.
-// This in-memory version is only suitable for single-instance setups or testing.
-
-// NewInMemoryTokenBlacklist creates a new instance of InMemoryTokenBlacklist and starts the garbage collection goroutine.
-func NewInMemoryTokenBlacklist() *InMemoryTokenBlacklist {
-	b := &InMemoryTokenBlacklist{
-		tokens: make(map[string]time.Time),
+// NewDBTokenBlacklist creates a new database-backed token blacklist and starts the cleanup goroutine.
+func NewDBTokenBlacklist(repo repository.TokenBlacklistRepository) *DBTokenBlacklist {
+	b := &DBTokenBlacklist{
+		repo:   repo,
 		stopCh: make(chan struct{}),
 	}
 	go b.gc()
-
 	return b
 }
 
-// Add adds a token to the blacklist with its expiry time. The token will be considered invalid until it expires.
-func (b *InMemoryTokenBlacklist) Add(token string, exp time.Time) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.tokens[token] = exp
+// Add adds a token to the blacklist with its expiry time.
+// The token is hashed using SHA-256 before storage for security.
+func (b *DBTokenBlacklist) Add(token string, tokenType string, exp time.Time) {
+	ctx := context.Background()
+	tokenHash := HashToken(token)
+
+	if err := b.repo.Add(ctx, tokenHash, models.TokenType(tokenType), exp); err != nil {
+		logger.Errorf("failed to add token to blacklist: %v", err)
+	}
 }
 
-// Contains checks if the provided token string is in the blacklist and has not yet expired.
-// If the token is found in the blacklist but has expired, it will be removed from the blacklist.
-func (b *InMemoryTokenBlacklist) Contains(token string) bool {
-	now := time.Now()
+// Contains checks if the provided token is in the blacklist and has not yet expired.
+func (b *DBTokenBlacklist) Contains(token string, tokenType string) bool {
+	ctx := context.Background()
+	tokenHash := HashToken(token)
 
-	// Fast path: read lock
-	b.mu.RLock()
-	exp, ok := b.tokens[token]
-	if !ok {
-		b.mu.RUnlock()
-
+	exists, err := b.repo.Contains(ctx, tokenHash, models.TokenType(tokenType))
+	if err != nil {
+		logger.Errorf("failed to check token blacklist: %v", err)
 		return false
 	}
-	if now.Before(exp) {
-		b.mu.RUnlock()
-
-		return true // revoked and not yet expired
-	}
-	b.mu.RUnlock()
-
-	// Slow path: token found but expired -> delete under write lock
-	b.mu.Lock()
-	// Re-check under write lock in case of races
-	if exp2, ok2 := b.tokens[token]; ok2 && now.After(exp2) {
-		delete(b.tokens, token)
-	}
-	b.mu.Unlock()
-
-	return false
+	return exists
 }
 
-// Stop signals the garbage collection goroutine to stop. This should be called when the blacklist is no longer needed to clean up resources.
-func (b *InMemoryTokenBlacklist) Stop() { close(b.stopCh) }
+// Stop signals the cleanup goroutine to stop.
+func (b *DBTokenBlacklist) Stop() {
+	close(b.stopCh)
+}
 
-// gc runs periodically to clean up expired tokens from the blacklist to prevent unbounded memory growth.
-func (b *InMemoryTokenBlacklist) gc() {
-	ticker := time.NewTicker(1 * time.Minute)
+// gc runs periodically to clean up expired tokens from the database.
+func (b *DBTokenBlacklist) gc() {
+	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-b.stopCh:
 			return
 		case <-ticker.C:
-			now := time.Now()
-			b.mu.Lock()
-			for t, exp := range b.tokens {
-				if now.After(exp) {
-					delete(b.tokens, t)
-				}
+			ctx := context.Background()
+			if err := b.repo.CleanupExpired(ctx); err != nil {
+				logger.Errorf("failed to cleanup expired tokens: %v", err)
 			}
-			b.mu.Unlock()
 		}
 	}
 }
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/repository/token_store.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/token_store.go
@@ -41,6 +41,7 @@ func NewDBTokenBlacklist(repo repository.TokenBlacklistRepository) *DBTokenBlack
 		stopCh: make(chan struct{}),
 	}
 	go b.gc()
+
 	return b
 }
 
@@ -63,8 +64,10 @@ func (b *DBTokenBlacklist) Contains(token string, tokenType string) bool {
 	exists, err := b.repo.Contains(ctx, tokenHash, models.TokenType(tokenType))
 	if err != nil {
 		logger.Errorf("failed to check token blacklist: %v", err)
+
 		return false
 	}
+
 	return exists
 }
 

--- a/ai-services/internal/pkg/catalog/apiserver/services/auth/service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/auth/service.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
+	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 )
 
@@ -24,7 +25,7 @@ const (
 
 type Service interface {
 	Login(ctx context.Context, username, password string) (accessToken, refreshToken string, err error)
-	Logout(ctx context.Context, accessToken string) error
+	Logout(ctx context.Context, accessToken, refreshToken string) error
 	RefreshTokens(ctx context.Context, refreshToken string) (newAccess, newRefresh string, err error)
 	GetUser(ctx context.Context, id string) (*models.User, error)
 }
@@ -61,30 +62,41 @@ func (s *service) Login(ctx context.Context, username, password string) (string,
 	return access, refresh, nil
 }
 
-// Logout invalidates the provided access token by adding it to the blacklist until its natural expiry time.
-// This ensures that even if the token is still valid, it cannot be used for authentication after logout.
-func (s *service) Logout(ctx context.Context, accessToken string) error {
-	// Parse to get expiry for blacklist TTL
-	_, exp, err := s.tokens.ValidateAccessToken(accessToken)
-	if err != nil {
-		// If token is already invalid, treat as success (idempotent)
-		return nil
+// Logout invalidates both the refresh token and access token by adding them to the blacklist until their
+// natural expiry time. This operation is idempotent - it always succeeds and only blacklists tokens if they
+// are valid. Invalid tokens are ignored, making logout safe to call multiple times.
+func (s *service) Logout(ctx context.Context, accessToken, refreshToken string) error {
+	// If refresh token exists, try to validate and blacklist it
+	if refreshToken != "" {
+		_, refreshExp, err := s.tokens.ValidateRefreshToken(refreshToken)
+		if err == nil {
+			s.blacklist.Add(refreshToken, catalogconstants.TokenTypeRefresh, refreshExp)
+		}
+		// Ignore invalid tokens
 	}
-	s.blacklist.Add(accessToken, exp)
+
+	// If access token exists, try to validate and blacklist it
+	if accessToken != "" {
+		_, accessExp, err := s.tokens.ValidateAccessToken(accessToken)
+		if err == nil {
+			s.blacklist.Add(accessToken, catalogconstants.TokenTypeAccess, accessExp)
+		}
+		// Ignore invalid tokens
+	}
 
 	return nil
 }
 
 // RefreshTokens validates the provided refresh token and, if valid, generates and returns a new access token
-// and refresh token pair. It also optionally blacklists the old refresh token to prevent reuse (not implemented
-// here but can be added with a separate blacklist store for refresh tokens).
+// and refresh token pair. It also blacklists the old refresh token to prevent reuse.
 func (s *service) RefreshTokens(ctx context.Context, refreshToken string) (string, string, error) {
 	uid, exp, err := s.tokens.ValidateRefreshToken(refreshToken)
 	if err != nil {
 		return "", "", err
 	}
-	// Optional: rotate refresh by blacklisting the old refresh token (if you also protect refresh endpoints with blacklist)
-	_ = exp // here not blacklisting refresh; can be added with separate store.
+
+	// Blacklist the old refresh token to prevent reuse
+	s.blacklist.Add(refreshToken, catalogconstants.TokenTypeRefresh, exp)
 
 	access, _, err := s.tokens.GenerateAccessToken(uid)
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/apiserver/services/auth/service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/auth/service.go
@@ -72,16 +72,12 @@ func (s *service) Logout(ctx context.Context, accessToken, refreshToken string) 
 		if err == nil {
 			s.blacklist.Add(refreshToken, catalogconstants.TokenTypeRefresh, refreshExp)
 		}
-		// Ignore invalid tokens
 	}
 
-	// If access token exists, try to validate and blacklist it
-	if accessToken != "" {
-		_, accessExp, err := s.tokens.ValidateAccessToken(accessToken)
-		if err == nil {
-			s.blacklist.Add(accessToken, catalogconstants.TokenTypeAccess, accessExp)
-		}
-		// Ignore invalid tokens
+	// validate and blacklist access token
+	_, accessExp, err := s.tokens.ValidateAccessToken(accessToken)
+	if err == nil {
+		s.blacklist.Add(accessToken, catalogconstants.TokenTypeAccess, accessExp)
 	}
 
 	return nil

--- a/ai-services/internal/pkg/catalog/constants/db.go
+++ b/ai-services/internal/pkg/catalog/constants/db.go
@@ -1,0 +1,29 @@
+// Package constants defines common constants used across the catalog service.
+package constants
+
+import "time"
+
+const (
+	// DriverName is the PostgreSQL driver name used for database connections.
+	DriverName = "pgx"
+	// DefaultDBHost is the default database host.
+	DefaultDBHost = "localhost"
+	// DefaultDBName is the default database name for the catalog service.
+	DefaultDBName = "ai_services"
+	// DefaultDBPort is the default PostgreSQL port.
+	DefaultDBPort = 5432
+	// DefaultDBUser is the default database user.
+	DefaultDBUser = "admin"
+	// DefaultSSLMode is the default SSL mode for database connections.
+	DefaultSSLMode = "disable"
+	// DefaultMaxOpenConns is the default maximum number of open connections.
+	DefaultMaxOpenConns = 25
+	// DefaultMaxIdleConns is the default maximum number of idle connections.
+	DefaultMaxIdleConns = 5
+	// DefaultConnMaxLifetime is the default maximum lifetime of a connection.
+	DefaultConnMaxLifetime = 5 * time.Minute
+	// DefaultPingTimeout is the default timeout for database ping operations.
+	DefaultPingTimeout = 5 * time.Second
+)
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/constants/db.go
+++ b/ai-services/internal/pkg/catalog/constants/db.go
@@ -1,4 +1,3 @@
-// Package constants defines common constants used across the catalog service.
 package constants
 
 import "time"

--- a/ai-services/internal/pkg/catalog/constants/token.go
+++ b/ai-services/internal/pkg/catalog/constants/token.go
@@ -1,0 +1,12 @@
+// Package constants defines common constants used across the catalog service.
+package constants
+
+// Token type constants for blacklist management.
+const (
+	// TokenTypeAccess represents an access token type.
+	TokenTypeAccess = "access"
+	// TokenTypeRefresh represents a refresh token type.
+	TokenTypeRefresh = "refresh"
+)
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/constants/token.go
+++ b/ai-services/internal/pkg/catalog/constants/token.go
@@ -1,4 +1,3 @@
-// Package constants defines common constants used across the catalog service.
 package constants
 
 // Token type constants for blacklist management.

--- a/ai-services/internal/pkg/catalog/db/db.go
+++ b/ai-services/internal/pkg/catalog/db/db.go
@@ -16,10 +16,16 @@ import (
 const (
 	// DriverName is the PostgreSQL driver name used for database connections.
 	DriverName = "pgx"
+	// DefaultDBHost is the default database host.
+	DefaultDBHost = "localhost"
 	// DefaultDBName is the default database name for the catalog service.
 	DefaultDBName = "ai_services"
 	// DefaultDBPort is the default PostgreSQL port.
 	DefaultDBPort = 5432
+	// DefaultDBUser is the default database user.
+	DefaultDBUser = "admin"
+	// DefaultSSLMode is the default SSL mode for database connections.
+	DefaultSSLMode = "disable"
 	// DefaultMaxOpenConns is the default maximum number of open connections.
 	DefaultMaxOpenConns = 25
 	// DefaultMaxIdleConns is the default maximum number of idle connections.

--- a/ai-services/internal/pkg/catalog/db/db.go
+++ b/ai-services/internal/pkg/catalog/db/db.go
@@ -6,34 +6,11 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
-	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-)
-
-const (
-	// DriverName is the PostgreSQL driver name used for database connections.
-	DriverName = "pgx"
-	// DefaultDBHost is the default database host.
-	DefaultDBHost = "localhost"
-	// DefaultDBName is the default database name for the catalog service.
-	DefaultDBName = "ai_services"
-	// DefaultDBPort is the default PostgreSQL port.
-	DefaultDBPort = 5432
-	// DefaultDBUser is the default database user.
-	DefaultDBUser = "admin"
-	// DefaultSSLMode is the default SSL mode for database connections.
-	DefaultSSLMode = "disable"
-	// DefaultMaxOpenConns is the default maximum number of open connections.
-	DefaultMaxOpenConns = 25
-	// DefaultMaxIdleConns is the default maximum number of idle connections.
-	DefaultMaxIdleConns = 5
-	// DefaultConnMaxLifetime is the default maximum lifetime of a connection.
-	DefaultConnMaxLifetime = 5 * time.Minute
-	// DefaultPingTimeout is the default timeout for database ping operations.
-	DefaultPingTimeout = 5 * time.Second
 )
 
 // Config holds database configuration parameters.
@@ -64,18 +41,18 @@ func (c *Config) ConnectionURL() string {
 
 // Connect establishes a connection to the PostgreSQL database using sql.DB (for migrations).
 func Connect(cfg Config) (*sql.DB, error) {
-	db, err := sql.Open(DriverName, cfg.ConnectionString())
+	db, err := sql.Open(constants.DriverName, cfg.ConnectionString())
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database connection: %w", err)
 	}
 
 	// Set connection pool settings
-	db.SetMaxOpenConns(DefaultMaxOpenConns)
-	db.SetMaxIdleConns(DefaultMaxIdleConns)
-	db.SetConnMaxLifetime(DefaultConnMaxLifetime)
+	db.SetMaxOpenConns(constants.DefaultMaxOpenConns)
+	db.SetMaxIdleConns(constants.DefaultMaxIdleConns)
+	db.SetConnMaxLifetime(constants.DefaultConnMaxLifetime)
 
 	// Verify connection
-	ctx, cancel := context.WithTimeout(context.Background(), DefaultPingTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultPingTimeout)
 	defer cancel()
 
 	if err := db.PingContext(ctx); err != nil {
@@ -97,9 +74,9 @@ func ConnectPool(ctx context.Context, cfg Config) (*pgxpool.Pool, error) {
 	}
 
 	// Set connection pool settings
-	poolConfig.MaxConns = int32(DefaultMaxOpenConns)
-	poolConfig.MinConns = int32(DefaultMaxIdleConns)
-	poolConfig.MaxConnLifetime = DefaultConnMaxLifetime
+	poolConfig.MaxConns = int32(constants.DefaultMaxOpenConns)
+	poolConfig.MinConns = int32(constants.DefaultMaxIdleConns)
+	poolConfig.MaxConnLifetime = constants.DefaultConnMaxLifetime
 
 	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
 	if err != nil {
@@ -107,7 +84,7 @@ func ConnectPool(ctx context.Context, cfg Config) (*pgxpool.Pool, error) {
 	}
 
 	// Verify connection
-	pingCtx, cancel := context.WithTimeout(ctx, DefaultPingTimeout)
+	pingCtx, cancel := context.WithTimeout(ctx, constants.DefaultPingTimeout)
 	defer cancel()
 
 	if err := pool.Ping(pingCtx); err != nil {

--- a/ai-services/internal/pkg/catalog/db/migrations/assets/20260430094505_create_tokens_blacklist_table.sql
+++ b/ai-services/internal/pkg/catalog/db/migrations/assets/20260430094505_create_tokens_blacklist_table.sql
@@ -8,8 +8,7 @@ CREATE TYPE token_type AS ENUM (
 
 -- Create tokens_blacklist table
 CREATE TABLE tokens_blacklist (
-    id SERIAL PRIMARY KEY,
-    token_hash VARCHAR(64) NOT NULL UNIQUE,
+    token_hash VARCHAR(64) PRIMARY KEY,
     token_type token_type NOT NULL,
     expires_at TIMESTAMPTZ NOT NULL
 );

--- a/ai-services/internal/pkg/catalog/db/models/token.go
+++ b/ai-services/internal/pkg/catalog/db/models/token.go
@@ -1,0 +1,20 @@
+// Package models defines the data models for the catalog database.
+package models
+
+import (
+	"time"
+)
+
+// TokenType represents the type of token (access or refresh).
+type TokenType = string
+
+// TokenBlacklist represents a blacklisted token in the database.
+// Tokens are stored as SHA-256 hashes for security.
+type TokenBlacklist struct {
+	ID        int       `json:"id"`
+	TokenHash string    `json:"token_hash"` // SHA-256 hash of the JWT token (64-character hex string)
+	TokenType TokenType `json:"token_type"` // Token type: "access" or "refresh"
+	ExpiresAt time.Time `json:"expires_at"` // Token expiry timestamp
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/db/models/token.go
+++ b/ai-services/internal/pkg/catalog/db/models/token.go
@@ -10,9 +10,9 @@ type TokenType = string
 
 // TokenBlacklist represents a blacklisted token in the database.
 // Tokens are stored as SHA-256 hashes for security.
+// token_hash serves as the primary key.
 type TokenBlacklist struct {
-	ID        int       `json:"id"`
-	TokenHash string    `json:"token_hash"` // SHA-256 hash of the JWT token (64-character hex string)
+	TokenHash string    `json:"token_hash"` // SHA-256 hash of the JWT token (64-character hex string) - Primary Key
 	TokenType TokenType `json:"token_type"` // Token type: "access" or "refresh"
 	ExpiresAt time.Time `json:"expires_at"` // Token expiry timestamp
 }

--- a/ai-services/internal/pkg/catalog/db/repository/token_blacklist_repo.go
+++ b/ai-services/internal/pkg/catalog/db/repository/token_blacklist_repo.go
@@ -67,6 +67,7 @@ func (r *tokenBlacklistRepo) Contains(ctx context.Context, tokenHash string, tok
 		if err == pgx.ErrNoRows {
 			return false, nil
 		}
+
 		return false, fmt.Errorf("failed to check token blacklist: %w", err)
 	}
 

--- a/ai-services/internal/pkg/catalog/db/repository/token_blacklist_repo.go
+++ b/ai-services/internal/pkg/catalog/db/repository/token_blacklist_repo.go
@@ -1,0 +1,91 @@
+// Package repository provides database repository implementations for the catalog service.
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
+)
+
+// TokenBlacklistRepository defines the interface for token blacklist data operations.
+type TokenBlacklistRepository interface {
+	// Add adds a token hash to the blacklist with its expiry time.
+	Add(ctx context.Context, tokenHash string, tokenType models.TokenType, expiresAt time.Time) error
+	// Contains checks if a token hash exists in the blacklist and is not expired.
+	Contains(ctx context.Context, tokenHash string, tokenType models.TokenType) (bool, error)
+	// CleanupExpired removes all expired tokens from the blacklist.
+	CleanupExpired(ctx context.Context) error
+}
+
+// tokenBlacklistRepo implements TokenBlacklistRepository using pgx.
+type tokenBlacklistRepo struct {
+	pool *pgxpool.Pool
+}
+
+// NewTokenBlacklistRepository creates a new TokenBlacklistRepository instance.
+func NewTokenBlacklistRepository(pool *pgxpool.Pool) TokenBlacklistRepository {
+	return &tokenBlacklistRepo{pool: pool}
+}
+
+// Add adds a token hash to the blacklist with its expiry time.
+// Uses ON CONFLICT DO NOTHING to handle duplicate entries gracefully.
+func (r *tokenBlacklistRepo) Add(ctx context.Context, tokenHash string, tokenType models.TokenType, expiresAt time.Time) error {
+	query := `
+		INSERT INTO tokens_blacklist (token_hash, token_type, expires_at)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (token_hash) DO NOTHING
+	`
+
+	_, err := r.pool.Exec(ctx, query, tokenHash, tokenType, expiresAt)
+	if err != nil {
+		return fmt.Errorf("failed to add token to blacklist: %w", err)
+	}
+
+	return nil
+}
+
+// Contains checks if a token hash exists in the blacklist and is not expired.
+// Returns true if the token is blacklisted and still valid (not expired).
+func (r *tokenBlacklistRepo) Contains(ctx context.Context, tokenHash string, tokenType models.TokenType) (bool, error) {
+	query := `
+		SELECT EXISTS(
+			SELECT 1 
+			FROM tokens_blacklist 
+			WHERE token_hash = $1 
+			AND token_type = $2 
+			AND expires_at > NOW()
+		)
+	`
+
+	var exists bool
+	err := r.pool.QueryRow(ctx, query, tokenHash, tokenType).Scan(&exists)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check token blacklist: %w", err)
+	}
+
+	return exists, nil
+}
+
+// CleanupExpired removes all expired tokens from the blacklist.
+func (r *tokenBlacklistRepo) CleanupExpired(ctx context.Context) error {
+	query := `
+		DELETE FROM tokens_blacklist 
+		WHERE expires_at < NOW()
+	`
+
+	_, err := r.pool.Exec(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to cleanup expired tokens: %w", err)
+	}
+
+	return nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -374,3 +374,11 @@ func FlattenMapToKeys(m map[string]any, prefix string) map[string]string {
 
 	return result
 }
+
+// GetEnv retrieves an environment variable or returns a default value if not set.
+func GetEnv(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -380,5 +380,6 @@ func GetEnv(key, defaultValue string) string {
 	if value := os.Getenv(key); value != "" {
 		return value
 	}
+
 	return defaultValue
 }


### PR DESCRIPTION
- DB Implementation to store blacklisted tokens (access & refresh).
- Take Refresh token as header as part of /logout api.
- Blacklist also the refresh token as part of /logout api.
- During /refresh, blacklist the passed refresh token.
- Also set default ttl of refresh token to 24 hr

Note: This removes our existing InMemory way of storing blacklist tokens.