### PR TITLE
[Catalog-API] App Deletion (conti)

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.43
+TAG?=0.0.44
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -136,6 +136,8 @@ spec:
         - name: iommu-groups
           mountPath: /sys/kernel/iommu_groups
           readOnly: true
+        - name: ai-services-data
+          mountPath: {{ .BaseDir }}
       resources:
         requests:
           podman.io/device=/dev/vfio: 4
@@ -156,3 +158,7 @@ spec:
       hostPath:
         path: /sys/kernel/iommu_groups
         type: Directory
+    - name: ai-services-data
+      hostPath:
+        path: {{ .BaseDir }}
+        type: DirectoryOrCreate

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.43
+  image: icr.io/ai-services-cicd/ai-services:0.0.44
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/components/llm/vllm-cpu/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/vllm-cpu/podman/templates/vllm-server.yaml.tmpl
@@ -4,6 +4,7 @@ metadata:
   name: "llm-{{ .InstanceSlug }}"
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
+    ai-services.io/secret: "vllm-secret-{{ .InstanceSlug }}"
   annotations:
     io.podman.annotations.ulimit: "nofile=134217728:134217728,memlock=-1:-1"
 spec:

--- a/ai-services/assets/components/llm/vllm-spyre/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/vllm-spyre/podman/templates/vllm-server.yaml.tmpl
@@ -4,6 +4,7 @@ metadata:
   name: "llm-{{ .InstanceSlug }}"
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
+    ai-services.io/secret: "vllm-secret-{{ .InstanceSlug }}"
   annotations:
     io.podman.annotations.ulimit: "nofile=134217728:134217728,memlock=-1:-1"
     io.podman.annotations.userns: "keep-id"

--- a/ai-services/assets/components/llm/watsonx/podman/templates/watsonx-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/watsonx/podman/templates/watsonx-server.yaml.tmpl
@@ -4,6 +4,7 @@ metadata:
   name: "llm-{{ .InstanceSlug }}"
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
+    ai-services.io/secret: "watsonx-secret-{{ .InstanceSlug }}"
 spec:
   containers:
     - name: litellm

--- a/ai-services/assets/components/vector_db/opensearch/podman/templates/opensearch.yaml.tmpl
+++ b/ai-services/assets/components/vector_db/opensearch/podman/templates/opensearch.yaml.tmpl
@@ -5,7 +5,7 @@ metadata:
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
     ai-services.io/secret: "opensearch-secret-{{ .InstanceSlug }}"
-    ai-services.io/secret-skip-cleanup: "false"
+    ai-services.io/secret-skip-cleanup: "true"
   annotations:
     io.podman.annotations.pids-limit/opensearch: "4096"
 spec:

--- a/ai-services/assets/components/vector_db/opensearch/podman/templates/opensearch.yaml.tmpl
+++ b/ai-services/assets/components/vector_db/opensearch/podman/templates/opensearch.yaml.tmpl
@@ -4,6 +4,8 @@ metadata:
   name: "opensearch-{{ .InstanceSlug }}"
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
+    ai-services.io/secret: "opensearch-secret-{{ .InstanceSlug }}"
+    ai-services.io/secret-skip-cleanup: "false"
   annotations:
     io.podman.annotations.pids-limit/opensearch: "4096"
 spec:

--- a/ai-services/assets/services/digitize/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/services/digitize/podman/templates/digitize.yaml.tmpl
@@ -4,6 +4,8 @@ metadata:
   name: "digitize-{{ .InstanceSlug }}"
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
+    ai-services.io/secret: "digitize-db-secret-{{ .InstanceSlug }}"
+    ai-services.io/secret-skip-cleanup: "false"
   annotations:
     ai-services.io/routes: "4001:digitize-ui-{{ .InstanceSlug }}:ui,4000:digitize-backend-{{ .InstanceSlug }}:api"
     # ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"  # Uncomment to expose ports directly (bypasses Caddy)

--- a/ai-services/assets/services/digitize/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/services/digitize/podman/templates/digitize.yaml.tmpl
@@ -5,7 +5,7 @@ metadata:
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
     ai-services.io/secret: "digitize-db-secret-{{ .InstanceSlug }}"
-    ai-services.io/secret-skip-cleanup: "false"
+    ai-services.io/secret-skip-cleanup: "true"
   annotations:
     ai-services.io/routes: "4001:digitize-ui-{{ .InstanceSlug }}:ui,4000:digitize-backend-{{ .InstanceSlug }}:api"
     # ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"  # Uncomment to expose ports directly (bypasses Caddy)

--- a/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
+++ b/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
@@ -4,6 +4,8 @@ metadata:
   name: "summarize-api-{{ .InstanceSlug }}"
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
+    ai-services.io/secret: "summarize-db-secret-{{ .InstanceSlug }}"
+    ai-services.io/secret-skip-cleanup: "false"
   annotations:
     ai-services.io/routes: "6000:summarize-api-{{ .InstanceSlug }}:api"
     # ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"  # Uncomment to expose ports directly (bypasses Caddy)

--- a/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
+++ b/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
@@ -5,7 +5,7 @@ metadata:
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
     ai-services.io/secret: "summarize-db-secret-{{ .InstanceSlug }}"
-    ai-services.io/secret-skip-cleanup: "false"
+    ai-services.io/secret-skip-cleanup: "true"
   annotations:
     ai-services.io/routes: "6000:summarize-api-{{ .InstanceSlug }}:api"
     # ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"  # Uncomment to expose ports directly (bypasses Caddy)

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -311,8 +311,8 @@ const docTemplate = `{
                     },
                     {
                         "type": "boolean",
-                        "description": "When true, also deletes orphaned component records",
-                        "name": "force",
+                        "description": "When true, preserves underlying data (volumes of databases/service resources)",
+                        "name": "keep_data",
                         "in": "query"
                     }
                 ],

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -310,8 +310,8 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "type": "boolean",
-                        "description": "When true, preserves underlying data (volumes of databases/service resources)",
+                        "type": "string",
+                        "description": "When 'true', preserves underlying data (volumes of databases/service resources). Default: 'false'",
                         "name": "keep_data",
                         "in": "query"
                     }
@@ -324,7 +324,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Invalid application ID",
+                        "description": "Invalid application ID or keep_data parameter",
                         "schema": {
                             "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
                         }

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -304,8 +304,8 @@
                         "required": true
                     },
                     {
-                        "type": "boolean",
-                        "description": "When true, preserves underlying data (volumes of databases/service resources)",
+                        "type": "string",
+                        "description": "When 'true', preserves underlying data (volumes of databases/service resources). Default: 'false'",
                         "name": "keep_data",
                         "in": "query"
                     }
@@ -318,7 +318,7 @@
                         }
                     },
                     "400": {
-                        "description": "Invalid application ID",
+                        "description": "Invalid application ID or keep_data parameter",
                         "schema": {
                             "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
                         }

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -305,8 +305,8 @@
                     },
                     {
                         "type": "boolean",
-                        "description": "When true, also deletes orphaned component records",
-                        "name": "force",
+                        "description": "When true, preserves underlying data (volumes of databases/service resources)",
+                        "name": "keep_data",
                         "in": "query"
                     }
                 ],

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -521,9 +521,10 @@ paths:
         name: id
         required: true
         type: string
-      - description: When true, also deletes orphaned component records
+      - description: When true, preserves underlying data (volumes of databases/service
+          resources)
         in: query
-        name: force
+        name: keep_data
         type: boolean
       produces:
       - application/json

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -521,11 +521,11 @@ paths:
         name: id
         required: true
         type: string
-      - description: When true, preserves underlying data (volumes of databases/service
-          resources)
+      - description: 'When ''true'', preserves underlying data (volumes of databases/service
+          resources). Default: ''false'''
         in: query
         name: keep_data
-        type: boolean
+        type: string
       produces:
       - application/json
       responses:
@@ -534,7 +534,7 @@ paths:
           schema:
             $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_apiserver_repository.DeleteApplicationResponse'
         "400":
-          description: Invalid application ID
+          description: Invalid application ID or keep_data parameter
           schema:
             $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
         "401":

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/application_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/application_handler.go
@@ -287,6 +287,7 @@ func (h *ApplicationHandler) DeleteApplication(c *gin.Context) {
 	if keepDataParam != "" {
 		if keepDataParam != "true" && keepDataParam != "false" {
 			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid keep_data parameter: must be 'true' or 'false'"})
+
 			return
 		}
 		keepData = keepDataParam == "true"

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/application_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/application_handler.go
@@ -255,9 +255,9 @@ func (h *ApplicationHandler) GetApplicationByID(c *gin.Context) {
 //	@Produce		json
 //	@Security		BearerAuth
 //	@Param			id			path		string	true	"Application ID (UUID)"
-//	@Param			keep_data	query		bool	false	"When true, preserves underlying data (volumes of databases/service resources)"
+//	@Param			keep_data	query		string	false	"When 'true', preserves underlying data (volumes of databases/service resources). Default: 'false'"
 //	@Success		202			{object}	repository.DeleteApplicationResponse
-//	@Failure		400			{object}	ErrorResponse	"Invalid application ID"
+//	@Failure		400			{object}	ErrorResponse	"Invalid application ID or keep_data parameter"
 //	@Failure		401			{object}	ErrorResponse	"Unauthorized"
 //	@Failure		403			{object}	ErrorResponse	"User doesn't own this application"
 //	@Failure		404			{object}	ErrorResponse	"Application not found"
@@ -272,8 +272,6 @@ func (h *ApplicationHandler) DeleteApplication(c *gin.Context) {
 		return
 	}
 
-	keepData := c.Query("keep_data") == "true"
-
 	userIDVal, exists := c.Get(middleware.CtxUserIDKey)
 	if !exists {
 		c.JSON(http.StatusUnauthorized, ErrorResponse{Error: "authentication required"})
@@ -282,6 +280,17 @@ func (h *ApplicationHandler) DeleteApplication(c *gin.Context) {
 	}
 
 	userID := userIDVal.(string)
+
+	// Parse and validate keep_data parameter (default: false)
+	keepData := false
+	keepDataParam := c.Query("keep_data")
+	if keepDataParam != "" {
+		if keepDataParam != "true" && keepDataParam != "false" {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid keep_data parameter: must be 'true' or 'false'"})
+			return
+		}
+		keepData = keepDataParam == "true"
+	}
 
 	response, err := h.appService.DeleteApplication(c.Request.Context(), appID, userID, keepData)
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/application_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/application_handler.go
@@ -255,7 +255,7 @@ func (h *ApplicationHandler) GetApplicationByID(c *gin.Context) {
 //	@Produce		json
 //	@Security		BearerAuth
 //	@Param			id		path		string	true	"Application ID (UUID)"
-//	@Param			force	query		bool	false	"When true, also deletes orphaned component records"
+//	@Param			keep_data	query		bool	false	"When true, preserves underlying data (pods, volumes, orphaned components)"
 //	@Success		202		{object}	repository.DeleteApplicationResponse
 //	@Failure		400		{object}	ErrorResponse	"Invalid application ID"
 //	@Failure		401		{object}	ErrorResponse	"Unauthorized"
@@ -272,7 +272,7 @@ func (h *ApplicationHandler) DeleteApplication(c *gin.Context) {
 		return
 	}
 
-	force := c.Query("force") == "true"
+	keepData := c.Query("keep_data") == "true"
 
 	userIDVal, exists := c.Get(middleware.CtxUserIDKey)
 	if !exists {
@@ -283,7 +283,7 @@ func (h *ApplicationHandler) DeleteApplication(c *gin.Context) {
 
 	userID := userIDVal.(string)
 
-	response, err := h.appService.DeleteApplication(c.Request.Context(), appID, userID, force)
+	response, err := h.appService.DeleteApplication(c.Request.Context(), appID, userID, keepData)
 	if err != nil {
 		h.handleDeleteError(c, err)
 

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/application_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/application_handler.go
@@ -254,15 +254,15 @@ func (h *ApplicationHandler) GetApplicationByID(c *gin.Context) {
 //	@Tags			Applications
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			id		path		string	true	"Application ID (UUID)"
-//	@Param			keep_data	query		bool	false	"When true, preserves underlying data (pods, volumes, orphaned components)"
-//	@Success		202		{object}	repository.DeleteApplicationResponse
-//	@Failure		400		{object}	ErrorResponse	"Invalid application ID"
-//	@Failure		401		{object}	ErrorResponse	"Unauthorized"
-//	@Failure		403		{object}	ErrorResponse	"User doesn't own this application"
-//	@Failure		404		{object}	ErrorResponse	"Application not found"
-//	@Failure		409		{object}	ErrorResponse	"Application is already being deleted"
-//	@Failure		500		{object}	ErrorResponse	"Internal Server Error"
+//	@Param			id			path		string	true	"Application ID (UUID)"
+//	@Param			keep_data	query		bool	false	"When true, preserves underlying data (volumes of databases/service resources)"
+//	@Success		202			{object}	repository.DeleteApplicationResponse
+//	@Failure		400			{object}	ErrorResponse	"Invalid application ID"
+//	@Failure		401			{object}	ErrorResponse	"Unauthorized"
+//	@Failure		403			{object}	ErrorResponse	"User doesn't own this application"
+//	@Failure		404			{object}	ErrorResponse	"Application not found"
+//	@Failure		409			{object}	ErrorResponse	"Application is already being deleted"
+//	@Failure		500			{object}	ErrorResponse	"Internal Server Error"
 //	@Router			/applications/{id} [delete]
 func (h *ApplicationHandler) DeleteApplication(c *gin.Context) {
 	appID, err := uuid.Parse(c.Param("id"))

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	apimodels "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/deletion"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/deployment"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
@@ -17,7 +18,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	podmanRuntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 )
 
@@ -35,6 +35,7 @@ type ApplicationService struct {
 	provider              *catalog.CatalogProvider
 	deploymentPlanner     *deployment.DeploymentPlanner
 	deploymentExecutor    *deployment.DeploymentExecutor
+	deletionService       *deletion.DeletionService
 }
 
 // NewApplicationService creates a new application service.
@@ -53,6 +54,7 @@ func NewApplicationService(
 		provider:              provider,
 		deploymentPlanner:     deployment.NewDeploymentPlanner(provider, componentRepo),
 		deploymentExecutor:    deployment.NewDeploymentExecutor(provider, appRepo, serviceRepo, componentRepo),
+		deletionService:       deletion.NewDeletionService(appRepo, serviceRepo, componentRepo, serviceDependencyRepo),
 	}
 }
 
@@ -567,7 +569,7 @@ type DeleteApplicationResponse struct {
 }
 
 // DeleteApplication initiates async deletion of an application and returns immediately.
-func (s *ApplicationService) DeleteApplication(ctx context.Context, id uuid.UUID, user string, force bool) (*DeleteApplicationResponse, error) {
+func (s *ApplicationService) DeleteApplication(ctx context.Context, id uuid.UUID, user string, keepData bool) (*DeleteApplicationResponse, error) {
 	app, err := s.appRepo.GetByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -589,124 +591,13 @@ func (s *ApplicationService) DeleteApplication(ctx context.Context, id uuid.UUID
 		return nil, err
 	}
 
-	go s.performDeletion(context.Background(), id, app.Services, force)
+	go s.deletionService.PerformDeletion(context.Background(), id, app.Services, keepData)
 
 	return &DeleteApplicationResponse{
 		ID:      id.String(),
 		Status:  string(models.ApplicationStatusDeleting),
 		Message: "Deletion initiated successfully",
 	}, nil
-}
-
-// performDeletion carries out the async cascade deletion for an application.
-// When force is true, orphaned component records are also deleted.
-//
-//nolint:cyclop,gocognit,nestif,funlen
-func (s *ApplicationService) performDeletion(ctx context.Context, appID uuid.UUID, services []models.Service, force bool) {
-	serviceIDs := make(map[uuid.UUID]bool, len(services))
-	for _, svc := range services {
-		serviceIDs[svc.ID] = true
-	}
-
-	// Identify orphaned components before deletion while service_dependencies still exist.
-	var orphanedComponents []uuid.UUID
-
-	if force {
-		componentCandidates := make(map[uuid.UUID]bool)
-
-		for _, svc := range services {
-			deps, err := s.serviceDependencyRepo.GetDependenciesByServiceID(ctx, svc.ID)
-			if err != nil {
-				logger.Errorf("failed to get dependencies for service %s: %s", svc.ID, err)
-				_ = s.appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, "failed to get service dependencies")
-
-				return
-			}
-
-			for _, dep := range deps {
-				if dep.DependencyType == models.DependencyTypeComponent {
-					componentCandidates[dep.DependencyID] = true
-				}
-			}
-		}
-
-		for componentID := range componentCandidates {
-			dependentServices, err := s.serviceDependencyRepo.GetServicesByDependency(ctx, componentID, models.DependencyTypeComponent)
-			if err != nil {
-				logger.Errorf("failed to check component %s orphan status: %s", componentID, err)
-
-				continue
-			}
-
-			isOrphan := true
-
-			for _, svcID := range dependentServices {
-				if !serviceIDs[svcID] {
-					isOrphan = false
-
-					break
-				}
-			}
-
-			if isOrphan {
-				orphanedComponents = append(orphanedComponents, componentID)
-			}
-		}
-	}
-
-	// delete pods before removing DB records
-	rt, err := podmanRuntime.NewPodmanClient()
-	if err != nil {
-		logger.Errorf("failed to init podman client for app %s: %s", appID, err)
-		_ = s.appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, "failed to init podman client")
-
-		return
-	}
-
-	forceDelete := true
-
-	for _, svc := range services {
-		pods, err := rt.ListPods(map[string][]string{
-			"label": {fmt.Sprintf("ai-services.io/template=%s", svc.ID)},
-		})
-		if err != nil {
-			logger.Errorf("failed to list pods for service %s: %s", svc.ID, err)
-
-			continue
-		}
-
-		for _, pod := range pods {
-			if err := rt.DeletePod(pod.ID, &forceDelete); err != nil {
-				logger.Errorf("failed to delete pod %s for service %s: %s", pod.ID, svc.ID, err)
-			}
-		}
-	}
-
-	// Delete the application; CASCADE removes services and service_dependencies.
-	if err := s.appRepo.Delete(ctx, appID); err != nil {
-		logger.Errorf("failed to delete application %s: %s", appID, err)
-
-		return
-	}
-
-	for _, componentID := range orphanedComponents {
-		pods, err := rt.ListPods(map[string][]string{
-			"label": {fmt.Sprintf("ai-services.io/template=%s", componentID)},
-		})
-		if err != nil {
-			logger.Errorf("failed to list pods for component %s: %s", componentID, err)
-		} else {
-			for _, pod := range pods {
-				if err := rt.DeletePod(pod.ID, &forceDelete); err != nil {
-					logger.Errorf("failed to delete pod %s for component %s: %s", pod.ID, componentID, err)
-				}
-			}
-		}
-
-		if err := s.componentRepo.Delete(ctx, componentID); err != nil {
-			logger.Errorf("failed to delete orphaned component %s: %s", componentID, err)
-		}
-	}
 }
 
 // filterComponentMetadata filters component parameters to exclude sensitive data.

--- a/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
@@ -1,0 +1,391 @@
+package deletion
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
+	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	appUtils "github.com/project-ai-services/ai-services/internal/pkg/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
+)
+
+// DeletionService handles application deletion operations.
+type DeletionService struct {
+	appRepo               dbrepo.ApplicationRepository
+	serviceRepo           dbrepo.ServiceRepository
+	componentRepo         dbrepo.ComponentRepository
+	serviceDependencyRepo dbrepo.ServiceDependencyRepository
+}
+
+// NewDeletionService creates a new deletion service instance.
+func NewDeletionService(
+	appRepo dbrepo.ApplicationRepository,
+	serviceRepo dbrepo.ServiceRepository,
+	componentRepo dbrepo.ComponentRepository,
+	serviceDependencyRepo dbrepo.ServiceDependencyRepository,
+) *DeletionService {
+	return &DeletionService{
+		appRepo:               appRepo,
+		serviceRepo:           serviceRepo,
+		componentRepo:         componentRepo,
+		serviceDependencyRepo: serviceDependencyRepo,
+	}
+}
+
+// PerformDeletion carries out the async cascade deletion for an application.
+// When keepData is true, preserves underlying data (pods, volumes, orphaned components).
+// When keepData is false, deletes all data including application data directory.
+func (s *DeletionService) PerformDeletion(ctx context.Context, appID uuid.UUID, services []models.Service, keepData bool) {
+	// Identify orphaned components before deletion
+	orphanedComponents, err := s.identifyOrphanedComponents(ctx, appID, services)
+	if err != nil {
+		return // Error already logged and status updated
+	}
+
+	// Initialize runtime client
+	rt, err := vars.RuntimeFactory.Create("")
+	if err != nil {
+		logger.Errorf("failed to init runtime client for app %s: %s", appID, err)
+		_ = s.appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, "failed to init runtime client")
+
+		return
+	}
+
+	// Delete services and track errors
+	errorMessages := s.deleteServices(ctx, rt, services, keepData)
+
+	// Delete orphaned components and track errors
+	componentErrors := s.deleteOrphanedComponents(ctx, rt, orphanedComponents, keepData)
+	errorMessages = append(errorMessages, componentErrors...)
+
+	// Delete application data directory if keepData is false
+	if !keepData {
+		if err := s.deleteInstanceData(appID, "application"); err != nil {
+			errMsg := fmt.Sprintf("failed to delete application data: %s", err)
+			errorMessages = append(errorMessages, errMsg)
+			logger.Errorf("application %s: %s", appID, errMsg)
+		}
+	}
+
+	// Check if any errors occurred during deletion
+	if len(errorMessages) > 0 {
+		s.handleDeletionFailure(ctx, appID, errorMessages)
+
+		return
+	}
+
+	// Delete application from DB only if no errors occurred
+	if err := s.appRepo.Delete(ctx, appID); err != nil {
+		errMsg := fmt.Sprintf("failed to delete application: %s", err)
+		logger.Errorf("application %s: %s", appID, errMsg)
+		_ = s.appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, errMsg)
+
+		return
+	}
+
+	logger.Infof("Application %s deleted successfully", appID)
+}
+
+// identifyOrphanedComponents identifies components that will become orphaned after service deletion.
+func (s *DeletionService) identifyOrphanedComponents(ctx context.Context, appID uuid.UUID, services []models.Service) ([]uuid.UUID, error) {
+	serviceIDs := s.buildServiceIDMap(services)
+
+	componentCandidates, err := s.collectComponentCandidates(ctx, appID, services)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.filterOrphanedComponents(ctx, componentCandidates, serviceIDs), nil
+}
+
+// buildServiceIDMap creates a map of service IDs for quick lookup.
+func (s *DeletionService) buildServiceIDMap(services []models.Service) map[uuid.UUID]bool {
+	serviceIDs := make(map[uuid.UUID]bool, len(services))
+	for _, svc := range services {
+		serviceIDs[svc.ID] = true
+	}
+
+	return serviceIDs
+}
+
+// collectComponentCandidates gathers all components used by services being deleted.
+func (s *DeletionService) collectComponentCandidates(ctx context.Context, appID uuid.UUID, services []models.Service) (map[uuid.UUID]bool, error) {
+	componentCandidates := make(map[uuid.UUID]bool)
+
+	for _, svc := range services {
+		deps, err := s.serviceDependencyRepo.GetDependenciesByServiceID(ctx, svc.ID)
+		if err != nil {
+			logger.Errorf("failed to get dependencies for service %s: %s", svc.ID, err)
+			_ = s.appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, "failed to get service dependencies")
+
+			return nil, err
+		}
+
+		for _, dep := range deps {
+			if dep.DependencyType == models.DependencyTypeComponent {
+				componentCandidates[dep.DependencyID] = true
+			}
+		}
+	}
+
+	return componentCandidates, nil
+}
+
+// filterOrphanedComponents checks which components are truly orphaned.
+func (s *DeletionService) filterOrphanedComponents(ctx context.Context, componentCandidates map[uuid.UUID]bool, serviceIDs map[uuid.UUID]bool) []uuid.UUID {
+	var orphanedComponents []uuid.UUID
+
+	for componentID := range componentCandidates {
+		if s.isComponentOrphaned(ctx, componentID, serviceIDs) {
+			orphanedComponents = append(orphanedComponents, componentID)
+		}
+	}
+
+	return orphanedComponents
+}
+
+// isComponentOrphaned checks if a component has no remaining dependent services.
+func (s *DeletionService) isComponentOrphaned(ctx context.Context, componentID uuid.UUID, serviceIDs map[uuid.UUID]bool) bool {
+	dependentServices, err := s.serviceDependencyRepo.GetServicesByDependency(ctx, componentID, models.DependencyTypeComponent)
+	if err != nil {
+		logger.Errorf("failed to check component %s orphan status: %s", componentID, err)
+
+		return false
+	}
+
+	for _, svcID := range dependentServices {
+		if !serviceIDs[svcID] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// deleteServices deletes all services (pods + DB records) and returns any error messages.
+func (s *DeletionService) deleteServices(ctx context.Context, rt runtime.Runtime, services []models.Service, keepData bool) []string {
+	var errorMessages []string
+	forceDelete := true
+
+	for _, svc := range services {
+		// List service pods
+		pods, err := rt.ListPods(map[string][]string{
+			"label": {fmt.Sprintf("ai-services.io/template=%s", svc.ID)},
+		})
+		if err != nil {
+			errMsg := fmt.Sprintf("service %s: failed to list pods: %s", svc.ID, err)
+			errorMessages = append(errorMessages, errMsg)
+			_ = s.serviceRepo.UpdateStatus(ctx, svc.ID, models.ServiceStatusError, fmt.Sprintf("failed to list pods: %s", err))
+
+			continue
+		}
+
+		// Delete service secrets
+		secretErrors := s.deleteSecretsFromPods(rt, pods, keepData, "service", svc.ID)
+		if len(secretErrors) > 0 {
+			errorMessages = append(errorMessages, secretErrors...)
+		}
+
+		// Delete service pods
+		podErrors := s.deleteServicePods(rt, pods, forceDelete)
+		if len(podErrors) > 0 {
+			errMsg := fmt.Sprintf("service %s: failed to delete %d pod(s)", svc.ID, len(podErrors))
+			errorMessages = append(errorMessages, errMsg)
+			_ = s.serviceRepo.UpdateStatus(ctx, svc.ID, models.ServiceStatusError, fmt.Sprintf("failed to delete %d pod(s)", len(podErrors)))
+		}
+
+		// Delete service from DB
+		if err := s.serviceRepo.Delete(ctx, svc.ID); err != nil {
+			errMsg := fmt.Sprintf("service %s: failed to delete from DB: %s", svc.ID, err)
+			errorMessages = append(errorMessages, errMsg)
+			_ = s.serviceRepo.UpdateStatus(ctx, svc.ID, models.ServiceStatusError, fmt.Sprintf("failed to delete from DB: %s", err))
+		}
+	}
+
+	return errorMessages
+}
+
+// deleteServicePods deletes all pods for a service and returns any error messages.
+func (s *DeletionService) deleteServicePods(rt runtime.Runtime, pods []runtimeTypes.Pod, forceDelete bool) []string {
+	var podErrors []string
+	for _, pod := range pods {
+		if err := rt.DeletePod(pod.ID, &forceDelete); err != nil {
+			errMsg := fmt.Sprintf("failed to delete pod %s: %s", pod.ID, err)
+			podErrors = append(podErrors, errMsg)
+		}
+	}
+
+	return podErrors
+}
+
+// deleteOrphanedComponents deletes orphaned components (pods + DB records) and returns any error messages.
+func (s *DeletionService) deleteOrphanedComponents(ctx context.Context, rt runtime.Runtime, componentIDs []uuid.UUID, keepData bool) []string {
+	var errorMessages []string
+	forceDelete := true
+
+	for _, componentID := range componentIDs {
+		// List component pods
+		pods, err := rt.ListPods(map[string][]string{
+			"label": {fmt.Sprintf("ai-services.io/template=%s", componentID)},
+		})
+		if err != nil {
+			errMsg := fmt.Sprintf("component %s: failed to list pods: %s", componentID, err)
+			errorMessages = append(errorMessages, errMsg)
+			_ = s.componentRepo.UpdateStatus(ctx, componentID, models.ComponentStatusError, fmt.Sprintf("failed to list pods: %s", err))
+
+			continue
+		}
+
+		// Delete component secrets
+		secretErrors := s.deleteSecretsFromPods(rt, pods, keepData, "component", componentID)
+		if len(secretErrors) > 0 {
+			errorMessages = append(errorMessages, secretErrors...)
+		}
+
+		// Delete component pods
+		podErrors := s.deleteComponentPods(rt, pods, forceDelete)
+		if len(podErrors) > 0 {
+			errMsg := fmt.Sprintf("component %s: failed to delete %d pod(s)", componentID, len(podErrors))
+			errorMessages = append(errorMessages, errMsg)
+			_ = s.componentRepo.UpdateStatus(ctx, componentID, models.ComponentStatusError, fmt.Sprintf("failed to delete %d pod(s)", len(podErrors)))
+		}
+
+		// Delete component data directory if keepData is false
+		if !keepData {
+			if err := s.deleteInstanceData(componentID, "component"); err != nil {
+				errMsg := fmt.Sprintf("component %s: failed to delete component data: %s", componentID, err)
+				errorMessages = append(errorMessages, errMsg)
+				logger.Errorf("component %s: %s", componentID, errMsg)
+			}
+		}
+
+		// Delete component from DB
+		if err := s.componentRepo.Delete(ctx, componentID); err != nil {
+			errMsg := fmt.Sprintf("component %s: failed to delete from DB: %s", componentID, err)
+			errorMessages = append(errorMessages, errMsg)
+			_ = s.componentRepo.UpdateStatus(ctx, componentID, models.ComponentStatusError, fmt.Sprintf("failed to delete from DB: %s", err))
+		}
+	}
+
+	return errorMessages
+}
+
+// deleteComponentPods deletes all pods for a component and returns any error messages.
+func (s *DeletionService) deleteComponentPods(rt runtime.Runtime, pods []runtimeTypes.Pod, forceDelete bool) []string {
+	var podErrors []string
+	for _, pod := range pods {
+		if err := rt.DeletePod(pod.ID, &forceDelete); err != nil {
+			errMsg := fmt.Sprintf("failed to delete pod %s: %s", pod.ID, err)
+			podErrors = append(podErrors, errMsg)
+		}
+	}
+
+	return podErrors
+}
+
+// handleDeletionFailure updates application status when deletion fails.
+func (s *DeletionService) handleDeletionFailure(ctx context.Context, appID uuid.UUID, errorMessages []string) {
+	errMsg := fmt.Sprintf("Application deletion failed with %d error(s), application not deleted", len(errorMessages))
+	logger.Errorf("application %s: %s", appID, errMsg)
+	_ = s.appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, errMsg)
+}
+
+// deleteInstanceData removes an instance's (application or component) data directory from the filesystem.
+// The data directory path is constructed using the instance ID slug.
+// instanceType should be either "application" or "component".
+func (s *DeletionService) deleteInstanceData(instanceID uuid.UUID, instanceType string) error {
+	// Generate slug from instance ID (same as used during deployment)
+	slug := utils.GenerateInstanceSlug(instanceID.String())
+
+	// Determine base path based on instance type
+	var basePath string
+	switch instanceType {
+	case "application":
+		basePath = appUtils.GetApplicationsPath()
+	case "component":
+		basePath = appUtils.GetComponentsPath()
+	default:
+		return fmt.Errorf("invalid instance type: %s", instanceType)
+	}
+
+	// Construct data path using the base directory and slug
+	dataPath := filepath.Join(basePath, slug)
+
+	// Check if data directory exists
+	if _, err := os.Stat(dataPath); os.IsNotExist(err) {
+		logger.Infof("%s data directory does not exist: %s", instanceType, dataPath)
+
+		return nil
+	}
+
+	logger.Infof("Deleting %s data at: %s", instanceType, dataPath)
+
+	// Remove the data directory
+	if err := os.RemoveAll(dataPath); err != nil {
+		return fmt.Errorf("failed to remove %s data directory: %w", instanceType, err)
+	}
+
+	logger.Infof("Successfully removed %s data at: %s", instanceType, dataPath)
+
+	return nil
+}
+
+// deleteSecretsFromPods extracts secret names from pod labels and deletes them.
+//
+// Deletion logic:
+//   - If keepData=false: Delete ALL secrets (default behavior - complete cleanup)
+//   - If keepData=true: Only delete secrets WITHOUT skip-cleanup label OR with skip-cleanup="false" (e.g., API keys)
+//     Preserve secrets WITH skip-cleanup="true" (e.g., DB credentials)
+//
+// Returns a list of error messages for any secrets that failed to delete.
+func (s *DeletionService) deleteSecretsFromPods(rt runtime.Runtime, pods []runtimeTypes.Pod, keepData bool, instanceType string, instanceID uuid.UUID) []string {
+	var errorMessages []string
+	secretsToDelete := make(map[string]bool) // Use map to avoid duplicates
+
+	// Extract secret names from pod labels
+	for _, pod := range pods {
+		if secretName, ok := pod.Labels[constants.CatalogSecretLabel]; ok {
+			// If keepData=false, delete ALL secrets
+			if !keepData {
+				secretsToDelete[secretName] = true
+			} else {
+				// If keepData=true, only delete secrets without skip-cleanup or with skip-cleanup="false"
+				if skipValue, hasSkipLabel := pod.Labels[constants.CatalogSecretSkipLabel]; !hasSkipLabel || skipValue == "false" {
+					secretsToDelete[secretName] = true
+				}
+			}
+		}
+	}
+
+	if len(secretsToDelete) == 0 {
+		logger.Infof("%s %s: no secrets found to delete", instanceType, instanceID)
+
+		return errorMessages
+	}
+
+	logger.Infof("Deleting %d secret(s) for %s %s (keepData=%v)", len(secretsToDelete), instanceType, instanceID, keepData)
+
+	// Delete each unique secret
+	for secretName := range secretsToDelete {
+		if err := rt.DeleteSecret(secretName); err != nil {
+			errMsg := fmt.Sprintf("%s %s: failed to delete secret %s: %s", instanceType, instanceID, secretName, err)
+			errorMessages = append(errorMessages, errMsg)
+			logger.Errorf(errMsg)
+		} else {
+			logger.Infof("Successfully deleted secret: %s", secretName)
+		}
+	}
+
+	return errorMessages
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -3,8 +3,6 @@ package podman
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"maps"
@@ -520,7 +518,7 @@ func (d *PodmanDeployer) mergeEndpointIntoService(comp *ComponentPlan, plan *Dep
 	// Add instanceSlug to the component's values in the service
 	// This allows templates to reference it as .Values.vector_store.instanceSlug
 	if componentValues, ok := svc.Values[comp.ComponentType].(map[string]any); ok {
-		instanceSlug := generateInstanceSlug(comp.DatabaseID.String())
+		instanceSlug := catalogutils.GenerateInstanceSlug(comp.DatabaseID.String())
 		componentValues["instanceSlug"] = instanceSlug
 		logger.Infof("Added instanceSlug '%s' to component %s in service %s\n", instanceSlug, comp.ComponentType, serviceID)
 	}
@@ -584,7 +582,7 @@ func (d *PodmanDeployer) deployComponentPods(
 			for _, podTemplateName := range layer {
 				// Prepare initialParams for the template
 				initialParams := map[string]any{
-					"InstanceSlug": generateInstanceSlug(comp.DatabaseID.String()),
+					"InstanceSlug": catalogutils.GenerateInstanceSlug(comp.DatabaseID.String()),
 					"TemplateID":   comp.DatabaseID,
 					"BaseDir":      utils.GetBaseDir(),
 					"Values":       values,
@@ -603,7 +601,7 @@ func (d *PodmanDeployer) deployComponentPods(
 		for templateName := range tmpls {
 			// Prepare initialParams for the template
 			initialParams := map[string]any{
-				"InstanceSlug": generateInstanceSlug(comp.DatabaseID.String()),
+				"InstanceSlug": catalogutils.GenerateInstanceSlug(comp.DatabaseID.String()),
 				"TemplateID":   comp.DatabaseID,
 				"BaseDir":      utils.GetBaseDir(),
 				"Values":       values,
@@ -810,7 +808,7 @@ func (d *PodmanDeployer) deployAllPodTemplates(
 // buildInitialParams creates the initial parameters map for template deployment.
 func (d *PodmanDeployer) buildInitialParams(applicationID uuid.UUID, databaseID uuid.UUID, values map[string]any) map[string]any {
 	return map[string]any{
-		"InstanceSlug": generateInstanceSlug(applicationID.String()),
+		"InstanceSlug": catalogutils.GenerateInstanceSlug(applicationID.String()),
 		"TemplateID":   databaseID,
 		"BaseDir":      utils.GetBaseDir(),
 		"Values":       values,
@@ -1153,15 +1151,6 @@ func (d *PodmanDeployer) getEnvParamsForComponent(podSpec *podmodels.PodSpec, pl
 	}
 
 	return env, nil
-}
-
-// generateInstanceSlug creates a short slug from an ID using SHA256 hash.
-// Returns the first 10 characters of the hex-encoded hash.
-func generateInstanceSlug(id string) string {
-	hash := sha256.Sum256([]byte(id))
-	hexHash := hex.EncodeToString(hash[:])
-
-	return hexHash[:10]
 }
 
 // registerApplicationRoutes registers routes for all services with Caddy proxy and updates endpoints in database.

--- a/ai-services/internal/pkg/catalog/utils/application_utils.go
+++ b/ai-services/internal/pkg/catalog/utils/application_utils.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log"
 
@@ -61,6 +63,16 @@ func BuildExternalURL(domain string, httpsPort string) string {
 	}
 
 	return url
+}
+
+// GenerateInstanceSlug creates a short slug from an ID using SHA256 hash.
+// Returns the first 10 characters of the hex-encoded hash.
+// This is used to create consistent directory names for applications and components.
+func GenerateInstanceSlug(id string) string {
+	hash := sha256.Sum256([]byte(id))
+	hexHash := hex.EncodeToString(hash[:])
+
+	return hexHash[:10]
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/runtime/interface.go
+++ b/ai-services/internal/pkg/runtime/interface.go
@@ -24,6 +24,7 @@ type Runtime interface {
 
 	// Secret operations
 	ListSecrets(filters map[string][]string) ([]string, error)
+	DeleteSecret(name string) error
 
 	// Container operations
 	// ListContainers(filters map[string][]string) ([]types.Container, error)

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -430,6 +430,12 @@ func (kc *OpenshiftClient) ListSecrets(filters map[string][]string) ([]string, e
 	return nil, nil
 }
 
+func (kc *OpenshiftClient) DeleteSecret(name string) error {
+	logger.Warningln("Not implemented")
+
+	return nil
+}
+
 // GetSystemInfo returns empty system information for OpenShift runtime.
 // Resource information is managed by Kubernetes/OpenShift and not directly accessible.
 func (kc *OpenshiftClient) GetSystemInfo() (*models.SystemInfo, error) {

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -506,7 +506,7 @@ func GetApplicationsPath() string {
 
 // GetComponentsPath returns the components path based on the configured base directory.
 func GetComponentsPath() string {
-	return filepath.Join(GetBaseDir(), "components")
+	return filepath.Join(GetBaseDir(), "applications", "components")
 }
 
 // GetModelsPath returns the models path based on the configured base directory.

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -504,6 +504,11 @@ func GetApplicationsPath() string {
 	return filepath.Join(GetBaseDir(), "applications")
 }
 
+// GetComponentsPath returns the components path based on the configured base directory.
+func GetComponentsPath() string {
+	return filepath.Join(GetBaseDir(), "components")
+}
+
 // GetModelsPath returns the models path based on the configured base directory.
 func GetModelsPath() string {
 	return filepath.Join(GetBaseDir(), "models")


### PR DESCRIPTION
- This is final PR and continuation from previous Deletion PR: https://github.com/IBM/project-ai-services/pull/840.
- Handles component and service deletion of pods with DB in right manner (First pods for respective services/components are deleted followed by DB deletion).
- Proper error handling in async deletion flow (Ensures DB tables are properly updated).
- Handling secret deletion and app/component data deletion based on `keep-data` flag.
- Mounting the BaseDir path to catalog-backend as catalog-backend is responsible for deleting the resources present on host.