### PR TITLE
Adding caddy support on ubi9 image

### DIFF
--- a/.github/workflows/caddy-image.yml
+++ b/.github/workflows/caddy-image.yml
@@ -1,0 +1,41 @@
+name: Caddy webserver
+on:
+  push:
+    paths:
+      - 'images/caddy/**'
+      - '.github/workflows/caddy-image.yml'
+    branches:
+      - main
+
+env:
+  ICR_REGISTRY: icr.io
+  ICR_NAMESPACE: ai-services-cicd
+
+jobs:
+  build-publish-image:
+    name: Build and Publish Image
+    runs-on: ubuntu-24.04-ppc64le
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      
+      - name: Build caddy image
+        working-directory: images/caddy
+        run: |
+          make build REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} REGISTRY_USER=${{ secrets.ICR_USERNAME }} REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
+
+      - name: Publish caddy image
+        working-directory: images/caddy
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          make push REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} REGISTRY_USER=${{ secrets.ICR_USERNAME }} REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
+
+  scan:
+    uses: ./.github/workflows/scanner.yml
+    with:
+      path: 'images/caddy'
+      image: 'caddy'
+    secrets:
+      ICR_USERNAME: ${{ secrets.ICR_USERNAME }}
+      ICR_APIKEY: ${{ secrets.ICR_APIKEY }}

--- a/images/caddy/Dockerfile
+++ b/images/caddy/Dockerfile
@@ -7,7 +7,7 @@ RUN set -eux; \
     wget -O /etc/caddy/Caddyfile "https://github.com/caddyserver/dist/raw/509c30cecd3cbc4012f6b1cc88d8f3f000fb06e4/config/Caddyfile"; \
     wget -O /usr/share/caddy/index.html "https://github.com/caddyserver/dist/raw/509c30cecd3cbc4012f6b1cc88d8f3f000fb06e4/welcome/index.html"
 
-ENV CADDY_VERSION=v2.8.4
+ENV CADDY_VERSION=v2.11.2
 
 RUN set -eux; \
     arch="$(uname -m)"; \

--- a/images/caddy/Dockerfile
+++ b/images/caddy/Dockerfile
@@ -38,11 +38,7 @@ ENV XDG_DATA_HOME=/data
 LABEL org.opencontainers.image.version=${CADDY_VERSION}
 LABEL org.opencontainers.image.title=Caddy
 LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"
-LABEL org.opencontainers.image.url=https://caddyserver.com
-LABEL org.opencontainers.image.documentation=https://caddyserver.com/docs
-LABEL org.opencontainers.image.vendor="Light Code Labs"
 LABEL org.opencontainers.image.licenses=Apache-2.0
-LABEL org.opencontainers.image.source=https://github.com/caddyserver/caddy-docker
 
 EXPOSE 80/tcp
 EXPOSE 443/tcp

--- a/images/caddy/Dockerfile
+++ b/images/caddy/Dockerfile
@@ -1,0 +1,55 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
+
+RUN microdnf install -y ca-certificates libcap wget tar gzip && microdnf clean all
+
+RUN set -eux; \
+    mkdir -p /config/caddy /data/caddy /etc/caddy /usr/share/caddy ; \
+    wget -O /etc/caddy/Caddyfile "https://github.com/caddyserver/dist/raw/509c30cecd3cbc4012f6b1cc88d8f3f000fb06e4/config/Caddyfile"; \
+    wget -O /usr/share/caddy/index.html "https://github.com/caddyserver/dist/raw/509c30cecd3cbc4012f6b1cc88d8f3f000fb06e4/welcome/index.html"
+
+ENV CADDY_VERSION=v2.8.4
+
+RUN set -eux; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+        x86_64)  binArch='amd64' ;; \
+        armv6l)  binArch='armv6' ;; \
+        armv7l)  binArch='armv7' ;; \
+        aarch64) binArch='arm64' ;; \
+        ppc64le) binArch='ppc64le' ;; \
+        riscv64) binArch='riscv64' ;; \
+        s390x)   binArch='s390x' ;; \
+        *) echo >&2 "error: unsupported architecture ($arch)"; exit 1 ;; \
+    esac; \
+    version="${CADDY_VERSION#v}"; \
+    wget -O /tmp/caddy_checksums.txt "https://github.com/caddyserver/caddy/releases/download/${CADDY_VERSION}/caddy_${version}_checksums.txt"; \
+    wget -O /tmp/caddy.tar.gz "https://github.com/caddyserver/caddy/releases/download/${CADDY_VERSION}/caddy_${version}_linux_${binArch}.tar.gz"; \
+    checksum=$(grep "caddy_${version}_linux_${binArch}.tar.gz" /tmp/caddy_checksums.txt | awk '{print $1}'); \
+    echo "$checksum  /tmp/caddy.tar.gz" | sha512sum -c; \
+    tar x -z -f /tmp/caddy.tar.gz -C /usr/bin caddy; \
+    rm -f /tmp/caddy.tar.gz /tmp/caddy_checksums.txt; \
+    setcap cap_net_bind_service=+ep /usr/bin/caddy; \
+    chmod +x /usr/bin/caddy; \
+    caddy version
+
+ENV XDG_CONFIG_HOME=/config
+ENV XDG_DATA_HOME=/data
+
+LABEL org.opencontainers.image.version=${CADDY_VERSION}
+LABEL org.opencontainers.image.title=Caddy
+LABEL org.opencontainers.image.description="a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"
+LABEL org.opencontainers.image.url=https://caddyserver.com
+LABEL org.opencontainers.image.documentation=https://caddyserver.com/docs
+LABEL org.opencontainers.image.vendor="Light Code Labs"
+LABEL org.opencontainers.image.licenses=Apache-2.0
+LABEL org.opencontainers.image.source=https://github.com/caddyserver/caddy-docker
+
+EXPOSE 80/tcp
+EXPOSE 443/tcp
+EXPOSE 443/udp
+EXPOSE 2019/tcp
+
+WORKDIR /srv
+
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+

--- a/images/caddy/Dockerfile
+++ b/images/caddy/Dockerfile
@@ -2,12 +2,12 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 
 RUN microdnf install -y ca-certificates libcap wget tar gzip && microdnf clean all
 
+ARG CADDY_VERSION=v2.11.2
+
 RUN set -eux; \
     mkdir -p /config/caddy /data/caddy /etc/caddy /usr/share/caddy ; \
-    wget -O /etc/caddy/Caddyfile "https://github.com/caddyserver/dist/raw/509c30cecd3cbc4012f6b1cc88d8f3f000fb06e4/config/Caddyfile"; \
-    wget -O /usr/share/caddy/index.html "https://github.com/caddyserver/dist/raw/509c30cecd3cbc4012f6b1cc88d8f3f000fb06e4/welcome/index.html"
-
-ENV CADDY_VERSION=v2.11.2
+    wget -O /etc/caddy/Caddyfile "https://github.com/caddyserver/dist/raw/${CADDY_VERSION}/config/Caddyfile"; \
+    wget -O /usr/share/caddy/index.html "https://github.com/caddyserver/dist/raw/${CADDY_VERSION}/welcome/index.html"
 
 RUN set -eux; \
     arch="$(uname -m)"; \
@@ -52,4 +52,3 @@ EXPOSE 2019/tcp
 WORKDIR /srv
 
 CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
-

--- a/images/caddy/Makefile
+++ b/images/caddy/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=caddy
-TAG?=v2.8.4
+TAG?=2.11.2
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 # Image references

--- a/images/caddy/Makefile
+++ b/images/caddy/Makefile
@@ -1,0 +1,20 @@
+REGISTRY?=icr.io/ai-services-private
+IMAGE=caddy
+TAG?=v2.8.4
+CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
+
+# Image references
+IMAGE_TAG := $(REGISTRY)/$(IMAGE):$(TAG)
+
+CONTAINER_BUILDER?=podman
+build:
+	$(CONTAINER_BUILDER) build -t $(IMAGE_TAG) .
+.PHONY: build
+
+push:
+	$(CONTAINER_BUILDER) push $(CREDS_ARG) $(IMAGE_TAG)
+.PHONY: push
+
+image-tag:
+	@echo $(TAG)
+.PHONY: image-tag

--- a/images/caddy/Makefile
+++ b/images/caddy/Makefile
@@ -8,7 +8,7 @@ IMAGE_TAG := $(REGISTRY)/$(IMAGE):$(TAG)
 
 CONTAINER_BUILDER?=podman
 build:
-	$(CONTAINER_BUILDER) build -t $(IMAGE_TAG) .
+	$(CONTAINER_BUILDER) build --build-arg CADDY_VERSION=$(TAG) -t $(IMAGE_TAG) .
 .PHONY: build
 
 push:


### PR DESCRIPTION
We need `caddy web server` to enable https for the ai-services.

As part of the PR installing `Caddy` [v2.11.2](https://github.com/caddyserver/caddy/releases/tag/v2.11.2) tool on ubi9 image.
