### PR TITLE
Support model list and download cli with the new template

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.68
+TAG?=0.0.69
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.68
+  image: icr.io/ai-services-cicd/ai-services:0.0.69
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/application/model/download.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/download.go
@@ -36,6 +36,10 @@ func init() {
 }
 
 func download(cmd *cobra.Command) error {
+	if experimentalModels && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+		return downloadCatalogModels(templateName)
+	}
+
 	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypeOpenShift {
 		// Since we do not have tmpl files in OpenShift marking it as unsupported for now
 		logger.Warningln("Not supported for openshift runtime")
@@ -54,6 +58,35 @@ func download(cmd *cobra.Command) error {
 			return fmt.Errorf("failed to download model: %w", err)
 		}
 	}
+
+	return nil
+}
+
+// downloadCatalogModels downloads models for services or architectures from the catalog.
+func downloadCatalogModels(templateID string) error {
+	models, err := getCatalogModels(templateID, "watsonx")
+	if err != nil {
+		return err
+	}
+
+	if len(models) == 0 {
+		logger.Infoln("No models to download")
+
+		return nil
+	}
+
+	// Download all models
+	logger.Infof("Downloading %d models for template '%s'...\n", len(models), templateID)
+
+	for _, model := range models {
+		logger.Infof("Downloading model: %s\n", model)
+
+		if err := helpers.DownloadModelContainer(model, modelDirectory); err != nil {
+			return fmt.Errorf("failed to download model %s: %w", model, err)
+		}
+	}
+
+	logger.Infof("Successfully downloaded all models for template '%s'\n", templateID)
 
 	return nil
 }

--- a/ai-services/cmd/ai-services/cmd/application/model/list.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/list.go
@@ -31,6 +31,10 @@ func init() {
 }
 
 func list(cmd *cobra.Command) error {
+	if experimentalModels && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+		return listCatalogModels(templateName)
+	}
+
 	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypeOpenShift {
 		// Since we do not have tmpl files in OpenShift marking it as unsupported for now
 		logger.Warningln("Not supported for openshift runtime")
@@ -45,6 +49,27 @@ func list(cmd *cobra.Command) error {
 	logger.Infoln("Models in application template " + templateName + ":")
 	for _, model := range models {
 		logger.Infoln("- " + model)
+	}
+
+	return nil
+}
+
+// listCatalogModels lists models for services or architectures from the catalog.
+func listCatalogModels(templateID string) error {
+	models, err := getCatalogModels(templateID)
+	if err != nil {
+		return err
+	}
+
+	if len(models) == 0 {
+		logger.Infoln("No models found")
+
+		return nil
+	}
+
+	logger.Infof("Models for template '%s':\n", templateID)
+	for _, model := range models {
+		logger.Infof("- %s\n", model)
 	}
 
 	return nil

--- a/ai-services/cmd/ai-services/cmd/application/model/model.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/model.go
@@ -47,14 +47,14 @@ func models(template string) ([]string, error) {
 }
 
 // getCatalogModels is a helper that creates a catalog provider and collects models.
-// excludeComponents is a variadic parameter that allows excluding specific components by ID.
-func getCatalogModels(templateID string, excludeComponents ...string) ([]string, error) {
+// excludeComponentProviders is a variadic parameter that allows excluding specific component provider by ID.
+func getCatalogModels(templateID string, excludeComponentProviders ...string) ([]string, error) {
 	provider, err := catalog.NewCatalogProvider()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create catalog provider: %w", err)
 	}
 
-	models, err := provider.GetCatalogModels(templateID, excludeComponents...)
+	models, err := provider.GetCatalogModels(templateID, excludeComponentProviders...)
 	if err != nil {
 		return nil, err
 	}

--- a/ai-services/cmd/ai-services/cmd/application/model/model.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/model.go
@@ -5,26 +5,31 @@ import (
 	"slices"
 
 	"github.com/project-ai-services/ai-services/assets"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
 	"github.com/spf13/cobra"
 )
 
-var ModelCmd = &cobra.Command{
-	Use:   "model",
-	Short: "Manage application models",
-	Long:  ``,
-	Args:  cobra.MaximumNArgs(0),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return cmd.Help()
-	},
-}
+var (
+	ModelCmd = &cobra.Command{
+		Use:   "model",
+		Short: "Manage application models",
+		Long:  ``,
+		Args:  cobra.MaximumNArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
 
-var hiddenTemplates bool
+	hiddenTemplates    bool
+	experimentalModels bool
+)
 
 func init() {
 	ModelCmd.AddCommand(listCmd)
 	ModelCmd.AddCommand(downloadCmd)
+	ModelCmd.PersistentFlags().BoolVar(&experimentalModels, "experimental", false, "Use experimental catalog-based model listing")
 }
 
 func models(template string) ([]string, error) {
@@ -39,4 +44,20 @@ func models(template string) ([]string, error) {
 	}
 
 	return helpers.ListModels(template, "")
+}
+
+// getCatalogModels is a helper that creates a catalog provider and collects models.
+// excludeComponents is a variadic parameter that allows excluding specific components by ID.
+func getCatalogModels(templateID string, excludeComponents ...string) ([]string, error) {
+	provider, err := catalog.NewCatalogProvider()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create catalog provider: %w", err)
+	}
+
+	models, err := provider.GetCatalogModels(templateID, excludeComponents...)
+	if err != nil {
+		return nil, err
+	}
+
+	return models, nil
 }

--- a/ai-services/internal/pkg/catalog/model_extractor.go
+++ b/ai-services/internal/pkg/catalog/model_extractor.go
@@ -90,6 +90,7 @@ func (p *CatalogProvider) collectComponentsByTypeModels(componentType string, co
 			if strings.EqualFold(comp.ID, excludedID) {
 				logger.Infof("Skipping model extraction for excluded component: %s/%s\n", comp.ComponentType, comp.ID, logger.VerbosityLevelDebug)
 				excluded = true
+
 				break
 			}
 		}
@@ -117,6 +118,7 @@ func (p *CatalogProvider) addComponentModels(componentType, componentID string, 
 	// If schema is empty, skip this component
 	if len(schema) == 0 {
 		logger.Infof("No schema found for component %s/%s, skipping model extraction\n", componentType, componentID, logger.VerbosityLevelDebug)
+
 		return nil
 	}
 
@@ -146,20 +148,26 @@ func extractModelsFromSchema(schema map[string]any, modelSet map[string]bool) {
 			continue
 		}
 
-		// Check for oneOf array with const values
-		if oneOf, ok := propMap["oneOf"].([]any); ok {
-			for _, option := range oneOf {
-				if optMap, ok := option.(map[string]any); ok {
-					if constVal, ok := optMap["const"].(string); ok && constVal != "" {
-						modelSet[constVal] = true
-					}
+		// Extract models from oneOf and default fields
+		extractModelsFromProperty(propMap, modelSet)
+	}
+}
+
+// extractModelsFromProperty extracts model values from a property's oneOf array and default field.
+func extractModelsFromProperty(propMap map[string]any, modelSet map[string]bool) {
+	// Check for oneOf array with const values
+	if oneOf, ok := propMap["oneOf"].([]any); ok {
+		for _, option := range oneOf {
+			if optMap, ok := option.(map[string]any); ok {
+				if constVal, ok := optMap["const"].(string); ok && constVal != "" {
+					modelSet[constVal] = true
 				}
 			}
 		}
+	}
 
-		// Also check for default value
-		if defaultVal, ok := propMap["default"].(string); ok && defaultVal != "" {
-			modelSet[defaultVal] = true
-		}
+	// Also check for default value
+	if defaultVal, ok := propMap["default"].(string); ok && defaultVal != "" {
+		modelSet[defaultVal] = true
 	}
 }

--- a/ai-services/internal/pkg/catalog/model_extractor.go
+++ b/ai-services/internal/pkg/catalog/model_extractor.go
@@ -30,7 +30,7 @@ func (p *CatalogProvider) GetCatalogModels(templateID string, excludeComponents 
 	service, err := p.LoadService(templateID)
 	if err == nil {
 		// Only collect component models (services don't have models in schemas)
-		if err := p.collectComponentsModels(service.Dependencies, allModels, nil, excludeComponents); err != nil {
+		if err := p.collectComponentsModels(service.Dependencies, allModels, excludeComponents); err != nil {
 			return nil, err
 		}
 
@@ -49,7 +49,7 @@ func (p *CatalogProvider) collectArchitectureModels(services []types.ServiceRefe
 		}
 
 		// Collect component models from service dependencies
-		if err := p.collectComponentsModels(service.Dependencies, allModels, nil, excludeComponents); err != nil {
+		if err := p.collectComponentsModels(service.Dependencies, allModels, excludeComponents); err != nil {
 			return fmt.Errorf("failed to collect models for service %s: %w", svcRef.ID, err)
 		}
 	}
@@ -58,8 +58,7 @@ func (p *CatalogProvider) collectArchitectureModels(services []types.ServiceRefe
 }
 
 // collectComponentsModels collects models for components based on dependencies.
-// If displayedComponents map is provided, it will track and skip duplicates.
-func (p *CatalogProvider) collectComponentsModels(dependencies []types.DependencyReference, allModels map[string]bool, displayedComponents map[string]bool, excludeComponents []string) error {
+func (p *CatalogProvider) collectComponentsModels(dependencies []types.DependencyReference, allModels map[string]bool, excludeComponents []string) error {
 	if len(dependencies) == 0 {
 		return nil
 	}
@@ -70,7 +69,7 @@ func (p *CatalogProvider) collectComponentsModels(dependencies []types.Dependenc
 	}
 
 	for _, dep := range dependencies {
-		if err := p.collectComponentsByTypeModels(dep.ID, components, allModels, displayedComponents, excludeComponents); err != nil {
+		if err := p.collectComponentsByTypeModels(dep.ID, components, allModels, excludeComponents); err != nil {
 			return err
 		}
 	}
@@ -79,7 +78,7 @@ func (p *CatalogProvider) collectComponentsModels(dependencies []types.Dependenc
 }
 
 // collectComponentsByTypeModels collects models for all components of a specific type.
-func (p *CatalogProvider) collectComponentsByTypeModels(componentType string, components []types.Component, allModels map[string]bool, displayedComponents map[string]bool, excludeComponents []string) error {
+func (p *CatalogProvider) collectComponentsByTypeModels(componentType string, components []types.Component, allModels map[string]bool, excludeComponents []string) error {
 	for _, comp := range components {
 		if comp.ComponentType != componentType {
 			continue
@@ -96,17 +95,6 @@ func (p *CatalogProvider) collectComponentsByTypeModels(componentType string, co
 		}
 		if excluded {
 			continue
-		}
-
-		componentKey := fmt.Sprintf("%s.%s", comp.ComponentType, comp.ID)
-
-		// Skip if already processed (only when tracking duplicates)
-		if displayedComponents != nil && displayedComponents[componentKey] {
-			continue
-		}
-
-		if displayedComponents != nil {
-			displayedComponents[componentKey] = true
 		}
 
 		if err := p.addComponentModels(comp.ComponentType, comp.ID, allModels); err != nil {

--- a/ai-services/internal/pkg/catalog/model_extractor.go
+++ b/ai-services/internal/pkg/catalog/model_extractor.go
@@ -11,15 +11,15 @@ import (
 
 // GetCatalogModels collects all unique models from component schemas in a service or architecture template.
 // This is the main entry point for catalog-based model collection from CLI or API.
-// excludeComponents is a variadic parameter that allows excluding specific components by ID.
+// excludeComponentProviders is a variadic parameter that allows excluding specific components provider by ID.
 // Note: Only components have models in their schemas; services do not define models.
-func (p *CatalogProvider) GetCatalogModels(templateID string, excludeComponents ...string) ([]string, error) {
+func (p *CatalogProvider) GetCatalogModels(templateID string, excludeComponentProviders ...string) ([]string, error) {
 	allModels := make(map[string]bool)
 
 	// Try to load as architecture first
 	arch, err := p.LoadArchitecture(templateID)
 	if err == nil {
-		if err := p.collectArchitectureModels(arch.Services, allModels, excludeComponents); err != nil {
+		if err := p.collectArchitectureModels(arch.Services, allModels, excludeComponentProviders); err != nil {
 			return nil, err
 		}
 
@@ -30,7 +30,7 @@ func (p *CatalogProvider) GetCatalogModels(templateID string, excludeComponents 
 	service, err := p.LoadService(templateID)
 	if err == nil {
 		// Only collect component models (services don't have models in schemas)
-		if err := p.collectComponentsModels(service.Dependencies, allModels, excludeComponents); err != nil {
+		if err := p.collectComponentsModels(service.Dependencies, allModels, excludeComponentProviders); err != nil {
 			return nil, err
 		}
 
@@ -41,7 +41,7 @@ func (p *CatalogProvider) GetCatalogModels(templateID string, excludeComponents 
 }
 
 // collectArchitectureModels collects models from all component dependencies across all services in an architecture.
-func (p *CatalogProvider) collectArchitectureModels(services []types.ServiceReference, allModels map[string]bool, excludeComponents []string) error {
+func (p *CatalogProvider) collectArchitectureModels(services []types.ServiceReference, allModels map[string]bool, excludeComponentProviders []string) error {
 	for _, svcRef := range services {
 		service, err := p.LoadService(svcRef.ID)
 		if err != nil {
@@ -49,7 +49,7 @@ func (p *CatalogProvider) collectArchitectureModels(services []types.ServiceRefe
 		}
 
 		// Collect component models from service dependencies
-		if err := p.collectComponentsModels(service.Dependencies, allModels, excludeComponents); err != nil {
+		if err := p.collectComponentsModels(service.Dependencies, allModels, excludeComponentProviders); err != nil {
 			return fmt.Errorf("failed to collect models for service %s: %w", svcRef.ID, err)
 		}
 	}
@@ -58,7 +58,7 @@ func (p *CatalogProvider) collectArchitectureModels(services []types.ServiceRefe
 }
 
 // collectComponentsModels collects models for components based on dependencies.
-func (p *CatalogProvider) collectComponentsModels(dependencies []types.DependencyReference, allModels map[string]bool, excludeComponents []string) error {
+func (p *CatalogProvider) collectComponentsModels(dependencies []types.DependencyReference, allModels map[string]bool, excludeComponentProviders []string) error {
 	if len(dependencies) == 0 {
 		return nil
 	}
@@ -69,7 +69,7 @@ func (p *CatalogProvider) collectComponentsModels(dependencies []types.Dependenc
 	}
 
 	for _, dep := range dependencies {
-		if err := p.collectComponentsByTypeModels(dep.ID, components, allModels, excludeComponents); err != nil {
+		if err := p.collectComponentsByTypeModels(dep.ID, components, allModels, excludeComponentProviders); err != nil {
 			return err
 		}
 	}
@@ -78,7 +78,7 @@ func (p *CatalogProvider) collectComponentsModels(dependencies []types.Dependenc
 }
 
 // collectComponentsByTypeModels collects models for all components of a specific type.
-func (p *CatalogProvider) collectComponentsByTypeModels(componentType string, components []types.Component, allModels map[string]bool, excludeComponents []string) error {
+func (p *CatalogProvider) collectComponentsByTypeModels(componentType string, components []types.Component, allModels map[string]bool, excludeComponentProviders []string) error {
 	for _, comp := range components {
 		if comp.ComponentType != componentType {
 			continue
@@ -86,7 +86,7 @@ func (p *CatalogProvider) collectComponentsByTypeModels(componentType string, co
 
 		// Skip excluded components (e.g., watsonx)
 		excluded := false
-		for _, excludedID := range excludeComponents {
+		for _, excludedID := range excludeComponentProviders {
 			if strings.EqualFold(comp.ID, excludedID) {
 				logger.Infof("Skipping model extraction for excluded component: %s/%s\n", comp.ComponentType, comp.ID, logger.VerbosityLevelDebug)
 				excluded = true
@@ -148,12 +148,12 @@ func extractModelsFromSchema(schema map[string]any, modelSet map[string]bool) {
 			continue
 		}
 
-		// Extract models from oneOf and default fields
+		// Extract models from oneOf field
 		extractModelsFromProperty(propMap, modelSet)
 	}
 }
 
-// extractModelsFromProperty extracts model values from a property's oneOf array and default field.
+// extractModelsFromProperty extracts model values from a property's oneOf array.
 func extractModelsFromProperty(propMap map[string]any, modelSet map[string]bool) {
 	// Check for oneOf array with const values
 	if oneOf, ok := propMap["oneOf"].([]any); ok {
@@ -164,10 +164,5 @@ func extractModelsFromProperty(propMap map[string]any, modelSet map[string]bool)
 				}
 			}
 		}
-	}
-
-	// Also check for default value
-	if defaultVal, ok := propMap["default"].(string); ok && defaultVal != "" {
-		modelSet[defaultVal] = true
 	}
 }

--- a/ai-services/internal/pkg/catalog/model_extractor.go
+++ b/ai-services/internal/pkg/catalog/model_extractor.go
@@ -1,0 +1,177 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+)
+
+// GetCatalogModels collects all unique models from component schemas in a service or architecture template.
+// This is the main entry point for catalog-based model collection from CLI or API.
+// excludeComponents is a variadic parameter that allows excluding specific components by ID.
+// Note: Only components have models in their schemas; services do not define models.
+func (p *CatalogProvider) GetCatalogModels(templateID string, excludeComponents ...string) ([]string, error) {
+	allModels := make(map[string]bool)
+
+	// Try to load as architecture first
+	arch, err := p.LoadArchitecture(templateID)
+	if err == nil {
+		if err := p.collectArchitectureModels(arch.Services, allModels, excludeComponents); err != nil {
+			return nil, err
+		}
+
+		return utils.ExtractMapKeys(allModels), nil
+	}
+
+	// Try to load as service
+	service, err := p.LoadService(templateID)
+	if err == nil {
+		// Only collect component models (services don't have models in schemas)
+		if err := p.collectComponentsModels(service.Dependencies, allModels, nil, excludeComponents); err != nil {
+			return nil, err
+		}
+
+		return utils.ExtractMapKeys(allModels), nil
+	}
+
+	return nil, fmt.Errorf("template '%s' not found as service or architecture", templateID)
+}
+
+// collectArchitectureModels collects models from all component dependencies across all services in an architecture.
+func (p *CatalogProvider) collectArchitectureModels(services []types.ServiceReference, allModels map[string]bool, excludeComponents []string) error {
+	for _, svcRef := range services {
+		service, err := p.LoadService(svcRef.ID)
+		if err != nil {
+			return fmt.Errorf("failed to load service %s: %w", svcRef.ID, err)
+		}
+
+		// Collect component models from service dependencies
+		if err := p.collectComponentsModels(service.Dependencies, allModels, nil, excludeComponents); err != nil {
+			return fmt.Errorf("failed to collect models for service %s: %w", svcRef.ID, err)
+		}
+	}
+
+	return nil
+}
+
+// collectComponentsModels collects models for components based on dependencies.
+// If displayedComponents map is provided, it will track and skip duplicates.
+func (p *CatalogProvider) collectComponentsModels(dependencies []types.DependencyReference, allModels map[string]bool, displayedComponents map[string]bool, excludeComponents []string) error {
+	if len(dependencies) == 0 {
+		return nil
+	}
+
+	components, err := p.ListComponents()
+	if err != nil {
+		return fmt.Errorf("failed to list components: %w", err)
+	}
+
+	for _, dep := range dependencies {
+		if err := p.collectComponentsByTypeModels(dep.ID, components, allModels, displayedComponents, excludeComponents); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// collectComponentsByTypeModels collects models for all components of a specific type.
+func (p *CatalogProvider) collectComponentsByTypeModels(componentType string, components []types.Component, allModels map[string]bool, displayedComponents map[string]bool, excludeComponents []string) error {
+	for _, comp := range components {
+		if comp.ComponentType != componentType {
+			continue
+		}
+
+		// Skip excluded components (e.g., watsonx)
+		excluded := false
+		for _, excludedID := range excludeComponents {
+			if strings.EqualFold(comp.ID, excludedID) {
+				logger.Infof("Skipping model extraction for excluded component: %s/%s\n", comp.ComponentType, comp.ID, logger.VerbosityLevelDebug)
+				excluded = true
+				break
+			}
+		}
+		if excluded {
+			continue
+		}
+
+		componentKey := fmt.Sprintf("%s.%s", comp.ComponentType, comp.ID)
+
+		// Skip if already processed (only when tracking duplicates)
+		if displayedComponents != nil && displayedComponents[componentKey] {
+			continue
+		}
+
+		if displayedComponents != nil {
+			displayedComponents[componentKey] = true
+		}
+
+		if err := p.addComponentModels(comp.ComponentType, comp.ID, allModels); err != nil {
+			return fmt.Errorf("failed to collect models for component %s/%s: %w", comp.ComponentType, comp.ID, err)
+		}
+	}
+
+	return nil
+}
+
+// addComponentModels adds component models to the provided map.
+// For components, models are read from values.schema.json file using GetComponentProviderParams.
+func (p *CatalogProvider) addComponentModels(componentType, componentID string, allModels map[string]bool) error {
+	// Use existing GetComponentProviderParams to load the schema
+	schema, err := p.GetComponentProviderParams(componentType, componentID)
+	if err != nil {
+		return fmt.Errorf("failed to get component schema for %s/%s: %w", componentType, componentID, err)
+	}
+
+	// If schema is empty, skip this component
+	if len(schema) == 0 {
+		logger.Infof("No schema found for component %s/%s, skipping model extraction\n", componentType, componentID, logger.VerbosityLevelDebug)
+		return nil
+	}
+
+	// Extract models from schema
+	extractModelsFromSchema(schema, allModels)
+
+	return nil
+}
+
+// extractModelsFromSchema extracts model names from a JSON schema.
+// It looks for properties with "model" in the key and extracts values from oneOf/const fields.
+func extractModelsFromSchema(schema map[string]any, modelSet map[string]bool) {
+	// Get properties object
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	// Look for model-related properties
+	for key, value := range properties {
+		if !strings.Contains(strings.ToLower(key), "model") {
+			continue
+		}
+
+		propMap, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		// Check for oneOf array with const values
+		if oneOf, ok := propMap["oneOf"].([]any); ok {
+			for _, option := range oneOf {
+				if optMap, ok := option.(map[string]any); ok {
+					if constVal, ok := optMap["const"].(string); ok && constVal != "" {
+						modelSet[constVal] = true
+					}
+				}
+			}
+		}
+
+		// Also check for default value
+		if defaultVal, ok := propMap["default"].(string); ok && defaultVal != "" {
+			modelSet[defaultVal] = true
+		}
+	}
+}


### PR DESCRIPTION
1. Support model list/download with new catalog structure.
2. Implement model_extractor.go for collecting component models for a given template.
3. Skip watsonx model during download.