### PR TITLE
feat(catalog): add configurable HTTPS port flag

### DIFF
--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -24,7 +24,7 @@ db:
 
 caddy:
   image: "icr.io/ai-services-cicd/caddy:v2.11.2"
-  # @description https port for caddy. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
-  httpsPort: ""
   # @description admin port for caddy. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   adminPort: ""
+  # @description HTTPS port for caddy. Set by configure command via --https-port flag.
+  httpsPort: ""

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -143,7 +143,7 @@ func configureConfigureFlags(cmd *cobra.Command, rawArgParams *[]string) {
 		&httpsPort,
 		"https-port",
 		defaultHTTPSPort,
-		"HTTPS port for the Caddy server (default: 443).\n"+
+		"Custom HTTPS port to expose the service endpoints externally (podman runtime only).\n"+
 			"Example: --https-port 8443\n",
 	)
 

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -25,6 +25,8 @@ var (
 	httpsPort int
 )
 
+const defaultHTTPSPort = 443
+
 // NewConfigureCmd creates a new configure command for the catalog service.
 func NewConfigureCmd() *cobra.Command {
 	var (
@@ -140,7 +142,7 @@ func configureConfigureFlags(cmd *cobra.Command, rawArgParams *[]string) {
 	cmd.Flags().IntVar(
 		&httpsPort,
 		"https-port",
-		443,
+		defaultHTTPSPort,
 		"HTTPS port for the Caddy server (default: 443).\n"+
 			"Example: --https-port 8443\n",
 	)

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -21,6 +21,8 @@ var (
 	runtimeType string
 	// Base directory flag for catalog configure command.
 	baseDir string
+	// HTTPS port flag for catalog configure command.
+	httpsPort int
 )
 
 // NewConfigureCmd creates a new configure command for the catalog service.
@@ -75,6 +77,7 @@ Examples:
 				Runtime:       vars.RuntimeFactory.GetRuntimeType(),
 				BaseDir:       aiServicesDir,
 				ArgParams:     argParams,
+				HttpsPort:     httpsPort,
 			})
 		},
 	}
@@ -98,6 +101,11 @@ func validateConfigureFlags(rawArgParams []string) (map[string]string, error) {
 	// Check if podman runtime is being used on unsupported platform
 	if err := utils.CheckPodmanPlatformSupport(vars.RuntimeFactory.GetRuntimeType()); err != nil {
 		return nil, err
+	}
+
+	// Validate HTTPS port range
+	if httpsPort < 1 || httpsPort > 65535 {
+		return nil, fmt.Errorf("invalid HTTPS port %d: must be between 1 and 65535", httpsPort)
 	}
 
 	// Parse params if provided
@@ -126,6 +134,15 @@ func configureConfigureFlags(cmd *cobra.Command, rawArgParams *[]string) {
 		"",
 		"Base directory for AI services data (applications, models, cache).\n"+
 			"Example: --basedir /custom/path\n",
+	)
+
+	// Add HTTPS port flag
+	cmd.Flags().IntVar(
+		&httpsPort,
+		"https-port",
+		443,
+		"HTTPS port for the Caddy server (default: 443).\n"+
+			"Example: --https-port 8443\n",
 	)
 
 	cmd.Flags().StringSliceVar(

--- a/ai-services/internal/pkg/catalog/cli/configure/common.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/common.go
@@ -23,6 +23,7 @@ type ConfigureOptions struct {
 	Runtime       types.RuntimeType
 	BaseDir       string
 	ArgParams     map[string]string
+	HttpsPort     int
 }
 
 // Run executes the configure process for the catalog service.
@@ -44,7 +45,7 @@ func Run(opts ConfigureOptions) error {
 		// Determine Podman URI
 		podmanURI := getPodmanURI()
 
-		return catalogPodman.DeployCatalog(ctx, podmanURI, passwordHashBase64, opts.BaseDir, opts.ArgParams)
+		return catalogPodman.DeployCatalog(ctx, podmanURI, passwordHashBase64, opts.BaseDir, opts.ArgParams, opts.HttpsPort)
 
 	case types.RuntimeTypeOpenShift:
 		return fmt.Errorf("openshift runtime is not yet supported for catalog configure")

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -35,7 +35,7 @@ const (
 )
 
 // DeployCatalog deploys the catalog service using the assets/catalog template for podman runtime.
-func DeployCatalog(ctx context.Context, podmanURI, passwordHash, baseDir string, argParams map[string]string) error {
+func DeployCatalog(ctx context.Context, podmanURI, passwordHash, baseDir string, argParams map[string]string, httpsPort int) error {
 	s := spinner.New("Deploying catalog service...")
 	s.Start(ctx)
 
@@ -54,6 +54,12 @@ func DeployCatalog(ctx context.Context, podmanURI, passwordHash, baseDir string,
 
 		return fmt.Errorf("failed to load catalog templates: %w", err)
 	}
+
+	// Set httpsPort in argParams before any template loading
+	if argParams == nil {
+		argParams = make(map[string]string)
+	}
+	argParams["caddy.httpsPort"] = fmt.Sprintf("%d", httpsPort)
 
 	// collect all secret names used as part of deployment
 	isDeployed, existingResources, err := checkCatalogStatus(rt, tp, tmpls, argParams)
@@ -152,10 +158,6 @@ func loadCatalogTemplates(s *spinner.Spinner) (templates.Template, *templates.Ap
 
 // prepareCatalogValues prepares the values map with configure-specific configuration.
 func prepareCatalogValues(tp templates.Template, podmanURI, passwordHash string, argParams map[string]string) (map[string]any, error) {
-	if argParams == nil {
-		argParams = make(map[string]string)
-	}
-
 	// Generate database password
 	dbPassword, err := utils.GenerateRandomPassword(utils.DefaultPasswordLength)
 	if err != nil {


### PR DESCRIPTION
- Add --https-port flag with default 443 and validation
- No random port assignment now


The output now looks like this for port other than the default 443

```
✔ Catalog service deployed successfully
-------
Found Caddy pod: ai-services--caddy
Registering routes for pod: ai-services--catalog
Next Steps:
-------
- Access the Catalog UI at https://catalog-ui.10.20.186.34.nip.io:8443

- Access the Catalog Backend at https://catalog-api.10.20.186.34.nip.io:8443

# ai-services catalog info --runtime podman
Catalog Service Name: ai-services
Catalog Template: catalog
Version: 0.0.1
Info:
-------
Day N:

- Catalog UI is available at https://catalog-ui.10.20.186.34.nip.io:8443

- Catalog Backend API is available at https://catalog-api.10.20.186.34.nip.io:8443
```

For default 443 port:

```
✔ Catalog service deployed successfully
-------
Found Caddy pod: ai-services--caddy
Registering routes for pod: ai-services--catalog
Next Steps:
-------
- Access the Catalog UI at https://catalog-ui.10.20.186.34.nip.io

- Access the Catalog Backend at https://catalog-api.10.20.186.34.nip.io


[root@onprem133726180 ai-services]# ai-services catalog info --runtime podman
Catalog Service Name: ai-services
Catalog Template: catalog
Version: 0.0.1
Info:
-------
Day N:

- Catalog UI is available at https://catalog-ui.10.20.186.34.nip.io

- Catalog Backend API is available at https://catalog-api.10.20.186.34.nip.io

```