### PR TITLE
Refactor images part in deployer code

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.58
+TAG?=0.0.59
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.58
+  image: icr.io/ai-services-cicd/ai-services:0.0.59
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
@@ -1,11 +1,8 @@
 package deployment
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"regexp"
-	"strconv"
 
 	"github.com/google/uuid"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
@@ -16,8 +13,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	podmodels "github.com/project-ai-services/ai-services/internal/pkg/models"
-	k8syaml "sigs.k8s.io/yaml"
 )
 
 // DeploymentPlanner plans the deployment of applications by:
@@ -251,72 +246,13 @@ func (p *DeploymentPlanner) getRequiredSpyreCardsForComponent(comp *ComponentPla
 		return 0, fmt.Errorf("failed to load component templates: %w", err)
 	}
 
-	totalSpyreCards := 0
-
-	for templateName, tmpl := range tmpls {
-		// Prepare minimal params for rendering
-		params := map[string]any{
-			"InstanceSlug": "slug", // dummy
-			"TemplateID":   "test", // dummy
-			"Values":       comp.Params,
-			"env":          map[string]map[string]string{},
-		}
-
-		// Render template
-		var rendered bytes.Buffer
-		if err := tmpl.Execute(&rendered, params); err != nil {
-			continue
-		}
-
-		// Parse rendered YAML to get pod spec
-		var podSpec podmodels.PodSpec
-		if err := k8syaml.Unmarshal(rendered.Bytes(), &podSpec); err != nil {
-			continue
-		}
-
-		// Extract Spyre card requirements from annotations
-		spyreCards, _, err := fetchSpyreCardsFromPodAnnotations(podSpec.Annotations)
-		if err != nil {
-			return 0, err
-		}
-
-		totalSpyreCards += spyreCards
-		if spyreCards > 0 {
-			logger.Infof("Template %s requires %d Spyre cards\n", templateName, spyreCards)
-		}
+	// Use the catalog provider's CollectSpyreCardsFromTemplates function
+	totalSpyreCards, err := p.catalogProvider.CollectSpyreCardsFromTemplates(tmpls, comp.Params)
+	if err != nil {
+		return 0, fmt.Errorf("failed to collect Spyre cards from templates: %w", err)
 	}
 
 	return totalSpyreCards, nil
-}
-
-// fetchSpyreCardsFromPodAnnotations extracts Spyre card requirements from pod annotations.
-func fetchSpyreCardsFromPodAnnotations(annotations map[string]string) (int, map[string]int, error) {
-	var spyreCards int
-	spyreCardContainerMap := map[string]int{}
-
-	spyreCardAnnotationRegex := regexp.MustCompile(`^ai-services\.io\/([A-Za-z0-9][-A-Za-z0-9_.]*)--spyre-cards$`)
-
-	isSpyreCardAnnotation := func(annotation string) (string, bool) {
-		matches := spyreCardAnnotationRegex.FindStringSubmatch(annotation)
-		if matches == nil {
-			return "", false
-		}
-
-		return matches[1], true
-	}
-
-	for annotationKey, val := range annotations {
-		if containerName, ok := isSpyreCardAnnotation(annotationKey); ok {
-			valInt, err := strconv.Atoi(val)
-			if err != nil {
-				return 0, spyreCardContainerMap, fmt.Errorf("failed to convert to int. Provided val: %s is not of int type", val)
-			}
-			spyreCardContainerMap[containerName] = valInt
-			spyreCards += valInt
-		}
-	}
-
-	return spyreCards, spyreCardContainerMap, nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -1044,10 +1043,8 @@ func (d *PodmanDeployer) fetchSpyreCardsFromPodAnnotations(annotations map[strin
 	var spyreCards int
 	spyreCardContainerMap := map[string]int{}
 
-	spyreCardAnnotationRegex := regexp.MustCompile(`^ai-services\.io\/([A-Za-z0-9][-A-Za-z0-9_.]*)--spyre-cards$`)
-
 	isSpyreCardAnnotation := func(annotation string) (string, bool) {
-		matches := spyreCardAnnotationRegex.FindStringSubmatch(annotation)
+		matches := vars.SpyreCardAnnotationRegex.FindStringSubmatch(annotation)
 		if matches == nil {
 			return "", false
 		}

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -232,7 +232,10 @@ func (d *PodmanDeployer) downloadModels(modelSet map[string]bool) error {
 func (d *PodmanDeployer) pullImagesForDeployment(plan *DeploymentPlan) error {
 	logger.Infof("Pulling container images for application '%s'\n", plan.ApplicationName)
 
-	imageSet := d.collectImagesFromPlan(plan)
+	imageSet, err := d.collectImagesFromPlan(plan)
+	if err != nil {
+		return fmt.Errorf("failed to collect images: %w", err)
+	}
 
 	if len(imageSet) == 0 {
 		logger.Infof("No images to pull for application '%s'\n", plan.ApplicationName)
@@ -250,7 +253,7 @@ func (d *PodmanDeployer) pullImagesForDeployment(plan *DeploymentPlan) error {
 }
 
 // collectImagesFromPlan collects all unique container images from the deployment plan.
-func (d *PodmanDeployer) collectImagesFromPlan(plan *DeploymentPlan) map[string]bool {
+func (d *PodmanDeployer) collectImagesFromPlan(plan *DeploymentPlan) (map[string]bool, error) {
 	imageSet := make(map[string]bool)
 
 	// Include tool image which is used for all housekeeping tasks
@@ -258,41 +261,51 @@ func (d *PodmanDeployer) collectImagesFromPlan(plan *DeploymentPlan) map[string]
 
 	// Extract images from component templates
 	for _, comp := range plan.Components {
-		d.extractImagesFromComponent(comp, imageSet)
+		if err := d.extractImagesFromComponent(comp, imageSet); err != nil {
+			return nil, err
+		}
 	}
 
 	// Extract images from service templates
 	for _, svc := range plan.Services {
-		d.extractImagesFromService(svc, imageSet)
+		if err := d.extractImagesFromService(svc, imageSet); err != nil {
+			return nil, err
+		}
 	}
 
-	return imageSet
+	return imageSet, nil
 }
 
 // extractImagesFromComponent extracts container images from a component's templates.
-func (d *PodmanDeployer) extractImagesFromComponent(comp *ComponentPlan, imageSet map[string]bool) {
+func (d *PodmanDeployer) extractImagesFromComponent(comp *ComponentPlan, imageSet map[string]bool) error {
 	// Load component templates
 	templates, err := d.catalogProvider.LoadComponentTemplates(comp.ComponentType, comp.ProviderID)
 	if err != nil {
-		logger.Errorf("Failed to load component templates for %s/%s: %v\n", comp.ComponentType, comp.ProviderID, err)
-		return
+		return fmt.Errorf("failed to load component templates for %s/%s: %w", comp.ComponentType, comp.ProviderID, err)
 	}
 
 	// Extract images from templates with custom values directly into imageSet
-	d.catalogProvider.CollectImagesFromTemplates(templates, comp.Values, imageSet)
+	if err := d.catalogProvider.CollectImagesFromTemplates(templates, comp.Values, imageSet); err != nil {
+		return fmt.Errorf("failed to extract images from component %s/%s: %w", comp.ComponentType, comp.ProviderID, err)
+	}
+
+	return nil
 }
 
 // extractImagesFromService extracts container images from a service's templates.
-func (d *PodmanDeployer) extractImagesFromService(svc *ServicePlan, imageSet map[string]bool) {
+func (d *PodmanDeployer) extractImagesFromService(svc *ServicePlan, imageSet map[string]bool) error {
 	// Load service templates
 	templates, err := d.catalogProvider.LoadServiceTemplates(svc.CatalogID)
 	if err != nil {
-		logger.Errorf("Failed to load service templates for %s: %v\n", svc.CatalogID, err)
-		return
+		return fmt.Errorf("failed to load service templates for %s: %w", svc.CatalogID, err)
 	}
 
 	// Extract images from templates with custom values directly into imageSet
-	d.catalogProvider.CollectImagesFromTemplates(templates, svc.Values, imageSet)
+	if err := d.catalogProvider.CollectImagesFromTemplates(templates, svc.Values, imageSet); err != nil {
+		return fmt.Errorf("failed to extract images from service %s: %w", svc.CatalogID, err)
+	}
+
+	return nil
 }
 
 // pullImages pulls only missing images from the provided set using the runtime.

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -272,73 +272,27 @@ func (d *PodmanDeployer) collectImagesFromPlan(plan *DeploymentPlan) map[string]
 // extractImagesFromComponent extracts container images from a component's templates.
 func (d *PodmanDeployer) extractImagesFromComponent(comp *ComponentPlan, imageSet map[string]bool) {
 	// Load component templates
-	tmpls, err := d.catalogProvider.LoadComponentTemplates(comp.ComponentType, comp.ProviderID)
+	templates, err := d.catalogProvider.LoadComponentTemplates(comp.ComponentType, comp.ProviderID)
 	if err != nil {
 		logger.Errorf("Failed to load component templates for %s/%s: %v\n", comp.ComponentType, comp.ProviderID, err)
-
 		return
 	}
 
-	// Extract images from each template
-	for templateName, tmpl := range tmpls {
-		d.extractImagesFromTemplate(tmpl, templateName, comp.Values, imageSet)
-	}
+	// Extract images from templates with custom values directly into imageSet
+	d.catalogProvider.CollectImagesFromTemplates(templates, comp.Values, imageSet)
 }
 
 // extractImagesFromService extracts container images from a service's templates.
 func (d *PodmanDeployer) extractImagesFromService(svc *ServicePlan, imageSet map[string]bool) {
 	// Load service templates
-	tmpls, err := d.catalogProvider.LoadServiceTemplates(svc.CatalogID)
+	templates, err := d.catalogProvider.LoadServiceTemplates(svc.CatalogID)
 	if err != nil {
 		logger.Errorf("Failed to load service templates for %s: %v\n", svc.CatalogID, err)
-
 		return
 	}
 
-	// Extract images from each template
-	for templateName, tmpl := range tmpls {
-		d.extractImagesFromTemplate(tmpl, templateName, svc.Values, imageSet)
-	}
-}
-
-// extractImagesFromTemplate renders a template and extracts container images from it.
-func (d *PodmanDeployer) extractImagesFromTemplate(
-	tmpl *template.Template,
-	templateName string,
-	values map[string]any,
-	imageSet map[string]bool,
-) {
-	// Prepare minimal params for rendering
-	initialParams := map[string]any{
-		"InstanceSlug": "image-extraction",
-		"TemplateID":   uuid.New(),
-		"BaseDir":      utils.GetBaseDir(),
-		"Values":       values,
-		"env":          map[string]map[string]string{},
-	}
-
-	// Render the template
-	var rendered bytes.Buffer
-	if err := tmpl.Execute(&rendered, initialParams); err != nil {
-		logger.Errorf("Failed to render template %s for image extraction: %v\n", templateName, err)
-
-		return
-	}
-
-	// Parse the rendered template
-	var podSpec podmodels.PodSpec
-	if err := k8syaml.Unmarshal(rendered.Bytes(), &podSpec); err != nil {
-		logger.Errorf("Failed to parse rendered template %s: %v\n", templateName, err)
-
-		return
-	}
-
-	// Extract images from containers
-	for _, container := range podSpec.Spec.Containers {
-		if container.Image != "" {
-			imageSet[container.Image] = true
-		}
-	}
+	// Extract images from templates with custom values directly into imageSet
+	d.catalogProvider.CollectImagesFromTemplates(templates, svc.Values, imageSet)
 }
 
 // pullImages pulls only missing images from the provided set using the runtime.

--- a/ai-services/internal/pkg/catalog/template_extractor.go
+++ b/ai-services/internal/pkg/catalog/template_extractor.go
@@ -2,6 +2,8 @@ package catalog
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	texttemplate "text/template"
 
 	k8syaml "sigs.k8s.io/yaml"
@@ -32,7 +34,10 @@ func extractContainerImages(podSpec *models.PodSpec, imageSet map[string]bool) {
 // CollectImagesFromTemplates extracts images from a set of pre-loaded templates
 // and adds them directly to the provided imageSet map.
 // This is the low-level function that callers use after loading templates themselves.
-func (p *CatalogProvider) CollectImagesFromTemplates(templates map[string]*texttemplate.Template, values map[string]any, imageSet map[string]bool) {
+// Returns an error if any template fails to render or parse.
+func (p *CatalogProvider) CollectImagesFromTemplates(templates map[string]*texttemplate.Template, values map[string]any, imageSet map[string]bool) error {
+	var errorResponses []error
+
 	// Process each template
 	for templateName, tmpl := range templates {
 		// Prepare minimal params for rendering
@@ -48,6 +53,7 @@ func (p *CatalogProvider) CollectImagesFromTemplates(templates map[string]*textt
 		var rendered bytes.Buffer
 		if err := tmpl.Execute(&rendered, initialParams); err != nil {
 			logger.Errorf("Failed to render template %s for image extraction: %v", templateName, err)
+			errorResponses = append(errorResponses, err)
 			continue
 		}
 
@@ -55,10 +61,18 @@ func (p *CatalogProvider) CollectImagesFromTemplates(templates map[string]*textt
 		var podSpec models.PodSpec
 		if err := k8syaml.Unmarshal(rendered.Bytes(), &podSpec); err != nil {
 			logger.Errorf("Failed to parse rendered template %s: %v", templateName, err)
+			errorResponses = append(errorResponses, err)
 			continue
 		}
 
 		// Extract images from containers directly into the provided set
 		extractContainerImages(&podSpec, imageSet)
 	}
+
+	// Return error if any template failed
+	if len(errorResponses) > 0 {
+		return fmt.Errorf("failed to process %d template(s): %w", len(errorResponses), errors.Join(errorResponses...))
+	}
+
+	return nil
 }

--- a/ai-services/internal/pkg/catalog/template_extractor.go
+++ b/ai-services/internal/pkg/catalog/template_extractor.go
@@ -48,6 +48,7 @@ func (p *CatalogProvider) ProcessTemplates(
 		if err := tmpl.Execute(&rendered, initialParams); err != nil {
 			logger.Errorf("Failed to render template %s: %v", templateName, err)
 			errorResponses = append(errorResponses, err)
+
 			continue
 		}
 
@@ -56,6 +57,7 @@ func (p *CatalogProvider) ProcessTemplates(
 		if err := k8syaml.Unmarshal(rendered.Bytes(), &podSpec); err != nil {
 			logger.Errorf("Failed to parse rendered template %s: %v", templateName, err)
 			errorResponses = append(errorResponses, err)
+
 			continue
 		}
 

--- a/ai-services/internal/pkg/catalog/template_extractor.go
+++ b/ai-services/internal/pkg/catalog/template_extractor.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"regexp"
+	"strconv"
 	texttemplate "text/template"
 
 	k8syaml "sigs.k8s.io/yaml"
@@ -14,35 +16,27 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
-// extractContainerImages extracts images from containers and init containers.
-func extractContainerImages(podSpec *models.PodSpec, imageSet map[string]bool) {
-	// Extract images from containers
-	for _, container := range podSpec.Spec.Containers {
-		if container.Image != "" {
-			imageSet[container.Image] = true
-		}
-	}
+// PodSpecProcessor is a callback function that processes a rendered pod spec.
+// It receives the template name and pod spec, and can return an error if processing fails.
+type PodSpecProcessor func(templateName string, podSpec *models.PodSpec) error
 
-	// Extract images from init containers
-	for _, container := range podSpec.Spec.InitContainers {
-		if container.Image != "" {
-			imageSet[container.Image] = true
-		}
-	}
-}
-
-// CollectImagesFromTemplates extracts images from a set of pre-loaded templates
-// and adds them directly to the provided imageSet map.
-// This is the low-level function that callers use after loading templates themselves.
-// Returns an error if any template fails to render or parse.
-func (p *CatalogProvider) CollectImagesFromTemplates(templates map[string]*texttemplate.Template, values map[string]any, imageSet map[string]bool) error {
+// ProcessTemplates is a generic function that renders templates and processes each pod spec
+// using the provided processor callback. This allows different use cases (image extraction,
+// Spyre card counting, etc.) to reuse the same template rendering logic.
+// Returns an error if any template fails to render, parse, or process.
+func (p *CatalogProvider) ProcessTemplates(
+	templates map[string]*texttemplate.Template,
+	values map[string]any,
+	instanceSlug string,
+	processor PodSpecProcessor,
+) error {
 	var errorResponses []error
 
 	// Process each template
 	for templateName, tmpl := range templates {
 		// Prepare minimal params for rendering
 		initialParams := map[string]any{
-			"InstanceSlug": "image-extraction",
+			"InstanceSlug": instanceSlug,
 			"TemplateID":   uuid.New(),
 			"BaseDir":      utils.GetBaseDir(),
 			"Values":       values,
@@ -52,7 +46,7 @@ func (p *CatalogProvider) CollectImagesFromTemplates(templates map[string]*textt
 		// Render the template
 		var rendered bytes.Buffer
 		if err := tmpl.Execute(&rendered, initialParams); err != nil {
-			logger.Errorf("Failed to render template %s for image extraction: %v", templateName, err)
+			logger.Errorf("Failed to render template %s: %v", templateName, err)
 			errorResponses = append(errorResponses, err)
 			continue
 		}
@@ -65,14 +59,110 @@ func (p *CatalogProvider) CollectImagesFromTemplates(templates map[string]*textt
 			continue
 		}
 
-		// Extract images from containers directly into the provided set
-		extractContainerImages(&podSpec, imageSet)
+		// Process the pod spec using the provided callback
+		if err := processor(templateName, &podSpec); err != nil {
+			return fmt.Errorf("failed to process template %s: %w", templateName, err)
+		}
 	}
 
-	// Return error if any template failed
+	// Return error if any template failed to render or parse
 	if len(errorResponses) > 0 {
 		return fmt.Errorf("failed to process %d template(s): %w", len(errorResponses), errors.Join(errorResponses...))
 	}
 
 	return nil
+}
+
+// CollectImagesFromTemplates extracts images from a set of pre-loaded templates
+// and adds them directly to the provided imageSet map.
+// This is a convenience wrapper around ProcessTemplates for image extraction.
+func (p *CatalogProvider) CollectImagesFromTemplates(
+	templates map[string]*texttemplate.Template,
+	values map[string]any,
+	imageSet map[string]bool,
+) error {
+	// Create processor that extracts container images
+	processor := func(templateName string, podSpec *models.PodSpec) error {
+		// Extract images from containers
+		for _, container := range podSpec.Spec.Containers {
+			if container.Image != "" {
+				imageSet[container.Image] = true
+			}
+		}
+
+		// Extract images from init containers
+		for _, container := range podSpec.Spec.InitContainers {
+			if container.Image != "" {
+				imageSet[container.Image] = true
+			}
+		}
+
+		return nil
+	}
+
+	return p.ProcessTemplates(templates, values, "image-extraction", processor)
+}
+
+// CollectSpyreCardsFromTemplates extracts Spyre card requirements from a set of pre-loaded templates
+// by analyzing pod annotations. Returns the total number of Spyre cards required.
+// This is a convenience wrapper around ProcessTemplates for Spyre card counting.
+func (p *CatalogProvider) CollectSpyreCardsFromTemplates(
+	templates map[string]*texttemplate.Template,
+	values map[string]any,
+) (int, error) {
+	totalSpyreCards := 0
+
+	// Create processor that counts Spyre cards from pod annotations
+	processor := func(templateName string, podSpec *models.PodSpec) error {
+		// Extract Spyre card requirements from annotations
+		spyreCards, _, err := fetchSpyreCardsFromPodAnnotations(podSpec.Annotations)
+		if err != nil {
+			return fmt.Errorf("failed to extract Spyre cards: %w", err)
+		}
+
+		totalSpyreCards += spyreCards
+		if spyreCards > 0 {
+			logger.Infof("Template %s requires %d Spyre cards\n", templateName, spyreCards)
+		}
+
+		return nil
+	}
+
+	// Use the generic ProcessTemplates function
+	if err := p.ProcessTemplates(templates, values, "spyre-card-calculation", processor); err != nil {
+		return 0, fmt.Errorf("failed to process templates for Spyre card calculation: %w", err)
+	}
+
+	return totalSpyreCards, nil
+}
+
+// fetchSpyreCardsFromPodAnnotations extracts Spyre card requirements from pod annotations.
+// Returns the total number of Spyre cards and a map of container names to their card requirements.
+func fetchSpyreCardsFromPodAnnotations(annotations map[string]string) (int, map[string]int, error) {
+	var spyreCards int
+	spyreCardContainerMap := map[string]int{}
+
+	spyreCardAnnotationRegex := regexp.MustCompile(`^ai-services\.io\/([A-Za-z0-9][-A-Za-z0-9_.]*)--spyre-cards$`)
+
+	isSpyreCardAnnotation := func(annotation string) (string, bool) {
+		matches := spyreCardAnnotationRegex.FindStringSubmatch(annotation)
+		if matches == nil {
+			return "", false
+		}
+
+		return matches[1], true
+	}
+
+	for annotationKey, val := range annotations {
+		if containerName, ok := isSpyreCardAnnotation(annotationKey); ok {
+			valInt, err := strconv.Atoi(val)
+			if err != nil {
+				return 0, spyreCardContainerMap, fmt.Errorf("failed to convert to int. Provided val: %s is not of int type", val)
+			}
+			spyreCardContainerMap[containerName] = valInt
+			spyreCards += valInt
+		}
+	}
+
+	return spyreCards, spyreCardContainerMap, nil
 }

--- a/ai-services/internal/pkg/catalog/template_extractor.go
+++ b/ai-services/internal/pkg/catalog/template_extractor.go
@@ -1,0 +1,64 @@
+package catalog
+
+import (
+	"bytes"
+	texttemplate "text/template"
+
+	k8syaml "sigs.k8s.io/yaml"
+
+	"github.com/google/uuid"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/models"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+)
+
+// extractContainerImages extracts images from containers and init containers.
+func extractContainerImages(podSpec *models.PodSpec, imageSet map[string]bool) {
+	// Extract images from containers
+	for _, container := range podSpec.Spec.Containers {
+		if container.Image != "" {
+			imageSet[container.Image] = true
+		}
+	}
+
+	// Extract images from init containers
+	for _, container := range podSpec.Spec.InitContainers {
+		if container.Image != "" {
+			imageSet[container.Image] = true
+		}
+	}
+}
+
+// CollectImagesFromTemplates extracts images from a set of pre-loaded templates
+// and adds them directly to the provided imageSet map.
+// This is the low-level function that callers use after loading templates themselves.
+func (p *CatalogProvider) CollectImagesFromTemplates(templates map[string]*texttemplate.Template, values map[string]any, imageSet map[string]bool) {
+	// Process each template
+	for templateName, tmpl := range templates {
+		// Prepare minimal params for rendering
+		initialParams := map[string]any{
+			"InstanceSlug": "image-extraction",
+			"TemplateID":   uuid.New(),
+			"BaseDir":      utils.GetBaseDir(),
+			"Values":       values,
+			"env":          map[string]map[string]string{},
+		}
+
+		// Render the template
+		var rendered bytes.Buffer
+		if err := tmpl.Execute(&rendered, initialParams); err != nil {
+			logger.Errorf("Failed to render template %s for image extraction: %v", templateName, err)
+			continue
+		}
+
+		// Parse the rendered template as Pod spec
+		var podSpec models.PodSpec
+		if err := k8syaml.Unmarshal(rendered.Bytes(), &podSpec); err != nil {
+			logger.Errorf("Failed to parse rendered template %s: %v", templateName, err)
+			continue
+		}
+
+		// Extract images from containers directly into the provided set
+		extractContainerImages(&podSpec, imageSet)
+	}
+}

--- a/ai-services/internal/pkg/catalog/template_extractor.go
+++ b/ai-services/internal/pkg/catalog/template_extractor.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"regexp"
 	"strconv"
 	texttemplate "text/template"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // PodSpecProcessor is a callback function that processes a rendered pod spec.
@@ -144,10 +144,8 @@ func fetchSpyreCardsFromPodAnnotations(annotations map[string]string) (int, map[
 	var spyreCards int
 	spyreCardContainerMap := map[string]int{}
 
-	spyreCardAnnotationRegex := regexp.MustCompile(`^ai-services\.io\/([A-Za-z0-9][-A-Za-z0-9_.]*)--spyre-cards$`)
-
 	isSpyreCardAnnotation := func(annotation string) (string, bool) {
-		matches := spyreCardAnnotationRegex.FindStringSubmatch(annotation)
+		matches := vars.SpyreCardAnnotationRegex.FindStringSubmatch(annotation)
 		if matches == nil {
 			return "", false
 		}

--- a/ai-services/internal/pkg/catalog/template_extractor_test.go
+++ b/ai-services/internal/pkg/catalog/template_extractor_test.go
@@ -1,0 +1,768 @@
+package catalog
+
+import (
+	"errors"
+	"testing"
+	texttemplate "text/template"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProcessTemplates_Success tests successful template processing
+func TestProcessTemplates_Success(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	// Create a simple pod template
+	templateContent := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: test-container
+    image: {{ .Values.image }}
+  initContainers:
+  - name: init-container
+    image: {{ .Values.initImage }}
+`
+
+	tmpl, err := texttemplate.New("test").Parse(templateContent)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"test-template": tmpl,
+	}
+
+	values := map[string]any{
+		"image":     "nginx:latest",
+		"initImage": "busybox:latest",
+	}
+
+	// Track processed templates
+	processedTemplates := make(map[string]*models.PodSpec)
+
+	processor := func(templateName string, podSpec *models.PodSpec) error {
+		processedTemplates[templateName] = podSpec
+		return nil
+	}
+
+	err = provider.ProcessTemplates(templates, values, "test-instance", processor)
+	require.NoError(t, err)
+
+	// Verify the template was processed
+	assert.Len(t, processedTemplates, 1)
+	assert.Contains(t, processedTemplates, "test-template")
+
+	podSpec := processedTemplates["test-template"]
+	assert.Equal(t, "test-pod", podSpec.Name)
+	assert.Len(t, podSpec.Spec.Containers, 1)
+	assert.Equal(t, "nginx:latest", podSpec.Spec.Containers[0].Image)
+	assert.Len(t, podSpec.Spec.InitContainers, 1)
+	assert.Equal(t, "busybox:latest", podSpec.Spec.InitContainers[0].Image)
+}
+
+// TestProcessTemplates_MultipleTemplates tests processing multiple templates
+func TestProcessTemplates_MultipleTemplates(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	template1 := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+spec:
+  containers:
+  - name: container1
+    image: image1:latest
+`
+
+	template2 := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod2
+spec:
+  containers:
+  - name: container2
+    image: image2:latest
+`
+
+	tmpl1, err := texttemplate.New("template1").Parse(template1)
+	require.NoError(t, err)
+
+	tmpl2, err := texttemplate.New("template2").Parse(template2)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"template1": tmpl1,
+		"template2": tmpl2,
+	}
+
+	processedCount := 0
+	processor := func(templateName string, podSpec *models.PodSpec) error {
+		processedCount++
+		return nil
+	}
+
+	err = provider.ProcessTemplates(templates, nil, "test-instance", processor)
+	require.NoError(t, err)
+	assert.Equal(t, 2, processedCount)
+}
+
+// TestProcessTemplates_RenderError tests handling of template rendering errors
+func TestProcessTemplates_RenderError(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	// Template with undefined variable
+	templateContent := `
+apiVersion: v1
+kind: Pod
+metadata:
+	 name: {{ .UndefinedVariable }}
+`
+
+	tmpl, err := texttemplate.New("test").Option("missingkey=error").Parse(templateContent)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"bad-template": tmpl,
+	}
+
+	processor := func(templateName string, podSpec *models.PodSpec) error {
+		return nil
+	}
+
+	err = provider.ProcessTemplates(templates, nil, "test-instance", processor)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process")
+}
+
+// TestProcessTemplates_ParseError tests handling of YAML parsing errors
+func TestProcessTemplates_ParseError(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	// Template that produces invalid YAML
+	templateContent := `
+this is not valid yaml: [[[
+`
+
+	tmpl, err := texttemplate.New("test").Parse(templateContent)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"invalid-yaml": tmpl,
+	}
+
+	processor := func(templateName string, podSpec *models.PodSpec) error {
+		return nil
+	}
+
+	err = provider.ProcessTemplates(templates, nil, "test-instance", processor)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process")
+}
+
+// TestProcessTemplates_ProcessorError tests handling of processor callback errors
+func TestProcessTemplates_ProcessorError(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	templateContent := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: test-container
+    image: nginx:latest
+`
+
+	tmpl, err := texttemplate.New("test").Parse(templateContent)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"test-template": tmpl,
+	}
+
+	expectedError := errors.New("processor failed")
+	processor := func(templateName string, podSpec *models.PodSpec) error {
+		return expectedError
+	}
+
+	err = provider.ProcessTemplates(templates, nil, "test-instance", processor)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process template test-template")
+	assert.ErrorIs(t, err, expectedError)
+}
+
+// TestProcessTemplates_MixedErrors tests handling when some templates fail and some succeed
+func TestProcessTemplates_MixedErrors(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	goodTemplate := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: good-pod
+spec:
+  containers:
+  - name: container
+    image: nginx:latest
+`
+
+	badTemplate := `
+this is invalid yaml
+`
+
+	tmpl1, err := texttemplate.New("good").Parse(goodTemplate)
+	require.NoError(t, err)
+
+	tmpl2, err := texttemplate.New("bad").Parse(badTemplate)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"good-template": tmpl1,
+		"bad-template":  tmpl2,
+	}
+
+	processedCount := 0
+	processor := func(templateName string, podSpec *models.PodSpec) error {
+		processedCount++
+		return nil
+	}
+
+	err = provider.ProcessTemplates(templates, nil, "test-instance", processor)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process")
+	// Good template should still be processed
+	assert.Equal(t, 1, processedCount)
+}
+
+// TestCollectImagesFromTemplates_Success tests successful image collection
+func TestCollectImagesFromTemplates_Success(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	templateContent := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: app
+    image: nginx:1.21
+  - name: sidecar
+    image: busybox:latest
+  initContainers:
+  - name: init
+    image: alpine:3.14
+`
+
+	tmpl, err := texttemplate.New("test").Parse(templateContent)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"test-template": tmpl,
+	}
+
+	imageSet := make(map[string]bool)
+
+	err = provider.CollectImagesFromTemplates(templates, nil, imageSet)
+	require.NoError(t, err)
+
+	// Verify all images were collected
+	assert.Len(t, imageSet, 3)
+	assert.True(t, imageSet["nginx:1.21"])
+	assert.True(t, imageSet["busybox:latest"])
+	assert.True(t, imageSet["alpine:3.14"])
+}
+
+// TestCollectImagesFromTemplates_EmptyImages tests handling of pods without images
+func TestCollectImagesFromTemplates_EmptyImages(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	templateContent := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers: []
+`
+
+	tmpl, err := texttemplate.New("test").Parse(templateContent)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"test-template": tmpl,
+	}
+
+	imageSet := make(map[string]bool)
+
+	err = provider.CollectImagesFromTemplates(templates, nil, imageSet)
+	require.NoError(t, err)
+	assert.Empty(t, imageSet)
+}
+
+// TestCollectImagesFromTemplates_Deduplication tests that duplicate images are deduplicated
+func TestCollectImagesFromTemplates_Deduplication(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	template1 := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+spec:
+  containers:
+  - name: container1
+    image: nginx:latest
+`
+
+	template2 := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod2
+spec:
+  containers:
+  - name: container2
+    image: nginx:latest
+`
+
+	tmpl1, err := texttemplate.New("template1").Parse(template1)
+	require.NoError(t, err)
+
+	tmpl2, err := texttemplate.New("template2").Parse(template2)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"template1": tmpl1,
+		"template2": tmpl2,
+	}
+
+	imageSet := make(map[string]bool)
+
+	err = provider.CollectImagesFromTemplates(templates, nil, imageSet)
+	require.NoError(t, err)
+
+	// Should only have one entry despite two templates using the same image
+	assert.Len(t, imageSet, 1)
+	assert.True(t, imageSet["nginx:latest"])
+}
+
+// TestCollectImagesFromTemplates_WithValues tests image collection with template values
+func TestCollectImagesFromTemplates_WithValues(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	templateContent := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: app
+    image: {{ .Values.appImage }}
+  initContainers:
+  - name: init
+    image: {{ .Values.initImage }}
+`
+
+	tmpl, err := texttemplate.New("test").Parse(templateContent)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"test-template": tmpl,
+	}
+
+	values := map[string]any{
+		"appImage":  "myapp:v1.0.0",
+		"initImage": "myinit:v2.0.0",
+	}
+
+	imageSet := make(map[string]bool)
+
+	err = provider.CollectImagesFromTemplates(templates, values, imageSet)
+	require.NoError(t, err)
+
+	assert.Len(t, imageSet, 2)
+	assert.True(t, imageSet["myapp:v1.0.0"])
+	assert.True(t, imageSet["myinit:v2.0.0"])
+}
+
+// TestCollectImagesFromTemplates_Error tests error handling in image collection
+func TestCollectImagesFromTemplates_Error(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	// Template with invalid YAML
+	templateContent := `
+invalid yaml content [[[
+`
+
+	tmpl, err := texttemplate.New("test").Parse(templateContent)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"bad-template": tmpl,
+	}
+
+	imageSet := make(map[string]bool)
+
+	err = provider.CollectImagesFromTemplates(templates, nil, imageSet)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process")
+}
+
+// Made with Bob
+
+// TestCollectSpyreCardsFromTemplates_WithRealTemplates tests Spyre card collection using real templates from assets
+func TestCollectSpyreCardsFromTemplates_WithRealTemplates(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	// Load real vllm-spyre template (has 4 Spyre cards)
+	llmTemplateContent := `apiVersion: v1
+kind: Pod
+metadata:
+  name: "llm-{{ .InstanceSlug }}"
+  labels:
+    ai-services.io/template: "{{ .TemplateID }}"
+  annotations:
+    io.podman.annotations.ulimit: "nofile=134217728:134217728,memlock=-1:-1"
+    ai-services.io/llm--spyre-cards: "4"
+spec:
+  containers:
+    - name: llm
+      image: "{{ .Values.image }}"
+      resources:
+        requests:
+          podman.io/device=/dev/vfio: 4
+          memory: "150Gi"
+`
+
+	// Load real reranker-spyre template (has 1 Spyre card)
+	rerankerTemplateContent := `apiVersion: v1
+kind: Pod
+metadata:
+  name: "reranker-{{ .InstanceSlug }}"
+  labels:
+    ai-services.io/template: "{{ .TemplateID }}"
+  annotations:
+    io.podman.annotations.ulimit: "nofile=134217728:134217728,memlock=-1:-1"
+    ai-services.io/reranker--spyre-cards: "1"
+spec:
+  containers:
+    - name: reranker
+      image: "{{ .Values.image }}"
+      resources:
+        requests:
+          podman.io/device=/dev/vfio: 1
+          memory: "5Gi"
+`
+
+	llmTmpl, err := texttemplate.New("vllm-server").Parse(llmTemplateContent)
+	require.NoError(t, err)
+
+	rerankerTmpl, err := texttemplate.New("reranker-server").Parse(rerankerTemplateContent)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"vllm-server.yaml.tmpl":     llmTmpl,
+		"reranker-server.yaml.tmpl": rerankerTmpl,
+	}
+
+	values := map[string]any{
+		"image": "registry.redhat.io/rhaii/vllm-spyre-rhel9:3.4.0",
+	}
+
+	totalCards, err := provider.CollectSpyreCardsFromTemplates(templates, values)
+	require.NoError(t, err)
+
+	// Should have 4 + 1 = 5 total Spyre cards
+	assert.Equal(t, 5, totalCards)
+}
+
+// TestCollectSpyreCardsFromTemplates_NoSpyreCards tests when templates have no Spyre card annotations
+func TestCollectSpyreCardsFromTemplates_NoSpyreCards(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	// Template without Spyre card annotations
+	templateContent := `apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  annotations:
+    some.other/annotation: "value"
+spec:
+  containers:
+  - name: test-container
+    image: nginx:latest
+`
+
+	tmpl, err := texttemplate.New("test").Parse(templateContent)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"test-template": tmpl,
+	}
+
+	values := map[string]any{}
+
+	totalCards, err := provider.CollectSpyreCardsFromTemplates(templates, values)
+	require.NoError(t, err)
+
+	// Should have 0 Spyre cards
+	assert.Equal(t, 0, totalCards)
+}
+
+// TestCollectSpyreCardsFromTemplates_MultipleContainers tests multiple containers with different Spyre card counts
+func TestCollectSpyreCardsFromTemplates_MultipleContainers(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	templateContent := `apiVersion: v1
+kind: Pod
+metadata:
+  name: multi-container-pod
+  annotations:
+    ai-services.io/container1--spyre-cards: "2"
+    ai-services.io/container2--spyre-cards: "3"
+    ai-services.io/container3--spyre-cards: "1"
+spec:
+  containers:
+  - name: container1
+    image: image1:latest
+  - name: container2
+    image: image2:latest
+  - name: container3
+    image: image3:latest
+`
+
+	tmpl, err := texttemplate.New("multi").Parse(templateContent)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"multi-template": tmpl,
+	}
+
+	values := map[string]any{}
+
+	totalCards, err := provider.CollectSpyreCardsFromTemplates(templates, values)
+	require.NoError(t, err)
+
+	// Should have 2 + 3 + 1 = 6 total Spyre cards
+	assert.Equal(t, 6, totalCards)
+}
+
+// TestCollectSpyreCardsFromTemplates_InvalidAnnotationValue tests error handling for invalid annotation values
+func TestCollectSpyreCardsFromTemplates_InvalidAnnotationValue(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	templateContent := `apiVersion: v1
+kind: Pod
+metadata:
+  name: invalid-pod
+  annotations:
+    ai-services.io/container1--spyre-cards: "not-a-number"
+spec:
+  containers:
+  - name: container1
+    image: image1:latest
+`
+
+	tmpl, err := texttemplate.New("invalid").Parse(templateContent)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"invalid-template": tmpl,
+	}
+
+	values := map[string]any{}
+
+	totalCards, err := provider.CollectSpyreCardsFromTemplates(templates, values)
+
+	// Should return an error
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to convert to int")
+	assert.Equal(t, 0, totalCards)
+}
+
+// TestCollectSpyreCardsFromTemplates_MixedTemplates tests a mix of templates with and without Spyre cards
+func TestCollectSpyreCardsFromTemplates_MixedTemplates(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	// Template with Spyre cards
+	template1Content := `apiVersion: v1
+kind: Pod
+metadata:
+  name: spyre-pod
+  annotations:
+    ai-services.io/llm--spyre-cards: "4"
+spec:
+  containers:
+  - name: llm
+    image: vllm:latest
+`
+
+	// Template without Spyre cards
+	template2Content := `apiVersion: v1
+kind: Pod
+metadata:
+  name: regular-pod
+spec:
+  containers:
+  - name: app
+    image: app:latest
+`
+
+	// Another template with Spyre cards
+	template3Content := `apiVersion: v1
+kind: Pod
+metadata:
+  name: another-spyre-pod
+  annotations:
+    ai-services.io/reranker--spyre-cards: "2"
+spec:
+  containers:
+  - name: reranker
+    image: reranker:latest
+`
+
+	tmpl1, err := texttemplate.New("spyre1").Parse(template1Content)
+	require.NoError(t, err)
+
+	tmpl2, err := texttemplate.New("regular").Parse(template2Content)
+	require.NoError(t, err)
+
+	tmpl3, err := texttemplate.New("spyre2").Parse(template3Content)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"spyre-template1":  tmpl1,
+		"regular-template": tmpl2,
+		"spyre-template2":  tmpl3,
+	}
+
+	values := map[string]any{}
+
+	totalCards, err := provider.CollectSpyreCardsFromTemplates(templates, values)
+	require.NoError(t, err)
+
+	// Should have 4 + 0 + 2 = 6 total Spyre cards
+	assert.Equal(t, 6, totalCards)
+}
+
+// TestCollectSpyreCardsFromTemplates_TemplateRenderError tests error handling when template rendering fails
+func TestCollectSpyreCardsFromTemplates_TemplateRenderError(t *testing.T) {
+	provider := &CatalogProvider{}
+
+	// Template with undefined variable that will cause render error
+	templateContent := `apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .UndefinedVariable }}
+  annotations:
+    ai-services.io/llm--spyre-cards: "4"
+spec:
+  containers:
+  - name: test
+    image: test:latest
+`
+
+	tmpl, err := texttemplate.New("error").Option("missingkey=error").Parse(templateContent)
+	require.NoError(t, err)
+
+	templates := map[string]*texttemplate.Template{
+		"error-template": tmpl,
+	}
+
+	values := map[string]any{}
+
+	totalCards, err := provider.CollectSpyreCardsFromTemplates(templates, values)
+
+	// Should return an error
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process")
+	assert.Equal(t, 0, totalCards)
+}
+
+// TestFetchSpyreCardsFromPodAnnotations tests the helper function directly
+func TestFetchSpyreCardsFromPodAnnotations(t *testing.T) {
+	tests := []struct {
+		name                 string
+		annotations          map[string]string
+		expectedTotal        int
+		expectedContainerMap map[string]int
+		expectError          bool
+	}{
+		{
+			name: "single container with Spyre cards",
+			annotations: map[string]string{
+				"ai-services.io/llm--spyre-cards": "4",
+			},
+			expectedTotal: 4,
+			expectedContainerMap: map[string]int{
+				"llm": 4,
+			},
+			expectError: false,
+		},
+		{
+			name: "multiple containers with Spyre cards",
+			annotations: map[string]string{
+				"ai-services.io/llm--spyre-cards":      "4",
+				"ai-services.io/reranker--spyre-cards": "1",
+			},
+			expectedTotal: 5,
+			expectedContainerMap: map[string]int{
+				"llm":      4,
+				"reranker": 1,
+			},
+			expectError: false,
+		},
+		{
+			name: "no Spyre card annotations",
+			annotations: map[string]string{
+				"some.other/annotation": "value",
+			},
+			expectedTotal:        0,
+			expectedContainerMap: map[string]int{},
+			expectError:          false,
+		},
+		{
+			name: "invalid annotation value",
+			annotations: map[string]string{
+				"ai-services.io/llm--spyre-cards": "not-a-number",
+			},
+			expectedTotal:        0,
+			expectedContainerMap: map[string]int{},
+			expectError:          true,
+		},
+		{
+			name: "container name with special characters",
+			annotations: map[string]string{
+				"ai-services.io/my-container-123--spyre-cards": "2",
+			},
+			expectedTotal: 2,
+			expectedContainerMap: map[string]int{
+				"my-container-123": 2,
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			total, containerMap, err := fetchSpyreCardsFromPodAnnotations(tt.annotations)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedTotal, total)
+				assert.Equal(t, tt.expectedContainerMap, containerMap)
+			}
+		})
+	}
+}

--- a/ai-services/internal/pkg/catalog/template_extractor_test.go
+++ b/ai-services/internal/pkg/catalog/template_extractor_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestProcessTemplates_Success tests successful template processing
+// TestProcessTemplates_Success tests successful template processing.
 func TestProcessTemplates_Success(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -46,6 +46,7 @@ spec:
 
 	processor := func(templateName string, podSpec *models.PodSpec) error {
 		processedTemplates[templateName] = podSpec
+
 		return nil
 	}
 
@@ -64,7 +65,7 @@ spec:
 	assert.Equal(t, "busybox:latest", podSpec.Spec.InitContainers[0].Image)
 }
 
-// TestProcessTemplates_MultipleTemplates tests processing multiple templates
+// TestProcessTemplates_MultipleTemplates tests processing multiple templates.
 func TestProcessTemplates_MultipleTemplates(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -104,6 +105,7 @@ spec:
 	processedCount := 0
 	processor := func(templateName string, podSpec *models.PodSpec) error {
 		processedCount++
+
 		return nil
 	}
 
@@ -112,7 +114,7 @@ spec:
 	assert.Equal(t, 2, processedCount)
 }
 
-// TestProcessTemplates_RenderError tests handling of template rendering errors
+// TestProcessTemplates_RenderError tests handling of template rendering errors.
 func TestProcessTemplates_RenderError(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -140,7 +142,7 @@ metadata:
 	assert.Contains(t, err.Error(), "failed to process")
 }
 
-// TestProcessTemplates_ParseError tests handling of YAML parsing errors
+// TestProcessTemplates_ParseError tests handling of YAML parsing errors.
 func TestProcessTemplates_ParseError(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -165,7 +167,7 @@ this is not valid yaml: [[[
 	assert.Contains(t, err.Error(), "failed to process")
 }
 
-// TestProcessTemplates_ProcessorError tests handling of processor callback errors
+// TestProcessTemplates_ProcessorError tests handling of processor callback errors.
 func TestProcessTemplates_ProcessorError(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -198,7 +200,7 @@ spec:
 	assert.ErrorIs(t, err, expectedError)
 }
 
-// TestProcessTemplates_MixedErrors tests handling when some templates fail and some succeed
+// TestProcessTemplates_MixedErrors tests handling when some templates fail and some succeed.
 func TestProcessTemplates_MixedErrors(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -231,6 +233,7 @@ this is invalid yaml
 	processedCount := 0
 	processor := func(templateName string, podSpec *models.PodSpec) error {
 		processedCount++
+
 		return nil
 	}
 
@@ -241,7 +244,7 @@ this is invalid yaml
 	assert.Equal(t, 1, processedCount)
 }
 
-// TestCollectImagesFromTemplates_Success tests successful image collection
+// TestCollectImagesFromTemplates_Success tests successful image collection.
 func TestCollectImagesFromTemplates_Success(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -280,7 +283,7 @@ spec:
 	assert.True(t, imageSet["alpine:3.14"])
 }
 
-// TestCollectImagesFromTemplates_EmptyImages tests handling of pods without images
+// TestCollectImagesFromTemplates_EmptyImages tests handling of pods without images.
 func TestCollectImagesFromTemplates_EmptyImages(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -307,7 +310,7 @@ spec:
 	assert.Empty(t, imageSet)
 }
 
-// TestCollectImagesFromTemplates_Deduplication tests that duplicate images are deduplicated
+// TestCollectImagesFromTemplates_Deduplication tests that duplicate images are deduplicated.
 func TestCollectImagesFromTemplates_Deduplication(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -354,7 +357,7 @@ spec:
 	assert.True(t, imageSet["nginx:latest"])
 }
 
-// TestCollectImagesFromTemplates_WithValues tests image collection with template values
+// TestCollectImagesFromTemplates_WithValues tests image collection with template values.
 func TestCollectImagesFromTemplates_WithValues(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -394,7 +397,7 @@ spec:
 	assert.True(t, imageSet["myinit:v2.0.0"])
 }
 
-// TestCollectImagesFromTemplates_Error tests error handling in image collection
+// TestCollectImagesFromTemplates_Error tests error handling in image collection.
 func TestCollectImagesFromTemplates_Error(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -419,7 +422,7 @@ invalid yaml content [[[
 
 // Made with Bob
 
-// TestCollectSpyreCardsFromTemplates_WithRealTemplates tests Spyre card collection using real templates from assets
+// TestCollectSpyreCardsFromTemplates_WithRealTemplates tests Spyre card collection using real templates from assets.
 func TestCollectSpyreCardsFromTemplates_WithRealTemplates(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -485,7 +488,7 @@ spec:
 	assert.Equal(t, 5, totalCards)
 }
 
-// TestCollectSpyreCardsFromTemplates_NoSpyreCards tests when templates have no Spyre card annotations
+// TestCollectSpyreCardsFromTemplates_NoSpyreCards tests when templates have no Spyre card annotations.
 func TestCollectSpyreCardsFromTemplates_NoSpyreCards(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -518,7 +521,7 @@ spec:
 	assert.Equal(t, 0, totalCards)
 }
 
-// TestCollectSpyreCardsFromTemplates_MultipleContainers tests multiple containers with different Spyre card counts
+// TestCollectSpyreCardsFromTemplates_MultipleContainers tests multiple containers with different Spyre card counts.
 func TestCollectSpyreCardsFromTemplates_MultipleContainers(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -556,7 +559,7 @@ spec:
 	assert.Equal(t, 6, totalCards)
 }
 
-// TestCollectSpyreCardsFromTemplates_InvalidAnnotationValue tests error handling for invalid annotation values
+// TestCollectSpyreCardsFromTemplates_InvalidAnnotationValue tests error handling for invalid annotation values.
 func TestCollectSpyreCardsFromTemplates_InvalidAnnotationValue(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -589,7 +592,7 @@ spec:
 	assert.Equal(t, 0, totalCards)
 }
 
-// TestCollectSpyreCardsFromTemplates_MixedTemplates tests a mix of templates with and without Spyre cards
+// TestCollectSpyreCardsFromTemplates_MixedTemplates tests a mix of templates with and without Spyre cards.
 func TestCollectSpyreCardsFromTemplates_MixedTemplates(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -654,7 +657,7 @@ spec:
 	assert.Equal(t, 6, totalCards)
 }
 
-// TestCollectSpyreCardsFromTemplates_TemplateRenderError tests error handling when template rendering fails
+// TestCollectSpyreCardsFromTemplates_TemplateRenderError tests error handling when template rendering fails.
 func TestCollectSpyreCardsFromTemplates_TemplateRenderError(t *testing.T) {
 	provider := &CatalogProvider{}
 
@@ -688,9 +691,17 @@ spec:
 	assert.Equal(t, 0, totalCards)
 }
 
-// TestFetchSpyreCardsFromPodAnnotations tests the helper function directly
-func TestFetchSpyreCardsFromPodAnnotations(t *testing.T) {
-	tests := []struct {
+// getSpyreCardTestCases returns test cases for Spyre card annotation parsing.
+//
+//nolint:funlen // Test data structure is intentionally long for comprehensive coverage
+func getSpyreCardTestCases() []struct {
+	name                 string
+	annotations          map[string]string
+	expectedTotal        int
+	expectedContainerMap map[string]int
+	expectError          bool
+} {
+	return []struct {
 		name                 string
 		annotations          map[string]string
 		expectedTotal        int
@@ -751,6 +762,11 @@ func TestFetchSpyreCardsFromPodAnnotations(t *testing.T) {
 			expectError: false,
 		},
 	}
+}
+
+// TestFetchSpyreCardsFromPodAnnotations tests the helper function directly.
+func TestFetchSpyreCardsFromPodAnnotations(t *testing.T) {
+	tests := getSpyreCardTestCases()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This refactor will help in writing new code for image list/pull cli.

1. `CollectImagesFromTemplates` will be reused and does append images to the imageSet by using the given templates.
2. Also collecting images specified in `podSpec.Spec.InitContainers`