### PR TITLE
[Catalog-API] List Applications

### DIFF
--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver"
 	apirepository "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
@@ -88,14 +89,23 @@ func runAPIServer(port int, accessTTL, refreshTTL time.Duration, adminUser, admi
 	blacklist := apirepository.NewDBTokenBlacklist(tokenBlacklistRepo)
 	defer blacklist.Stop()
 
+	// Initialize application repository and service
+	applicationRepo := repository.NewApplicationRepository(pool)
+	catalogProvider, err := catalog.NewCatalogProvider()
+	if err != nil {
+		return fmt.Errorf("failed to initialize catalog provider: %w", err)
+	}
+	applicationService := apirepository.NewApplicationService(applicationRepo, catalogProvider)
+
 	tokenMgr := auth.NewTokenManager(secretKey, accessTTL, refreshTTL)
 	authSvc := auth.NewAuthService(userRepo, tokenMgr, blacklist)
 
 	return apiserver.NewAPIserver(apiserver.APIServerOptions{
-		Port:         port,
-		AuthService:  authSvc,
-		TokenManager: tokenMgr,
-		Blacklist:    blacklist,
+		Port:               port,
+		AuthService:        authSvc,
+		TokenManager:       tokenMgr,
+		Blacklist:          blacklist,
+		ApplicationService: applicationService,
 	}).Start()
 }
 

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -25,6 +25,75 @@ const docTemplate = `{
     "basePath": "{{.BasePath}}",
     "paths": {
         "/applications": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieves a paginated list of all applications for the authenticated user with optional filters",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Applications"
+                ],
+                "summary": "List applications",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number (1-indexed)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Number of items per page (max: 100)",
+                        "name": "page_size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by deployment type: 'architectures' or 'services'",
+                        "name": "deployment_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by catalog ID (e.g., 'rag', 'chat', 'digitize', 'summarize')",
+                        "name": "catalog_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid query parameters",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -869,6 +938,55 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationListResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationSummary"
+                    }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PaginationMetadata"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationSummary": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "deployment_type": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "services": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceStatus"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture": {
             "type": "object",
             "properties": {
@@ -1047,6 +1165,29 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PaginationMetadata": {
+            "type": "object",
+            "properties": {
+                "has_next": {
+                    "type": "boolean"
+                },
+                "has_prev": {
+                    "type": "boolean"
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "total_items": {
+                    "type": "integer"
+                },
+                "total_pages": {
+                    "type": "integer"
+                }
+            }
+        },
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Service": {
             "type": "object",
             "properties": {
@@ -1090,6 +1231,17 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceStatus": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -1238,6 +1238,9 @@ const docTemplate = `{
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceStatus": {
             "type": "object",
             "properties": {
+                "id": {
+                    "type": "string"
+                },
                 "status": {
                     "type": "string"
                 },

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -938,21 +938,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationListResponse": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationSummary"
-                    }
-                },
-                "pagination": {
-                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PaginationMetadata"
-                }
-            }
-        },
-        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationSummary": {
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Application": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -984,6 +970,20 @@ const docTemplate = `{
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationListResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Application"
+                    }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PaginationMetadata"
                 }
             }
         },

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -1232,6 +1232,9 @@
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceStatus": {
             "type": "object",
             "properties": {
+                "id": {
+                    "type": "string"
+                },
                 "status": {
                     "type": "string"
                 },

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -19,6 +19,75 @@
     "basePath": "/api/v1",
     "paths": {
         "/applications": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieves a paginated list of all applications for the authenticated user with optional filters",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Applications"
+                ],
+                "summary": "List applications",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "Page number (1-indexed)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Number of items per page (max: 100)",
+                        "name": "page_size",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by deployment type: 'architectures' or 'services'",
+                        "name": "deployment_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by catalog ID (e.g., 'rag', 'chat', 'digitize', 'summarize')",
+                        "name": "catalog_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationListResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid query parameters",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -863,6 +932,55 @@
         }
     },
     "definitions": {
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationListResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationSummary"
+                    }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PaginationMetadata"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationSummary": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "deployment_type": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "services": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceStatus"
+                    }
+                },
+                "status": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture": {
             "type": "object",
             "properties": {
@@ -1041,6 +1159,29 @@
                 }
             }
         },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PaginationMetadata": {
+            "type": "object",
+            "properties": {
+                "has_next": {
+                    "type": "boolean"
+                },
+                "has_prev": {
+                    "type": "boolean"
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "page_size": {
+                    "type": "integer"
+                },
+                "total_items": {
+                    "type": "integer"
+                },
+                "total_pages": {
+                    "type": "integer"
+                }
+            }
+        },
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Service": {
             "type": "object",
             "properties": {
@@ -1084,6 +1225,17 @@
                     "type": "boolean"
                 },
                 "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceStatus": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -932,21 +932,7 @@
         }
     },
     "definitions": {
-        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationListResponse": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationSummary"
-                    }
-                },
-                "pagination": {
-                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PaginationMetadata"
-                }
-            }
-        },
-        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationSummary": {
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Application": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -978,6 +964,20 @@
                 },
                 "updated_at": {
                     "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationListResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Application"
+                    }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PaginationMetadata"
                 }
             }
         },

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -196,6 +196,8 @@ definitions:
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceStatus:
     properties:
+      id:
+        type: string
       status:
         type: string
       type:

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -1,15 +1,6 @@
 basePath: /api/v1
 definitions:
-  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationListResponse:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationSummary'
-        type: array
-      pagination:
-        $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PaginationMetadata'
-    type: object
-  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationSummary:
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Application:
     properties:
       created_at:
         type: string
@@ -31,6 +22,15 @@ definitions:
         type: string
       updated_at:
         type: string
+    type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Application'
+        type: array
+      pagination:
+        $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PaginationMetadata'
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture:
     properties:

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -1,5 +1,37 @@
 basePath: /api/v1
 definitions:
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationListResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationSummary'
+        type: array
+      pagination:
+        $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PaginationMetadata'
+    type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationSummary:
+    properties:
+      created_at:
+        type: string
+      deployment_type:
+        type: string
+      id:
+        type: string
+      message:
+        type: string
+      name:
+        type: string
+      services:
+        items:
+          $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceStatus'
+        type: array
+      status:
+        type: string
+      type:
+        type: string
+      updated_at:
+        type: string
+    type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture:
     properties:
       certified_by:
@@ -116,6 +148,21 @@ definitions:
       type:
         type: string
     type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PaginationMetadata:
+    properties:
+      has_next:
+        type: boolean
+      has_prev:
+        type: boolean
+      page:
+        type: integer
+      page_size:
+        type: integer
+      total_items:
+        type: integer
+      total_pages:
+        type: integer
+    type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Service:
     properties:
       architectures:
@@ -145,6 +192,13 @@ definitions:
       optional:
         type: boolean
       version:
+        type: string
+    type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceStatus:
+    properties:
+      status:
+        type: string
+      type:
         type: string
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceSummary:
@@ -199,6 +253,52 @@ info:
   version: "1.0"
 paths:
   /applications:
+    get:
+      description: Retrieves a paginated list of all applications for the authenticated
+        user with optional filters
+      parameters:
+      - default: 1
+        description: Page number (1-indexed)
+        in: query
+        name: page
+        type: integer
+      - default: 20
+        description: 'Number of items per page (max: 100)'
+        in: query
+        name: page_size
+        type: integer
+      - description: 'Filter by deployment type: ''architectures'' or ''services'''
+        in: query
+        name: deployment_type
+        type: string
+      - description: Filter by catalog ID (e.g., 'rag', 'chat', 'digitize', 'summarize')
+        in: query
+        name: catalog_id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationListResponse'
+        "400":
+          description: Invalid query parameters
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: List applications
+      tags:
+      - Applications
     post:
       consumes:
       - application/json

--- a/ai-services/internal/pkg/catalog/apiserver/apiserver.go
+++ b/ai-services/internal/pkg/catalog/apiserver/apiserver.go
@@ -41,18 +41,20 @@ import (
 // APIServerOptions defines the configuration options for the API server such as the port to listen
 // on and the authentication provider.
 type APIServerOptions struct {
-	Port         int
-	AuthService  auth.Service
-	TokenManager *auth.TokenManager
-	Blacklist    repository.TokenBlacklist
+	Port               int
+	AuthService        auth.Service
+	TokenManager       *auth.TokenManager
+	Blacklist          repository.TokenBlacklist
+	ApplicationService *repository.ApplicationService
 }
 
 // APIserver represents the API server instance, holding the configuration and authentication provider.
 type APIserver struct {
-	port         int
-	authService  auth.Service
-	tokenManager *auth.TokenManager
-	blacklist    repository.TokenBlacklist
+	port               int
+	authService        auth.Service
+	tokenManager       *auth.TokenManager
+	blacklist          repository.TokenBlacklist
+	applicationService *repository.ApplicationService
 }
 
 // NewAPIserver creates a new instance of the API server with the provided options, setting default values where necessary.
@@ -63,17 +65,18 @@ func NewAPIserver(options APIServerOptions) *APIserver {
 	}
 
 	return &APIserver{
-		port:         options.Port,
-		authService:  options.AuthService,
-		tokenManager: options.TokenManager,
-		blacklist:    options.Blacklist,
+		port:               options.Port,
+		authService:        options.AuthService,
+		tokenManager:       options.TokenManager,
+		blacklist:          options.Blacklist,
+		applicationService: options.ApplicationService,
 	}
 }
 
 // Start initializes the API server and begins listening for incoming requests on the configured port.
 // It sets up the router with authentication middleware and routes.
 func (a *APIserver) Start() error {
-	r := CreateRouter(a.authService, a.tokenManager, a.blacklist)
+	r := CreateRouter(a.authService, a.tokenManager, a.blacklist, a.applicationService)
 
 	return r.Run(fmt.Sprintf(":%d", a.port))
 }

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/application_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/application_handler.go
@@ -11,7 +11,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 )
 
-// Ensure types package is imported for Swagger documentation
+// Ensure types package is imported for Swagger documentation.
 var _ types.ApplicationListResponse
 
 // ApplicationHandler handles application-related HTTP requests.
@@ -33,7 +33,7 @@ func NewApplicationHandler(appService *repository.ApplicationService) *Applicati
 //	@Tags			Applications
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			page			query		int		false	"Page number (1-indexed)"	default(1)
+//	@Param			page			query		int		false	"Page number (1-indexed)"				default(1)
 //	@Param			page_size		query		int		false	"Number of items per page (max: 100)"	default(20)
 //	@Param			deployment_type	query		string	false	"Filter by deployment type: 'architectures' or 'services'"
 //	@Param			catalog_id		query		string	false	"Filter by catalog ID (e.g., 'rag', 'chat', 'digitize', 'summarize')"
@@ -51,6 +51,7 @@ func (h *ApplicationHandler) ListApplications(c *gin.Context) {
 	page, pageSize, err := repository.ValidatePaginationParams(page, pageSize)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+
 		return
 	}
 
@@ -63,6 +64,7 @@ func (h *ApplicationHandler) ListApplications(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Error: fmt.Sprintf("deployment_type must be '%s' or '%s'", models.DeploymentTypeArchitectures, models.DeploymentTypeServices),
 		})
+
 		return
 	}
 
@@ -80,6 +82,7 @@ func (h *ApplicationHandler) ListApplications(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{
 			Error: fmt.Sprintf("Failed to retrieve applications: %v", err),
 		})
+
 		return
 	}
 

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/application_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/application_handler.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+)
+
+// Ensure types package is imported for Swagger documentation
+var _ types.ApplicationListResponse
+
+// ApplicationHandler handles application-related HTTP requests.
+type ApplicationHandler struct {
+	appService *repository.ApplicationService
+}
+
+// NewApplicationHandler creates a new application handler.
+func NewApplicationHandler(appService *repository.ApplicationService) *ApplicationHandler {
+	return &ApplicationHandler{
+		appService: appService,
+	}
+}
+
+// ListApplications godoc
+//
+//	@Summary		List applications
+//	@Description	Retrieves a paginated list of all applications for the authenticated user with optional filters
+//	@Tags			Applications
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			page			query		int		false	"Page number (1-indexed)"	default(1)
+//	@Param			page_size		query		int		false	"Number of items per page (max: 100)"	default(20)
+//	@Param			deployment_type	query		string	false	"Filter by deployment type: 'architectures' or 'services'"
+//	@Param			catalog_id		query		string	false	"Filter by catalog ID (e.g., 'rag', 'chat', 'digitize', 'summarize')"
+//	@Success		200				{object}	types.ApplicationListResponse
+//	@Failure		400				{object}	ErrorResponse	"Invalid query parameters"
+//	@Failure		401				{object}	ErrorResponse	"Unauthorized"
+//	@Failure		500				{object}	ErrorResponse	"Internal Server Error"
+//	@Router			/applications [get]
+func (h *ApplicationHandler) ListApplications(c *gin.Context) {
+	// Parse pagination parameters
+	page, _ := strconv.Atoi(c.Query("page"))
+	pageSize, _ := strconv.Atoi(c.Query("page_size"))
+
+	// Validate and apply defaults
+	page, pageSize, err := repository.ValidatePaginationParams(page, pageSize)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+		return
+	}
+
+	// Parse filter parameters
+	deploymentType := c.Query("deployment_type")
+	catalogID := c.Query("catalog_id")
+
+	// Validate deployment_type if provided
+	if deploymentType != "" && deploymentType != string(models.DeploymentTypeArchitectures) && deploymentType != string(models.DeploymentTypeServices) {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: fmt.Sprintf("deployment_type must be '%s' or '%s'", models.DeploymentTypeArchitectures, models.DeploymentTypeServices),
+		})
+		return
+	}
+
+	// Build request
+	req := repository.ListApplicationsRequest{
+		Page:           page,
+		PageSize:       pageSize,
+		DeploymentType: deploymentType,
+		CatalogID:      catalogID,
+	}
+
+	// Call service layer
+	response, err := h.appService.ListApplications(c.Request.Context(), req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: fmt.Sprintf("Failed to retrieve applications: %v", err),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -120,8 +120,8 @@ func (s *ApplicationService) buildServiceStatuses(services []models.Service) []t
 
 	for _, svc := range services {
 		// Get service display name from catalog metadata
-		serviceDisplayName := svc.Type // Default to service type
-		if service, err := s.provider.LoadService(svc.Type); err == nil && service.Name != "" {
+		serviceDisplayName := svc.CatalogID // Default to catalog_id
+		if service, err := s.provider.LoadService(svc.CatalogID); err == nil && service.Name != "" {
 			serviceDisplayName = service.Name
 		}
 

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -106,8 +106,8 @@ func (s *ApplicationService) buildApplication(app models.Application) (types.App
 		UpdatedAt:      app.UpdatedAt.Format(constants.RFC3339WithTimezone),
 	}
 
-	// Add services array (services already loaded from DB via JOIN)
-	if len(app.Services) > 0 {
+	// Add services array only for architectures (not for individual services)
+	if app.DeploymentType == models.DeploymentTypeArchitectures && len(app.Services) > 0 {
 		appData.Services = s.buildServiceStatuses(app.Services)
 	}
 

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -55,44 +55,15 @@ func (s *ApplicationService) ListApplications(ctx context.Context, req ListAppli
 		return nil, fmt.Errorf("failed to retrieve applications: %w", err)
 	}
 
-	// Build application summaries with type information
-	summaries := []types.ApplicationSummary{}
+	// Build application list with type information
+	apps := make([]types.Application, 0, len(applications))
 	for _, app := range applications {
-		// Get type (display name) from catalog metadata
-		typeName, err := s.getApplicationType(app.CatalogID, app.DeploymentType)
+		appData, err := s.buildApplication(app)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get application type for catalog_id '%s': %w", app.CatalogID, err)
+			return nil, err
 		}
 
-		summary := types.ApplicationSummary{
-			ID:             app.ID.String(),
-			Name:           app.Name,
-			DeploymentType: string(app.DeploymentType),
-			Type:           typeName,
-			Status:         string(app.Status),
-			Message:        app.Message,
-			CreatedAt:      app.CreatedAt.Format(constants.RFC3339WithTimezone),
-			UpdatedAt:      app.UpdatedAt.Format(constants.RFC3339WithTimezone),
-		}
-
-		// Add services array (services already loaded from DB via JOIN)
-		if len(app.Services) > 0 {
-			summary.Services = make([]types.ServiceStatus, 0, len(app.Services))
-			for _, svc := range app.Services {
-				// Get service display name from catalog metadata
-				serviceDisplayName := svc.Type // Default to service type
-				if service, err := s.provider.LoadService(svc.Type); err == nil && service.Name != "" {
-					serviceDisplayName = service.Name
-				}
-
-				summary.Services = append(summary.Services, types.ServiceStatus{
-					Type:   serviceDisplayName,
-					Status: string(svc.Status),
-				})
-			}
-		}
-
-		summaries = append(summaries, summary)
+		apps = append(apps, appData)
 	}
 
 	// All pagination is done at DB level, so summaries are already paginated
@@ -102,7 +73,7 @@ func (s *ApplicationService) ListApplications(ctx context.Context, req ListAppli
 	}
 
 	response := &types.ApplicationListResponse{
-		Data: summaries,
+		Data: apps,
 		Pagination: types.PaginationMetadata{
 			Page:       req.Page,
 			PageSize:   req.PageSize,
@@ -116,6 +87,53 @@ func (s *ApplicationService) ListApplications(ctx context.Context, req ListAppli
 	return response, nil
 }
 
+// buildApplication creates an Application from a models.Application.
+func (s *ApplicationService) buildApplication(app models.Application) (types.Application, error) {
+	// Get type (display name) from catalog metadata
+	typeName, err := s.getApplicationType(app.CatalogID, app.DeploymentType)
+	if err != nil {
+		return types.Application{}, fmt.Errorf("failed to get application type for catalog_id '%s': %w", app.CatalogID, err)
+	}
+
+	appData := types.Application{
+		ID:             app.ID.String(),
+		Name:           app.Name,
+		DeploymentType: string(app.DeploymentType),
+		Type:           typeName,
+		Status:         string(app.Status),
+		Message:        app.Message,
+		CreatedAt:      app.CreatedAt.Format(constants.RFC3339WithTimezone),
+		UpdatedAt:      app.UpdatedAt.Format(constants.RFC3339WithTimezone),
+	}
+
+	// Add services array (services already loaded from DB via JOIN)
+	if len(app.Services) > 0 {
+		appData.Services = s.buildServiceStatuses(app.Services)
+	}
+
+	return appData, nil
+}
+
+// buildServiceStatuses creates ServiceStatus array from models.Service slice.
+func (s *ApplicationService) buildServiceStatuses(services []models.Service) []types.ServiceStatus {
+	statuses := make([]types.ServiceStatus, 0, len(services))
+
+	for _, svc := range services {
+		// Get service display name from catalog metadata
+		serviceDisplayName := svc.Type // Default to service type
+		if service, err := s.provider.LoadService(svc.Type); err == nil && service.Name != "" {
+			serviceDisplayName = service.Name
+		}
+
+		statuses = append(statuses, types.ServiceStatus{
+			Type:   serviceDisplayName,
+			Status: string(svc.Status),
+		})
+	}
+
+	return statuses
+}
+
 // getApplicationType retrieves the application type from catalog metadata.
 func (s *ApplicationService) getApplicationType(catalogID string, deploymentType models.DeploymentType) (string, error) {
 	if deploymentType == models.DeploymentTypeArchitectures {
@@ -123,6 +141,7 @@ func (s *ApplicationService) getApplicationType(catalogID string, deploymentType
 		if err != nil {
 			return "", fmt.Errorf("failed to load architecture metadata: %w", err)
 		}
+
 		return arch.Name, nil
 	}
 
@@ -131,6 +150,7 @@ func (s *ApplicationService) getApplicationType(catalogID string, deploymentType
 	if err != nil {
 		return "", fmt.Errorf("failed to load service metadata: %w", err)
 	}
+
 	return service.Name, nil
 }
 

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -126,6 +126,7 @@ func (s *ApplicationService) buildServiceStatuses(services []models.Service) []t
 		}
 
 		statuses = append(statuses, types.ServiceStatus{
+			ID:     svc.ID.String(),
 			Type:   serviceDisplayName,
 			Status: string(svc.Status),
 		})

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -1,0 +1,160 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
+	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+)
+
+// ApplicationService provides business logic for application operations.
+type ApplicationService struct {
+	appRepo  dbrepo.ApplicationRepository
+	provider *catalog.CatalogProvider
+}
+
+// NewApplicationService creates a new application service.
+func NewApplicationService(appRepo dbrepo.ApplicationRepository, provider *catalog.CatalogProvider) *ApplicationService {
+	return &ApplicationService{
+		appRepo:  appRepo,
+		provider: provider,
+	}
+}
+
+// ListApplicationsRequest contains parameters for listing applications.
+type ListApplicationsRequest struct {
+	Page           int
+	PageSize       int
+	DeploymentType string
+	CatalogID      string
+}
+
+// ListApplications retrieves a paginated list of applications with filters.
+func (s *ApplicationService) ListApplications(ctx context.Context, req ListApplicationsRequest) (*types.ApplicationListResponse, error) {
+	// Build filters for repository query (all filters are at DB level now)
+	filters := &dbrepo.ApplicationFilters{
+		DeploymentType: req.DeploymentType,
+		CatalogID:      req.CatalogID,
+		Limit:          req.PageSize,
+		Offset:         (req.Page - 1) * req.PageSize,
+	}
+
+	// Get total count for pagination metadata
+	totalCount, err := s.appRepo.GetCount(ctx, filters)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get application count: %w", err)
+	}
+
+	// Get applications from database with filters
+	applications, err := s.appRepo.GetAll(ctx, filters)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve applications: %w", err)
+	}
+
+	// Build application summaries with type information
+	summaries := []types.ApplicationSummary{}
+	for _, app := range applications {
+		// Get type (display name) from catalog metadata
+		typeName, err := s.getApplicationType(app.CatalogID, app.DeploymentType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get application type for catalog_id '%s': %w", app.CatalogID, err)
+		}
+
+		summary := types.ApplicationSummary{
+			ID:             app.ID.String(),
+			Name:           app.Name,
+			DeploymentType: string(app.DeploymentType),
+			Type:           typeName,
+			Status:         string(app.Status),
+			Message:        app.Message,
+			CreatedAt:      app.CreatedAt.Format(constants.RFC3339WithTimezone),
+			UpdatedAt:      app.UpdatedAt.Format(constants.RFC3339WithTimezone),
+		}
+
+		// Add services array (services already loaded from DB via JOIN)
+		if len(app.Services) > 0 {
+			summary.Services = make([]types.ServiceStatus, 0, len(app.Services))
+			for _, svc := range app.Services {
+				// Get service display name from catalog metadata
+				serviceDisplayName := svc.Type // Default to service type
+				if service, err := s.provider.LoadService(svc.Type); err == nil && service.Name != "" {
+					serviceDisplayName = service.Name
+				}
+
+				summary.Services = append(summary.Services, types.ServiceStatus{
+					Type:   serviceDisplayName,
+					Status: string(svc.Status),
+				})
+			}
+		}
+
+		summaries = append(summaries, summary)
+	}
+
+	// All pagination is done at DB level, so summaries are already paginated
+	totalPages := (totalCount + req.PageSize - 1) / req.PageSize
+	if totalPages == 0 {
+		totalPages = 1
+	}
+
+	response := &types.ApplicationListResponse{
+		Data: summaries,
+		Pagination: types.PaginationMetadata{
+			Page:       req.Page,
+			PageSize:   req.PageSize,
+			TotalItems: totalCount,
+			TotalPages: totalPages,
+			HasNext:    req.Page < totalPages,
+			HasPrev:    req.Page > 1,
+		},
+	}
+
+	return response, nil
+}
+
+// getApplicationType retrieves the application type from catalog metadata.
+func (s *ApplicationService) getApplicationType(catalogID string, deploymentType models.DeploymentType) (string, error) {
+	if deploymentType == models.DeploymentTypeArchitectures {
+		arch, err := s.provider.LoadArchitecture(catalogID)
+		if err != nil {
+			return "", fmt.Errorf("failed to load architecture metadata: %w", err)
+		}
+		return arch.Name, nil
+	}
+
+	// For services
+	service, err := s.provider.LoadService(catalogID)
+	if err != nil {
+		return "", fmt.Errorf("failed to load service metadata: %w", err)
+	}
+	return service.Name, nil
+}
+
+// ValidatePaginationParams validates and returns pagination parameters with defaults.
+func ValidatePaginationParams(page, pageSize int) (int, int, error) {
+	// Apply defaults
+	if page == 0 {
+		page = constants.MinPage
+	}
+	if pageSize == 0 {
+		pageSize = constants.DefaultPageSize
+	}
+
+	// Validate page
+	if page < constants.MinPage {
+		return 0, 0, fmt.Errorf("invalid page parameter: must be a positive integer")
+	}
+
+	// Validate page_size
+	if pageSize < constants.MinPage || pageSize > constants.MaxPageSize {
+		return 0, 0, fmt.Errorf("invalid page_size parameter: must be between 1 and %d", constants.MaxPageSize)
+	}
+
+	return page, pageSize, nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/router.go
+++ b/ai-services/internal/pkg/catalog/apiserver/router.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CreateRouter sets up the Gin router with the necessary routes and authentication middleware for the API server.
-func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist repository.TokenBlacklist) *gin.Engine {
+func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist repository.TokenBlacklist, appService *repository.ApplicationService) *gin.Engine {
 	router := gin.Default()
 
 	// Health check endpoint
@@ -28,6 +28,7 @@ func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist r
 	authHandler := handlers.NewAuthHandler(authSvc)
 	catalogHandler := handlers.NewCatalogHandler()
 	deployOptionsHandler := handlers.NewDeployOptionsHandler()
+	applicationHandler := handlers.NewApplicationHandler(appService)
 
 	v1 := router.Group("/api/v1")
 	{
@@ -52,17 +53,20 @@ func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist r
 
 	applications := v1.Group("applications")
 	applications.Use(middleware.AuthMiddleware(tokenMgr, blacklist))
+	{
+		// Implemented endpoints
+		applications.GET("/", applicationHandler.ListApplications)
 
-	// Draft endpoints and more discussion needed to finalize the API design. For now, these are placeholders.
-	// TODO: Define the API design for application management, including request/response formats and error handling.
-	applications.GET("/templates", getTemplates)
-	applications.POST("/", createApplication)
-	applications.GET("/:name", getApplication)
-	applications.DELETE("/:name", deleteApplication)
-	applications.GET("/:name/ps", getApplicationStatus)
-	applications.POST("/:name/start", startApplication)
-	applications.POST("/:name/stop", stopApplication)
-	applications.GET("/:name/logs", getApplicationLogs)
+		// Draft endpoints - placeholders for future implementation
+		applications.GET("/templates", getTemplates)
+		applications.POST("/", createApplication)
+		applications.GET("/:name", getApplication)
+		applications.DELETE("/:name", deleteApplication)
+		applications.GET("/:name/ps", getApplicationStatus)
+		applications.POST("/:name/start", startApplication)
+		applications.POST("/:name/stop", stopApplication)
+		applications.GET("/:name/logs", getApplicationLogs)
+	}
 
 	return router
 }

--- a/ai-services/internal/pkg/catalog/constants/catalog.go
+++ b/ai-services/internal/pkg/catalog/constants/catalog.go
@@ -20,4 +20,20 @@ const (
 	CatalogAppName = "ai-services"
 )
 
+// Pagination constants.
+const (
+	// DefaultPageSize is the default number of items per page.
+	DefaultPageSize = 20
+	// MaxPageSize is the maximum number of items per page.
+	MaxPageSize = 100
+	// MinPage is the minimum page number.
+	MinPage = 1
+)
+
+// Time format constants.
+const (
+	// RFC3339WithTimezone is the time format for API responses (ISO 8601 with timezone).
+	RFC3339WithTimezone = "2006-01-02T15:04:05Z07:00"
+)
+
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/db/migrations/assets/20260430094502_create_applications_table.sql
+++ b/ai-services/internal/pkg/catalog/db/migrations/assets/20260430094502_create_applications_table.sql
@@ -10,7 +10,7 @@ CREATE TYPE deployment_type AS ENUM (
 CREATE TABLE applications (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name VARCHAR(100),
-    template VARCHAR(100),
+    catalog_id VARCHAR(100),
     deployment_type deployment_type,
     status status,
     message TEXT,

--- a/ai-services/internal/pkg/catalog/db/migrations/assets/20260430094503_create_services_table.sql
+++ b/ai-services/internal/pkg/catalog/db/migrations/assets/20260430094503_create_services_table.sql
@@ -4,7 +4,7 @@
 CREATE TABLE services (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     app_id UUID NOT NULL,
-    type VARCHAR(100),
+    catalog_id VARCHAR(100),
     status status,
     endpoints JSONB,
     version TEXT,

--- a/ai-services/internal/pkg/catalog/db/models/application.go
+++ b/ai-services/internal/pkg/catalog/db/models/application.go
@@ -29,7 +29,7 @@ const (
 type Application struct {
 	ID             uuid.UUID         `json:"id"`
 	Name           string            `json:"name"`
-	Template       string            `json:"template"`
+	CatalogID      string            `json:"catalog_id"`
 	DeploymentType DeploymentType    `json:"deployment_type"`
 	Status         ApplicationStatus `json:"status"`
 	Message        string            `json:"message,omitempty"`

--- a/ai-services/internal/pkg/catalog/db/models/service.go
+++ b/ai-services/internal/pkg/catalog/db/models/service.go
@@ -10,7 +10,7 @@ import (
 type Service struct {
 	ID        uuid.UUID         `json:"id"`
 	AppID     uuid.UUID         `json:"app_id"`
-	Type      string            `json:"type"`
+	CatalogID string            `json:"catalog_id"`
 	Status    ApplicationStatus `json:"status"`
 	Endpoints map[string]any    `json:"endpoints,omitempty"`
 	Version   string            `json:"version,omitempty"`

--- a/ai-services/internal/pkg/catalog/db/repository/application_repo.go
+++ b/ai-services/internal/pkg/catalog/db/repository/application_repo.go
@@ -64,6 +64,19 @@ func NewApplicationRepository(pool *pgxpool.Pool) ApplicationRepository {
 // GetAll retrieves all applications from the database with optional filters.
 // Includes associated services via INNER JOIN.
 func (r *applicationRepo) GetAll(ctx context.Context, filters *ApplicationFilters) ([]models.Application, error) {
+	query, args := r.buildGetAllQuery(filters)
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query applications: %w", err)
+	}
+	defer rows.Close()
+
+	return r.scanApplicationsWithServices(rows)
+}
+
+// buildGetAllQuery constructs the SQL query and arguments for GetAll.
+func (r *applicationRepo) buildGetAllQuery(filters *ApplicationFilters) (string, []interface{}) {
 	query := `
 		SELECT
 			a.id, a.name, a.catalog_id, a.deployment_type, a.status, a.message, a.created_by, a.created_at, a.updated_at,
@@ -81,6 +94,11 @@ func (r *applicationRepo) GetAll(ctx context.Context, filters *ApplicationFilter
 			whereClauses = append(whereClauses, fmt.Sprintf("a.deployment_type = $%d", len(args)+1))
 			args = append(args, filters.DeploymentType)
 		}
+
+		if filters.CatalogID != "" {
+			whereClauses = append(whereClauses, fmt.Sprintf("a.catalog_id = $%d", len(args)+1))
+			args = append(args, filters.CatalogID)
+		}
 	}
 
 	// Add WHERE clause if any filters are present
@@ -88,17 +106,27 @@ func (r *applicationRepo) GetAll(ctx context.Context, filters *ApplicationFilter
 		query += " WHERE " + strings.Join(whereClauses, " AND ")
 	}
 
-	query += " ORDER BY a.created_at DESC, s.created_at"
+	query += " ORDER BY a.created_at DESC, s.created_at ASC"
 
-	rows, err := r.pool.Query(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query applications: %w", err)
+	// Add pagination if provided
+	if filters != nil {
+		if filters.Limit > 0 {
+			query += fmt.Sprintf(" LIMIT $%d", len(args)+1)
+			args = append(args, filters.Limit)
+		}
+		if filters.Offset > 0 {
+			query += fmt.Sprintf(" OFFSET $%d", len(args)+1)
+			args = append(args, filters.Offset)
+		}
 	}
-	defer rows.Close()
 
-	// Use a map to group services by application ID
+	return query, args
+}
+
+// scanApplicationsWithServices scans rows into Application structs with their services.
+func (r *applicationRepo) scanApplicationsWithServices(rows pgx.Rows) ([]models.Application, error) {
 	appMap := make(map[string]*models.Application)
-	var appOrder []string // Track order of applications
+	var appOrder []string
 
 	for rows.Next() {
 		var (

--- a/ai-services/internal/pkg/catalog/db/repository/application_repo.go
+++ b/ai-services/internal/pkg/catalog/db/repository/application_repo.go
@@ -80,7 +80,7 @@ func (r *applicationRepo) buildGetAllQuery(filters *ApplicationFilters) (string,
 	query := `
 		SELECT
 			a.id, a.name, a.catalog_id, a.deployment_type, a.status, a.message, a.created_by, a.created_at, a.updated_at,
-			s.id, s.app_id, s.type, s.status, s.endpoints, s.version, s.created_at, s.updated_at
+			s.id, s.app_id, s.catalog_id, s.status, s.endpoints, s.version, s.created_at, s.updated_at
 		FROM applications a
 		INNER JOIN services s ON a.id = s.app_id
 	`
@@ -225,7 +225,7 @@ func (s *scannedServiceFields) toService() (*models.Service, error) {
 	service := &models.Service{
 		ID:        s.id.UUID,
 		AppID:     s.appID.UUID,
-		Type:      s.typ.String,
+		CatalogID: s.typ.String,
 		Status:    models.ApplicationStatus(s.status.String),
 		CreatedAt: s.created.Time,
 		UpdatedAt: s.updated.Time,

--- a/ai-services/internal/pkg/catalog/db/repository/application_repo.go
+++ b/ai-services/internal/pkg/catalog/db/repository/application_repo.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -12,10 +13,20 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
 )
 
+// ApplicationFilters defines optional filters for querying applications.
+type ApplicationFilters struct {
+	DeploymentType string // Optional: filter by deployment_type ("architectures" or "services")
+	CatalogID      string // Optional: filter by catalog_id (e.g., "rag", "chat", "digitize")
+	Limit          int    // Optional: number of records to return (for pagination)
+	Offset         int    // Optional: number of records to skip (for pagination)
+}
+
 // ApplicationRepository defines the interface for application data operations.
 type ApplicationRepository interface {
-	// GetAll retrieves all applications from the database.
-	GetAll(ctx context.Context) ([]models.Application, error)
+	// GetAll retrieves all applications from the database with optional filters and pagination.
+	GetAll(ctx context.Context, filters *ApplicationFilters) ([]models.Application, error)
+	// GetCount returns the total count of applications matching the filters.
+	GetCount(ctx context.Context, filters *ApplicationFilters) (int, error)
 	// GetByID retrieves an application by ID with its associated services.
 	GetByID(ctx context.Context, id uuid.UUID) (*models.Application, error)
 	// GetByName retrieves an application by name with its associated services.
@@ -50,52 +61,130 @@ func NewApplicationRepository(pool *pgxpool.Pool) ApplicationRepository {
 	return &applicationRepo{pool: pool}
 }
 
-// GetAll retrieves all applications from the database.
-func (r *applicationRepo) GetAll(ctx context.Context) ([]models.Application, error) {
+// GetAll retrieves all applications from the database with optional filters.
+// Includes associated services via INNER JOIN.
+func (r *applicationRepo) GetAll(ctx context.Context, filters *ApplicationFilters) ([]models.Application, error) {
 	query := `
-		SELECT id, name, template, deployment_type, status, message, created_by, created_at, updated_at
-		FROM applications
-		ORDER BY created_at DESC
+		SELECT
+			a.id, a.name, a.catalog_id, a.deployment_type, a.status, a.message, a.created_by, a.created_at, a.updated_at,
+			s.id, s.app_id, s.type, s.status, s.endpoints, s.version, s.created_at, s.updated_at
+		FROM applications a
+		INNER JOIN services s ON a.id = s.app_id
 	`
 
-	rows, err := r.pool.Query(ctx, query)
+	args := []interface{}{}
+	whereClauses := []string{}
+
+	// Build WHERE clause dynamically based on provided filters
+	if filters != nil {
+		if filters.DeploymentType != "" {
+			whereClauses = append(whereClauses, fmt.Sprintf("a.deployment_type = $%d", len(args)+1))
+			args = append(args, filters.DeploymentType)
+		}
+	}
+
+	// Add WHERE clause if any filters are present
+	if len(whereClauses) > 0 {
+		query += " WHERE " + strings.Join(whereClauses, " AND ")
+	}
+
+	query += " ORDER BY a.created_at DESC, s.created_at"
+
+	rows, err := r.pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query applications: %w", err)
 	}
 	defer rows.Close()
 
-	var applications []models.Application
+	// Use a map to group services by application ID
+	appMap := make(map[string]*models.Application)
+	var appOrder []string // Track order of applications
+
 	for rows.Next() {
-		var app models.Application
-		var message sql.NullString
+		var (
+			app     models.Application
+			message sql.NullString
+			svc     scannedServiceFields
+		)
 
 		err := rows.Scan(
-			&app.ID,
-			&app.Name,
-			&app.Template,
-			&app.DeploymentType,
-			&app.Status,
-			&message,
-			&app.CreatedBy,
-			&app.CreatedAt,
-			&app.UpdatedAt,
+			&app.ID, &app.Name, &app.CatalogID, &app.DeploymentType, &app.Status,
+			&message, &app.CreatedBy, &app.CreatedAt, &app.UpdatedAt,
+			&svc.id, &svc.appID, &svc.typ, &svc.status,
+			&svc.endpoint, &svc.version, &svc.created, &svc.updated,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to scan application: %w", err)
+			return nil, fmt.Errorf("failed to scan application with services: %w", err)
 		}
 
 		if message.Valid {
 			app.Message = message.String
 		}
 
-		applications = append(applications, app)
+		appID := app.ID.String()
+
+		// If this is a new application, add it to the map
+		if _, exists := appMap[appID]; !exists {
+			appMap[appID] = &app
+			appOrder = append(appOrder, appID)
+		}
+
+		// Add service to the application
+		service, err := svc.toService()
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert service: %w", err)
+		}
+		if service != nil {
+			appMap[appID].Services = append(appMap[appID].Services, *service)
+		}
 	}
 
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error iterating applications: %w", err)
 	}
 
+	// Convert map to slice in original order
+	applications := make([]models.Application, 0, len(appOrder))
+	for _, appID := range appOrder {
+		applications = append(applications, *appMap[appID])
+	}
+
 	return applications, nil
+}
+
+// GetCount returns the total count of applications matching the filters.
+// This is used for pagination metadata.
+func (r *applicationRepo) GetCount(ctx context.Context, filters *ApplicationFilters) (int, error) {
+	query := `SELECT COUNT(DISTINCT a.id) FROM applications a`
+	args := []interface{}{}
+	argIndex := 1
+	whereAdded := false
+
+	// Add deployment_type filter if provided
+	if filters != nil && filters.DeploymentType != "" {
+		query += fmt.Sprintf(" WHERE a.deployment_type = $%d", argIndex)
+		args = append(args, filters.DeploymentType)
+		argIndex++
+		whereAdded = true
+	}
+
+	// Add catalog_id filter if provided
+	if filters != nil && filters.CatalogID != "" {
+		if whereAdded {
+			query += fmt.Sprintf(" AND a.catalog_id = $%d", argIndex)
+		} else {
+			query += fmt.Sprintf(" WHERE a.catalog_id = $%d", argIndex)
+		}
+		args = append(args, filters.CatalogID)
+	}
+
+	var count int
+	err := r.pool.QueryRow(ctx, query, args...).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get application count: %w", err)
+	}
+
+	return count, nil
 }
 
 // toService converts scanned fields to a Service model.
@@ -137,7 +226,7 @@ func scanApplicationWithService(rows pgx.Rows, app *models.Application) (*models
 	)
 
 	err := rows.Scan(
-		&app.ID, &app.Name, &app.Template, &app.DeploymentType, &app.Status,
+		&app.ID, &app.Name, &app.CatalogID, &app.DeploymentType, &app.Status,
 		&message, &app.CreatedBy, &app.CreatedAt, &app.UpdatedAt,
 		&svc.id, &svc.appID, &svc.typ, &svc.status,
 		&svc.endpoint, &svc.version, &svc.created, &svc.updated,
@@ -243,7 +332,7 @@ func (r *applicationRepo) Insert(ctx context.Context, app *models.Application) e
 		query,
 		app.ID,
 		app.Name,
-		app.Template,
+		app.CatalogID,
 		app.DeploymentType,
 		app.Status,
 		sql.NullString{String: app.Message, Valid: app.Message != ""},

--- a/ai-services/internal/pkg/catalog/db/repository/service_repo.go
+++ b/ai-services/internal/pkg/catalog/db/repository/service_repo.go
@@ -37,7 +37,7 @@ func NewServiceRepository(pool *pgxpool.Pool) ServiceRepository {
 // Insert creates a new service in the database.
 func (r *serviceRepo) Insert(ctx context.Context, service *models.Service) error {
 	query := `
-		INSERT INTO services (id, app_id, type, status, endpoints, version)
+		INSERT INTO services (id, app_id, catalog_id, status, endpoints, version)
 		VALUES ($1, $2, $3, $4, $5, $6)
 		RETURNING created_at, updated_at
 	`
@@ -62,7 +62,7 @@ func (r *serviceRepo) Insert(ctx context.Context, service *models.Service) error
 		query,
 		service.ID,
 		service.AppID,
-		service.Type,
+		service.CatalogID,
 		service.Status,
 		endpointsJSON,
 		sql.NullString{String: service.Version, Valid: service.Version != ""},
@@ -117,7 +117,7 @@ func (r *serviceRepo) GetByAppID(ctx context.Context, appID uuid.UUID) ([]models
 		err := rows.Scan(
 			&service.ID,
 			&service.AppID,
-			&service.Type,
+			&service.CatalogID,
 			&service.Status,
 			&endpointsJSON,
 			&serviceVersion,
@@ -172,7 +172,7 @@ func (r *serviceRepo) Update(ctx context.Context, service *models.Service) error
 	err = r.pool.QueryRow(
 		ctx,
 		query,
-		service.Type,
+		service.CatalogID,
 		service.Status,
 		endpointsJSON,
 		sql.NullString{String: service.Version, Valid: service.Version != ""},

--- a/ai-services/internal/pkg/catalog/types/application_response.go
+++ b/ai-services/internal/pkg/catalog/types/application_response.go
@@ -2,12 +2,12 @@ package types
 
 // ApplicationListResponse represents the response for listing applications.
 type ApplicationListResponse struct {
-	Data       []ApplicationSummary `json:"data"`
-	Pagination PaginationMetadata   `json:"pagination"`
+	Data       []Application      `json:"data"`
+	Pagination PaginationMetadata `json:"pagination"`
 }
 
-// ApplicationSummary represents a summary of an application in the list.
-type ApplicationSummary struct {
+// Application represents an application in the list response.
+type Application struct {
 	ID             string          `json:"id"`
 	Name           string          `json:"name"`
 	DeploymentType string          `json:"deployment_type"`

--- a/ai-services/internal/pkg/catalog/types/application_response.go
+++ b/ai-services/internal/pkg/catalog/types/application_response.go
@@ -21,6 +21,7 @@ type Application struct {
 
 // ServiceStatus represents the status of a service within an application.
 type ServiceStatus struct {
+	ID     string `json:"id"`
 	Type   string `json:"type"`
 	Status string `json:"status"`
 }

--- a/ai-services/internal/pkg/catalog/types/application_response.go
+++ b/ai-services/internal/pkg/catalog/types/application_response.go
@@ -1,0 +1,38 @@
+package types
+
+// ApplicationListResponse represents the response for listing applications.
+type ApplicationListResponse struct {
+	Data       []ApplicationSummary `json:"data"`
+	Pagination PaginationMetadata   `json:"pagination"`
+}
+
+// ApplicationSummary represents a summary of an application in the list.
+type ApplicationSummary struct {
+	ID             string          `json:"id"`
+	Name           string          `json:"name"`
+	DeploymentType string          `json:"deployment_type"`
+	Type           string          `json:"type"`
+	Status         string          `json:"status"`
+	Message        string          `json:"message,omitempty"`
+	Services       []ServiceStatus `json:"services,omitempty"`
+	CreatedAt      string          `json:"created_at"`
+	UpdatedAt      string          `json:"updated_at"`
+}
+
+// ServiceStatus represents the status of a service within an application.
+type ServiceStatus struct {
+	Type   string `json:"type"`
+	Status string `json:"status"`
+}
+
+// PaginationMetadata represents pagination information in the response.
+type PaginationMetadata struct {
+	Page       int  `json:"page"`
+	PageSize   int  `json:"page_size"`
+	TotalItems int  `json:"total_items"`
+	TotalPages int  `json:"total_pages"`
+	HasNext    bool `json:"has_next"`
+	HasPrev    bool `json:"has_prev"`
+}
+
+// Made with Bob

--- a/docs/proposals/catalog/application-deployment-api-proposal.md
+++ b/docs/proposals/catalog/application-deployment-api-proposal.md
@@ -519,14 +519,17 @@ Authorization: Bearer <access_token>
       "message": "All services are operational",
       "services": [
         {
+          "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
           "type": "Questions and Answers",
           "status": "Running"
         },
         {
+          "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
           "type": "Digitize",
           "status": "Running"
         },
         {
+          "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
           "type": "Summarize",
           "status": "Running"
         }
@@ -580,6 +583,7 @@ Authorization: Bearer <access_token>
 **Service Object (services[]):**
 | Field | Type | Description |
 |-------|------|-------------|
+| id | string | Service ID (UUID) |
 | type | string | Service type: "Questions and Answers", "Digitize", "Summarize" |
 | status | string | Service status: "Downloading", "Deploying", "Running", "Deleting", "Error" |
 
@@ -609,7 +613,7 @@ Authorization: Bearer <access_token>
 4. Query applications table with pagination and filters:
    - Apply WHERE clauses for deployment_type and type if provided
    - Use template field to fetch corresponding type and deployment_type from metadata
-5. For Digital Assistant applications (type="Digital Assistant"), fetch and include services array with type and status
+5. For Digital Assistant applications (type="Digital Assistant"), fetch and include services array with id, type (display name from catalog), and status from the services table
 6. Construct paginated response with application data and metadata
 
 **Example Requests:**

--- a/docs/proposals/catalog/application-deployment-api-proposal.md
+++ b/docs/proposals/catalog/application-deployment-api-proposal.md
@@ -500,6 +500,8 @@ Authorization: Bearer <access_token>
 |-----------|------|----------|---------|-------------|
 | page | integer | No | 1 | Page number (1-indexed) |
 | page_size | integer | No | 20 | Number of items per page (max: 100) |
+| deployment_type | string | No | - | Filter by deployment type: "architectures" or "services" |
+| catalog_id | string | No | - | Filter by catalog ID (e.g., "rag", "chat", "digitize", "summarize") |
 
 **Request Body:** None
 
@@ -511,17 +513,31 @@ Authorization: Bearer <access_token>
     {
       "id": "123e4567-e89b-12d3-a456-426614174000",
       "name": "RAG Production",
-      "deployment_type": "architecture",
+      "deployment_type": "architectures",
       "type": "Digital Assistant",
       "status": "Running",
       "message": "All services are operational",
+      "services": [
+        {
+          "type": "Questions and Answers",
+          "status": "Running"
+        },
+        {
+          "type": "Digitize",
+          "status": "Running"
+        },
+        {
+          "type": "Summarize",
+          "status": "Running"
+        }
+      ],
       "created_at": "2026-04-15T10:30:00Z",
       "updated_at": "2026-04-15T10:35:00Z"
     },
     {
       "id": "223e4567-e89b-12d3-a456-426614174001",
       "name": "Summarization Dev",
-      "deployment_type": "service",
+      "deployment_type": "services",
       "type": "Summary",
       "status": "Running",
       "message": "Service deployed successfully",
@@ -557,8 +573,15 @@ Authorization: Bearer <access_token>
 | type | string | Application type: "Digital Assistant" for architectures, "Summary" for summarization services |
 | status | string | Current status: "Downloading", "Deploying", "Running", "Deleting", "Error" |
 | message | string | Status message or error details |
+| services | array | Array of service objects (only present for Digital Assistant type) |
 | created_at | string | ISO 8601 timestamp of creation |
 | updated_at | string | ISO 8601 timestamp of last update |
+
+**Service Object (services[]):**
+| Field | Type | Description |
+|-------|------|-------------|
+| type | string | Service type: "Questions and Answers", "Digitize", "Summarize" |
+| status | string | Service status: "Downloading", "Deploying", "Running", "Deleting", "Error" |
 
 **Pagination Object:**
 | Field | Type | Description |
@@ -580,9 +603,14 @@ Authorization: Bearer <access_token>
 
 1. Validate JWT token from Authorization header via `AuthMiddleware`
 2. Validate pagination parameters (page >= 1, page_size between 1-100)
-3. Query all rows from the applications table with pagination support
-4. For each application, use the template field to fetch the corresponding type (Digital Assistant) and deployment_type (architecture or service) from the architecure or service metadata file for the corresponding template id (This will be unique and belongs to either architecture or service).
-5. Construct paginated response with application data and metadata
+3. Validate filter parameters:
+   - deployment_type: must be "architectures" or "services" if provided
+   - type: must match valid application types if provided
+4. Query applications table with pagination and filters:
+   - Apply WHERE clauses for deployment_type and type if provided
+   - Use template field to fetch corresponding type and deployment_type from metadata
+5. For Digital Assistant applications (type="Digital Assistant"), fetch and include services array with type and status
+6. Construct paginated response with application data and metadata
 
 **Example Requests:**
 
@@ -592,6 +620,18 @@ GET /api/v1/applications
 
 # Get second page with 50 items per page
 GET /api/v1/applications?page=2&page_size=50
+
+# Filter by deployment type (architectures only)
+GET /api/v1/applications?deployment_type=architectures
+
+# Filter by application type (Digital Assistant only)
+GET /api/v1/applications?type=Digital%20Assistant
+
+# Combine filters
+GET /api/v1/applications?deployment_type=architectures&type=Digital%20Assistant&page=1&page_size=10
+
+# Filter services only
+GET /api/v1/applications?deployment_type=services
 ```
 
 ---

--- a/docs/proposals/catalog/db-design-proposal.md
+++ b/docs/proposals/catalog/db-design-proposal.md
@@ -98,7 +98,7 @@ CREATE TYPE status AS ENUM (
 |---------------------|-------------------|-------------|-------------|
 | id                  | UUID              | PRIMARY KEY | Unique service identifier |
 | app_id              | UUID              | FOREIGN KEY | References applications(id) |
-| type                | VARCHAR(100)      |             | Service type (e.g., Summarization, Digitization) |
+| catalog_id          | VARCHAR(100)      |             | Service catalog ID (e.g., chat, summarize, digitize) |
 | status              | ServiceStatus     | ENUM        | Current status (Running, Error) |
 | endpoints           | JSONB             |             | Array of endpoint objects with name and endpoint fields: `[{"name": "ui", "endpoint": "http://..."}, {"name": "backend", "endpoint": "http://..."}]` |
 | version             | TEXT              |             | Service version |
@@ -229,7 +229,7 @@ erDiagram
     services {
         UUID id PK
         UUID app_id FK
-        VARCHAR type
+        VARCHAR catalog_id
         ServiceStatus status
         JSONB endpoints
         TEXT version
@@ -336,11 +336,11 @@ The tokens_blacklist table provides token revocation management with enhanced se
 
 ### 6. Services and Components Separation
 The schema separates application-specific services from shared infrastructure components:
-- **Services Table**: Application-specific deployable units (e.g., Summarization, Digitization) with app_id foreign key
+- **Services Table**: Application-specific deployable units (e.g., chat, summarize, digitize) with app_id foreign key and catalog_id referencing the service template
 - **Components Table**: Shared infrastructure resources (e.g., vector_store, llm, reranker, embedding) without app_id
 - **Clear Separation**: Services belong to applications, components are shared across applications
 - **Flexible Design**: Easy to add new service and component types
-- **Type-based Filtering**: Use type field to distinguish different types
+- **Catalog ID**: Use catalog_id field to identify the service template from the catalog
 
 ### 7. Components Table Design
 The components table stores shared infrastructure with specific design choices:


### PR DESCRIPTION
- A new endpoint for Listing Applications.
- Supports 2 query params: deployment_type and catalog_id.
- deployment_type can be `architectures/services` and catalog_id will be `rag/chat` etc.
- Supports Pagination.
- Rename from `template` to `catalog_id` in Applications table and change from `type` to `catalog_id` in Services table.

Note: This can be used for `Digitial Assistants` and `Services` page in UI to list down the running instances.