### PR TITLE
[CATALOG-CLI] Making catalog password idempotent and password reset support

### DIFF
--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -1,15 +1,17 @@
 package catalog
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
+	"strconv"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure"
+	catalogPodman "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure/podman"
+	catalogConstant "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
@@ -29,9 +31,12 @@ var (
 	sslKeyPath  string
 	// HTTPS port flag for catalog configure command.
 	httpsPort int
+	// Reset password flag for catalog configure command.
+	resetPasswordFlag bool
 )
 
 const defaultHTTPSPort = 443
+const catalogContainerName = "ai-services--catalog-backend"
 
 // NewConfigureCmd creates a new configure command for the catalog service.
 func NewConfigureCmd() *cobra.Command {
@@ -52,27 +57,33 @@ Examples:
 			return validateConfigureFlags()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Prompt for admin password
-			return runConfigure()
+			if resetPasswordFlag {
+				// Reset Admin password
+				if err := processResetPassword(); err != nil {
+					return fmt.Errorf("failed to reset the password: %w", err)
+				}
+			} else {
+				// Configure catalog service
+				if err := runConfigure(); err != nil {
+					return fmt.Errorf("failed to configure catalog service: %w", err)
+				}
+			}
+
+			return nil
 		},
 	}
 
 	configureConfigureFlags(cmd)
+	configureBoolFlags(cmd)
 
 	return cmd
 }
 
 // runConfigure executes the catalog configuration process.
 func runConfigure() error {
-	// Prompt for admin password
-	adminPassword, err := promptForPassword()
-	if err != nil {
-		return fmt.Errorf("failed to read admin password: %w", err)
-	}
-
 	var aiServicesDir string
+	var err error
 
-	// Use default base directory if not specified, otherwise validate
 	if baseDir == "" {
 		aiServicesDir = constants.DefaultBaseDir
 	} else {
@@ -103,14 +114,107 @@ func runConfigure() error {
 	}
 
 	return configure.Run(configure.ConfigureOptions{
-		AdminPassword: adminPassword,
-		Runtime:       vars.RuntimeFactory.GetRuntimeType(),
-		BaseDir:       aiServicesDir,
-		DomainName:    domainName,
-		SSLCertPath:   cleanCertPath,
-		SSLKeyPath:    cleanKeyPath,
-		HttpsPort:     httpsPort,
+		BaseDir:     aiServicesDir,
+		DomainName:  domainName,
+		SSLCertPath: cleanCertPath,
+		SSLKeyPath:  cleanKeyPath,
+		HttpsPort:   httpsPort,
 	})
+}
+
+func processResetPassword() error {
+	rt, err := vars.RuntimeFactory.Create("")
+	if err != nil {
+		return fmt.Errorf("failed to create runtime: %w", err)
+	}
+
+	podId, podEnv, err := getCatalogPodDetails(rt)
+	if err != nil {
+		return fmt.Errorf("failed to get existing catalog pod details: %w", err)
+	}
+
+	secretExists, err := rt.SecretExists(catalogConstant.CatalogSecretName)
+	if err != nil {
+		return fmt.Errorf("failed to check existing secrets: %w", err)
+	}
+
+	if secretExists {
+		// Delete existing secret
+		logger.Infof("Deleting existing catalog secret %s", catalogConstant.CatalogSecretName)
+		err = rt.DeleteSecret(catalogConstant.CatalogSecretName)
+		if err != nil {
+			return fmt.Errorf("failed to delete existing catalog secret: %w", err)
+		}
+	}
+
+	logger.Infof("Deleting existing catalog pod %s", podId)
+	err = rt.DeletePod(podId, utils.BoolPtr(true))
+	if err != nil {
+		return fmt.Errorf("failed to delete existing catalog pod: %w", err)
+	}
+
+	setGlobalFlagValues(podEnv)
+
+	return catalogPodman.DeployCatalog(context.Background(), baseDir, map[string]string{}, domainName, "", "", httpsPort)
+}
+
+func setGlobalFlagValues(podEnv map[string]string) {
+	// Setting baseDir global variable
+	if value, ok := podEnv["AI_SERVICES_BASE_DIR"]; ok {
+		baseDir = value
+	}
+
+	// Setting domainName global variable
+	if value, ok := podEnv["DOMAIN_SUFFIX"]; ok {
+		domainName = value
+	}
+
+	// Setting httpsPort global variable
+	if value, ok := podEnv["CADDY_HTTPS_PORT"]; ok {
+		httpsPort, _ = strconv.Atoi(value)
+	}
+}
+
+func getCatalogPodDetails(rt runtime.Runtime) (string, map[string]string, error) {
+	// Build filter to find all pods using the catalog secret via label
+	logger.Infof("Getting catalog pod details")
+	filter := map[string][]string{
+		"label": {fmt.Sprintf(
+			"%s=%s",
+			catalogConstant.CatalogSecretLabel,
+			catalogConstant.CatalogSecretName,
+		)},
+	}
+
+	// List all pods that reference the catalog secret
+	pods, err := rt.ListPods(filter)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to list pods: %w", err)
+	}
+	if len(pods) == 0 {
+		return "", nil, fmt.Errorf("no catalog pod found")
+	}
+
+	// Inspect catalog pod
+	pod := pods[0]
+	pInfo, err := rt.InspectPod(pod.ID)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to inspect pod %s: %w", pod.Name, err)
+	}
+
+	for _, container := range pInfo.Containers {
+		if container.Name == catalogContainerName {
+			// Inspect container for get hold of envs
+			cInfo, err := rt.InspectContainer(container.ID)
+			if err != nil {
+				return "", nil, fmt.Errorf("failed to inspect container %s: %w", container.Name, err)
+			}
+
+			return pod.ID, cInfo.Env, nil
+		}
+	}
+
+	return "", nil, fmt.Errorf("failed to find catalog container in pod %s", pod.Name)
 }
 
 // validateConfigureFlags validates the configure command flags and initializes runtime.
@@ -195,6 +299,15 @@ func validateSSLCertificates() error {
 	return nil
 }
 
+func configureBoolFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(
+		&resetPasswordFlag,
+		"reset-password",
+		false,
+		"Reset the password for the admin user",
+	)
+}
+
 // configureConfigureFlags configures the flags for the configure command.
 func configureConfigureFlags(cmd *cobra.Command) {
 	// Add runtime flag as required
@@ -248,36 +361,6 @@ func configureConfigureFlags(cmd *cobra.Command) {
 			"Must be used together with --ssl-cert.\n"+
 			"Example: --ssl-key /path/to/key.pem\n",
 	)
-}
-
-// promptForPassword prompts the user to enter a password securely.
-func promptForPassword() (string, error) {
-	fmt.Print("Enter admin password: ")
-	passwordBytes, err := term.ReadPassword(int(syscall.Stdin))
-	fmt.Println() // Print newline after password input
-	if err != nil {
-		return "", err
-	}
-
-	password := string(passwordBytes)
-	if password == "" {
-		return "", fmt.Errorf("password cannot be empty")
-	}
-
-	// Prompt for confirmation
-	fmt.Print("Confirm admin password: ")
-	confirmBytes, err := term.ReadPassword(int(syscall.Stdin))
-	fmt.Println() // Print newline after password input
-	if err != nil {
-		return "", err
-	}
-
-	confirm := string(confirmBytes)
-	if password != confirm {
-		return "", fmt.Errorf("passwords do not match")
-	}
-
-	return password, nil
 }
 
 // Made with Bob

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -155,7 +155,7 @@ func processResetPassword() error {
 
 	setGlobalFlagValues(podEnv)
 
-	return catalogPodman.DeployCatalog(context.Background(), baseDir, map[string]string{}, domainName, "", "", httpsPort)
+	return catalogPodman.DeployCatalog(context.Background(), baseDir, domainName, "", "", httpsPort)
 }
 
 func setGlobalFlagValues(podEnv map[string]string) {

--- a/ai-services/internal/pkg/catalog/cli/configure/common.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/common.go
@@ -2,27 +2,15 @@ package configure
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
-	"os"
 
 	catalogPodman "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure/podman"
-	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
-	"github.com/project-ai-services/ai-services/internal/pkg/utils"
-	"golang.org/x/crypto/pbkdf2"
-)
-
-const (
-	defaultPasswordIterations = 100000
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // ConfigureOptions contains the configuration for configuring the catalog service.
 type ConfigureOptions struct {
-	AdminPassword string
-	Runtime       types.RuntimeType
 	BaseDir       string
 	// SSL/TLS certificate configuration
 	DomainName  string // Custom domain name for self-signed certificates
@@ -35,62 +23,18 @@ type ConfigureOptions struct {
 func Run(opts ConfigureOptions) error {
 	ctx := context.Background()
 
-	// Generate password hash using PBKDF2
-	passwordHash, err := hashPasswordPBKDF2(opts.AdminPassword, defaultPasswordIterations)
-	if err != nil {
-		return fmt.Errorf("failed to hash password: %w", err)
-	}
-
 	// Deploy catalog service based on runtime
-	switch opts.Runtime {
+	rt := vars.RuntimeFactory.GetRuntimeType()
+	switch rt {
 	case types.RuntimeTypePodman:
-		// Determine Podman URI
-		podmanURI, err := utils.ResolvePodmanURI()
-		if err != nil {
-			return fmt.Errorf("failed to generate podman uri: %w", err)
-		}
-
-		// Determine auth file path
-		authFilePath, err := getAuthFilePath()
-		if err != nil {
-			return fmt.Errorf("failed to get auth file path: %w", err)
-		}
-
-		return catalogPodman.DeployCatalog(ctx, podmanURI, authFilePath, passwordHash, opts.BaseDir, opts.DomainName, opts.SSLCertPath, opts.SSLKeyPath, opts.HttpsPort)
+		return catalogPodman.DeployCatalog(ctx, opts.BaseDir, opts.DomainName, opts.SSLCertPath, opts.SSLKeyPath, opts.HttpsPort)
 
 	case types.RuntimeTypeOpenShift:
 		return fmt.Errorf("openshift runtime is not yet supported for catalog configure")
 
 	default:
-		return fmt.Errorf("unsupported runtime type: %s", opts.Runtime)
+		return fmt.Errorf("unsupported runtime type: %s", rt)
 	}
-}
-
-// getAuthFilePath determines the auth.json file path.
-func getAuthFilePath() (string, error) {
-	if os.Geteuid() == 0 {
-		return "/run/user/0/containers/auth.json", nil
-	}
-
-	return fmt.Sprintf("/run/user/%d/containers/auth.json", os.Getuid()), nil
-}
-
-// hashPasswordPBKDF2 generates a PBKDF2 hash of the password with a random salt.
-func hashPasswordPBKDF2(password string, iteration int) (string, error) {
-	salt := make([]byte, constants.Pbkdf2SaltLen)
-	if _, err := rand.Read(salt); err != nil {
-		return "", err
-	}
-
-	hash := pbkdf2.Key([]byte(password), salt, iteration, constants.Pbkdf2KeyLen, sha256.New)
-
-	// Format: iterations.salt.hash (base64 encoded)
-	encoded := fmt.Sprintf("%d.%s.%s",
-		iteration,
-		base64.RawStdEncoding.EncodeToString(salt),
-		base64.RawStdEncoding.EncodeToString(hash))
-
-	return encoded, nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -26,15 +26,17 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/specs"
 	"github.com/project-ai-services/ai-services/internal/pkg/spinner"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 const (
-	catalogAppTemplate    = "catalog"
-	dirPerm               = 0o755
-	filePerm              = 0o644
-	kindSecret            = "Secret"
-	caddyCertsDirName     = "certs"
-	caddyContainerDataDir = "/data/caddy"
+	catalogAppTemplate        = "catalog"
+	dirPerm                   = 0o755
+	filePerm                  = 0o644
+	kindSecret                = "Secret"
+	caddyCertsDirName         = "certs"
+	caddyContainerDataDir     = "/data/caddy"
+	defaultPasswordIterations = 100000
 )
 
 // catalogDeploymentContext holds cached values during catalog deployment to avoid redundant lookups.
@@ -92,7 +94,7 @@ func (c *catalogDeploymentContext) getCaddyHostAdminURL(rt *podman.PodmanClient,
 }
 
 // DeployCatalog deploys the catalog service using the assets/catalog template for podman runtime.
-func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, baseDir string, domainName string, sslCertPath, sslKeyPath string, httpsPort int) error {
+func DeployCatalog(ctx context.Context, baseDir string, domainName string, sslCertPath, sslKeyPath string, httpsPort int) error {
 	s := spinner.New("Deploying catalog service...")
 	s.Start(ctx)
 
@@ -121,7 +123,7 @@ func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, b
 	}
 
 	// Prepare deployment with domain suffix computation
-	values, err := prepareCatalogDeployment(deployCtx, tp, podmanURI, authFilePath, passwordHash, baseDir, domainName, sslCertPath, sslKeyPath, argParams, s)
+	values, err := prepareCatalogDeployment(deployCtx, tp, baseDir, domainName, sslCertPath, sslKeyPath, argParams, s)
 	if err != nil {
 		return err
 	}
@@ -226,7 +228,7 @@ func extractCertDomainIfProvided(sslCertPath, sslKeyPath string, s *spinner.Spin
 }
 
 // prepareCatalogDeployment prepares all necessary data for deployment including domain suffix computation.
-func prepareCatalogDeployment(deployCtx *catalogDeploymentContext, tp templates.Template, podmanURI, authFilePath, passwordHash, baseDir, domainName, sslCertPath, sslKeyPath string, argParams map[string]string, s *spinner.Spinner) (map[string]any, error) {
+func prepareCatalogDeployment(deployCtx *catalogDeploymentContext, tp templates.Template, baseDir, domainName, sslCertPath, sslKeyPath string, argParams map[string]string, s *spinner.Spinner) (map[string]any, error) {
 	// Extract domain from certificate if provided
 	certDomain, err := extractCertDomainIfProvided(sslCertPath, sslKeyPath, s)
 	if err != nil {
@@ -256,7 +258,7 @@ func prepareCatalogDeployment(deployCtx *catalogDeploymentContext, tp templates.
 	deployCtx.caddyContainerAdminURL = fmt.Sprintf("http://%s:2019", caddyPodName)
 
 	// Prepare values with configure-specific configuration
-	values, err := prepareCatalogValues(tp, podmanURI, authFilePath, passwordHash, argParams)
+	values, err := prepareCatalogValues(tp, argParams)
 	if err != nil {
 		s.Fail("failed to load values")
 
@@ -371,7 +373,7 @@ func loadCatalogTemplates(s *spinner.Spinner) (templates.Template, *templates.Ap
 }
 
 // prepareCatalogValues prepares the values map with configure-specific configuration.
-func prepareCatalogValues(tp templates.Template, podmanURI, authFilePath, passwordHash string, argParams map[string]string) (map[string]any, error) {
+func prepareCatalogValues(tp templates.Template, argParams map[string]string) (map[string]any, error) {
 	if argParams == nil {
 		argParams = make(map[string]string)
 	}
@@ -383,6 +385,11 @@ func prepareCatalogValues(tp templates.Template, podmanURI, authFilePath, passwo
 	}
 
 	// Read and encode auth file content for secret
+	authFilePath, err := helpers.GetAuthFilePath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get auth file path: %w", err)
+	}
+
 	authFileContent, err := os.ReadFile(authFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read auth file from %s: %w", authFilePath, err)
@@ -391,12 +398,30 @@ func prepareCatalogValues(tp templates.Template, podmanURI, authFilePath, passwo
 	// Base64 encode the auth file content for Kubernetes secret
 	authFileBase64 := base64.StdEncoding.EncodeToString(authFileContent)
 
+	// Determine Podman URI
+	podmanURI, err := utils.ResolvePodmanURI()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate podman uri: %w", err)
+	}
+
 	// Strip unix:// prefix from podmanURI for hostPath volume mount
 	// The CONTAINER_HOST env var needs the full URI, but the hostPath needs just the file path
 	podmanSocketPath := strings.TrimPrefix(podmanURI, "unix://")
 
-	// Set configure-specific values
-	argParams["backend.adminPasswordHash"] = passwordHash
+	// Get the admin password from the user if secret is not credated
+	adminPassword, err := collectPassword()
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect admin password: %w", err)
+	}
+	if adminPassword != "" {
+		passwordHash, err := helpers.HashPasswordPBKDF2(adminPassword, defaultPasswordIterations)
+		if err != nil {
+			return nil, fmt.Errorf("failed to hash password: %w", err)
+		}
+		argParams["backend.adminPasswordHash"] = passwordHash
+	}
+
+	// Set configure-specific value
 	argParams["backend.runtime"] = "podman"
 	argParams["backend.podman.authFileContent"] = authFileBase64
 	argParams["backend.podman.uri"] = podmanSocketPath
@@ -831,6 +856,29 @@ func GetCatalogRouteInfo(rt *podman.PodmanClient, tp templates.Template, appTemp
 	}
 
 	return routeDomains, httpsPort, nil
+}
+
+func collectPassword() (string, error) {
+	rt, err := vars.RuntimeFactory.Create("")
+	if err != nil {
+		return "", fmt.Errorf("failed to create runtime: %w", err)
+	}
+
+	secretExists, err := rt.SecretExists(catalogconstants.CatalogSecretName)
+	if err != nil {
+		return "", fmt.Errorf("failed to check existing secrets: %w", err)
+	}
+
+	var adminPassword string
+	// Prompt for admin password if secret doesn't exist or reset password flag is set
+	if !secretExists {
+		adminPassword, err = helpers.PromptForPassword()
+		if err != nil {
+			return "", fmt.Errorf("failed to read admin password: %w", err)
+		}
+	}
+
+	return adminPassword, nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/constants/catalog.go
+++ b/ai-services/internal/pkg/catalog/constants/catalog.go
@@ -34,6 +34,8 @@ const (
 	CatalogVolumeSkipLabel = "ai-services.io/volume-skip-cleanup"
 	// PodmanAuthSecret represents podman auth secret name.
 	PodmanAuthSecret = "podman-auth-secret"
+	// CatalogSecretName represents the catalog secret name.
+	CatalogSecretName = "catalog-secret"
 )
 
 // Pagination constants.

--- a/ai-services/internal/pkg/cli/helpers/helper.go
+++ b/ai-services/internal/pkg/cli/helpers/helper.go
@@ -1,9 +1,17 @@
 package helpers
 
 import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
+	"os"
 	"strings"
+	"syscall"
 	"time"
+
+	"golang.org/x/crypto/pbkdf2"
+	"golang.org/x/term"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/accelerator/spyre"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
@@ -173,4 +181,61 @@ func existingSecrets(runtime runtime.Runtime, secretNames []string) ([]string, e
 	}
 
 	return secretsToSkip, nil
+}
+
+// PromptForPassword prompts the user to enter a password securely.
+func PromptForPassword() (string, error) {
+	fmt.Print("Enter admin password: ")
+	passwordBytes, err := term.ReadPassword(int(syscall.Stdin))
+	fmt.Println() // Print newline after password input
+	if err != nil {
+		return "", err
+	}
+
+	password := string(passwordBytes)
+	if password == "" {
+		return "", fmt.Errorf("password cannot be empty")
+	}
+
+	// Prompt for confirmation
+	fmt.Print("Confirm admin password: ")
+	confirmBytes, err := term.ReadPassword(int(syscall.Stdin))
+	fmt.Println() // Print newline after password input
+	if err != nil {
+		return "", err
+	}
+
+	confirm := string(confirmBytes)
+	if password != confirm {
+		return "", fmt.Errorf("passwords do not match")
+	}
+
+	return password, nil
+}
+
+// HashPasswordPBKDF2 generates a PBKDF2 hash of the password with a random salt.
+func HashPasswordPBKDF2(password string, iteration int) (string, error) {
+	salt := make([]byte, constants.Pbkdf2SaltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return "", err
+	}
+
+	hash := pbkdf2.Key([]byte(password), salt, iteration, constants.Pbkdf2KeyLen, sha256.New)
+
+	// Format: iterations.salt.hash (base64 encoded)
+	encoded := fmt.Sprintf("%d.%s.%s",
+		iteration,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(hash))
+
+	return encoded, nil
+}
+
+// GetAuthFilePath determines the auth.json file path.
+func GetAuthFilePath() (string, error) {
+	if os.Geteuid() == 0 {
+		return "/run/user/0/containers/auth.json", nil
+	}
+
+	return fmt.Sprintf("/run/user/%d/containers/auth.json", os.Getuid()), nil
 }

--- a/ai-services/internal/pkg/runtime/interface.go
+++ b/ai-services/internal/pkg/runtime/interface.go
@@ -26,6 +26,7 @@ type Runtime interface {
 	// Secret operations
 	ListSecrets(filters map[string][]string) ([]string, error)
 	DeleteSecret(name string) error
+	SecretExists(nameOrID string) (bool, error)
 
 	// Volume operations
 	DeleteVolume(name string) error

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -436,6 +436,12 @@ func (kc *OpenshiftClient) DeleteSecret(name string) error {
 	return nil
 }
 
+func (kc *OpenshiftClient) SecretExists(nameOrID string) (bool, error) {
+	logger.Warningln("Not implemented")
+
+	return false, nil
+}
+
 func (kc *OpenshiftClient) DeleteVolume(name string) error {
 	logger.Warningln("Not implemented")
 

--- a/ai-services/internal/pkg/runtime/podman/mapper.go
+++ b/ai-services/internal/pkg/runtime/podman/mapper.go
@@ -1,6 +1,8 @@
 package podman
 
 import (
+	"strings"
+
 	"github.com/containers/podman/v5/libpod/define"
 	podmanTypes "github.com/containers/podman/v5/pkg/domain/entities/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
@@ -146,6 +148,16 @@ func toInspectContainer(input *define.InspectContainerData) *types.Container {
 	if input.Config != nil && input.Config.Healthcheck != nil {
 		container.HealthcheckStartPeriod = input.Config.Healthcheck.StartPeriod
 	}
+
+	envMap := make(map[string]string)
+	const envLen = 2
+	for _, env := range input.Config.Env {
+		values := strings.Split(env, "=")
+		if len(values) == envLen {
+			envMap[values[0]] = values[1]
+		}
+	}
+	container.Env = envMap
 
 	return container
 }

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -421,6 +421,10 @@ func (pc *PodmanClient) ListSecrets(filters map[string][]string) ([]string, erro
 	return secretIDorNames, nil
 }
 
+func (pc *PodmanClient) SecretExists(nameOrID string) (bool, error) {
+	return secrets.Exists(pc.Context, nameOrID)
+}
+
 // Type returns the runtime type for PodmanClient.
 func (pc *PodmanClient) Type() types.RuntimeType {
 	return types.RuntimeTypePodman

--- a/ai-services/internal/pkg/runtime/types/types.go
+++ b/ai-services/internal/pkg/runtime/types/types.go
@@ -44,6 +44,7 @@ type Container struct {
 	Status                 string
 	Health                 string
 	Annotations            map[string]string
+	Env                    map[string]string
 	HealthcheckStartPeriod time.Duration
 }
 


### PR DESCRIPTION
# Summary

Improved user experience for the catalog configure command by skipping password prompt when the catalog secret already exists.

### What Changed
**Before:**

- The catalog configure command always prompted users for an admin password, even when the catalog-secret already existed in the runtime environment

After:
- Added secret existence check before prompting for password
- If catalog-secret exists, the password prompt is skipped entirely
- Password is only requested when the secret is not present