### PR TITLE
feat: implement automatic HTTPS route registration for catalog-deployed applications

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.21
+TAG?=0.0.22
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/applications/rag-cpu/podman/templates/chat-bot.yaml.tmpl
@@ -7,7 +7,8 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"
+    ai-services.io/routes: "3000:chat-bot-ui,5000:chat-bot-backend"
+    # ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
   containers:
     - name: ui

--- a/ai-services/assets/applications/rag-cpu/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/applications/rag-cpu/podman/templates/digitize.yaml.tmpl
@@ -7,7 +7,8 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"
+    ai-services.io/routes: "4001:digitize-ui,4000:digitize-backend"
+    # ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"  # Uncomment to expose ports directly (bypasses Caddy)
     io.podman.annotations.pids-limit/backend-server: "4096"
 spec:
   initContainers:

--- a/ai-services/assets/applications/rag-cpu/podman/templates/similarity-api.yaml.tmpl
+++ b/ai-services/assets/applications/rag-cpu/podman/templates/similarity-api.yaml.tmpl
@@ -7,7 +7,8 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"
+    ai-services.io/routes: "7000:similarity-api"
+    # ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
   containers:
     - name: similarity-api

--- a/ai-services/assets/applications/rag-cpu/podman/templates/summarize-api.yaml.tmpl
+++ b/ai-services/assets/applications/rag-cpu/podman/templates/summarize-api.yaml.tmpl
@@ -7,7 +7,8 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"
+    ai-services.io/routes: "6000:summarize-api"
+    # ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
   containers:
     - name: summarize-api

--- a/ai-services/assets/applications/rag-dev/podman/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/applications/rag-dev/podman/templates/chat-bot.yaml.tmpl
@@ -7,7 +7,8 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"
+    ai-services.io/routes: "3000:chat-bot-ui,5000:chat-bot-backend"
+    # ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
   containers:
     - name: ui

--- a/ai-services/assets/applications/rag-dev/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/applications/rag-dev/podman/templates/digitize.yaml.tmpl
@@ -7,7 +7,8 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"
+    ai-services.io/routes: "4001:digitize-ui,4000:digitize-backend"
+    # ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"  # Uncomment to expose ports directly (bypasses Caddy)
     io.podman.annotations.pids-limit/backend-server: "4096"
 spec:
   initContainers:

--- a/ai-services/assets/applications/rag-dev/podman/templates/similarity-api.yaml.tmpl
+++ b/ai-services/assets/applications/rag-dev/podman/templates/similarity-api.yaml.tmpl
@@ -7,7 +7,8 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"
+    ai-services.io/routes: "7000:similarity-api"
+    # ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
   containers:
     - name: similarity-api

--- a/ai-services/assets/applications/rag-dev/podman/templates/summarize-api.yaml.tmpl
+++ b/ai-services/assets/applications/rag-dev/podman/templates/summarize-api.yaml.tmpl
@@ -7,7 +7,8 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"
+    ai-services.io/routes: "6000:summarize-api"
+    # ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
   containers:
     - name: summarize-api

--- a/ai-services/assets/applications/rag/podman/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/chat-bot.yaml.tmpl
@@ -7,7 +7,8 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"
+    ai-services.io/routes: "3000:chat-bot-ui,5000:chat-bot-backend"
+    # ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
   containers:
     - name: ui

--- a/ai-services/assets/applications/rag/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/digitize.yaml.tmpl
@@ -7,7 +7,8 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"
+    ai-services.io/routes: "4001:digitize-ui,4000:digitize-backend"
+    # ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"  # Uncomment to expose ports directly (bypasses Caddy)
     io.podman.annotations.pids-limit/backend-server: "4096"
 spec:
   initContainers:

--- a/ai-services/assets/applications/rag/podman/templates/similarity-api.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/similarity-api.yaml.tmpl
@@ -7,7 +7,8 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"
+    ai-services.io/routes: "7000:similarity-api"
+    # ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
   containers:
     - name: similarity-api

--- a/ai-services/assets/applications/rag/podman/templates/summarize-api.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/summarize-api.yaml.tmpl
@@ -7,7 +7,8 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"
+    ai-services.io/routes: "6000:summarize-api"
+    # ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
   containers:
     - name: summarize-api

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -115,6 +115,10 @@ spec:
           value: "{{ .BaseDir }}"
         - name: HOST_IP
           value: "{{ .HostIP }}"
+        - name: CADDY_ADMIN_URL
+          value: "{{ .CaddyAdminURL }}"
+        - name: CADDY_HTTPS_PORT
+          value: "{{ .Values.caddy.httpsPort }}"
       ports:
         - containerPort: 8080
           protocol: TCP

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -113,6 +113,8 @@ spec:
               key: db-password
         - name: AI_SERVICES_BASE_DIR
           value: "{{ .BaseDir }}"
+        - name: HOST_IP
+          value: "{{ .HostIP }}"
       ports:
         - containerPort: 8080
           protocol: TCP

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.21
+  image: icr.io/ai-services-cicd/ai-services:0.0.22
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/chat/podman/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/services/chat/podman/templates/chat-bot.yaml.tmpl
@@ -5,7 +5,8 @@ metadata:
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
   annotations:
-    ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"
+    ai-services.io/routes: "3000:chat-bot-ui,5000:chat-bot-backend"
+    # ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
   containers:
     - name: ui

--- a/ai-services/assets/services/digitize/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/services/digitize/podman/templates/digitize.yaml.tmpl
@@ -5,7 +5,8 @@ metadata:
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
   annotations:
-    ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"
+    ai-services.io/routes: "4001:digitize-ui,4000:digitize-backend"
+    # ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"  # Uncomment to expose ports directly (bypasses Caddy)
     io.podman.annotations.pids-limit/backend-server: "4096"
 spec:
   initContainers:

--- a/ai-services/assets/services/similarity/podman/templates/similarity-api.yaml.tmpl
+++ b/ai-services/assets/services/similarity/podman/templates/similarity-api.yaml.tmpl
@@ -5,7 +5,8 @@ metadata:
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
   annotations:
-    ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"
+    ai-services.io/routes: "7000:similarity-api"
+    # ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
   containers:
     - name: similarity-api

--- a/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
+++ b/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
@@ -3,9 +3,10 @@ kind: Pod
 metadata:
   name: "summarize-api-{{ .InstanceSlug }}"
   labels:
-  ai-services.io/template: "{{ .TemplateID }}"
+    ai-services.io/template: "{{ .TemplateID }}"
   annotations:
-    ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"
+    ai-services.io/routes: "6000:summarize-api"
+    # ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
   containers:
     - name: summarize-api

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -15,7 +15,6 @@ import (
 	"text/template"
 
 	"github.com/google/uuid"
-	"github.com/project-ai-services/ai-services/assets"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	apimodels "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
 	deploymenttypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/deployment/types"
@@ -731,12 +730,49 @@ func (d *PodmanDeployer) deployServicePods(
 
 	// If PodTemplateExecutions is defined, use it for ordered deployment
 	if len(metadata.PodTemplateExecutions) > 0 {
-		if err := d.deployServicePodsWithExecutions(metadata, tmpls, applicationID, svc, values); err != nil {
-			return err
+		// Execute each pod template in the service following the defined order
+		for _, layer := range metadata.PodTemplateExecutions {
+			for _, podTemplateName := range layer {
+				// Prepare initialParams for the template
+				initialParams := map[string]any{
+					"InstanceSlug": generateInstanceSlug(applicationID.String()),
+					"TemplateID":   svc.DatabaseID,
+					"BaseDir":      utils.GetBaseDir(),
+					"Values":       values,
+					"env":          map[string]map[string]string{},
+				}
+
+				_, podName, routes, err := d.deployPodTemplate(podTemplateName, tmpls, initialParams)
+				if err != nil {
+					return fmt.Errorf("failed to deploy pod template %s: %w", podTemplateName, err)
+				}
+
+				if routes != "" {
+					svc.Routes[podName] = routes
+				}
+			}
 		}
 	} else {
-		if err := d.deployServicePodsWithoutExecutions(tmpls, applicationID, svc, values); err != nil {
-			return err
+		// If no PodTemplateExecutions defined, deploy all templates
+		logger.Infof("No PodTemplateExecutions defined for service %s, deploying all templates\n", svc.CatalogID)
+		for templateName := range tmpls {
+			// Prepare initialParams for the template
+			initialParams := map[string]any{
+				"InstanceSlug": generateInstanceSlug(applicationID.String()),
+				"TemplateID":   svc.DatabaseID,
+				"BaseDir":      utils.GetBaseDir(),
+				"Values":       values,
+				"env":          map[string]map[string]string{},
+			}
+
+			_, podName, routes, err := d.deployPodTemplate(templateName, tmpls, initialParams)
+			if err != nil {
+				return fmt.Errorf("failed to deploy pod template %s: %w", templateName, err)
+			}
+
+			if routes != "" {
+				svc.Routes[podName] = routes
+			}
 		}
 	}
 
@@ -795,58 +831,6 @@ func (d *PodmanDeployer) deployComponentTemplate(
 	return nil
 }
 
-// deployServicePodsWithExecutions deploys service pods following PodTemplateExecutions order.
-func (d *PodmanDeployer) deployServicePodsWithExecutions(metadata *templates.AppMetadata, tmpls map[string]*template.Template, applicationID uuid.UUID, svc *ServicePlan, values map[string]any) error {
-	for _, layer := range metadata.PodTemplateExecutions {
-		for _, podTemplateName := range layer {
-			initialParams := map[string]any{
-				"InstanceSlug": generateInstanceSlug(applicationID.String()),
-				"TemplateID":   svc.DatabaseID,
-				"BaseDir":      utils.GetBaseDir(),
-				"Values":       values,
-				"env":          map[string]map[string]string{},
-			}
-
-			_, podName, routes, err := d.deployPodTemplate(podTemplateName, tmpls, initialParams)
-			if err != nil {
-				return fmt.Errorf("failed to deploy pod template %s: %w", podTemplateName, err)
-			}
-
-			if routes != "" {
-				svc.Routes[podName] = routes
-			}
-		}
-	}
-
-	return nil
-}
-
-// deployServicePodsWithoutExecutions deploys all service pod templates without specific order.
-func (d *PodmanDeployer) deployServicePodsWithoutExecutions(tmpls map[string]*template.Template, applicationID uuid.UUID, svc *ServicePlan, values map[string]any) error {
-	logger.Infof("No PodTemplateExecutions defined for service %s, deploying all templates\n", svc.CatalogID)
-
-	for templateName := range tmpls {
-		initialParams := map[string]any{
-			"InstanceSlug": generateInstanceSlug(applicationID.String()),
-			"TemplateID":   svc.DatabaseID,
-			"BaseDir":      utils.GetBaseDir(),
-			"Values":       values,
-			"env":          map[string]map[string]string{},
-		}
-
-		_, podName, routes, err := d.deployPodTemplate(templateName, tmpls, initialParams)
-		if err != nil {
-			return fmt.Errorf("failed to deploy pod template %s: %w", templateName, err)
-		}
-
-		if routes != "" {
-			svc.Routes[podName] = routes
-		}
-	}
-
-	return nil
-}
-
 // renderAndParsePodTemplate renders a pod template and parses it into a PodSpec.
 func (d *PodmanDeployer) renderAndParsePodTemplate(
 	podTemplate *template.Template,
@@ -880,9 +864,8 @@ func (d *PodmanDeployer) renderFinalPodTemplate(
 		return nil, nil, fmt.Errorf("failed to get env params: %w", err)
 	}
 
-	if _, exists := initialParams["env"]; !exists {
-		initialParams["env"] = env
-	}
+	// Always set/overwrite the env to ensure Spyre card PCI addresses are included
+	initialParams["env"] = env
 
 	var finalRendered bytes.Buffer
 	if err := podTemplate.Execute(&finalRendered, initialParams); err != nil {
@@ -1139,8 +1122,6 @@ func generateInstanceSlug(id string) string {
 	return hexHash[:10]
 }
 
-// Made with Bob
-
 // registerApplicationRoutes registers routes for all services with Caddy proxy.
 func (d *PodmanDeployer) registerApplicationRoutes(ctx context.Context, plan *DeploymentPlan) error {
 	logger.Infof("Registering routes for application '%s'\n", plan.ApplicationName)
@@ -1164,13 +1145,21 @@ func (d *PodmanDeployer) registerApplicationRoutes(ctx context.Context, plan *De
 		return nil
 	}
 
-	// Find catalog Caddy pod
-	caddyPodName, err := d.findCatalogCaddyPod()
-	if err != nil {
-		return fmt.Errorf("failed to find catalog Caddy pod: %w", err)
+	// Get Caddy admin URL from env var (set during catalog configure)
+	// Running in catalog backend container, so env vars should be available
+	adminURL := utils.GetEnv("CADDY_ADMIN_URL", "")
+	if adminURL == "" {
+		return fmt.Errorf("CADDY_ADMIN_URL environment variable not set")
 	}
 
-	logger.Infof("Found catalog Caddy pod: %s\n", caddyPodName)
+	// Get host IP from env var (set during catalog configure)
+	hostIP := utils.GetEnv("HOST_IP", "")
+	if hostIP == "" {
+		return fmt.Errorf("HOST_IP environment variable not set")
+	}
+
+	logger.Infof("Using Caddy admin URL: %s\n", adminURL)
+	logger.Infof("Using host IP: %s\n", hostIP)
 
 	// Register routes for each pod
 	var registrationErrors []error
@@ -1180,7 +1169,8 @@ func (d *PodmanDeployer) registerApplicationRoutes(ctx context.Context, plan *De
 			catalogconstants.CatalogAppName,
 			constants.CaddyServerName,
 			routes,
-			caddyPodName,
+			adminURL,
+			hostIP,
 			podName,
 		); err != nil {
 			registrationErrors = append(registrationErrors, fmt.Errorf("pod %s: %w", podName, err))
@@ -1198,15 +1188,4 @@ func (d *PodmanDeployer) registerApplicationRoutes(ctx context.Context, plan *De
 	return nil
 }
 
-// findCatalogCaddyPod finds the catalog Caddy pod name from catalog templates.
-func (d *PodmanDeployer) findCatalogCaddyPod() (string, error) {
-	tp := templates.NewEmbedTemplateProvider(&assets.CatalogFS, "")
-	argParams := make(map[string]string)
-
-	caddyPodName, err := proxy.FindCaddyPodNameFromTemplates(tp, "catalog", catalogconstants.CatalogAppName, argParams)
-	if err != nil {
-		return "", fmt.Errorf("failed to find Caddy pod from templates: %w", err)
-	}
-
-	return caddyPodName, nil
-}
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"maps"
 	"regexp"
@@ -14,9 +15,11 @@ import (
 	"text/template"
 
 	"github.com/google/uuid"
+	"github.com/project-ai-services/ai-services/assets"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	apimodels "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
 	deploymenttypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/deployment/types"
+	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
@@ -28,6 +31,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/image"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	podmodels "github.com/project-ai-services/ai-services/internal/pkg/models"
+	"github.com/project-ai-services/ai-services/internal/pkg/proxy"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/specs"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
@@ -131,7 +135,14 @@ func (d *PodmanDeployer) ExecuteDeployment(
 		}
 	}
 
-	// Step 5: Update application status to Running
+	logger.Infof("Starting routing for '%s'\n", plan.ApplicationName)
+	// Step 5: Register routes with Caddy proxy
+	if err := d.registerApplicationRoutes(ctx, plan); err != nil {
+		logger.Errorf("Failed to register routes: %v\n", err)
+		// Don't fail deployment if route registration fails
+	}
+
+	// Step 6: Update application status to Running
 	d.updateStatusIgnoreError(ctx, plan.ApplicationID, models.ApplicationStatusRunning, "Deployment completed successfully")
 
 	logger.Infof("Deployment completed successfully for '%s'\n", plan.ApplicationName)
@@ -703,7 +714,7 @@ func (d *PodmanDeployer) deployService(ctx context.Context, plan *DeploymentPlan
 	return nil
 }
 
-// deployServicePods deploys all pods for a service.
+// deployServicePods deploys all pods for a service and collects routes annotations.
 func (d *PodmanDeployer) deployServicePods(
 	applicationID uuid.UUID,
 	svc *ServicePlan,
@@ -713,43 +724,19 @@ func (d *PodmanDeployer) deployServicePods(
 	// Use the values already loaded in the service plan
 	values := svc.Values
 
+	// Initialize routes map to collect routes from deployed pods
+	if svc.Routes == nil {
+		svc.Routes = make(map[string]string)
+	}
+
 	// If PodTemplateExecutions is defined, use it for ordered deployment
 	if len(metadata.PodTemplateExecutions) > 0 {
-		// Execute each pod template in the service following the defined order
-		for _, layer := range metadata.PodTemplateExecutions {
-			for _, podTemplateName := range layer {
-				// Prepare initialParams for the template
-				initialParams := map[string]any{
-					"InstanceSlug": generateInstanceSlug(applicationID.String()),
-					"TemplateID":   svc.DatabaseID,
-					"BaseDir":      utils.GetBaseDir(),
-					"Values":       values,
-					"env":          map[string]map[string]string{},
-				}
-
-				_, err := d.deployPodTemplate(podTemplateName, tmpls, initialParams)
-				if err != nil {
-					return fmt.Errorf("failed to deploy pod template %s: %w", podTemplateName, err)
-				}
-			}
+		if err := d.deployServicePodsWithExecutions(metadata, tmpls, applicationID, svc, values); err != nil {
+			return err
 		}
 	} else {
-		// If no PodTemplateExecutions defined, deploy all templates
-		logger.Infof("No PodTemplateExecutions defined for service %s, deploying all templates\n", svc.CatalogID)
-		for templateName := range tmpls {
-			// Prepare initialParams for the template
-			initialParams := map[string]any{
-				"InstanceSlug": generateInstanceSlug(applicationID.String()),
-				"TemplateID":   svc.DatabaseID,
-				"BaseDir":      utils.GetBaseDir(),
-				"Values":       values,
-				"env":          map[string]map[string]string{},
-			}
-
-			_, err := d.deployPodTemplate(templateName, tmpls, initialParams)
-			if err != nil {
-				return fmt.Errorf("failed to deploy pod template %s: %w", templateName, err)
-			}
+		if err := d.deployServicePodsWithoutExecutions(tmpls, applicationID, svc, values); err != nil {
+			return err
 		}
 	}
 
@@ -808,6 +795,58 @@ func (d *PodmanDeployer) deployComponentTemplate(
 	return nil
 }
 
+// deployServicePodsWithExecutions deploys service pods following PodTemplateExecutions order.
+func (d *PodmanDeployer) deployServicePodsWithExecutions(metadata *templates.AppMetadata, tmpls map[string]*template.Template, applicationID uuid.UUID, svc *ServicePlan, values map[string]any) error {
+	for _, layer := range metadata.PodTemplateExecutions {
+		for _, podTemplateName := range layer {
+			initialParams := map[string]any{
+				"InstanceSlug": generateInstanceSlug(applicationID.String()),
+				"TemplateID":   svc.DatabaseID,
+				"BaseDir":      utils.GetBaseDir(),
+				"Values":       values,
+				"env":          map[string]map[string]string{},
+			}
+
+			_, podName, routes, err := d.deployPodTemplate(podTemplateName, tmpls, initialParams)
+			if err != nil {
+				return fmt.Errorf("failed to deploy pod template %s: %w", podTemplateName, err)
+			}
+
+			if routes != "" {
+				svc.Routes[podName] = routes
+			}
+		}
+	}
+
+	return nil
+}
+
+// deployServicePodsWithoutExecutions deploys all service pod templates without specific order.
+func (d *PodmanDeployer) deployServicePodsWithoutExecutions(tmpls map[string]*template.Template, applicationID uuid.UUID, svc *ServicePlan, values map[string]any) error {
+	logger.Infof("No PodTemplateExecutions defined for service %s, deploying all templates\n", svc.CatalogID)
+
+	for templateName := range tmpls {
+		initialParams := map[string]any{
+			"InstanceSlug": generateInstanceSlug(applicationID.String()),
+			"TemplateID":   svc.DatabaseID,
+			"BaseDir":      utils.GetBaseDir(),
+			"Values":       values,
+			"env":          map[string]map[string]string{},
+		}
+
+		_, podName, routes, err := d.deployPodTemplate(templateName, tmpls, initialParams)
+		if err != nil {
+			return fmt.Errorf("failed to deploy pod template %s: %w", templateName, err)
+		}
+
+		if routes != "" {
+			svc.Routes[podName] = routes
+		}
+	}
+
+	return nil
+}
+
 // renderAndParsePodTemplate renders a pod template and parses it into a PodSpec.
 func (d *PodmanDeployer) renderAndParsePodTemplate(
 	podTemplate *template.Template,
@@ -841,8 +880,9 @@ func (d *PodmanDeployer) renderFinalPodTemplate(
 		return nil, nil, fmt.Errorf("failed to get env params: %w", err)
 	}
 
-	// Always set/overwrite the env to ensure Spyre card PCI addresses are included
-	initialParams["env"] = env
+	if _, exists := initialParams["env"]; !exists {
+		initialParams["env"] = env
+	}
 
 	var finalRendered bytes.Buffer
 	if err := podTemplate.Execute(&finalRendered, initialParams); err != nil {
@@ -935,17 +975,17 @@ func (d *PodmanDeployer) extractComponentEndpointInfo(podSpec *podmodels.PodSpec
 	}, nil
 }
 
-// deployPodTemplate deploys a single pod template for a service and returns endpoint information.
+// deployPodTemplate deploys a single pod template for a service and returns endpoint information and routes.
 func (d *PodmanDeployer) deployPodTemplate(
 	podTemplateName string,
 	tmpls map[string]*template.Template,
 	initialParams map[string]any,
-) (map[string]string, error) {
+) (map[string]string, string, string, error) {
 	logger.Infof("Deploying service template '%s'...\n", podTemplateName)
 
 	podTemplate, ok := tmpls[podTemplateName]
 	if !ok {
-		return nil, fmt.Errorf("pod template '%s' not found", podTemplateName)
+		return nil, "", "", fmt.Errorf("pod template '%s' not found", podTemplateName)
 	}
 
 	// Render template to get both PodSpec and raw bytes
@@ -959,28 +999,42 @@ func (d *PodmanDeployer) deployPodTemplate(
 	// Parse into PodSpec for metadata
 	var podSpec podmodels.PodSpec
 	if err := k8syaml.Unmarshal(renderedBytes, &podSpec); err != nil {
-		return nil, fmt.Errorf("failed to parse rendered pod spec: %w", err)
+		return nil, "", "", fmt.Errorf("failed to parse rendered pod spec: %w", err)
+	}
+
+	// Extract routes annotation if present
+	routes := ""
+	if podSpec.Annotations != nil {
+		logger.Infof("DEBUG: Pod '%s' annotations: %+v\n", podSpec.Name, podSpec.Annotations)
+		if r, ok := podSpec.Annotations[constants.PodRoutesAnnotationKey]; ok {
+			routes = r
+			logger.Infof("DEBUG: Found routes annotation for pod '%s': %s\n", podSpec.Name, routes)
+		} else {
+			logger.Infof("DEBUG: No routes annotation found for pod '%s' (key: %s)\n", podSpec.Name, constants.PodRoutesAnnotationKey)
+		}
+	} else {
+		logger.Infof("DEBUG: Pod '%s' has nil annotations\n", podSpec.Name)
 	}
 
 	exists, err := d.runtime.PodExists(podSpec.Name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check pod existence: %w", err)
+		return nil, "", "", fmt.Errorf("failed to check pod existence: %w", err)
 	}
 
 	if exists {
 		logger.Infof("Pod '%s' already exists, skipping deployment\n", podSpec.Name)
 
-		return d.extractPodEndpoints(&podSpec), nil
+		return d.extractPodEndpoints(&podSpec), podSpec.Name, routes, nil
 	}
 
 	// Deploy using rendered bytes directly (same as components)
 	if err := d.deployPodSpec(&podSpec, renderedBytes, podTemplateName); err != nil {
-		return nil, err
+		return nil, "", "", err
 	}
 
 	logger.Infof("Service template '%s' deployed successfully\n", podTemplateName)
 
-	return d.extractPodEndpoints(&podSpec), nil
+	return d.extractPodEndpoints(&podSpec), podSpec.Name, routes, nil
 }
 
 // extractPodEndpoints extracts endpoint information from a pod specification.
@@ -1086,3 +1140,73 @@ func generateInstanceSlug(id string) string {
 }
 
 // Made with Bob
+
+// registerApplicationRoutes registers routes for all services with Caddy proxy.
+func (d *PodmanDeployer) registerApplicationRoutes(ctx context.Context, plan *DeploymentPlan) error {
+	logger.Infof("Registering routes for application '%s'\n", plan.ApplicationName)
+
+	// Collect all routes from services
+	allRoutes := make(map[string]string) // podName -> routes annotation
+	logger.Infof("DEBUG: Checking %d services for routes\n", len(plan.Services))
+	for serviceID, svc := range plan.Services {
+		logger.Infof("DEBUG: Service '%s' has %d routes entries\n", serviceID, len(svc.Routes))
+		if len(svc.Routes) > 0 {
+			logger.Infof("Service '%s' has %d pod(s) with routes\n", serviceID, len(svc.Routes))
+			for podName, routes := range svc.Routes {
+				allRoutes[podName] = routes
+			}
+		}
+	}
+
+	if len(allRoutes) == 0 {
+		logger.Infof("No routes found for application '%s', skipping route registration\n", plan.ApplicationName)
+
+		return nil
+	}
+
+	// Find catalog Caddy pod
+	caddyPodName, err := d.findCatalogCaddyPod()
+	if err != nil {
+		return fmt.Errorf("failed to find catalog Caddy pod: %w", err)
+	}
+
+	logger.Infof("Found catalog Caddy pod: %s\n", caddyPodName)
+
+	// Register routes for each pod
+	var registrationErrors []error
+	for podName, routes := range allRoutes {
+		if _, err := proxy.RegisterRoutesForAppAndReturn(
+			d.runtime,
+			catalogconstants.CatalogAppName,
+			constants.CaddyServerName,
+			routes,
+			caddyPodName,
+			podName,
+		); err != nil {
+			registrationErrors = append(registrationErrors, fmt.Errorf("pod %s: %w", podName, err))
+
+			continue
+		}
+	}
+
+	if len(registrationErrors) > 0 {
+		return fmt.Errorf("failed to register routes for %d pod(s): %w", len(registrationErrors), errors.Join(registrationErrors...))
+	}
+
+	logger.Infof("Registered %d route(s) for application '%s'\n", len(allRoutes), plan.ApplicationName)
+
+	return nil
+}
+
+// findCatalogCaddyPod finds the catalog Caddy pod name from catalog templates.
+func (d *PodmanDeployer) findCatalogCaddyPod() (string, error) {
+	tp := templates.NewEmbedTemplateProvider(&assets.CatalogFS, "")
+	argParams := make(map[string]string)
+
+	caddyPodName, err := proxy.FindCaddyPodNameFromTemplates(tp, "catalog", catalogconstants.CatalogAppName, argParams)
+	if err != nil {
+		return "", fmt.Errorf("failed to find Caddy pod from templates: %w", err)
+	}
+
+	return caddyPodName, nil
+}

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -730,53 +730,89 @@ func (d *PodmanDeployer) deployServicePods(
 
 	// If PodTemplateExecutions is defined, use it for ordered deployment
 	if len(metadata.PodTemplateExecutions) > 0 {
-		// Execute each pod template in the service following the defined order
-		for _, layer := range metadata.PodTemplateExecutions {
-			for _, podTemplateName := range layer {
-				// Prepare initialParams for the template
-				initialParams := map[string]any{
-					"InstanceSlug": generateInstanceSlug(applicationID.String()),
-					"TemplateID":   svc.DatabaseID,
-					"BaseDir":      utils.GetBaseDir(),
-					"Values":       values,
-					"env":          map[string]map[string]string{},
-				}
+		return d.deployPodTemplatesInOrder(applicationID, svc, metadata, tmpls, values)
+	}
 
-				_, podName, routes, err := d.deployPodTemplate(podTemplateName, tmpls, initialParams)
-				if err != nil {
-					return fmt.Errorf("failed to deploy pod template %s: %w", podTemplateName, err)
-				}
+	// If no PodTemplateExecutions defined, deploy all templates
+	logger.Infof("No PodTemplateExecutions defined for service %s, deploying all templates\n", svc.CatalogID)
 
-				if routes != "" {
-					svc.Routes[podName] = routes
-				}
-			}
-		}
-	} else {
-		// If no PodTemplateExecutions defined, deploy all templates
-		logger.Infof("No PodTemplateExecutions defined for service %s, deploying all templates\n", svc.CatalogID)
-		for templateName := range tmpls {
-			// Prepare initialParams for the template
-			initialParams := map[string]any{
-				"InstanceSlug": generateInstanceSlug(applicationID.String()),
-				"TemplateID":   svc.DatabaseID,
-				"BaseDir":      utils.GetBaseDir(),
-				"Values":       values,
-				"env":          map[string]map[string]string{},
-			}
+	return d.deployAllPodTemplates(applicationID, svc, tmpls, values)
+}
 
-			_, podName, routes, err := d.deployPodTemplate(templateName, tmpls, initialParams)
-			if err != nil {
-				return fmt.Errorf("failed to deploy pod template %s: %w", templateName, err)
-			}
-
-			if routes != "" {
-				svc.Routes[podName] = routes
-			}
+// deployPodTemplatesInOrder deploys pod templates following the defined execution order.
+func (d *PodmanDeployer) deployPodTemplatesInOrder(
+	applicationID uuid.UUID,
+	svc *ServicePlan,
+	metadata *templates.AppMetadata,
+	tmpls map[string]*template.Template,
+	values map[string]any,
+) error {
+	// Execute each pod template in the service following the defined order
+	for _, layer := range metadata.PodTemplateExecutions {
+		if err := d.deployPodTemplateLayer(applicationID, svc, layer, tmpls, values); err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+// deployPodTemplateLayer deploys all pod templates in a single layer.
+func (d *PodmanDeployer) deployPodTemplateLayer(
+	applicationID uuid.UUID,
+	svc *ServicePlan,
+	layer []string,
+	tmpls map[string]*template.Template,
+	values map[string]any,
+) error {
+	for _, podTemplateName := range layer {
+		initialParams := d.buildInitialParams(applicationID, svc.DatabaseID, values)
+
+		_, podName, routes, err := d.deployPodTemplate(podTemplateName, tmpls, initialParams)
+		if err != nil {
+			return fmt.Errorf("failed to deploy pod template %s: %w", podTemplateName, err)
+		}
+
+		if routes != "" {
+			svc.Routes[podName] = routes
+		}
+	}
+
+	return nil
+}
+
+// deployAllPodTemplates deploys all pod templates without a specific order.
+func (d *PodmanDeployer) deployAllPodTemplates(
+	applicationID uuid.UUID,
+	svc *ServicePlan,
+	tmpls map[string]*template.Template,
+	values map[string]any,
+) error {
+	for templateName := range tmpls {
+		initialParams := d.buildInitialParams(applicationID, svc.DatabaseID, values)
+
+		_, podName, routes, err := d.deployPodTemplate(templateName, tmpls, initialParams)
+		if err != nil {
+			return fmt.Errorf("failed to deploy pod template %s: %w", templateName, err)
+		}
+
+		if routes != "" {
+			svc.Routes[podName] = routes
+		}
+	}
+
+	return nil
+}
+
+// buildInitialParams creates the initial parameters map for template deployment.
+func (d *PodmanDeployer) buildInitialParams(applicationID uuid.UUID, databaseID uuid.UUID, values map[string]any) map[string]any {
+	return map[string]any{
+		"InstanceSlug": generateInstanceSlug(applicationID.String()),
+		"TemplateID":   databaseID,
+		"BaseDir":      utils.GetBaseDir(),
+		"Values":       values,
+		"env":          map[string]map[string]string{},
+	}
 }
 
 // deployComponentTemplate deploys a component pod template.

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -134,11 +134,11 @@ func (d *PodmanDeployer) ExecuteDeployment(
 		}
 	}
 
-	logger.Infof("Starting routing for '%s'\n", plan.ApplicationName)
 	// Step 5: Register routes with Caddy proxy
 	if err := d.registerApplicationRoutes(ctx, plan); err != nil {
-		logger.Errorf("Failed to register routes: %v\n", err)
-		// Don't fail deployment if route registration fails
+		d.handleDeploymentError(ctx, plan.ApplicationID, "Failed to register application routes", err)
+
+		return fmt.Errorf("failed to register application routes: %w", err)
 	}
 
 	// Step 6: Update application status to Running
@@ -734,8 +734,6 @@ func (d *PodmanDeployer) deployServicePods(
 	}
 
 	// If no PodTemplateExecutions defined, deploy all templates
-	logger.Infof("No PodTemplateExecutions defined for service %s, deploying all templates\n", svc.CatalogID)
-
 	return d.deployAllPodTemplates(applicationID, svc, tmpls, values)
 }
 
@@ -1024,15 +1022,9 @@ func (d *PodmanDeployer) deployPodTemplate(
 	// Extract routes annotation if present
 	routes := ""
 	if podSpec.Annotations != nil {
-		logger.Infof("DEBUG: Pod '%s' annotations: %+v\n", podSpec.Name, podSpec.Annotations)
 		if r, ok := podSpec.Annotations[constants.PodRoutesAnnotationKey]; ok {
 			routes = r
-			logger.Infof("DEBUG: Found routes annotation for pod '%s': %s\n", podSpec.Name, routes)
-		} else {
-			logger.Infof("DEBUG: No routes annotation found for pod '%s' (key: %s)\n", podSpec.Name, constants.PodRoutesAnnotationKey)
 		}
-	} else {
-		logger.Infof("DEBUG: Pod '%s' has nil annotations\n", podSpec.Name)
 	}
 
 	exists, err := d.runtime.PodExists(podSpec.Name)
@@ -1164,11 +1156,8 @@ func (d *PodmanDeployer) registerApplicationRoutes(ctx context.Context, plan *De
 
 	// Collect all routes from services
 	allRoutes := make(map[string]string) // podName -> routes annotation
-	logger.Infof("DEBUG: Checking %d services for routes\n", len(plan.Services))
-	for serviceID, svc := range plan.Services {
-		logger.Infof("DEBUG: Service '%s' has %d routes entries\n", serviceID, len(svc.Routes))
+	for _, svc := range plan.Services {
 		if len(svc.Routes) > 0 {
-			logger.Infof("Service '%s' has %d pod(s) with routes\n", serviceID, len(svc.Routes))
 			for podName, routes := range svc.Routes {
 				allRoutes[podName] = routes
 			}
@@ -1193,9 +1182,6 @@ func (d *PodmanDeployer) registerApplicationRoutes(ctx context.Context, plan *De
 	if hostIP == "" {
 		return fmt.Errorf("HOST_IP environment variable not set")
 	}
-
-	logger.Infof("Using Caddy admin URL: %s\n", adminURL)
-	logger.Infof("Using host IP: %s\n", hostIP)
 
 	// Register routes for each pod
 	var registrationErrors []error

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -1008,7 +1008,7 @@ func (d *PodmanDeployer) deployPodTemplate(
 	// Render template to get both PodSpec and raw bytes
 	var rendered bytes.Buffer
 	if err := podTemplate.Execute(&rendered, initialParams); err != nil {
-		return nil, fmt.Errorf("failed to render template %s: %w", podTemplateName, err)
+		return nil, "", "", fmt.Errorf("failed to render template %s: %w", podTemplateName, err)
 	}
 
 	renderedBytes := rendered.Bytes()

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/types/plan.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/types/plan.go
@@ -35,12 +35,13 @@ type ComponentPlan struct {
 
 // ServicePlan represents a single service deployment.
 type ServicePlan struct {
-	CatalogID     string         // Service catalog ID (e.g., "chat", "digitize")
-	CatalogPath   string         // Dynamic catalog path (e.g., "services/chat/podman")
-	DatabaseID    uuid.UUID      // Database UUID for this service record (set after DB insertion)
-	Version       string         // Service version
-	ComponentRefs []string       // List of component hashes this service uses
-	Values        map[string]any // Structured values from LoadServiceValues + component values
+	CatalogID     string            // Service catalog ID (e.g., "chat", "digitize")
+	CatalogPath   string            // Dynamic catalog path (e.g., "services/chat/podman")
+	DatabaseID    uuid.UUID         // Database UUID for this service record (set after DB insertion)
+	Version       string            // Service version
+	ComponentRefs []string          // List of component hashes this service uses
+	Values        map[string]any    // Structured values from LoadServiceValues + component values
+	Routes        map[string]string // Routes extracted during deployment: podName -> routes annotation
 }
 
 // SpyreCardPool manages allocation of PCI addresses to components.

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -60,8 +60,8 @@ func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, b
 		return nil
 	}
 
-	// Prepare deployment
-	hostIP, caddyPodName, caddyAdminURL, values, err := prepareCatalogDeployment(tp, podmanURI, passwordHash, baseDir, argParams, s)
+	// Prepare deployment with authFilePath
+	hostIP, caddyPodName, caddyAdminURL, values, err := prepareCatalogDeployment(tp, podmanURI, authFilePath, passwordHash, baseDir, argParams, s)
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func initializeCatalogDeployment(argParams map[string]string, httpsPort int, s *
 }
 
 // prepareCatalogDeployment prepares all necessary data for deployment.
-func prepareCatalogDeployment(tp templates.Template, podmanURI, passwordHash, baseDir string, argParams map[string]string, s *spinner.Spinner) (string, string, string, map[string]any, error) {
+func prepareCatalogDeployment(tp templates.Template, podmanURI, authFilePath, passwordHash, baseDir string, argParams map[string]string, s *spinner.Spinner) (string, string, string, map[string]any, error) {
 	// Get host IP for template rendering
 	hostIP, err := utils.GetHostIP()
 	if err != nil {
@@ -133,7 +133,7 @@ func prepareCatalogDeployment(tp templates.Template, podmanURI, passwordHash, ba
 	caddyAdminURL := fmt.Sprintf("http://%s:2019", caddyPodName)
 
 	// Prepare values with configure-specific configuration
-	values, err := prepareCatalogValues(tp, podmanURI, passwordHash, argParams)
+	values, err := prepareCatalogValues(tp, podmanURI, authFilePath, passwordHash, argParams)
 	if err != nil {
 		s.Fail("failed to load values")
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -39,29 +39,16 @@ func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, b
 	s := spinner.New("Deploying catalog service...")
 	s.Start(ctx)
 
-	// Initialize runtime
-	rt, err := podman.NewPodmanClient()
-	if err != nil {
-		s.Fail("failed to initialize podman client")
-
-		return fmt.Errorf("failed to initialize podman client: %w", err)
-	}
-
-	// Load template provider and metadata
-	tp, appMetadata, tmpls, err := loadCatalogTemplates(s)
-	if err != nil {
-		s.Fail("failed to load catalog templates")
-
-		return fmt.Errorf("failed to load catalog templates: %w", err)
-	}
-
-	// Set httpsPort in argParams before any template loading
+	// Initialize argParams if nil to ensure modifications are preserved
 	if argParams == nil {
 		argParams = make(map[string]string)
 	}
-	argParams["caddy.httpsPort"] = fmt.Sprintf("%d", httpsPort)
 
-	// collect all secret names used as part of deployment
+	rt, tp, appMetadata, tmpls, err := initializeCatalogDeployment(s, argParams, httpsPort)
+	if err != nil {
+		return err
+	}
+
 	isDeployed, existingResources, err := checkCatalogStatus(rt, tp, tmpls, argParams)
 	if err != nil {
 		s.Fail("failed to check existing resources")
@@ -76,23 +63,12 @@ func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, b
 		return nil
 	}
 
-	// Prepare values with configure-specific configuration
-	values, err := prepareCatalogValues(tp, podmanURI, authFilePath, passwordHash, argParams)
+	hostIP, values, err := prepareCatalogDeployment(tp, podmanURI, authFilePath, passwordHash, baseDir, argParams, s)
 	if err != nil {
-		s.Fail("failed to load values")
-
-		return fmt.Errorf("failed to load values: %w", err)
+		return err
 	}
 
-	// Generate and write Caddyfile before deploying
-	if err := generateCaddyfile(baseDir, values); err != nil {
-		s.Fail("failed to generate Caddyfile")
-
-		return fmt.Errorf("failed to generate Caddyfile: %w", err)
-	}
-
-	// Execute pod templates
-	if err := executePodLayers(rt, tp, tmpls, appMetadata, values, baseDir, argParams, s, existingResources); err != nil {
+	if err := executePodLayers(rt, tp, tmpls, appMetadata, values, baseDir, hostIP, argParams, s, existingResources); err != nil {
 		return err
 	}
 
@@ -100,6 +76,53 @@ func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, b
 	logger.Infoln("-------")
 
 	return handlePostDeployment(rt, tp, argParams)
+}
+
+// initializeCatalogDeployment initializes runtime and loads catalog templates.
+func initializeCatalogDeployment(s *spinner.Spinner, argParams map[string]string, httpsPort int) (*podman.PodmanClient, templates.Template, *templates.AppMetadata, map[string]*template.Template, error) {
+	rt, err := podman.NewPodmanClient()
+	if err != nil {
+		s.Fail("failed to initialize podman client")
+
+		return nil, nil, nil, nil, fmt.Errorf("failed to initialize podman client: %w", err)
+	}
+
+	tp, appMetadata, tmpls, err := loadCatalogTemplates(s)
+	if err != nil {
+		s.Fail("failed to load catalog templates")
+
+		return nil, nil, nil, nil, fmt.Errorf("failed to load catalog templates: %w", err)
+	}
+
+	// Set HTTPS port in argParams (caller ensures argParams is not nil)
+	argParams["caddy.httpsPort"] = fmt.Sprintf("%d", httpsPort)
+
+	return rt, tp, appMetadata, tmpls, nil
+}
+
+// prepareCatalogDeployment prepares host IP, values, and Caddyfile for deployment.
+func prepareCatalogDeployment(tp templates.Template, podmanURI, passwordHash, baseDir string, argParams map[string]string, s *spinner.Spinner) (string, map[string]any, error) {
+	hostIP, err := utils.GetHostIP()
+	if err != nil {
+		s.Fail("failed to get host IP")
+
+		return "", nil, fmt.Errorf("failed to get host IP: %w", err)
+	}
+
+	values, err := prepareCatalogValues(tp, podmanURI, passwordHash, argParams)
+	if err != nil {
+		s.Fail("failed to load values")
+
+		return "", nil, fmt.Errorf("failed to load values: %w", err)
+	}
+
+	if err := generateCaddyfile(baseDir, values); err != nil {
+		s.Fail("failed to generate Caddyfile")
+
+		return "", nil, fmt.Errorf("failed to generate Caddyfile: %w", err)
+	}
+
+	return hostIP, values, nil
 }
 
 // handlePostDeployment handles route registration and next steps display after catalog deployment.
@@ -173,6 +196,11 @@ func prepareCatalogValues(tp templates.Template, podmanURI, authFilePath, passwo
 	// Base64 encode the auth file content for Kubernetes secret
 	authFileBase64 := base64.StdEncoding.EncodeToString(authFileContent)
 
+	// Initialize argParams if nil
+	if argParams == nil {
+		argParams = make(map[string]string)
+	}
+
 	// Set configure-specific values
 	argParams["backend.adminPasswordHash"] = passwordHash
 	argParams["backend.runtime"] = "podman"
@@ -186,13 +214,13 @@ func prepareCatalogValues(tp templates.Template, podmanURI, authFilePath, passwo
 
 // executePodLayers executes all pod template layers.
 func executePodLayers(rt *podman.PodmanClient, tp templates.Template, tmpls map[string]*template.Template,
-	appMetadata *templates.AppMetadata, values map[string]any, baseDir string, argParams map[string]string,
+	appMetadata *templates.AppMetadata, values map[string]any, baseDir, hostIP string, argParams map[string]string,
 	s *spinner.Spinner, existingResources []string) error {
 	for i, layer := range appMetadata.PodTemplateExecutions {
 		logger.Infof("\n Executing Layer %d/%d: %v\n", i+1, len(appMetadata.PodTemplateExecutions), layer)
 		logger.Infoln("-------")
 
-		if err := executeLayer(rt, tp, tmpls, layer, appMetadata.Version, values, baseDir, argParams, i, existingResources); err != nil {
+		if err := executeLayer(rt, tp, tmpls, layer, appMetadata.Version, values, baseDir, hostIP, argParams, i, existingResources); err != nil {
 			s.Fail("failed to deploy catalog pod")
 
 			return err
@@ -206,7 +234,7 @@ func executePodLayers(rt *podman.PodmanClient, tp templates.Template, tmpls map[
 
 // executeLayer executes a single layer of pod templates.
 func executeLayer(rt *podman.PodmanClient, tp templates.Template, tmpls map[string]*template.Template,
-	layer []string, version string, values map[string]any, baseDir string, argParams map[string]string,
+	layer []string, version string, values map[string]any, baseDir, hostIP string, argParams map[string]string,
 	layerIndex int, existingResources []string) error {
 	var wg sync.WaitGroup
 	errCh := make(chan error, len(layer))
@@ -216,7 +244,7 @@ func executeLayer(rt *podman.PodmanClient, tp templates.Template, tmpls map[stri
 		wg.Add(1)
 		go func(t string) {
 			defer wg.Done()
-			if err := executePodTemplate(rt, tp, tmpls, t, catalogAppTemplate, catalogconstants.CatalogAppName, values, version, nil, baseDir, argParams, existingResources); err != nil {
+			if err := executePodTemplate(rt, tp, tmpls, t, catalogAppTemplate, catalogconstants.CatalogAppName, values, version, nil, baseDir, hostIP, argParams, existingResources); err != nil {
 				errCh <- err
 			}
 		}(podTemplateName)
@@ -242,7 +270,7 @@ func executeLayer(rt *podman.PodmanClient, tp templates.Template, tmpls map[stri
 // executePodTemplate executes a single pod template.
 func executePodTemplate(rt *podman.PodmanClient, tp templates.Template, tmpls map[string]*template.Template,
 	podTemplateName, appTemplateName, appName string, values map[string]any, version string,
-	valuesFiles []string, baseDir string, argParams map[string]string, existingResources []string) error {
+	valuesFiles []string, baseDir, hostIP string, argParams map[string]string, existingResources []string) error {
 	logger.Infof("Processing template: %s\n", podTemplateName)
 
 	// Fetch pod spec
@@ -257,6 +285,7 @@ func executePodTemplate(rt *podman.PodmanClient, tp templates.Template, tmpls ma
 		"AppTemplateName": appTemplateName,
 		"Version":         version,
 		"BaseDir":         baseDir,
+		"HostIP":          hostIP,
 		"Values":          values,
 		"env":             map[string]map[string]string{},
 	}
@@ -384,32 +413,6 @@ func extractAllRoutesFromTemplates(tp templates.Template, appTemplateName string
 	return routeInfos, nil
 }
 
-// findCaddyPodNameFromTemplates finds the Caddy pod name by looking for the pod with component=proxy label in templates.
-func findCaddyPodNameFromTemplates(tp templates.Template, appTemplateName string, argParams map[string]string) (string, error) {
-	// Load all templates
-	tmpls, err := tp.LoadAllTemplates(appTemplateName)
-	if err != nil {
-		return "", fmt.Errorf("failed to load templates: %w", err)
-	}
-
-	// Loop through all templates to find the Caddy pod
-	for templateName := range tmpls {
-		podSpec, err := tp.LoadPodTemplateWithValues(appTemplateName, templateName, catalogconstants.CatalogAppName, nil, argParams)
-		if err != nil {
-			return "", fmt.Errorf("failed to load template %s: %w", templateName, err)
-		}
-
-		// Check if this is the Caddy pod (component=proxy label)
-		if podSpec.Labels != nil {
-			if component, ok := podSpec.Labels["ai-services.io/component"]; ok && component == "proxy" {
-				return podSpec.Name, nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("no Caddy pod found with component=proxy label in templates")
-}
-
 // registerCatalogRoutes registers routes with Caddy and returns route domains and HTTPS port.
 func registerCatalogRoutes(rt *podman.PodmanClient, tp templates.Template, appTemplateName string, argParams map[string]string) (map[string]string, string, error) {
 	// Extract routes from all templates
@@ -425,7 +428,7 @@ func registerCatalogRoutes(rt *podman.PodmanClient, tp templates.Template, appTe
 	}
 
 	// Find Caddy pod from templates
-	caddyPodName, err := findCaddyPodNameFromTemplates(tp, appTemplateName, argParams)
+	caddyPodName, err := proxy.FindCaddyPodNameFromTemplates(tp, appTemplateName, catalogconstants.CatalogAppName, argParams)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to find Caddy pod: %w", err)
 	}
@@ -464,35 +467,24 @@ func registerCatalogRoutes(rt *podman.PodmanClient, tp templates.Template, appTe
 		return nil, "", fmt.Errorf("failed to register routes for %d pod(s): %w", len(registrationErrors), errors.Join(registrationErrors...))
 	}
 
-	// Get Caddy HTTPS port
-	httpsPort, err := getCaddyHTTPSPort(rt, caddyPodName)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Caddy HTTPS port: %w", err)
-	}
+	// Get Caddy HTTPS port from argParams
+	httpsPort := getCaddyHTTPSPort(argParams)
 
 	logger.Infof("Successfully registered routes for %d pod(s)\n", len(routeInfos))
 
 	return routeDomains, httpsPort, nil
 }
 
-// getCaddyHTTPSPort retrieves the host port mapped to Caddy's HTTPS port (container port 443).
-func getCaddyHTTPSPort(rt *podman.PodmanClient, caddyPodName string) (string, error) {
-	pod, err := rt.InspectPod(caddyPodName)
-	if err != nil {
-		return "", fmt.Errorf("failed to inspect Caddy pod: %w", err)
+// getCaddyHTTPSPort retrieves the configured HTTPS port from argParams.
+// Returns the port that users should use to access HTTPS services (typically 443).
+func getCaddyHTTPSPort(argParams map[string]string) string {
+	// Get the configured HTTPS port from argParams
+	if httpsPort, ok := argParams["caddy.httpsPort"]; ok {
+		return httpsPort
 	}
 
-	// Get port mappings from the Ports field
-	// Ports is a map[string][]string where key is "containerPort/protocol" and value is list of host ports
-	// Example: {"443/tcp": ["39341"], "2019/tcp": ["37249"]}
-	for containerPort, hostPorts := range pod.Ports {
-		// Check if this is the HTTPS port (443)
-		if strings.HasPrefix(containerPort, "443/") && len(hostPorts) > 0 {
-			return hostPorts[0], nil
-		}
-	}
-
-	return "", fmt.Errorf("HTTPS port mapping not found in pod ports")
+	// Default to 443 if not configured
+	return "443"
 }
 
 // GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service.
@@ -505,12 +497,6 @@ func GetCatalogRouteInfo(rt *podman.PodmanClient, tp templates.Template, appTemp
 
 	if len(routeInfos) == 0 {
 		return nil, "", fmt.Errorf("no templates found with routes annotation")
-	}
-
-	// Find Caddy pod from templates
-	caddyPodName, err := findCaddyPodNameFromTemplates(tp, appTemplateName, argParams)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to find Caddy pod: %w", err)
 	}
 
 	// Get host IP for route domain generation
@@ -540,11 +526,8 @@ func GetCatalogRouteInfo(rt *podman.PodmanClient, tp templates.Template, appTemp
 		}
 	}
 
-	// Get Caddy HTTPS port
-	httpsPort, err := getCaddyHTTPSPort(rt, caddyPodName)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Caddy HTTPS port: %w", err)
-	}
+	// Get Caddy HTTPS port from argParams
+	httpsPort := getCaddyHTTPSPort(argParams)
 
 	return routeDomains, httpsPort, nil
 }

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -39,29 +39,13 @@ func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, b
 	s := spinner.New("Deploying catalog service...")
 	s.Start(ctx)
 
-	// Initialize runtime
-	rt, err := podman.NewPodmanClient()
+	// Initialize and validate
+	rt, tp, appMetadata, tmpls, argParams, err := initializeCatalogDeployment(argParams, httpsPort, s)
 	if err != nil {
-		s.Fail("failed to initialize podman client")
-
-		return fmt.Errorf("failed to initialize podman client: %w", err)
+		return err
 	}
 
-	// Load template provider and metadata
-	tp, appMetadata, tmpls, err := loadCatalogTemplates(s)
-	if err != nil {
-		s.Fail("failed to load catalog templates")
-
-		return fmt.Errorf("failed to load catalog templates: %w", err)
-	}
-
-	// Set httpsPort in argParams before any template loading
-	if argParams == nil {
-		argParams = make(map[string]string)
-	}
-	argParams["caddy.httpsPort"] = fmt.Sprintf("%d", httpsPort)
-
-	// collect all secret names used as part of deployment
+	// Check existing deployment status
 	isDeployed, existingResources, err := checkCatalogStatus(rt, tp, tmpls, argParams)
 	if err != nil {
 		s.Fail("failed to check existing resources")
@@ -76,76 +60,10 @@ func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, b
 		return nil
 	}
 
-	hostIP, values, err := prepareCatalogDeployment(tp, podmanURI, authFilePath, passwordHash, baseDir, argParams, s)
+	// Prepare deployment
+	hostIP, caddyPodName, caddyAdminURL, values, err := prepareCatalogDeployment(tp, podmanURI, passwordHash, baseDir, argParams, s)
 	if err != nil {
 		return err
-	}
-
-	if err := executePodLayers(rt, tp, tmpls, appMetadata, values, baseDir, hostIP, argParams, s, existingResources); err != nil {
-		return err
-	}
-
-	s.Stop("Catalog service deployed successfully")
-	logger.Infoln("-------")
-
-	return handlePostDeployment(rt, tp, argParams)
-}
-
-// initializeCatalogDeployment initializes runtime and loads catalog templates.
-func initializeCatalogDeployment(s *spinner.Spinner, argParams map[string]string, httpsPort int) (*podman.PodmanClient, templates.Template, *templates.AppMetadata, map[string]*template.Template, error) {
-	rt, err := podman.NewPodmanClient()
-	if err != nil {
-		s.Fail("failed to initialize podman client")
-
-		return nil, nil, nil, nil, fmt.Errorf("failed to initialize podman client: %w", err)
-	}
-
-	tp, appMetadata, tmpls, err := loadCatalogTemplates(s)
-	if err != nil {
-		s.Fail("failed to load catalog templates")
-
-		return nil, nil, nil, nil, fmt.Errorf("failed to load catalog templates: %w", err)
-	}
-
-	// Set HTTPS port in argParams (caller ensures argParams is not nil)
-	argParams["caddy.httpsPort"] = fmt.Sprintf("%d", httpsPort)
-
-	return rt, tp, appMetadata, tmpls, nil
-}
-
-// prepareCatalogDeployment prepares host IP, values, and Caddyfile for deployment.
-func prepareCatalogDeployment(tp templates.Template, podmanURI, passwordHash, baseDir string, argParams map[string]string, s *spinner.Spinner) (string, map[string]any, error) {
-	hostIP, err := utils.GetHostIP()
-	if err != nil {
-		s.Fail("failed to get host IP")
-
-		return fmt.Errorf("failed to get host IP: %w", err)
-	}
-
-	// Find Caddy pod name from templates to build admin URL for container
-	caddyPodName, err := findCaddyPodNameFromTemplates(tp, catalogAppTemplate, argParams)
-	if err != nil {
-		s.Fail("failed to find Caddy pod name")
-
-		return fmt.Errorf("failed to find Caddy pod name: %w", err)
-	}
-
-	// Build admin URL for container (uses internal port 2019)
-	caddyAdminURL := fmt.Sprintf("http://%s:2019", caddyPodName)
-
-	// Prepare values with configure-specific configuration
-	values, err := prepareCatalogValues(tp, podmanURI, passwordHash, argParams)
-	if err != nil {
-		s.Fail("failed to load values")
-
-		return fmt.Errorf("failed to load values: %w", err)
-	}
-
-	// Generate and write Caddyfile before deploying
-	if err := generateCaddyfile(baseDir, values); err != nil {
-		s.Fail("failed to generate Caddyfile")
-
-		return fmt.Errorf("failed to generate Caddyfile: %w", err)
 	}
 
 	// Execute pod templates
@@ -157,6 +75,79 @@ func prepareCatalogDeployment(tp templates.Template, podmanURI, passwordHash, ba
 	logger.Infoln("-------")
 
 	return handlePostDeployment(rt, tp, argParams, hostIP, caddyPodName)
+}
+
+// initializeCatalogDeployment handles initialization and validation steps.
+func initializeCatalogDeployment(argParams map[string]string, httpsPort int, s *spinner.Spinner) (
+	*podman.PodmanClient,
+	templates.Template,
+	*templates.AppMetadata,
+	map[string]*template.Template,
+	map[string]string,
+	error,
+) {
+	// Initialize runtime
+	rt, err := podman.NewPodmanClient()
+	if err != nil {
+		s.Fail("failed to initialize podman client")
+
+		return nil, nil, nil, nil, nil, fmt.Errorf("failed to initialize podman client: %w", err)
+	}
+
+	// Load template provider and metadata
+	tp, appMetadata, tmpls, err := loadCatalogTemplates(s)
+	if err != nil {
+		s.Fail("failed to load catalog templates")
+
+		return nil, nil, nil, nil, nil, fmt.Errorf("failed to load catalog templates: %w", err)
+	}
+
+	// Set httpsPort in argParams
+	if argParams == nil {
+		argParams = make(map[string]string)
+	}
+	argParams["caddy.httpsPort"] = fmt.Sprintf("%d", httpsPort)
+
+	return rt, tp, appMetadata, tmpls, argParams, nil
+}
+
+// prepareCatalogDeployment prepares all necessary data for deployment.
+func prepareCatalogDeployment(tp templates.Template, podmanURI, passwordHash, baseDir string, argParams map[string]string, s *spinner.Spinner) (string, string, string, map[string]any, error) {
+	// Get host IP for template rendering
+	hostIP, err := utils.GetHostIP()
+	if err != nil {
+		s.Fail("failed to get host IP")
+
+		return "", "", "", nil, fmt.Errorf("failed to get host IP: %w", err)
+	}
+
+	// Find Caddy pod name from templates to build admin URL for container
+	caddyPodName, err := findCaddyPodNameFromTemplates(tp, catalogAppTemplate, argParams)
+	if err != nil {
+		s.Fail("failed to find Caddy pod name")
+
+		return "", "", "", nil, fmt.Errorf("failed to find Caddy pod name: %w", err)
+	}
+
+	// Build admin URL for container (uses internal port 2019)
+	caddyAdminURL := fmt.Sprintf("http://%s:2019", caddyPodName)
+
+	// Prepare values with configure-specific configuration
+	values, err := prepareCatalogValues(tp, podmanURI, passwordHash, argParams)
+	if err != nil {
+		s.Fail("failed to load values")
+
+		return "", "", "", nil, fmt.Errorf("failed to load values: %w", err)
+	}
+
+	// Generate and write Caddyfile before deploying
+	if err := generateCaddyfile(baseDir, values); err != nil {
+		s.Fail("failed to generate Caddyfile")
+
+		return "", "", "", nil, fmt.Errorf("failed to generate Caddyfile: %w", err)
+	}
+
+	return hostIP, caddyPodName, caddyAdminURL, values, nil
 }
 
 // handlePostDeployment handles route registration and next steps display after catalog deployment.

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -39,16 +39,29 @@ func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, b
 	s := spinner.New("Deploying catalog service...")
 	s.Start(ctx)
 
-	// Initialize argParams if nil to ensure modifications are preserved
+	// Initialize runtime
+	rt, err := podman.NewPodmanClient()
+	if err != nil {
+		s.Fail("failed to initialize podman client")
+
+		return fmt.Errorf("failed to initialize podman client: %w", err)
+	}
+
+	// Load template provider and metadata
+	tp, appMetadata, tmpls, err := loadCatalogTemplates(s)
+	if err != nil {
+		s.Fail("failed to load catalog templates")
+
+		return fmt.Errorf("failed to load catalog templates: %w", err)
+	}
+
+	// Set httpsPort in argParams before any template loading
 	if argParams == nil {
 		argParams = make(map[string]string)
 	}
+	argParams["caddy.httpsPort"] = fmt.Sprintf("%d", httpsPort)
 
-	rt, tp, appMetadata, tmpls, err := initializeCatalogDeployment(s, argParams, httpsPort)
-	if err != nil {
-		return err
-	}
-
+	// collect all secret names used as part of deployment
 	isDeployed, existingResources, err := checkCatalogStatus(rt, tp, tmpls, argParams)
 	if err != nil {
 		s.Fail("failed to check existing resources")
@@ -106,31 +119,65 @@ func prepareCatalogDeployment(tp templates.Template, podmanURI, passwordHash, ba
 	if err != nil {
 		s.Fail("failed to get host IP")
 
-		return "", nil, fmt.Errorf("failed to get host IP: %w", err)
+		return fmt.Errorf("failed to get host IP: %w", err)
 	}
 
+	// Find Caddy pod name from templates to build admin URL for container
+	caddyPodName, err := findCaddyPodNameFromTemplates(tp, catalogAppTemplate, argParams)
+	if err != nil {
+		s.Fail("failed to find Caddy pod name")
+
+		return fmt.Errorf("failed to find Caddy pod name: %w", err)
+	}
+
+	// Build admin URL for container (uses internal port 2019)
+	caddyAdminURL := fmt.Sprintf("http://%s:2019", caddyPodName)
+
+	// Prepare values with configure-specific configuration
 	values, err := prepareCatalogValues(tp, podmanURI, passwordHash, argParams)
 	if err != nil {
 		s.Fail("failed to load values")
 
-		return "", nil, fmt.Errorf("failed to load values: %w", err)
+		return fmt.Errorf("failed to load values: %w", err)
 	}
 
+	// Generate and write Caddyfile before deploying
 	if err := generateCaddyfile(baseDir, values); err != nil {
 		s.Fail("failed to generate Caddyfile")
 
-		return "", nil, fmt.Errorf("failed to generate Caddyfile: %w", err)
+		return fmt.Errorf("failed to generate Caddyfile: %w", err)
 	}
 
-	return hostIP, values, nil
+	// Execute pod templates
+	if err := executePodLayers(rt, tp, tmpls, appMetadata, values, baseDir, hostIP, caddyAdminURL, argParams, s, existingResources); err != nil {
+		return err
+	}
+
+	s.Stop("Catalog service deployed successfully")
+	logger.Infoln("-------")
+
+	return handlePostDeployment(rt, tp, argParams, hostIP, caddyPodName)
 }
 
 // handlePostDeployment handles route registration and next steps display after catalog deployment.
-func handlePostDeployment(rt *podman.PodmanClient, tp templates.Template, argParams map[string]string) error {
+func handlePostDeployment(rt *podman.PodmanClient, tp templates.Template, argParams map[string]string, hostIP, caddyPodName string) error {
+	// Get Caddy admin port for route registration (running on host VM during catalog configure)
+	adminPort, err := proxy.GetCaddyAdminPort(rt, caddyPodName)
+	if err != nil {
+		return fmt.Errorf("failed to get Caddy admin port: %w", err)
+	}
+	adminURL := fmt.Sprintf("http://localhost:%s", adminPort)
+
 	// Register routes with Caddy and get the registered route domains
-	routeDomains, httpsPort, err := registerCatalogRoutes(rt, tp, catalogAppTemplate, argParams)
+	routeDomains, err := registerCatalogRoutes(rt, tp, catalogAppTemplate, argParams, hostIP, adminURL)
 	if err != nil {
 		return fmt.Errorf("route registration failed: %w", err)
+	}
+
+	// Get Caddy HTTPS port for next steps display
+	httpsPort, err := getCaddyHTTPSPort(rt, caddyPodName)
+	if err != nil {
+		return fmt.Errorf("failed to get Caddy HTTPS port: %w", err)
 	}
 
 	// Print next steps with proxy route information
@@ -196,11 +243,6 @@ func prepareCatalogValues(tp templates.Template, podmanURI, authFilePath, passwo
 	// Base64 encode the auth file content for Kubernetes secret
 	authFileBase64 := base64.StdEncoding.EncodeToString(authFileContent)
 
-	// Initialize argParams if nil
-	if argParams == nil {
-		argParams = make(map[string]string)
-	}
-
 	// Set configure-specific values
 	argParams["backend.adminPasswordHash"] = passwordHash
 	argParams["backend.runtime"] = "podman"
@@ -214,13 +256,13 @@ func prepareCatalogValues(tp templates.Template, podmanURI, authFilePath, passwo
 
 // executePodLayers executes all pod template layers.
 func executePodLayers(rt *podman.PodmanClient, tp templates.Template, tmpls map[string]*template.Template,
-	appMetadata *templates.AppMetadata, values map[string]any, baseDir, hostIP string, argParams map[string]string,
+	appMetadata *templates.AppMetadata, values map[string]any, baseDir, hostIP, caddyAdminURL string, argParams map[string]string,
 	s *spinner.Spinner, existingResources []string) error {
 	for i, layer := range appMetadata.PodTemplateExecutions {
 		logger.Infof("\n Executing Layer %d/%d: %v\n", i+1, len(appMetadata.PodTemplateExecutions), layer)
 		logger.Infoln("-------")
 
-		if err := executeLayer(rt, tp, tmpls, layer, appMetadata.Version, values, baseDir, hostIP, argParams, i, existingResources); err != nil {
+		if err := executeLayer(rt, tp, tmpls, layer, appMetadata.Version, values, baseDir, hostIP, caddyAdminURL, argParams, i, existingResources); err != nil {
 			s.Fail("failed to deploy catalog pod")
 
 			return err
@@ -234,7 +276,7 @@ func executePodLayers(rt *podman.PodmanClient, tp templates.Template, tmpls map[
 
 // executeLayer executes a single layer of pod templates.
 func executeLayer(rt *podman.PodmanClient, tp templates.Template, tmpls map[string]*template.Template,
-	layer []string, version string, values map[string]any, baseDir, hostIP string, argParams map[string]string,
+	layer []string, version string, values map[string]any, baseDir, hostIP, caddyAdminURL string, argParams map[string]string,
 	layerIndex int, existingResources []string) error {
 	var wg sync.WaitGroup
 	errCh := make(chan error, len(layer))
@@ -244,7 +286,7 @@ func executeLayer(rt *podman.PodmanClient, tp templates.Template, tmpls map[stri
 		wg.Add(1)
 		go func(t string) {
 			defer wg.Done()
-			if err := executePodTemplate(rt, tp, tmpls, t, catalogAppTemplate, catalogconstants.CatalogAppName, values, version, nil, baseDir, hostIP, argParams, existingResources); err != nil {
+			if err := executePodTemplate(rt, tp, tmpls, t, catalogAppTemplate, catalogconstants.CatalogAppName, values, version, nil, baseDir, hostIP, caddyAdminURL, argParams, existingResources); err != nil {
 				errCh <- err
 			}
 		}(podTemplateName)
@@ -270,7 +312,7 @@ func executeLayer(rt *podman.PodmanClient, tp templates.Template, tmpls map[stri
 // executePodTemplate executes a single pod template.
 func executePodTemplate(rt *podman.PodmanClient, tp templates.Template, tmpls map[string]*template.Template,
 	podTemplateName, appTemplateName, appName string, values map[string]any, version string,
-	valuesFiles []string, baseDir, hostIP string, argParams map[string]string, existingResources []string) error {
+	valuesFiles []string, baseDir, hostIP, caddyAdminURL string, argParams map[string]string, existingResources []string) error {
 	logger.Infof("Processing template: %s\n", podTemplateName)
 
 	// Fetch pod spec
@@ -286,6 +328,7 @@ func executePodTemplate(rt *podman.PodmanClient, tp templates.Template, tmpls ma
 		"Version":         version,
 		"BaseDir":         baseDir,
 		"HostIP":          hostIP,
+		"CaddyAdminURL":   caddyAdminURL,
 		"Values":          values,
 		"env":             map[string]map[string]string{},
 	}
@@ -413,27 +456,45 @@ func extractAllRoutesFromTemplates(tp templates.Template, appTemplateName string
 	return routeInfos, nil
 }
 
-// registerCatalogRoutes registers routes with Caddy and returns route domains and HTTPS port.
-func registerCatalogRoutes(rt *podman.PodmanClient, tp templates.Template, appTemplateName string, argParams map[string]string) (map[string]string, string, error) {
+// findCaddyPodNameFromTemplates finds the Caddy pod name by looking for the pod with component=proxy label in templates.
+func findCaddyPodNameFromTemplates(tp templates.Template, appTemplateName string, argParams map[string]string) (string, error) {
+	// Load all templates
+	tmpls, err := tp.LoadAllTemplates(appTemplateName)
+	if err != nil {
+		return "", fmt.Errorf("failed to load templates: %w", err)
+	}
+
+	// Loop through all templates to find the Caddy pod
+	for templateName := range tmpls {
+		podSpec, err := tp.LoadPodTemplateWithValues(appTemplateName, templateName, catalogconstants.CatalogAppName, nil, argParams)
+		if err != nil {
+			return "", fmt.Errorf("failed to load template %s: %w", templateName, err)
+		}
+
+		// Check if this is the Caddy pod (component=proxy label)
+		if podSpec.Labels != nil {
+			if component, ok := podSpec.Labels["ai-services.io/component"]; ok && component == "proxy" {
+				return podSpec.Name, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no Caddy pod found with component=proxy label in templates")
+}
+
+// registerCatalogRoutes registers routes with Caddy and returns route domains.
+func registerCatalogRoutes(rt *podman.PodmanClient, tp templates.Template, appTemplateName string, argParams map[string]string, hostIP, adminURL string) (map[string]string, error) {
 	// Extract routes from all templates
 	routeInfos, err := extractAllRoutesFromTemplates(tp, appTemplateName, argParams)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to extract routes from templates: %w", err)
+		return nil, fmt.Errorf("failed to extract routes from templates: %w", err)
 	}
 
 	if len(routeInfos) == 0 {
 		logger.Infof("No templates found with routes annotation, skipping route registration\n")
 
-		return nil, "", nil
+		return nil, nil
 	}
-
-	// Find Caddy pod from templates
-	caddyPodName, err := proxy.FindCaddyPodNameFromTemplates(tp, appTemplateName, catalogconstants.CatalogAppName, argParams)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to find Caddy pod: %w", err)
-	}
-
-	logger.Infof("Found Caddy pod: %s\n", caddyPodName)
 
 	// Build route domains map
 	routeDomains := make(map[string]string)
@@ -444,7 +505,7 @@ func registerCatalogRoutes(rt *podman.PodmanClient, tp templates.Template, appTe
 		logger.Infof("Registering routes for pod: %s\n", info.PodName)
 
 		// Register routes and get the built routes back
-		routes, err := proxy.RegisterRoutesForAppAndReturn(rt, catalogconstants.CatalogAppName, constants.CaddyServerName, info.RoutesAnnotation, caddyPodName, info.PodName)
+		routes, err := proxy.RegisterRoutesForAppAndReturn(rt, catalogconstants.CatalogAppName, constants.CaddyServerName, info.RoutesAnnotation, adminURL, hostIP, info.PodName)
 		if err != nil {
 			registrationErrors = append(registrationErrors, fmt.Errorf("pod %s: %w", info.PodName, err))
 
@@ -464,27 +525,32 @@ func registerCatalogRoutes(rt *podman.PodmanClient, tp templates.Template, appTe
 
 	// Return error if any routes failed to register
 	if len(registrationErrors) > 0 {
-		return nil, "", fmt.Errorf("failed to register routes for %d pod(s): %w", len(registrationErrors), errors.Join(registrationErrors...))
+		return nil, fmt.Errorf("failed to register routes for %d pod(s): %w", len(registrationErrors), errors.Join(registrationErrors...))
 	}
-
-	// Get Caddy HTTPS port from argParams
-	httpsPort := getCaddyHTTPSPort(argParams)
 
 	logger.Infof("Successfully registered routes for %d pod(s)\n", len(routeInfos))
 
-	return routeDomains, httpsPort, nil
+	return routeDomains, nil
 }
 
-// getCaddyHTTPSPort retrieves the configured HTTPS port from argParams.
-// Returns the port that users should use to access HTTPS services (typically 443).
-func getCaddyHTTPSPort(argParams map[string]string) string {
-	// Get the configured HTTPS port from argParams
-	if httpsPort, ok := argParams["caddy.httpsPort"]; ok {
-		return httpsPort
+// getCaddyHTTPSPort retrieves the host port mapped to Caddy's HTTPS port (container port 443).
+func getCaddyHTTPSPort(rt *podman.PodmanClient, caddyPodName string) (string, error) {
+	pod, err := rt.InspectPod(caddyPodName)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect Caddy pod: %w", err)
 	}
 
-	// Default to 443 if not configured
-	return "443"
+	// Get port mappings from the Ports field
+	// Ports is a map[string][]string where key is "containerPort/protocol" and value is list of host ports
+	// Example: {"443/tcp": ["39341"], "2019/tcp": ["37249"]}
+	for containerPort, hostPorts := range pod.Ports {
+		// Check if this is the HTTPS port (443)
+		if strings.HasPrefix(containerPort, "443/") && len(hostPorts) > 0 {
+			return hostPorts[0], nil
+		}
+	}
+
+	return "", fmt.Errorf("HTTPS port mapping not found in pod ports")
 }
 
 // GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service.
@@ -497,6 +563,12 @@ func GetCatalogRouteInfo(rt *podman.PodmanClient, tp templates.Template, appTemp
 
 	if len(routeInfos) == 0 {
 		return nil, "", fmt.Errorf("no templates found with routes annotation")
+	}
+
+	// Find Caddy pod from templates
+	caddyPodName, err := findCaddyPodNameFromTemplates(tp, appTemplateName, argParams)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to find Caddy pod: %w", err)
 	}
 
 	// Get host IP for route domain generation
@@ -526,8 +598,11 @@ func GetCatalogRouteInfo(rt *podman.PodmanClient, tp templates.Template, appTemp
 		}
 	}
 
-	// Get Caddy HTTPS port from argParams
-	httpsPort := getCaddyHTTPSPort(argParams)
+	// Get Caddy HTTPS port
+	httpsPort, err := getCaddyHTTPSPort(rt, caddyPodName)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get Caddy HTTPS port: %w", err)
+	}
 
 	return routeDomains, httpsPort, nil
 }

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -5,28 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
-	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
-
-// isRunningInContainer checks if the code is running inside a container
-// by checking for the presence of /.dockerenv or /run/.containerenv files.
-func isRunningInContainer() bool {
-	// Check for Docker container indicator
-	if _, err := os.Stat("/.dockerenv"); err == nil {
-		return true
-	}
-	// Check for Podman container indicator
-	if _, err := os.Stat("/run/.containerenv"); err == nil {
-		return true
-	}
-
-	return false
-}
 
 // caddyManager implements ProxyManager interface for Caddy.
 type caddyManager struct {
@@ -155,7 +138,8 @@ func (c *caddyManager) createRoute(routeConfig map[string]interface{}) error {
 //   - appName: Name of the application (e.g., "ai-services" for catalog)
 //   - serverName: Caddy server name (e.g., "ai_services")
 //   - routesAnnotation: Routes annotation value in format "port:subdomain,port:subdomain,..."
-//   - caddyPodName: Name of the Caddy pod
+//   - adminURL: Caddy admin API URL (e.g., "http://localhost:37249" or "http://ai-services--caddy:2019")
+//   - hostIP: Host IP for building route domains (e.g., "192.168.1.100")
 //   - servicePodName: Name of the service pod for upstream configuration
 //
 // Returns:
@@ -166,32 +150,14 @@ func RegisterRoutesForAppAndReturn(
 	appName string,
 	serverName string,
 	routesAnnotation string,
-	caddyPodName string,
+	adminURL string,
+	hostIP string,
 	servicePodName string,
 ) ([]Route, error) {
-	// Step 1: Get Caddy admin port from Caddy pod port mappings
-	adminPort, err := GetCaddyAdminPort(rt, caddyPodName)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"failed to get Caddy admin port, routes not registered: %w",
-			err,
-		)
-	}
-
-	// Step 2: Determine admin URL based on context
-	// If we're running inside a container (catalog backend), use pod name
-	// If we're running on host (CLI), use localhost
-	var adminURL string
-	if isRunningInContainer() {
-		// Running in catalog backend container - use Caddy pod name with internal port
-		adminURL = fmt.Sprintf("http://%s:2019", caddyPodName)
-	} else {
-		// Running on host (CLI) - use localhost with mapped port
-		adminURL = fmt.Sprintf("http://localhost:%s", adminPort)
-	}
+	// Step 1: Create proxy manager with the provided admin URL
 	proxyManager := NewCaddyManager(adminURL, serverName)
 
-	// Step 3: Perform health check on Caddy
+	// Step 2: Perform health check on Caddy
 	if err := proxyManager.HealthCheck(); err != nil {
 		return nil, fmt.Errorf(
 			"caddy health check failed, routes not registered: %w",
@@ -199,25 +165,13 @@ func RegisterRoutesForAppAndReturn(
 		)
 	}
 
-	// Step 4: Get host IP for route domain generation
-	// Prefer HOST_IP env var (set in catalog backend) over auto-detection
-	hostIP := os.Getenv("HOST_IP")
-	if hostIP == "" {
-		// Fallback to auto-detection (for CLI usage)
-		var err error
-		hostIP, err = utils.GetHostIP()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get host IP: %w", err)
-		}
-	}
-
-	// Step 5: Build routes from the annotation string using service pod name for upstreams
+	// Step 3: Build routes from the annotation string using service pod name for upstreams
 	routes, err := BuildRoutesFromAnnotation(routesAnnotation, hostIP, servicePodName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build routes: %w", err)
 	}
 
-	// Step 6: Register each route with Caddy
+	// Step 4: Register each route with Caddy
 	var registrationErrors []error
 	for _, route := range routes {
 		if err := proxyManager.RegisterRoute(route); err != nil {

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -5,12 +5,28 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
+
+// isRunningInContainer checks if the code is running inside a container
+// by checking for the presence of /.dockerenv or /run/.containerenv files.
+func isRunningInContainer() bool {
+	// Check for Docker container indicator
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	// Check for Podman container indicator
+	if _, err := os.Stat("/run/.containerenv"); err == nil {
+		return true
+	}
+
+	return false
+}
 
 // caddyManager implements ProxyManager interface for Caddy.
 type caddyManager struct {
@@ -162,8 +178,17 @@ func RegisterRoutesForAppAndReturn(
 		)
 	}
 
-	// Step 2: Create proxy manager with the discovered admin URL
-	adminURL := fmt.Sprintf("http://localhost:%s", adminPort)
+	// Step 2: Determine admin URL based on context
+	// If we're running inside a container (catalog backend), use pod name
+	// If we're running on host (CLI), use localhost
+	var adminURL string
+	if isRunningInContainer() {
+		// Running in catalog backend container - use Caddy pod name with internal port
+		adminURL = fmt.Sprintf("http://%s:2019", caddyPodName)
+	} else {
+		// Running on host (CLI) - use localhost with mapped port
+		adminURL = fmt.Sprintf("http://localhost:%s", adminPort)
+	}
 	proxyManager := NewCaddyManager(adminURL, serverName)
 
 	// Step 3: Perform health check on Caddy
@@ -175,9 +200,15 @@ func RegisterRoutesForAppAndReturn(
 	}
 
 	// Step 4: Get host IP for route domain generation
-	hostIP, err := utils.GetHostIP()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get host IP: %w", err)
+	// Prefer HOST_IP env var (set in catalog backend) over auto-detection
+	hostIP := os.Getenv("HOST_IP")
+	if hostIP == "" {
+		// Fallback to auto-detection (for CLI usage)
+		var err error
+		hostIP, err = utils.GetHostIP()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get host IP: %w", err)
+		}
 	}
 
 	// Step 5: Build routes from the annotation string using service pod name for upstreams

--- a/ai-services/internal/pkg/proxy/utils.go
+++ b/ai-services/internal/pkg/proxy/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 )
 
@@ -99,6 +100,32 @@ func BuildRoutesFromAnnotation(routesAnnotation, hostIP, podName string) ([]Rout
 	}
 
 	return routes, nil
+}
+
+// FindCaddyPodNameFromTemplates finds the Caddy pod name by looking for the pod with component=proxy label in templates.
+func FindCaddyPodNameFromTemplates(tp templates.Template, appTemplateName, catalogAppName string, argParams map[string]string) (string, error) {
+	// Load all templates
+	tmpls, err := tp.LoadAllTemplates(appTemplateName)
+	if err != nil {
+		return "", fmt.Errorf("failed to load templates: %w", err)
+	}
+
+	// Loop through all templates to find the Caddy pod
+	for templateName := range tmpls {
+		podSpec, err := tp.LoadPodTemplateWithValues(appTemplateName, templateName, catalogAppName, nil, argParams)
+		if err != nil {
+			return "", fmt.Errorf("failed to load template %s: %w", templateName, err)
+		}
+
+		// Check if this is the Caddy pod (component=proxy label)
+		if podSpec.Labels != nil {
+			if component, ok := podSpec.Labels["ai-services.io/component"]; ok && component == "proxy" {
+				return podSpec.Name, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no Caddy pod found with component=proxy label in templates")
 }
 
 // Made with Bob


### PR DESCRIPTION
- Add routes annotation support to all service and application templates
- Implement automatic route extraction and registration during deployment
- Move common code to shared proxy utilities for Caddy pod discovery and route management
- Configure HOST_IP environment variable for consistent domain generation in case of [nip.io](http://nip.io/) domains