### PR TITLE
Fixing opensearch startup issue

### DIFF
--- a/ai-services/assets/applications/rag-dev/openshift/templates/opensearch-statefulset.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/templates/opensearch-statefulset.yaml
@@ -25,6 +25,8 @@ spec:
         ai-services.io/version: {{ default .Chart.AppVersion | quote }}
         ai-services.io/component: vectordb
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: opensearch
           image: "{{ .Values.opensearch.image }}"
@@ -67,7 +69,7 @@ spec:
           startupProbe:
             tcpSocket:
               port: 9200
-            initialDelaySeconds: 5
+            initialDelaySeconds: 60
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 30

--- a/ai-services/assets/applications/rag/openshift/templates/opensearch-statefulset.yaml
+++ b/ai-services/assets/applications/rag/openshift/templates/opensearch-statefulset.yaml
@@ -25,6 +25,8 @@ spec:
         ai-services.io/version: {{ default .Chart.AppVersion | quote }}
         ai-services.io/component: vectordb
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: opensearch
           image: "{{ .Values.opensearch.image }}"
@@ -67,7 +69,7 @@ spec:
           startupProbe:
             tcpSocket:
               port: 9200
-            initialDelaySeconds: 5
+            initialDelaySeconds: 60
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 30


### PR DESCRIPTION
### Problem
The OpenSearch pod was failing to start due to two issues:

1. **Permission denied on data directory** — The mounted volume (`/usr/share/opensearch/data/nodes`) was owned by `root`, but OpenSearch runs as a non-root user, causing the following error on startup:
```
OpenSearchException[failed to bind service]; nested: AccessDeniedException[/usr/share/opensearch/data/nodes];
Likely root cause: java.nio.file.AccessDeniedException: /usr/share/opensearch/data/nodes
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:90)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:414)
```

2. **Startup probe failure** — The pod was not initializing within the configured probe window, causing Kubernetes to repeatedly kill and restart the container.

### Changes
- Set `securityContext.fsGroup: 1000` on the pod spec so the mounted volume is accessible to the `opensearch` user at startup
- Increased `initialDelaySeconds` on the startup probe to allow sufficient time for initialization