### PR TITLE
Updating service-base image to use devpi for python pkgs

### DIFF
--- a/images/service-base/Containerfile
+++ b/images/service-base/Containerfile
@@ -1,6 +1,4 @@
-FROM localhost/prebuilder as prebuilder
-
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8
 
 RUN microdnf install -y python3.12-devel python3.12-pip \
         lcms2-devel openblas-devel freetype libicu libjpeg-turbo && \
@@ -18,10 +16,9 @@ ENV DOCLING_MODELS_PATH=/var/docling-models
 COPY requirements.txt .
 COPY download_docling_models.py .
 
-RUN --mount=type=bind,from=prebuilder,source=/wheels,target=/wheels,ro \
-    python -m venv /var/venv && source /var/venv/bin/activate && \
+RUN python -m venv /var/venv && source /var/venv/bin/activate && \
     pip install --upgrade pip && \
-    pip install  /wheels/*.whl -r requirements.txt \
+    pip install -r requirements.txt \
         --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux \
         --prefer-binary && \
     pip cache purge && \

--- a/images/service-base/Makefile
+++ b/images/service-base/Makefile
@@ -1,11 +1,10 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=service-base
-TAG?=v0.0.29
+TAG?=v0.0.30
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman
 build:
-	cd prebuilder && $(CONTAINER_BUILDER) build -t prebuilder . && cd -
 	$(CONTAINER_BUILDER) build -t $(REGISTRY)/$(IMAGE):$(TAG) .
 .PHONY: build
 

--- a/images/service-base/prebuilder/Containerfile
+++ b/images/service-base/prebuilder/Containerfile
@@ -1,3 +1,9 @@
+# Pre-builder image for building Python packages from source
+# This image contains all build dependencies required to compile Python packages
+# that may not have pre-built wheels available for all architectures.
+#
+# Note: Most packages are now available in the devpi index, reducing the need for this stage.
+# This stage is maintained for future requirements or architecture-specific builds.
 FROM registry.access.redhat.com/ubi9/ubi:9.7
 
 RUN yum install -y --setopt=tsflags=nodocs gcc-c++ python3.12-devel python3.12-pip git rust cargo openssl-devel libffi-devel zlib-devel && \


### PR DESCRIPTION
`lingua-language-detector `and `ujson` are now available in devpi index, so updating service-base to make use of it.

Verified docling in updated service base image by parsing one pdf document. Snapshot of parsed result.

<img width="1473" height="588" alt="image" src="https://github.com/user-attachments/assets/6fdc603f-c99d-413d-9dd0-c3e5fcd9c514" />

