### PR TITLE
Make version as mandatory else the GET applications APIs will fail

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.37
+TAG?=0.0.38
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.37
+  image: icr.io/ai-services-cicd/ai-services:0.0.38
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -999,7 +999,8 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "component_type",
-                "provider_id"
+                "provider_id",
+                "version"
             ],
             "properties": {
                 "component_type": {
@@ -1025,7 +1026,8 @@ const docTemplate = `{
             "required": [
                 "catalog_id",
                 "name",
-                "services"
+                "services",
+                "version"
             ],
             "properties": {
                 "catalog_id": {
@@ -1059,7 +1061,8 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "catalog_id",
-                "components"
+                "components",
+                "version"
             ],
             "properties": {
                 "catalog_id": {

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -993,7 +993,8 @@
             "type": "object",
             "required": [
                 "component_type",
-                "provider_id"
+                "provider_id",
+                "version"
             ],
             "properties": {
                 "component_type": {
@@ -1019,7 +1020,8 @@
             "required": [
                 "catalog_id",
                 "name",
-                "services"
+                "services",
+                "version"
             ],
             "properties": {
                 "catalog_id": {
@@ -1053,7 +1055,8 @@
             "type": "object",
             "required": [
                 "catalog_id",
-                "components"
+                "components",
+                "version"
             ],
             "properties": {
                 "catalog_id": {

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -16,6 +16,7 @@ definitions:
     required:
     - component_type
     - provider_id
+    - version
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_apiserver_models.CreateApplicationRequest:
     properties:
@@ -35,6 +36,7 @@ definitions:
     - catalog_id
     - name
     - services
+    - version
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_apiserver_models.CreateApplicationResponse:
     properties:
@@ -58,6 +60,7 @@ definitions:
     required:
     - catalog_id
     - components
+    - version
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_apiserver_repository.DeleteApplicationResponse:
     properties:

--- a/ai-services/internal/pkg/catalog/apiserver/models/create_application.go
+++ b/ai-services/internal/pkg/catalog/apiserver/models/create_application.go
@@ -4,7 +4,7 @@ package models
 type CreateApplicationRequest struct {
 	Name      string    `json:"name" binding:"required,min=3,max=100"`
 	CatalogID string    `json:"catalog_id" binding:"required"`
-	Version   string    `json:"version"`
+	Version   string    `json:"version" binding:"required"`
 	Services  []Service `json:"services" binding:"required,dive"`
 	CreatedBy string    `json:"-"` // Set from auth context, not from request body
 }
@@ -12,7 +12,7 @@ type CreateApplicationRequest struct {
 // Service represents a service configuration in the application.
 type Service struct {
 	CatalogID  string         `json:"catalog_id" binding:"required"`
-	Version    string         `json:"version"`
+	Version    string         `json:"version" binding:"required"`
 	Components []Component    `json:"components" binding:"required,dive"`
 	Params     map[string]any `json:"params"` // Service-level parameters
 }
@@ -22,7 +22,7 @@ type Component struct {
 	ComponentType string         `json:"component_type" binding:"required"`
 	ProviderID    string         `json:"provider_id" binding:"required"`
 	InstanceID    string         `json:"instance_id"`
-	Version       string         `json:"version"`
+	Version       string         `json:"version" binding:"required"`
 	Params        map[string]any `json:"params"`
 }
 

--- a/ai-services/internal/pkg/catalog/db/models/application.go
+++ b/ai-services/internal/pkg/catalog/db/models/application.go
@@ -51,7 +51,7 @@ type Application struct {
 	DeploymentType DeploymentType    `json:"deployment_type"`
 	Status         ApplicationStatus `json:"status"`
 	Message        string            `json:"message,omitempty"`
-	Version        string            `json:"version,omitempty"`
+	Version        string            `json:"version"`
 	CreatedBy      string            `json:"created_by"`
 	CreatedAt      time.Time         `json:"created_at"`
 	UpdatedAt      time.Time         `json:"updated_at"`

--- a/ai-services/internal/pkg/catalog/db/models/component.go
+++ b/ai-services/internal/pkg/catalog/db/models/component.go
@@ -16,7 +16,7 @@ type Component struct {
 	Status    ComponentStatus `json:"status"`
 	Message   string          `json:"message,omitempty"`
 	Endpoints map[string]any  `json:"endpoints,omitempty"` // JSONB field for endpoint configurations
-	Version   string          `json:"version,omitempty"`   // Component version
+	Version   string          `json:"version"`             // Component version
 	Metadata  map[string]any  `json:"metadata,omitempty"`  // JSONB field for additional metadata
 	CreatedAt time.Time       `json:"created_at"`
 	UpdatedAt time.Time       `json:"updated_at"`

--- a/ai-services/internal/pkg/catalog/db/models/service.go
+++ b/ai-services/internal/pkg/catalog/db/models/service.go
@@ -15,7 +15,7 @@ type Service struct {
 	Message   string           `json:"message,omitempty"`
 	Endpoints []map[string]any `json:"endpoints,omitempty"`
 	Component Component        `json:"component,omitempty"`
-	Version   string           `json:"version,omitempty"`
+	Version   string           `json:"version"`
 	CreatedAt time.Time        `json:"created_at"`
 	UpdatedAt time.Time        `json:"updated_at"`
 }


### PR DESCRIPTION
There is minor issue (since validation is not in place) if version is not provided for each service and architecture deploy params, the GET APIs are failing.
Making it required in the POST API for deployment and also in A/S/C struct while reading.