### PR TITLE
Add pod teardown to delete application flow

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.30
+TAG?=0.0.31
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.30
+  image: icr.io/ai-services-cicd/ai-services:0.0.31
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -16,7 +16,6 @@ import (
 	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
-	globalConstants "github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	podmanRuntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
@@ -583,7 +582,7 @@ func (s *ApplicationService) DeleteApplication(ctx context.Context, id uuid.UUID
 		return nil, err
 	}
 
-	go s.performDeletion(context.Background(), id, app.Name, app.Services, force)
+	go s.performDeletion(context.Background(), id, app.Services, force)
 
 	return &DeleteApplicationResponse{
 		ID:      id.String(),
@@ -596,7 +595,7 @@ func (s *ApplicationService) DeleteApplication(ctx context.Context, id uuid.UUID
 // When force is true, orphaned component records are also deleted.
 //
 //nolint:cyclop,gocognit,nestif,funlen
-func (s *ApplicationService) performDeletion(ctx context.Context, appID uuid.UUID, appName string, services []models.Service, force bool) {
+func (s *ApplicationService) performDeletion(ctx context.Context, appID uuid.UUID, services []models.Service, force bool) {
 	serviceIDs := make(map[uuid.UUID]bool, len(services))
 	for _, svc := range services {
 		serviceIDs[svc.ID] = true
@@ -657,21 +656,21 @@ func (s *ApplicationService) performDeletion(ctx context.Context, appID uuid.UUI
 		return
 	}
 
-	pods, err := rt.ListPods(map[string][]string{
-		"label": {fmt.Sprintf("%s=%s", globalConstants.ApplicationAnnotationKey, appName)},
-	})
-	if err != nil {
-		logger.Errorf("failed to list pods for app %s: %s", appID, err)
-		_ = s.appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, "failed to list pods")
-
-		return
-	}
-
 	forceDelete := true
 
-	for _, pod := range pods {
-		if err := rt.DeletePod(pod.ID, &forceDelete); err != nil {
-			logger.Errorf("failed to delete pod %s for app %s: %s", pod.ID, appID, err)
+	for _, svc := range services {
+		pods, err := rt.ListPods(map[string][]string{
+			"label": {fmt.Sprintf("ai-services.io/template=%s", svc.ID)},
+		})
+		if err != nil {
+			logger.Errorf("failed to list pods for service %s: %s", svc.ID, err)
+			continue
+		}
+
+		for _, pod := range pods {
+			if err := rt.DeletePod(pod.ID, &forceDelete); err != nil {
+				logger.Errorf("failed to delete pod %s for service %s: %s", pod.ID, svc.ID, err)
+			}
 		}
 	}
 
@@ -683,6 +682,19 @@ func (s *ApplicationService) performDeletion(ctx context.Context, appID uuid.UUI
 	}
 
 	for _, componentID := range orphanedComponents {
+		pods, err := rt.ListPods(map[string][]string{
+			"label": {fmt.Sprintf("ai-services.io/template=%s", componentID)},
+		})
+		if err != nil {
+			logger.Errorf("failed to list pods for component %s: %s", componentID, err)
+		} else {
+			for _, pod := range pods {
+				if err := rt.DeletePod(pod.ID, &forceDelete); err != nil {
+					logger.Errorf("failed to delete pod %s for component %s: %s", pod.ID, componentID, err)
+				}
+			}
+		}
+
 		if err := s.componentRepo.Delete(ctx, componentID); err != nil {
 			logger.Errorf("failed to delete orphaned component %s: %s", componentID, err)
 		}

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -16,7 +16,9 @@ import (
 	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
+	globalConstants "github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	podmanRuntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 )
 
@@ -581,8 +583,7 @@ func (s *ApplicationService) DeleteApplication(ctx context.Context, id uuid.UUID
 		return nil, err
 	}
 
-	// Service status update deferred until later
-	go s.performDeletion(context.Background(), id, app.Services, force)
+	go s.performDeletion(context.Background(), id, app.Name, app.Services, force)
 
 	return &DeleteApplicationResponse{
 		ID:      id.String(),
@@ -595,7 +596,7 @@ func (s *ApplicationService) DeleteApplication(ctx context.Context, id uuid.UUID
 // When force is true, orphaned component records are also deleted.
 //
 //nolint:cyclop,gocognit,nestif,funlen
-func (s *ApplicationService) performDeletion(ctx context.Context, appID uuid.UUID, services []models.Service, force bool) {
+func (s *ApplicationService) performDeletion(ctx context.Context, appID uuid.UUID, appName string, services []models.Service, force bool) {
 	serviceIDs := make(map[uuid.UUID]bool, len(services))
 	for _, svc := range services {
 		serviceIDs[svc.ID] = true
@@ -644,6 +645,33 @@ func (s *ApplicationService) performDeletion(ctx context.Context, appID uuid.UUI
 			if isOrphan {
 				orphanedComponents = append(orphanedComponents, componentID)
 			}
+		}
+	}
+
+	// delete pods before removing DB records
+	rt, err := podmanRuntime.NewPodmanClient()
+	if err != nil {
+		logger.Errorf("failed to init podman client for app %s: %s", appID, err)
+		_ = s.appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, "failed to init podman client")
+
+		return
+	}
+
+	pods, err := rt.ListPods(map[string][]string{
+		"label": {fmt.Sprintf("%s=%s", globalConstants.ApplicationAnnotationKey, appName)},
+	})
+	if err != nil {
+		logger.Errorf("failed to list pods for app %s: %s", appID, err)
+		_ = s.appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, "failed to list pods")
+
+		return
+	}
+
+	forceDelete := true
+
+	for _, pod := range pods {
+		if err := rt.DeletePod(pod.ID, &forceDelete); err != nil {
+			logger.Errorf("failed to delete pod %s for app %s: %s", pod.ID, appID, err)
 		}
 	}
 

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -664,6 +664,7 @@ func (s *ApplicationService) performDeletion(ctx context.Context, appID uuid.UUI
 		})
 		if err != nil {
 			logger.Errorf("failed to list pods for service %s: %s", svc.ID, err)
+
 			continue
 		}
 


### PR DESCRIPTION
Follow-up from https://github.com/IBM/project-ai-services/pull/822 

Added pod teardown to application flow, this will teardown pods before deleting records in DB. Was requested by @mayuka-c to make this change in a subsequent PR. 

- Init Podman client and lists pods 
- Force deletes each pd before cascade deleting the DB records
- Host data cleanup (BaseDir) deferred to a follow-up PR as confirmed with @mayuka-c on 06/01/2026