### PR TITLE
Add missing similarity in rag app and introduce standalone flag

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.29
+TAG?=0.0.30
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/architectures/rag/metadata.yaml
+++ b/ai-services/assets/architectures/rag/metadata.yaml
@@ -20,10 +20,13 @@ global_components:
 services:
   - id: chat
     version: ">=1.0.0"
-    
+
   - id: digitize
     version: ">=1.0.0"
-  
+
+  - id: similarity
+    version: ">=1.0.0"
+
   - id: summarize
     version: ">=1.0.0"
     optional: true

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.29
+  image: icr.io/ai-services-cicd/ai-services:0.0.30
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/chat/metadata.yaml
+++ b/ai-services/assets/services/chat/metadata.yaml
@@ -17,3 +17,5 @@ dependencies:
   - id: embedding
   - id: llm
   - id: reranker
+
+standalone: false

--- a/ai-services/assets/services/digitize/metadata.yaml
+++ b/ai-services/assets/services/digitize/metadata.yaml
@@ -17,4 +17,6 @@ dependencies:
   - id: embedding
   - id: llm
 
+standalone: false
+
 # Made with Bob

--- a/ai-services/assets/services/similarity/metadata.yaml
+++ b/ai-services/assets/services/similarity/metadata.yaml
@@ -1,6 +1,6 @@
 # Service identification
 id: similarity
-name: "Similarity Search"
+name: "Find Similar Items"
 description: "Finds semantically similar content using embeddings and reranking"
 type: service
 
@@ -16,5 +16,7 @@ dependencies:
   - id: vector_store
   - id: embedding
   - id: reranker
+
+standalone: true
 
 # Made with Bob

--- a/ai-services/assets/services/summarize/metadata.yaml
+++ b/ai-services/assets/services/summarize/metadata.yaml
@@ -14,3 +14,5 @@ architectures:
 # Dependencies on other components
 dependencies:
   - id: llm
+
+standalone: true


### PR DESCRIPTION
1. Added similarity service which was missed before under the rag architecture.
2. Added a standalone flag in services metadata to allow installing individual services.