### PR TITLE
Fix container readiness failure in ingest-docs cli pod

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.42
+TAG?=0.0.43
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/templates/ingest-docs.yaml.tmpl
+++ b/ai-services/assets/applications/rag-cpu/podman/templates/ingest-docs.yaml.tmpl
@@ -9,21 +9,6 @@ metadata:
   annotations:
     ai-services.io/start: "off"
 spec:
-  initContainers:
-    - name: digitize-db-init
-      image: "{{ .Values.digitize.image }}"
-      command: ["/var/venv/bin/python", "db/scripts/init_db.py"]
-      env:
-        - name: POSTGRES_HOST
-          value: "{{ .AppName }}--postgres"
-        - name: POSTGRES_PORT
-          value: "5432"
-        - name: POSTGRES_DB
-          value: "{{ .Values.digitize.database }}"
-        - name: POSTGRES_USER
-          value: "postgres"
-        - name: POSTGRES_PASSWORD
-          value: "{{ .Values.postgres.password }}"
   containers:
     - name: ingest-docs
       image: "{{ .Values.digitize.image }}"

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.12
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.13
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -24,7 +24,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.12
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.13
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/templates/ingest-docs.yaml.tmpl
+++ b/ai-services/assets/applications/rag-dev/podman/templates/ingest-docs.yaml.tmpl
@@ -9,21 +9,6 @@ metadata:
   annotations:
     ai-services.io/start: "off"
 spec:
-  initContainers:
-    - name: digitize-db-init
-      image: "{{ .Values.digitize.image }}"
-      command: ["/var/venv/bin/python", "db/scripts/init_db.py"]
-      env:
-        - name: POSTGRES_HOST
-          value: "{{ .AppName }}--postgres"
-        - name: POSTGRES_PORT
-          value: "5432"
-        - name: POSTGRES_DB
-          value: "{{ .Values.digitize.database }}"
-        - name: POSTGRES_USER
-          value: "postgres"
-        - name: POSTGRES_PASSWORD
-          value: "{{ .Values.postgres.password }}"
   containers:
     - name: ingest-docs
       image: "{{ .Values.digitize.image }}"

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.12
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.13
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/templates/digitize-api-deployment.yaml
+++ b/ai-services/assets/applications/rag/openshift/templates/digitize-api-deployment.yaml
@@ -21,26 +21,6 @@ spec:
         ai-services.io/version: {{ default .Chart.AppVersion | quote }}
     spec:
       automountServiceAccountToken: false
-      initContainers:
-        - name: digitize-db-init
-          image: "{{ .Values.digitize.image }}"
-          command:
-            - "/var/venv/bin/python"
-            - "db/scripts/init_db.py"
-          env:
-            - name: POSTGRES_HOST
-              value: "postgres"
-            - name: POSTGRES_PORT
-              value: "5432"
-            - name: POSTGRES_DB
-              value: "{{ .Values.digitize.database }}"
-            - name: POSTGRES_USER
-              value: "postgres"
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "postgres-credentials"
-                  key: password
       containers:
         - name: digitize-api
           image: "{{ .Values.digitize.image }}"

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -24,7 +24,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.12
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.13
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/templates/ingest-docs.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/ingest-docs.yaml.tmpl
@@ -9,21 +9,6 @@ metadata:
   annotations:
     ai-services.io/start: "off"
 spec:
-  initContainers:
-    - name: digitize-db-init
-      image: "{{ .Values.digitize.image }}"
-      command: ["/var/venv/bin/python", "db/scripts/init_db.py"]
-      env:
-        - name: POSTGRES_HOST
-          value: "{{ .AppName }}--postgres"
-        - name: POSTGRES_PORT
-          value: "5432"
-        - name: POSTGRES_DB
-          value: "{{ .Values.digitize.database }}"
-        - name: POSTGRES_USER
-          value: "postgres"
-        - name: POSTGRES_PASSWORD
-          value: "{{ .Values.postgres.password }}"
   containers:
     - name: ingest-docs
       image: "{{ .Values.digitize.image }}"

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.12
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.13
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.42
+  image: icr.io/ai-services-cicd/ai-services:0.0.43
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,6 +1,6 @@
 digitize:
   port: ""
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.12
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.13
   log_level: "INFO"
   database: "digitize_metadata"
 

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.12
+TAG?=v0.0.13
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/cli.py
+++ b/services/digitize/cli.py
@@ -47,12 +47,35 @@ if command_args.debug:
 set_log_level(log_level)
 
 from digitize.cleanup import reset_db
-from digitize.db.connection import check_db_connection
+from digitize.db.connection import check_db_connection, engine
 from digitize.digitize_utils import generate_uuid, has_active_jobs, initialize_job_state
 from digitize.ingest import ingest
 from digitize.models import OperationType, OutputFormat
 
 logger = get_logger("Ingest")
+
+
+def initialize_database_schema() -> bool:
+    """
+    Initialize database schema by creating tables if they don't exist.
+
+    Returns:
+        True if schema initialization successful, False otherwise
+    """
+    try:
+        from digitize.db.models import Base
+
+        if not engine:
+            logger.error("❌ Database engine not initialized")
+            return False
+
+        logger.info("Initializing database schema...")
+        Base.metadata.create_all(bind=engine)
+        logger.info("✅ Database schema initialized")
+        return True
+    except Exception as schema_error:
+        logger.error(f"❌ Failed to initialize database schema: {schema_error}")
+        return False
 
 
 def validate_input_directory(base_path: Path) -> list[Path]:
@@ -136,8 +159,16 @@ def print_ingestion_stats(converted_pdf_stats: dict) -> None:
 
 def run_ingest() -> int:
     """Run CLI ingestion with database validation and job initialization."""
+    # Check database connection (required for ingestion operation)
     if not check_db_connection():
-        logger.error("Database connection required but not available. Please check PostgreSQL configuration.")
+        logger.error("❌ Database connection required but not available. Please check PostgreSQL configuration.")
+        return 1
+
+    logger.debug("✅ Database connection established")
+
+    # Initialize database schema (create tables if they don't exist)
+    if not initialize_database_schema():
+        logger.error("❌ Database schema initialization failed - cannot proceed with ingestion")
         return 1
 
     has_active, active_job_ids = has_active_jobs(operation=OperationType.INGESTION.value)
@@ -174,8 +205,16 @@ def run_ingest() -> int:
 
 def run_clean_db() -> int:
     """Run cleanup with database validation."""
+    # Check database connection (required for cleanup operation)
     if not check_db_connection():
-        logger.error("Database connection required but not available. Please check PostgreSQL configuration.")
+        logger.error("❌ Database connection required but not available. Please check PostgreSQL configuration.")
+        return 1
+
+    logger.debug("✅ Database connection established")
+
+    # Initialize database schema (create tables if they don't exist)
+    if not initialize_database_schema():
+        logger.error("❌ Database schema initialization failed - cannot proceed with cleanup")
         return 1
 
     try:


### PR DESCRIPTION
- Ingest-docs cli pod was failing with container readiness failure due to the db init container added in the manifest files. removed init container and added db initialization logic in cli.py to take care of initial table creation.