### PR TITLE
[Catalog-API] Adding application ps API

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.50
+TAG?=0.0.51
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.50
+  image: icr.io/ai-services-cicd/ai-services:0.0.51
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -1500,6 +1500,46 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Pod": {
+            "type": "object",
+            "properties": {
+                "containers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PodContainer"
+                    }
+                },
+                "created": {
+                    "type": "string"
+                },
+                "healthy": {
+                    "type": "boolean"
+                },
+                "pod_id": {
+                    "type": "string"
+                },
+                "pod_name": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Status"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PodContainer": {
+            "type": "object",
+            "properties": {
+                "healthy": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Status"
+                }
+            }
+        },
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Resources": {
             "type": "object",
             "properties": {
@@ -1560,6 +1600,9 @@ const docTemplate = `{
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceComponentResp": {
             "type": "object",
             "properties": {
+                "id": {
+                    "type": "string"
+                },
                 "metadata": {
                     "type": "object",
                     "additionalProperties": {}
@@ -1608,6 +1651,31 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Status": {
+            "type": "string",
+            "enum": [
+                "waiting",
+                "running",
+                "terminated",
+                "created",
+                "paused",
+                "restarting",
+                "exited",
+                "removing",
+                "dead"
+            ],
+            "x-enum-varnames": [
+                "Waiting",
+                "Running",
+                "Terminated",
+                "Created",
+                "Paused",
+                "Restarting",
+                "Exited",
+                "Removing",
+                "Dead"
+            ]
         },
         "github_com_project-ai-services_ai-services_internal_pkg_models.AcceleratorInfo": {
             "type": "object",

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -362,6 +362,64 @@ const docTemplate = `{
                 }
             }
         },
+        "/applications/{id}/ps": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieves the process status and runtime information for an application",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Applications"
+                ],
+                "summary": "Get application process status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Application ID (UUID)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationPSResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid application ID format",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Application not found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/applications/{id}/resources": {
             "get": {
                 "security": [
@@ -1225,6 +1283,29 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationPSResponse": {
+            "type": "object",
+            "properties": {
+                "components": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Pod"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "services": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Pod"
+                    }
+                }
+            }
+        },
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationResourcesResponse": {
             "type": "object",
             "properties": {
@@ -1600,9 +1681,6 @@ const docTemplate = `{
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceComponentResp": {
             "type": "object",
             "properties": {
-                "id": {
-                    "type": "string"
-                },
                 "metadata": {
                     "type": "object",
                     "additionalProperties": {}

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -356,58 +356,6 @@
                 }
             }
         },
-        "/applications/{id}/resources": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Retrieves used and total allocated CPU (in cores) and memory usage (in bytes), along with the hardware accelerator cards for an application and its services",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Applications"
-                ],
-                "summary": "Get application resources",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Application ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationResourcesResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
-                        }
-                    },
-                    "404": {
-                        "description": "Application not found",
-                        "schema": {
-                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/architectures": {
             "get": {
                 "security": [
@@ -1206,39 +1154,6 @@
                 }
             }
         },
-        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationMemInfo": {
-            "type": "object",
-            "properties": {
-                "total_bytes": {
-                    "description": "Total allocated memory in bytes",
-                    "type": "integer"
-                },
-                "used_bytes": {
-                    "description": "Actually used memory in bytes",
-                    "type": "integer"
-                }
-            }
-        },
-        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationResourcesResponse": {
-            "type": "object",
-            "properties": {
-                "accelerators": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "cpu": {
-                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationCPUInfo"
-                },
-                "memory": {
-                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationMemInfo"
-                }
-            }
-        },
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationService": {
             "type": "object",
             "properties": {
@@ -1494,6 +1409,46 @@
                 }
             }
         },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Pod": {
+            "type": "object",
+            "properties": {
+                "containers": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PodContainer"
+                    }
+                },
+                "created": {
+                    "type": "string"
+                },
+                "healthy": {
+                    "type": "boolean"
+                },
+                "pod_id": {
+                    "type": "string"
+                },
+                "pod_name": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Status"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PodContainer": {
+            "type": "object",
+            "properties": {
+                "healthy": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Status"
+                }
+            }
+        },
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Resources": {
             "type": "object",
             "properties": {
@@ -1554,6 +1509,9 @@
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceComponentResp": {
             "type": "object",
             "properties": {
+                "id": {
+                    "type": "string"
+                },
                 "metadata": {
                     "type": "object",
                     "additionalProperties": {}
@@ -1602,6 +1560,31 @@
                     "type": "string"
                 }
             }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Status": {
+            "type": "string",
+            "enum": [
+                "waiting",
+                "running",
+                "terminated",
+                "created",
+                "paused",
+                "restarting",
+                "exited",
+                "removing",
+                "dead"
+            ],
+            "x-enum-varnames": [
+                "Waiting",
+                "Running",
+                "Terminated",
+                "Created",
+                "Paused",
+                "Restarting",
+                "Exited",
+                "Removing",
+                "Dead"
+            ]
         },
         "github_com_project-ai-services_ai-services_internal_pkg_models.AcceleratorInfo": {
             "type": "object",

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -356,6 +356,116 @@
                 }
             }
         },
+        "/applications/{id}/ps": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieves the process status and runtime information for an application",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Applications"
+                ],
+                "summary": "Get application process status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Application ID (UUID)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationPSResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid application ID format",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Application not found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/applications/{id}/resources": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retrieves used and total allocated CPU (in cores) and memory usage (in bytes), along with the hardware accelerator cards for an application and its services",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Applications"
+                ],
+                "summary": "Get application resources",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Application ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationResourcesResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Application not found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/architectures": {
             "get": {
                 "security": [
@@ -1154,6 +1264,62 @@
                 }
             }
         },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationMemInfo": {
+            "type": "object",
+            "properties": {
+                "total_bytes": {
+                    "description": "Total allocated memory in bytes",
+                    "type": "integer"
+                },
+                "used_bytes": {
+                    "description": "Actually used memory in bytes",
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationPSResponse": {
+            "type": "object",
+            "properties": {
+                "components": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Pod"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "services": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Pod"
+                    }
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationResourcesResponse": {
+            "type": "object",
+            "properties": {
+                "accelerators": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "cpu": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationCPUInfo"
+                },
+                "memory": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationMemInfo"
+                }
+            }
+        },
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationService": {
             "type": "object",
             "properties": {
@@ -1509,9 +1675,6 @@
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceComponentResp": {
             "type": "object",
             "properties": {
-                "id": {
-                    "type": "string"
-                },
                 "metadata": {
                     "type": "object",
                     "additionalProperties": {}

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -112,6 +112,7 @@ definitions:
       pagination:
         $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PaginationMetadata'
     type: object
+<<<<<<< HEAD
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationMemInfo:
     properties:
       total_bytes:
@@ -133,6 +134,22 @@ definitions:
         $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationCPUInfo'
       memory:
         $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationMemInfo'
+=======
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationPSResponse:
+    properties:
+      components:
+        items:
+          $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Pod'
+        type: array
+      id:
+        type: string
+      name:
+        type: string
+      services:
+        items:
+          $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Pod'
+        type: array
+>>>>>>> 91352e5 (Application ps endpoint)
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationService:
     properties:
@@ -301,6 +318,32 @@ definitions:
       total_pages:
         type: integer
     type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Pod:
+    properties:
+      containers:
+        items:
+          $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PodContainer'
+        type: array
+      created:
+        type: string
+      healthy:
+        type: boolean
+      pod_id:
+        type: string
+      pod_name:
+        type: string
+      status:
+        $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Status'
+    type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PodContainer:
+    properties:
+      healthy:
+        type: boolean
+      name:
+        type: string
+      status:
+        $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Status'
+    type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Resources:
     properties:
       accelerators:
@@ -342,6 +385,8 @@ definitions:
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceComponentResp:
     properties:
+      id:
+        type: string
       metadata:
         additionalProperties: {}
         type: object
@@ -374,6 +419,28 @@ definitions:
       name:
         type: string
     type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Status:
+    enum:
+    - waiting
+    - running
+    - terminated
+    - created
+    - paused
+    - restarting
+    - exited
+    - removing
+    - dead
+    type: string
+    x-enum-varnames:
+    - Waiting
+    - Running
+    - Terminated
+    - Created
+    - Paused
+    - Restarting
+    - Exited
+    - Removing
+    - Dead
   github_com_project-ai-services_ai-services_internal_pkg_models.AcceleratorInfo:
     properties:
       available:
@@ -674,6 +741,7 @@ paths:
       summary: Update application
       tags:
       - Applications
+<<<<<<< HEAD
   /applications/{id}/resources:
     get:
       description: Retrieves used and total allocated CPU (in cores) and memory usage
@@ -681,6 +749,13 @@ paths:
         its services
       parameters:
       - description: Application ID
+=======
+  /applications/{id}/ps:
+    get:
+      description: Retrieves the process status and runtime information for an application
+      parameters:
+      - description: Application ID (UUID)
+>>>>>>> 91352e5 (Application ps endpoint)
         in: path
         name: id
         required: true
@@ -691,7 +766,15 @@ paths:
         "200":
           description: OK
           schema:
+<<<<<<< HEAD
             $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationResourcesResponse'
+=======
+            $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationPSResponse'
+        "400":
+          description: Invalid application ID format
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+>>>>>>> 91352e5 (Application ps endpoint)
         "401":
           description: Unauthorized
           schema:
@@ -706,7 +789,11 @@ paths:
             $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
       security:
       - BearerAuth: []
+<<<<<<< HEAD
       summary: Get application resources
+=======
+      summary: Get application process status
+>>>>>>> 91352e5 (Application ps endpoint)
       tags:
       - Applications
   /architectures:

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -112,7 +112,6 @@ definitions:
       pagination:
         $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.PaginationMetadata'
     type: object
-<<<<<<< HEAD
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationMemInfo:
     properties:
       total_bytes:
@@ -122,19 +121,6 @@ definitions:
         description: Actually used memory in bytes
         type: integer
     type: object
-  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationResourcesResponse:
-    properties:
-      accelerators:
-        additionalProperties:
-          items:
-            type: string
-          type: array
-        type: object
-      cpu:
-        $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationCPUInfo'
-      memory:
-        $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationMemInfo'
-=======
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationPSResponse:
     properties:
       components:
@@ -149,7 +135,19 @@ definitions:
         items:
           $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Pod'
         type: array
->>>>>>> 91352e5 (Application ps endpoint)
+    type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationResourcesResponse:
+    properties:
+      accelerators:
+        additionalProperties:
+          items:
+            type: string
+          type: array
+        type: object
+      cpu:
+        $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationCPUInfo'
+      memory:
+        $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationMemInfo'
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationService:
     properties:
@@ -385,8 +383,6 @@ definitions:
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ServiceComponentResp:
     properties:
-      id:
-        type: string
       metadata:
         additionalProperties: {}
         type: object
@@ -741,21 +737,11 @@ paths:
       summary: Update application
       tags:
       - Applications
-<<<<<<< HEAD
-  /applications/{id}/resources:
-    get:
-      description: Retrieves used and total allocated CPU (in cores) and memory usage
-        (in bytes), along with the hardware accelerator cards for an application and
-        its services
-      parameters:
-      - description: Application ID
-=======
   /applications/{id}/ps:
     get:
       description: Retrieves the process status and runtime information for an application
       parameters:
       - description: Application ID (UUID)
->>>>>>> 91352e5 (Application ps endpoint)
         in: path
         name: id
         required: true
@@ -766,15 +752,11 @@ paths:
         "200":
           description: OK
           schema:
-<<<<<<< HEAD
-            $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationResourcesResponse'
-=======
             $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationPSResponse'
         "400":
           description: Invalid application ID format
           schema:
             $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
->>>>>>> 91352e5 (Application ps endpoint)
         "401":
           description: Unauthorized
           schema:
@@ -789,11 +771,42 @@ paths:
             $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
       security:
       - BearerAuth: []
-<<<<<<< HEAD
-      summary: Get application resources
-=======
       summary: Get application process status
->>>>>>> 91352e5 (Application ps endpoint)
+      tags:
+      - Applications
+  /applications/{id}/resources:
+    get:
+      description: Retrieves used and total allocated CPU (in cores) and memory usage
+        (in bytes), along with the hardware accelerator cards for an application and
+        its services
+      parameters:
+      - description: Application ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationResourcesResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "404":
+          description: Application not found
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get application resources
       tags:
       - Applications
   /architectures:

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/application_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/application_handler.go
@@ -17,8 +17,13 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 )
 
+var (
+	ErrInvalidIDParameter = ErrorResponse{Error: "Invalid application ID format"}
+)
+
 // Ensure types package is imported for Swagger documentation.
 var _ types.ApplicationListResponse
+var _ types.ApplicationPSResponse
 
 // ApplicationHandler handles application-related HTTP requests.
 type ApplicationHandler struct {
@@ -119,7 +124,7 @@ func (h *ApplicationHandler) ListApplications(c *gin.Context) {
 func (h *ApplicationHandler) UpdateApplication(c *gin.Context) {
 	appID, err := uuid.Parse(c.Param("id"))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid application ID format"})
+		c.JSON(http.StatusBadRequest, ErrInvalidIDParameter)
 
 		return
 	}
@@ -223,7 +228,7 @@ func (h *ApplicationHandler) CreateApplication(c *gin.Context) {
 func (h *ApplicationHandler) GetApplicationByID(c *gin.Context) {
 	appID, err := uuid.Parse(c.Param("id"))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Invalid application ID format"})
+		c.JSON(http.StatusBadRequest, ErrInvalidIDParameter)
 
 		return
 	}
@@ -307,7 +312,7 @@ func (h *ApplicationHandler) GetApplicationResources(c *gin.Context) {
 func (h *ApplicationHandler) DeleteApplication(c *gin.Context) {
 	appID, err := uuid.Parse(c.Param("id"))
 	if err != nil {
-		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid application ID format, expected UUID"})
+		c.JSON(http.StatusBadRequest, ErrInvalidIDParameter)
 
 		return
 	}
@@ -356,6 +361,46 @@ func (h *ApplicationHandler) handleDeleteError(c *gin.Context, err error) {
 	default:
 		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "internal server error"})
 	}
+}
+
+// ApplicationPS godoc
+//
+//	@Summary		Get application process status
+//	@Description	Retrieves the process status and runtime information for an application
+//	@Tags			Applications
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id	path		string	true	"Application ID (UUID)"
+//	@Success		200	{object}	types.ApplicationPSResponse
+//	@Failure		400	{object}	ErrorResponse	"Invalid application ID format"
+//	@Failure		401	{object}	ErrorResponse	"Unauthorized"
+//	@Failure		404	{object}	ErrorResponse	"Application not found"
+//	@Failure		500	{object}	ErrorResponse	"Internal Server Error"
+//	@Router			/applications/{id}/ps [get]
+func (h *ApplicationHandler) ApplicationPS(c *gin.Context) {
+	appID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ErrInvalidIDParameter)
+
+		return
+	}
+
+	response, err := h.appService.ApplicationsPs(c.Request.Context(), appID)
+	if err != nil {
+		if err == repository.ErrApplicationNotFound {
+			c.JSON(http.StatusNotFound, ErrorResponse{Error: "Application not found"})
+
+			return
+		}
+
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: fmt.Sprintf("Failed to get application: %v", err),
+		})
+
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -947,6 +947,8 @@ func buildResourcesResponse(totals *resourceTotals) *types.ApplicationResourcesR
 		},
 		Accelerators: accelerators,
 	}
+}
+
 // ApplicationsPs retrieves runtime pod status for an application and its related resources.
 // It loads the application from the database, inspects service pods directly, and then
 // resolves component pods through service dependencies so shared components are returned once.

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -22,6 +23,7 @@ import (
 	consts "github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/common"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
@@ -945,6 +947,170 @@ func buildResourcesResponse(totals *resourceTotals) *types.ApplicationResourcesR
 		},
 		Accelerators: accelerators,
 	}
+// ApplicationsPs retrieves runtime pod status for an application and its related resources.
+// It loads the application from the database, inspects service pods directly, and then
+// resolves component pods through service dependencies so shared components are returned once.
+func (s *ApplicationService) ApplicationsPs(ctx context.Context, appID uuid.UUID) (*types.ApplicationPSResponse, error) {
+	app, err := s.appRepo.GetByID(ctx, appID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrApplicationNotFound
+		}
+
+		return nil, fmt.Errorf("failed to get application: %w", err)
+	}
+
+	// Initialize runtime client for pod operations
+	rt, err := vars.RuntimeFactory.Create("")
+	if err != nil {
+		return nil, fmt.Errorf("failed to init %s client: %w", rt.Type(), err)
+	}
+
+	// Collect service pod details (one pod per service)
+	servicePods, err := s.collectServicePods(ctx, rt, app.Services)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect service pods: %w", err)
+	}
+
+	// Collect component pod details
+	componentPods, err := s.collectComponentPods(ctx, rt, app.Services)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect component pods: %w", err)
+	}
+
+	// Build response with application metadata and all pods
+	return &types.ApplicationPSResponse{
+		ID:         app.ID.String(),
+		Name:       app.Name,
+		Services:   servicePods,
+		Components: componentPods,
+	}, nil
+}
+
+// collectServicePods resolves one pod view per service by querying Podman with the
+// service template label. Missing or failed lookups are logged and skipped so one
+// unhealthy service does not prevent returning status for the rest of the application.
+func (s *ApplicationService) collectServicePods(
+	ctx context.Context,
+	rt runtime.Runtime,
+	services []models.Service,
+) ([]types.Pod, error) {
+	// Pre-allocate slice for efficiency (one pod per service expected)
+	servicePods := make([]types.Pod, 0, len(services))
+
+	// Load pod details for each service
+	for _, service := range services {
+		// Query runtime using service ID as template label
+		pod, err := loadApplicationPod(rt, service.ID.String())
+		if err != nil {
+			// Log error but continue with other services (fault-tolerant)
+			logger.Errorf("Failed to load service pod: %w", err)
+
+			continue
+		}
+		servicePods = append(servicePods, pod)
+	}
+
+	logger.Infof("Successfully collected %d service pods", len(servicePods))
+
+	return servicePods, nil
+}
+
+// collectComponentPods resolves pod details for component dependencies referenced by
+// application services. Components are deduplicated by dependency ID because the same
+// backing component can be shared by multiple services within one application.
+func (s *ApplicationService) collectComponentPods(
+	ctx context.Context,
+	rt runtime.Runtime,
+	services []models.Service,
+) ([]types.Pod, error) {
+	// Use map to deduplicate shared components (key: component ID)
+	componentMap := make(map[string]types.Pod)
+
+	// Iterate through services to find component dependencies
+	for _, service := range services {
+		// Fetch service dependencies from database
+		serviceDependencies, err := s.serviceDependencyRepo.GetDependenciesByServiceID(ctx, service.ID)
+		if err != nil {
+			logger.Errorf("Failed to get dependencies for service %s: %v", service.ID, err)
+
+			continue
+		}
+
+		// Extract component pods from dependencies
+		for _, dependency := range serviceDependencies {
+			if dependency.DependencyType != models.DependencyTypeComponent {
+				continue
+			}
+
+			componentID := dependency.DependencyID.String()
+
+			// Skip if component already processed (deduplication)
+			if _, exists := componentMap[componentID]; exists {
+				continue
+			}
+
+			// Load component pod from runtime
+			componentPod, err := loadApplicationPod(rt, componentID)
+			if err != nil {
+				logger.Errorf("Failed to load component pod: %w", err)
+
+				continue
+			}
+
+			// Store in map to prevent duplicate processing
+			componentMap[componentID] = componentPod
+		}
+	}
+
+	// Convert map to slice for response
+	componentPods := make([]types.Pod, 0, len(componentMap))
+	for _, podDetails := range componentMap {
+		componentPods = append(componentPods, podDetails)
+	}
+
+	logger.Infof("Successfully collected %d unique component pods", len(componentPods))
+
+	return componentPods, nil
+}
+
+// loadApplicationPod fetches the application pod from the runtime.
+func loadApplicationPod(rt runtime.Runtime, appID string) (types.Pod, error) {
+	filteredPod, err := common.FetchFilteredPods(rt, appID)
+	if err != nil {
+		return types.Pod{}, err
+	}
+	// Validate exactly one pod exists
+	if len(filteredPod) == 0 {
+		return types.Pod{}, fmt.Errorf("no pod found with given id")
+	}
+
+	pod := filteredPod[0]
+
+	processedPod, err := common.ProcessPod(rt, pod)
+	if err != nil {
+		return types.Pod{}, fmt.Errorf("failed to process pod: %w", err)
+	}
+
+	// Transform containers to API response format with health indicators
+	containers := make([]types.PodContainer, 0, len(pod.Containers))
+	for _, container := range processedPod.Containers {
+		containers = append(containers, types.PodContainer{
+			Name:    container.Name,
+			Status:  types.Status(strings.ToLower(processedPod.Status)),
+			Healthy: strings.ToLower(container.Health) == "healthy",
+		})
+	}
+
+	// Build pod response with metadata and container details
+	return types.Pod{
+		PodID:      processedPod.ID,
+		PodName:    processedPod.Name,
+		Status:     types.Status(strings.ToLower(processedPod.Status)),
+		Healthy:    processedPod.Health == "healthy",
+		Created:    pod.Created.Format(constants.RFC3339WithTimezone),
+		Containers: containers,
+	}, nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/router.go
+++ b/ai-services/internal/pkg/catalog/apiserver/router.go
@@ -67,6 +67,7 @@ func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist r
 		applications.POST("/", applicationHandler.CreateApplication)
 		applications.PUT("/:id", applicationHandler.UpdateApplication)
 		applications.DELETE("/:id", applicationHandler.DeleteApplication)
+		applications.GET("/:id/ps", applicationHandler.ApplicationPS)
 	}
 
 	return router

--- a/ai-services/internal/pkg/catalog/types/application_response.go
+++ b/ai-services/internal/pkg/catalog/types/application_response.go
@@ -68,4 +68,43 @@ type ApplicationMemInfo struct {
 	UsedBytes  int64 `json:"used_bytes"`  // Actually used memory in bytes
 }
 
+// ApplicationPSResponse represents the response for pod/container status.
+type ApplicationPSResponse struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Services   []Pod  `json:"services"`
+	Components []Pod  `json:"components"`
+}
+
+type Status string
+
+const (
+	Waiting    Status = "waiting"
+	Running    Status = "running"
+	Terminated Status = "terminated"
+	Created    Status = "created"
+	Paused     Status = "paused"
+	Restarting Status = "restarting"
+	Exited     Status = "exited"
+	Removing   Status = "removing"
+	Dead       Status = "dead"
+)
+
+// Pod represents the details of a pod.
+type Pod struct {
+	PodID      string         `json:"pod_id"`
+	PodName    string         `json:"pod_name"`
+	Status     Status         `json:"status"`
+	Created    string         `json:"created"`
+	Healthy    bool           `json:"healthy"`
+	Containers []PodContainer `json:"containers"`
+}
+
+// PodContainer represents a container in a pod.
+type PodContainer struct {
+	Name    string `json:"name"`
+	Status  Status `json:"status"`
+	Healthy bool   `json:"healthy"`
+}
+
 // Made with Bob

--- a/ai-services/internal/pkg/constants/annotations.go
+++ b/ai-services/internal/pkg/constants/annotations.go
@@ -6,4 +6,5 @@ const (
 	PodStartAnnotationkey    = "ai-services.io/start"
 	PodPortsAnnotationKey    = "ai-services.io/ports"
 	PodRoutesAnnotationKey   = "ai-services.io/routes"
+	ApplicationTemplateKey   = "ai-services.io/template"
 )

--- a/ai-services/internal/pkg/runtime/common/common.go
+++ b/ai-services/internal/pkg/runtime/common/common.go
@@ -1,0 +1,100 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+)
+
+// FetchFilteredPods Fetch all pods for a given app based on label.
+func FetchFilteredPods(r runtime.Runtime, appID string) ([]types.Pod, error) {
+	listFilters := map[string][]string{}
+	if appID != "" {
+		listFilters["label"] = []string{fmt.Sprintf("%s=%s", constants.ApplicationTemplateKey, appID)}
+	}
+
+	pods, err := r.ListPods(listFilters)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods: %w", err)
+	}
+
+	return pods, nil
+}
+
+func ProcessPod(r runtime.Runtime, pod types.Pod) (*types.Pod, error) {
+	// do pod inspect
+	pInfo, err := r.InspectPod(pod.ID)
+	if err != nil {
+		// log and skip pod if inspect failed
+		logger.Errorf("Failed to do pod inspect: '%s' with error: %v", pod.ID, err)
+
+		return nil, nil
+	}
+	// load pod status
+	pInfo.Status, pInfo.Health = getPodStatus(r, pInfo)
+
+	// truncate podID to 13 characters
+	const podIDShortLength = 13
+	truncatedPodID := pod.ID
+	if len(pod.ID) > podIDShortLength {
+		truncatedPodID = pod.ID[:podIDShortLength]
+	}
+
+	pInfo.ID = truncatedPodID
+
+	return pInfo, nil
+}
+
+func getPodStatus(r runtime.Runtime, pInfo *types.Pod) (string, string) {
+	// if the pod Status is running, make sure to check if its healthy or not, otherwise fallback to default pod state
+	if pInfo.State == "Running" {
+		healthyContainers := 0
+		for i, container := range pInfo.Containers {
+			cInfo, err := r.InspectContainer(container.ID)
+			if err != nil {
+				// skip container if inspect failed
+				logger.Infof("failed to do container inspect for pod: '%s', containerID: '%s' with error: %v", pInfo.Name, container.ID, err, logger.VerbosityLevelDebug)
+
+				continue
+			}
+
+			status := fetchContainerStatus(cInfo)
+			if status == string(constants.Ready) {
+				healthyContainers++
+			}
+			pInfo.Containers[i].Health = status
+		}
+
+		// if all the containers are healthy, then append 'healthy' to pod state or else mark it as unhealthy
+		if healthyContainers == len(pInfo.Containers) {
+			return pInfo.State, string(constants.Ready)
+		} else {
+			return pInfo.State, string(constants.NotReady)
+		}
+	}
+
+	return pInfo.State, string(constants.NotReady)
+}
+
+func fetchContainerStatus(cInfo *types.Container) string {
+	containerStatus := cInfo.Status
+
+	// if container status is not running, then return the container status
+	if containerStatus != "running" {
+		return containerStatus
+	}
+
+	// if running, proceed with checking health status of the container
+	healthStatusCheck := cInfo.Health
+
+	// if health status check is set, then return the particular health status
+	if healthStatusCheck != "" {
+		return healthStatusCheck
+	}
+
+	// if health status check is not set, consider it to be healthy by default
+	return string(constants.Ready)
+}

--- a/ai-services/internal/pkg/runtime/podman/mapper.go
+++ b/ai-services/internal/pkg/runtime/podman/mapper.go
@@ -18,6 +18,7 @@ func toPodsList(input any) []types.Pod {
 				Status:     r.Status,
 				Labels:     r.Labels,
 				Containers: toPodContainerList(r.Containers),
+				Created:    r.Created,
 			})
 		}
 

--- a/ai-services/internal/pkg/runtime/types/types.go
+++ b/ai-services/internal/pkg/runtime/types/types.go
@@ -29,6 +29,7 @@ type Pod struct {
 	ID               string
 	Name             string
 	Status           string
+	Health           string
 	Labels           map[string]string
 	Containers       []Container
 	Created          time.Time


### PR DESCRIPTION
Summary
This PR adds a new endpoint, `/api/v1/application/<id>/ps`, to return pod information for a given application.

What changed

- Added the `api/v1/application/<id>/ps` endpoint
- The endpoint accepts an application ID as input
- It fetches the services and components associated with that application ID from the database
- It maps those services and components to their corresponding running pods
- It returns the list of service pods and component pods for the application