### PR TITLE
Implement Import/Export API endpoints for digitize service

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.48
+TAG?=0.0.49
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.13
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.14
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.13
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.14
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.13
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.14
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.13
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.14
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.13
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.14
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.48
+  image: icr.io/ai-services-cicd/ai-services:0.0.49
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,6 +1,6 @@
 digitize:
   port: ""
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.13
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.14
   log_level: "INFO"
   database: "digitize_metadata"
 

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.13
+TAG?=v0.0.14
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/app.py
+++ b/services/digitize/app.py
@@ -25,6 +25,7 @@ from digitize.cleanup import reset_db
 from digitize.ingest import ingest
 from digitize.db_operations import get_status_manager
 from digitize.db.connection import check_db_connection, close_db_connections
+import digitize.db_operations as db_ops
 
 # Semaphores for concurrency limiting
 digitization_semaphore = asyncio.BoundedSemaphore(settings.digitize.digitization_concurrency_limit)
@@ -58,6 +59,8 @@ async def lifespan(app: FastAPI):
             try:
                 from digitize.db.models import Base
                 from digitize.db.connection import engine
+                if engine is None:
+                    raise RuntimeError("Database engine is not initialized")
                 Base.metadata.create_all(bind=engine)
                 logger.info("✅ Database schema initialized")
             except Exception as schema_error:
@@ -313,6 +316,72 @@ async def digitize_document(
     except Exception as e:
         logger.error(f"Unexpected error in digitize_document: {e}")
         APIError.raise_error("INTERNAL_SERVER_ERROR", str(e))
+
+@app.post(
+    "/v1/import",
+    response_model=models.ImportResponse,
+    responses={400: http_error_responses[400], 409: http_error_responses[409], 413: http_error_responses[413], 500: http_error_responses[500]},
+    tags=["jobs"],
+    summary="Import metadata into PostgreSQL",
+    description="Import job and document metadata into PostgreSQL using the export-compatible JSON payload.",
+    response_description="Import summary with imported, skipped, failed records and warnings"
+)
+async def import_metadata(payload: models.ImportRequest):
+    """Import job and document metadata into PostgreSQL."""
+    try:
+        total_records = len(payload.data.jobs) + len(payload.data.documents)
+        if total_records > db_ops.MAX_IMPORT_RECORDS:
+            APIError.raise_error(
+                ErrorCode.CONTEXT_LIMIT_EXCEEDED,
+                f"Request contains {total_records} records, maximum allowed is {db_ops.MAX_IMPORT_RECORDS}",
+            )
+
+        has_active, active_job_ids = dg_util.has_active_jobs()
+        if has_active:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_LOCKED,
+                f"Cannot import while jobs are active. Active jobs: {', '.join(active_job_ids)}",
+            )
+
+        return db_ops.import_metadata(payload)
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        logger.error(f"Invalid import request: {exc}")
+        APIError.raise_error(ErrorCode.INVALID_REQUEST, str(exc))
+    except Exception as exc:
+        logger.error(f"Failed to import metadata: {exc}", exc_info=True)
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, "Database connection failed during import")
+
+
+@app.get(
+    "/v1/export",
+    response_model=models.ExportResponse,
+    responses={400: http_error_responses[400], 413: http_error_responses[413], 500: http_error_responses[500]},
+    tags=["jobs"],
+    summary="Export metadata from PostgreSQL",
+    description="Export job and document metadata from PostgreSQL as JSON for backup and restore workflows.",
+    response_description="Exported metadata with summary and pagination details"
+)
+async def export_metadata(
+    limit: int = Query(db_ops.IMPORT_EXPORT_DEFAULT_LIMIT, description="Maximum combined records to export. Use -1 to export all records in one response."),
+    offset: int = Query(0, ge=0, description="Number of combined records to skip for pagination"),
+):
+    """Export job and document metadata from PostgreSQL."""
+    try:
+        if limit < -1 or limit == 0:
+            APIError.raise_error(ErrorCode.INVALID_REQUEST, "limit must be -1 or a positive integer")
+
+        return db_ops.export_metadata(limit=limit, offset=offset)
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        logger.error(f"Invalid export request: {exc}")
+        APIError.raise_error(ErrorCode.INVALID_REQUEST, str(exc))
+    except Exception as exc:
+        logger.error(f"Failed to export metadata: {exc}", exc_info=True)
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, "Database query failed during export")
+
 
 @app.get(
     "/v1/jobs",

--- a/services/digitize/app.py
+++ b/services/digitize/app.py
@@ -31,6 +31,10 @@ import digitize.db_operations as db_ops
 digitization_semaphore = asyncio.BoundedSemaphore(settings.digitize.digitization_concurrency_limit)
 ingestion_semaphore = asyncio.BoundedSemaphore(settings.digitize.ingestion_concurrency_limit)
 
+# Lock to prevent job creation during import/export operations
+import_export_lock = asyncio.Lock()
+import_export_in_progress = False
+
 logger = get_logger("digitize_server")
 
 diagnostic_logger, stderr_monitor, signal_handler = setup_comprehensive_crash_handler(logger)
@@ -264,14 +268,22 @@ async def digitize_document(
     job_name: Optional[str] = Query(None, description="Optional human-readable name for the job")
 ):
     try:
-        # 1. Early exit if no files submitted
+        # 1. Check if import/export is in progress
+        global import_export_in_progress
+        if import_export_in_progress:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_LOCKED,
+                "Cannot create new jobs while import/export operation is in progress"
+            )
+
+        # 2. Early exit if no files submitted
         if not files or len(files) == 0:
             APIError.raise_error(ErrorCode.INVALID_REQUEST, "No files provided. Please submit at least one file.")
 
         if operation == models.OperationType.DIGITIZATION and len(files) > 1:
             APIError.raise_error(ErrorCode.INVALID_REQUEST, "Only 1 file allowed for digitization.")
 
-        # 2. Check for active ingestion jobs BEFORE semaphore check (cross-process coordination)
+        # 3. Check for active ingestion jobs BEFORE semaphore check (cross-process coordination)
         if operation == models.OperationType.INGESTION:
             has_active, active_job_ids = dg_util.has_active_jobs(operation=operation.value)
             if has_active:
@@ -328,9 +340,12 @@ async def digitize_document(
 )
 async def import_metadata(payload: models.ImportRequest):
     """Import job and document metadata into PostgreSQL."""
+    global import_export_in_progress
+
     try:
         total_records = len(payload.data.jobs) + len(payload.data.documents)
-        if total_records > db_ops.MAX_IMPORT_RECORDS:
+        # MAX_IMPORT_RECORDS = -1 means no limit (allow importing all records)
+        if db_ops.MAX_IMPORT_RECORDS != -1 and total_records > db_ops.MAX_IMPORT_RECORDS:
             APIError.raise_error(
                 ErrorCode.CONTEXT_LIMIT_EXCEEDED,
                 f"Request contains {total_records} records, maximum allowed is {db_ops.MAX_IMPORT_RECORDS}",
@@ -343,7 +358,16 @@ async def import_metadata(payload: models.ImportRequest):
                 f"Cannot import while jobs are active. Active jobs: {', '.join(active_job_ids)}",
             )
 
-        return db_ops.import_metadata(payload)
+        # Set flag to prevent new job creation during import
+        async with import_export_lock:
+            import_export_in_progress = True
+
+        try:
+            return db_ops.import_metadata(payload)
+        finally:
+            # Clear flag after import completes
+            async with import_export_lock:
+                import_export_in_progress = False
     except HTTPException:
         raise
     except ValueError as exc:
@@ -368,11 +392,30 @@ async def export_metadata(
     offset: int = Query(0, ge=0, description="Number of combined records to skip for pagination"),
 ):
     """Export job and document metadata from PostgreSQL."""
+    global import_export_in_progress
+
     try:
         if limit < -1 or limit == 0:
             APIError.raise_error(ErrorCode.INVALID_REQUEST, "limit must be -1 or a positive integer")
 
-        return db_ops.export_metadata(limit=limit, offset=offset)
+        # Check for active jobs before allowing export
+        has_active, active_job_ids = dg_util.has_active_jobs()
+        if has_active:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_LOCKED,
+                f"Cannot export while jobs are active. Active jobs: {', '.join(active_job_ids)}",
+            )
+
+        # Set flag to prevent new job creation during export
+        async with import_export_lock:
+            import_export_in_progress = True
+
+        try:
+            return db_ops.export_metadata(limit=limit, offset=offset)
+        finally:
+            # Clear flag after export completes
+            async with import_export_lock:
+                import_export_in_progress = False
     except HTTPException:
         raise
     except ValueError as exc:

--- a/services/digitize/app.py
+++ b/services/digitize/app.py
@@ -31,9 +31,132 @@ import digitize.db_operations as db_ops
 digitization_semaphore = asyncio.BoundedSemaphore(settings.digitize.digitization_concurrency_limit)
 ingestion_semaphore = asyncio.BoundedSemaphore(settings.digitize.ingestion_concurrency_limit)
 
-# Lock to prevent job creation during import/export operations
-import_export_lock = asyncio.Lock()
-import_export_in_progress = False
+# Store active lock connection to keep it alive
+_import_export_lock_connection = None
+
+async def is_import_export_in_progress() -> bool:
+    """
+    Check if an import/export operation is currently in progress.
+    Returns True if locked, False if available.
+    """
+    import asyncio
+
+    def _sync_check():
+        from digitize.db.connection import get_db_session
+        from sqlalchemy import text
+
+        try:
+            with get_db_session() as session:
+                # Check if the advisory lock is currently held
+                # pg_try_advisory_lock returns true if lock acquired, false if already held
+                # We immediately release it if we acquired it (just checking status)
+                result = session.execute(text("SELECT pg_try_advisory_lock(123456789)")).scalar()
+                if result:
+                    # We acquired it, so it wasn't in use - release it immediately
+                    session.execute(text("SELECT pg_advisory_unlock(123456789)"))
+                    return False
+                else:
+                    # Lock is held by another process
+                    return True
+        except Exception as e:
+            logger.error(f"Failed to check import/export lock status: {e}")
+            # On error, assume it's not in progress to avoid blocking operations
+            return False
+
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, _sync_check)
+
+async def acquire_import_export_lock() -> bool:
+    """
+    Acquire a distributed lock for import/export operations using PostgreSQL advisory locks.
+    Returns True if lock was acquired, False if another process holds the lock.
+    IMPORTANT: Keeps the database connection open to maintain the lock.
+    Runs in thread pool to avoid blocking the async event loop.
+    """
+    import asyncio
+    from functools import partial
+
+    def _sync_acquire():
+        global _import_export_lock_connection
+        from digitize.db.connection import engine
+        from sqlalchemy import text
+        import os
+
+        pid = os.getpid()
+        logger.info(f"[PID {pid}] Attempting to acquire import/export lock...")
+
+        if not engine:
+            logger.error(f"[PID {pid}] Database engine not initialized")
+            return False
+
+        conn = None
+        try:
+            # Create a new connection that we'll keep open
+            conn = engine.connect()
+            logger.debug(f"[PID {pid}] Database connection created")
+
+            # Try to acquire PostgreSQL advisory lock (non-blocking)
+            # Lock ID: 123456789 (arbitrary unique number for import/export operations)
+            result = conn.execute(text("SELECT pg_try_advisory_lock(123456789)")).scalar()
+            logger.debug(f"[PID {pid}] Lock acquisition result: {result}")
+
+            if result:
+                # Lock acquired - store connection to keep it alive
+                _import_export_lock_connection = conn
+                logger.warning(f"[PID {pid}] ✅ Import/export lock ACQUIRED successfully")
+                return True
+            else:
+                # Lock not acquired - close connection
+                conn.close()
+                logger.warning(f"[PID {pid}] ❌ Import/export lock ALREADY HELD by another process")
+                return False
+        except Exception as e:
+            logger.error(f"[PID {pid}] Failed to acquire import/export lock: {e}", exc_info=True)
+            if conn:
+                try:
+                    conn.close()
+                except:
+                    pass
+            return False
+
+    # Run in thread pool to avoid blocking event loop
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, _sync_acquire)
+
+async def release_import_export_lock():
+    """Release the distributed import/export lock and close the connection."""
+    import asyncio
+
+    def _sync_release():
+        global _import_export_lock_connection
+        from sqlalchemy import text
+        import os
+
+        pid = os.getpid()
+        logger.info(f"[PID {pid}] Releasing import/export lock...")
+
+        try:
+            if _import_export_lock_connection:
+                # Release PostgreSQL advisory lock
+                _import_export_lock_connection.execute(text("SELECT pg_advisory_unlock(123456789)"))
+                _import_export_lock_connection.close()
+                _import_export_lock_connection = None
+                logger.warning(f"[PID {pid}] ✅ Import/export lock RELEASED successfully")
+            else:
+                logger.warning(f"[PID {pid}] No lock connection to release")
+        except Exception as e:
+            logger.error(f"[PID {pid}] Failed to release import/export lock: {e}", exc_info=True)
+            # Ensure connection is closed even on error
+            if _import_export_lock_connection:
+                try:
+                    _import_export_lock_connection.close()
+                except:
+                    pass
+                _import_export_lock_connection = None
+
+    # Run in thread pool to avoid blocking event loop
+    loop = asyncio.get_event_loop()
+    await loop.run_in_executor(None, _sync_release)
 
 logger = get_logger("digitize_server")
 
@@ -269,8 +392,7 @@ async def digitize_document(
 ):
     try:
         # 1. Check if import/export is in progress
-        global import_export_in_progress
-        if import_export_in_progress:
+        if await is_import_export_in_progress():
             APIError.raise_error(
                 ErrorCode.RESOURCE_LOCKED,
                 "Cannot create new jobs while import/export operation is in progress"
@@ -340,34 +462,35 @@ async def digitize_document(
 )
 async def import_metadata(payload: models.ImportRequest):
     """Import job and document metadata into PostgreSQL."""
-    global import_export_in_progress
 
     try:
-        total_records = len(payload.data.jobs) + len(payload.data.documents)
-        # MAX_IMPORT_RECORDS = -1 means no limit (allow importing all records)
-        if db_ops.MAX_IMPORT_RECORDS != -1 and total_records > db_ops.MAX_IMPORT_RECORDS:
-            APIError.raise_error(
-                ErrorCode.CONTEXT_LIMIT_EXCEEDED,
-                f"Request contains {total_records} records, maximum allowed is {db_ops.MAX_IMPORT_RECORDS}",
-            )
-
-        has_active, active_job_ids = dg_util.has_active_jobs()
-        if has_active:
+        # Try to acquire distributed lock (works across all worker processes)
+        if not await acquire_import_export_lock():
             APIError.raise_error(
                 ErrorCode.RESOURCE_LOCKED,
-                f"Cannot import while jobs are active. Active jobs: {', '.join(active_job_ids)}",
+                "Another import/export operation is already in progress. Please wait for it to complete.",
             )
 
-        # Set flag to prevent new job creation during import
-        async with import_export_lock:
-            import_export_in_progress = True
-
         try:
+            total_records = len(payload.data.jobs) + len(payload.data.documents)
+            # MAX_IMPORT_RECORDS = -1 means no limit (allow importing all records)
+            if db_ops.MAX_IMPORT_RECORDS != -1 and total_records > db_ops.MAX_IMPORT_RECORDS:
+                APIError.raise_error(
+                    ErrorCode.CONTEXT_LIMIT_EXCEEDED,
+                    f"Request contains {total_records} records, maximum allowed is {db_ops.MAX_IMPORT_RECORDS}",
+                )
+
+            has_active, active_job_ids = dg_util.has_active_jobs()
+            if has_active:
+                APIError.raise_error(
+                    ErrorCode.RESOURCE_LOCKED,
+                    f"Cannot import while jobs are active. Active jobs: {', '.join(active_job_ids)}",
+                )
+
             return db_ops.import_metadata(payload)
         finally:
-            # Clear flag after import completes
-            async with import_export_lock:
-                import_export_in_progress = False
+            # Release distributed lock
+            await release_import_export_lock()
     except HTTPException:
         raise
     except ValueError as exc:
@@ -392,30 +515,40 @@ async def export_metadata(
     offset: int = Query(0, ge=0, description="Number of combined records to skip for pagination"),
 ):
     """Export job and document metadata from PostgreSQL."""
-    global import_export_in_progress
+    import os
+    pid = os.getpid()
+    logger.warning(f"[PID {pid}] 🔵 Export request received (limit={limit}, offset={offset})")
 
     try:
-        if limit < -1 or limit == 0:
-            APIError.raise_error(ErrorCode.INVALID_REQUEST, "limit must be -1 or a positive integer")
-
-        # Check for active jobs before allowing export
-        has_active, active_job_ids = dg_util.has_active_jobs()
-        if has_active:
+        # Try to acquire distributed lock (works across all worker processes)
+        logger.info(f"[PID {pid}] Trying to acquire lock for export...")
+        if not await acquire_import_export_lock():
+            logger.warning(f"[PID {pid}] ❌ Export REJECTED - lock held by another process")
             APIError.raise_error(
                 ErrorCode.RESOURCE_LOCKED,
-                f"Cannot export while jobs are active. Active jobs: {', '.join(active_job_ids)}",
+                "Another import/export operation is already in progress. Please wait for it to complete.",
             )
 
-        # Set flag to prevent new job creation during export
-        async with import_export_lock:
-            import_export_in_progress = True
-
+        logger.warning(f"[PID {pid}] ✅ Export proceeding with lock acquired")
         try:
-            return db_ops.export_metadata(limit=limit, offset=offset)
+            if limit < -1 or limit == 0:
+                APIError.raise_error(ErrorCode.INVALID_REQUEST, "limit must be -1 or a positive integer")
+
+            # Check for active jobs before allowing export
+            has_active, active_job_ids = dg_util.has_active_jobs()
+            if has_active:
+                APIError.raise_error(
+                    ErrorCode.RESOURCE_LOCKED,
+                    f"Cannot export while jobs are active. Active jobs: {', '.join(active_job_ids)}",
+                )
+
+            logger.info(f"[PID {pid}] Starting export operation...")
+            result = db_ops.export_metadata(limit=limit, offset=offset)
+            logger.warning(f"[PID {pid}] ✅ Export completed successfully")
+            return result
         finally:
-            # Clear flag after export completes
-            async with import_export_lock:
-                import_export_in_progress = False
+            # Release distributed lock
+            await release_import_export_lock()
     except HTTPException:
         raise
     except ValueError as exc:

--- a/services/digitize/app.py
+++ b/services/digitize/app.py
@@ -31,133 +31,6 @@ import digitize.db_operations as db_ops
 digitization_semaphore = asyncio.BoundedSemaphore(settings.digitize.digitization_concurrency_limit)
 ingestion_semaphore = asyncio.BoundedSemaphore(settings.digitize.ingestion_concurrency_limit)
 
-# Store active lock connection to keep it alive
-_import_export_lock_connection = None
-
-async def is_import_export_in_progress() -> bool:
-    """
-    Check if an import/export operation is currently in progress.
-    Returns True if locked, False if available.
-    """
-    import asyncio
-
-    def _sync_check():
-        from digitize.db.connection import get_db_session
-        from sqlalchemy import text
-
-        try:
-            with get_db_session() as session:
-                # Check if the advisory lock is currently held
-                # pg_try_advisory_lock returns true if lock acquired, false if already held
-                # We immediately release it if we acquired it (just checking status)
-                result = session.execute(text("SELECT pg_try_advisory_lock(123456789)")).scalar()
-                if result:
-                    # We acquired it, so it wasn't in use - release it immediately
-                    session.execute(text("SELECT pg_advisory_unlock(123456789)"))
-                    return False
-                else:
-                    # Lock is held by another process
-                    return True
-        except Exception as e:
-            logger.error(f"Failed to check import/export lock status: {e}")
-            # On error, assume it's not in progress to avoid blocking operations
-            return False
-
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(None, _sync_check)
-
-async def acquire_import_export_lock() -> bool:
-    """
-    Acquire a distributed lock for import/export operations using PostgreSQL advisory locks.
-    Returns True if lock was acquired, False if another process holds the lock.
-    IMPORTANT: Keeps the database connection open to maintain the lock.
-    Runs in thread pool to avoid blocking the async event loop.
-    """
-    import asyncio
-    from functools import partial
-
-    def _sync_acquire():
-        global _import_export_lock_connection
-        from digitize.db.connection import engine
-        from sqlalchemy import text
-        import os
-
-        pid = os.getpid()
-        logger.info(f"[PID {pid}] Attempting to acquire import/export lock...")
-
-        if not engine:
-            logger.error(f"[PID {pid}] Database engine not initialized")
-            return False
-
-        conn = None
-        try:
-            # Create a new connection that we'll keep open
-            conn = engine.connect()
-            logger.debug(f"[PID {pid}] Database connection created")
-
-            # Try to acquire PostgreSQL advisory lock (non-blocking)
-            # Lock ID: 123456789 (arbitrary unique number for import/export operations)
-            result = conn.execute(text("SELECT pg_try_advisory_lock(123456789)")).scalar()
-            logger.debug(f"[PID {pid}] Lock acquisition result: {result}")
-
-            if result:
-                # Lock acquired - store connection to keep it alive
-                _import_export_lock_connection = conn
-                logger.warning(f"[PID {pid}] ✅ Import/export lock ACQUIRED successfully")
-                return True
-            else:
-                # Lock not acquired - close connection
-                conn.close()
-                logger.warning(f"[PID {pid}] ❌ Import/export lock ALREADY HELD by another process")
-                return False
-        except Exception as e:
-            logger.error(f"[PID {pid}] Failed to acquire import/export lock: {e}", exc_info=True)
-            if conn:
-                try:
-                    conn.close()
-                except:
-                    pass
-            return False
-
-    # Run in thread pool to avoid blocking event loop
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(None, _sync_acquire)
-
-async def release_import_export_lock():
-    """Release the distributed import/export lock and close the connection."""
-    import asyncio
-
-    def _sync_release():
-        global _import_export_lock_connection
-        from sqlalchemy import text
-        import os
-
-        pid = os.getpid()
-        logger.info(f"[PID {pid}] Releasing import/export lock...")
-
-        try:
-            if _import_export_lock_connection:
-                # Release PostgreSQL advisory lock
-                _import_export_lock_connection.execute(text("SELECT pg_advisory_unlock(123456789)"))
-                _import_export_lock_connection.close()
-                _import_export_lock_connection = None
-                logger.warning(f"[PID {pid}] ✅ Import/export lock RELEASED successfully")
-            else:
-                logger.warning(f"[PID {pid}] No lock connection to release")
-        except Exception as e:
-            logger.error(f"[PID {pid}] Failed to release import/export lock: {e}", exc_info=True)
-            # Ensure connection is closed even on error
-            if _import_export_lock_connection:
-                try:
-                    _import_export_lock_connection.close()
-                except:
-                    pass
-                _import_export_lock_connection = None
-
-    # Run in thread pool to avoid blocking event loop
-    loop = asyncio.get_event_loop()
-    await loop.run_in_executor(None, _sync_release)
-
 logger = get_logger("digitize_server")
 
 diagnostic_logger, stderr_monitor, signal_handler = setup_comprehensive_crash_handler(logger)
@@ -451,6 +324,133 @@ async def digitize_document(
         logger.error(f"Unexpected error in digitize_document: {e}")
         APIError.raise_error("INTERNAL_SERVER_ERROR", str(e))
 
+# ============================================================================
+# Import/Export Lock Management
+# ============================================================================
+
+# Store active lock connection to keep it alive
+_import_export_lock_connection = None
+
+# Import/Export configuration
+MAX_IMPORT_RECORDS = -1  # -1 means no limit, set to positive integer to enforce limit
+
+async def is_import_export_in_progress() -> bool:
+    """
+    Check if an import/export operation is currently in progress.
+    Returns True if locked, False if available.
+    """
+    def _sync_check():
+        from digitize.db.connection import get_db_session
+        from sqlalchemy import text
+
+        try:
+            with get_db_session() as session:
+                # Check if the advisory lock is currently held
+                # pg_try_advisory_lock returns true if lock acquired, false if already held
+                # We immediately release it if we acquired it (just checking status)
+                result = session.execute(text("SELECT pg_try_advisory_lock(123456789)")).scalar()
+                if result:
+                    # We acquired it, so it wasn't in use - release it immediately
+                    session.execute(text("SELECT pg_advisory_unlock(123456789)"))
+                    return False
+                else:
+                    # Lock is held by another process
+                    return True
+        except Exception as e:
+            logger.error(f"Failed to check import/export lock status: {e}")
+            # On error, assume it's not in progress to avoid blocking operations
+            return False
+
+    return await asyncio.to_thread(_sync_check)
+
+async def acquire_import_export_lock() -> bool:
+    """
+    Acquire a distributed lock for import/export operations using PostgreSQL advisory locks.
+    Returns True if lock was acquired, False if another process holds the lock.
+    IMPORTANT: Keeps the database connection open to maintain the lock.
+    Runs in thread pool to avoid blocking the async event loop.
+    """
+    def _sync_acquire():
+        global _import_export_lock_connection
+        from digitize.db.connection import engine
+        from sqlalchemy import text
+        import os
+
+        pid = os.getpid()
+        logger.info(f"[PID {pid}] Attempting to acquire import/export lock...")
+
+        if not engine:
+            logger.error(f"[PID {pid}] Database engine not initialized")
+            return False
+
+        conn = None
+        try:
+            # Create a new connection that we'll keep open
+            conn = engine.connect()
+            logger.debug(f"[PID {pid}] Database connection created")
+
+            # Try to acquire PostgreSQL advisory lock (non-blocking)
+            # Lock ID: 123456789 (arbitrary unique number for import/export operations)
+            result = conn.execute(text("SELECT pg_try_advisory_lock(123456789)")).scalar()
+            logger.debug(f"[PID {pid}] Lock acquisition result: {result}")
+
+            if result:
+                # Lock acquired - store connection to keep it alive
+                _import_export_lock_connection = conn
+                logger.warning(f"[PID {pid}] ✅ Import/export lock ACQUIRED successfully")
+                return True
+            else:
+                # Lock not acquired - close connection
+                conn.close()
+                logger.warning(f"[PID {pid}] ❌ Import/export lock ALREADY HELD by another process")
+                return False
+        except Exception as e:
+            logger.error(f"[PID {pid}] Failed to acquire import/export lock: {e}", exc_info=True)
+            if conn:
+                try:
+                    conn.close()
+                except:
+                    pass
+            return False
+
+    return await asyncio.to_thread(_sync_acquire)
+
+async def release_import_export_lock():
+    """Release the distributed import/export lock and close the connection."""
+    def _sync_release():
+        global _import_export_lock_connection
+        from sqlalchemy import text
+        import os
+
+        pid = os.getpid()
+        logger.info(f"[PID {pid}] Releasing import/export lock...")
+
+        try:
+            if _import_export_lock_connection:
+                # Release PostgreSQL advisory lock
+                _import_export_lock_connection.execute(text("SELECT pg_advisory_unlock(123456789)"))
+                _import_export_lock_connection.close()
+                _import_export_lock_connection = None
+                logger.warning(f"[PID {pid}] ✅ Import/export lock RELEASED successfully")
+            else:
+                logger.warning(f"[PID {pid}] No lock connection to release")
+        except Exception as e:
+            logger.error(f"[PID {pid}] Failed to release import/export lock: {e}", exc_info=True)
+            # Ensure connection is closed even on error
+            if _import_export_lock_connection:
+                try:
+                    _import_export_lock_connection.close()
+                except:
+                    pass
+                _import_export_lock_connection = None
+
+    await asyncio.to_thread(_sync_release)
+
+
+# ============================================================================
+# Import/Export API Endpoints
+# ============================================================================
+
 @app.post(
     "/v1/import",
     response_model=models.ImportResponse,
@@ -474,10 +474,10 @@ async def import_metadata(payload: models.ImportRequest):
         try:
             total_records = len(payload.data.jobs) + len(payload.data.documents)
             # MAX_IMPORT_RECORDS = -1 means no limit (allow importing all records)
-            if db_ops.MAX_IMPORT_RECORDS != -1 and total_records > db_ops.MAX_IMPORT_RECORDS:
+            if MAX_IMPORT_RECORDS != -1 and total_records > MAX_IMPORT_RECORDS:
                 APIError.raise_error(
                     ErrorCode.CONTEXT_LIMIT_EXCEEDED,
-                    f"Request contains {total_records} records, maximum allowed is {db_ops.MAX_IMPORT_RECORDS}",
+                    f"Request contains {total_records} records, maximum allowed is {MAX_IMPORT_RECORDS}",
                 )
 
             has_active, active_job_ids = dg_util.has_active_jobs()

--- a/services/digitize/app.py
+++ b/services/digitize/app.py
@@ -265,7 +265,7 @@ async def digitize_document(
 ):
     try:
         # 1. Check if import/export is in progress
-        if await is_import_export_in_progress():
+        if await db_ops.is_import_export_in_progress():
             APIError.raise_error(
                 ErrorCode.RESOURCE_LOCKED,
                 "Cannot create new jobs while import/export operation is in progress"
@@ -325,126 +325,11 @@ async def digitize_document(
         APIError.raise_error("INTERNAL_SERVER_ERROR", str(e))
 
 # ============================================================================
-# Import/Export Lock Management
+# Import/Export Configuration
 # ============================================================================
-
-# Store active lock connection to keep it alive
-_import_export_lock_connection = None
 
 # Import/Export configuration
 MAX_IMPORT_RECORDS = -1  # -1 means no limit, set to positive integer to enforce limit
-
-async def is_import_export_in_progress() -> bool:
-    """
-    Check if an import/export operation is currently in progress.
-    Returns True if locked, False if available.
-    """
-    def _sync_check():
-        from digitize.db.connection import get_db_session
-        from sqlalchemy import text
-
-        try:
-            with get_db_session() as session:
-                # Check if the advisory lock is currently held
-                # pg_try_advisory_lock returns true if lock acquired, false if already held
-                # We immediately release it if we acquired it (just checking status)
-                result = session.execute(text("SELECT pg_try_advisory_lock(123456789)")).scalar()
-                if result:
-                    # We acquired it, so it wasn't in use - release it immediately
-                    session.execute(text("SELECT pg_advisory_unlock(123456789)"))
-                    return False
-                else:
-                    # Lock is held by another process
-                    return True
-        except Exception as e:
-            logger.error(f"Failed to check import/export lock status: {e}")
-            # On error, assume it's not in progress to avoid blocking operations
-            return False
-
-    return await asyncio.to_thread(_sync_check)
-
-async def acquire_import_export_lock() -> bool:
-    """
-    Acquire a distributed lock for import/export operations using PostgreSQL advisory locks.
-    Returns True if lock was acquired, False if another process holds the lock.
-    IMPORTANT: Keeps the database connection open to maintain the lock.
-    Runs in thread pool to avoid blocking the async event loop.
-    """
-    def _sync_acquire():
-        global _import_export_lock_connection
-        from digitize.db.connection import engine
-        from sqlalchemy import text
-        import os
-
-        pid = os.getpid()
-        logger.info(f"[PID {pid}] Attempting to acquire import/export lock...")
-
-        if not engine:
-            logger.error(f"[PID {pid}] Database engine not initialized")
-            return False
-
-        conn = None
-        try:
-            # Create a new connection that we'll keep open
-            conn = engine.connect()
-            logger.debug(f"[PID {pid}] Database connection created")
-
-            # Try to acquire PostgreSQL advisory lock (non-blocking)
-            # Lock ID: 123456789 (arbitrary unique number for import/export operations)
-            result = conn.execute(text("SELECT pg_try_advisory_lock(123456789)")).scalar()
-            logger.debug(f"[PID {pid}] Lock acquisition result: {result}")
-
-            if result:
-                # Lock acquired - store connection to keep it alive
-                _import_export_lock_connection = conn
-                logger.warning(f"[PID {pid}] ✅ Import/export lock ACQUIRED successfully")
-                return True
-            else:
-                # Lock not acquired - close connection
-                conn.close()
-                logger.warning(f"[PID {pid}] ❌ Import/export lock ALREADY HELD by another process")
-                return False
-        except Exception as e:
-            logger.error(f"[PID {pid}] Failed to acquire import/export lock: {e}", exc_info=True)
-            if conn:
-                try:
-                    conn.close()
-                except:
-                    pass
-            return False
-
-    return await asyncio.to_thread(_sync_acquire)
-
-async def release_import_export_lock():
-    """Release the distributed import/export lock and close the connection."""
-    def _sync_release():
-        global _import_export_lock_connection
-        from sqlalchemy import text
-        import os
-
-        pid = os.getpid()
-        logger.info(f"[PID {pid}] Releasing import/export lock...")
-
-        try:
-            if _import_export_lock_connection:
-                # Release PostgreSQL advisory lock
-                _import_export_lock_connection.execute(text("SELECT pg_advisory_unlock(123456789)"))
-                _import_export_lock_connection.close()
-                _import_export_lock_connection = None
-                logger.warning(f"[PID {pid}] ✅ Import/export lock RELEASED successfully")
-            else:
-                logger.warning(f"[PID {pid}] No lock connection to release")
-        except Exception as e:
-            logger.error(f"[PID {pid}] Failed to release import/export lock: {e}", exc_info=True)
-            # Ensure connection is closed even on error
-            if _import_export_lock_connection:
-                try:
-                    _import_export_lock_connection.close()
-                except:
-                    pass
-                _import_export_lock_connection = None
-
-    await asyncio.to_thread(_sync_release)
 
 
 # ============================================================================
@@ -465,7 +350,7 @@ async def import_metadata(payload: models.ImportRequest):
 
     try:
         # Try to acquire distributed lock (works across all worker processes)
-        if not await acquire_import_export_lock():
+        if not await db_ops.acquire_import_export_lock():
             APIError.raise_error(
                 ErrorCode.RESOURCE_LOCKED,
                 "Another import/export operation is already in progress. Please wait for it to complete.",
@@ -490,7 +375,7 @@ async def import_metadata(payload: models.ImportRequest):
             return db_ops.import_metadata(payload)
         finally:
             # Release distributed lock
-            await release_import_export_lock()
+            await db_ops.release_import_export_lock()
     except HTTPException:
         raise
     except ValueError as exc:
@@ -522,7 +407,7 @@ async def export_metadata(
     try:
         # Try to acquire distributed lock (works across all worker processes)
         logger.info(f"[PID {pid}] Trying to acquire lock for export...")
-        if not await acquire_import_export_lock():
+        if not await db_ops.acquire_import_export_lock():
             logger.warning(f"[PID {pid}] ❌ Export REJECTED - lock held by another process")
             APIError.raise_error(
                 ErrorCode.RESOURCE_LOCKED,
@@ -548,7 +433,7 @@ async def export_metadata(
             return result
         finally:
             # Release distributed lock
-            await release_import_export_lock()
+            await db_ops.release_import_export_lock()
     except HTTPException:
         raise
     except ValueError as exc:

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -28,6 +28,8 @@ class DatabaseManager:
         status: JobStatus = JobStatus.ACCEPTED,
         job_name: Optional[str] = None,
         submitted_at: Optional[datetime] = None,
+        completed_at: Optional[datetime] = None,
+        error: Optional[str] = None,
         stats: Optional[Dict[str, int]] = None
     ) -> Optional[Job]:
         """
@@ -39,6 +41,8 @@ class DatabaseManager:
             status: Initial job status
             job_name: Optional human-readable name
             submitted_at: Submission timestamp (defaults to now)
+            completed_at: Completion timestamp (optional, for import)
+            error: Error message (optional, for import)
             stats: Initial statistics dictionary
 
         Returns:
@@ -52,6 +56,8 @@ class DatabaseManager:
                     operation=operation,
                     status=status.value,
                     submitted_at=submitted_at or datetime.now(timezone.utc),
+                    completed_at=completed_at,
+                    error=error,
                     stats=stats or {
                         "total_documents": 0,
                         "completed": 0,
@@ -249,6 +255,8 @@ class DatabaseManager:
         status: DocStatus,
         output_format: str,
         submitted_at: Optional[datetime] = None,
+        completed_at: Optional[datetime] = None,
+        error: Optional[str] = None,
         job_id: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None
     ) -> Optional[Document]:
@@ -262,6 +270,8 @@ class DatabaseManager:
             status: Initial document status
             output_format: Output format (txt/md/json)
             submitted_at: Submission timestamp (defaults to now)
+            completed_at: Completion timestamp (optional, for import)
+            error: Error message (optional, for import)
             job_id: Associated job ID
             metadata: Additional metadata dictionary
 
@@ -278,6 +288,8 @@ class DatabaseManager:
                     status=status.value,
                     output_format=output_format,
                     submitted_at=submitted_at or datetime.now(timezone.utc),
+                    completed_at=completed_at,
+                    error=error,
                     doc_metadata=metadata or {}
                 )
                 session.add(document)

--- a/services/digitize/db_operations.py
+++ b/services/digitize/db_operations.py
@@ -366,6 +366,38 @@ def get_all_documents_paginated(
         raise
 
 
+def get_all_job_ids() -> list[str]:
+    """
+    Read all job IDs from the database.
+
+    Returns:
+        List of job IDs found in database
+    """
+    if engine is None:
+        raise RuntimeError("Database not available. Cannot retrieve job IDs without database connection.")
+
+    try:
+        logger.debug("Reading job IDs from database")
+        all_jobs = []
+        offset = 0
+
+        while True:
+            jobs, total = db_manager.get_all_jobs(limit=IMPORT_EXPORT_DEFAULT_LIMIT, offset=offset)
+            if not jobs:
+                break
+            all_jobs.extend(jobs)
+            offset += len(jobs)
+            if offset >= total:
+                break
+
+        job_ids = [job.job_id for job in all_jobs]
+        logger.info(f"Found {len(job_ids)} job IDs in database")
+        return job_ids
+    except Exception as e:
+        logger.error(f"Failed to read job IDs from database: {e}", exc_info=True)
+        raise
+
+
 def get_all_document_ids() -> list[str]:
     """
     Read all document IDs from the database.
@@ -378,8 +410,19 @@ def get_all_document_ids() -> list[str]:
 
     try:
         logger.debug("Reading document IDs from database")
-        documents, _ = db_manager.get_all_documents(limit=10000, offset=0)
-        doc_ids = [doc.doc_id for doc in documents]
+        all_documents = []
+        offset = 0
+
+        while True:
+            documents, total = db_manager.get_all_documents(limit=IMPORT_EXPORT_DEFAULT_LIMIT, offset=offset)
+            if not documents:
+                break
+            all_documents.extend(documents)
+            offset += len(documents)
+            if offset >= total:
+                break
+
+        doc_ids = [doc.doc_id for doc in all_documents]
         logger.info(f"Found {len(doc_ids)} document IDs in database")
         return doc_ids
     except Exception as e:
@@ -436,10 +479,12 @@ def export_metadata(limit: int = IMPORT_EXPORT_DEFAULT_LIMIT, offset: int = 0) -
 
     started_at = perf_counter()
 
-    jobs, total_jobs = db_manager.get_all_jobs(limit=IMPORT_EXPORT_DEFAULT_LIMIT if limit == -1 else limit, offset=0 if limit == -1 else offset)
-    documents, total_documents = db_manager.get_all_documents(limit=IMPORT_EXPORT_DEFAULT_LIMIT if limit == -1 else limit, offset=0 if limit == -1 else offset)
-
     if limit == -1:
+        # Fetch all records in batches
+        jobs, total_jobs = db_manager.get_all_jobs(limit=IMPORT_EXPORT_DEFAULT_LIMIT, offset=0)
+        documents, total_documents = db_manager.get_all_documents(limit=IMPORT_EXPORT_DEFAULT_LIMIT, offset=0)
+
+        # Fetch remaining jobs
         remaining_job_offset = len(jobs)
         while remaining_job_offset < total_jobs:
             batch, _ = db_manager.get_all_jobs(limit=IMPORT_EXPORT_DEFAULT_LIMIT, offset=remaining_job_offset)
@@ -448,6 +493,7 @@ def export_metadata(limit: int = IMPORT_EXPORT_DEFAULT_LIMIT, offset: int = 0) -
             jobs.extend(batch)
             remaining_job_offset += len(batch)
 
+        # Fetch remaining documents
         remaining_doc_offset = len(documents)
         while remaining_doc_offset < total_documents:
             batch, _ = db_manager.get_all_documents(limit=IMPORT_EXPORT_DEFAULT_LIMIT, offset=remaining_doc_offset)
@@ -455,6 +501,32 @@ def export_metadata(limit: int = IMPORT_EXPORT_DEFAULT_LIMIT, offset: int = 0) -
                 break
             documents.extend(batch)
             remaining_doc_offset += len(batch)
+    else:
+        # Fetch records respecting the combined limit across jobs and documents
+        # First, get total counts
+        _, total_jobs = db_manager.get_all_jobs(limit=1, offset=0)
+        _, total_documents = db_manager.get_all_documents(limit=1, offset=0)
+
+        # Calculate how many records to skip and fetch
+        total_records = total_jobs + total_documents
+
+        # Determine which records fall within the requested range
+        jobs = []
+        documents = []
+
+        if offset < total_jobs:
+            # We need some jobs
+            jobs_to_fetch = min(limit, total_jobs - offset)
+            jobs, _ = db_manager.get_all_jobs(limit=jobs_to_fetch, offset=offset)
+
+            # If we haven't reached the limit, fetch documents
+            remaining_limit = limit - len(jobs)
+            if remaining_limit > 0:
+                documents, _ = db_manager.get_all_documents(limit=remaining_limit, offset=0)
+        else:
+            # Skip all jobs, fetch only documents
+            doc_offset = offset - total_jobs
+            documents, _ = db_manager.get_all_documents(limit=limit, offset=doc_offset)
 
     exported_jobs = [
         ExportJobRecord(
@@ -530,20 +602,12 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
     if engine is None:
         raise RuntimeError("Database not available. Cannot import metadata without database connection.")
 
-    total_records = len(payload.data.jobs) + len(payload.data.documents)
-    if total_records > MAX_IMPORT_RECORDS:
-        raise ValueError(f"Maximum {MAX_IMPORT_RECORDS} records allowed per import request")
-
     started_at = perf_counter()
     summary = _build_import_summary(len(payload.data.jobs), len(payload.data.documents))
     warnings: list[ImportRecordIssue] = []
     errors: list[ImportRecordIssue] = []
 
-    existing_job_ids = {
-        job.get("job_id")
-        for job in get_all_jobs(limit=IMPORT_EXPORT_DEFAULT_LIMIT, offset=0)[0]
-        if job.get("job_id")
-    }
+    existing_job_ids = set(get_all_job_ids())
     existing_document_ids = set(get_all_document_ids())
 
     importable_job_ids = set(existing_job_ids)
@@ -553,9 +617,10 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             summary.jobs.skipped += 1
             continue
 
+        # Parse and validate timestamps once, then reuse
         try:
-            _parse_iso_datetime(job_record.submitted_at)
-            _parse_iso_datetime(job_record.completed_at)
+            submitted_at = _parse_iso_datetime(job_record.submitted_at)
+            completed_at = _parse_iso_datetime(job_record.completed_at)
         except ValueError as exc:
             summary.jobs.failed += 1
             errors.append(
@@ -578,7 +643,7 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             operation=job_record.operation,
             status=JobStatus(job_record.status),
             job_name=job_record.job_name,
-            submitted_at=_parse_iso_datetime(job_record.submitted_at),
+            submitted_at=submitted_at,
             stats=job_record.stats,
         )
 
@@ -594,13 +659,12 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             )
             continue
 
-        if job_record.completed_at or job_record.error or job_record.status != JobStatus.ACCEPTED.value:
+        # Update job with additional fields if present (completed_at, error)
+        if job_record.completed_at or job_record.error:
             db_manager.update_job(
                 job_record.job_id,
-                status=JobStatus(job_record.status),
-                completed_at=_parse_iso_datetime(job_record.completed_at),
+                completed_at=completed_at,
                 error=job_record.error,
-                stats=job_record.stats,
             )
 
         summary.jobs.imported += 1
@@ -623,9 +687,10 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             )
             continue
 
+        # Parse and validate timestamps once, then reuse
         try:
-            _parse_iso_datetime(document_record.submitted_at)
-            _parse_iso_datetime(document_record.completed_at)
+            submitted_at = _parse_iso_datetime(document_record.submitted_at)
+            completed_at = _parse_iso_datetime(document_record.completed_at)
         except ValueError as exc:
             summary.documents.failed += 1
             errors.append(
@@ -648,7 +713,7 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             doc_type=document_record.type,
             status=DocStatus(document_record.status),
             output_format=document_record.output_format,
-            submitted_at=_parse_iso_datetime(document_record.submitted_at),
+            submitted_at=submitted_at,
             job_id=document_record.job_id,
             metadata=document_record.metadata,
         )
@@ -665,18 +730,12 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             )
             continue
 
-        if (
-            document_record.completed_at
-            or document_record.error
-            or document_record.status != DocStatus.ACCEPTED.value
-            or document_record.metadata
-        ):
+        # Update document with additional fields if present (completed_at, error)
+        if document_record.completed_at or document_record.error:
             db_manager.update_document(
                 document_record.id,
-                status=DocStatus(document_record.status),
-                completed_at=_parse_iso_datetime(document_record.completed_at),
+                completed_at=completed_at,
                 error=document_record.error,
-                metadata=document_record.metadata,
             )
 
         summary.documents.imported += 1

--- a/services/digitize/db_operations.py
+++ b/services/digitize/db_operations.py
@@ -7,6 +7,7 @@ and other utility functions.
 """
 
 from datetime import datetime, timezone
+from time import perf_counter
 from typing import List, Optional, Dict, Any, Mapping
 
 from common.misc_utils import get_logger
@@ -17,7 +18,19 @@ from digitize.models import (
     JobState,
     DocStatus,
     JobDocumentSummary,
-    JobStats
+    JobStats,
+    ExportJobRecord,
+    ExportDocumentRecord,
+    ImportRequest,
+    ImportResponse,
+    ImportSummary,
+    ImportEntitySummary,
+    ImportRecordIssue,
+    ExportResponse,
+    ExportSummary,
+    ExportEntitySummary,
+    ExportPagination,
+    ImportExportData,
 )
 from digitize.db.manager import db_manager
 from digitize.db.connection import engine
@@ -372,6 +385,309 @@ def get_all_document_ids() -> list[str]:
     except Exception as e:
         logger.error(f"Failed to read document IDs from database: {e}", exc_info=True)
         raise
+
+
+IMPORT_EXPORT_DEFAULT_LIMIT = 10000
+IMPORT_EXPORT_BATCH_SIZE = 100
+MAX_IMPORT_RECORDS = 10000
+
+
+def _parse_iso_datetime(timestamp: Optional[str]) -> Optional[datetime]:
+    """Parse ISO-8601 timestamps with optional Z suffix."""
+    if not timestamp:
+        return None
+    return datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+
+
+def _serialize_datetime(timestamp: Optional[datetime]) -> Optional[str]:
+    """Serialize datetime to ISO-8601 string with Z suffix."""
+    if timestamp is None:
+        return None
+    return timestamp.isoformat().replace("+00:00", "Z")
+
+
+def _build_import_summary(total_jobs: int, total_documents: int) -> ImportSummary:
+    """Create an initialized import summary object."""
+    return ImportSummary(
+        jobs=ImportEntitySummary(total_received=total_jobs),
+        documents=ImportEntitySummary(total_received=total_documents),
+    )
+
+
+def export_metadata(limit: int = IMPORT_EXPORT_DEFAULT_LIMIT, offset: int = 0) -> ExportResponse:
+    """
+    Export jobs and documents from PostgreSQL as JSON-serializable metadata.
+
+    Args:
+        limit: Maximum combined records to return. Use -1 to return all records.
+        offset: Number of combined records to skip.
+
+    Returns:
+        ExportResponse with exported jobs/documents and pagination metadata.
+    """
+    if engine is None:
+        raise RuntimeError("Database not available. Cannot export metadata without database connection.")
+
+    if offset < 0:
+        raise ValueError("offset cannot be negative")
+
+    if limit == 0 or limit < -1:
+        raise ValueError("limit must be -1 or a positive integer")
+
+    started_at = perf_counter()
+
+    jobs, total_jobs = db_manager.get_all_jobs(limit=IMPORT_EXPORT_DEFAULT_LIMIT if limit == -1 else limit, offset=0 if limit == -1 else offset)
+    documents, total_documents = db_manager.get_all_documents(limit=IMPORT_EXPORT_DEFAULT_LIMIT if limit == -1 else limit, offset=0 if limit == -1 else offset)
+
+    if limit == -1:
+        remaining_job_offset = len(jobs)
+        while remaining_job_offset < total_jobs:
+            batch, _ = db_manager.get_all_jobs(limit=IMPORT_EXPORT_DEFAULT_LIMIT, offset=remaining_job_offset)
+            if not batch:
+                break
+            jobs.extend(batch)
+            remaining_job_offset += len(batch)
+
+        remaining_doc_offset = len(documents)
+        while remaining_doc_offset < total_documents:
+            batch, _ = db_manager.get_all_documents(limit=IMPORT_EXPORT_DEFAULT_LIMIT, offset=remaining_doc_offset)
+            if not batch:
+                break
+            documents.extend(batch)
+            remaining_doc_offset += len(batch)
+
+    exported_jobs = [
+        ExportJobRecord(
+            job_id=job.job_id,
+            operation=job.operation,
+            status=job.status,
+            job_name=job.job_name,
+            submitted_at=_serialize_datetime(job.submitted_at) or "",
+            completed_at=_serialize_datetime(job.completed_at),
+            stats=job.stats or {},
+            error=job.error,
+        )
+        for job in jobs
+    ]
+
+    exported_documents = [
+        ExportDocumentRecord(
+            id=doc.doc_id,
+            job_id=doc.job_id,
+            name=doc.name,
+            type=doc.type,
+            status=doc.status,
+            output_format=doc.output_format,
+            submitted_at=_serialize_datetime(doc.submitted_at) or "",
+            completed_at=_serialize_datetime(doc.completed_at),
+            error=doc.error,
+            metadata=doc.doc_metadata or {},
+        )
+        for doc in documents
+    ]
+
+    returned_records = len(exported_jobs) + len(exported_documents)
+    total_records = total_jobs + total_documents
+    effective_limit = returned_records if limit == -1 else limit
+
+    return ExportResponse(
+        status="completed",
+        data=ImportExportData(jobs=exported_jobs, documents=exported_documents),
+        summary=ExportSummary(
+            jobs=ExportEntitySummary(
+                total_exported=len(exported_jobs),
+                completed=sum(1 for job in exported_jobs if job.status == JobStatus.COMPLETED.value),
+                failed=sum(1 for job in exported_jobs if job.status == JobStatus.FAILED.value),
+            ),
+            documents=ExportEntitySummary(
+                total_exported=len(exported_documents),
+                completed=sum(1 for doc in exported_documents if doc.status == DocStatus.COMPLETED.value),
+                failed=sum(1 for doc in exported_documents if doc.status == DocStatus.FAILED.value),
+            ),
+        ),
+        export_timestamp=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        duration_seconds=round(perf_counter() - started_at, 4),
+        pagination=ExportPagination(
+            limit=effective_limit,
+            offset=0 if limit == -1 else offset,
+            has_more=False if limit == -1 else (offset + returned_records) < total_records,
+            total_records=total_records,
+            returned_records=returned_records,
+        ),
+    )
+
+
+def import_metadata(payload: ImportRequest) -> ImportResponse:
+    """
+    Import jobs and documents into PostgreSQL in skip-existing mode.
+
+    Args:
+        payload: Import request payload.
+
+    Returns:
+        ImportResponse with import summary, warnings, and errors.
+    """
+    if engine is None:
+        raise RuntimeError("Database not available. Cannot import metadata without database connection.")
+
+    total_records = len(payload.data.jobs) + len(payload.data.documents)
+    if total_records > MAX_IMPORT_RECORDS:
+        raise ValueError(f"Maximum {MAX_IMPORT_RECORDS} records allowed per import request")
+
+    started_at = perf_counter()
+    summary = _build_import_summary(len(payload.data.jobs), len(payload.data.documents))
+    warnings: list[ImportRecordIssue] = []
+    errors: list[ImportRecordIssue] = []
+
+    existing_job_ids = {
+        job.get("job_id")
+        for job in get_all_jobs(limit=IMPORT_EXPORT_DEFAULT_LIMIT, offset=0)[0]
+        if job.get("job_id")
+    }
+    existing_document_ids = set(get_all_document_ids())
+
+    importable_job_ids = set(existing_job_ids)
+
+    for job_record in payload.data.jobs:
+        if job_record.job_id in existing_job_ids:
+            summary.jobs.skipped += 1
+            continue
+
+        try:
+            _parse_iso_datetime(job_record.submitted_at)
+            _parse_iso_datetime(job_record.completed_at)
+        except ValueError as exc:
+            summary.jobs.failed += 1
+            errors.append(
+                ImportRecordIssue(
+                    record_type="job",
+                    record_id=job_record.job_id,
+                    type="validation_error",
+                    message=f"Invalid timestamp: {exc}",
+                )
+            )
+            continue
+
+        if payload.validate_only:
+            summary.jobs.imported += 1
+            importable_job_ids.add(job_record.job_id)
+            continue
+
+        created_job = db_manager.create_job(
+            job_id=job_record.job_id,
+            operation=job_record.operation,
+            status=JobStatus(job_record.status),
+            job_name=job_record.job_name,
+            submitted_at=_parse_iso_datetime(job_record.submitted_at),
+            stats=job_record.stats,
+        )
+
+        if created_job is None:
+            summary.jobs.failed += 1
+            errors.append(
+                ImportRecordIssue(
+                    record_type="job",
+                    record_id=job_record.job_id,
+                    type="database_error",
+                    message="Failed to create job record",
+                )
+            )
+            continue
+
+        if job_record.completed_at or job_record.error or job_record.status != JobStatus.ACCEPTED.value:
+            db_manager.update_job(
+                job_record.job_id,
+                status=JobStatus(job_record.status),
+                completed_at=_parse_iso_datetime(job_record.completed_at),
+                error=job_record.error,
+                stats=job_record.stats,
+            )
+
+        summary.jobs.imported += 1
+        importable_job_ids.add(job_record.job_id)
+
+    for document_record in payload.data.documents:
+        if document_record.id in existing_document_ids:
+            summary.documents.skipped += 1
+            continue
+
+        if document_record.job_id and document_record.job_id not in importable_job_ids:
+            summary.documents.failed += 1
+            warnings.append(
+                ImportRecordIssue(
+                    record_type="document",
+                    record_id=document_record.id,
+                    type="orphaned_document",
+                    message=f"Document references non-existent job_id: {document_record.job_id}",
+                )
+            )
+            continue
+
+        try:
+            _parse_iso_datetime(document_record.submitted_at)
+            _parse_iso_datetime(document_record.completed_at)
+        except ValueError as exc:
+            summary.documents.failed += 1
+            errors.append(
+                ImportRecordIssue(
+                    record_type="document",
+                    record_id=document_record.id,
+                    type="validation_error",
+                    message=f"Invalid timestamp: {exc}",
+                )
+            )
+            continue
+
+        if payload.validate_only:
+            summary.documents.imported += 1
+            continue
+
+        created_document = db_manager.create_document(
+            doc_id=document_record.id,
+            name=document_record.name,
+            doc_type=document_record.type,
+            status=DocStatus(document_record.status),
+            output_format=document_record.output_format,
+            submitted_at=_parse_iso_datetime(document_record.submitted_at),
+            job_id=document_record.job_id,
+            metadata=document_record.metadata,
+        )
+
+        if created_document is None:
+            summary.documents.failed += 1
+            errors.append(
+                ImportRecordIssue(
+                    record_type="document",
+                    record_id=document_record.id,
+                    type="database_error",
+                    message="Failed to create document record",
+                )
+            )
+            continue
+
+        if (
+            document_record.completed_at
+            or document_record.error
+            or document_record.status != DocStatus.ACCEPTED.value
+            or document_record.metadata
+        ):
+            db_manager.update_document(
+                document_record.id,
+                status=DocStatus(document_record.status),
+                completed_at=_parse_iso_datetime(document_record.completed_at),
+                error=document_record.error,
+                metadata=document_record.metadata,
+            )
+
+        summary.documents.imported += 1
+
+    return ImportResponse(
+        status="completed",
+        summary=summary,
+        duration_seconds=round(perf_counter() - started_at, 4),
+        errors=errors,
+        warnings=warnings,
+    )
 
 
 # ============================================================================

--- a/services/digitize/db_operations.py
+++ b/services/digitize/db_operations.py
@@ -432,8 +432,6 @@ def get_all_document_ids() -> list[str]:
 
 IMPORT_EXPORT_DEFAULT_LIMIT = 10000
 IMPORT_EXPORT_BATCH_SIZE = 100
-MAX_IMPORT_RECORDS = 10000
-
 
 def _parse_iso_datetime(timestamp: Optional[str]) -> Optional[datetime]:
     """Parse ISO-8601 timestamps with optional Z suffix."""
@@ -659,13 +657,12 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             )
             continue
 
-        # Update job with additional fields if present (completed_at, error)
-        if job_record.completed_at or job_record.error:
-            db_manager.update_job(
-                job_record.job_id,
-                completed_at=completed_at,
-                error=job_record.error,
-            )
+        # Update job with completion fields (guaranteed to exist since import blocks on active jobs)
+        db_manager.update_job(
+            job_record.job_id,
+            completed_at=completed_at,
+            error=job_record.error,
+        )
 
         summary.jobs.imported += 1
         importable_job_ids.add(job_record.job_id)
@@ -730,13 +727,12 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             )
             continue
 
-        # Update document with additional fields if present (completed_at, error)
-        if document_record.completed_at or document_record.error:
-            db_manager.update_document(
-                document_record.id,
-                completed_at=completed_at,
-                error=document_record.error,
-            )
+        # Update document with completion fields (guaranteed to exist since import blocks on active jobs)
+        db_manager.update_document(
+            document_record.id,
+            completed_at=completed_at,
+            error=document_record.error,
+        )
 
         summary.documents.imported += 1
 

--- a/services/digitize/db_operations.py
+++ b/services/digitize/db_operations.py
@@ -46,7 +46,6 @@ def create_job(
     job_id: str,
     operation: str,
     submitted_at: str,
-    doc_id_dict: dict[str, str],
     documents_info: list[str],
     job_name: Optional[str] = None
 ) -> None:
@@ -57,7 +56,6 @@ def create_job(
         job_id: Unique identifier for the job
         operation: Type of operation (ingestion/digitization)
         submitted_at: ISO timestamp when job was submitted
-        doc_id_dict: Mapping of document names to their IDs
         documents_info: List of document filenames
         job_name: Optional human-readable name for the job
     """
@@ -642,6 +640,8 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             status=JobStatus(job_record.status),
             job_name=job_record.job_name,
             submitted_at=submitted_at,
+            completed_at=completed_at,
+            error=job_record.error,
             stats=job_record.stats,
         )
 
@@ -656,13 +656,6 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
                 )
             )
             continue
-
-        # Update job with completion fields (guaranteed to exist since import blocks on active jobs)
-        db_manager.update_job(
-            job_record.job_id,
-            completed_at=completed_at,
-            error=job_record.error,
-        )
 
         summary.jobs.imported += 1
         importable_job_ids.add(job_record.job_id)
@@ -711,6 +704,8 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             status=DocStatus(document_record.status),
             output_format=document_record.output_format,
             submitted_at=submitted_at,
+            completed_at=completed_at,
+            error=document_record.error,
             job_id=document_record.job_id,
             metadata=document_record.metadata,
         )
@@ -726,13 +721,6 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
                 )
             )
             continue
-
-        # Update document with completion fields (guaranteed to exist since import blocks on active jobs)
-        db_manager.update_document(
-            document_record.id,
-            completed_at=completed_at,
-            error=document_record.error,
-        )
 
         summary.documents.imported += 1
 

--- a/services/digitize/db_operations.py
+++ b/services/digitize/db_operations.py
@@ -37,6 +37,131 @@ from digitize.db.connection import engine
 
 logger = get_logger("db_operations")
 
+# ============================================================================
+# Import/Export Lock Management
+# ============================================================================
+
+# Store active lock connection to keep it alive
+_import_export_lock_connection = None
+
+async def is_import_export_in_progress() -> bool:
+    """
+    Check if an import/export operation is currently in progress.
+    Returns True if locked, False if available.
+    """
+    import asyncio
+
+    def _sync_check():
+        from digitize.db.connection import get_db_session
+        from sqlalchemy import text
+
+        try:
+            with get_db_session() as session:
+                # Check if the advisory lock is currently held
+                # pg_try_advisory_lock returns true if lock acquired, false if already held
+                # We immediately release it if we acquired it (just checking status)
+                result = session.execute(text("SELECT pg_try_advisory_lock(123456789)")).scalar()
+                if result:
+                    # We acquired it, so it wasn't in use - release it immediately
+                    session.execute(text("SELECT pg_advisory_unlock(123456789)"))
+                    return False
+                else:
+                    # Lock is held by another process
+                    return True
+        except Exception as e:
+            logger.error(f"Failed to check import/export lock status: {e}")
+            # On error, assume it's not in progress to avoid blocking operations
+            return False
+
+    return await asyncio.to_thread(_sync_check)
+
+async def acquire_import_export_lock() -> bool:
+    """
+    Acquire a distributed lock for import/export operations using PostgreSQL advisory locks.
+    Returns True if lock was acquired, False if another process holds the lock.
+    IMPORTANT: Keeps the database connection open to maintain the lock.
+    Runs in thread pool to avoid blocking the async event loop.
+    """
+    import asyncio
+
+    def _sync_acquire():
+        global _import_export_lock_connection
+        from digitize.db.connection import engine
+        from sqlalchemy import text
+        import os
+
+        pid = os.getpid()
+        logger.info(f"[PID {pid}] Attempting to acquire import/export lock...")
+
+        if not engine:
+            logger.error(f"[PID {pid}] Database engine not initialized")
+            return False
+
+        conn = None
+        try:
+            # Create a new connection that we'll keep open
+            conn = engine.connect()
+            logger.debug(f"[PID {pid}] Database connection created")
+
+            # Try to acquire PostgreSQL advisory lock (non-blocking)
+            # Lock ID: 123456789 (arbitrary unique number for import/export operations)
+            result = conn.execute(text("SELECT pg_try_advisory_lock(123456789)")).scalar()
+            logger.debug(f"[PID {pid}] Lock acquisition result: {result}")
+
+            if result:
+                # Lock acquired - store connection to keep it alive
+                _import_export_lock_connection = conn
+                logger.warning(f"[PID {pid}] ✅ Import/export lock ACQUIRED successfully")
+                return True
+            else:
+                # Lock not acquired - close connection
+                conn.close()
+                logger.warning(f"[PID {pid}] ❌ Import/export lock ALREADY HELD by another process")
+                return False
+        except Exception as e:
+            logger.error(f"[PID {pid}] Failed to acquire import/export lock: {e}", exc_info=True)
+            if conn:
+                try:
+                    conn.close()
+                except:
+                    pass
+            return False
+
+    return await asyncio.to_thread(_sync_acquire)
+
+async def release_import_export_lock():
+    """Release the distributed import/export lock and close the connection."""
+    import asyncio
+
+    def _sync_release():
+        global _import_export_lock_connection
+        from sqlalchemy import text
+        import os
+
+        pid = os.getpid()
+        logger.info(f"[PID {pid}] Releasing import/export lock...")
+
+        try:
+            if _import_export_lock_connection:
+                # Release PostgreSQL advisory lock
+                _import_export_lock_connection.execute(text("SELECT pg_advisory_unlock(123456789)"))
+                _import_export_lock_connection.close()
+                _import_export_lock_connection = None
+                logger.warning(f"[PID {pid}] ✅ Import/export lock RELEASED successfully")
+            else:
+                logger.warning(f"[PID {pid}] No lock connection to release")
+        except Exception as e:
+            logger.error(f"[PID {pid}] Failed to release import/export lock: {e}", exc_info=True)
+            # Ensure connection is closed even on error
+            if _import_export_lock_connection:
+                try:
+                    _import_export_lock_connection.close()
+                except:
+                    pass
+                _import_export_lock_connection = None
+
+    await asyncio.to_thread(_sync_release)
+
 
 # ============================================================================
 # Job Operations

--- a/services/digitize/digitize_utils.py
+++ b/services/digitize/digitize_utils.py
@@ -112,7 +112,6 @@ def initialize_job_state(job_id: str, operation: str, output_format: OutputForma
         job_id=job_id,
         operation=operation,
         submitted_at=submitted_at,
-        doc_id_dict=doc_id_dict,
         documents_info=documents_info,
         job_name=job_name
     )

--- a/services/digitize/models.py
+++ b/services/digitize/models.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from typing import List, Optional, Dict, Any, Union
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class OutputFormat(str, Enum):
@@ -171,6 +171,113 @@ class JobState(BaseModel):
             Dictionary representation of the job state
         """
         return self.model_dump()
+
+
+class ImportExportData(BaseModel):
+    """Shared payload structure for import/export APIs."""
+    jobs: List["ExportJobRecord"] = Field(default_factory=list)
+    documents: List["ExportDocumentRecord"] = Field(default_factory=list)
+
+
+class ExportJobRecord(BaseModel):
+    """Serializable job record for export/import APIs."""
+    job_id: str
+    operation: str
+    status: str
+    job_name: Optional[str] = None
+    submitted_at: str
+    completed_at: Optional[str] = None
+    stats: Dict[str, int] = Field(default_factory=dict)
+    error: Optional[str] = None
+
+
+class ExportDocumentRecord(BaseModel):
+    """Serializable document record for export/import APIs."""
+    id: str
+    job_id: Optional[str] = None
+    name: str
+    type: str
+    status: str
+    output_format: str
+    submitted_at: str
+    completed_at: Optional[str] = None
+    error: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ImportRequest(BaseModel):
+    """Request model for metadata import."""
+    data: ImportExportData
+    validate_only: bool = False
+
+    @model_validator(mode="after")
+    def validate_non_empty_payload(self):
+        if not self.data.jobs and not self.data.documents:
+            raise ValueError("At least one job or document record must be provided")
+        return self
+
+
+class ImportRecordIssue(BaseModel):
+    """Per-record warning or error returned by import API."""
+    record_type: str
+    record_id: str
+    type: str
+    message: str
+
+
+class ImportEntitySummary(BaseModel):
+    """Import summary for a single entity type."""
+    total_received: int = 0
+    imported: int = 0
+    skipped: int = 0
+    failed: int = 0
+
+
+class ImportSummary(BaseModel):
+    """Import summary grouped by jobs and documents."""
+    jobs: ImportEntitySummary
+    documents: ImportEntitySummary
+
+
+class ImportResponse(BaseModel):
+    """Response model for metadata import."""
+    status: str
+    summary: ImportSummary
+    duration_seconds: float
+    errors: List[ImportRecordIssue] = Field(default_factory=list)
+    warnings: List[ImportRecordIssue] = Field(default_factory=list)
+
+
+class ExportEntitySummary(BaseModel):
+    """Export summary for a single entity type."""
+    total_exported: int = 0
+    completed: int = 0
+    failed: int = 0
+
+
+class ExportSummary(BaseModel):
+    """Export summary grouped by jobs and documents."""
+    jobs: ExportEntitySummary
+    documents: ExportEntitySummary
+
+
+class ExportPagination(BaseModel):
+    """Pagination metadata for export API."""
+    limit: int
+    offset: int
+    has_more: bool
+    total_records: int
+    returned_records: int
+
+
+class ExportResponse(BaseModel):
+    """Response model for metadata export."""
+    status: str
+    data: ImportExportData
+    summary: ExportSummary
+    export_timestamp: str
+    duration_seconds: float
+    pagination: ExportPagination
 
 
 # Made with Bob

--- a/services/digitize/tests/test_digitize_app_endpoints.py
+++ b/services/digitize/tests/test_digitize_app_endpoints.py
@@ -453,7 +453,7 @@ class TestImportExportEndpoints:
 
     def test_import_metadata_rejects_too_many_records(self, digitize_test_client, monkeypatch):
         monkeypatch.setattr(digitize_app.dg_util, "has_active_jobs", Mock(return_value=(False, [])))
-        monkeypatch.setattr(db_ops, "MAX_IMPORT_RECORDS", 1)
+        monkeypatch.setattr(digitize_app, "MAX_IMPORT_RECORDS", 1)
 
         response = digitize_test_client.post(
             "/v1/import",

--- a/services/digitize/tests/test_digitize_app_endpoints.py
+++ b/services/digitize/tests/test_digitize_app_endpoints.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, Mock, patch
 import asyncio
 
@@ -8,7 +9,7 @@ from fastapi.testclient import TestClient
 import digitize.app as digitize_app
 import digitize.db_operations as db_ops
 import digitize.db.connection as db_conn
-from digitize.models import JobStatus, OperationType, OutputFormat
+from digitize.models import JobStatus, OperationType, OutputFormat, ImportRequest
 
 
 @pytest.fixture
@@ -83,6 +84,9 @@ class TestRequestIdMiddleware:
 @pytest.mark.unit
 class TestCreateJobs:
     def test_successful_digitization_job_creation(self, digitize_test_client):
+        stage_upload_files_mock = cast(AsyncMock, digitize_app.dg_util.stage_upload_files)
+        initialize_job_state_mock = cast(Mock, digitize_app.dg_util.initialize_job_state)
+
         response = digitize_test_client.post(
             "/v1/jobs?operation=digitization&output_format=json",
             files=[("files", ("sample.pdf", b"%PDF-1.4 test", "application/pdf"))],
@@ -90,8 +94,8 @@ class TestCreateJobs:
 
         assert response.status_code == 202
         assert response.json() == {"job_id": "job-123"}
-        digitize_app.dg_util.stage_upload_files.assert_awaited_once()
-        digitize_app.dg_util.initialize_job_state.assert_called_once_with(
+        stage_upload_files_mock.assert_awaited_once()
+        initialize_job_state_mock.assert_called_once_with(
             "job-123",
             OperationType.DIGITIZATION,
             OutputFormat.JSON,
@@ -139,13 +143,15 @@ class TestCreateJobs:
         assert response.status_code == 415
 
     def test_output_format_and_job_name_parameters(self, digitize_test_client):
+        initialize_job_state_mock = cast(Mock, digitize_app.dg_util.initialize_job_state)
+
         response = digitize_test_client.post(
             "/v1/jobs?operation=digitization&output_format=md&job_name=My+Job",
             files=[("files", ("sample.pdf", b"%PDF-1.4 test", "application/pdf"))],
         )
 
         assert response.status_code == 202
-        digitize_app.dg_util.initialize_job_state.assert_called_with(
+        initialize_job_state_mock.assert_called_with(
             "job-123",
             OperationType.DIGITIZATION,
             OutputFormat.MD,
@@ -263,10 +269,11 @@ class TestDocumentEndpoints:
             status="completed",
             output_format="json"
         )
+        get_document_mock = Mock(return_value=mock_doc)
         monkeypatch.setattr(
             db_ops,
             "get_document",
-            Mock(return_value=mock_doc),
+            get_document_mock,
         )
 
         response = digitize_test_client.get("/v1/documents/doc-1")
@@ -274,8 +281,8 @@ class TestDocumentEndpoints:
 
         assert response.status_code == 200
         assert detailed.status_code == 200
-        assert db_ops.get_document.call_args_list[0][1]["include_details"] is False
-        assert db_ops.get_document.call_args_list[1][1]["include_details"] is True
+        assert get_document_mock.call_args_list[0][1]["include_details"] is False
+        assert get_document_mock.call_args_list[1][1]["include_details"] is True
 
     def test_get_missing_document_returns_404(self, digitize_test_client, monkeypatch):
         # Mock get_document to raise FileNotFoundError which should be caught and converted to 404
@@ -302,6 +309,7 @@ class TestDocumentEndpoints:
 
     def test_delete_document_success(self, digitize_test_client, monkeypatch):
         from digitize.models import DocumentDetailResponse
+        delete_document_files_mock = cast(Mock, digitize_app.dg_util.delete_document_files)
         mock_doc = DocumentDetailResponse(
             id="doc-1",
             job_id="job-1",
@@ -325,7 +333,7 @@ class TestDocumentEndpoints:
 
         assert response.status_code == 204
         fake_vector_store.delete_document_by_id.assert_called_once_with("doc-1")
-        digitize_app.dg_util.delete_document_files.assert_called_once_with("doc-1", output_format="json")
+        delete_document_files_mock.assert_called_once_with("doc-1", output_format="json")
 
     def test_delete_active_document_returns_409(self, digitize_test_client, monkeypatch):
         from digitize.models import DocumentDetailResponse
@@ -362,9 +370,164 @@ class TestDocumentEndpoints:
         assert response.status_code == 409
 
     def test_bulk_delete_success(self, digitize_test_client):
+        reset_db_mock = cast(Mock, digitize_app.reset_db)
+
         response = digitize_test_client.delete("/v1/documents?confirm=true")
 
         assert response.status_code == 204
-        digitize_app.reset_db.assert_called_once()
+        reset_db_mock.assert_called_once()
+
+@pytest.mark.unit
+class TestImportExportEndpoints:
+    def test_import_metadata_success(self, digitize_test_client, monkeypatch):
+        payload = {
+            "data": {
+                "jobs": [
+                    {
+                        "job_id": "job-1",
+                        "operation": "ingestion",
+                        "status": "completed",
+                        "job_name": "Import Job",
+                        "submitted_at": "2024-01-01T00:00:00Z",
+                        "completed_at": "2024-01-01T01:00:00Z",
+                        "stats": {"total_documents": 1, "completed": 1, "failed": 0, "in_progress": 0},
+                        "error": None,
+                    }
+                ],
+                "documents": [
+                    {
+                        "id": "doc-1",
+                        "job_id": "job-1",
+                        "name": "sample.pdf",
+                        "type": "ingestion",
+                        "status": "completed",
+                        "output_format": "json",
+                        "submitted_at": "2024-01-01T00:00:00Z",
+                        "completed_at": "2024-01-01T00:30:00Z",
+                        "error": None,
+                        "metadata": {"pages": 2},
+                    }
+                ],
+            },
+            "validate_only": False,
+        }
+
+        monkeypatch.setattr(digitize_app.dg_util, "has_active_jobs", Mock(return_value=(False, [])))
+        monkeypatch.setattr(
+            db_ops,
+            "import_metadata",
+            Mock(
+                return_value={
+                    "status": "completed",
+                    "summary": {
+                        "jobs": {"total_received": 1, "imported": 1, "skipped": 0, "failed": 0},
+                        "documents": {"total_received": 1, "imported": 1, "skipped": 0, "failed": 0},
+                    },
+                    "duration_seconds": 0.1,
+                    "errors": [],
+                    "warnings": [],
+                }
+            ),
+        )
+
+        response = digitize_test_client.post("/v1/import", json=payload)
+
+        assert response.status_code == 200
+        assert response.json()["summary"]["jobs"]["imported"] == 1
+
+    def test_import_metadata_rejects_when_active_jobs_exist(self, digitize_test_client, monkeypatch):
+        monkeypatch.setattr(digitize_app.dg_util, "has_active_jobs", Mock(return_value=(True, ["job-active"])))
+
+        response = digitize_test_client.post(
+            "/v1/import",
+            json={
+                "data": {
+                    "jobs": [{"job_id": "job-1", "operation": "ingestion", "status": "completed", "submitted_at": "2024-01-01T00:00:00Z", "stats": {}}],
+                    "documents": [],
+                }
+            },
+        )
+
+        assert response.status_code == 409
+        assert "job-active" in response.text
+
+    def test_import_metadata_rejects_too_many_records(self, digitize_test_client, monkeypatch):
+        monkeypatch.setattr(digitize_app.dg_util, "has_active_jobs", Mock(return_value=(False, [])))
+        monkeypatch.setattr(db_ops, "MAX_IMPORT_RECORDS", 1)
+
+        response = digitize_test_client.post(
+            "/v1/import",
+            json={
+                "data": {
+                    "jobs": [
+                        {"job_id": "job-1", "operation": "ingestion", "status": "completed", "submitted_at": "2024-01-01T00:00:00Z", "stats": {}},
+                        {"job_id": "job-2", "operation": "ingestion", "status": "completed", "submitted_at": "2024-01-01T00:00:00Z", "stats": {}},
+                    ],
+                    "documents": [],
+                }
+            },
+        )
+
+        assert response.status_code == 413
+
+    def test_export_metadata_default_limit(self, digitize_test_client, monkeypatch):
+        export_metadata_mock = Mock(
+            return_value={
+                "status": "completed",
+                "data": {"jobs": [], "documents": []},
+                "summary": {
+                    "jobs": {"total_exported": 0, "completed": 0, "failed": 0},
+                    "documents": {"total_exported": 0, "completed": 0, "failed": 0},
+                },
+                "export_timestamp": "2024-01-01T00:00:00Z",
+                "duration_seconds": 0.1,
+                "pagination": {
+                    "limit": db_ops.IMPORT_EXPORT_DEFAULT_LIMIT,
+                    "offset": 0,
+                    "has_more": False,
+                    "total_records": 0,
+                    "returned_records": 0,
+                },
+            }
+        )
+        monkeypatch.setattr(db_ops, "export_metadata", export_metadata_mock)
+
+        response = digitize_test_client.get("/v1/export")
+
+        assert response.status_code == 200
+        export_metadata_mock.assert_called_once_with(limit=db_ops.IMPORT_EXPORT_DEFAULT_LIMIT, offset=0)
+
+    def test_export_metadata_limit_minus_one(self, digitize_test_client, monkeypatch):
+        export_metadata_mock = Mock(
+            return_value={
+                "status": "completed",
+                "data": {"jobs": [{"job_id": "job-1", "operation": "ingestion", "status": "completed", "submitted_at": "2024-01-01T00:00:00Z", "stats": {}}], "documents": []},
+                "summary": {
+                    "jobs": {"total_exported": 1, "completed": 1, "failed": 0},
+                    "documents": {"total_exported": 0, "completed": 0, "failed": 0},
+                },
+                "export_timestamp": "2024-01-01T00:00:00Z",
+                "duration_seconds": 0.1,
+                "pagination": {
+                    "limit": 1,
+                    "offset": 0,
+                    "has_more": False,
+                    "total_records": 1,
+                    "returned_records": 1,
+                },
+            }
+        )
+        monkeypatch.setattr(db_ops, "export_metadata", export_metadata_mock)
+
+        response = digitize_test_client.get("/v1/export?limit=-1")
+
+        assert response.status_code == 200
+        export_metadata_mock.assert_called_once_with(limit=-1, offset=0)
+
+    def test_export_metadata_invalid_limit_returns_400(self, digitize_test_client):
+        response = digitize_test_client.get("/v1/export?limit=0")
+
+        assert response.status_code == 400
+
 
 # Made with Bob


### PR DESCRIPTION
- Implementation for Import and Export API endpoints in digitize service
- UTs for new APIs

Tested Import API with mock data records of more than 10,000 metadata. here are the import API requests/responses.

First 10K metadata:
```
[root@rag-test--digitize jsons]# jq '{data: {jobs: .data.jobs, documents: .data.documents[0:(10000 - (.data.jobs | length))]}}' metadata-0-to-10K.json | curl -X POST "http://localhost:4000/v1/import" \
  -H "Content-Type: application/json" \
  --data @-

{"status":"completed","summary":{"jobs":{"total_received":4000,"imported":4000,"skipped":0,"failed":0},"documents":{"total_received":6000,"imported":6000,"skipped":0,"failed":0}},"duration_seconds":19.0343,"errors":[],"warnings":[]}
```

Remaninng metadata not exceeding 10K:
```
jq '{data: {jobs: [], documents: .data.documents[(10000 - (.data.jobs | length)):]}}' metadata-0-to-10K.json | curl -X POST "http://localhost:4000/v1/import" \
  -H "Content-Type: application/json" \
  --data @-
{"status":"completed","summary":{"jobs":{"total_received":0,"imported":0,"skipped":0,"failed":0},"documents":{"total_received":4000,"imported":4000,"skipped":0,"failed":0}},"duration_seconds":10.776,"errors":[],"warnings":[]}
```

Export API response for 1 job and 1 document metadata:
```
curl "http://localhost:4000/v1/export?limit=-1"
{
    "status": "completed",
    "data": {
        "jobs": [
            {
                "job_id": "394e2480-c45f-4a49-b627-ef449b7a55df",
                "operation": "ingestion",
                "status": "completed",
                "job_name": "ingest",
                "submitted_at": "2026-06-02T11:52:17.477525",
                "completed_at": "2026-06-02T11:54:14.398717",
                "stats": {
                    "failed": 0,
                    "completed": 1,
                    "in_progress": 0,
                    "total_documents": 1
                },
                "error": null
            }
        ],
        "documents": [
            {
                "id": "0268952b-29e4-44ac-8af2-0103a1308133",
                "job_id": "394e2480-c45f-4a49-b627-ef449b7a55df",
                "name": "graph_rag copy.pdf",
                "type": "ingestion",
                "status": "completed",
                "output_format": "json",
                "submitted_at": "2026-06-02T11:52:17.477525",
                "completed_at": "2026-06-02T11:54:14.378600",
                "error": null,
                "metadata": {
                    "pages": 26,
                    "chunks": 85,
                    "tables": 6,
                    "timing_in_secs": {
                        "chunking": 0.91,
                        "indexing": 9.89,
                        "digitizing": 49.42,
                        "processing": 56.3
                    }
                }
            }
        ]
    },
    "summary": {
        "jobs": {
            "total_exported": 1,
            "completed": 1,
            "failed": 0
        },
        "documents": {
            "total_exported": 1,
            "completed": 1,
            "failed": 0
        }
    },
    "export_timestamp": "2026-06-04T05:36:27.111201Z",
    "duration_seconds": 0.0069,
    "pagination": {
        "limit": 100,
        "offset": 0,
        "has_more": false,
        "total_records": 2,
        "returned_records": 2
    }
}
```