### PR TITLE
migrate pod logs to use new catalog structure api way

### DIFF
--- a/ai-services/cmd/ai-services/cmd/application/logs.go
+++ b/ai-services/cmd/ai-services/cmd/application/logs.go
@@ -12,7 +12,10 @@ import (
 )
 
 var (
-	podName           string
+	// common flags.
+	podName string
+
+	// openshift flags.
 	containerNameOrID string
 )
 
@@ -62,12 +65,16 @@ Arguments
 
 func init() {
 	initLogsCommonFlags()
+	initLogsOpenshiftFlags()
 }
 
 func initLogsCommonFlags() {
 	logsCmd.Flags().StringVar(&podName, appFlags.Logs.Pod, "", "Pod name to show logs from (required)")
-	logsCmd.Flags().StringVar(&containerNameOrID, appFlags.Logs.Container, "", "Container logs to show logs from (Optional)")
 	_ = logsCmd.MarkFlagRequired(appFlags.Logs.Pod)
+}
+
+func initLogsOpenshiftFlags() {
+	logsCmd.Flags().StringVar(&containerNameOrID, appFlags.Logs.Container, "", "Container logs to show logs from (Optional)")
 }
 
 // buildLogsFlagValidator creates and configures the flag validator for the logs command.
@@ -78,8 +85,11 @@ func buildLogsFlagValidator() *flagvalidator.FlagValidator {
 
 	// Register common flags
 	builder.
-		AddCommonFlag(appFlags.Logs.Pod, nil).
-		AddCommonFlag(appFlags.Logs.Container, nil)
+		AddCommonFlag(appFlags.Logs.Pod, nil)
+
+	// Register openshift flags
+	builder.
+		AddOpenShiftFlag(appFlags.Logs.Container, nil)
 
 	return builder.Build()
 }

--- a/ai-services/cmd/ai-services/cmd/application/templates.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates.go
@@ -34,7 +34,7 @@ var templatesCmd = &cobra.Command{
 		// For openshift runtime, always use the older/stable code path regardless of experimental flag
 		if experimentalTemplates && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
 			// Use experimental catalog templates listing (architectures and services)
-			return listCatalogTemplates(cmd)
+			return listCatalogTemplates()
 		}
 
 		tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
@@ -100,7 +100,7 @@ func init() {
 }
 
 // listCatalogTemplates lists architectures, services, and components from the catalog.
-func listCatalogTemplates(cmd *cobra.Command) error {
+func listCatalogTemplates() error {
 	// Create catalog provider
 	provider, err := catalog.NewCatalogProvider()
 	if err != nil {

--- a/ai-services/internal/pkg/application/podman/logs.go
+++ b/ai-services/internal/pkg/application/podman/logs.go
@@ -10,28 +10,10 @@ import (
 // Logs displays logs from an application pod.
 func (p *PodmanApplication) Logs(opts types.LogsOptions) error {
 	logger.Warningln("Press Ctrl+C to exit the logs and return to the terminal.")
-	logger.Infof("Fetching logs for application pod: %s", opts.PodName)
 
-	if opts.ContainerNameOrID == "" {
-		if err := p.runtime.PodLogs(opts.PodName); err != nil {
-			return fmt.Errorf("failed to fetch pod: %s logs; err: %w", opts.PodName, err)
-		}
-
-		return nil
-	}
-
-	// Fetch container logs
-	exists, err := p.runtime.ContainerExists(opts.ContainerNameOrID)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return fmt.Errorf("container %s doesn't exists", opts.ContainerNameOrID)
-	}
-
-	logger.Infof("Fetching logs for container: %s", opts.ContainerNameOrID)
-	if err := p.runtime.ContainerLogs(opts.ContainerNameOrID); err != nil {
-		return fmt.Errorf("failed to fetch container: %s logs; err: %w", opts.ContainerNameOrID, err)
+	logger.Infof("Fetching logs for pod: %s", opts.PodName)
+	if err := p.runtime.PodLogs(opts.PodName); err != nil {
+		return fmt.Errorf("failed to fetch pod: %s logs; err: %w", opts.PodName, err)
 	}
 
 	return nil


### PR DESCRIPTION
This PR implements new way of consuming application logs. 
`--container` flag is not required anymore for podman, since each component is deployed as a standalone pod.