### PR TITLE
fix: preserve context while streaming/stopping logs

### DIFF
--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -214,7 +214,7 @@ func (pc *PodmanClient) streamContainerLogs(ctx context.Context, containerNameOr
 		waitDone := make(chan struct{})
 		go func() {
 			defer close(waitDone)
-			_, err := containers.Wait(pc.Context, containerNameOrID, nil)
+			_, err := containers.Wait(ctx, containerNameOrID, nil)
 			if err == nil {
 				// Container exited, cancel the logs streaming
 				cancelLogs()
@@ -228,8 +228,8 @@ func (pc *PodmanClient) streamContainerLogs(ctx context.Context, containerNameOr
 		<-waitDone
 	}()
 
-	// Print logs as they arrive
-	pc.printLogsFromChannels(logsCtx, stdoutChan, stderrChan)
+	// passing both contexts so it respects Ctrl+C and container exit
+	pc.printLogsFromChannels(ctx, logsCtx, stdoutChan, stderrChan)
 
 	// Wait for goroutine to complete
 	<-done
@@ -238,10 +238,14 @@ func (pc *PodmanClient) streamContainerLogs(ctx context.Context, containerNameOr
 }
 
 // printLogsFromChannels reads from stdout and stderr channels and prints logs.
-func (pc *PodmanClient) printLogsFromChannels(ctx context.Context, stdoutChan, stderrChan <-chan string) {
+func (pc *PodmanClient) printLogsFromChannels(parentCtx, logsCtx context.Context, stdoutChan, stderrChan <-chan string) {
 	for {
 		select {
-		case <-ctx.Done():
+		case <-parentCtx.Done():
+			// Parent context cancelled (e.g., Ctrl+C)
+			return
+		case <-logsCtx.Done():
+			// Logs context cancelled (e.g., container exited)
 			return
 		case line, ok := <-stdoutChan:
 			if !ok {


### PR DESCRIPTION
The ctrl+c command does not work to exit the streaming. Ctrl+z had to be used to exit.
This is because proper ctx was not used.
JIRA: https://jsw.ibm.com/browse/AISERVICES-1021 