### PR TITLE
chore(catalog-ui): Logout API call update

### DIFF
--- a/catalog-ui/src/services/auth.ts
+++ b/catalog-ui/src/services/auth.ts
@@ -13,7 +13,12 @@ export const login = async (payload: LoginRequest): Promise<LoginResponse> => {
 };
 
 export const logout = async () => {
-  await api.post(AUTH_ENDPOINTS.LOGOUT);
+  const refreshToken = useAuthStore.getState().refreshToken;
+  await api.post(AUTH_ENDPOINTS.LOGOUT, null, {
+    headers: {
+      "X-Refresh-Token": refreshToken,
+    },
+  });
   useAuthStore.getState().clearTokens();
 };
 


### PR DESCRIPTION
Added X-Refresh-Token header to logout API call in catalog-ui for session-specific token blacklisting

Commands used to setup backend locally:
```
podman run -d \
  --name catalog-postgres \
  -e POSTGRES_USER=admin \
  -e POSTGRES_PASSWORD=catalogpass \
  -e POSTGRES_DB=ai_services \
  -p 5432:5432 \
  docker.io/library/postgres:15

export DB_PASSWORD=catalogpass
export AUTH_JWT_SECRET="abcd123"

PASSWORD=$(printf '%s\n' 'S3cureP@ss!' | ./bin/ai-services-linux-amd64 catalog hashpw --stdin --iterations 1500000)
./bin/ai-services-linux-amd64 catalog migrate init --db-password catalogpass
./bin/ai-services-linux-amd64 catalog apiserver --admin-password-hash=$PASSWORD
```

Logs when I performed login and logout on the UI:
<img width="1918" height="783" alt="image" src="https://github.com/user-attachments/assets/4e267e70-7862-4656-85f9-9675f34cd393" />
