### PR TITLE
migrating cli logs to use catalog structure

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.56
+TAG?=0.0.57
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.56
+  image: icr.io/ai-services-cicd/ai-services:0.0.57
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/application/logs.go
+++ b/ai-services/cmd/ai-services/cmd/application/logs.go
@@ -5,8 +5,11 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
+	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	appFlags "github.com/project-ai-services/ai-services/internal/pkg/cli/constants/application"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/flagvalidator"
+	"github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	"github.com/spf13/cobra"
 )
@@ -14,6 +17,7 @@ import (
 var (
 	podName           string
 	containerNameOrID string
+	experimentalLogs  bool
 )
 
 var logsCmd = &cobra.Command{
@@ -44,6 +48,14 @@ Arguments
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
+		// When experimentalLogs is true and runtime is podman, validate application name using catalog API
+		// For openshift runtime, always use the older/stable code path regardless of experimental flag
+		if experimentalLogs && rt == types.RuntimeTypePodman {
+			if err := validateApplicationName(applicationName); err != nil {
+				return err
+			}
+		}
+
 		// Create application instance using factory
 		factory := application.NewFactory(rt)
 		app, err := factory.Create(applicationName)
@@ -65,6 +77,7 @@ func init() {
 }
 
 func initLogsCommonFlags() {
+	logsCmd.Flags().BoolVar(&experimentalLogs, "experimental", false, "Include experimental application templates")
 	logsCmd.Flags().StringVar(&podName, appFlags.Logs.Pod, "", "Pod name to show logs from (required)")
 	logsCmd.Flags().StringVar(&containerNameOrID, appFlags.Logs.Container, "", "Container logs to show logs from (Optional)")
 	_ = logsCmd.MarkFlagRequired(appFlags.Logs.Pod)
@@ -82,4 +95,19 @@ func buildLogsFlagValidator() *flagvalidator.FlagValidator {
 		AddCommonFlag(appFlags.Logs.Container, nil)
 
 	return builder.Build()
+}
+
+func validateApplicationName(appName string) error {
+	appClient, err := catalogClient.NewApplicationClient()
+	if err != nil {
+		return fmt.Errorf("failed to create application client: %w", err)
+	}
+
+	// Fetch specific application by name
+	_, err = utils.GetAppByName(appClient, appName)
+	if err != nil {
+		return fmt.Errorf("failed to fetch application '%s': %w", appName, err)
+	}
+
+	return nil
 }

--- a/ai-services/cmd/ai-services/cmd/application/logs.go
+++ b/ai-services/cmd/ai-services/cmd/application/logs.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
-	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	appFlags "github.com/project-ai-services/ai-services/internal/pkg/cli/constants/application"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/flagvalidator"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
@@ -51,7 +50,7 @@ Arguments
 		// When experimentalLogs is true and runtime is podman, validate application name using catalog API
 		// For openshift runtime, always use the older/stable code path regardless of experimental flag
 		if experimentalLogs && rt == types.RuntimeTypePodman {
-			if err := validateApplicationName(applicationName); err != nil {
+			if err := utils.ValidateApplicationName(applicationName); err != nil {
 				return err
 			}
 		}
@@ -95,19 +94,4 @@ func buildLogsFlagValidator() *flagvalidator.FlagValidator {
 		AddCommonFlag(appFlags.Logs.Container, nil)
 
 	return builder.Build()
-}
-
-func validateApplicationName(appName string) error {
-	appClient, err := catalogClient.NewApplicationClient()
-	if err != nil {
-		return fmt.Errorf("failed to create application client: %w", err)
-	}
-
-	// Fetch specific application by name
-	_, err = utils.GetAppByName(appClient, appName)
-	if err != nil {
-		return fmt.Errorf("failed to fetch application '%s': %w", appName, err)
-	}
-
-	return nil
 }

--- a/ai-services/internal/pkg/cli/utils/common.go
+++ b/ai-services/internal/pkg/cli/utils/common.go
@@ -97,3 +97,18 @@ func getContainerNamesFromAPI(pod catalogTypes.Pod) []string {
 
 	return containerNames
 }
+
+func ValidateApplicationName(appName string) error {
+	appClient, err := catalogClient.NewApplicationClient()
+	if err != nil {
+		return fmt.Errorf("failed to create application client: %w", err)
+	}
+
+	// Fetch specific application by name
+	_, err = GetAppByName(appClient, appName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR implements new way consuming `application logs`, using `--experimental` flag
Added a validation check where it checks if application exists in catalog.