### PR TITLE
Fix pgdata permission issue on podman

### DIFF
--- a/ai-services/assets/catalog/podman/templates/catalog-db.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog-db.yaml.tmpl
@@ -9,6 +9,20 @@ metadata:
     ai-services.io/secret: "catalog-db-secret"
     ai-services.io/secret-skip-cleanup: "true"
 spec:
+  initContainers:
+  - name: fix-permissions
+    image: "{{ .Values.db.image }}"
+    command:
+    - /bin/sh
+    - -c
+    - |
+      chown -R 26:0 /var/lib/pgsql
+      chmod -R g=u /var/lib/pgsql
+    volumeMounts:
+    - name: postgres-data
+      mountPath: /var/lib/pgsql
+    securityContext:
+      runAsUser: 0
   containers:
   - name: postgresql
     image: "{{ .Values.db.image }}"
@@ -25,9 +39,11 @@ spec:
           key: db-password
     - name: POSTGRES_DB
       value: "{{ .Values.db.database }}"
+    - name: PGDATA
+      value: "/var/lib/pgsql/data"
     volumeMounts:
     - name: postgres-data
-      mountPath: /var/lib/pgsql/18/data
+      mountPath: /var/lib/pgsql
     livenessProbe:
       exec:
         command:
@@ -46,5 +62,5 @@ spec:
   volumes:
   - name: postgres-data
     hostPath:
-      path: {{ .BaseDir }}/db
+      path: "{{ .BaseDir }}/db"
       type: DirectoryOrCreate


### PR DESCRIPTION
Since the host-mounted path could be 0 for root and other ids for non-root and the postgres uid is 26, we were getting permission issues in the entrypoint script for the postgres db pod. To overcome adding a workaround of setting the permission to the pgsql path.
In an ideal case, we could use podman pvc, but then other places in the application need changes ie. delete with/without cleanup, etc. Also, PostgreSQL in the digitize and OpenSearch pod needed a similar fix.