### PR TITLE
feat(catalog): show dynamic HTTPS URLs in next steps

### DIFF
--- a/ai-services/assets/catalog/podman/steps/next.md
+++ b/ai-services/assets/catalog/podman/steps/next.md
@@ -1,3 +1,3 @@
-- Access the Catalog UI at https://{{ .CATALOG_UI_DOMAIN }}:{{ .CADDY_HTTPS_PORT }}
+- Access the Catalog UI at https://{{ .CATALOG_UI_DOMAIN }}:{{ .HTTPS_PORT }}
 
-- Access the Catalog Backend at https://{{ .CATALOG_API_DOMAIN }}:{{ .CADDY_HTTPS_PORT }}
+- Access the Catalog Backend at https://{{ .CATALOG_API_DOMAIN }}:{{ .HTTPS_PORT }}

--- a/ai-services/assets/catalog/podman/steps/next.md
+++ b/ai-services/assets/catalog/podman/steps/next.md
@@ -1,3 +1,3 @@
-- Access the Catalog UI at http://{{ .HOST_IP }}:{{ .UI_PORT }}
+- Access the Catalog UI at https://{{ .CATALOG_UI_DOMAIN }}:{{ .CADDY_HTTPS_PORT }}
 
-- Access the Catalog Backend at http://{{ .HOST_IP }}:{{ .BACKEND_PORT }}
+- Access the Catalog Backend at https://{{ .CATALOG_API_DOMAIN }}:{{ .CADDY_HTTPS_PORT }}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"text/template"
 
@@ -92,13 +93,13 @@ func DeployCatalog(ctx context.Context, podmanURI, passwordHash, baseDir string,
 	s.Stop("Catalog service deployed successfully")
 	logger.Infoln("-------")
 
-	// Register routes with Caddy
-	if err := registerCatalogRoutes(rt, tp, catalogAppTemplate, argParams); err != nil {
+	// Register routes with Caddy and get the registered route domains
+	routeDomains, httpsPort, err := registerCatalogRoutes(rt, tp, catalogAppTemplate, argParams)
+	if err != nil {
 		return fmt.Errorf("route registration failed: %w", err)
 	}
 
-	// Print next steps similar to application create
-	if err := helpers.PrintNextSteps(tp, rt, catalogconstants.CatalogAppName, catalogAppTemplate); err != nil {
+	if err := helpers.PrintNextStepsWithProxy(tp, rt, catalogconstants.CatalogAppName, catalogAppTemplate, routeDomains, httpsPort); err != nil {
 		// do not want to fail the overall configure if we cannot print next steps
 		logger.Infof("failed to display next steps: %v\n", err)
 	}
@@ -394,46 +395,89 @@ func findCaddyPodNameFromTemplates(tp templates.Template, appTemplateName string
 	return "", fmt.Errorf("no Caddy pod found with component=proxy label in templates")
 }
 
-// registerCatalogRoutes extracts routes from all templates and registers them with Caddy.
-func registerCatalogRoutes(rt *podman.PodmanClient, tp templates.Template, appTemplateName string, argParams map[string]string) error {
+// registerCatalogRoutes registers routes with Caddy and returns route domains and HTTPS port.
+func registerCatalogRoutes(rt *podman.PodmanClient, tp templates.Template, appTemplateName string, argParams map[string]string) (map[string]string, string, error) {
 	// Extract routes from all templates
 	routeInfos, err := extractAllRoutesFromTemplates(tp, appTemplateName, argParams)
 	if err != nil {
-		return fmt.Errorf("failed to extract routes from templates: %w", err)
+		return nil, "", fmt.Errorf("failed to extract routes from templates: %w", err)
 	}
 
 	if len(routeInfos) == 0 {
 		logger.Infof("No templates found with routes annotation, skipping route registration\n")
 
-		return nil
+		return nil, "", nil
 	}
 
 	// Find Caddy pod from templates
 	caddyPodName, err := findCaddyPodNameFromTemplates(tp, appTemplateName, argParams)
 	if err != nil {
-		return fmt.Errorf("failed to find Caddy pod: %w", err)
+		return nil, "", fmt.Errorf("failed to find Caddy pod: %w", err)
 	}
 
 	logger.Infof("Found Caddy pod: %s\n", caddyPodName)
+
+	// Build route domains map
+	routeDomains := make(map[string]string)
 
 	// Register routes for each template that has them
 	var registrationErrors []error
 	for _, info := range routeInfos {
 		logger.Infof("Registering routes for pod: %s\n", info.PodName)
-		// Pass caddyPodName for admin port and info.PodName for upstream addresses
-		if err := proxy.RegisterRoutesForApp(rt, catalogconstants.CatalogAppName, constants.CaddyServerName, info.RoutesAnnotation, caddyPodName, info.PodName); err != nil {
+
+		// Register routes and get the built routes back
+		routes, err := proxy.RegisterRoutesForAppAndReturn(rt, catalogconstants.CatalogAppName, constants.CaddyServerName, info.RoutesAnnotation, caddyPodName, info.PodName)
+		if err != nil {
 			registrationErrors = append(registrationErrors, fmt.Errorf("pod %s: %w", info.PodName, err))
+
+			continue
+		}
+
+		for _, route := range routes {
+			parts := strings.Split(route.Domain, ".")
+			if len(parts) > 0 {
+				subdomain := parts[0]
+				sanitizedSubdomain := strings.ReplaceAll(subdomain, "-", "_")
+				varName := strings.ToUpper(fmt.Sprintf("%s_DOMAIN", sanitizedSubdomain))
+				routeDomains[varName] = route.Domain
+			}
 		}
 	}
 
 	// Return error if any routes failed to register
 	if len(registrationErrors) > 0 {
-		return fmt.Errorf("failed to register routes for %d pod(s): %w", len(registrationErrors), errors.Join(registrationErrors...))
+		return nil, "", fmt.Errorf("failed to register routes for %d pod(s): %w", len(registrationErrors), errors.Join(registrationErrors...))
+	}
+
+	// Get Caddy HTTPS port
+	httpsPort, err := getCaddyHTTPSPort(rt, caddyPodName)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get Caddy HTTPS port: %w", err)
 	}
 
 	logger.Infof("Successfully registered routes for %d pod(s)\n", len(routeInfos))
 
-	return nil
+	return routeDomains, httpsPort, nil
+}
+
+// getCaddyHTTPSPort retrieves the host port mapped to Caddy's HTTPS port (container port 443).
+func getCaddyHTTPSPort(rt *podman.PodmanClient, caddyPodName string) (string, error) {
+	pod, err := rt.InspectPod(caddyPodName)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect Caddy pod: %w", err)
+	}
+
+	// Get port mappings from the Ports field
+	// Ports is a map[string][]string where key is "containerPort/protocol" and value is list of host ports
+	// Example: {"443/tcp": ["39341"], "2019/tcp": ["37249"]}
+	for containerPort, hostPorts := range pod.Ports {
+		// Check if this is the HTTPS port (443)
+		if strings.HasPrefix(containerPort, "443/") && len(hostPorts) > 0 {
+			return hostPorts[0], nil
+		}
+	}
+
+	return "", fmt.Errorf("HTTPS port mapping not found in pod ports")
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -93,12 +93,18 @@ func DeployCatalog(ctx context.Context, podmanURI, passwordHash, baseDir string,
 	s.Stop("Catalog service deployed successfully")
 	logger.Infoln("-------")
 
+	return handlePostDeployment(rt, tp, argParams)
+}
+
+// handlePostDeployment handles route registration and next steps display after catalog deployment.
+func handlePostDeployment(rt *podman.PodmanClient, tp templates.Template, argParams map[string]string) error {
 	// Register routes with Caddy and get the registered route domains
 	routeDomains, httpsPort, err := registerCatalogRoutes(rt, tp, catalogAppTemplate, argParams)
 	if err != nil {
 		return fmt.Errorf("route registration failed: %w", err)
 	}
 
+	// Print next steps with proxy route information
 	if err := helpers.PrintNextStepsWithProxy(tp, rt, catalogconstants.CatalogAppName, catalogAppTemplate, routeDomains, httpsPort); err != nil {
 		// do not want to fail the overall configure if we cannot print next steps
 		logger.Infof("failed to display next steps: %v\n", err)

--- a/ai-services/internal/pkg/cli/helpers/steps.go
+++ b/ai-services/internal/pkg/cli/helpers/steps.go
@@ -42,7 +42,7 @@ func PrintNextStepsWithProxy(tp templates.Template, runtime runtime.Runtime, app
 
 	// Add HTTPS port to params if provided
 	if httpsPort != "" {
-		params["CADDY_HTTPS_PORT"] = httpsPort
+		params["HTTPS_PORT"] = httpsPort
 	}
 
 	if err := renderStepsMarkdown(tp, runtime, appTemplate, params, nextStepsMDFile, nextStepsTitle); err != nil {

--- a/ai-services/internal/pkg/cli/helpers/steps.go
+++ b/ai-services/internal/pkg/cli/helpers/steps.go
@@ -31,6 +31,29 @@ func PrintNextSteps(tp templates.Template, runtime runtime.Runtime, app, appTemp
 	return nil
 }
 
+// PrintNextStepsWithProxy prints next steps with proxy route information.
+func PrintNextStepsWithProxy(tp templates.Template, runtime runtime.Runtime, app, appTemplate string, routeDomains map[string]string, httpsPort string) error {
+	params := map[string]string{"AppName": app}
+
+	// Add route domains to params
+	for key, value := range routeDomains {
+		params[key] = value
+	}
+
+	// Add HTTPS port to params if provided
+	if httpsPort != "" {
+		params["CADDY_HTTPS_PORT"] = httpsPort
+	}
+
+	if err := renderStepsMarkdown(tp, runtime, appTemplate, params, nextStepsMDFile, nextStepsTitle); err != nil {
+		logger.Infof("Unable to load steps: %v\n", err)
+
+		return nil
+	}
+
+	return nil
+}
+
 func PrintInfo(tp templates.Template, runtime runtime.Runtime, app, appTemplate string) error {
 	params := map[string]string{"AppName": app}
 	if err := renderStepsMarkdown(tp, runtime, appTemplate, params, infoMDFile, infoTitle); err != nil {

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -132,38 +132,31 @@ func (c *caddyManager) createRoute(routeConfig map[string]interface{}) error {
 	return nil
 }
 
-// RegisterRoutesForApp registers routes for an application with Caddy proxy.
-// This is a reusable function that can be called from catalog, application, or service deployments.
+// RegisterRoutesForAppAndReturn registers routes for an application with Caddy proxy and returns the built routes.
 //
 // Parameters:
 //   - rt: Runtime interface for interacting with pods
 //   - appName: Name of the application (e.g., "ai-services" for catalog)
 //   - serverName: Caddy server name (e.g., "ai_services")
-//   - routesAnnotation: Routes annotation value in format "port:subdomain, port:subdomain, ..."
+//   - routesAnnotation: Routes annotation value in format "port:subdomain,port:subdomain,..."
+//   - caddyPodName: Name of the Caddy pod
+//   - servicePodName: Name of the service pod for upstream configuration
 //
 // Returns:
+//   - []Route: List of successfully built and registered routes
 //   - error: nil if routes were registered successfully, error otherwise
-//
-// The function performs the following steps:
-//  1. Discovers Caddy admin port from pod port mappings
-//  2. Creates a proxy manager with the admin URL
-//  3. Performs health check on Caddy
-//  4. Builds routes from the provided annotation string
-//  5. Registers each route with Caddy
-//
-// If any step fails, appropriate warnings are logged and the function returns early.
-func RegisterRoutesForApp(
+func RegisterRoutesForAppAndReturn(
 	rt runtime.Runtime,
 	appName string,
 	serverName string,
 	routesAnnotation string,
 	caddyPodName string,
 	servicePodName string,
-) error {
+) ([]Route, error) {
 	// Step 1: Get Caddy admin port from Caddy pod port mappings
 	adminPort, err := GetCaddyAdminPort(rt, caddyPodName)
 	if err != nil {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"failed to get Caddy admin port, routes not registered: %w",
 			err,
 		)
@@ -175,7 +168,7 @@ func RegisterRoutesForApp(
 
 	// Step 3: Perform health check on Caddy
 	if err := proxyManager.HealthCheck(); err != nil {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"caddy health check failed, routes not registered: %w",
 			err,
 		)
@@ -184,13 +177,13 @@ func RegisterRoutesForApp(
 	// Step 4: Get host IP for route domain generation
 	hostIP, err := utils.GetHostIP()
 	if err != nil {
-		return fmt.Errorf("failed to get host IP: %w", err)
+		return nil, fmt.Errorf("failed to get host IP: %w", err)
 	}
 
 	// Step 5: Build routes from the annotation string using service pod name for upstreams
 	routes, err := BuildRoutesFromAnnotation(routesAnnotation, hostIP, servicePodName)
 	if err != nil {
-		return fmt.Errorf("failed to build routes: %w", err)
+		return nil, fmt.Errorf("failed to build routes: %w", err)
 	}
 
 	// Step 6: Register each route with Caddy
@@ -203,10 +196,10 @@ func RegisterRoutesForApp(
 
 	// Return error if any routes failed to register
 	if len(registrationErrors) > 0 {
-		return fmt.Errorf("failed to register %d route(s): %w", len(registrationErrors), errors.Join(registrationErrors...))
+		return nil, fmt.Errorf("failed to register %d route(s): %w", len(registrationErrors), errors.Join(registrationErrors...))
 	}
 
-	return nil
+	return routes, nil
 }
 
 // Made with Bob


### PR DESCRIPTION
Display registered Caddy route domains and HTTPS port in catalog next steps instead of   HTTP URLs