### PR TITLE
Fix openshift template

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.43
+TAG?=0.0.44
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-dev/openshift/templates/postgres-statefulset.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/templates/postgres-statefulset.yaml
@@ -24,6 +24,7 @@ spec:
         ai-services.io/version: {{ default .Chart.AppVersion | quote }}
         ai-services.io/component: database
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: postgres
           image: "{{ .Values.postgres.image }}"

--- a/ai-services/assets/applications/rag-dev/openshift/templates/summarize-api-deployment.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/templates/summarize-api-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           command: [ "/var/venv/bin/python", "db/scripts/init_db.py" ]
           env:
             - name: POSTGRES_HOST
-              value: "{{ .AppName }}--postgres"
+              value: "postgres"
             - name: POSTGRES_PORT
               value: "5432"
             - name: POSTGRES_DB
@@ -61,7 +61,7 @@ spec:
             - name: POSTGRES_PORT
               value: "5432"
             - name: POSTGRES_DB
-              value: "{{ .Values.digitize.database }}"
+              value: "{{ .Values.summarize.database }}"
             - name: POSTGRES_USER
               value: "postgres"
             - name: POSTGRES_PASSWORD
@@ -118,3 +118,10 @@ spec:
             limits:
               cpu: "500m"
               memory: "512Mi"
+          volumeMounts:
+            - mountPath: /var/cache
+              name: cache
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: cache

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -15,6 +15,8 @@ summarize:
   image: icr.io/ai-services-cicd/summarize-service:v0.0.6
   # @hidden
   log_level: "INFO"
+  # @description Database name for the SUMMARIZE service. Default is "summarize_metadata".
+  database: "summarize_metadata"
 
 similarity:
   # @hidden

--- a/ai-services/assets/applications/rag/openshift/templates/postgres-statefulset.yaml
+++ b/ai-services/assets/applications/rag/openshift/templates/postgres-statefulset.yaml
@@ -24,6 +24,7 @@ spec:
         ai-services.io/version: {{ default .Chart.AppVersion | quote }}
         ai-services.io/component: database
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: postgres
           image: "{{ .Values.postgres.image }}"

--- a/ai-services/assets/applications/rag/openshift/templates/summarize-api-deployment.yaml
+++ b/ai-services/assets/applications/rag/openshift/templates/summarize-api-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           command: [ "/var/venv/bin/python", "db/scripts/init_db.py" ]
           env:
             - name: POSTGRES_HOST
-              value: "{{ .AppName }}--postgres"
+              value: "postgres"
             - name: POSTGRES_PORT
               value: "5432"
             - name: POSTGRES_DB
@@ -61,7 +61,7 @@ spec:
             - name: POSTGRES_PORT
               value: "5432"
             - name: POSTGRES_DB
-              value: "{{ .Values.digitize.database }}"
+              value: "{{ .Values.summarize.database }}"
             - name: POSTGRES_USER
               value: "postgres"
             - name: POSTGRES_PASSWORD
@@ -118,3 +118,10 @@ spec:
             limits:
               cpu: "500m"
               memory: "512Mi"
+          volumeMounts:
+            - mountPath: /var/cache
+              name: cache
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: cache

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -15,6 +15,8 @@ summarize:
   image: icr.io/ai-services-cicd/summarize-service:v0.0.6
   # @hidden
   log_level: "INFO"
+  # @description Database name for the SUMMARIZE service. Default is "summarize_metadata".
+  database: "summarize_metadata"
 
 similarity:
   # @hidden

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.43
+  image: icr.io/ai-services-cicd/ai-services:0.0.44
   runtime: ""
   adminPasswordHash: ""
   podman:


### PR DESCRIPTION
Did not get chance to test the openshift template wrt to the changes added in this release due to cluster unavailability, Now while testing it, found issues with service account permissions in postgres and minor templating issues in summarize pod. Following things are modified to fix the openshift template overall. 
- Add automountServiceAccountToken: false to postgres statefulset for security
- Fix POSTGRES_HOST value from {{ .AppName }}--postgres to postgres in summarize-api init container
- Fix POSTGRES_DB to use summarize.database instead of digitize.database
- Add cache volume mount configuration to summarize-api deployment
- Add database configuration field to summarize service in values.yaml
