### PR TITLE
fix: use values instead of param due to load failure in opensearch template

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.63
+TAG?=0.0.64
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.63
+  image: icr.io/ai-services-cicd/ai-services:0.0.64
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
@@ -247,7 +247,8 @@ func (p *DeploymentPlanner) getRequiredSpyreCardsForComponent(comp *ComponentPla
 	}
 
 	// Use the catalog provider's CollectSpyreCardsFromTemplates function
-	totalSpyreCards, err := p.catalogProvider.CollectSpyreCardsFromTemplates(tmpls, comp.Params)
+	// Use comp.Values instead of comp.Params to include defaults from values.yaml
+	totalSpyreCards, err := p.catalogProvider.CollectSpyreCardsFromTemplates(tmpls, comp.Values)
 	if err != nil {
 		return 0, fmt.Errorf("failed to collect Spyre cards from templates: %w", err)
 	}


### PR DESCRIPTION
After adding error handling to planner code while loading templates for calculating spyre card numbers we are facing following issue:
```
{
  "error": "Failed to create application: failed to create deployment plan: failed to allocate Spyre cards: failed to get Spyre card requirements for component vector_store: failed to collect Spyre cards from templates: failed to process templates for Spyre card calculation: failed to process 1 template(s): error unmarshaling JSON: while decoding JSON: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'"
}
```

This is due to an empty memoryLimit in opensearch template, even with values.yaml, which contains the default value.