### PR TITLE
Fix cert and key path as part of catalog configure

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.47
+TAG?=0.0.48
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.47
+  image: icr.io/ai-services-cicd/ai-services:0.0.48
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -100,8 +100,15 @@ func runConfigure(argParams map[string]string) error {
 	}
 
 	// Sanitize SSL certificate paths to prevent path traversal attacks
-	cleanCertPath := filepath.Clean(sslCertPath)
-	cleanKeyPath := filepath.Clean(sslKeyPath)
+	// Only clean if paths are provided (filepath.Clean("") returns ".")
+	cleanCertPath := ""
+	cleanKeyPath := ""
+	if sslCertPath != "" {
+		cleanCertPath = filepath.Clean(sslCertPath)
+	}
+	if sslKeyPath != "" {
+		cleanKeyPath = filepath.Clean(sslKeyPath)
+	}
 
 	return configure.Run(configure.ConfigureOptions{
 		AdminPassword: adminPassword,


### PR DESCRIPTION
- Only if cert and key paths are provided as part `catalog configure` do the filepath clean