### PR TITLE
Support image pull and list with new catalog architecture

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.59
+TAG?=0.0.60
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.59
+  image: icr.io/ai-services-cicd/ai-services:0.0.60
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/application/image/image.go
+++ b/ai-services/cmd/ai-services/cmd/application/image/image.go
@@ -1,10 +1,17 @@
 package image
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 )
 
-var templateName string
+var (
+	templateName       string
+	experimentalImages bool
+)
 
 var ImageCmd = &cobra.Command{
 	Use:   "image",
@@ -16,9 +23,25 @@ var ImageCmd = &cobra.Command{
 	},
 }
 
+// getCatalogImages is a helper that creates a catalog provider and collects images.
+func getCatalogImages(templateID string) ([]string, error) {
+	provider, err := catalog.NewCatalogProvider()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create catalog provider: %w", err)
+	}
+
+	images, err := provider.GetCatalogImages(templateID)
+	if err != nil {
+		return nil, err
+	}
+
+	return images, nil
+}
+
 func init() {
 	ImageCmd.AddCommand(listCmd)
 	ImageCmd.AddCommand(pullCmd)
 	ImageCmd.PersistentFlags().StringVarP(&templateName, "template", "t", "", "Application template name (Required)")
 	_ = ImageCmd.MarkPersistentFlagRequired("template")
+	ImageCmd.PersistentFlags().BoolVar(&experimentalImages, "experimental", false, "Use experimental catalog-based image listing")
 }

--- a/ai-services/cmd/ai-services/cmd/application/image/list.go
+++ b/ai-services/cmd/ai-services/cmd/application/image/list.go
@@ -3,11 +3,12 @@ package image
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/project-ai-services/ai-services/internal/pkg/image"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
-	"github.com/spf13/cobra"
 )
 
 var listCmd = &cobra.Command{
@@ -24,10 +25,12 @@ var listCmd = &cobra.Command{
 }
 
 func list(templateName string) error {
-	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypeOpenShift {
-		// Since we do not have tmpl files in OpenShift marking it as unsupported for now
-		logger.Warningln("Not supported for openshift runtime")
+	if experimentalImages && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+		return listCatalogImages(templateName)
+	}
 
+	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypeOpenShift {
+		logger.Warningln("Not supported for openshift runtime")
 		return nil
 	}
 
@@ -42,6 +45,26 @@ func list(templateName string) error {
 	logger.Infof("Container images for application template '%s' are:\n", templateName)
 	for _, image := range images {
 		logger.Infoln("- " + image)
+	}
+
+	return nil
+}
+
+// listCatalogImages lists container images for services or architectures from the catalog.
+func listCatalogImages(templateID string) error {
+	images, err := getCatalogImages(templateID)
+	if err != nil {
+		return err
+	}
+
+	if len(images) == 0 {
+		logger.Infoln("No images found")
+		return nil
+	}
+
+	logger.Infof("Container images for template '%s':\n", templateID)
+	for _, img := range images {
+		logger.Infof("- %s\n", img)
 	}
 
 	return nil

--- a/ai-services/cmd/ai-services/cmd/application/image/list.go
+++ b/ai-services/cmd/ai-services/cmd/application/image/list.go
@@ -31,6 +31,7 @@ func list(templateName string) error {
 
 	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypeOpenShift {
 		logger.Warningln("Not supported for openshift runtime")
+
 		return nil
 	}
 
@@ -59,6 +60,7 @@ func listCatalogImages(templateID string) error {
 
 	if len(images) == 0 {
 		logger.Infoln("No images found")
+
 		return nil
 	}
 

--- a/ai-services/cmd/ai-services/cmd/application/image/pull.go
+++ b/ai-services/cmd/ai-services/cmd/application/image/pull.go
@@ -32,6 +32,7 @@ func pull(template string) error {
 
 	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypeOpenShift {
 		logger.Warningln("Not supported for openshift runtime")
+
 		return nil
 	}
 
@@ -62,6 +63,7 @@ func pullCatalogImages(templateID string) error {
 
 	if len(images) == 0 {
 		logger.Infoln("No images to pull")
+
 		return nil
 	}
 
@@ -78,5 +80,6 @@ func pullCatalogImages(templateID string) error {
 	}
 
 	logger.Infof("Successfully pulled all images for template '%s'\n", templateID)
+
 	return nil
 }

--- a/ai-services/cmd/ai-services/cmd/application/image/pull.go
+++ b/ai-services/cmd/ai-services/cmd/application/image/pull.go
@@ -3,12 +3,13 @@ package image
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/project-ai-services/ai-services/internal/pkg/image"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
-	"github.com/spf13/cobra"
 )
 
 var pullCmd = &cobra.Command{
@@ -25,10 +26,12 @@ var pullCmd = &cobra.Command{
 }
 
 func pull(template string) error {
-	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypeOpenShift {
-		// Since we do not have templates in OpenShift marking it as unsupported for now
-		logger.Warningln("Not supported for openshift runtime")
+	if experimentalImages && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+		return pullCatalogImages(templateName)
+	}
 
+	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypeOpenShift {
+		logger.Warningln("Not supported for openshift runtime")
 		return nil
 	}
 
@@ -46,11 +49,34 @@ func pull(template string) error {
 		return fmt.Errorf("failed to connect to podman: %w", err)
 	}
 
-	for _, image := range images {
-		if err := runtimeClient.PullImage(image); err != nil {
-			return fmt.Errorf("failed to pull the image: %w", err)
-		}
+	// Use shared helper function with retry logic
+	return image.PullImageFromRegistry(runtimeClient, images)
+}
+
+// pullCatalogImages pulls container images for services or architectures from the catalog.
+func pullCatalogImages(templateID string) error {
+	images, err := getCatalogImages(templateID)
+	if err != nil {
+		return err
 	}
 
+	if len(images) == 0 {
+		logger.Infoln("No images to pull")
+		return nil
+	}
+
+	// Pull all images
+	logger.Infof("Downloading %d images for template '%s'...\n", len(images), templateID)
+	runtimeClient, err := podman.NewPodmanClient()
+	if err != nil {
+		return fmt.Errorf("failed to connect to podman: %w", err)
+	}
+
+	// Use shared helper function with retry logic
+	if err := image.PullImageFromRegistry(runtimeClient, images); err != nil {
+		return err
+	}
+
+	logger.Infof("Successfully pulled all images for template '%s'\n", templateID)
 	return nil
 }

--- a/ai-services/internal/pkg/catalog/constants/catalog.go
+++ b/ai-services/internal/pkg/catalog/constants/catalog.go
@@ -22,6 +22,8 @@ const (
 const (
 	// CatalogAppName represents the catalog name.
 	CatalogAppName = "ai-services"
+	// CatalogAppTemplate represents the catalog template name used for loading catalog infrastructure templates.
+	CatalogAppTemplate = "catalog"
 	// CatalogSecretLabel represents the catalog secret name associated with Catalog Pod.
 	CatalogSecretLabel = "ai-services.io/secret"
 	// CatalogSecretSkipLabel represents if catalog secret associated with pod should be skipped while deletion.

--- a/ai-services/internal/pkg/catalog/image_extractor.go
+++ b/ai-services/internal/pkg/catalog/image_extractor.go
@@ -1,0 +1,144 @@
+package catalog
+
+import (
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+)
+
+// GetCatalogImages collects all unique images from a service or architecture template.
+// This is the main entry point for catalog-based image collection from CLI or API.
+func (p *CatalogProvider) GetCatalogImages(templateID string) ([]string, error) {
+	allImages := make(map[string]bool)
+
+	// Try to load as architecture first
+	arch, err := p.LoadArchitecture(templateID)
+	if err == nil {
+		if err := p.collectArchitectureImages(arch.Services, allImages); err != nil {
+			return nil, err
+		}
+	} else {
+		// Try to load as service
+		service, err := p.LoadService(templateID)
+		if err == nil {
+			if err := p.collectServiceWithDependencies(templateID, service.Dependencies, allImages); err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, fmt.Errorf("template '%s' not found as service or architecture", templateID)
+		}
+	}
+
+	return utils.ExtractMapKeys(allImages), nil
+}
+
+// collectArchitectureImages collects all images for all services in an architecture.
+func (p *CatalogProvider) collectArchitectureImages(services []types.ServiceReference, allImages map[string]bool) error {
+	for _, svcRef := range services {
+		service, err := p.LoadService(svcRef.ID)
+		if err != nil {
+			continue
+		}
+
+		// Reuse collectServiceWithDependencies to collect both service and component images
+		if err := p.collectServiceWithDependencies(svcRef.ID, service.Dependencies, allImages); err != nil {
+			logger.Errorf("Failed to collect images for service %s: %v", svcRef.ID, err)
+		}
+	}
+
+	return nil
+}
+
+// collectServiceWithDependencies collects images for a specific service and its dependencies.
+func (p *CatalogProvider) collectServiceWithDependencies(serviceID string, dependencies []types.DependencyReference, allImages map[string]bool) error {
+	// Get service images
+	if err := p.addServiceImages(serviceID, allImages); err != nil {
+		return err
+	}
+
+	// Get component images
+	return p.collectComponentsImages(dependencies, allImages, nil)
+}
+
+// addServiceImages adds service images to the provided map.
+func (p *CatalogProvider) addServiceImages(serviceID string, allImages map[string]bool) error {
+	values, err := p.LoadServiceValues(serviceID, map[string]string{})
+	if err != nil {
+		return fmt.Errorf("failed to load values for service %s: %w", serviceID, err)
+	}
+
+	templates, err := p.LoadServiceTemplates(serviceID)
+	if err != nil {
+		return fmt.Errorf("failed to load service templates: %w", err)
+	}
+
+	p.CollectImagesFromTemplates(templates, values, allImages)
+	return nil
+}
+
+// collectComponentsImages collects images for components based on dependencies.
+// If displayedComponents map is provided, it will track and skip duplicates.
+func (p *CatalogProvider) collectComponentsImages(dependencies []types.DependencyReference, allImages map[string]bool, displayedComponents map[string]bool) error {
+	if len(dependencies) == 0 {
+		return nil
+	}
+
+	components, err := p.ListComponents()
+	if err != nil {
+		return fmt.Errorf("failed to list components: %w", err)
+	}
+
+	for _, dep := range dependencies {
+		if err := p.collectComponentsByType(dep.ID, components, allImages, displayedComponents); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// collectComponentsByType collects images for all components of a specific type.
+func (p *CatalogProvider) collectComponentsByType(componentType string, components []types.Component, allImages map[string]bool, displayedComponents map[string]bool) error {
+	for _, comp := range components {
+		if comp.ComponentType != componentType {
+			continue
+		}
+
+		componentKey := fmt.Sprintf("%s.%s", comp.ComponentType, comp.ID)
+
+		// Skip if already processed (only when tracking duplicates)
+		if displayedComponents != nil && displayedComponents[componentKey] {
+			continue
+		}
+
+		if displayedComponents != nil {
+			displayedComponents[componentKey] = true
+		}
+
+		if err := p.addComponentImages(comp.ComponentType, comp.ID, allImages); err != nil {
+			logger.Errorf("Failed to collect images for component %s/%s: %v", comp.ComponentType, comp.ID, err)
+		}
+	}
+
+	return nil
+}
+
+// addComponentImages adds component images to the provided map.
+func (p *CatalogProvider) addComponentImages(componentType, componentID string, allImages map[string]bool) error {
+	values, err := p.LoadComponentValues(componentType, componentID, map[string]string{})
+	if err != nil {
+		return fmt.Errorf("failed to load values for component %s/%s: %w", componentType, componentID, err)
+	}
+
+	templates, err := p.LoadComponentTemplates(componentType, componentID)
+	if err != nil {
+		return fmt.Errorf("failed to load component templates: %w", err)
+	}
+
+	p.CollectImagesFromTemplates(templates, values, allImages)
+	return nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/image_extractor.go
+++ b/ai-services/internal/pkg/catalog/image_extractor.go
@@ -3,15 +3,27 @@ package catalog
 import (
 	"fmt"
 
+	"github.com/project-ai-services/ai-services/assets"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // GetCatalogImages collects all unique images from a service or architecture template.
 // This is the main entry point for catalog-based image collection from CLI or API.
 func (p *CatalogProvider) GetCatalogImages(templateID string) ([]string, error) {
 	allImages := make(map[string]bool)
+
+	// Include catalog asset images (tool image used for housekeeping tasks)
+	allImages[vars.ToolImage] = true
+
+	// Include catalog infrastructure images (catalog service itself)
+	if err := p.addCatalogInfrastructureImages(allImages); err != nil {
+		logger.Errorf("Failed to collect catalog infrastructure images: %v", err)
+	}
 
 	// Try to load as architecture first
 	arch, err := p.LoadArchitecture(templateID)
@@ -32,6 +44,29 @@ func (p *CatalogProvider) GetCatalogImages(templateID string) ([]string, error) 
 	}
 
 	return utils.ExtractMapKeys(allImages), nil
+}
+
+// addCatalogInfrastructureImages adds images from the catalog service templates.
+func (p *CatalogProvider) addCatalogInfrastructureImages(allImages map[string]bool) error {
+	// Use the embed template provider to load catalog templates and values
+	// Similar to loadCatalogTemplates() in configure.go
+	tp := templates.NewEmbedTemplateProvider(&assets.CatalogFS, "")
+
+	// Load catalog values (no overrides needed for image collection)
+	values, err := tp.LoadValues(constants.CatalogAppTemplate, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to load catalog values: %w", err)
+	}
+
+	// Load catalog templates
+	catalogTemplates, err := tp.LoadAllTemplates(constants.CatalogAppTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to load catalog templates: %w", err)
+	}
+
+	// Collect images from catalog templates
+	p.CollectImagesFromTemplates(catalogTemplates, values, allImages)
+	return nil
 }
 
 // collectArchitectureImages collects all images for all services in an architecture.

--- a/ai-services/internal/pkg/catalog/image_extractor.go
+++ b/ai-services/internal/pkg/catalog/image_extractor.go
@@ -79,12 +79,12 @@ func (p *CatalogProvider) collectArchitectureImages(services []types.ServiceRefe
 	for _, svcRef := range services {
 		service, err := p.LoadService(svcRef.ID)
 		if err != nil {
-			continue
+			return fmt.Errorf("failed to load service %s: %w", svcRef.ID, err)
 		}
 
 		// Reuse collectServiceWithDependencies to collect both service and component images
 		if err := p.collectServiceWithDependencies(svcRef.ID, service.Dependencies, allImages); err != nil {
-			logger.Errorf("Failed to collect images for service %s: %v", svcRef.ID, err)
+			return fmt.Errorf("failed to collect images for service %s: %w", svcRef.ID, err)
 		}
 	}
 
@@ -161,7 +161,7 @@ func (p *CatalogProvider) collectComponentsByType(componentType string, componen
 		}
 
 		if err := p.addComponentImages(comp.ComponentType, comp.ID, allImages); err != nil {
-			logger.Errorf("Failed to collect images for component %s/%s: %v", comp.ComponentType, comp.ID, err)
+			return fmt.Errorf("failed to collect images for component %s/%s: %w", comp.ComponentType, comp.ID, err)
 		}
 	}
 

--- a/ai-services/internal/pkg/catalog/image_extractor.go
+++ b/ai-services/internal/pkg/catalog/image_extractor.go
@@ -31,19 +31,21 @@ func (p *CatalogProvider) GetCatalogImages(templateID string) ([]string, error) 
 		if err := p.collectArchitectureImages(arch.Services, allImages); err != nil {
 			return nil, err
 		}
-	} else {
-		// Try to load as service
-		service, err := p.LoadService(templateID)
-		if err == nil {
-			if err := p.collectServiceWithDependencies(templateID, service.Dependencies, allImages); err != nil {
-				return nil, err
-			}
-		} else {
-			return nil, fmt.Errorf("template '%s' not found as service or architecture", templateID)
-		}
+
+		return utils.ExtractMapKeys(allImages), nil
 	}
 
-	return utils.ExtractMapKeys(allImages), nil
+	// Try to load as service
+	service, err := p.LoadService(templateID)
+	if err == nil {
+		if err := p.collectServiceWithDependencies(templateID, service.Dependencies, allImages); err != nil {
+			return nil, err
+		}
+
+		return utils.ExtractMapKeys(allImages), nil
+	}
+
+	return nil, fmt.Errorf("template '%s' not found as service or architecture", templateID)
 }
 
 // addCatalogInfrastructureImages adds images from the catalog service templates.
@@ -65,7 +67,10 @@ func (p *CatalogProvider) addCatalogInfrastructureImages(allImages map[string]bo
 	}
 
 	// Collect images from catalog templates
-	p.CollectImagesFromTemplates(catalogTemplates, values, allImages)
+	if err := p.CollectImagesFromTemplates(catalogTemplates, values, allImages); err != nil {
+		return fmt.Errorf("failed to collect images from catalog templates: %w", err)
+	}
+
 	return nil
 }
 
@@ -109,7 +114,10 @@ func (p *CatalogProvider) addServiceImages(serviceID string, allImages map[strin
 		return fmt.Errorf("failed to load service templates: %w", err)
 	}
 
-	p.CollectImagesFromTemplates(templates, values, allImages)
+	if err := p.CollectImagesFromTemplates(templates, values, allImages); err != nil {
+		return fmt.Errorf("failed to collect images from service templates: %w", err)
+	}
+
 	return nil
 }
 
@@ -172,7 +180,10 @@ func (p *CatalogProvider) addComponentImages(componentType, componentID string, 
 		return fmt.Errorf("failed to load component templates: %w", err)
 	}
 
-	p.CollectImagesFromTemplates(templates, values, allImages)
+	if err := p.CollectImagesFromTemplates(templates, values, allImages); err != nil {
+		return fmt.Errorf("failed to collect images from component templates: %w", err)
+	}
+
 	return nil
 }
 

--- a/ai-services/internal/pkg/image/helper.go
+++ b/ai-services/internal/pkg/image/helper.go
@@ -9,8 +9,8 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
-// pullImageFromRegistry pulls the required images from registry.
-func pullImageFromRegistry(runtime runtime.Runtime, images []string) error {
+// PullImageFromRegistry pulls the required images from registry with retry logic.
+func PullImageFromRegistry(runtime runtime.Runtime, images []string) error {
 	for _, image := range images {
 		logger.Infoln("Downloading image: " + image + "...")
 		if err := utils.Retry(vars.RetryCount, vars.RetryInterval, nil, func() error {
@@ -23,8 +23,8 @@ func pullImageFromRegistry(runtime runtime.Runtime, images []string) error {
 	return nil
 }
 
-// fetchImagesNotFound returns list of images which are not present locally.
-func fetchImagesNotFound(runtime runtime.Runtime, reqImages []string) ([]string, error) {
+// FetchImagesNotFound returns list of images which are not present locally.
+func FetchImagesNotFound(runtime runtime.Runtime, reqImages []string) ([]string, error) {
 	notfoundImages := make([]string, 0, len(reqImages))
 
 	// Verify the images existing locally

--- a/ai-services/internal/pkg/image/images.go
+++ b/ai-services/internal/pkg/image/images.go
@@ -95,12 +95,12 @@ func (img *Images) Run(policy ImagePullPolicy) error {
 func (img *Images) always(images []string) error {
 	logger.Infoln("Downloading container images required for application template " + img.AppTemplate + ":")
 
-	return pullImageFromRegistry(img.Runtime, images)
+	return PullImageFromRegistry(img.Runtime, images)
 }
 
 // IfNotPresent pulls only the missing images for a given app template.
 func (img *Images) IfNotPresent(images []string) error {
-	notFoundImages, err := fetchImagesNotFound(img.Runtime, images)
+	notFoundImages, err := FetchImagesNotFound(img.Runtime, images)
 	if err != nil {
 		return err
 	}
@@ -111,13 +111,13 @@ func (img *Images) IfNotPresent(images []string) error {
 		return nil
 	}
 
-	return pullImageFromRegistry(img.Runtime, notFoundImages)
+	return PullImageFromRegistry(img.Runtime, notFoundImages)
 }
 
 // never -> never pulls any image.
 // It checks whether all the images for given appTemplate is present locally, if not then raises an error.
 func (img *Images) never(images []string) error {
-	notFoundImages, err := fetchImagesNotFound(img.Runtime, images)
+	notFoundImages, err := FetchImagesNotFound(img.Runtime, images)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Created image_extractor.go with CollectImagesFromTemplates() function to extract container images from templates by parsing YAML and collecting image references from pod specs.
- Integrated image extraction into catalog CLI commands (image pull and image list) to enable pulling and listing container images required by catalog services.
- Added tools and catalog infrastructure images (Caddy, Catalog, Postgres, etc.) to support the catalog deployment.

Note for reviewers: Please look at each commit, it will be easy to review. 😄 