### PR TITLE
fix the dependbot alerts for alredy fixed items

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.60
+TAG?=0.0.61
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.15
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.16
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
@@ -85,7 +85,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.6
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.7
   # @hidden
   log_level: "INFO"
   database: "summarize_metadata"
@@ -94,7 +94,7 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.6
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.7
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.10
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.11
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -12,7 +12,7 @@ backend:
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.6
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.7
   # @hidden
   log_level: "INFO"
   # @description Database name for the SUMMARIZE service. Default is "summarize_metadata".
@@ -20,13 +20,13 @@ summarize:
 
 similarity:
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.6
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.7
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.15
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.16
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.10
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.11
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.15
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.16
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
@@ -83,7 +83,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.6
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.7
   # @hidden
   log_level: "INFO"
   database: "summarize_metadata"
@@ -92,7 +92,7 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.6
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.7
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.10
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.11
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -12,7 +12,7 @@ backend:
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.6
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.7
   # @hidden
   log_level: "INFO"
   # @description Database name for the SUMMARIZE service. Default is "summarize_metadata".
@@ -20,13 +20,13 @@ summarize:
 
 similarity:
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.6
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.7
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.15
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.16
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.10
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.11
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.15
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.16
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
@@ -83,7 +83,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.6
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.7
   # @hidden
   log_level: "INFO"
   database: "summarize_metadata"
@@ -92,7 +92,7 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.6
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.7
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.10
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.11
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.60
+  image: icr.io/ai-services-cicd/ai-services:0.0.61
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/chat/podman/values.yaml
+++ b/ai-services/assets/services/chat/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.10
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.11
   log_level: "INFO"
   chatbot:
     searchMode: "hybrid"

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,6 +1,6 @@
 digitize:
   port: ""
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.15
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.16
   log_level: "INFO"
   database: "digitize_metadata"
 

--- a/ai-services/assets/services/similarity/podman/values.yaml
+++ b/ai-services/assets/services/similarity/podman/values.yaml
@@ -1,6 +1,6 @@
 similarity:
   port: ""
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.6
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.7
   log_level: "INFO"
 
 # Made with Bob

--- a/ai-services/assets/services/summarize/podman/values.yaml
+++ b/ai-services/assets/services/summarize/podman/values.yaml
@@ -1,6 +1,6 @@
 summarize:
   port: ""
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.6
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.7
   log_level: "INFO"
   database: "summarize_metadata"
 

--- a/services/chatbot/Containerfile
+++ b/services/chatbot/Containerfile
@@ -7,7 +7,8 @@ ENV PYTHONPATH=/opt/services
 COPY common /opt/services/common
 COPY chatbot/ .
 
-RUN source /var/venv/bin/activate && pip install -r requirements.txt && pip cache purge
+# Uncomment when you have chatbot specific requirements.txt
+# RUN source /var/venv/bin/activate && pip install -r requirements.txt && pip cache purge
 
 CMD ["/var/venv/bin/python", "-m", "uvicorn", "app:app", \
      "--host", "0.0.0.0", "--port", "5000", \

--- a/services/chatbot/Makefile
+++ b/services/chatbot/Makefile
@@ -1,5 +1,5 @@
 IMAGE=chatbot-service
-TAG?=v0.0.10
+TAG?=v0.0.11
 
 run:
 	PORT=$${PORT:-5000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/chatbot/requirements.txt
+++ b/services/chatbot/requirements.txt
@@ -1,1 +1,0 @@
-# chatbot-specific dependencies beyond services-common

--- a/services/digitize/Containerfile
+++ b/services/digitize/Containerfile
@@ -7,7 +7,8 @@ ENV PYTHONPATH=/opt/services
 COPY common /opt/services/common
 COPY digitize/ .
 
-RUN source /var/venv/bin/activate && pip install -r requirements.txt && pip cache purge
+# Uncomment when you have digitize specific requirements.txt
+# RUN source /var/venv/bin/activate && pip install -r requirements.txt && pip cache purge
 
 CMD ["/var/venv/bin/python", "-m", "uvicorn", "app:app", \
      "--host", "0.0.0.0", "--port", "4000", \

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.15
+TAG?=v0.0.16
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/requirements.txt
+++ b/services/digitize/requirements.txt
@@ -1,1 +1,0 @@
-# digitize-specific dependencies beyond services-common

--- a/services/similarity/Containerfile
+++ b/services/similarity/Containerfile
@@ -7,7 +7,8 @@ ENV PYTHONPATH=/opt/services
 COPY common /opt/services/common
 COPY similarity/ .
 
-RUN source /var/venv/bin/activate && pip install -r requirements.txt && pip cache purge
+# Uncomment when you have similarity specific requirements.txt
+# RUN source /var/venv/bin/activate && pip install -r requirements.txt && pip cache purge
 
 CMD ["/var/venv/bin/python", "-m", "uvicorn", "app:app", \
      "--host", "0.0.0.0", "--port", "7000", \

--- a/services/similarity/Makefile
+++ b/services/similarity/Makefile
@@ -1,5 +1,5 @@
 IMAGE=similarity-service
-TAG?=v0.0.6
+TAG?=v0.0.7
 
 run:
 	PORT=$${PORT:-7000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/similarity/requirements.txt
+++ b/services/similarity/requirements.txt
@@ -1,1 +1,0 @@
-# similarity-specific dependencies beyond services-common

--- a/services/summarize/Containerfile
+++ b/services/summarize/Containerfile
@@ -7,7 +7,8 @@ ENV PYTHONPATH=/opt/services
 COPY common /opt/services/common
 COPY summarize/ .
 
-RUN source /var/venv/bin/activate && pip install -r requirements.txt && pip cache purge
+# Uncomment when you have summarize specific requirements.txt
+# RUN source /var/venv/bin/activate && pip install -r requirements.txt && pip cache purge
 
 CMD ["/var/venv/bin/python", "-m", "uvicorn", "app:app", \
      "--host", "0.0.0.0", "--port", "6000", \

--- a/services/summarize/Makefile
+++ b/services/summarize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=summarize-service
-TAG?=v0.0.6
+TAG?=v0.0.7
 
 run:
 	PORT=$${PORT:-6000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/summarize/requirements.txt
+++ b/services/summarize/requirements.txt
@@ -1,1 +1,0 @@
-# summarize-specific dependencies beyond services-common


### PR DESCRIPTION
The dependabot is flagging some vulnerabilities listed for docling, which are already fixed in the main code. This is due to empty requirements.txt file.

It is getting stuck at something like:
```
Dependabot is creating a security update to fix [4 Dependabot alerts](https://github.com/IBM/project-ai-services/security/dependabot?q=is%3Aopen+package%3Adocling+manifest%3Aservices%2Fdigitize%2Frequirements.txt+has%3Apatch) on docling in [services/digitize/requirements.txt](https://github.com/IBM/project-ai-services/blob/-/services/digitize/requirements.txt).
```

.. where `services/digitize/requirements.txt` is empty file.

