### PR TITLE
[Catalog-API] Fix setting Spyre PCI address in container env

### DIFF
--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -659,9 +659,8 @@ func (d *PodmanDeployer) renderFinalPodTemplate(
 		return nil, fmt.Errorf("failed to get env params: %w", err)
 	}
 
-	if _, exists := initialParams["env"]; !exists {
-		initialParams["env"] = env
-	}
+	// Always set/overwrite the env to ensure Spyre card PCI addresses are included
+	initialParams["env"] = env
 
 	var finalRendered bytes.Buffer
 	if err := podTemplate.Execute(&finalRendered, initialParams); err != nil {


### PR DESCRIPTION
- This fixes the issue where currently the PCI Addresses are not getting populated in pod env