### PR TITLE
Updating path in schedule cve scan

### DIFF
--- a/.github/workflows/image-scanner.yml
+++ b/.github/workflows/image-scanner.yml
@@ -28,8 +28,8 @@ jobs:
            image: litellm
          - path: images/postgres
            image: postgres
-         - path: images/python-base
-           image: python-base
+         - path: images/service-base
+           image: service-base
          - path: images/tools
            image: tools
          - path: ui/catalog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           make binaries
 
       - name: Archive all binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ai-services-binaries
           path: ai-services/bin/ai-services-*

--- a/.github/workflows/scanner.yml
+++ b/.github/workflows/scanner.yml
@@ -140,7 +140,7 @@ jobs:
           parlay ecosystems enrich ${{ env.TRIVY_SBOM_FILE }} | jq . > ${{ env.PARLAY_SBOM_FILE }}
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: ${{ inputs.image || 'ai-services' }}-sbom-json-artifact
           path: |


### PR DESCRIPTION
Changes:

- Updating the `service-base` image path in the job
- Upgrading `upload action` to use latest version (v7)