### PR TITLE
[Catalog-API] Deletion API fixes

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.50
+TAG?=0.0.51
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.50
+  image: icr.io/ai-services-cicd/ai-services:0.0.51
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/components/llm/vllm-cpu/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/vllm-cpu/podman/templates/vllm-server.yaml.tmpl
@@ -4,7 +4,9 @@ metadata:
   name: "llm-{{ .InstanceSlug }}"
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
+    {{- if .Values.apiKey }}
     ai-services.io/secret: "vllm-secret-{{ .InstanceSlug }}"
+    {{- end }}
   annotations:
     io.podman.annotations.ulimit: "nofile=134217728:134217728,memlock=-1:-1"
 spec:

--- a/ai-services/assets/components/llm/vllm-spyre/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/vllm-spyre/podman/templates/vllm-server.yaml.tmpl
@@ -4,7 +4,9 @@ metadata:
   name: "llm-{{ .InstanceSlug }}"
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
+    {{- if .Values.apiKey }}
     ai-services.io/secret: "vllm-secret-{{ .InstanceSlug }}"
+    {{- end }}
   annotations:
     io.podman.annotations.ulimit: "nofile=134217728:134217728,memlock=-1:-1"
     io.podman.annotations.userns: "keep-id"

--- a/ai-services/assets/components/vector_db/opensearch/podman/templates/opensearch.yaml.tmpl
+++ b/ai-services/assets/components/vector_db/opensearch/podman/templates/opensearch.yaml.tmpl
@@ -6,18 +6,10 @@ metadata:
     ai-services.io/template: "{{ .TemplateID }}"
     ai-services.io/secret: "opensearch-secret-{{ .InstanceSlug }}"
     ai-services.io/secret-skip-cleanup: "true"
+    ai-services.io/volume: "opensearch-{{ .InstanceSlug }}"
   annotations:
     io.podman.annotations.pids-limit/opensearch: "4096"
 spec:
-  initContainers:
-    - name: fix-permissions
-      image: "{{ .Values.image }}"
-      command: ["sh", "-c", "chown -R 1000:1000 /usr/share/opensearch/data"]
-      securityContext:
-        runAsUser: 0
-      volumeMounts:
-        - name: opensearch-data
-          mountPath: /usr/share/opensearch/data
   containers:
     - name: opensearch
       image: "{{ .Values.image }}"
@@ -64,6 +56,5 @@ spec:
         failureThreshold: 5
   volumes:
     - name: opensearch-data
-      hostPath:
-        path: "{{ .BaseDir }}/applications/components/{{ .InstanceSlug }}/volumes/opensearch"
-        type: DirectoryOrCreate
+      persistentVolumeClaim:
+        claimName: "opensearch-{{ .InstanceSlug }}"

--- a/ai-services/assets/services/digitize/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/services/digitize/podman/templates/digitize.yaml.tmpl
@@ -6,6 +6,7 @@ metadata:
     ai-services.io/template: "{{ .TemplateID }}"
     ai-services.io/secret: "digitize-db-secret-{{ .InstanceSlug }}"
     ai-services.io/secret-skip-cleanup: "true"
+    ai-services.io/volume: "digitize-cache-{{ .InstanceSlug }}"
   annotations:
     ai-services.io/routes: "4001:digitize-ui-{{ .InstanceSlug }}:ui,4000:digitize-backend-{{ .InstanceSlug }}:api"
     # ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001, {{ .Values.digitize.port }}:4000"  # Uncomment to expose ports directly (bypasses Caddy)
@@ -156,6 +157,5 @@ spec:
   restartPolicy: Always
   volumes:
     - name: cache
-      hostPath:
-        path: "{{ .BaseDir }}/applications/{{ .InstanceSlug }}/cache"
-        type: DirectoryOrCreate
+      persistentVolumeClaim:
+        claimName: "digitize-cache-{{ .InstanceSlug }}"

--- a/ai-services/assets/services/digitize/podman/templates/postgres.yaml.tmpl
+++ b/ai-services/assets/services/digitize/podman/templates/postgres.yaml.tmpl
@@ -4,18 +4,10 @@ metadata:
   name: "digitize-db-{{ .InstanceSlug }}"
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
+    ai-services.io/volume: "postgres-digitize-{{ .InstanceSlug }}"
   annotations:
     io.podman.annotations.pids-limit/postgres: "4096"
 spec:
-  initContainers:
-    - name: fix-permissions
-      image: "{{ .Values.postgres.image }}"
-      command: ["sh", "-c", "chown -R 26:26 /var/lib/pgsql"]
-      securityContext:
-        runAsUser: 0
-      volumeMounts:
-        - name: postgres-data
-          mountPath: /var/lib/pgsql
   containers:
     - name: postgres
       image: "{{ .Values.postgres.image }}"
@@ -66,6 +58,5 @@ spec:
 
   volumes:
     - name: postgres-data
-      hostPath:
-        path: "{{ .BaseDir }}/applications/{{ .InstanceSlug }}/volumes/postgres-digitize"
-        type: DirectoryOrCreate
+      persistentVolumeClaim:
+        claimName: "postgres-digitize-{{ .InstanceSlug }}"

--- a/ai-services/assets/services/summarize/podman/templates/postgres.yaml.tmpl
+++ b/ai-services/assets/services/summarize/podman/templates/postgres.yaml.tmpl
@@ -4,18 +4,10 @@ metadata:
   name: "summarize-db-{{ .InstanceSlug }}"
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
+    ai-services.io/volume: "postgres-summarize-{{ .InstanceSlug }}"
   annotations:
     io.podman.annotations.pids-limit/postgres: "4096"
 spec:
-  initContainers:
-    - name: fix-permissions
-      image: "{{ .Values.postgres.image }}"
-      command: ["sh", "-c", "chown -R 26:26 /var/lib/pgsql"]
-      securityContext:
-        runAsUser: 0
-      volumeMounts:
-        - name: postgres-data
-          mountPath: /var/lib/pgsql
   containers:
     - name: postgres
       image: "{{ .Values.postgres.image }}"
@@ -66,6 +58,5 @@ spec:
 
   volumes:
     - name: postgres-data
-      hostPath:
-        path: "{{ .BaseDir }}/applications/{{ .InstanceSlug }}/volumes/postgres-summarize"
-        type: DirectoryOrCreate
+      persistentVolumeClaim:
+        claimName: "postgres-summarize-{{ .InstanceSlug }}"

--- a/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
@@ -195,6 +196,14 @@ func (s *DeletionService) deleteServices(ctx context.Context, rt runtime.Runtime
 			errorMessages = append(errorMessages, secretErrors...)
 		}
 
+		// Delete volumes if keepData is false
+		if !keepData {
+			volumeErrors := s.deleteVolumesFromPods(rt, pods, "service", svc.ID)
+			if len(volumeErrors) > 0 {
+				errorMessages = append(errorMessages, volumeErrors...)
+			}
+		}
+
 		// Delete service pods
 		podErrors := s.deleteServicePods(rt, pods, forceDelete)
 		if len(podErrors) > 0 {
@@ -337,6 +346,50 @@ func (s *DeletionService) deleteInstanceData(instanceID uuid.UUID, instanceType 
 	logger.Infof("Successfully removed %s data at: %s", instanceType, dataPath)
 
 	return nil
+}
+
+// deleteVolumesFromPods extracts volume names from pod labels and deletes them using the runtime client.
+// Volumes are always deleted when keepData=false. This method is only called when keepData=false.
+//
+// Returns a list of error messages for any volumes that failed to delete.
+func (s *DeletionService) deleteVolumesFromPods(rt runtime.Runtime, pods []runtimeTypes.Pod, instanceType string, instanceID uuid.UUID) []string {
+	var errorMessages []string
+	volumesToDelete := make(map[string]bool) // Use map to avoid duplicates
+
+	// Extract volume names from pod labels
+	for _, pod := range pods {
+		if volumeNames, ok := pod.Labels[constants.CatalogVolumeLabel]; ok && volumeNames != "" {
+			// Split comma-separated volume names (in case a pod has multiple volumes)
+			volumes := strings.Split(volumeNames, ",")
+			for _, volumeName := range volumes {
+				volumeName = strings.TrimSpace(volumeName)
+				if volumeName != "" {
+					volumesToDelete[volumeName] = true
+				}
+			}
+		}
+	}
+
+	if len(volumesToDelete) == 0 {
+		logger.Infof("%s %s: no volumes found to delete", instanceType, instanceID)
+
+		return errorMessages
+	}
+
+	logger.Infof("Deleting %d volume(s) for %s %s", len(volumesToDelete), instanceType, instanceID)
+
+	// Delete each unique volume using the runtime client
+	for volumeName := range volumesToDelete {
+		if err := rt.DeleteVolume(volumeName); err != nil {
+			errMsg := fmt.Sprintf("%s %s: failed to delete volume %s: %s", instanceType, instanceID, volumeName, err)
+			errorMessages = append(errorMessages, errMsg)
+			logger.Errorf(errMsg)
+		} else {
+			logger.Infof("Successfully deleted volume: %s", volumeName)
+		}
+	}
+
+	return errorMessages
 }
 
 // deleteSecretsFromPods extracts secret names from pod labels and deletes them.

--- a/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
@@ -9,6 +9,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
 	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
@@ -222,6 +223,11 @@ func (s *DeletionService) deletePods(rt runtime.Runtime, pods []runtimeTypes.Pod
 	var podErrors []string
 	for _, pod := range pods {
 		if err := rt.DeletePod(pod.ID, &forceDelete); err != nil {
+			// Ignore "not found" errors - pod already deleted or never existed
+			if utils.IsNotFoundError(err) {
+				logger.Infof("Pod %s already deleted or does not exist", pod.ID)
+				continue
+			}
 			errMsg := fmt.Sprintf("failed to delete pod %s: %s", pod.ID, err)
 			podErrors = append(podErrors, errMsg)
 		}
@@ -328,6 +334,11 @@ func (s *DeletionService) deleteVolumesFromPods(rt runtime.Runtime, pods []runti
 	// Delete each unique volume using the runtime client
 	for volumeName := range volumesToDelete {
 		if err := rt.DeleteVolume(volumeName); err != nil {
+			// Ignore "not found" errors - volume already deleted or never existed
+			if utils.IsNotFoundError(err) {
+				logger.Infof("Volume %s already deleted or does not exist", volumeName)
+				continue
+			}
 			errMsg := fmt.Sprintf("%s %s: failed to delete volume %s: %s", instanceType, instanceID, volumeName, err)
 			errorMessages = append(errorMessages, errMsg)
 			logger.Errorf(errMsg)
@@ -377,6 +388,11 @@ func (s *DeletionService) deleteSecretsFromPods(rt runtime.Runtime, pods []runti
 	// Delete each unique secret
 	for secretName := range secretsToDelete {
 		if err := rt.DeleteSecret(secretName); err != nil {
+			// Ignore "not found" errors - secret already deleted or never existed
+			if utils.IsNotFoundError(err) {
+				logger.Infof("Secret %s already deleted or does not exist", secretName)
+				continue
+			}
 			errMsg := fmt.Sprintf("%s %s: failed to delete secret %s: %s", instanceType, instanceID, secretName, err)
 			errorMessages = append(errorMessages, errMsg)
 			logger.Errorf(errMsg)

--- a/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
@@ -380,8 +380,7 @@ func (s *DeletionService) deleteSecretsFromPods(rt runtime.Runtime, pods []runti
 	}
 
 	if len(secretsToDelete) == 0 {
-		logger.Infof("%s %s: no secrets found to delete", instanceType, instanceID)
-
+		// no secrets found to delete, just return
 		return errorMessages
 	}
 

--- a/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
@@ -3,19 +3,15 @@ package deletion
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/google/uuid"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
 	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
-	appUtils "github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
@@ -67,15 +63,6 @@ func (s *DeletionService) PerformDeletion(ctx context.Context, appID uuid.UUID, 
 	// Delete orphaned components and track errors
 	componentErrors := s.deleteOrphanedComponents(ctx, rt, orphanedComponents, keepData)
 	errorMessages = append(errorMessages, componentErrors...)
-
-	// Delete application data directory if keepData is false
-	if !keepData {
-		if err := s.deleteInstanceData(appID, "application"); err != nil {
-			errMsg := fmt.Sprintf("failed to delete application data: %s", err)
-			errorMessages = append(errorMessages, errMsg)
-			logger.Errorf("application %s: %s", appID, errMsg)
-		}
-	}
 
 	// Check if any errors occurred during deletion
 	if len(errorMessages) > 0 {
@@ -196,20 +183,27 @@ func (s *DeletionService) deleteServices(ctx context.Context, rt runtime.Runtime
 			errorMessages = append(errorMessages, secretErrors...)
 		}
 
-		// Delete volumes if keepData is false
+		// Delete service pods first so runtime releases attached volumes.
+		podErrors := s.deletePods(rt, pods, forceDelete)
+		hasDeletionErrors := false
+		if len(podErrors) > 0 {
+			hasDeletionErrors = true
+			errMsg := fmt.Sprintf("service %s: failed to delete %d pod(s)", svc.ID, len(podErrors))
+			errorMessages = append(errorMessages, errMsg)
+			_ = s.serviceRepo.UpdateStatus(ctx, svc.ID, models.ServiceStatusError, fmt.Sprintf("failed to delete %d pod(s)", len(podErrors)))
+		}
+
+		// Delete volumes only after pods are deleted and only when keepData is false.
 		if !keepData {
 			volumeErrors := s.deleteVolumesFromPods(rt, pods, "service", svc.ID)
 			if len(volumeErrors) > 0 {
+				hasDeletionErrors = true
 				errorMessages = append(errorMessages, volumeErrors...)
 			}
 		}
 
-		// Delete service pods
-		podErrors := s.deleteServicePods(rt, pods, forceDelete)
-		if len(podErrors) > 0 {
-			errMsg := fmt.Sprintf("service %s: failed to delete %d pod(s)", svc.ID, len(podErrors))
-			errorMessages = append(errorMessages, errMsg)
-			_ = s.serviceRepo.UpdateStatus(ctx, svc.ID, models.ServiceStatusError, fmt.Sprintf("failed to delete %d pod(s)", len(podErrors)))
+		if hasDeletionErrors {
+			continue
 		}
 
 		// Delete service from DB
@@ -223,8 +217,8 @@ func (s *DeletionService) deleteServices(ctx context.Context, rt runtime.Runtime
 	return errorMessages
 }
 
-// deleteServicePods deletes all pods for a service and returns any error messages.
-func (s *DeletionService) deleteServicePods(rt runtime.Runtime, pods []runtimeTypes.Pod, forceDelete bool) []string {
+// deletePods deletes all pods and returns any error messages.
+func (s *DeletionService) deletePods(rt runtime.Runtime, pods []runtimeTypes.Pod, forceDelete bool) []string {
 	var podErrors []string
 	for _, pod := range pods {
 		if err := rt.DeletePod(pod.ID, &forceDelete); err != nil {
@@ -260,21 +254,27 @@ func (s *DeletionService) deleteOrphanedComponents(ctx context.Context, rt runti
 			errorMessages = append(errorMessages, secretErrors...)
 		}
 
-		// Delete component pods
-		podErrors := s.deleteComponentPods(rt, pods, forceDelete)
+		// Delete component pods first so runtime releases attached volumes.
+		podErrors := s.deletePods(rt, pods, forceDelete)
+		hasDeletionErrors := false
 		if len(podErrors) > 0 {
+			hasDeletionErrors = true
 			errMsg := fmt.Sprintf("component %s: failed to delete %d pod(s)", componentID, len(podErrors))
 			errorMessages = append(errorMessages, errMsg)
 			_ = s.componentRepo.UpdateStatus(ctx, componentID, models.ComponentStatusError, fmt.Sprintf("failed to delete %d pod(s)", len(podErrors)))
 		}
 
-		// Delete component data directory if keepData is false
+		// Delete component volumes only after pods are deleted and only when keepData is false.
 		if !keepData {
-			if err := s.deleteInstanceData(componentID, "component"); err != nil {
-				errMsg := fmt.Sprintf("component %s: failed to delete component data: %s", componentID, err)
-				errorMessages = append(errorMessages, errMsg)
-				logger.Errorf("component %s: %s", componentID, errMsg)
+			volumeErrors := s.deleteVolumesFromPods(rt, pods, "component", componentID)
+			if len(volumeErrors) > 0 {
+				hasDeletionErrors = true
+				errorMessages = append(errorMessages, volumeErrors...)
 			}
+		}
+
+		if hasDeletionErrors {
+			continue
 		}
 
 		// Delete component from DB
@@ -288,64 +288,11 @@ func (s *DeletionService) deleteOrphanedComponents(ctx context.Context, rt runti
 	return errorMessages
 }
 
-// deleteComponentPods deletes all pods for a component and returns any error messages.
-func (s *DeletionService) deleteComponentPods(rt runtime.Runtime, pods []runtimeTypes.Pod, forceDelete bool) []string {
-	var podErrors []string
-	for _, pod := range pods {
-		if err := rt.DeletePod(pod.ID, &forceDelete); err != nil {
-			errMsg := fmt.Sprintf("failed to delete pod %s: %s", pod.ID, err)
-			podErrors = append(podErrors, errMsg)
-		}
-	}
-
-	return podErrors
-}
-
 // handleDeletionFailure updates application status when deletion fails.
 func (s *DeletionService) handleDeletionFailure(ctx context.Context, appID uuid.UUID, errorMessages []string) {
 	errMsg := fmt.Sprintf("Application deletion failed with %d error(s), application not deleted", len(errorMessages))
 	logger.Errorf("application %s: %s", appID, errMsg)
 	_ = s.appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, errMsg)
-}
-
-// deleteInstanceData removes an instance's (application or component) data directory from the filesystem.
-// The data directory path is constructed using the instance ID slug.
-// instanceType should be either "application" or "component".
-func (s *DeletionService) deleteInstanceData(instanceID uuid.UUID, instanceType string) error {
-	// Generate slug from instance ID (same as used during deployment)
-	slug := utils.GenerateInstanceSlug(instanceID.String())
-
-	// Determine base path based on instance type
-	var basePath string
-	switch instanceType {
-	case "application":
-		basePath = appUtils.GetApplicationsPath()
-	case "component":
-		basePath = appUtils.GetComponentsPath()
-	default:
-		return fmt.Errorf("invalid instance type: %s", instanceType)
-	}
-
-	// Construct data path using the base directory and slug
-	dataPath := filepath.Join(basePath, slug)
-
-	// Check if data directory exists
-	if _, err := os.Stat(dataPath); os.IsNotExist(err) {
-		logger.Infof("%s data directory does not exist: %s", instanceType, dataPath)
-
-		return nil
-	}
-
-	logger.Infof("Deleting %s data at: %s", instanceType, dataPath)
-
-	// Remove the data directory
-	if err := os.RemoveAll(dataPath); err != nil {
-		return fmt.Errorf("failed to remove %s data directory: %w", instanceType, err)
-	}
-
-	logger.Infof("Successfully removed %s data at: %s", instanceType, dataPath)
-
-	return nil
 }
 
 // deleteVolumesFromPods extracts volume names from pod labels and deletes them using the runtime client.

--- a/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
@@ -226,6 +226,7 @@ func (s *DeletionService) deletePods(rt runtime.Runtime, pods []runtimeTypes.Pod
 			// Ignore "not found" errors - pod already deleted or never existed
 			if utils.IsNotFoundError(err) {
 				logger.Infof("Pod %s already deleted or does not exist", pod.ID)
+
 				continue
 			}
 			errMsg := fmt.Sprintf("failed to delete pod %s: %s", pod.ID, err)
@@ -337,6 +338,7 @@ func (s *DeletionService) deleteVolumesFromPods(rt runtime.Runtime, pods []runti
 			// Ignore "not found" errors - volume already deleted or never existed
 			if utils.IsNotFoundError(err) {
 				logger.Infof("Volume %s already deleted or does not exist", volumeName)
+
 				continue
 			}
 			errMsg := fmt.Sprintf("%s %s: failed to delete volume %s: %s", instanceType, instanceID, volumeName, err)
@@ -391,6 +393,7 @@ func (s *DeletionService) deleteSecretsFromPods(rt runtime.Runtime, pods []runti
 			// Ignore "not found" errors - secret already deleted or never existed
 			if utils.IsNotFoundError(err) {
 				logger.Infof("Secret %s already deleted or does not exist", secretName)
+
 				continue
 			}
 			errMsg := fmt.Sprintf("%s %s: failed to delete secret %s: %s", instanceType, instanceID, secretName, err)

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -558,20 +558,16 @@ func generateCaddyfile(baseDir string, values map[string]any) error {
 	return nil
 }
 
-// createBaseDirectories creates the applications directory with SGID and group-writable permissions.
-// Uses 02775 (rwxrwsr-x) which:
-// - 2 (SGID bit): Forces all subdirectories to inherit the parent's group ownership
-// - 775: Owner and group have full access, others have read/execute only
-// This allows the catalog container to delete subdirectories created by other containers.
-// The components subdirectory will be created automatically when needed and inherit these permissions.
+// createBaseDirectories creates the applications directory with standard permissions.
+// The components subdirectory will be created automatically when needed.
 func createBaseDirectories(baseDir string) error {
-	// Create applications directory with SGID + 0775 permissions
+	// Create applications directory with standard 0755 permissions
 	applicationsDir := filepath.Join(baseDir, "applications")
-	if err := os.MkdirAll(applicationsDir, 0o2775); err != nil {
+	if err := os.MkdirAll(applicationsDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create applications directory: %w", err)
 	}
 
-	logger.Infof("Created applications directory with SGID and group-writable permissions (02775) at: %s", applicationsDir)
+	logger.Infof("Created applications directory at: %s", applicationsDir)
 	return nil
 }
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -120,6 +120,12 @@ func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, b
 		return nil
 	}
 
+	// Create base directories with proper permissions for data cleanup
+	if err := createBaseDirectories(baseDir); err != nil {
+		s.Fail("failed to create base directories")
+		return fmt.Errorf("failed to create base directories: %w", err)
+	}
+
 	// Prepare deployment with domain suffix computation
 	values, err := prepareCatalogDeployment(deployCtx, tp, podmanURI, authFilePath, passwordHash, baseDir, domainName, sslCertPath, sslKeyPath, argParams, s)
 	if err != nil {
@@ -549,6 +555,23 @@ func generateCaddyfile(baseDir string, values map[string]any) error {
 		return fmt.Errorf("failed to write Caddyfile: %w", err)
 	}
 
+	return nil
+}
+
+// createBaseDirectories creates the applications directory with SGID and group-writable permissions.
+// Uses 02775 (rwxrwsr-x) which:
+// - 2 (SGID bit): Forces all subdirectories to inherit the parent's group ownership
+// - 775: Owner and group have full access, others have read/execute only
+// This allows the catalog container to delete subdirectories created by other containers.
+// The components subdirectory will be created automatically when needed and inherit these permissions.
+func createBaseDirectories(baseDir string) error {
+	// Create applications directory with SGID + 0775 permissions
+	applicationsDir := filepath.Join(baseDir, "applications")
+	if err := os.MkdirAll(applicationsDir, 0o2775); err != nil {
+		return fmt.Errorf("failed to create applications directory: %w", err)
+	}
+
+	logger.Infof("Created applications directory with SGID and group-writable permissions (02775) at: %s", applicationsDir)
 	return nil
 }
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -120,12 +120,6 @@ func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, b
 		return nil
 	}
 
-	// Create base directories with proper permissions for data cleanup
-	if err := createBaseDirectories(baseDir); err != nil {
-		s.Fail("failed to create base directories")
-		return fmt.Errorf("failed to create base directories: %w", err)
-	}
-
 	// Prepare deployment with domain suffix computation
 	values, err := prepareCatalogDeployment(deployCtx, tp, podmanURI, authFilePath, passwordHash, baseDir, domainName, sslCertPath, sslKeyPath, argParams, s)
 	if err != nil {
@@ -555,19 +549,6 @@ func generateCaddyfile(baseDir string, values map[string]any) error {
 		return fmt.Errorf("failed to write Caddyfile: %w", err)
 	}
 
-	return nil
-}
-
-// createBaseDirectories creates the applications directory with standard permissions.
-// The components subdirectory will be created automatically when needed.
-func createBaseDirectories(baseDir string) error {
-	// Create applications directory with standard 0755 permissions
-	applicationsDir := filepath.Join(baseDir, "applications")
-	if err := os.MkdirAll(applicationsDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create applications directory: %w", err)
-	}
-
-	logger.Infof("Created applications directory at: %s", applicationsDir)
 	return nil
 }
 

--- a/ai-services/internal/pkg/catalog/constants/catalog.go
+++ b/ai-services/internal/pkg/catalog/constants/catalog.go
@@ -26,6 +26,8 @@ const (
 	CatalogSecretLabel = "ai-services.io/secret"
 	// CatalogSecretSkipLabel represents if catalog secret associated with pod should be skipped while deletion.
 	CatalogSecretSkipLabel = "ai-services.io/secret-skip-cleanup"
+	// CatalogVolumeLabel represents the catalog volume name associated with Catalog Pod.
+	CatalogVolumeLabel = "ai-services.io/volume"
 	// PodmanAuthSecret represents podman auth secret name.
 	PodmanAuthSecret = "podman-auth-secret"
 )

--- a/ai-services/internal/pkg/catalog/utils/application_utils.go
+++ b/ai-services/internal/pkg/catalog/utils/application_utils.go
@@ -83,6 +83,7 @@ func IsNotFoundError(err error) bool {
 		return false
 	}
 	errMsg := err.Error()
+
 	return strings.Contains(errMsg, "no such pod") ||
 		strings.Contains(errMsg, "no pod with name or ID") ||
 		strings.Contains(errMsg, "no such secret") ||

--- a/ai-services/internal/pkg/catalog/utils/application_utils.go
+++ b/ai-services/internal/pkg/catalog/utils/application_utils.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
@@ -73,6 +74,19 @@ func GenerateInstanceSlug(id string) string {
 	hexHash := hex.EncodeToString(hash[:])
 
 	return hexHash[:10]
+}
+
+// IsNotFoundError checks if an error indicates a resource was not found.
+// Returns true for "no such pod", "no such secret", "no such volume" errors.
+func IsNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errMsg := err.Error()
+	return strings.Contains(errMsg, "no such pod") ||
+		strings.Contains(errMsg, "no pod with name or ID") ||
+		strings.Contains(errMsg, "no such secret") ||
+		strings.Contains(errMsg, "no such volume")
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/runtime/interface.go
+++ b/ai-services/internal/pkg/runtime/interface.go
@@ -27,6 +27,9 @@ type Runtime interface {
 	ListSecrets(filters map[string][]string) ([]string, error)
 	DeleteSecret(name string) error
 
+	// Volume operations
+	DeleteVolume(name string) error
+
 	// Container operations
 	// ListContainers(filters map[string][]string) ([]types.Container, error)
 	InspectContainer(nameOrId string) (*types.Container, error)

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -436,6 +436,12 @@ func (kc *OpenshiftClient) DeleteSecret(name string) error {
 	return nil
 }
 
+func (kc *OpenshiftClient) DeleteVolume(name string) error {
+	logger.Warningln("Not implemented")
+
+	return nil
+}
+
 // GetSystemInfo returns empty system information for OpenShift runtime.
 // Resource information is managed by Kubernetes/OpenShift and not directly accessible.
 func (kc *OpenshiftClient) GetSystemInfo() (*models.SystemInfo, error) {

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -18,6 +18,7 @@ import (
 	"github.com/containers/podman/v5/pkg/bindings/pods"
 	"github.com/containers/podman/v5/pkg/bindings/secrets"
 	"github.com/containers/podman/v5/pkg/bindings/system"
+	"github.com/containers/podman/v5/pkg/bindings/volumes"
 	"github.com/containers/podman/v5/pkg/domain/entities"
 	"github.com/containers/podman/v5/pkg/specgen"
 	"github.com/project-ai-services/ai-services/internal/pkg/accelerator/spyre"
@@ -385,6 +386,15 @@ func (pc *PodmanClient) DeleteSecret(name string) error {
 	err := secrets.Remove(pc.Context, name)
 	if err != nil {
 		return fmt.Errorf("failed to remove secret: %w", err)
+	}
+
+	return nil
+}
+
+func (pc *PodmanClient) DeleteVolume(name string) error {
+	err := volumes.Remove(pc.Context, name, nil)
+	if err != nil {
+		return fmt.Errorf("failed to remove volume: %w", err)
 	}
 
 	return nil

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -504,11 +504,6 @@ func GetApplicationsPath() string {
 	return filepath.Join(GetBaseDir(), "applications")
 }
 
-// GetComponentsPath returns the components path based on the configured base directory.
-func GetComponentsPath() string {
-	return filepath.Join(GetBaseDir(), "applications", "components")
-}
-
 // GetModelsPath returns the models path based on the configured base directory.
 func GetModelsPath() string {
 	return filepath.Join(GetBaseDir(), "models")


### PR DESCRIPTION
- Move from hostPath to volumes for application data. This is required because the catalog service cannot delete the application data which are created by other containers.
- Making delete operations idempotent.

Note: Still the Catalog assets and models relies on hostpath