### PR TITLE
[Revert] Hardcoding of license, as upstream issue is fixed

### DIFF
--- a/.github/scripts/license_scan.py
+++ b/.github/scripts/license_scan.py
@@ -74,12 +74,6 @@ def classify_license(trivy_data, parlay_data):
             "License by Parlay": parlay_pkg_license,
         }
 
-        # TODO: Remove this temporary override after Parlay fixes PyPI license enrichment.
-        # Upstream issue: https://github.com/snyk/parlay/issues/146
-        if pkg_name == "scipy" or pkg_name == "pandas":
-            pkg_licenses = "BSD-3-Clause"
-            pkg_license_dic["License by Parlay"] = pkg_licenses
-
         if is_pkg_license_approved(pkg_name, pkg_licenses, approved_pkgs):
             classified_pkg["allowed"][pkg_name_and_version] = pkg_license_dic
         elif is_licence_exist(deny_license_list, pkg_licenses):

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -9,6 +9,7 @@ on:
       - main
 
 
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Upstream Issues has been fixed for parlay https://github.com/snyk/parlay/issues/146 therefore we no longer need hardcoding of license.