### PR TITLE
fix: enable root user to create model dir

### DIFF
--- a/ai-services/internal/pkg/cli/helpers/models.go
+++ b/ai-services/internal/pkg/cli/helpers/models.go
@@ -47,29 +47,8 @@ func ListModels(template, appName string) ([]string, error) {
 }
 
 func DownloadModel(model, targetDir string) error {
-	// check for target model directory
-	fileInfo, err := os.Stat(targetDir)
-	if err != nil {
-		return fmt.Errorf("cannot access directory: %s, err: %w", targetDir, err)
-	}
-
-	// verify it's a directory
-	if !fileInfo.IsDir() {
-		return fmt.Errorf("path is not a directory: %s", targetDir)
-	}
-
-	// check if user has write permissions to the directory
-	// try to create a temporary file to verify write access
-	testFile := targetDir + "/.write_test"
-	f, err := os.Create(testFile)
-	if err != nil {
-		return fmt.Errorf("user does not have write permission to directory: %s, err: %w", targetDir, err)
-	}
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("failed to close test file: %w", err)
-	}
-	if err := os.Remove(testFile); err != nil {
-		return fmt.Errorf("failed to remove test file: %w", err)
+	if err := prepareModelTargetDir(targetDir); err != nil {
+		return err
 	}
 
 	logger.Infof("Downloading model %s to %s\n", model, targetDir)
@@ -111,6 +90,53 @@ func DownloadModel(model, targetDir string) error {
 	}
 
 	logger.Infoln("Model downloaded successfully")
+
+	return nil
+}
+
+func prepareModelTargetDir(targetDir string) error {
+	if os.Geteuid() == 0 {
+		return createTargetDir(targetDir)
+	}
+
+	return validateWritableTargetDir(targetDir)
+}
+
+func createTargetDir(targetDir string) error {
+	if err := os.MkdirAll(targetDir, constants.DirPerm); err != nil {
+		return fmt.Errorf("cannot create directory: %s, err: %w", targetDir, err)
+	}
+
+	return nil
+}
+
+func validateWritableTargetDir(targetDir string) error {
+	fileInfo, err := os.Stat(targetDir)
+	if err != nil {
+		return fmt.Errorf("cannot access directory: %s, err: %w", targetDir, err)
+	}
+
+	if !fileInfo.IsDir() {
+		return fmt.Errorf("path is not a directory: %s", targetDir)
+	}
+
+	return validateDirWriteAccess(targetDir)
+}
+
+func validateDirWriteAccess(targetDir string) error {
+	testFile := targetDir + "/.write_test"
+	f, err := os.Create(testFile)
+	if err != nil {
+		return fmt.Errorf("user does not have write permission to directory: %s, err: %w", targetDir, err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to close test file: %w", err)
+	}
+
+	if err := os.Remove(testFile); err != nil {
+		return fmt.Errorf("failed to remove test file: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
root users should be able to create models directory from `application create`.
Made changes in code so that it fails for non-root but works fine for root users
