### PR TITLE
Bumping up python-multipart pkg

### DIFF
--- a/spyre-rag/requirements-test.txt
+++ b/spyre-rag/requirements-test.txt
@@ -13,7 +13,7 @@ fastapi>=0.104.0
 starlette>=0.27.0
 uvicorn==0.38.0
 requests==2.33.0
-python-multipart==0.0.26
+python-multipart==0.0.27
 
 # Additional utilities
 python-dotenv>=1.0.0


### PR DESCRIPTION
There is a high cve in `python-multipart==0.0.26`, therefore bumping up the version
https://github.com/IBM/project-ai-services/security/dependabot/123
