### PR TITLE
[Ai-Services Images] Use UBI Minimal for final stage build

### DIFF
--- a/ai-services/Containerfile
+++ b/ai-services/Containerfile
@@ -31,7 +31,7 @@ RUN CGO_ENABLED=0 go build \
     " \
     ./cmd/ai-services
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.8
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8
 
 COPY --from=builder /go/src/github.com/project-ai-services/ai-services/bin/ai-services /usr/bin/ai-services
 

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.6
+TAG?=0.0.7
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.5
+  image: icr.io/ai-services-cicd/ai-services:0.0.7
   runtime: ""
   adminPasswordHash: ""
   podman:


### PR DESCRIPTION
- This is required as the liveness probe for catalog backend is failing with curl not installed. So have moved from ubi-micro to ubi-minimal which has curl-minimal installed.

Note: In case of podman, it uses the containers `curl` package to do the liveness probe.