### PR TITLE
fix: query Caddy API for actual catalog endpoints instead of hardcoding domains

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.55
+TAG?=0.0.56
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.55
+  image: icr.io/ai-services-cicd/ai-services:0.0.56
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -35,6 +35,7 @@ const (
 	kindSecret            = "Secret"
 	caddyCertsDirName     = "certs"
 	caddyContainerDataDir = "/data/caddy"
+	routeFormatParts      = 3 // Expected number of parts in route format: "port:subdomain:type"
 )
 
 // catalogDeploymentContext holds cached values during catalog deployment to avoid redundant lookups.
@@ -750,6 +751,55 @@ func getCaddyHTTPSPort(rt *podman.PodmanClient, caddyPodName string) (string, er
 	return "", fmt.Errorf("HTTPS port mapping not found in pod ports")
 }
 
+// parseRouteEntry parses a single route entry and returns the subdomain.
+// Route format: "port:subdomain:type"
+// Returns empty string if the entry is invalid.
+func parseRouteEntry(routeEntry, podName string) string {
+	routeEntry = strings.TrimSpace(routeEntry)
+	if routeEntry == "" {
+		return ""
+	}
+
+	// Split by colon to get subdomain (second part)
+	parts := strings.Split(routeEntry, ":")
+	if len(parts) != routeFormatParts {
+		logger.Warningf("Invalid route format '%s' in pod %s, expected 'port:subdomain:type'", routeEntry, podName)
+
+		return ""
+	}
+
+	subdomain := strings.TrimSpace(parts[1])
+
+	return subdomain
+}
+
+// processRouteInfo processes route information and populates the routeDomains map.
+func processRouteInfo(info TemplateRouteInfo, proxyManager proxy.ProxyManager, routeDomains map[string]string) {
+	// Parse routes annotation directly to extract subdomains
+	// Format: "port:subdomain:type, port:subdomain:type, ..."
+	// Example: "8081:catalog-ui:ui, 8080:catalog-api:api"
+	for _, routeEntry := range strings.Split(info.RoutesAnnotation, ",") {
+		subdomain := parseRouteEntry(routeEntry, info.PodName)
+		if subdomain == "" {
+			continue
+		}
+
+		// Query Caddy for this route (route ID is just the subdomain)
+		actualRoute, err := proxyManager.GetRouteByID(subdomain)
+		if err != nil {
+			// Log warning but continue - route might not exist yet
+			logger.Warningf("Failed to query route %s from Caddy: %v", subdomain, err)
+
+			continue
+		}
+
+		// Create variable name from subdomain
+		sanitizedSubdomain := strings.ReplaceAll(subdomain, "-", "_")
+		varName := strings.ToUpper(fmt.Sprintf("%s_DOMAIN", sanitizedSubdomain))
+		routeDomains[varName] = actualRoute.Domain
+	}
+}
+
 // GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service.
 func GetCatalogRouteInfo(rt *podman.PodmanClient, tp templates.Template, appTemplateName string, argParams map[string]string) (map[string]string, string, error) {
 	// Find Caddy pod from templates
@@ -777,40 +827,7 @@ func GetCatalogRouteInfo(rt *podman.PodmanClient, tp templates.Template, appTemp
 	// Build route domains map by querying Caddy for each route
 	routeDomains := make(map[string]string)
 	for _, info := range routeInfos {
-		// Parse routes annotation directly to extract subdomains
-		// Format: "port:subdomain:type, port:subdomain:type, ..."
-		// Example: "8081:catalog-ui:ui, 8080:catalog-api:api"
-		for _, routeEntry := range strings.Split(info.RoutesAnnotation, ",") {
-			routeEntry = strings.TrimSpace(routeEntry)
-			if routeEntry == "" {
-				continue
-			}
-
-			// Split by colon to get subdomain (second part)
-			parts := strings.Split(routeEntry, ":")
-			if len(parts) != 3 {
-				logger.Warningf("Invalid route format '%s' in pod %s, expected 'port:subdomain:type'", routeEntry, info.PodName)
-				continue
-			}
-
-			subdomain := strings.TrimSpace(parts[1])
-			if subdomain == "" {
-				continue
-			}
-
-			// Query Caddy for this route (route ID is just the subdomain)
-			actualRoute, err := proxyManager.GetRouteByID(subdomain)
-			if err != nil {
-				// Log warning but continue - route might not exist yet
-				logger.Warningf("Failed to query route %s from Caddy: %v", subdomain, err)
-				continue
-			}
-
-			// Create variable name from subdomain
-			sanitizedSubdomain := strings.ReplaceAll(subdomain, "-", "_")
-			varName := strings.ToUpper(fmt.Sprintf("%s_DOMAIN", sanitizedSubdomain))
-			routeDomains[varName] = actualRoute.Domain
-		}
+		processRouteInfo(info, proxyManager, routeDomains)
 	}
 
 	// Get Caddy HTTPS port

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -774,11 +774,10 @@ func GetCatalogRouteInfo(rt *podman.PodmanClient, tp templates.Template, appTemp
 
 	// Build route domains map from actual registered routes
 	routeDomains := make(map[string]string)
-	catalogRoutePrefix := catalogconstants.CatalogAppName + "--"
 	for _, route := range registeredRoutes {
 		// Filter catalog routes by checking if route ID starts with catalog app name
 		// Route IDs follow pattern: "appName--podName--subdomain" (e.g., "ai-services--catalog--catalog-ui")
-		if strings.HasPrefix(route.ID, catalogRoutePrefix) {
+		if strings.HasPrefix(route.ID, catalogconstants.CatalogAppName) {
 			parts := strings.Split(route.Domain, ".")
 			if len(parts) > 0 {
 				subdomain := parts[0]

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -752,42 +752,33 @@ func getCaddyHTTPSPort(rt *podman.PodmanClient, caddyPodName string) (string, er
 
 // GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service.
 func GetCatalogRouteInfo(rt *podman.PodmanClient, tp templates.Template, appTemplateName string, argParams map[string]string) (map[string]string, string, error) {
-	// Extract routes from all templates
-	routeInfos, err := extractAllRoutesFromTemplates(tp, appTemplateName, argParams)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to extract routes from templates: %w", err)
-	}
-
-	if len(routeInfos) == 0 {
-		return nil, "", fmt.Errorf("no templates found with routes annotation")
-	}
-
 	// Find Caddy pod from templates
 	caddyPodName, err := findCaddyPodNameFromTemplates(tp, appTemplateName, argParams)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to find Caddy pod: %w", err)
 	}
 
-	// Get host IP for route domain generation
-	hostIP, err := utils.GetHostIP()
+	// Get Caddy admin URL for querying actual registered routes
+	caddyAdminPort, err := proxy.GetCaddyAdminPort(rt, caddyPodName)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get host IP: %w", err)
+		return nil, "", fmt.Errorf("failed to get Caddy admin port: %w", err)
+	}
+	caddyAdminURL := fmt.Sprintf("http://localhost:%s", caddyAdminPort)
+
+	// Query actual registered routes from Caddy
+	proxyManager := proxy.NewCaddyManager(caddyAdminURL, constants.CaddyServerName)
+	registeredRoutes, err := proxyManager.GetRegisteredRoutes()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to query Caddy routes: %w", err)
 	}
 
-	// Compute domain suffix (default to nip.io)
-	domainSuffix := fmt.Sprintf("%s.nip.io", hostIP)
-
-	// Build route domains map
+	// Build route domains map from actual registered routes
 	routeDomains := make(map[string]string)
-
-	// Build routes from annotations to get domains
-	for _, info := range routeInfos {
-		routes, err := proxy.BuildRoutesFromAnnotation(info.RoutesAnnotation, domainSuffix, info.PodName)
-		if err != nil {
-			continue // Skip if routes can't be built
-		}
-
-		for _, route := range routes {
+	catalogRoutePrefix := catalogconstants.CatalogAppName + "--"
+	for _, route := range registeredRoutes {
+		// Filter catalog routes by checking if route ID starts with catalog app name
+		// Route IDs follow pattern: "appName--podName--subdomain" (e.g., "ai-services--catalog--catalog-ui")
+		if strings.HasPrefix(route.ID, catalogRoutePrefix) {
 			parts := strings.Split(route.Domain, ".")
 			if len(parts) > 0 {
 				subdomain := parts[0]

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -265,7 +265,7 @@ func prepareCatalogDeployment(deployCtx *catalogDeploymentContext, tp templates.
 	}
 
 	// Generate and write Caddyfile before deploying
-	if err := generateCaddyfile(baseDir, values); err != nil {
+	if err := generateCaddyfile(baseDir); err != nil {
 		s.Fail("failed to generate Caddyfile")
 
 		return nil, fmt.Errorf("failed to generate Caddyfile: %w", err)
@@ -514,7 +514,7 @@ func executePodTemplate(rt *podman.PodmanClient, tp templates.Template, tmpls ma
 }
 
 // generateCaddyfile copies the static Caddyfile to the caddy directory.
-func generateCaddyfile(baseDir string, values map[string]any) error {
+func generateCaddyfile(baseDir string) error {
 	// Read the Caddyfile template
 	caddyfileContent, err := assets.CatalogFS.ReadFile("catalog/podman/Caddyfile.tmpl")
 	if err != nil {
@@ -528,7 +528,7 @@ func generateCaddyfile(baseDir string, values map[string]any) error {
 	}
 
 	// Prepare template data with the server name constant
-	templateData := map[string]interface{}{
+	templateData := map[string]any{
 		"CaddyServerName": constants.CaddyServerName,
 	}
 
@@ -758,33 +758,58 @@ func GetCatalogRouteInfo(rt *podman.PodmanClient, tp templates.Template, appTemp
 		return nil, "", fmt.Errorf("failed to find Caddy pod: %w", err)
 	}
 
-	// Get Caddy admin URL for querying actual registered routes
+	// Get Caddy admin URL for querying specific routes
 	caddyAdminPort, err := proxy.GetCaddyAdminPort(rt, caddyPodName)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to get Caddy admin port: %w", err)
 	}
 	caddyAdminURL := fmt.Sprintf("http://localhost:%s", caddyAdminPort)
 
-	// Query actual registered routes from Caddy
-	proxyManager := proxy.NewCaddyManager(caddyAdminURL, constants.CaddyServerName)
-	registeredRoutes, err := proxyManager.GetRegisteredRoutes()
+	// Extract routes from all templates (same as during registration)
+	routeInfos, err := extractAllRoutesFromTemplates(tp, appTemplateName, argParams)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to query Caddy routes: %w", err)
+		return nil, "", fmt.Errorf("failed to extract routes from templates: %w", err)
 	}
 
-	// Build route domains map from actual registered routes
+	// Create proxy manager
+	proxyManager := proxy.NewCaddyManager(caddyAdminURL, constants.CaddyServerName)
+
+	// Build route domains map by querying Caddy for each route
 	routeDomains := make(map[string]string)
-	for _, route := range registeredRoutes {
-		// Filter catalog routes by checking if route ID starts with catalog app name
-		// Route IDs follow pattern: "appName--podName--subdomain" (e.g., "ai-services--catalog--catalog-ui")
-		if strings.HasPrefix(route.ID, catalogconstants.CatalogAppName) {
-			parts := strings.Split(route.Domain, ".")
-			if len(parts) > 0 {
-				subdomain := parts[0]
-				sanitizedSubdomain := strings.ReplaceAll(subdomain, "-", "_")
-				varName := strings.ToUpper(fmt.Sprintf("%s_DOMAIN", sanitizedSubdomain))
-				routeDomains[varName] = route.Domain
+	for _, info := range routeInfos {
+		// Parse routes annotation directly to extract subdomains
+		// Format: "port:subdomain:type, port:subdomain:type, ..."
+		// Example: "8081:catalog-ui:ui, 8080:catalog-api:api"
+		for _, routeEntry := range strings.Split(info.RoutesAnnotation, ",") {
+			routeEntry = strings.TrimSpace(routeEntry)
+			if routeEntry == "" {
+				continue
 			}
+
+			// Split by colon to get subdomain (second part)
+			parts := strings.Split(routeEntry, ":")
+			if len(parts) != 3 {
+				logger.Warningf("Invalid route format '%s' in pod %s, expected 'port:subdomain:type'", routeEntry, info.PodName)
+				continue
+			}
+
+			subdomain := strings.TrimSpace(parts[1])
+			if subdomain == "" {
+				continue
+			}
+
+			// Query Caddy for this route (route ID is just the subdomain)
+			actualRoute, err := proxyManager.GetRouteByID(subdomain)
+			if err != nil {
+				// Log warning but continue - route might not exist yet
+				logger.Warningf("Failed to query route %s from Caddy: %v", subdomain, err)
+				continue
+			}
+
+			// Create variable name from subdomain
+			sanitizedSubdomain := strings.ReplaceAll(subdomain, "-", "_")
+			varName := strings.ToUpper(fmt.Sprintf("%s_DOMAIN", sanitizedSubdomain))
+			routeDomains[varName] = actualRoute.Domain
 		}
 	}
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -35,7 +35,6 @@ const (
 	kindSecret            = "Secret"
 	caddyCertsDirName     = "certs"
 	caddyContainerDataDir = "/data/caddy"
-	routeFormatParts      = 3 // Expected number of parts in route format: "port:subdomain:type"
 )
 
 // catalogDeploymentContext holds cached values during catalog deployment to avoid redundant lookups.
@@ -755,22 +754,15 @@ func getCaddyHTTPSPort(rt *podman.PodmanClient, caddyPodName string) (string, er
 // Route format: "port:subdomain:type"
 // Returns empty string if the entry is invalid.
 func parseRouteEntry(routeEntry, podName string) string {
-	routeEntry = strings.TrimSpace(routeEntry)
-	if routeEntry == "" {
-		return ""
-	}
-
-	// Split by colon to get subdomain (second part)
-	parts := strings.Split(routeEntry, ":")
-	if len(parts) != routeFormatParts {
-		logger.Warningf("Invalid route format '%s' in pod %s, expected 'port:subdomain:type'", routeEntry, podName)
+	// Use shared helper from proxy package
+	parts, err := proxy.ParseRouteEntry(routeEntry)
+	if err != nil {
+		logger.Warningf("Invalid route format '%s' in pod %s: %v", routeEntry, podName, err)
 
 		return ""
 	}
 
-	subdomain := strings.TrimSpace(parts[1])
-
-	return subdomain
+	return parts.Subdomain
 }
 
 // processRouteInfo processes route information and populates the routeDomains map.

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -157,52 +157,42 @@ func extractDomainFromRoute(rawRoute map[string]any) (string, bool) {
 	return domain, true
 }
 
-// GetRegisteredRoutes retrieves all routes currently registered with Caddy.
-// Only extracts route ID and domain for efficiency.
-func (c *caddyManager) GetRegisteredRoutes() ([]Route, error) {
-	// Build URL to get routes from Caddy config
-	routesURL, err := url.JoinPath(c.adminURL, "config", "apps", "http", "servers", c.serverName, "routes")
+// GetRouteByID retrieves a specific route by its ID from Caddy.
+func (c *caddyManager) GetRouteByID(routeID string) (*Route, error) {
+	// Build URL to get specific route by ID
+	idURL, err := url.JoinPath(c.adminURL, "id", routeID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build routes URL: %w", err)
+		return nil, fmt.Errorf("failed to build route ID URL: %w", err)
 	}
 
-	// Query Caddy for registered routes
-	var rawRoutes []map[string]any
+	// Query Caddy for the specific route
+	var rawRoute map[string]any
 	resp, err := c.httpClient.R().
-		SetResult(&rawRoutes).
-		Get(routesURL)
+		SetResult(&rawRoute).
+		Get(idURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query Caddy routes: %w", err)
+		return nil, fmt.Errorf("failed to query route %s: %w", routeID, err)
+	}
+
+	if resp.StatusCode() == http.StatusNotFound {
+		return nil, fmt.Errorf("route %s not found", routeID)
 	}
 
 	if resp.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("caddy returned status %d when querying routes", resp.StatusCode())
+		return nil, fmt.Errorf("caddy returned status %d for route %s", resp.StatusCode(), routeID)
 	}
 
-	// Parse routes from Caddy response - only extract ID and domain
-	routes := []Route{}
-	for _, rawRoute := range rawRoutes {
-		// Extract route ID
-		routeID, ok := rawRoute["@id"].(string)
-		if !ok || routeID == "" {
-			continue // Skip routes without ID
-		}
-
-		// Extract domain using helper function
-		domain, ok := extractDomainFromRoute(rawRoute)
-		if !ok {
-			continue
-		}
-
-		// Build Route object with only ID and Domain populated
-		route := Route{
-			ID:     routeID,
-			Domain: domain,
-		}
-		routes = append(routes, route)
+	// Extract domain using helper function
+	domain, ok := extractDomainFromRoute(rawRoute)
+	if !ok {
+		return nil, fmt.Errorf("failed to extract domain from route %s", routeID)
 	}
 
-	return routes, nil
+	// Build Route object with ID and Domain
+	return &Route{
+		ID:     routeID,
+		Domain: domain,
+	}, nil
 }
 
 // RegisterRoutesForAppAndReturn registers routes for an application with Caddy proxy and returns the built routes.

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -131,6 +131,80 @@ func (c *caddyManager) createRoute(routeConfig map[string]interface{}) error {
 	return nil
 }
 
+// extractDomainFromRoute extracts the domain from a Caddy route configuration.
+// Returns the domain and a boolean indicating success.
+func extractDomainFromRoute(rawRoute map[string]interface{}) (string, bool) {
+	matches, ok := rawRoute["match"].([]interface{})
+	if !ok || len(matches) == 0 {
+		return "", false
+	}
+
+	firstMatch, ok := matches[0].(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+
+	hosts, ok := firstMatch["host"].([]interface{})
+	if !ok || len(hosts) == 0 {
+		return "", false
+	}
+
+	domain, ok := hosts[0].(string)
+	if !ok || domain == "" {
+		return "", false
+	}
+
+	return domain, true
+}
+
+// GetRegisteredRoutes retrieves all routes currently registered with Caddy.
+// Only extracts route ID and domain for efficiency.
+func (c *caddyManager) GetRegisteredRoutes() ([]Route, error) {
+	// Build URL to get routes from Caddy config
+	routesURL, err := url.JoinPath(c.adminURL, "config", "apps", "http", "servers", c.serverName, "routes")
+	if err != nil {
+		return nil, fmt.Errorf("failed to build routes URL: %w", err)
+	}
+
+	// Query Caddy for registered routes
+	var rawRoutes []map[string]interface{}
+	resp, err := c.httpClient.R().
+		SetResult(&rawRoutes).
+		Get(routesURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query Caddy routes: %w", err)
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("caddy returned status %d when querying routes", resp.StatusCode())
+	}
+
+	// Parse routes from Caddy response - only extract ID and domain
+	routes := []Route{}
+	for _, rawRoute := range rawRoutes {
+		// Extract route ID
+		routeID, ok := rawRoute["@id"].(string)
+		if !ok || routeID == "" {
+			continue // Skip routes without ID
+		}
+
+		// Extract domain using helper function
+		domain, ok := extractDomainFromRoute(rawRoute)
+		if !ok {
+			continue
+		}
+
+		// Build Route object with only ID and Domain populated
+		route := Route{
+			ID:     routeID,
+			Domain: domain,
+		}
+		routes = append(routes, route)
+	}
+
+	return routes, nil
+}
+
 // RegisterRoutesForAppAndReturn registers routes for an application with Caddy proxy and returns the built routes.
 //
 // Parameters:

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -132,29 +132,29 @@ func (c *caddyManager) createRoute(routeConfig map[string]any) error {
 }
 
 // extractDomainFromRoute extracts the domain from a Caddy route configuration.
-// Returns the domain and a boolean indicating success.
-func extractDomainFromRoute(rawRoute map[string]any) (string, bool) {
+// Returns the domain or an error if extraction fails.
+func extractDomainFromRoute(rawRoute map[string]any) (string, error) {
 	matches, ok := rawRoute["match"].([]any)
 	if !ok || len(matches) == 0 {
-		return "", false
+		return "", errors.New("missing or empty 'match' field in route")
 	}
 
 	firstMatch, ok := matches[0].(map[string]any)
 	if !ok {
-		return "", false
+		return "", errors.New("invalid match format in route")
 	}
 
 	hosts, ok := firstMatch["host"].([]any)
 	if !ok || len(hosts) == 0 {
-		return "", false
+		return "", errors.New("missing or empty 'host' field in route")
 	}
 
 	domain, ok := hosts[0].(string)
 	if !ok || domain == "" {
-		return "", false
+		return "", errors.New("invalid or empty domain in route")
 	}
 
-	return domain, true
+	return domain, nil
 }
 
 // GetRouteByID retrieves a specific route by its ID from Caddy.
@@ -183,9 +183,9 @@ func (c *caddyManager) GetRouteByID(routeID string) (*Route, error) {
 	}
 
 	// Extract domain using helper function
-	domain, ok := extractDomainFromRoute(rawRoute)
-	if !ok {
-		return nil, fmt.Errorf("failed to extract domain from route %s", routeID)
+	domain, err := extractDomainFromRoute(rawRoute)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract domain from route %s: %w", routeID, err)
 	}
 
 	// Build Route object with ID and Domain

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -64,12 +64,12 @@ func (c *caddyManager) RegisterRoute(route Route) error {
 		return fmt.Errorf("cannot register route: route ID is empty")
 	}
 
-	routeConfig := map[string]interface{}{
+	routeConfig := map[string]any{
 		"@id":   route.ID,
-		"match": []map[string]interface{}{{"host": []string{route.Domain}}},
-		"handle": []map[string]interface{}{{
+		"match": []map[string]any{{"host": []string{route.Domain}}},
+		"handle": []map[string]any{{
 			"handler":   "reverse_proxy",
-			"upstreams": []map[string]interface{}{{"dial": route.Upstream}},
+			"upstreams": []map[string]any{{"dial": route.Upstream}},
 		}},
 		"terminal": route.Terminal,
 	}
@@ -95,7 +95,7 @@ func (c *caddyManager) RegisterRoute(route Route) error {
 }
 
 // Helper to update an existing route via its specific ID URL.
-func (c *caddyManager) updateRoute(idURL string, routeConfig map[string]interface{}) error {
+func (c *caddyManager) updateRoute(idURL string, routeConfig map[string]any) error {
 	resp, err := c.httpClient.R().
 		SetHeader("Content-Type", "application/json").
 		SetBody(routeConfig).
@@ -111,7 +111,7 @@ func (c *caddyManager) updateRoute(idURL string, routeConfig map[string]interfac
 }
 
 // Helper to append a new route to the server's route array.
-func (c *caddyManager) createRoute(routeConfig map[string]interface{}) error {
+func (c *caddyManager) createRoute(routeConfig map[string]any) error {
 	routeURL, err := url.JoinPath(c.adminURL, "config", "apps", "http", "servers", c.serverName, "routes")
 	if err != nil {
 		return err
@@ -133,18 +133,18 @@ func (c *caddyManager) createRoute(routeConfig map[string]interface{}) error {
 
 // extractDomainFromRoute extracts the domain from a Caddy route configuration.
 // Returns the domain and a boolean indicating success.
-func extractDomainFromRoute(rawRoute map[string]interface{}) (string, bool) {
-	matches, ok := rawRoute["match"].([]interface{})
+func extractDomainFromRoute(rawRoute map[string]any) (string, bool) {
+	matches, ok := rawRoute["match"].([]any)
 	if !ok || len(matches) == 0 {
 		return "", false
 	}
 
-	firstMatch, ok := matches[0].(map[string]interface{})
+	firstMatch, ok := matches[0].(map[string]any)
 	if !ok {
 		return "", false
 	}
 
-	hosts, ok := firstMatch["host"].([]interface{})
+	hosts, ok := firstMatch["host"].([]any)
 	if !ok || len(hosts) == 0 {
 		return "", false
 	}
@@ -167,7 +167,7 @@ func (c *caddyManager) GetRegisteredRoutes() ([]Route, error) {
 	}
 
 	// Query Caddy for registered routes
-	var rawRoutes []map[string]interface{}
+	var rawRoutes []map[string]any
 	resp, err := c.httpClient.R().
 		SetResult(&rawRoutes).
 		Get(routesURL)

--- a/ai-services/internal/pkg/proxy/types.go
+++ b/ai-services/internal/pkg/proxy/types.go
@@ -7,6 +7,9 @@ type ProxyManager interface {
 
 	// HealthCheck verifies the proxy is available and responding
 	HealthCheck() error
+
+	// GetRegisteredRoutes retrieves all routes currently registered with the proxy
+	GetRegisteredRoutes() ([]Route, error)
 }
 
 // Route represents a reverse proxy route configuration.

--- a/ai-services/internal/pkg/proxy/types.go
+++ b/ai-services/internal/pkg/proxy/types.go
@@ -8,8 +8,8 @@ type ProxyManager interface {
 	// HealthCheck verifies the proxy is available and responding
 	HealthCheck() error
 
-	// GetRegisteredRoutes retrieves all routes currently registered with the proxy
-	GetRegisteredRoutes() ([]Route, error)
+	// GetRouteByID retrieves a specific route by its ID from the proxy
+	GetRouteByID(routeID string) (*Route, error)
 }
 
 // Route represents a reverse proxy route configuration.

--- a/ai-services/internal/pkg/proxy/utils.go
+++ b/ai-services/internal/pkg/proxy/utils.go
@@ -69,8 +69,9 @@ func BuildRoutesFromAnnotation(routesAnnotation, domainSuffix, podName string) (
 
 		// Build route - use pod name as upstream since containers are in the same pod
 		// Domain is simply: subdomain.domainSuffix
+		// Route ID uses just the subdomain since subdomains are already globally unique
 		route := Route{
-			ID:       fmt.Sprintf("%s--%s", podName, subdomain),
+			ID:       subdomain,
 			Domain:   fmt.Sprintf("%s.%s", subdomain, domainSuffix),
 			Upstream: fmt.Sprintf("%s:%s", podName, port),
 			Terminal: true,

--- a/ai-services/internal/pkg/proxy/utils.go
+++ b/ai-services/internal/pkg/proxy/utils.go
@@ -28,9 +28,53 @@ func GetCaddyAdminPort(rt runtime.Runtime, podName string) (string, error) {
 	return "", fmt.Errorf("admin port mapping not found in pod ports")
 }
 
+// RouteEntryParts represents the parsed components of a route entry.
+type RouteEntryParts struct {
+	Port      string
+	Subdomain string
+	Type      string
+}
+
+// ParseRouteEntry parses a single route entry string in the format "port:subdomain:type".
+// Returns the parsed parts or an error if the format is invalid.
+func ParseRouteEntry(routeEntry string) (*RouteEntryParts, error) {
+	const expectedParts = 3
+
+	routeEntry = strings.TrimSpace(routeEntry)
+	if routeEntry == "" {
+		return nil, fmt.Errorf("route entry is empty")
+	}
+
+	// Split by colon
+	parts := strings.Split(routeEntry, ":")
+	if len(parts) != expectedParts {
+		return nil, fmt.Errorf("invalid route format '%s': expected 'port:subdomain:type', got %d parts", routeEntry, len(parts))
+	}
+
+	port := strings.TrimSpace(parts[0])
+	subdomain := strings.TrimSpace(parts[1])
+	routeType := strings.ToLower(strings.TrimSpace(parts[2]))
+
+	if port == "" {
+		return nil, fmt.Errorf("invalid route '%s': port cannot be empty", routeEntry)
+	}
+	if subdomain == "" {
+		return nil, fmt.Errorf("invalid route '%s': subdomain cannot be empty", routeEntry)
+	}
+	if routeType == "" {
+		return nil, fmt.Errorf("invalid route '%s': type cannot be empty", routeEntry)
+	}
+
+	return &RouteEntryParts{
+		Port:      port,
+		Subdomain: subdomain,
+		Type:      routeType,
+	}, nil
+}
+
 // BuildRoutesFromAnnotation parses a routes annotation string and builds Route objects.
-// The annotation format is: "port:subdomain, port:subdomain, ...".
-// Example: "8081:catalog-ui, 8080:catalog-api".
+// The annotation format is: "port:subdomain:type, port:subdomain:type, ...".
+// Example: "8081:catalog-ui:ui, 8080:catalog-api:api".
 // The domainSuffix is pre-computed (e.g., "example.com" or "192.168.1.100.nip.io").
 func BuildRoutesFromAnnotation(routesAnnotation, domainSuffix, podName string) ([]Route, error) {
 	if routesAnnotation == "" {
@@ -38,44 +82,29 @@ func BuildRoutesFromAnnotation(routesAnnotation, domainSuffix, podName string) (
 	}
 
 	routes := []Route{}
-	const expectedParts = 3
 
-	// Parse routes annotation (format: "port:subdomain, port:subdomain, ...")
+	// Parse routes annotation (format: "port:subdomain:type, port:subdomain:type, ...")
 	for _, r := range strings.Split(routesAnnotation, ",") {
 		r = strings.TrimSpace(r)
 		if r == "" {
 			continue
 		}
 
-		// Split by colon
-		parts := strings.Split(r, ":")
-		if len(parts) != expectedParts {
-			return nil, fmt.Errorf("invalid route format '%s': expected 'port:subdomain:type', got %d parts", r, len(parts))
-		}
-
-		port := strings.TrimSpace(parts[0])
-		subdomain := strings.TrimSpace(parts[1])
-		routeType := strings.ToLower(strings.TrimSpace(parts[2]))
-
-		if port == "" {
-			return nil, fmt.Errorf("invalid route '%s': port cannot be empty", r)
-		}
-		if subdomain == "" {
-			return nil, fmt.Errorf("invalid route '%s': subdomain cannot be empty", r)
-		}
-		if routeType == "" {
-			return nil, fmt.Errorf("invalid route '%s': type cannot be empty", r)
+		// Parse the route entry using shared helper
+		parts, err := ParseRouteEntry(r)
+		if err != nil {
+			return nil, err
 		}
 
 		// Build route - use pod name as upstream since containers are in the same pod
 		// Domain is simply: subdomain.domainSuffix
 		// Route ID uses just the subdomain since subdomains are already globally unique
 		route := Route{
-			ID:       subdomain,
-			Domain:   fmt.Sprintf("%s.%s", subdomain, domainSuffix),
-			Upstream: fmt.Sprintf("%s:%s", podName, port),
+			ID:       parts.Subdomain,
+			Domain:   fmt.Sprintf("%s.%s", parts.Subdomain, domainSuffix),
+			Upstream: fmt.Sprintf("%s:%s", podName, parts.Port),
 			Terminal: true,
-			Type:     routeType,
+			Type:     parts.Type,
 		}
 		routes = append(routes, route)
 	}


### PR DESCRIPTION
Replaces hardcoded domain suffix logic with Caddy admin API query to retrieve actual registered routes, fixing 'catalog info' showing wrong endpoints.


catalog info now:

```
-------
✔ Catalog service deployed successfully
-------
Next Steps:
-------
- Access the Catalog UI at https://catalog-ui.example.com:8446

- Access the Catalog Backend at https://catalog-api.example.com:8446


[root@onprem133726180 ~]# ai-services catalog info --runtime podman
Catalog Service Name: ai-services
Catalog Template: catalog
Version: 0.0.1
Info:
-------
Day N:

- Catalog UI is available at https://catalog-ui.example.com:8446

- Catalog Backend API is available at https://catalog-api.example.com:8446
```