### PR TITLE
[Catalog] New Postgres instance for Summarize

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.36
+TAG?=0.0.37
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.36
+  image: icr.io/ai-services-cicd/ai-services:0.0.37
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/digitize/podman/templates/postgres.yaml.tmpl
+++ b/ai-services/assets/services/digitize/podman/templates/postgres.yaml.tmpl
@@ -67,5 +67,5 @@ spec:
   volumes:
     - name: postgres-data
       hostPath:
-        path: "{{ .BaseDir }}/applications/{{ .InstanceSlug }}/volumes/digitize/postgres"
+        path: "{{ .BaseDir }}/applications/{{ .InstanceSlug }}/volumes/postgres-digitize"
         type: DirectoryOrCreate

--- a/ai-services/assets/services/summarize/podman/metadata.yaml
+++ b/ai-services/assets/services/summarize/podman/metadata.yaml
@@ -1,8 +1,14 @@
 name: summarize
 version: "1.0.0"
+podTemplateExecutions:
+  - [postgres-secret.yaml.tmpl]
+  - [postgres.yaml.tmpl]
+  - [summarize-api.yaml.tmpl]
 
 # Resource requirements
 resources:
-  cpu: 1 # 500m (0.5 cores) rounded up
+  cpu: 1 # 500m rounded up
   memory: 1073741824 # 1Gi in bytes
-  storage: 0 # No persistent storage required
+  storage: 10737418240 # 10Gi for PostgreSQL database storage in bytes
+
+# Made with Bob

--- a/ai-services/assets/services/summarize/podman/templates/postgres-secret.yaml.tmpl
+++ b/ai-services/assets/services/summarize/podman/templates/postgres-secret.yaml.tmpl
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "summarize-db-secret-{{ .InstanceSlug }}"
+  labels:
+    ai-services.io/template: "{{ .TemplateID }}"
+type: Opaque
+stringData:
+  username: "{{ .Values.postgres.username }}"
+  password: "{{ .Values.postgres.password }}"

--- a/ai-services/assets/services/summarize/podman/templates/postgres.yaml.tmpl
+++ b/ai-services/assets/services/summarize/podman/templates/postgres.yaml.tmpl
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "digitize-db-{{ .InstanceSlug }}"
+  name: "summarize-db-{{ .InstanceSlug }}"
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
   annotations:
@@ -23,12 +23,12 @@ spec:
         - name: POSTGRES_USER
           valueFrom:
             secretKeyRef:
-              name: "digitize-db-secret-{{ .InstanceSlug }}"
+              name: "summarize-db-secret-{{ .InstanceSlug }}"
               key: username
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: "digitize-db-secret-{{ .InstanceSlug }}"
+              name: "summarize-db-secret-{{ .InstanceSlug }}"
               key: password
         - name: POSTGRES_DB
           value: "postgres"
@@ -67,5 +67,5 @@ spec:
   volumes:
     - name: postgres-data
       hostPath:
-        path: "{{ .BaseDir }}/applications/{{ .InstanceSlug }}/volumes/digitize/postgres"
+        path: "{{ .BaseDir }}/applications/{{ .InstanceSlug }}/volumes/summarize/postgres"
         type: DirectoryOrCreate

--- a/ai-services/assets/services/summarize/podman/templates/postgres.yaml.tmpl
+++ b/ai-services/assets/services/summarize/podman/templates/postgres.yaml.tmpl
@@ -67,5 +67,5 @@ spec:
   volumes:
     - name: postgres-data
       hostPath:
-        path: "{{ .BaseDir }}/applications/{{ .InstanceSlug }}/volumes/summarize/postgres"
+        path: "{{ .BaseDir }}/applications/{{ .InstanceSlug }}/volumes/postgres-summarize"
         type: DirectoryOrCreate

--- a/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
+++ b/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
@@ -8,6 +8,29 @@ metadata:
     ai-services.io/routes: "6000:summarize-api-{{ .InstanceSlug }}:api"
     # ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
+  initContainers:
+    - name: summarize-db-init
+      image: "{{ .Values.summarize.image }}"
+      command:
+        - "/var/venv/bin/python"
+        - "db/scripts/init_db.py"
+      env:
+        - name: POSTGRES_HOST
+          value: "summarize-db-{{ .InstanceSlug }}"
+        - name: POSTGRES_PORT
+          value: "5432"
+        - name: POSTGRES_DB
+          value: "{{ .Values.summarize.database }}"
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: "summarize-db-secret-{{ .InstanceSlug }}"
+              key: username
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "summarize-db-secret-{{ .InstanceSlug }}"
+              key: password
   containers:
     - name: summarize-api
       image: "{{ .Values.summarize.image }}"
@@ -25,6 +48,26 @@ spec:
         - "--http"
         - "httptools"
       env:
+        - name: POSTGRES_HOST
+          value: "summarize-db-{{ .InstanceSlug }}"
+        - name: POSTGRES_PORT
+          value: "5432"
+        - name: POSTGRES_DB
+          value: "{{ .Values.summarize.database }}"
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: "summarize-db-secret-{{ .InstanceSlug }}"
+              key: username
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "summarize-db-secret-{{ .InstanceSlug }}"
+              key: password
+        - name: DB_POOL_SIZE
+          value: "5"
+        - name: DB_MAX_OVERFLOW
+          value: "5"
         - name: PORT
           value: "6000"
         - name: LLM_ENDPOINT

--- a/ai-services/assets/services/summarize/podman/values.yaml
+++ b/ai-services/assets/services/summarize/podman/values.yaml
@@ -2,3 +2,12 @@ summarize:
   port: ""
   image: icr.io/ai-services-cicd/summarize-service:v0.0.6
   log_level: "INFO"
+  database: "summarize_metadata"
+
+postgres:
+  image: icr.io/ai-services-cicd/postgres:18-2
+  username: "postgres"
+  # @generate:password
+  password: ""
+
+# Made with Bob


### PR DESCRIPTION
- Fixes the Summarize failure with the Catalog flow of Application Deployment as Postgres instance is not present

Note: This ensures that a separate DB instance is used for Summarize