### PR TITLE
Upgrade Spyre operator to v1.2

### DIFF
--- a/ai-services/assets/bootstrap/openshift/02-operators/03-spyre-operator.yaml
+++ b/ai-services/assets/bootstrap/openshift/02-operators/03-spyre-operator.yaml
@@ -24,8 +24,8 @@ metadata:
   name: spyre-operator
   namespace: spyre-operator
 spec:
-  channel: stable-v1.1
+  channel: stable-v1.2
   name: spyre-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: spyre-operator.v1.1.1
+  startingCSV: spyre-operator.v1.2.1


### PR DESCRIPTION
We can check the following metadata to know what OCP versions can be available for the releases.

v1.1.x: https://github.com/redhat-openshift-ecosystem/certified-operators/blob/main/operators/spyre-operator/v1.1.1/metadata/annotations.yaml
v1.2.x: https://github.com/redhat-openshift-ecosystem/certified-operators/blob/main/operators/spyre-operator/v1.2.1/metadata/annotations.yaml
The installable OCP version is defined in this annotation file. so v1.1.x can be setup on v4.16 - v4.20, and v1.2.x can be setup on v4.16 - v4.21.