### PR TITLE
fix: Add registry authentication for catalog image pulls

### DIFF
--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -149,8 +149,10 @@ spec:
     - name: podman-auth
       hostPath:
         # Mount the auth file from host
+        # For rootless podman: /run/user/$(id -u)/containers/auth.json
+        # For root podman: /run/user/0/containers/auth.json
         # NOTE: Ensure the file has read permissions (chmod 644) for the container user
-        path: /run/user/0/containers/auth.json
+        path: {{ .Values.backend.podman.authFile }}
         type: File
     - name: iommu-groups
       hostPath:

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -93,6 +93,8 @@ spec:
       env:
         - name: CONTAINER_HOST
           value: "unix://{{ .Values.backend.podman.uri }}"
+        - name: REGISTRY_AUTH_FILE
+          value: "/run/containers/auth.json"
         - name: ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -125,6 +127,9 @@ spec:
       volumeMounts:
         - name: podman-socket
           mountPath: {{ .Values.backend.podman.uri }}
+        - name: podman-auth
+          mountPath: /run/containers/auth.json
+          readOnly: true
         - name: iommu-groups
           mountPath: /sys/kernel/iommu_groups
           readOnly: true
@@ -141,6 +146,12 @@ spec:
         # For root podman: /run/podman/podman.sock
         path: {{ .Values.backend.podman.uri }}
         type: Socket
+    - name: podman-auth
+      hostPath:
+        # Mount the auth file from host
+        # NOTE: Ensure the file has read permissions (chmod 644) for the container user
+        path: /run/user/0/containers/auth.json
+        type: File
     - name: iommu-groups
       hostPath:
         path: /sys/kernel/iommu_groups

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -9,6 +9,7 @@ backend:
   adminPasswordHash: ""
   podman:
     uri: "/run/podman/podman.sock"
+    authFile: "/run/user/0/containers/auth.json"
 
 db:
   port: ""

--- a/ai-services/internal/pkg/catalog/cli/configure/common.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/common.go
@@ -45,7 +45,10 @@ func Run(opts ConfigureOptions) error {
 		// Determine Podman URI
 		podmanURI := getPodmanURI()
 
-		return catalogPodman.DeployCatalog(ctx, podmanURI, passwordHashBase64, opts.BaseDir, opts.ArgParams, opts.HttpsPort)
+		// Determine auth file path
+		authFilePath := getAuthFilePath()
+
+		return catalogPodman.DeployCatalog(ctx, podmanURI, authFilePath, passwordHashBase64, opts.BaseDir, opts.ArgParams, opts.HttpsPort)
 
 	case types.RuntimeTypeOpenShift:
 		return fmt.Errorf("openshift runtime is not yet supported for catalog configure")
@@ -60,6 +63,13 @@ func getPodmanURI() string {
 	// TODO: Need to take care for getting rootless socket
 	// Return default local Unix socket
 	return "/run/podman/podman.sock"
+}
+
+// getAuthFilePath determines the auth.json file path.
+func getAuthFilePath() string {
+	// TODO: Need to take care for getting rootless user auth file path
+	// Return default root user auth file path
+	return "/run/user/0/containers/auth.json"
 }
 
 // hashPasswordPBKDF2 generates a PBKDF2 hash of the password with a random salt.

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -35,7 +35,7 @@ const (
 )
 
 // DeployCatalog deploys the catalog service using the assets/catalog template for podman runtime.
-func DeployCatalog(ctx context.Context, podmanURI, passwordHash, baseDir string, argParams map[string]string, httpsPort int) error {
+func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, baseDir string, argParams map[string]string, httpsPort int) error {
 	s := spinner.New("Deploying catalog service...")
 	s.Start(ctx)
 
@@ -77,7 +77,7 @@ func DeployCatalog(ctx context.Context, podmanURI, passwordHash, baseDir string,
 	}
 
 	// Prepare values with configure-specific configuration
-	values, err := prepareCatalogValues(tp, podmanURI, passwordHash, argParams)
+	values, err := prepareCatalogValues(tp, podmanURI, authFilePath, passwordHash, argParams)
 	if err != nil {
 		s.Fail("failed to load values")
 
@@ -157,7 +157,7 @@ func loadCatalogTemplates(s *spinner.Spinner) (templates.Template, *templates.Ap
 }
 
 // prepareCatalogValues prepares the values map with configure-specific configuration.
-func prepareCatalogValues(tp templates.Template, podmanURI, passwordHash string, argParams map[string]string) (map[string]any, error) {
+func prepareCatalogValues(tp templates.Template, podmanURI, authFilePath, passwordHash string, argParams map[string]string) (map[string]any, error) {
 	// Generate database password
 	dbPassword, err := utils.GenerateRandomPassword(utils.DefaultPasswordLength)
 	if err != nil {
@@ -171,6 +171,7 @@ func prepareCatalogValues(tp templates.Template, podmanURI, passwordHash string,
 	argParams["backend.adminPasswordHash"] = passwordHash
 	argParams["backend.runtime"] = "podman"
 	argParams["backend.podman.uri"] = podmanURI
+	argParams["backend.podman.authFile"] = authFilePath
 	argParams["db.password"] = dbPasswordBase64
 
 	// Load values from catalog

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -102,7 +102,14 @@ func (pc *PodmanClient) ListImages() ([]types.Image, error) {
 
 func (pc *PodmanClient) PullImage(image string) error {
 	logger.Infof("Pulling image %s...\n", image)
-	_, err := images.Pull(pc.Context, image, nil)
+
+	// Create pull options with auth file from environment
+	opts := &images.PullOptions{}
+	if authFile := os.Getenv("REGISTRY_AUTH_FILE"); authFile != "" {
+		opts.Authfile = &authFile
+	}
+
+	_, err := images.Pull(pc.Context, image, opts)
 	if err != nil {
 		return fmt.Errorf("failed to pull image %s: %w", image, err)
 	}


### PR DESCRIPTION
Mount registry auth file and pass to Podman API to enable pulling
from private registries like icr.io

**Requires: chmod 644 /run/user/0/containers/auth.json on host**