### PR TITLE
feat: enable catalog to run as non root user

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.22
+TAG?=0.0.23
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.21
+TAG?=0.0.22
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -10,7 +10,6 @@ metadata:
   annotations:
     ai-services.io/routes: "8081:catalog-ui, 8080:catalog-api"
     # ai-services.io/ports: "{{ .Values.ui.port }}:8081, {{ .Values.backend.port }}:8080"  # Uncomment to expose ports directly (bypasses Caddy)
-    run.oci.keep_original_groups: "1"
 spec:
   initContainers:
     - name: db-migration

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -87,9 +87,6 @@ spec:
       command: ["/bin/sh", "-c"]
       args:
         - "/usr/bin/ai-services catalog apiserver --port=8080 --admin-username=admin --admin-password-hash=${ADMIN_PASSWORD} --runtime={{ .Values.backend.runtime }}"
-      securityContext:
-        seLinuxOptions:
-          type: "spc_t"
       env:
         - name: CONTAINER_HOST
           value: "unix://{{ .Values.backend.podman.uri }}"

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -10,7 +10,6 @@ metadata:
   annotations:
     ai-services.io/routes: "8081:catalog-ui, 8080:catalog-api"
     # ai-services.io/ports: "{{ .Values.ui.port }}:8081, {{ .Values.backend.port }}:8080"  # Uncomment to expose ports directly (bypasses Caddy)
-    io.podman.annotations.userns: "keep-id"
     run.oci.keep_original_groups: "1"
 spec:
   initContainers:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.22
+  image: icr.io/ai-services-cicd/ai-services:0.0.23
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.21
+  image: icr.io/ai-services-cicd/ai-services:0.0.22
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
@@ -508,24 +508,41 @@ func isSELinuxEnabledAndActive() (bool, string) {
 // fixSELinuxVFIOPolicy configures SELinux policy for VFIO device access.
 // This allows containers with container_t type to access VFIO devices.
 func fixSELinuxVFIOPolicy() RepairResult {
-	checkName := "SELinux VFIO policy configuration"
+	result := applySELinuxPolicy(
+		"SELinux VFIO policy configuration",
+		"vllm_vfio_policy",
+		vfioPolicyContent,
+		"SELinux VFIO policy configured successfully",
+	)
 
+	// Reload udev rules to apply SELinux labels to existing devices if policy was fixed
+	if result.Status == StatusFixed {
+		if err := utils.ReloadUdevRules(); err != nil {
+			return RepairResult{
+				CheckName: result.CheckName,
+				Status:    StatusFailedToFix,
+				Error:     err,
+			}
+		}
+	}
+
+	return result
+}
+
+// applySELinuxPolicy is a generic helper to apply SELinux policies.
+func applySELinuxPolicy(checkName, policyName, policyContent, successMessage string) RepairResult {
 	enabled, msg := isSELinuxEnabledAndActive()
 	if !enabled {
 		return RepairResult{CheckName: checkName, Status: StatusSkipped, Message: msg}
 	}
 
-	// Check if policy is already installed
-	exitCode, stdout, _, err := utils.ExecuteCommand("semodule", "-l")
-	if err == nil && exitCode == 0 && strings.Contains(stdout, "vllm_vfio_policy") {
-		return RepairResult{CheckName: checkName, Status: StatusSkipped,
-			Message: "SELinux VFIO policy already installed"}
-	}
-
 	tmpDir, err := os.MkdirTemp("", "selinux_build")
 	if err != nil {
-		return RepairResult{CheckName: checkName, Status: StatusFailedToFix,
-			Error: fmt.Errorf("failed to create temp directory: %w", err)}
+		return RepairResult{
+			CheckName: checkName,
+			Status:    StatusFailedToFix,
+			Error:     fmt.Errorf("failed to create temp directory: %w", err),
+		}
 	}
 	defer func() {
 		if err := os.RemoveAll(tmpDir); err != nil {
@@ -533,34 +550,12 @@ func fixSELinuxVFIOPolicy() RepairResult {
 		}
 	}()
 
-	const policyName = "vllm_vfio_policy"
-	const teContent = `
-module vllm_vfio_policy 1.0;
-
-require {
-    type container_t;
-    type vfio_device_t;
-    class chr_file { ioctl open read write getattr };
-}
-
-# Allow container_t (vLLM) to access vfio_device_t
-allow container_t vfio_device_t:chr_file { ioctl open read write getattr };
-`
-
 	// Use reinstall=true to ensure policy is updated if it already exists
-	if err := buildAndInstallSELinuxPolicy(tmpDir, policyName, teContent, true); err != nil {
+	if err := buildAndInstallSELinuxPolicy(tmpDir, policyName, policyContent, true); err != nil {
 		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
 	}
 
-	// Reload udev rules to apply SELinux labels to existing devices.
-	// The udev rules include SECLABEL{selinux} directive which automatically
-	// labels devices on creation (including hotplug)
-	if err := utils.ReloadUdevRules(); err != nil {
-		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
-	}
-
-	return RepairResult{CheckName: checkName, Status: StatusFixed,
-		Message: "SELinux VFIO policy configured successfully"}
+	return RepairResult{CheckName: checkName, Status: StatusFixed, Message: successMessage}
 }
 
 // buildAndInstallSELinuxPolicy builds and installs a SELinux policy module.
@@ -602,71 +597,13 @@ func buildAndInstallSELinuxPolicy(tmpDir, policyName, teContent string, reinstal
 
 // fixSELinuxPodmanSocketPolicy configures SELinux policy for Podman socket access.
 // This allows containers with container_t type to access the Podman socket.
-// The policy will be reinstalled if it already exists to ensure it's up to date.
 func fixSELinuxPodmanSocketPolicy() RepairResult {
-	checkName := "SELinux Podman socket policy configuration"
-
-	enabled, msg := isSELinuxEnabledAndActive()
-	if !enabled {
-		return RepairResult{CheckName: checkName, Status: StatusSkipped, Message: msg}
-	}
-
-	tmpDir, err := os.MkdirTemp("", "selinux_podman_build")
-	if err != nil {
-		return RepairResult{CheckName: checkName, Status: StatusFailedToFix,
-			Error: fmt.Errorf("failed to create temp directory: %w", err)}
-	}
-	defer func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to remove temp directory %s: %v\n", tmpDir, err)
-		}
-	}()
-
-	const policyName = "podman_socket_policy"
-	const teContent = `
-module podman_socket_policy 1.0;
-
-require {
-    type container_t;
-    type var_run_t;
-	type user_tmp_t;
-
-    class sock_file { getattr read write open };
-    class unix_stream_socket connectto;
-    class dir search;
-}
-
-# ------------------------------------------------------------------
-# Root/system Podman socket
-# Example:
-#   /run/podman/podman.sock
-# SELinux type:
-#   var_run_t
-# ------------------------------------------------------------------
-
-allow container_t var_run_t:sock_file { getattr read write open };
-allow container_t var_run_t:unix_stream_socket connectto;
-
-# ------------------------------------------------------------------
-# Rootless Podman socket
-# Example:
-#   /run/user/<uid>/podman/podman.sock
-# SELinux type:
-#   user_tmp_t
-# ------------------------------------------------------------------
-
-allow container_t user_tmp_t:sock_file { getattr read write open };
-allow container_t user_tmp_t:unix_stream_socket connectto;
-allow container_t user_tmp_t:dir search;
-`
-
-	// Use reinstall=true to ensure policy is updated if it already exists
-	if err := buildAndInstallSELinuxPolicy(tmpDir, policyName, teContent, true); err != nil {
-		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
-	}
-
-	return RepairResult{CheckName: checkName, Status: StatusFixed,
-		Message: "SELinux Podman socket policy configured successfully"}
+	return applySELinuxPolicy(
+		"SELinux Podman socket policy configuration",
+		"podman_socket_policy",
+		podmanSocketPolicyContent,
+		"SELinux Podman socket policy configured successfully",
+	)
 }
 
 // fixPodmanServiceSupplementaryGroups repairs the podman service SupplementaryGroups configuration.

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
@@ -515,13 +515,6 @@ func fixSELinuxVFIOPolicy() RepairResult {
 		return RepairResult{CheckName: checkName, Status: StatusSkipped, Message: msg}
 	}
 
-	// Check if policy is already installed
-	exitCode, stdout, _, err := utils.ExecuteCommand("semodule", "-l")
-	if err == nil && exitCode == 0 && strings.Contains(stdout, "vllm_vfio_policy") {
-		return RepairResult{CheckName: checkName, Status: StatusSkipped,
-			Message: "SELinux VFIO policy already installed"}
-	}
-
 	tmpDir, err := os.MkdirTemp("", "selinux_build")
 	if err != nil {
 		return RepairResult{CheckName: checkName, Status: StatusFailedToFix,
@@ -533,7 +526,22 @@ func fixSELinuxVFIOPolicy() RepairResult {
 		}
 	}()
 
-	if err := buildAndInstallVFIOPolicy(tmpDir); err != nil {
+	const policyName = "vllm_vfio_policy"
+	const teContent = `
+module vllm_vfio_policy 1.0;
+
+require {
+    type container_t;
+    type vfio_device_t;
+    class chr_file { ioctl open read write getattr };
+}
+
+# Allow container_t (vLLM) to access vfio_device_t
+allow container_t vfio_device_t:chr_file { ioctl open read write getattr };
+`
+
+	// Use reinstall=true to ensure policy is updated if it already exists
+	if err := buildAndInstallSELinuxPolicy(tmpDir, policyName, teContent, true); err != nil {
 		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
 	}
 
@@ -585,25 +593,6 @@ func buildAndInstallSELinuxPolicy(tmpDir, policyName, teContent string, reinstal
 	return nil
 }
 
-// buildAndInstallVFIOPolicy builds and installs the VFIO SELinux policy module.
-func buildAndInstallVFIOPolicy(tmpDir string) error {
-	const policyName = "vllm_vfio_policy"
-	const teContent = `
-module vllm_vfio_policy 1.0;
-
-require {
-    type container_t;
-    type vfio_device_t;
-    class chr_file { ioctl open read write getattr };
-}
-
-# Allow container_t (vLLM) to access vfio_device_t
-allow container_t vfio_device_t:chr_file { ioctl open read write getattr };
-`
-
-	return buildAndInstallSELinuxPolicy(tmpDir, policyName, teContent, false)
-}
-
 // fixSELinuxPodmanSocketPolicy configures SELinux policy for Podman socket access.
 // This allows containers with container_t type to access the Podman socket.
 // The policy will be reinstalled if it already exists to ensure it's up to date.
@@ -613,13 +602,6 @@ func fixSELinuxPodmanSocketPolicy() RepairResult {
 	enabled, msg := isSELinuxEnabledAndActive()
 	if !enabled {
 		return RepairResult{CheckName: checkName, Status: StatusSkipped, Message: msg}
-	}
-
-	// Check if policy is already installed
-	policyInstalled := false
-	exitCode, stdout, _, err := utils.ExecuteCommand("semodule", "-l")
-	if err == nil && exitCode == 0 && strings.Contains(stdout, "podman_socket_policy") {
-		policyInstalled = true
 	}
 
 	tmpDir, err := os.MkdirTemp("", "selinux_podman_build")
@@ -633,21 +615,6 @@ func fixSELinuxPodmanSocketPolicy() RepairResult {
 		}
 	}()
 
-	if err := buildAndInstallPodmanSocketPolicy(tmpDir, policyInstalled); err != nil {
-		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
-	}
-
-	statusMsg := "SELinux Podman socket policy configured successfully"
-	if policyInstalled {
-		statusMsg = "SELinux Podman socket policy updated successfully"
-	}
-
-	return RepairResult{CheckName: checkName, Status: StatusFixed, Message: statusMsg}
-}
-
-// buildAndInstallPodmanSocketPolicy builds and installs the SELinux policy module for Podman socket access.
-// If reinstall is true, the policy will be updated even if it already exists.
-func buildAndInstallPodmanSocketPolicy(tmpDir string, reinstall bool) error {
 	const policyName = "podman_socket_policy"
 	const teContent = `
 module podman_socket_policy 1.0;
@@ -665,7 +632,13 @@ allow container_t var_run_t:sock_file { getattr read write };
 allow container_t var_run_t:unix_stream_socket connectto;
 `
 
-	return buildAndInstallSELinuxPolicy(tmpDir, policyName, teContent, reinstall)
+	// Use reinstall=true to ensure policy is updated if it already exists
+	if err := buildAndInstallSELinuxPolicy(tmpDir, policyName, teContent, true); err != nil {
+		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
+	}
+
+	return RepairResult{CheckName: checkName, Status: StatusFixed,
+		Message: "SELinux Podman socket policy configured successfully"}
 }
 
 // fixPodmanServiceSupplementaryGroups repairs the podman service SupplementaryGroups configuration.
@@ -728,29 +701,9 @@ SupplementaryGroups=sentient
 	return utils.WriteToFile(dropInFile, dropInContent)
 }
 
-func reloadAndRestartPodmanServices() error {
-	// Reload systemd daemon
-	exitCode, _, _, err := utils.ExecuteCommand("systemctl", "daemon-reload")
-	if err != nil || exitCode != 0 {
-		if err == nil {
-			err = os.ErrInvalid
-		}
-
-		return err
-	}
-
-	// Restart podman service
-	exitCode, _, _, err = utils.ExecuteCommand("systemctl", "restart", "podman.service")
-	if err != nil || exitCode != 0 {
-		if err == nil {
-			err = os.ErrInvalid
-		}
-
-		return err
-	}
-
-	// Restart podman socket
-	exitCode, _, _, err = utils.ExecuteCommand("systemctl", "restart", "podman.socket")
+// executeSystemctlCommand is a helper function to execute systemctl commands with consistent error handling.
+func executeSystemctlCommand(args ...string) error {
+	exitCode, _, _, err := utils.ExecuteCommand("systemctl", args...)
 	if err != nil || exitCode != 0 {
 		if err == nil {
 			err = os.ErrInvalid
@@ -760,6 +713,21 @@ func reloadAndRestartPodmanServices() error {
 	}
 
 	return nil
+}
+
+func reloadAndRestartPodmanServices() error {
+	// Reload systemd daemon
+	if err := executeSystemctlCommand("daemon-reload"); err != nil {
+		return err
+	}
+
+	// Restart podman service
+	if err := executeSystemctlCommand("restart", "podman.service"); err != nil {
+		return err
+	}
+
+	// Restart podman socket
+	return executeSystemctlCommand("restart", "podman.socket")
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
@@ -629,14 +629,35 @@ module podman_socket_policy 1.0;
 require {
     type container_t;
     type var_run_t;
-    class sock_file { getattr read write };
+	type user_tmp_t;
+
+    class sock_file { getattr read write open };
     class unix_stream_socket connectto;
+    class dir search;
 }
 
-# Allow container_t to access Podman socket (var_run_t)
-# This enables containers to communicate with the host Podman socket
-allow container_t var_run_t:sock_file { getattr read write };
+# ------------------------------------------------------------------
+# Root/system Podman socket
+# Example:
+#   /run/podman/podman.sock
+# SELinux type:
+#   var_run_t
+# ------------------------------------------------------------------
+
+allow container_t var_run_t:sock_file { getattr read write open };
 allow container_t var_run_t:unix_stream_socket connectto;
+
+# ------------------------------------------------------------------
+# Rootless Podman socket
+# Example:
+#   /run/user/<uid>/podman/podman.sock
+# SELinux type:
+#   user_tmp_t
+# ------------------------------------------------------------------
+
+allow container_t user_tmp_t:sock_file { getattr read write open };
+allow container_t user_tmp_t:unix_stream_socket connectto;
+allow container_t user_tmp_t:dir search;
 `
 
 	// Use reinstall=true to ensure policy is updated if it already exists

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
@@ -60,6 +60,7 @@ func Repair(checks []check.CheckResult) []RepairResult {
 	results = append(results, fixVFIOPermissions(checkMap, userGroupResult))
 	results = append(results, fixSystemdUserSliceLimits(checkMap))
 	results = append(results, fixSELinuxVFIOPolicy())
+	results = append(results, fixSELinuxPodmanSocketPolicy())
 	results = append(results, fixPodmanServiceSupplementaryGroups(checkMap))
 
 	return results
@@ -532,7 +533,7 @@ func fixSELinuxVFIOPolicy() RepairResult {
 		}
 	}()
 
-	if err := buildAndInstallSELinuxPolicy(tmpDir); err != nil {
+	if err := buildAndInstallVFIOPolicy(tmpDir); err != nil {
 		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
 	}
 
@@ -547,22 +548,8 @@ func fixSELinuxVFIOPolicy() RepairResult {
 		Message: "SELinux VFIO policy configured successfully"}
 }
 
-// buildAndInstallSELinuxPolicy builds and installs the SELinux policy module.
-func buildAndInstallSELinuxPolicy(tmpDir string) error {
-	const policyName = "vllm_vfio_policy"
-	const teContent = `
-module vllm_vfio_policy 1.0;
-
-require {
-    type container_t;
-    type vfio_device_t;
-    class chr_file { ioctl open read write getattr };
-}
-
-# Allow container_t (vLLM) to access vfio_device_t
-allow container_t vfio_device_t:chr_file { ioctl open read write getattr };
-`
-
+// buildAndInstallSELinuxPolicy builds and installs a generic SELinux policy module.
+func buildAndInstallSELinuxPolicy(tmpDir, policyName, teContent string, reinstall bool) error {
 	// Write the .te file
 	tePath := fmt.Sprintf("%s/%s.te", tmpDir, policyName)
 	if err := utils.WriteToFile(tePath, teContent); err != nil {
@@ -583,6 +570,12 @@ allow container_t vfio_device_t:chr_file { ioctl open read write getattr };
 		return fmt.Errorf("failed to package policy module: %v, stderr: %s", err, stderr)
 	}
 
+	// Install or update the module
+	if reinstall {
+		// Remove old module first
+		_, _, _, _ = utils.ExecuteCommand("semodule", "-r", policyName)
+	}
+
 	// Install the module
 	exitCode, _, stderr, err = utils.ExecuteCommand("semodule", "-i", ppPath)
 	if err != nil || exitCode != 0 {
@@ -590,6 +583,89 @@ allow container_t vfio_device_t:chr_file { ioctl open read write getattr };
 	}
 
 	return nil
+}
+
+// buildAndInstallVFIOPolicy builds and installs the VFIO SELinux policy module.
+func buildAndInstallVFIOPolicy(tmpDir string) error {
+	const policyName = "vllm_vfio_policy"
+	const teContent = `
+module vllm_vfio_policy 1.0;
+
+require {
+    type container_t;
+    type vfio_device_t;
+    class chr_file { ioctl open read write getattr };
+}
+
+# Allow container_t (vLLM) to access vfio_device_t
+allow container_t vfio_device_t:chr_file { ioctl open read write getattr };
+`
+
+	return buildAndInstallSELinuxPolicy(tmpDir, policyName, teContent, false)
+}
+
+// fixSELinuxPodmanSocketPolicy configures SELinux policy for Podman socket access.
+// This allows containers with container_t type to access the Podman socket.
+// The policy will be reinstalled if it already exists to ensure it's up to date.
+func fixSELinuxPodmanSocketPolicy() RepairResult {
+	checkName := "SELinux Podman socket policy configuration"
+
+	enabled, msg := isSELinuxEnabledAndActive()
+	if !enabled {
+		return RepairResult{CheckName: checkName, Status: StatusSkipped, Message: msg}
+	}
+
+	// Check if policy is already installed
+	policyInstalled := false
+	exitCode, stdout, _, err := utils.ExecuteCommand("semodule", "-l")
+	if err == nil && exitCode == 0 && strings.Contains(stdout, "podman_socket_policy") {
+		policyInstalled = true
+	}
+
+	tmpDir, err := os.MkdirTemp("", "selinux_podman_build")
+	if err != nil {
+		return RepairResult{CheckName: checkName, Status: StatusFailedToFix,
+			Error: fmt.Errorf("failed to create temp directory: %w", err)}
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to remove temp directory %s: %v\n", tmpDir, err)
+		}
+	}()
+
+	if err := buildAndInstallPodmanSocketPolicy(tmpDir, policyInstalled); err != nil {
+		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
+	}
+
+	statusMsg := "SELinux Podman socket policy configured successfully"
+	if policyInstalled {
+		statusMsg = "SELinux Podman socket policy updated successfully"
+	}
+
+	return RepairResult{CheckName: checkName, Status: StatusFixed, Message: statusMsg}
+}
+
+// buildAndInstallPodmanSocketPolicy builds and installs the SELinux policy module for Podman socket access.
+// If reinstall is true, the policy will be updated even if it already exists.
+func buildAndInstallPodmanSocketPolicy(tmpDir string, reinstall bool) error {
+	const policyName = "podman_socket_policy"
+	const teContent = `
+module podman_socket_policy 1.0;
+
+require {
+    type container_t;
+    type var_run_t;
+    class sock_file { getattr read write };
+    class unix_stream_socket connectto;
+}
+
+# Allow container_t to access Podman socket (var_run_t)
+# This enables containers to communicate with the host Podman socket
+allow container_t var_run_t:sock_file { getattr read write };
+allow container_t var_run_t:unix_stream_socket connectto;
+`
+
+	return buildAndInstallSELinuxPolicy(tmpDir, policyName, teContent, reinstall)
 }
 
 // fixPodmanServiceSupplementaryGroups repairs the podman service SupplementaryGroups configuration.

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
@@ -556,7 +556,7 @@ allow container_t vfio_device_t:chr_file { ioctl open read write getattr };
 		Message: "SELinux VFIO policy configured successfully"}
 }
 
-// buildAndInstallSELinuxPolicy builds and installs a generic SELinux policy module.
+// buildAndInstallSELinuxPolicy builds and installs a SELinux policy module.
 func buildAndInstallSELinuxPolicy(tmpDir, policyName, teContent string, reinstall bool) error {
 	// Write the .te file
 	tePath := fmt.Sprintf("%s/%s.te", tmpDir, policyName)
@@ -602,6 +602,13 @@ func fixSELinuxPodmanSocketPolicy() RepairResult {
 	enabled, msg := isSELinuxEnabledAndActive()
 	if !enabled {
 		return RepairResult{CheckName: checkName, Status: StatusSkipped, Message: msg}
+	}
+
+	// Check if policy is already installed
+	exitCode, stdout, _, err := utils.ExecuteCommand("semodule", "-l")
+	if err == nil && exitCode == 0 && strings.Contains(stdout, "vllm_vfio_policy") {
+		return RepairResult{CheckName: checkName, Status: StatusSkipped,
+			Message: "SELinux VFIO policy already installed"}
 	}
 
 	tmpDir, err := os.MkdirTemp("", "selinux_podman_build")
@@ -701,9 +708,29 @@ SupplementaryGroups=sentient
 	return utils.WriteToFile(dropInFile, dropInContent)
 }
 
-// executeSystemctlCommand is a helper function to execute systemctl commands with consistent error handling.
-func executeSystemctlCommand(args ...string) error {
-	exitCode, _, _, err := utils.ExecuteCommand("systemctl", args...)
+func reloadAndRestartPodmanServices() error {
+	// Reload systemd daemon
+	exitCode, _, _, err := utils.ExecuteCommand("systemctl", "daemon-reload")
+	if err != nil || exitCode != 0 {
+		if err == nil {
+			err = os.ErrInvalid
+		}
+
+		return err
+	}
+
+	// Restart podman service
+	exitCode, _, _, err = utils.ExecuteCommand("systemctl", "restart", "podman.service")
+	if err != nil || exitCode != 0 {
+		if err == nil {
+			err = os.ErrInvalid
+		}
+
+		return err
+	}
+
+	// Restart podman socket
+	exitCode, _, _, err = utils.ExecuteCommand("systemctl", "restart", "podman.socket")
 	if err != nil || exitCode != 0 {
 		if err == nil {
 			err = os.ErrInvalid
@@ -713,21 +740,6 @@ func executeSystemctlCommand(args ...string) error {
 	}
 
 	return nil
-}
-
-func reloadAndRestartPodmanServices() error {
-	// Reload systemd daemon
-	if err := executeSystemctlCommand("daemon-reload"); err != nil {
-		return err
-	}
-
-	// Restart podman service
-	if err := executeSystemctlCommand("restart", "podman.service"); err != nil {
-		return err
-	}
-
-	// Restart podman socket
-	return executeSystemctlCommand("restart", "podman.socket")
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
@@ -515,6 +515,13 @@ func fixSELinuxVFIOPolicy() RepairResult {
 		return RepairResult{CheckName: checkName, Status: StatusSkipped, Message: msg}
 	}
 
+	// Check if policy is already installed
+	exitCode, stdout, _, err := utils.ExecuteCommand("semodule", "-l")
+	if err == nil && exitCode == 0 && strings.Contains(stdout, "vllm_vfio_policy") {
+		return RepairResult{CheckName: checkName, Status: StatusSkipped,
+			Message: "SELinux VFIO policy already installed"}
+	}
+
 	tmpDir, err := os.MkdirTemp("", "selinux_build")
 	if err != nil {
 		return RepairResult{CheckName: checkName, Status: StatusFailedToFix,
@@ -602,13 +609,6 @@ func fixSELinuxPodmanSocketPolicy() RepairResult {
 	enabled, msg := isSELinuxEnabledAndActive()
 	if !enabled {
 		return RepairResult{CheckName: checkName, Status: StatusSkipped, Message: msg}
-	}
-
-	// Check if policy is already installed
-	exitCode, stdout, _, err := utils.ExecuteCommand("semodule", "-l")
-	if err == nil && exitCode == 0 && strings.Contains(stdout, "vllm_vfio_policy") {
-		return RepairResult{CheckName: checkName, Status: StatusSkipped,
-			Message: "SELinux VFIO policy already installed"}
 	}
 
 	tmpDir, err := os.MkdirTemp("", "selinux_podman_build")

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/selinux_policies.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/selinux_policies.go
@@ -1,0 +1,57 @@
+package spyre
+
+// vfioPolicyContent defines the SELinux policy for VFIO device access.
+// This allows containers with container_t type to access VFIO devices.
+const vfioPolicyContent = `
+module vllm_vfio_policy 1.0;
+
+require {
+    type container_t;
+    type vfio_device_t;
+    class chr_file { ioctl open read write getattr };
+}
+
+# Allow container_t (vLLM) to access vfio_device_t
+allow container_t vfio_device_t:chr_file { ioctl open read write getattr };
+`
+
+// podmanSocketPolicyContent defines the SELinux policy for Podman socket access.
+// This allows containers with container_t type to access the Podman socket.
+const podmanSocketPolicyContent = `
+module podman_socket_policy 1.0;
+
+require {
+    type container_t;
+    type var_run_t;
+	type user_tmp_t;
+
+    class sock_file { getattr read write open };
+    class unix_stream_socket connectto;
+    class dir search;
+}
+
+# ------------------------------------------------------------------
+# Root/system Podman socket
+# Example:
+#   /run/podman/podman.sock
+# SELinux type:
+#   var_run_t
+# ------------------------------------------------------------------
+
+allow container_t var_run_t:sock_file { getattr read write open };
+allow container_t var_run_t:unix_stream_socket connectto;
+
+# ------------------------------------------------------------------
+# Rootless Podman socket
+# Example:
+#   /run/user/<uid>/podman/podman.sock
+# SELinux type:
+#   user_tmp_t
+# ------------------------------------------------------------------
+
+allow container_t user_tmp_t:sock_file { getattr read write open };
+allow container_t user_tmp_t:unix_stream_socket connectto;
+allow container_t user_tmp_t:dir search;
+`
+
+// Made with Bob

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
@@ -77,6 +77,7 @@ func RunChecks() []check.CheckResult {
 		checkVfioModule(),
 		checkVfioAccessPermission(),
 		checkSELinuxVFIOPolicy(),
+		checkSELinuxPodmanSocketPolicy(),
 		checkSystemdUserSliceLimits(),
 		checkPodmanServiceSupplementaryGroups(),
 	}
@@ -615,8 +616,7 @@ func checkSELinuxVFIOPolicy() *check.Check {
 	}
 
 	// Check if policy is installed (requires root/sudo)
-	var stderr string
-	exitCode, stdout, stderr, err = utils.ExecuteCommand("semodule", "-l")
+	exitCode, stdout, stderr, err := utils.ExecuteCommand("semodule", "-l")
 	if err != nil || exitCode != 0 {
 		// If permission denied, assume policy needs to be checked with sudo
 		// This is expected when running without sudo - skip check (pass)
@@ -634,6 +634,60 @@ func checkSELinuxVFIOPolicy() *check.Check {
 	// Policy should be installed
 	policyInstalled := strings.Contains(stdout, "vllm_vfio_policy")
 	selinuxCheck.SetStatus(policyInstalled)
+
+	return selinuxCheck
+}
+
+// checkSELinuxPodmanSocketPolicy validates SELinux policy for Podman socket access.
+// This check always fails (returns false) when SELinux is enabled and Podman socket exists,
+// forcing the policy to be reinstalled on every run to ensure it's up to date.
+func checkSELinuxPodmanSocketPolicy() *check.Check {
+	selinuxCheck := check.NewCheck("SELinux Podman socket policy configuration")
+
+	// Check if SELinux is enabled
+	exitCode, stdout, _, err := utils.ExecuteCommand("getenforce")
+	if err != nil || exitCode != 0 {
+		// SELinux not available - skip check (pass)
+		selinuxCheck.SetStatus(true)
+
+		return selinuxCheck
+	}
+
+	status := strings.TrimSpace(stdout)
+	if status == "Disabled" {
+		// SELinux disabled - skip check (pass)
+		selinuxCheck.SetStatus(true)
+
+		return selinuxCheck
+	}
+
+	// Check if Podman socket exists
+	if !utils.FileExists("/run/podman/podman.sock") {
+		// No Podman socket - skip check (pass)
+		selinuxCheck.SetStatus(true)
+
+		return selinuxCheck
+	}
+
+	// Check if policy is installed (requires root/sudo)
+	exitCode, _, stderr, err := utils.ExecuteCommand("semodule", "-l")
+	if err != nil || exitCode != 0 {
+		// If permission denied, assume policy needs to be checked with sudo
+		// This is expected when running without sudo - skip check (pass)
+		if strings.Contains(stderr, "Permission denied") || strings.Contains(stderr, "access") {
+			selinuxCheck.SetStatus(true)
+
+			return selinuxCheck
+		}
+		// Other errors mean policy is not installed
+		selinuxCheck.SetStatus(false)
+
+		return selinuxCheck
+	}
+
+	// Always return false to force policy reinstallation on every run
+	// This ensures the policy is always up to date with the latest permissions
+	selinuxCheck.SetStatus(false)
 
 	return selinuxCheck
 }

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
@@ -586,9 +586,10 @@ func isSentientGroupPresent(value string) bool {
 	return slices.Contains(groups, sentientGroup)
 }
 
-// checkSELinuxVFIOPolicy validates SELinux policy for VFIO device access.
-func checkSELinuxVFIOPolicy() *check.Check {
-	selinuxCheck := check.NewCheck("SELinux VFIO policy configuration")
+// checkSELinuxPolicy is a helper function that validates SELinux policy installation.
+// It checks if SELinux is enabled, if the required path exists, and if the policy is installed.
+func checkSELinuxPolicy(checkName, policyName, requiredPath string) *check.Check {
+	selinuxCheck := check.NewCheck(checkName)
 
 	// Check if SELinux is enabled
 	exitCode, stdout, _, err := utils.ExecuteCommand("getenforce")
@@ -607,61 +608,9 @@ func checkSELinuxVFIOPolicy() *check.Check {
 		return selinuxCheck
 	}
 
-	// Check if VFIO devices exist
-	if !utils.FileExists("/dev/vfio") {
-		// No VFIO devices - skip check (pass)
-		selinuxCheck.SetStatus(true)
-
-		return selinuxCheck
-	}
-
-	// Check if policy is installed (requires root/sudo)
-	exitCode, stdout, stderr, err := utils.ExecuteCommand("semodule", "-l")
-	if err != nil || exitCode != 0 {
-		// If permission denied, assume policy needs to be checked with sudo
-		// This is expected when running without sudo - skip check (pass)
-		if strings.Contains(stderr, "Permission denied") || strings.Contains(stderr, "access") {
-			selinuxCheck.SetStatus(true)
-
-			return selinuxCheck
-		}
-		// Other errors mean policy is not installed
-		selinuxCheck.SetStatus(false)
-
-		return selinuxCheck
-	}
-
-	// Policy should be installed
-	policyInstalled := strings.Contains(stdout, "vllm_vfio_policy")
-	selinuxCheck.SetStatus(policyInstalled)
-
-	return selinuxCheck
-}
-
-// checkSELinuxPodmanSocketPolicy validates SELinux policy for Podman socket access.
-func checkSELinuxPodmanSocketPolicy() *check.Check {
-	selinuxCheck := check.NewCheck("SELinux Podman socket policy configuration")
-
-	// Check if SELinux is enabled
-	exitCode, stdout, _, err := utils.ExecuteCommand("getenforce")
-	if err != nil || exitCode != 0 {
-		// SELinux not available - skip check (pass)
-		selinuxCheck.SetStatus(true)
-
-		return selinuxCheck
-	}
-
-	status := strings.TrimSpace(stdout)
-	if status == "Disabled" {
-		// SELinux disabled - skip check (pass)
-		selinuxCheck.SetStatus(true)
-
-		return selinuxCheck
-	}
-
-	// Check if Podman socket exists
-	if !utils.FileExists("/run/podman/podman.sock") {
-		// No Podman socket - skip check (pass)
+	// Check if required path exists (if specified)
+	if requiredPath != "" && !utils.FileExists(requiredPath) {
+		// Required path doesn't exist - skip check (pass)
 		selinuxCheck.SetStatus(true)
 
 		return selinuxCheck
@@ -684,10 +633,20 @@ func checkSELinuxPodmanSocketPolicy() *check.Check {
 	}
 
 	// Check if policy is installed
-	policyInstalled := strings.Contains(stdout, "podman_socket_policy")
+	policyInstalled := strings.Contains(stdout, policyName)
 	selinuxCheck.SetStatus(policyInstalled)
 
 	return selinuxCheck
+}
+
+// checkSELinuxVFIOPolicy validates SELinux policy for VFIO device access.
+func checkSELinuxVFIOPolicy() *check.Check {
+	return checkSELinuxPolicy("SELinux VFIO policy configuration", "vllm_vfio_policy", "/dev/vfio")
+}
+
+// checkSELinuxPodmanSocketPolicy validates SELinux policy for Podman socket access.
+func checkSELinuxPodmanSocketPolicy() *check.Check {
+	return checkSELinuxPolicy("SELinux Podman socket policy configuration", "podman_socket_policy", "/run/podman/podman.sock")
 }
 
 func setCheckResult(confCheck *check.ConfigurationFileCheck, found, correctValue bool) {

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
@@ -639,8 +639,6 @@ func checkSELinuxVFIOPolicy() *check.Check {
 }
 
 // checkSELinuxPodmanSocketPolicy validates SELinux policy for Podman socket access.
-// This check always fails (returns false) when SELinux is enabled and Podman socket exists,
-// forcing the policy to be reinstalled on every run to ensure it's up to date.
 func checkSELinuxPodmanSocketPolicy() *check.Check {
 	selinuxCheck := check.NewCheck("SELinux Podman socket policy configuration")
 
@@ -670,7 +668,7 @@ func checkSELinuxPodmanSocketPolicy() *check.Check {
 	}
 
 	// Check if policy is installed (requires root/sudo)
-	exitCode, _, stderr, err := utils.ExecuteCommand("semodule", "-l")
+	exitCode, stdout, stderr, err := utils.ExecuteCommand("semodule", "-l")
 	if err != nil || exitCode != 0 {
 		// If permission denied, assume policy needs to be checked with sudo
 		// This is expected when running without sudo - skip check (pass)
@@ -685,9 +683,9 @@ func checkSELinuxPodmanSocketPolicy() *check.Check {
 		return selinuxCheck
 	}
 
-	// Always return false to force policy reinstallation on every run
-	// This ensures the policy is always up to date with the latest permissions
-	selinuxCheck.SetStatus(false)
+	// Check if policy is installed
+	policyInstalled := strings.Contains(stdout, "podman_socket_policy")
+	selinuxCheck.SetStatus(policyInstalled)
 
 	return selinuxCheck
 }

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -496,8 +496,6 @@ func (d *PodmanDeployer) mergeEndpointIntoService(comp *ComponentPlan, plan *Dep
 		return
 	}
 
-	logger.Infof("Service %s Values before merge: %v\n", serviceID, svc.Values)
-
 	if svc.Values == nil {
 		svc.Values = make(map[string]any)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/common.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/common.go
@@ -10,6 +10,7 @@ import (
 	catalogPodman "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"golang.org/x/crypto/pbkdf2"
 )
 
@@ -40,7 +41,10 @@ func Run(opts ConfigureOptions) error {
 	switch opts.Runtime {
 	case types.RuntimeTypePodman:
 		// Determine Podman URI
-		podmanURI := getPodmanURI()
+		podmanURI, err := utils.ResolvePodmanURI()
+		if err != nil {
+			return fmt.Errorf("failed to generate podman uri: %w", err)
+		}
 
 		// Determine auth file path
 		authFilePath := getAuthFilePath()
@@ -53,13 +57,6 @@ func Run(opts ConfigureOptions) error {
 	default:
 		return fmt.Errorf("unsupported runtime type: %s", opts.Runtime)
 	}
-}
-
-// getPodmanURI determines the Podman socket URI.
-func getPodmanURI() string {
-	// TODO: Need to take care for getting rootless socket
-	// Return default local Unix socket
-	return "/run/podman/podman.sock"
 }
 
 // getAuthFilePath determines the auth.json file path.

--- a/ai-services/internal/pkg/catalog/cli/configure/common.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/common.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"os"
 
 	catalogPodman "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
@@ -47,7 +48,10 @@ func Run(opts ConfigureOptions) error {
 		}
 
 		// Determine auth file path
-		authFilePath := getAuthFilePath()
+		authFilePath, err := getAuthFilePath()
+		if err != nil {
+			return fmt.Errorf("failed to get auth file path: %w", err)
+		}
 
 		return catalogPodman.DeployCatalog(ctx, podmanURI, authFilePath, passwordHash, opts.BaseDir, opts.ArgParams, opts.HttpsPort)
 
@@ -60,10 +64,12 @@ func Run(opts ConfigureOptions) error {
 }
 
 // getAuthFilePath determines the auth.json file path.
-func getAuthFilePath() string {
-	// TODO: Need to take care for getting rootless user auth file path
-	// Return default root user auth file path
-	return "/run/user/0/containers/auth.json"
+func getAuthFilePath() (string, error) {
+	if os.Geteuid() == 0 {
+		return "/run/user/0/containers/auth.json", nil
+	}
+
+	return fmt.Sprintf("/run/user/%d/containers/auth.json", os.Getuid()), nil
 }
 
 // hashPasswordPBKDF2 generates a PBKDF2 hash of the password with a random salt.

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -173,11 +173,15 @@ func prepareCatalogValues(tp templates.Template, podmanURI, authFilePath, passwo
 	// Base64 encode the auth file content for Kubernetes secret
 	authFileBase64 := base64.StdEncoding.EncodeToString(authFileContent)
 
+	// Strip unix:// prefix from podmanURI for hostPath volume mount
+	// The CONTAINER_HOST env var needs the full URI, but the hostPath needs just the file path
+	podmanSocketPath := strings.TrimPrefix(podmanURI, "unix://")
+
 	// Set configure-specific values
 	argParams["backend.adminPasswordHash"] = passwordHash
 	argParams["backend.runtime"] = "podman"
-	argParams["backend.podman.uri"] = podmanURI
 	argParams["backend.podman.authFileContent"] = authFileBase64
+	argParams["backend.podman.uri"] = podmanSocketPath
 	argParams["db.password"] = dbPassword
 
 	// Load values from catalog

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"os/user"
 	"strings"
 	"syscall"
 
@@ -37,6 +36,17 @@ type PodmanClient struct {
 
 // NewPodmanClient creates and returns a new PodmanClient instance.
 func NewPodmanClient() (*PodmanClient, error) {
+	// Set XDG_RUNTIME_DIR for non-root users if not already set
+	// This is required for rootless Podman to access runtime directories
+	euid := os.Geteuid()
+	if euid != 0 && os.Getenv("XDG_RUNTIME_DIR") == "" {
+		uid := os.Getuid()
+		logger.Infof("Running as non-root user %d, setting XDG_RUNTIME_DIR\n", uid, logger.VerbosityLevelDebug)
+		if err := os.Setenv("XDG_RUNTIME_DIR", fmt.Sprintf("/run/user/%d", uid)); err != nil {
+			return nil, fmt.Errorf("failed to set XDG_RUNTIME_DIR: %w", err)
+		}
+	}
+
 	// Default Podman socket URI is unix:///run/podman/podman.sock running on the local machine,
 	// but it can be overridden by the CONTAINER_HOST and CONTAINER_SSHKEY environment variable to support remote connections.
 	// Please use `podman system connection list` to see available connections.
@@ -44,7 +54,7 @@ func NewPodmanClient() (*PodmanClient, error) {
 	// MacOS instructions running in a remote VM:
 	// export CONTAINER_HOST=ssh://root@127.0.0.1:62904/run/podman/podman.sock
 	// export CONTAINER_SSHKEY=/Users/manjunath/.local/share/containers/podman/machine/machine
-	uri, err := resolvePodmanURI()
+	uri, err := utils.ResolvePodmanURI()
 	if err != nil {
 		return nil, err
 	}
@@ -55,39 +65,6 @@ func NewPodmanClient() (*PodmanClient, error) {
 	}
 
 	return &PodmanClient{Context: ctx}, nil
-}
-
-func resolvePodmanURI() (string, error) {
-	if v, found := os.LookupEnv("CONTAINER_HOST"); found {
-		return v, nil
-	}
-
-	if os.Geteuid() == 0 {
-		return getPodmanURIAsRoot()
-	}
-
-	return fmt.Sprintf("unix:///run/user/%d/podman/podman.sock", os.Getuid()), nil
-}
-
-// getPodmanURIAsRoot determines the appropriate Podman socket URI when running with root privileges.
-// If the process was elevated via sudo (SUDO_USER is set), it returns the socket path
-// for the original user's rootless Podman instance to maintain user context.
-// Otherwise, it returns the system-wide root Podman socket path.
-func getPodmanURIAsRoot() (string, error) {
-	sudoUser := os.Getenv("SUDO_USER")
-	if sudoUser == "" {
-		return "unix:///run/podman/podman.sock", nil
-	}
-
-	u, err := user.Lookup(sudoUser)
-	if err != nil {
-		return "", fmt.Errorf("failed to lookup user %s: %w", sudoUser, err)
-	}
-
-	return fmt.Sprintf(
-		"unix:///run/user/%s/podman/podman.sock",
-		u.Uid,
-	), nil
 }
 
 // ListImages function to list images (you can expand with more Podman functionalities).

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -41,7 +41,7 @@ func NewPodmanClient() (*PodmanClient, error) {
 	euid := os.Geteuid()
 	if euid != 0 && os.Getenv("XDG_RUNTIME_DIR") == "" {
 		uid := os.Getuid()
-		logger.Infof("Running as non-root user %d, setting XDG_RUNTIME_DIR\n", uid, logger.VerbosityLevelDebug)
+		logger.Infof("Running as non-root user %d, setting XDG_RUNTIME_DIR", uid, logger.VerbosityLevelDebug)
 		if err := os.Setenv("XDG_RUNTIME_DIR", fmt.Sprintf("/run/user/%d", uid)); err != nil {
 			return nil, fmt.Errorf("failed to set XDG_RUNTIME_DIR: %w", err)
 		}

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"net"
 	"os"
+	"os/user"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -531,4 +532,37 @@ func CreateDir(path string) error {
 	}
 
 	return nil
+}
+
+func ResolvePodmanURI() (string, error) {
+	if v, found := os.LookupEnv("CONTAINER_HOST"); found {
+		return v, nil
+	}
+
+	if os.Geteuid() == 0 {
+		return getPodmanURIAsRoot()
+	}
+
+	return fmt.Sprintf("unix:///run/user/%d/podman/podman.sock", os.Getuid()), nil
+}
+
+// getPodmanURIAsRoot determines the appropriate Podman socket URI when running with root privileges.
+// If the process was elevated via sudo (SUDO_USER is set), it returns the socket path
+// for the original user's rootless Podman instance to maintain user context.
+// Otherwise, it returns the system-wide root Podman socket path.
+func getPodmanURIAsRoot() (string, error) {
+	sudoUser := os.Getenv("SUDO_USER")
+	if sudoUser == "" {
+		return "unix:///run/podman/podman.sock", nil
+	}
+
+	u, err := user.Lookup(sudoUser)
+	if err != nil {
+		return "", fmt.Errorf("failed to lookup user %s: %w", sudoUser, err)
+	}
+
+	return fmt.Sprintf(
+		"unix:///run/user/%s/podman/podman.sock",
+		u.Uid,
+	), nil
 }


### PR DESCRIPTION
This PR enables the the tool to run as a non-root user 
It implements proper SELinux policies and Podman socket access configuration for rootless containers.

1. Policy: added SELinux policy module (podman_socket_policy) to allow containers with container_t type to access the Podman socket.
2. Resolving podman socket for both root and non-root scenarios
3. Resolving podman auth file path for both root and non-root scenarios
4. Removed dependency on keep-id user namespace mapping by handling Podman socket access through SELinux policy configuration

**One Assumption:**
User will have to run catalog configure using --http-port 8443 as for nonroot users, its not allowed
```
ERRO[0003] "rootlessport cannot expose privileged port 443, you can add 'net.ipv4.ip_unprivileged_port_start=443' to /etc/sysctl.conf (currently 1024), or choose a larger port number (>= 1024): listen tcp 0.0.0.0:443: bind: permission denied"
Error: unable to start container "f72329a97540825bb753ec41806021c9fd15890ae54f6874b2f13e2c6bc8890a": starting some containers: internal libpod error
```