### PR TITLE
Catalog CLI logout to pass RefreshToken during Logout

### DIFF
--- a/ai-services/internal/pkg/catalog/client/client.go
+++ b/ai-services/internal/pkg/catalog/client/client.go
@@ -186,7 +186,10 @@ func (c *Client) Logout() error {
 	_ = c.httpClient.Do(httpclient.Request{
 		Method:   http.MethodPost,
 		Endpoint: "/api/v1/auth/logout",
-		Headers:  map[string]string{"Authorization": "Bearer " + c.creds.AccessToken},
+		Headers: map[string]string{
+			"Authorization":   "Bearer " + c.creds.AccessToken,
+			"X-Refresh-Token": c.creds.RefreshToken,
+		},
 	})
 
 	return config.Delete()


### PR DESCRIPTION
- Ref from this PR: https://github.com/IBM/project-ai-services/pull/709.
- This is to enable Catalog logout CLI command to pass refresh token as header during logout.