### PR TITLE
restrict Caddy admin port to localhost

### DIFF
--- a/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
@@ -8,7 +8,7 @@ metadata:
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/component: "proxy"
   annotations:
-    ai-services.io/ports: "{{ .Values.caddy.adminPort }}:2019, {{ .Values.caddy.httpsPort }}:443"
+    ai-services.io/ports: "127.0.0.1:{{ .Values.caddy.adminPort }}:2019, {{ .Values.caddy.httpsPort }}:443"
 spec:
   containers:
     - name: caddy
@@ -18,11 +18,6 @@ spec:
       env:
         - name: CADDY_ADMIN
           value: "0.0.0.0:2019"
-      ports:
-        - containerPort: 2019
-          hostIP: 127.0.0.1
-        - containerPort: 443
-          hostIP: 0.0.0.0
       volumeMounts:
         - name: caddy-data
           mountPath: /data/caddy:z


### PR DESCRIPTION
We initially relied on hostIP: 127.0.0.1 in the pod spec to keep the Caddy admin port local to the VM, but the ai-services.io/ports annotation was actually generating the Podman publish rules and exposing the port externally. This updates the annotation to explicitly bind the admin port to 127.0.0.1, ensuring the Caddy admin API is only accessible from the host VM while keeping the HTTPS endpoint publicly available.


To test:

Curl to host VM : `curl http://127.0.0.1:36487/config/`
Should pass, listing all routes

Curl to admin from external VM :` curl http://10.20.186.34:36487/config/`
Should Fail with : ` Couldn't connect to server`