### PR TITLE
fix: add new routes to info.md

### DIFF
--- a/ai-services/assets/catalog/podman/steps/info.md
+++ b/ai-services/assets/catalog/podman/steps/info.md
@@ -3,7 +3,7 @@ Day N:
 {{- if ne .CATALOG_UI_DOMAIN "" }}
 {{- if eq .UI_STATUS "running" }}
 
-- Catalog UI is available at https://{{ .CATALOG_UI_DOMAIN }}{{ if and (ne .HTTPS_PORT "") (ne .HTTPS_PORT "443") }}:{{ .HTTPS_PORT }}{{ end }}
+- Catalog UI is available at https://{{ .CATALOG_UI_DOMAIN }}{{ if ne .HTTPS_PORT "443" }}:{{ .HTTPS_PORT }}{{ end }}
 {{- else }}
 
 - Catalog UI is unavailable. Please make sure '{{ .AppName }}--catalog-ui' container is running.
@@ -13,7 +13,7 @@ Day N:
 {{- if ne .CATALOG_API_DOMAIN "" }}
 {{- if eq .BACKEND_STATUS "running" }}
 
-- Catalog Backend API is available at https://{{ .CATALOG_API_DOMAIN }}{{ if and (ne .HTTPS_PORT "") (ne .HTTPS_PORT "443") }}:{{ .HTTPS_PORT }}{{ end }}
+- Catalog Backend API is available at https://{{ .CATALOG_API_DOMAIN }}{{ if ne .HTTPS_PORT "443" }}:{{ .HTTPS_PORT }}{{ end }}
 {{- else }}
 
 - Catalog Backend API is unavailable. Please make sure '{{ .AppName }}--catalog-backend' container is running.

--- a/ai-services/assets/catalog/podman/steps/info.md
+++ b/ai-services/assets/catalog/podman/steps/info.md
@@ -3,7 +3,7 @@ Day N:
 {{- if ne .CATALOG_UI_DOMAIN "" }}
 {{- if eq .UI_STATUS "running" }}
 
-- Catalog UI is available at https://{{ .CATALOG_UI_DOMAIN }}:{{ if eq .HTTPS_PORT "" }}443{{ else }}{{ .HTTPS_PORT }}{{ end }}
+- Catalog UI is available at https://{{ .CATALOG_UI_DOMAIN }}{{ if and (ne .HTTPS_PORT "") (ne .HTTPS_PORT "443") }}:{{ .HTTPS_PORT }}{{ end }}
 {{- else }}
 
 - Catalog UI is unavailable. Please make sure '{{ .AppName }}--catalog-ui' container is running.
@@ -13,7 +13,7 @@ Day N:
 {{- if ne .CATALOG_API_DOMAIN "" }}
 {{- if eq .BACKEND_STATUS "running" }}
 
-- Catalog Backend API is available at https://{{ .CATALOG_API_DOMAIN }}:{{ if eq .HTTPS_PORT "" }}443{{ else }}{{ .HTTPS_PORT }}{{ end }}
+- Catalog Backend API is available at https://{{ .CATALOG_API_DOMAIN }}{{ if and (ne .HTTPS_PORT "") (ne .HTTPS_PORT "443") }}:{{ .HTTPS_PORT }}{{ end }}
 {{- else }}
 
 - Catalog Backend API is unavailable. Please make sure '{{ .AppName }}--catalog-backend' container is running.

--- a/ai-services/assets/catalog/podman/steps/info.md
+++ b/ai-services/assets/catalog/podman/steps/info.md
@@ -1,21 +1,21 @@
 Day N:
 
-{{- if ne .UI_PORT "" }}
+{{- if ne .CATALOG_UI_DOMAIN "" }}
 {{- if eq .UI_STATUS "running" }}
 
-- Catalog UI is available at http://{{ .HOST_IP }}:{{ .UI_PORT }}
+- Catalog UI is available at https://{{ .CATALOG_UI_DOMAIN }}:{{ .HTTPS_PORT }}
 {{- else }}
 
-- Catalog UI is unavailable. Please make sure '{{ .AppName }}--catalog' pod is running.
+- Catalog UI is unavailable. Please make sure '{{ .AppName }}--catalog-ui' container is running.
 {{- end }}
 {{- end }}
 
-{{- if ne .BACKEND_PORT "" }}
+{{- if ne .CATALOG_API_DOMAIN "" }}
 {{- if eq .BACKEND_STATUS "running" }}
 
-- Catalog Backend API is available at http://{{ .HOST_IP }}:{{ .BACKEND_PORT }}
+- Catalog Backend API is available at https://{{ .CATALOG_API_DOMAIN }}:{{ .HTTPS_PORT }}
 {{- else }}
 
-- Catalog Backend API is unavailable. Please make sure '{{ .AppName }}--catalog' pod is running.
+- Catalog Backend API is unavailable. Please make sure '{{ .AppName }}--catalog-backend' container is running.
 {{- end }}
 {{- end }}

--- a/ai-services/assets/catalog/podman/steps/info.md
+++ b/ai-services/assets/catalog/podman/steps/info.md
@@ -3,7 +3,7 @@ Day N:
 {{- if ne .CATALOG_UI_DOMAIN "" }}
 {{- if eq .UI_STATUS "running" }}
 
-- Catalog UI is available at https://{{ .CATALOG_UI_DOMAIN }}:{{ .HTTPS_PORT }}
+- Catalog UI is available at https://{{ .CATALOG_UI_DOMAIN }}:{{ if eq .HTTPS_PORT "" }}443{{ else }}{{ .HTTPS_PORT }}{{ end }}
 {{- else }}
 
 - Catalog UI is unavailable. Please make sure '{{ .AppName }}--catalog-ui' container is running.
@@ -13,7 +13,7 @@ Day N:
 {{- if ne .CATALOG_API_DOMAIN "" }}
 {{- if eq .BACKEND_STATUS "running" }}
 
-- Catalog Backend API is available at https://{{ .CATALOG_API_DOMAIN }}:{{ .HTTPS_PORT }}
+- Catalog Backend API is available at https://{{ .CATALOG_API_DOMAIN }}:{{ if eq .HTTPS_PORT "" }}443{{ else }}{{ .HTTPS_PORT }}{{ end }}
 {{- else }}
 
 - Catalog Backend API is unavailable. Please make sure '{{ .AppName }}--catalog-backend' container is running.

--- a/ai-services/assets/catalog/podman/steps/next.md
+++ b/ai-services/assets/catalog/podman/steps/next.md
@@ -1,3 +1,3 @@
-- Access the Catalog UI at https://{{ .CATALOG_UI_DOMAIN }}{{ if and (ne .HTTPS_PORT "") (ne .HTTPS_PORT "443") }}:{{ .HTTPS_PORT }}{{ end }}
+- Access the Catalog UI at https://{{ .CATALOG_UI_DOMAIN }}{{ if ne .HTTPS_PORT "443" }}:{{ .HTTPS_PORT }}{{ end }}
 
-- Access the Catalog Backend at https://{{ .CATALOG_API_DOMAIN }}{{ if and (ne .HTTPS_PORT "") (ne .HTTPS_PORT "443") }}:{{ .HTTPS_PORT }}{{ end }}
+- Access the Catalog Backend at https://{{ .CATALOG_API_DOMAIN }}{{ if ne .HTTPS_PORT "443" }}:{{ .HTTPS_PORT }}{{ end }}

--- a/ai-services/assets/catalog/podman/steps/next.md
+++ b/ai-services/assets/catalog/podman/steps/next.md
@@ -1,3 +1,3 @@
-- Access the Catalog UI at https://{{ .CATALOG_UI_DOMAIN }}:{{ if eq .HTTPS_PORT "" }}443{{ else }}{{ .HTTPS_PORT }}{{ end }}
+- Access the Catalog UI at https://{{ .CATALOG_UI_DOMAIN }}{{ if and (ne .HTTPS_PORT "") (ne .HTTPS_PORT "443") }}:{{ .HTTPS_PORT }}{{ end }}
 
-- Access the Catalog Backend at https://{{ .CATALOG_API_DOMAIN }}:{{ if eq .HTTPS_PORT "" }}443{{ else }}{{ .HTTPS_PORT }}{{ end }}
+- Access the Catalog Backend at https://{{ .CATALOG_API_DOMAIN }}{{ if and (ne .HTTPS_PORT "") (ne .HTTPS_PORT "443") }}:{{ .HTTPS_PORT }}{{ end }}

--- a/ai-services/assets/catalog/podman/steps/next.md
+++ b/ai-services/assets/catalog/podman/steps/next.md
@@ -1,3 +1,3 @@
-- Access the Catalog UI at https://{{ .CATALOG_UI_DOMAIN }}:{{ .HTTPS_PORT }}
+- Access the Catalog UI at https://{{ .CATALOG_UI_DOMAIN }}:{{ if eq .HTTPS_PORT "" }}443{{ else }}{{ .HTTPS_PORT }}{{ end }}
 
-- Access the Catalog Backend at https://{{ .CATALOG_API_DOMAIN }}:{{ .HTTPS_PORT }}
+- Access the Catalog Backend at https://{{ .CATALOG_API_DOMAIN }}:{{ if eq .HTTPS_PORT "" }}443{{ else }}{{ .HTTPS_PORT }}{{ end }}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -486,7 +486,7 @@ func getCaddyHTTPSPort(rt *podman.PodmanClient, caddyPodName string) (string, er
 	return "", fmt.Errorf("HTTPS port mapping not found in pod ports")
 }
 
-// GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service without registering routes.
+// GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service.
 func GetCatalogRouteInfo(rt *podman.PodmanClient, tp templates.Template, appTemplateName string, argParams map[string]string) (map[string]string, string, error) {
 	// Extract routes from all templates
 	routeInfos, err := extractAllRoutesFromTemplates(tp, appTemplateName, argParams)

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -486,4 +486,58 @@ func getCaddyHTTPSPort(rt *podman.PodmanClient, caddyPodName string) (string, er
 	return "", fmt.Errorf("HTTPS port mapping not found in pod ports")
 }
 
+// GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service without registering routes.
+func GetCatalogRouteInfo(rt *podman.PodmanClient, tp templates.Template, appTemplateName string, argParams map[string]string) (map[string]string, string, error) {
+	// Extract routes from all templates
+	routeInfos, err := extractAllRoutesFromTemplates(tp, appTemplateName, argParams)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to extract routes from templates: %w", err)
+	}
+
+	if len(routeInfos) == 0 {
+		return nil, "", fmt.Errorf("no templates found with routes annotation")
+	}
+
+	// Find Caddy pod from templates
+	caddyPodName, err := findCaddyPodNameFromTemplates(tp, appTemplateName, argParams)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to find Caddy pod: %w", err)
+	}
+
+	// Get host IP for route domain generation
+	hostIP, err := utils.GetHostIP()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get host IP: %w", err)
+	}
+
+	// Build route domains map
+	routeDomains := make(map[string]string)
+
+	// Build routes from annotations to get domains
+	for _, info := range routeInfos {
+		routes, err := proxy.BuildRoutesFromAnnotation(info.RoutesAnnotation, hostIP, info.PodName)
+		if err != nil {
+			continue // Skip if routes can't be built
+		}
+
+		for _, route := range routes {
+			parts := strings.Split(route.Domain, ".")
+			if len(parts) > 0 {
+				subdomain := parts[0]
+				sanitizedSubdomain := strings.ReplaceAll(subdomain, "-", "_")
+				varName := strings.ToUpper(fmt.Sprintf("%s_DOMAIN", sanitizedSubdomain))
+				routeDomains[varName] = route.Domain
+			}
+		}
+	}
+
+	// Get Caddy HTTPS port
+	httpsPort, err := getCaddyHTTPSPort(rt, caddyPodName)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get Caddy HTTPS port: %w", err)
+	}
+
+	return routeDomains, httpsPort, nil
+}
+
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/info/podman/info.go
+++ b/ai-services/internal/pkg/catalog/cli/info/podman/info.go
@@ -4,18 +4,19 @@ import (
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/assets"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
+	rt "github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // DisplayCatalogInfo displays detailed information about the catalog service.
 func DisplayCatalogInfo() error {
 	// Initialize runtime
-	rt, err := podman.NewPodmanClient()
+	runtime, err := rt.NewPodmanClient()
 	if err != nil {
 		return fmt.Errorf("failed to initialize podman client: %w", err)
 	}
@@ -25,7 +26,7 @@ func DisplayCatalogInfo() error {
 		"label": {fmt.Sprintf("ai-services.io/application=%s", constants.CatalogAppName)},
 	}
 
-	pods, err := rt.ListPods(listFilters)
+	pods, err := runtime.ListPods(listFilters)
 	if err != nil {
 		return fmt.Errorf("failed to list pods: %w", err)
 	}
@@ -47,10 +48,21 @@ func DisplayCatalogInfo() error {
 	version := pods[0].Labels[string(vars.VersionLabel)]
 	logger.Infoln("Version: " + version)
 
-	// Step 3: Read and print the info.md file
+	// Step 3: Fetch route information
 	tp := templates.NewEmbedTemplateProvider(&assets.CatalogFS, "")
+	routeDomains, httpsPort, err := podman.GetCatalogRouteInfo(runtime, tp, catalogTemplate, nil)
+	if err != nil {
+		logger.Errorf("failed to get route info: %v\n", err)
+		// Continue with basic info display
+		if err := helpers.PrintInfo(tp, runtime, constants.CatalogAppName, catalogTemplate); err != nil {
+			logger.Errorf("failed to display info: %v\n", err)
+		}
 
-	if err := helpers.PrintInfo(tp, rt, constants.CatalogAppName, catalogTemplate); err != nil {
+		return nil
+	}
+
+	// Step 4: Read and print the info.md file with route information
+	if err := helpers.PrintInfoWithProxy(tp, runtime, constants.CatalogAppName, catalogTemplate, routeDomains, httpsPort); err != nil {
 		// not failing overall info command if we cannot display Info
 		logger.Errorf("failed to display info: %v\n", err)
 

--- a/ai-services/internal/pkg/cli/helpers/steps.go
+++ b/ai-services/internal/pkg/cli/helpers/steps.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"strings"
 	"text/template"
 
@@ -56,6 +57,27 @@ func PrintNextStepsWithProxy(tp templates.Template, runtime runtime.Runtime, app
 
 func PrintInfo(tp templates.Template, runtime runtime.Runtime, app, appTemplate string) error {
 	params := map[string]string{"AppName": app}
+	if err := renderStepsMarkdown(tp, runtime, appTemplate, params, infoMDFile, infoTitle); err != nil {
+		logger.Infof("Unable to load steps: %v\n", err)
+
+		return nil
+	}
+
+	return nil
+}
+
+// PrintInfoWithProxy prints info with proxy route information.
+func PrintInfoWithProxy(tp templates.Template, runtime runtime.Runtime, app, appTemplate string, routeDomains map[string]string, httpsPort string) error {
+	params := map[string]string{"AppName": app}
+
+	// Add route domains to params
+	maps.Copy(params, routeDomains)
+
+	// Add HTTPS port to params if provided
+	if httpsPort != "" {
+		params["HTTPS_PORT"] = httpsPort
+	}
+
 	if err := renderStepsMarkdown(tp, runtime, appTemplate, params, infoMDFile, infoTitle); err != nil {
 		logger.Infof("Unable to load steps: %v\n", err)
 


### PR DESCRIPTION
Fix catalog info command to display catalog UI and backend API endpoints by fetching route information from Caddy proxy.
Updated info.md template to check route domain variables instead of empty pod port mappings.