### PR TITLE
remove routes annotation from application assets

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.34
+TAG?=0.0.35
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/applications/rag-cpu/podman/templates/chat-bot.yaml.tmpl
@@ -7,8 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/routes: "3000:chat-bot-ui,5000:chat-bot-backend"
-    # ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"  # Uncomment to expose ports directly (bypasses Caddy)
+    ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"
 spec:
   containers:
     - name: ui

--- a/ai-services/assets/applications/rag-cpu/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/applications/rag-cpu/podman/templates/digitize.yaml.tmpl
@@ -7,8 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/routes: "4001:digitize-ui,4000:digitize-backend"
-    # ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"  # Uncomment to expose ports directly (bypasses Caddy)
+    ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"
     io.podman.annotations.pids-limit/backend-server: "4096"
 spec:
   initContainers:

--- a/ai-services/assets/applications/rag-cpu/podman/templates/similarity-api.yaml.tmpl
+++ b/ai-services/assets/applications/rag-cpu/podman/templates/similarity-api.yaml.tmpl
@@ -7,8 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/routes: "7000:similarity-api"
-    # ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"  # Uncomment to expose ports directly (bypasses Caddy)
+    ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"
 spec:
   containers:
     - name: similarity-api

--- a/ai-services/assets/applications/rag-cpu/podman/templates/summarize-api.yaml.tmpl
+++ b/ai-services/assets/applications/rag-cpu/podman/templates/summarize-api.yaml.tmpl
@@ -7,8 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/routes: "6000:summarize-api"
-    # ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"  # Uncomment to expose ports directly (bypasses Caddy)
+    ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"
 spec:
   initContainers:
     - name: summarize-db-init

--- a/ai-services/assets/applications/rag-dev/podman/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/applications/rag-dev/podman/templates/chat-bot.yaml.tmpl
@@ -7,8 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/routes: "3000:chat-bot-ui,5000:chat-bot-backend"
-    # ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"  # Uncomment to expose ports directly (bypasses Caddy)
+    ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"
 spec:
   containers:
     - name: ui

--- a/ai-services/assets/applications/rag-dev/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/applications/rag-dev/podman/templates/digitize.yaml.tmpl
@@ -7,8 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/routes: "4001:digitize-ui,4000:digitize-backend"
-    # ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"  # Uncomment to expose ports directly (bypasses Caddy)
+    ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"
     io.podman.annotations.pids-limit/backend-server: "4096"
 spec:
   initContainers:

--- a/ai-services/assets/applications/rag-dev/podman/templates/similarity-api.yaml.tmpl
+++ b/ai-services/assets/applications/rag-dev/podman/templates/similarity-api.yaml.tmpl
@@ -7,8 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/routes: "7000:similarity-api"
-    # ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"  # Uncomment to expose ports directly (bypasses Caddy)
+    ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"
 spec:
   containers:
     - name: similarity-api

--- a/ai-services/assets/applications/rag-dev/podman/templates/summarize-api.yaml.tmpl
+++ b/ai-services/assets/applications/rag-dev/podman/templates/summarize-api.yaml.tmpl
@@ -7,8 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/routes: "6000:summarize-api"
-    # ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"  # Uncomment to expose ports directly (bypasses Caddy)
+    ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"
 spec:
   initContainers:
     - name: summarize-db-init

--- a/ai-services/assets/applications/rag/podman/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/chat-bot.yaml.tmpl
@@ -7,9 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/routes: "3000:chat-bot-ui,5000:chat-bot-backend"
-    # ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"  # Uncomment to expose ports directly (bypasses Caddy)
-spec:
+    ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"
   containers:
     - name: ui
       image: "{{ .Values.ui.image }}"

--- a/ai-services/assets/applications/rag/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/digitize.yaml.tmpl
@@ -7,8 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/routes: "4001:digitize-ui,4000:digitize-backend"
-    # ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"  # Uncomment to expose ports directly (bypasses Caddy)
+    ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"
     io.podman.annotations.pids-limit/backend-server: "4096"
 spec:
   initContainers:

--- a/ai-services/assets/applications/rag/podman/templates/similarity-api.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/similarity-api.yaml.tmpl
@@ -7,8 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/routes: "7000:similarity-api"
-    # ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"  # Uncomment to expose ports directly (bypasses Caddy)
+    ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"
 spec:
   containers:
     - name: similarity-api

--- a/ai-services/assets/applications/rag/podman/templates/summarize-api.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/summarize-api.yaml.tmpl
@@ -7,8 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
   annotations:
-    ai-services.io/routes: "6000:summarize-api"
-    # ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"  # Uncomment to expose ports directly (bypasses Caddy)
+    ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"
 spec:
   initContainers:
     - name: summarize-db-init

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.34
+  image: icr.io/ai-services-cicd/ai-services:0.0.35
   runtime: ""
   adminPasswordHash: ""
   podman:


### PR DESCRIPTION
### Issue
application info and Next Steps were not showing correct service endpoints. Ports were missing from URLs (e.g. http://10.48.64.114:) and only the Summarize API was displayed in the Info section.

### Root cause
PR #823 removed/disabled `ai-services.io/ports`, which CLI uses for service discovery and endpoint rendering.

### Fix
Re-enabled `ai-services.io/ports` and ensured all services define correct port mappings.