### PR TITLE
Update service versions in ai-services

### DIFF
--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.107
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.1
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.2
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.3
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
@@ -83,7 +83,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.1
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.2
   # @hidden
   log_level: "INFO"
 
@@ -91,6 +91,6 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.1
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.2
   # @hidden
   log_level: "INFO"

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -4,25 +4,25 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.107
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.1
   # @hidden
   log_level: "INFO"
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.1
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.2
   # @hidden
   log_level: "INFO"
 
 similarity:
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.1
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.2
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.2
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.3
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.107
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.1
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.2
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.3
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
@@ -81,7 +81,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.1
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.2
   # @hidden
   log_level: "INFO"
 
@@ -89,6 +89,6 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.1
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.2
   # @hidden
   log_level: "INFO"

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -4,25 +4,25 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.107
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.1
   # @hidden
   log_level: "INFO"
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.1
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.2
   # @hidden
   log_level: "INFO"
 
 similarity:
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.1
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.2
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.2
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.3
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.107
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.1
   # @hidden
   log_level: "INFO"
 
@@ -16,7 +16,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.2
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.3
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
@@ -81,7 +81,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.1
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.2
   # @hidden
   log_level: "INFO"
 
@@ -89,6 +89,6 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.1
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.2
   # @hidden
   log_level: "INFO"

--- a/images/service-base/Makefile
+++ b/images/service-base/Makefile
@@ -1,5 +1,5 @@
 REGISTRY?=icr.io/ai-services-private
-IMAGE=python-base
+IMAGE=service-base
 TAG?=v0.0.28
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/services/chatbot/Containerfile
+++ b/services/chatbot/Containerfile
@@ -1,4 +1,4 @@
-FROM icr.io/ai-services-cicd/services-common:v0.0.1
+FROM icr.io/ai-services-cicd/services-common:v0.0.2
 
 WORKDIR /opt/services/chatbot
 

--- a/services/chatbot/Makefile
+++ b/services/chatbot/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=chatbot-service
-TAG?=v0.0.107
+TAG?=v0.0.1
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman

--- a/services/common/Containerfile
+++ b/services/common/Containerfile
@@ -1,4 +1,4 @@
-FROM icr.io/ai-services-cicd/python-base:v0.0.28
+FROM icr.io/ai-services-cicd/service-base:v0.0.28
 
 WORKDIR /opt/services
 

--- a/services/digitize/Containerfile
+++ b/services/digitize/Containerfile
@@ -1,4 +1,4 @@
-FROM icr.io/ai-services-cicd/services-common:v0.0.1
+FROM icr.io/ai-services-cicd/services-common:v0.0.2
 
 WORKDIR /opt/services/digitize
 

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=digitize-service
-TAG?=v0.0.2
+TAG?=v0.0.3
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman

--- a/services/similarity/Containerfile
+++ b/services/similarity/Containerfile
@@ -1,4 +1,4 @@
-FROM icr.io/ai-services-cicd/services-common:v0.0.1
+FROM icr.io/ai-services-cicd/services-common:v0.0.2
 
 WORKDIR /opt/services/similarity
 

--- a/services/similarity/Makefile
+++ b/services/similarity/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=similarity-service
-TAG?=v0.0.1
+TAG?=v0.0.2
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman

--- a/services/summarize/Containerfile
+++ b/services/summarize/Containerfile
@@ -1,4 +1,4 @@
-FROM icr.io/ai-services-cicd/services-common:v0.0.1
+FROM icr.io/ai-services-cicd/services-common:v0.0.2
 
 WORKDIR /opt/services/summarize
 

--- a/services/summarize/Makefile
+++ b/services/summarize/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=summarize-service
-TAG?=v0.0.1
+TAG?=v0.0.2
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman


### PR DESCRIPTION
- chatbot: v0.0.107 -> v0.0.1 # After code reorg chatbot still uses old rag image version, resetting to be in consistent with other services
- digitize: v0.0.2 -> v0.0.3
- summarize: v0.0.1 -> v0.0.2
- similarity: v0.0.1 -> v0.0.2

Updated across all deployment configurations (rag, rag-dev, rag-cpu) for both podman and openshift platforms.