### PR TITLE
feat(catalog): add /health endpoint and backend liveness probe

### DIFF
--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -112,6 +112,14 @@ spec:
       ports:
         - containerPort: 8080
           protocol: TCP
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: 8080
+        initialDelaySeconds: 10
+        periodSeconds: 30
+        timeoutSeconds: 5
+        failureThreshold: 3
       volumeMounts:
         - name: podman-socket
           mountPath: {{ .Values.backend.podman.uri }}

--- a/ai-services/internal/pkg/catalog/apiserver/router.go
+++ b/ai-services/internal/pkg/catalog/apiserver/router.go
@@ -22,6 +22,11 @@ func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist r
 		c.JSON(http.StatusOK, gin.H{"message": "ok"})
 	})
 
+	// Expose /health for liveness probes
+	router.GET("/health", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "ok"})
+	})
+
 	// Swagger documentation endpoint
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 


### PR DESCRIPTION
Defines Health Check API and adds it to Catalog backend liveness probe

https://jsw.ibm.com/browse/AISERVICES-1112