### PR TITLE
migrating cli start cmd to use catalog structure 

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.61
+TAG?=0.0.62
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.61
+  image: icr.io/ai-services-cicd/ai-services:0.0.62
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/application/logs.go
+++ b/ai-services/cmd/ai-services/cmd/application/logs.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
+	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	appFlags "github.com/project-ai-services/ai-services/internal/pkg/cli/constants/application"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/flagvalidator"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
@@ -50,7 +51,11 @@ Arguments
 		// When experimentalLogs is true and runtime is podman, validate application name using catalog API
 		// For openshift runtime, always use the older/stable code path regardless of experimental flag
 		if experimentalLogs && rt == types.RuntimeTypePodman {
-			if err := utils.ValidateApplicationName(applicationName); err != nil {
+			appClient, err := catalogClient.NewApplicationClient()
+			if err != nil {
+				return fmt.Errorf("failed to create application client: %w", err)
+			}
+			if _, err := utils.GetAppByName(appClient, applicationName); err != nil {
 				return err
 			}
 		}

--- a/ai-services/cmd/ai-services/cmd/application/logs.go
+++ b/ai-services/cmd/ai-services/cmd/application/logs.go
@@ -81,7 +81,7 @@ func init() {
 }
 
 func initLogsCommonFlags() {
-	logsCmd.Flags().BoolVar(&experimentalLogs, "experimental", false, "Include experimental application templates")
+	logsCmd.Flags().BoolVar(&experimentalLogs, "experimental", false, "Include experimental application logs")
 	logsCmd.Flags().StringVar(&podName, appFlags.Logs.Pod, "", "Pod name to show logs from (required)")
 	logsCmd.Flags().StringVar(&containerNameOrID, appFlags.Logs.Container, "", "Container logs to show logs from (Optional)")
 	_ = logsCmd.MarkFlagRequired(appFlags.Logs.Pod)

--- a/ai-services/cmd/ai-services/cmd/application/start.go
+++ b/ai-services/cmd/ai-services/cmd/application/start.go
@@ -5,14 +5,18 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
+	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
+	"github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	"github.com/spf13/cobra"
 )
 
 var (
-	skipLogs      bool
-	startPodNames []string
-	autoYes       bool
+	skipLogs          bool
+	startPodNames     []string
+	autoYes           bool
+	experimentalStart bool
 )
 
 var startCmd = &cobra.Command{
@@ -45,6 +49,23 @@ Note: Supported for podman runtime only.
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
+		// When experimentalLogs is true and runtime is podman, validate application name using catalog API
+		// For openshift runtime, always use the older/stable code path regardless of experimental flag
+		if experimentalStart && rt == types.RuntimeTypePodman {
+			// users need to specify at least one pod to start, using --pod flag in experimental mode
+			// as we cannot start all pods like we used to for legacy mode
+			if len(startPodNames) == 0 {
+				return fmt.Errorf("must specify at least one pod to start using --pod flag")
+			}
+			appClient, err := catalogClient.NewApplicationClient()
+			if err != nil {
+				return fmt.Errorf("failed to create application client: %w", err)
+			}
+			if _, err := utils.GetAppByName(appClient, applicationName); err != nil {
+				return err
+			}
+		}
+
 		// Create application instance using factory
 		factory := application.NewFactory(rt)
 		app, err := factory.Create(applicationName)
@@ -54,10 +75,11 @@ Note: Supported for podman runtime only.
 
 		// start application with options
 		opts := appTypes.StartOptions{
-			Name:     applicationName,
-			PodNames: startPodNames,
-			AutoYes:  autoYes,
-			SkipLogs: skipLogs,
+			Name:         applicationName,
+			PodNames:     startPodNames,
+			AutoYes:      autoYes,
+			SkipLogs:     skipLogs,
+			Experimental: experimentalStart,
 		}
 
 		return app.Start(opts)
@@ -65,6 +87,7 @@ Note: Supported for podman runtime only.
 }
 
 func init() {
+	startCmd.Flags().BoolVar(&experimentalStart, "experimental", false, "Include experimental application start")
 	startCmd.Flags().StringSlice("pod", []string{}, "Specific pod name(s) to start (optional)\nCan be specified multiple times: --pod pod1 --pod pod2\nOr comma-separated: --pod pod1,pod2")
 	startCmd.Flags().BoolVar(&skipLogs, "skip-logs", false, "Skip displaying logs after starting the pod")
 	startCmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "Automatically accept all confirmation prompts (default=false)")

--- a/ai-services/cmd/ai-services/cmd/application/start.go
+++ b/ai-services/cmd/ai-services/cmd/application/start.go
@@ -52,11 +52,6 @@ Note: Supported for podman runtime only.
 		// When experimentalLogs is true and runtime is podman, validate application name using catalog API
 		// For openshift runtime, always use the older/stable code path regardless of experimental flag
 		if experimentalStart && rt == types.RuntimeTypePodman {
-			// users need to specify at least one pod to start, using --pod flag in experimental mode
-			// as we cannot start all pods like we used to for legacy mode
-			if len(startPodNames) == 0 {
-				return fmt.Errorf("must specify at least one pod to start using --pod flag")
-			}
 			appClient, err := catalogClient.NewApplicationClient()
 			if err != nil {
 				return fmt.Errorf("failed to create application client: %w", err)

--- a/ai-services/cmd/ai-services/cmd/application/start.go
+++ b/ai-services/cmd/ai-services/cmd/application/start.go
@@ -49,7 +49,7 @@ Note: Supported for podman runtime only.
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
-		// When experimentalLogs is true and runtime is podman, validate application name using catalog API
+		// When experimentalStart is true and runtime is podman, validate application name using catalog API
 		// For openshift runtime, always use the older/stable code path regardless of experimental flag
 		if experimentalStart && rt == types.RuntimeTypePodman {
 			appClient, err := catalogClient.NewApplicationClient()

--- a/ai-services/internal/pkg/application/podman/start.go
+++ b/ai-services/internal/pkg/application/podman/start.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
-	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	cliutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
@@ -24,7 +23,7 @@ func (p *PodmanApplication) Start(opts appTypes.StartOptions) error {
 			return err
 		}
 	} else {
-		pods, err = p.getPodsFromApplicationsPS(opts.Name)
+		pods, err = cliutils.GetPodsFromApplicationsPS(opts.Name)
 		if err != nil {
 			return err
 		}
@@ -48,44 +47,6 @@ func (p *PodmanApplication) Start(opts appTypes.StartOptions) error {
 	}
 
 	return p.confirmAndStartPods(podsToStart, opts.AutoYes, opts.SkipLogs)
-}
-
-func (p *PodmanApplication) getPodsFromApplicationsPS(appName string) ([]types.Pod, error) {
-	var pods []types.Pod //nolint: prealloc
-	appClient, err := catalogClient.NewApplicationClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create application client: %w", err)
-	}
-
-	app, err := cliutils.GetAppByName(appClient, appName)
-	if err != nil {
-		return nil, err
-	}
-
-	psResp, err := appClient.GetApplicationPS(app.ID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch application: %w", err)
-	}
-
-	// add components to the list of pods
-	for _, resp := range psResp.Components {
-		pod := types.Pod{
-			ID:   resp.PodName,
-			Name: resp.PodName,
-		}
-		pods = append(pods, pod)
-	}
-
-	// add services to the list of pods
-	for _, resp := range psResp.Services {
-		pod := types.Pod{
-			ID:   resp.PodName,
-			Name: resp.PodName,
-		}
-		pods = append(pods, pod)
-	}
-
-	return pods, nil
 }
 
 // Start implementation helper methods.

--- a/ai-services/internal/pkg/application/podman/start.go
+++ b/ai-services/internal/pkg/application/podman/start.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
+	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
+	cliutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
@@ -13,21 +15,21 @@ import (
 
 // Start starts a stopped application.
 func (p *PodmanApplication) Start(opts appTypes.StartOptions) error {
-	var filter map[string][]string
 	var pods []types.Pod
-	// if experimental mode is enabled, we should not be filtering based on label,
-	// as the application label is not set as per new catalog structure.
-	// so we list all pods and then filter based on pod names.
+	var err error
+	// if experimental flag is set, get pods from applications-ps
 	if !opts.Experimental {
-		filter = map[string][]string{
-			"label": {fmt.Sprintf("ai-services.io/application=%s", opts.Name)},
+		pods, err = p.fetchPodsFromRuntime(opts.Name)
+		if err != nil {
+			return err
+		}
+	} else {
+		pods, err = p.getPodsFromApplicationsPS(opts.Name)
+		if err != nil {
+			return err
 		}
 	}
 
-	pods, err := p.fetchPodsFromRuntime(filter)
-	if err != nil {
-		return err
-	}
 	if len(pods) == 0 {
 		logger.Infof("No pods found with given application: %s\n", opts.Name)
 
@@ -35,7 +37,7 @@ func (p *PodmanApplication) Start(opts appTypes.StartOptions) error {
 	}
 
 	// Filter pods based on provided pod names or annotation
-	podsToStart, err := p.fetchPodsToStart(pods, opts.PodNames, opts.Experimental)
+	podsToStart, err := p.fetchPodsToStart(pods, opts.PodNames)
 	if err != nil {
 		return err
 	}
@@ -48,9 +50,49 @@ func (p *PodmanApplication) Start(opts appTypes.StartOptions) error {
 	return p.confirmAndStartPods(podsToStart, opts.AutoYes, opts.SkipLogs)
 }
 
+func (p *PodmanApplication) getPodsFromApplicationsPS(appName string) ([]types.Pod, error) {
+	var pods []types.Pod //nolint: prealloc
+	appClient, err := catalogClient.NewApplicationClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create application client: %w", err)
+	}
+
+	app, err := cliutils.GetAppByName(appClient, appName)
+	if err != nil {
+		return nil, err
+	}
+
+	psResp, err := appClient.GetApplicationPS(app.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch application: %w", err)
+	}
+
+	// add components to the list of pods
+	for _, resp := range psResp.Components {
+		pod := types.Pod{
+			ID:   resp.PodName,
+			Name: resp.PodName,
+		}
+		pods = append(pods, pod)
+	}
+
+	// add services to the list of pods
+	for _, resp := range psResp.Services {
+		pod := types.Pod{
+			ID:   resp.PodName,
+			Name: resp.PodName,
+		}
+		pods = append(pods, pod)
+	}
+
+	return pods, nil
+}
+
 // Start implementation helper methods.
-func (p *PodmanApplication) fetchPodsFromRuntime(filter map[string][]string) ([]types.Pod, error) {
-	pods, err := p.runtime.ListPods(filter)
+func (p *PodmanApplication) fetchPodsFromRuntime(appName string) ([]types.Pod, error) {
+	pods, err := p.runtime.ListPods(map[string][]string{
+		"label": {fmt.Sprintf("ai-services.io/application=%s", appName)},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods: %w", err)
 	}
@@ -58,19 +100,12 @@ func (p *PodmanApplication) fetchPodsFromRuntime(filter map[string][]string) ([]
 	return pods, nil
 }
 
-func (p *PodmanApplication) fetchPodsToStart(pods []types.Pod, podNames []string, experimental bool) ([]types.Pod, error) {
+func (p *PodmanApplication) fetchPodsToStart(pods []types.Pod, podNames []string) ([]types.Pod, error) {
 	if len(podNames) > 0 {
 		return p.filterPodsByNameForStart(pods, podNames)
 	}
-
-	// not filtering based on annotations if experimental mode is enabled,
-	// to avoid starting of all pods, since we are listing all of them.
-	if !experimental {
-		// No pod names provided, start pods based on annotation
-		return p.filterPodsByAnnotationForStart(pods)
-	}
-
-	return nil, fmt.Errorf("no matching pods found")
+	// No pod names provided, start pods based on annotation
+	return p.filterPodsByAnnotationForStart(pods)
 }
 
 func (p *PodmanApplication) confirmAndStartPods(podsToStart []types.Pod, autoYes, skipLogs bool) error {

--- a/ai-services/internal/pkg/application/podman/start.go
+++ b/ai-services/internal/pkg/application/podman/start.go
@@ -13,7 +13,18 @@ import (
 
 // Start starts a stopped application.
 func (p *PodmanApplication) Start(opts appTypes.StartOptions) error {
-	pods, err := p.fetchPodsFromRuntime(opts.Name)
+	var filter map[string][]string
+	var pods []types.Pod
+	// if experimental mode is enabled, we should not be filtering based on label,
+	// as the application label is not set as per new catalog structure.
+	// so we list all pods and then filter based on pod names.
+	if !opts.Experimental {
+		filter = map[string][]string{
+			"label": {fmt.Sprintf("ai-services.io/application=%s", opts.Name)},
+		}
+	}
+
+	pods, err := p.fetchPodsFromRuntime(filter)
 	if err != nil {
 		return err
 	}
@@ -24,7 +35,7 @@ func (p *PodmanApplication) Start(opts appTypes.StartOptions) error {
 	}
 
 	// Filter pods based on provided pod names or annotation
-	podsToStart, err := p.fetchPodsToStart(pods, opts.PodNames)
+	podsToStart, err := p.fetchPodsToStart(pods, opts.PodNames, opts.Experimental)
 	if err != nil {
 		return err
 	}
@@ -38,10 +49,8 @@ func (p *PodmanApplication) Start(opts appTypes.StartOptions) error {
 }
 
 // Start implementation helper methods.
-func (p *PodmanApplication) fetchPodsFromRuntime(appName string) ([]types.Pod, error) {
-	pods, err := p.runtime.ListPods(map[string][]string{
-		"label": {fmt.Sprintf("ai-services.io/application=%s", appName)},
-	})
+func (p *PodmanApplication) fetchPodsFromRuntime(filter map[string][]string) ([]types.Pod, error) {
+	pods, err := p.runtime.ListPods(filter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods: %w", err)
 	}
@@ -49,12 +58,19 @@ func (p *PodmanApplication) fetchPodsFromRuntime(appName string) ([]types.Pod, e
 	return pods, nil
 }
 
-func (p *PodmanApplication) fetchPodsToStart(pods []types.Pod, podNames []string) ([]types.Pod, error) {
+func (p *PodmanApplication) fetchPodsToStart(pods []types.Pod, podNames []string, experimental bool) ([]types.Pod, error) {
 	if len(podNames) > 0 {
 		return p.filterPodsByNameForStart(pods, podNames)
 	}
-	// No pod names provided, start pods based on annotation
-	return p.filterPodsByAnnotationForStart(pods)
+
+	// not filtering based on annotations if experimental mode is enabled,
+	// to avoid starting of all pods, since we are listing all of them.
+	if !experimental {
+		// No pod names provided, start pods based on annotation
+		return p.filterPodsByAnnotationForStart(pods)
+	}
+
+	return nil, fmt.Errorf("no matching pods found")
 }
 
 func (p *PodmanApplication) confirmAndStartPods(podsToStart []types.Pod, autoYes, skipLogs bool) error {

--- a/ai-services/internal/pkg/application/types/types.go
+++ b/ai-services/internal/pkg/application/types/types.go
@@ -39,10 +39,11 @@ type DeleteOptions struct {
 
 // StartOptions contains parameters for starting an application.
 type StartOptions struct {
-	Name     string
-	PodNames []string
-	SkipLogs bool
-	AutoYes  bool
+	Name         string
+	PodNames     []string
+	SkipLogs     bool
+	AutoYes      bool
+	Experimental bool
 }
 
 // StopOptions contains parameters for stopping an application.

--- a/ai-services/internal/pkg/cli/utils/common.go
+++ b/ai-services/internal/pkg/cli/utils/common.go
@@ -9,6 +9,7 @@ import (
 	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
@@ -96,4 +97,42 @@ func getContainerNamesFromAPI(pod catalogTypes.Pod) []string {
 	}
 
 	return containerNames
+}
+
+func GetPodsFromApplicationsPS(appName string) ([]types.Pod, error) {
+	var pods []types.Pod //nolint: prealloc
+	appClient, err := catalogClient.NewApplicationClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create application client: %w", err)
+	}
+
+	app, err := GetAppByName(appClient, appName)
+	if err != nil {
+		return nil, err
+	}
+
+	psResp, err := appClient.GetApplicationPS(app.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch application: %w", err)
+	}
+
+	// add components to the list of pods
+	for _, resp := range psResp.Components {
+		pod := types.Pod{
+			ID:   resp.PodName,
+			Name: resp.PodName,
+		}
+		pods = append(pods, pod)
+	}
+
+	// add services to the list of pods
+	for _, resp := range psResp.Services {
+		pod := types.Pod{
+			ID:   resp.PodName,
+			Name: resp.PodName,
+		}
+		pods = append(pods, pod)
+	}
+
+	return pods, nil
 }

--- a/ai-services/internal/pkg/cli/utils/common.go
+++ b/ai-services/internal/pkg/cli/utils/common.go
@@ -97,18 +97,3 @@ func getContainerNamesFromAPI(pod catalogTypes.Pod) []string {
 
 	return containerNames
 }
-
-func ValidateApplicationName(appName string) error {
-	appClient, err := catalogClient.NewApplicationClient()
-	if err != nil {
-		return fmt.Errorf("failed to create application client: %w", err)
-	}
-
-	// Fetch specific application by name
-	_, err = GetAppByName(appClient, appName)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}


### PR DESCRIPTION
1. Added experimental mode for starting application pods via CLI.
2. If experimental mode is enabled, we do not filter pods via label, but fetch all pods using application ps api