### PR TITLE
Switch Caddy readiness probe to HTTP GET health endpoint

### DIFF
--- a/ai-services/assets/catalog/podman/Caddyfile
+++ b/ai-services/assets/catalog/podman/Caddyfile
@@ -10,5 +10,10 @@
 	tls internal
 }
 
+# Internal health check endpoint (Bypasses automatic HTTPS redirection)
+:8080 {
+    respond /health "OK" 200
+}
+
 # This file serves as the base configuration
 # Routes will be dynamically added via Caddy Admin API

--- a/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
@@ -34,10 +34,10 @@ spec:
         limits:
           memory: "512Mi"
       livenessProbe:
-        exec:
-          command:
-            - /usr/bin/caddy
-            - version
+        httpGet:
+          path: /health
+          port: 8080
+          scheme: HTTP
         initialDelaySeconds: 5
         periodSeconds: 10
         timeoutSeconds: 5


### PR DESCRIPTION
This PR adds dedicated HTTP health endpoint for Caddy probes