### PR TITLE
Support application templates sub-command for catalog

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.27
+TAG?=0.0.28
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.27
+  image: icr.io/ai-services-cicd/ai-services:0.0.28
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/application/templates.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates.go
@@ -4,12 +4,22 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/project-ai-services/ai-services/assets"
+	appTemplates "github.com/project-ai-services/ai-services/cmd/ai-services/cmd/application/templates"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
+	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
+)
+
+var (
+	experimentalTemplates bool
 )
 
 var templatesCmd = &cobra.Command{
@@ -19,6 +29,13 @@ var templatesCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true
+
+		// When experimentalTemplates is true and runtime is podman, use experimental catalog templates
+		// For openshift runtime, always use the older/stable code path regardless of experimental flag
+		if experimentalTemplates && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+			// Use experimental catalog templates listing (architectures and services)
+			return listCatalogTemplates(cmd)
+		}
 
 		tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
 
@@ -50,7 +67,7 @@ var templatesCmd = &cobra.Command{
 				continue
 			}
 
-			logger.Infof("- %s\n", name)
+			logger.Infof("- %s", name)
 			var metadata templates.AppMetadata
 			if err := tp.LoadMetadata(name, false, &metadata); err != nil {
 				logger.Errorf("failed to load application metadata: %v", err)
@@ -69,9 +86,101 @@ var templatesCmd = &cobra.Command{
 			for k, v := range appTemplatesParametersWithDescription {
 				logger.Infoln("\t" + k + ":  " + v)
 			}
-			cmd.Println()
 		}
 
 		return nil
 	},
+}
+
+func init() {
+	templatesCmd.Flags().BoolVar(&experimentalTemplates, "experimental", false, "Include experimental application templates")
+
+	// Add parameters subcommand
+	templatesCmd.AddCommand(appTemplates.NewParametersCmd())
+}
+
+// listCatalogTemplates lists architectures, services, and components from the catalog
+func listCatalogTemplates(cmd *cobra.Command) error {
+	// Create catalog provider
+	provider, err := catalog.NewCatalogProvider()
+	if err != nil {
+		return fmt.Errorf("failed to create catalog provider: %w", err)
+	}
+
+	// Get all data
+	architectures, err := provider.ListArchitectures()
+	if err != nil {
+		return fmt.Errorf("failed to list architectures: %w", err)
+	}
+
+	services, err := provider.ListServices()
+	if err != nil {
+		return fmt.Errorf("failed to list services: %w", err)
+	}
+
+	components, err := provider.ListComponents()
+	if err != nil {
+		return fmt.Errorf("failed to list components: %w", err)
+	}
+
+	// Section 1: Deployment Architectures with list of services
+	logger.Infoln("Available Deployment Architectures:")
+	for _, arch := range architectures {
+		displayArchitectureWithServiceList(arch)
+	}
+
+	// Section 2: Deployment Services with metadata and required components
+	logger.Infoln("\nAvailable Services:")
+	for _, svc := range services {
+		displayServiceWithComponents(svc, components)
+	}
+
+	// Inform user about parameters subcommand
+	logger.Infoln("\nTo list supported parameters for each template use: application templates parameters --template <Template ID>\n")
+
+	return nil
+}
+
+// displayArchitectureWithServiceList displays an architecture with just the list of service IDs
+func displayArchitectureWithServiceList(arch catalogTypes.Architecture) {
+	logger.Infof("- %s (%s)", arch.ID, arch.Name)
+	if arch.Description != "" {
+		logger.Infof("  Description: %s", arch.Description)
+	}
+
+	// Display list of services in this architecture
+	if len(arch.Services) > 0 {
+		logger.Infoln("  Services:")
+		for _, svcRef := range arch.Services {
+			logger.Infof("     - %s", svcRef.ID)
+		}
+	}
+}
+
+// displayServiceWithComponents displays a service with its metadata and required components
+func displayServiceWithComponents(svc catalogTypes.Service, components []catalogTypes.Component) {
+	logger.Infof("- %s (%s)", svc.ID, svc.Name)
+	if svc.Description != "" {
+		logger.Infof("  Description: %s", svc.Description)
+	}
+
+	// Display component dependencies
+	if len(svc.Dependencies) > 0 {
+		logger.Infoln("  Required Components:")
+		for _, dep := range svc.Dependencies {
+			// Find matching components by type
+			matchingComps := []string{}
+			for _, comp := range components {
+				if comp.ComponentType == dep.ID {
+					matchingComps = append(matchingComps, comp.ID)
+				}
+			}
+
+			if len(matchingComps) > 0 {
+				logger.Infof("    %s: %s", dep.ID, strings.Join(matchingComps, ", "))
+			} else {
+				logger.Infof("    %s: (no components available)", dep.ID)
+			}
+		}
+	}
 }

--- a/ai-services/cmd/ai-services/cmd/application/templates.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates.go
@@ -99,7 +99,7 @@ func init() {
 	templatesCmd.AddCommand(appTemplates.NewParametersCmd())
 }
 
-// listCatalogTemplates lists architectures, services, and components from the catalog
+// listCatalogTemplates lists architectures, services, and components from the catalog.
 func listCatalogTemplates(cmd *cobra.Command) error {
 	// Create catalog provider
 	provider, err := catalog.NewCatalogProvider()
@@ -141,7 +141,7 @@ func listCatalogTemplates(cmd *cobra.Command) error {
 	return nil
 }
 
-// displayArchitectureWithServiceList displays an architecture with just the list of service IDs
+// displayArchitectureWithServiceList displays an architecture with just the list of service IDs.
 func displayArchitectureWithServiceList(arch catalogTypes.Architecture) {
 	logger.Infof("- %s (%s)", arch.ID, arch.Name)
 	if arch.Description != "" {
@@ -157,7 +157,7 @@ func displayArchitectureWithServiceList(arch catalogTypes.Architecture) {
 	}
 }
 
-// displayServiceWithComponents displays a service with its metadata and required components
+// displayServiceWithComponents displays a service with its metadata and required components.
 func displayServiceWithComponents(svc catalogTypes.Service, components []catalogTypes.Component) {
 	logger.Infof("- %s (%s)", svc.ID, svc.Name)
 	if svc.Description != "" {

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -157,13 +157,28 @@ func displaySchemaParameters(schema map[string]any, prefix string) {
 		return
 	}
 
+	displayPropertiesRecursive(properties, prefix)
+}
+
+// displayPropertiesRecursive recursively displays properties, handling nested objects.
+func displayPropertiesRecursive(properties map[string]any, prefix string) {
 	for paramName, propValue := range properties {
 		prop, ok := propValue.(map[string]any)
 		if !ok {
 			continue
 		}
 
+		propType, _ := prop["type"].(string)
 		description, _ := prop["description"].(string)
+
+		// If this is an object type with nested properties, recurse into it
+		if propType == "object" {
+			if nestedProps, ok := prop["properties"].(map[string]any); ok {
+				displayPropertiesRecursive(nestedProps, fmt.Sprintf("%s.%s", prefix, paramName))
+
+				continue
+			}
+		}
 
 		// Append default value if present and not empty
 		if defaultValue, hasDefault := prop["default"]; hasDefault && defaultValue != nil && defaultValue != "" {

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -16,7 +16,7 @@ var (
 	templateID string
 )
 
-// NewParametersCmd creates the parameters subcommand
+// NewParametersCmd creates the parameters subcommand.
 func NewParametersCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "parameters",
@@ -57,12 +57,12 @@ func NewParametersCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&templateID, "template", "", "Template ID (service or architecture)")
-	cmd.MarkFlagRequired("template")
+	_ = cmd.MarkFlagRequired("template")
 
 	return cmd
 }
 
-// displayServiceParameters displays all parameters for a specific service
+// displayServiceParameters displays all parameters for a specific service.
 func displayServiceParameters(provider *catalog.CatalogProvider, serviceID string, dependencies []catalogTypes.DependencyReference) error {
 	logger.Infof("Supported Parameters for '%s':", serviceID)
 
@@ -73,71 +73,73 @@ func displayServiceParameters(provider *catalog.CatalogProvider, serviceID strin
 	}
 
 	// Display component parameters
-	if len(dependencies) > 0 {
-		components, err := provider.ListComponents()
-		if err != nil {
-			return fmt.Errorf("failed to list components: %w", err)
-		}
-
-		for _, dep := range dependencies {
-			// Find all components of this type
-			for _, comp := range components {
-				if comp.ComponentType == dep.ID {
-					schema, err := provider.GetComponentProviderParams(comp.ComponentType, comp.ID)
-					if err == nil && schema != nil {
-						displaySchemaParameters(schema, fmt.Sprintf("%s.%s", comp.ComponentType, comp.ID))
-					}
-				}
-			}
-		}
-	}
-
-	return nil
+	return displayComponentsParameters(provider, dependencies, nil)
 }
 
-// displayArchitectureParameters displays all parameters for all services in an architecture
+// displayArchitectureParameters displays all parameters for all services in an architecture.
 func displayArchitectureParameters(provider *catalog.CatalogProvider, archID string, services []catalogTypes.ServiceReference) error {
 	logger.Infof("Supported Parameters for '%s':", archID)
-
-	// Get all components for later use
-	components, err := provider.ListComponents()
-	if err != nil {
-		return fmt.Errorf("failed to list components: %w", err)
-	}
 
 	// Track displayed components to avoid duplicates
 	displayedComponents := make(map[string]bool)
 
 	// Display parameters for each service in the architecture
 	for _, svcRef := range services {
-		// Load the service to get its dependencies
-		service, err := provider.LoadService(svcRef.ID)
-		if err != nil {
+		if err := displayServiceInArchitecture(provider, svcRef.ID, displayedComponents); err != nil {
 			continue
 		}
+	}
 
-		// Display service parameters
-		schema, err := provider.GetServiceParams(svcRef.ID)
-		if err == nil && schema != nil {
-			displaySchemaParameters(schema, svcRef.ID)
-		}
+	return nil
+}
 
-		// Display component parameters for this service
-		for _, dep := range service.Dependencies {
-			for _, comp := range components {
-				if comp.ComponentType == dep.ID {
-					componentKey := fmt.Sprintf("%s.%s", comp.ComponentType, comp.ID)
+// displayServiceInArchitecture displays parameters for a single service within an architecture.
+func displayServiceInArchitecture(provider *catalog.CatalogProvider, serviceID string, displayedComponents map[string]bool) error {
+	// Load the service to get its dependencies
+	service, err := provider.LoadService(serviceID)
+	if err != nil {
+		return err
+	}
 
-					// Skip if already displayed
+	// Display service parameters
+	schema, err := provider.GetServiceParams(serviceID)
+	if err == nil && schema != nil {
+		displaySchemaParameters(schema, serviceID)
+	}
+
+	// Display component parameters for this service
+	return displayComponentsParameters(provider, service.Dependencies, displayedComponents)
+}
+
+// displayComponentsParameters displays parameters for components based on dependencies.
+// If displayedComponents map is provided, it will track and skip duplicates.
+func displayComponentsParameters(provider *catalog.CatalogProvider, dependencies []catalogTypes.DependencyReference, displayedComponents map[string]bool) error {
+	if len(dependencies) == 0 {
+		return nil
+	}
+
+	components, err := provider.ListComponents()
+	if err != nil {
+		return fmt.Errorf("failed to list components: %w", err)
+	}
+
+	for _, dep := range dependencies {
+		// Find all components of this type
+		for _, comp := range components {
+			if comp.ComponentType == dep.ID {
+				componentKey := fmt.Sprintf("%s.%s", comp.ComponentType, comp.ID)
+
+				// Skip if already displayed (only when tracking duplicates)
+				if displayedComponents != nil {
 					if displayedComponents[componentKey] {
 						continue
 					}
 					displayedComponents[componentKey] = true
+				}
 
-					schema, err := provider.GetComponentProviderParams(comp.ComponentType, comp.ID)
-					if err == nil && schema != nil {
-						displaySchemaParameters(schema, componentKey)
-					}
+				schema, err := provider.GetComponentProviderParams(comp.ComponentType, comp.ID)
+				if err == nil && schema != nil {
+					displaySchemaParameters(schema, componentKey)
 				}
 			}
 		}
@@ -148,7 +150,7 @@ func displayArchitectureParameters(provider *catalog.CatalogProvider, archID str
 
 // Made with Bob
 
-// displaySchemaParameters displays parameters from a schema with the given prefix
+// displaySchemaParameters displays parameters from a schema with the given prefix.
 func displaySchemaParameters(schema map[string]any, prefix string) {
 	properties, ok := schema["properties"].(map[string]any)
 	if !ok || len(properties) == 0 {

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -1,0 +1,173 @@
+package templates
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
+	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
+)
+
+var (
+	templateID string
+)
+
+// NewParametersCmd creates the parameters subcommand
+func NewParametersCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "parameters",
+		Short: "Display supported parameters for a specific template",
+		Long:  `Display all supported parameters for a specific template ID (service or architecture) from the catalog`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+
+			// Check runtime - only supported for Podman
+			if vars.RuntimeFactory.GetRuntimeType() != types.RuntimeTypePodman {
+				return fmt.Errorf("templates parameters subcommand is only supported for Podman runtime")
+			}
+
+			if templateID == "" {
+				return fmt.Errorf("--template flag is required")
+			}
+
+			// Create catalog provider
+			provider, err := catalog.NewCatalogProvider()
+			if err != nil {
+				return fmt.Errorf("failed to create catalog provider: %w", err)
+			}
+
+			// Try to load as architecture first
+			arch, err := provider.LoadArchitecture(templateID)
+			if err == nil {
+				return displayArchitectureParameters(provider, templateID, arch.Services)
+			}
+
+			// Try to load as service
+			service, err := provider.LoadService(templateID)
+			if err == nil {
+				return displayServiceParameters(provider, templateID, service.Dependencies)
+			}
+
+			return fmt.Errorf("template '%s' not found as service or architecture", templateID)
+		},
+	}
+
+	cmd.Flags().StringVar(&templateID, "template", "", "Template ID (service or architecture)")
+	cmd.MarkFlagRequired("template")
+
+	return cmd
+}
+
+// displayServiceParameters displays all parameters for a specific service
+func displayServiceParameters(provider *catalog.CatalogProvider, serviceID string, dependencies []catalogTypes.DependencyReference) error {
+	logger.Infof("Supported Parameters for '%s':", serviceID)
+
+	// Display service's own parameters
+	schema, err := provider.GetServiceParams(serviceID)
+	if err == nil && schema != nil {
+		displaySchemaParameters(schema, serviceID)
+	}
+
+	// Display component parameters
+	if len(dependencies) > 0 {
+		components, err := provider.ListComponents()
+		if err != nil {
+			return fmt.Errorf("failed to list components: %w", err)
+		}
+
+		for _, dep := range dependencies {
+			// Find all components of this type
+			for _, comp := range components {
+				if comp.ComponentType == dep.ID {
+					schema, err := provider.GetComponentProviderParams(comp.ComponentType, comp.ID)
+					if err == nil && schema != nil {
+						displaySchemaParameters(schema, fmt.Sprintf("%s.%s", comp.ComponentType, comp.ID))
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// displayArchitectureParameters displays all parameters for all services in an architecture
+func displayArchitectureParameters(provider *catalog.CatalogProvider, archID string, services []catalogTypes.ServiceReference) error {
+	logger.Infof("Supported Parameters for '%s':", archID)
+
+	// Get all components for later use
+	components, err := provider.ListComponents()
+	if err != nil {
+		return fmt.Errorf("failed to list components: %w", err)
+	}
+
+	// Track displayed components to avoid duplicates
+	displayedComponents := make(map[string]bool)
+
+	// Display parameters for each service in the architecture
+	for _, svcRef := range services {
+		// Load the service to get its dependencies
+		service, err := provider.LoadService(svcRef.ID)
+		if err != nil {
+			continue
+		}
+
+		// Display service parameters
+		schema, err := provider.GetServiceParams(svcRef.ID)
+		if err == nil && schema != nil {
+			displaySchemaParameters(schema, svcRef.ID)
+		}
+
+		// Display component parameters for this service
+		for _, dep := range service.Dependencies {
+			for _, comp := range components {
+				if comp.ComponentType == dep.ID {
+					componentKey := fmt.Sprintf("%s.%s", comp.ComponentType, comp.ID)
+
+					// Skip if already displayed
+					if displayedComponents[componentKey] {
+						continue
+					}
+					displayedComponents[componentKey] = true
+
+					schema, err := provider.GetComponentProviderParams(comp.ComponentType, comp.ID)
+					if err == nil && schema != nil {
+						displaySchemaParameters(schema, componentKey)
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// Made with Bob
+
+// displaySchemaParameters displays parameters from a schema with the given prefix
+func displaySchemaParameters(schema map[string]any, prefix string) {
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok || len(properties) == 0 {
+		return
+	}
+
+	for paramName, propValue := range properties {
+		prop, ok := propValue.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		description, _ := prop["description"].(string)
+
+		// Append default value if present and not empty
+		if defaultValue, hasDefault := prop["default"]; hasDefault && defaultValue != nil && defaultValue != "" {
+			logger.Infof("  %s.%s: %s (Default: %v)", prefix, paramName, description, defaultValue)
+		} else {
+			logger.Infof("  %s.%s: %s", prefix, paramName, description)
+		}
+	}
+}

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -22,6 +22,11 @@ func NewParametersCmd() *cobra.Command {
 		Use:   "parameters",
 		Short: "Display supported parameters for a specific template",
 		Long:  `Display all supported parameters for a specific template ID (service or architecture) from the catalog`,
+		Example: `  # Display parameters for a service
+  ai-services application templates parameters --template digitize --runtime podman
+
+  # Display parameters for an architecture
+  ai-services application templates parameters --template rag --runtime podman`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 


### PR DESCRIPTION
1. Updates to templates subcommand to display architecture and service
2. Added experimental flag for now, once all application commands are migrated to new structure will remove it.
3. Added new templates parameters - podman only - which will display supported parameters for each template id (services or architecture)