### PR TITLE
chore: update UI component versions in ai-services assets

### DIFF
--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -2,7 +2,7 @@ ui:
   # @description Host port for the RAG UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.35
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.36
 
 backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
@@ -26,7 +26,7 @@ digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.18
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.19
 
 ingest:
   # @hidden

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -1,6 +1,6 @@
 ui:
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.35
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.36
 
 backend:
   # @hidden
@@ -30,7 +30,7 @@ digitize:
 
 digitizeUi:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.18
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.19
 
 instruct:
   # @description API key for vLLM instruct service authentication. If empty, authentication is disabled. Provide a key to enable authentication.

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -2,7 +2,7 @@ ui:
   # @description Host port for the RAG UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.35
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.36
 
 backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
@@ -26,7 +26,7 @@ digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.18
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.19
 
 ingest:
   # @hidden

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -1,6 +1,6 @@
 ui:
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.35
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.36
 
 backend:
   # @hidden
@@ -30,7 +30,7 @@ digitize:
 
 digitizeUi:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.18
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.19
 
 instruct:
   # @hidden

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -2,7 +2,7 @@ ui:
   # @description Host port for the RAG UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.35
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.36
 
 backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
@@ -26,7 +26,7 @@ digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.18
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.19
 
 ingest:
   # @hidden

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -6,6 +6,6 @@ digitize:
 
 digitizeUi:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.16
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.19
 
 # Made with Bob

--- a/services/common/Containerfile
+++ b/services/common/Containerfile
@@ -1,4 +1,4 @@
-FROM icr.io/ai-services-cicd/python-base:v0.0.27
+FROM icr.io/ai-services-cicd/python-base:v0.0.28
 
 WORKDIR /opt/services
 

--- a/services/common/Makefile
+++ b/services/common/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=services-common
-TAG?=v0.0.1
+TAG?=v0.0.2
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=digitize-service
-TAG?=v0.0.1
+TAG?=v0.0.2
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman


### PR DESCRIPTION
- Update chatbot-ui from v0.0.35 to v0.0.36
- Update digitize-ui from v0.0.16/v0.0.18 to v0.0.19
- Update digitize-service references

Updated across all deployment configurations:
- rag/podman, rag/openshift
- rag-dev/podman, rag-dev/openshift
- rag-cpu/podman
- services/digitize/podman