### PR TITLE
[Catalog] About Section for services and Digital Assistant

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.75
+TAG?=0.0.76
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/architectures/rag/metadata.yaml
+++ b/ai-services/assets/architectures/rag/metadata.yaml
@@ -31,10 +31,68 @@ services:
     version: ">=1.0.0"
     optional: true
 
-# Links
-links:
-  demo: "https://example.com/demo/rag"
-  code: "https://github.com/project-ai-services/spyre-rag"
-  documentation: "https://docs.example.com/rag"
+about:
+  - title: "Services"
+    values:
+      - "Question and Answer"
+      - "Digitize Documents"
+      - "Find Similar Items"
+      - "Summarize"
+
+  - title: "Use case domains"
+    sections:
+      - title: "Agriculture"
+        values:
+          - "Agriculture assistant"
+      - title: "Banking"
+        values:
+          - "Analyst assistant"
+          - "Financial documents assistant"
+          - "Open account agent"
+      - title: "Enterprise resource planning"
+        values:
+          - "BI assistant"
+          - "Invoice matching assistant"
+          - "Order processing assistant"
+      - title: "Insurance"
+        values:
+          - "Claims & policy management agent"
+      - title: "IT operations"
+        values:
+          - "Invoice matching assistant"
+      - title: "Public sector"
+        values:
+          - "Private documents assistant"
+          - "Product sales assistant"
+      - title: "Professional services"
+        values:
+          - "Conference slide search"
+      - title: "Real estate"
+        values:
+          - "Real estate assistant"
+
+  - title: "Minimum resource allocation"
+    values:
+      - title: "Required cores"
+        value: "15 - 20"
+      - title: "Required memory"
+        value: "256 - 300GB"
+      - title: "Required Spyre cards"
+        value: "4 cards"
+
+  - title: "Code and architecture"
+    sections:
+      - title: "Source code"
+        ctaLabel: "View source code"
+        url: "https://github.com/IBM/project-ai-services"
+      - image:
+          source: "images/ragArchDiagram.webp"
+
+  - title: "Demos and prototypes"
+    sections:
+      - title: "Retrieval-Augmented Generation (RAG)"
+        description: "Discover the architecture behind this pre-built digital assistant"
+        ctaLabel: "Watch"
+        url: "https://github.com/user-attachments/assets/958980a7-f653-4474-84a7-28d657b5f7d1"
 
 # Made with Bob

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.75
+  image: icr.io/ai-services-cicd/ai-services:0.0.76
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/components/embedding/vllm-cpu/metadata.yaml
+++ b/ai-services/assets/components/embedding/vllm-cpu/metadata.yaml
@@ -1,7 +1,7 @@
 # Component identification
 type: component
 id: vllm-cpu
-name: "vLLM CPU Embeddings"
+name: "AI Inference on CPU"
 description: "Deploy embedding models on vLLM inference engine (CPU-only)"
 
 # Component type this provider belongs to

--- a/ai-services/assets/components/llm/vllm-cpu/metadata.yaml
+++ b/ai-services/assets/components/llm/vllm-cpu/metadata.yaml
@@ -1,7 +1,7 @@
 # Component identification
 type: component
 id: vllm-cpu
-name: "vLLM CPU Instruct"
+name: "AI Inference on CPU"
 description: "Deploy instruct models on vLLM inference engine (CPU-only)"
 
 # Component type this provider belongs to

--- a/ai-services/assets/components/llm/vllm-spyre/metadata.yaml
+++ b/ai-services/assets/components/llm/vllm-spyre/metadata.yaml
@@ -1,7 +1,7 @@
 # Component identification
 type: component
 id: vllm-spyre
-name: "vLLM Spyre Instruct"
+name: "RedHat AI Inference with Spyre"
 description: "Deploy instruct models on vLLM inference engine with Spyre acceleration"
 
 # Component type this provider belongs to

--- a/ai-services/assets/components/llm/watsonx/metadata.yaml
+++ b/ai-services/assets/components/llm/watsonx/metadata.yaml
@@ -1,7 +1,7 @@
 # Component identification
 type: component
 id: watsonx
-name: "Watsonx Instruct"
+name: "IBM watsonx.ai on IBM Cloud"
 description: "Deploy llm models using watsonx"
 
 # Component type this provider belongs to

--- a/ai-services/assets/components/reranker/vllm-cpu/metadata.yaml
+++ b/ai-services/assets/components/reranker/vllm-cpu/metadata.yaml
@@ -1,7 +1,7 @@
 # Component identification
 type: component
 id: vllm-cpu
-name: "vLLM CPU Reranker"
+name: "AI Inference on CPU"
 description: "Deploy reranker models on vLLM inference engine (CPU-only)"
 
 # Component type this provider belongs to

--- a/ai-services/assets/components/reranker/vllm-spyre/metadata.yaml
+++ b/ai-services/assets/components/reranker/vllm-spyre/metadata.yaml
@@ -1,7 +1,7 @@
 # Component identification
 type: component
 id: vllm-spyre
-name: "vLLM Spyre Instruct"
+name: "RedHat AI Inference with Spyre"
 description: "Deploy reranker models on vLLM inference engine"
 
 # Component type this provider belongs to

--- a/ai-services/assets/services/chat/metadata.yaml
+++ b/ai-services/assets/services/chat/metadata.yaml
@@ -18,3 +18,77 @@ dependencies:
   - id: llm
 
 standalone: false
+
+# About field containing detailed service information
+about:
+  - title: "Service details"
+    sections:
+      - title: "Version"
+        value: "1.0.0"
+      - title: "Large Language Model (LLM)"
+        value: "granite-3.3-8b-instruct"
+      - title: "Inference backend"
+        values:
+          - "RedHat AI Inference with Spyre"
+          - "AI Inference on CPU"
+          - "IBM watsonx.ai on IBM Cloud"
+      - title: "Embedding Model"
+        value: "granite-embedding-278m-multilingual"
+      - title: "Reranker Model"
+        value: "bge-reranker-v2-m3"
+      - title: "Vector Store"
+        value: "OpenSearch"
+
+  - title: "Inputs and outputs"
+    sections:
+      - title: "Inputs"
+        values:
+          - "Question in natural language"
+      - title: "Outputs"
+        values:
+          - "Answer to the input question"
+          - "If augmented with documents from the knowledge base: list of excerpts from the knowledge base, along with pointers from the knowledge base"
+
+  - title: "Dependencies and integration"
+    sections:
+      - title: "External dependencies"
+        values:
+          - "Inferencing endpoint compatible with OpenAI or similar AI APIs (required for LLM-based Q&A capabilities)"
+          - "Find similar items (required for augmenting the prompt to the LLM with knowledge from the knowledge base)"
+
+  - title: "Content and format support"
+    sections:
+      - title: "Languages"
+        values:
+          - "English"
+          - "French"
+          - "German"
+          - "Italian"
+      - title: "Content"
+        values:
+          - "Text"
+          - "Tables"
+
+  - title: "Expected resource consumption"
+    sections:
+      - title: "per 5 concurrent users"
+        values:
+          - title: "Compute"
+            value: "12 CPU cores"
+          - title: "Memory"
+            value: "113.50 GB"
+          - title: "Storage"
+            value: "80.00 GB"
+          - title: "Spyre acceleration cards"
+            value: 5
+
+  - title: "Assets"
+    sections:
+      - title: "Architectures"
+        values:
+          - "Digital assistant"
+      - title: "Source code"
+        ctaLabel: "View source code"
+        url: "https://github.com/IBM/project-ai-services"
+
+# Made with Bob

--- a/ai-services/assets/services/digitize/metadata.yaml
+++ b/ai-services/assets/services/digitize/metadata.yaml
@@ -19,4 +19,80 @@ dependencies:
 
 standalone: true
 
+# About field containing detailed service information
+about:
+  - title: "Service details"
+    sections:
+      - title: "Version"
+        value: "1.0.0"
+      - title: "Large Language Model (LLM)"
+        value: "granite-3.3-8b-instruct"
+      - title: "Inference backend"
+        values:
+          - "RedHat AI Inference with Spyre"
+          - "AI Inference on CPU"
+          - "IBM watsonx.ai on IBM Cloud"
+      - title: "Embedding Model"
+        value: "granite-embedding-278m-multilingual"
+      - title: "Vector Store"
+        value: "OpenSearch"
+
+  - title: "Inputs and outputs"
+    sections:
+      - title: "Inputs"
+        values:
+          - "Document files (e.g., PDFs)"
+          - "Flag if texts shall be filtered, embedded, and indexed into knowledge management (optional)"
+      - title: "Outputs"
+        values:
+          - "Texts digitized from input documents"
+          - "Pointers to digitized input documents"
+          - "Knowledge management indexing status"
+
+  - title: "Dependencies and integration"
+    sections:
+      - title: "External dependencies"
+        values:
+          - "Inferencing endpoint compatible with OpenAI or similar AI APIs (required for LLM-based summarization capabilities)"
+          - "Supported VectorDB (required for knowledge management features such as embeddings, indexing, and similarity search)"
+
+  - title: "Content and format support"
+    sections:
+      - title: "Languages"
+        values:
+          - "English"
+          - "French"
+          - "German"
+          - "Italian"
+      - title: "Document formats"
+        values:
+          - "PDF"
+          - "DOCX"
+      - title: "Content"
+        values:
+          - "Text"
+          - "Tables"
+
+  - title: "Expected resource consumption"
+    sections:
+      - title: "per 5 concurrent users"
+        values:
+          - title: "Compute"
+            value: "19 CPU cores"
+          - title: "Memory"
+            value: "162.50 GB"
+          - title: "Storage"
+            value: "90.00 GB"
+          - title: "Spyre acceleration cards"
+            value: 4
+
+  - title: "Assets"
+    sections:
+      - title: "Architectures"
+        values:
+          - "Digital assistant"
+      - title: "Source code"
+        ctaLabel: "View source code"
+        url: "https://github.com/IBM/project-ai-services"
+
 # Made with Bob

--- a/ai-services/assets/services/similarity/metadata.yaml
+++ b/ai-services/assets/services/similarity/metadata.yaml
@@ -19,4 +19,76 @@ dependencies:
 
 standalone: false
 
+# About field containing detailed service information
+about:
+  - title: "Service details"
+    sections:
+      - title: "Version"
+        value: "1.0.0"
+      - title: "Inference backend"
+        values:
+          - "RedHat AI Inference with Spyre"
+          - "AI Inference on CPU"
+      - title: "Embedding Model"
+        value: "granite-embedding-278m-multilingual"
+      - title: "Reranker Model"
+        value: "bge-reranker-v2-m3"
+      - title: "Vector Store"
+        value: "OpenSearch"
+
+  - title: "Inputs and outputs"
+    sections:
+      - title: "Inputs"
+        values:
+          - "Item to find similar items for (e.g., text or document)"
+          - "Number of documents to receive, (optional) flag to activate reranking"
+      - title: "Outputs"
+        values:
+          - "Ranked list of items (e.g., text chunks) and pointers to their associated source (e.g., originating document)"
+
+  - title: "Dependencies and integration"
+    sections:
+      - title: "External dependencies"
+        values:
+          - "Inferencing endpoint compatible with OpenAI or similar AI APIs (required for embedding and reranking capabilities)"
+          - "Supported VectorDB (required as source for similar items)"
+
+  - title: "Content and format support"
+    sections:
+      - title: "Languages"
+        values:
+          - "English"
+          - "French"
+          - "German"
+          - "Italian"
+      - title: "Content"
+        values:
+          - "Text"
+          - "Tables"
+      - title: "Reranking"
+        values:
+          - "Improved ranking through reranking AI model"
+
+  - title: "Expected resource consumption"
+    sections:
+      - title: "per 5 concurrent users"
+        values:
+          - title: "Compute"
+            value: "10 CPU cores"
+          - title: "Memory"
+            value: "18.00 GB"
+          - title: "Storage"
+            value: "40.00 GB"
+          - title: "Spyre acceleration cards"
+            value: 1
+
+  - title: "Assets"
+    sections:
+      - title: "Architectures"
+        values:
+          - "Digital assistant"
+      - title: "Source code"
+        ctaLabel: "View source code"
+        url: "https://github.com/IBM/project-ai-services"
+
 # Made with Bob

--- a/ai-services/assets/services/summarize/metadata.yaml
+++ b/ai-services/assets/services/summarize/metadata.yaml
@@ -16,3 +16,65 @@ dependencies:
   - id: llm
 
 standalone: true
+
+# About field containing detailed service information
+about:
+  - title: "Service details"
+    sections:
+      - title: "Version"
+        value: "1.0.0"
+      - title: "Large Language Model (LLM)"
+        value: "granite-3.3-8b-instruct"
+      - title: "Inference backend"
+        values:
+          - "RedHat AI Inference with Spyre"
+          - "AI Inference on CPU"
+          - "IBM watsonx.ai on IBM Cloud"
+
+  - title: "Inputs and outputs"
+    sections:
+      - title: "Inputs"
+        values:
+          - "Text to be summarized"
+          - "level (string, optional): Abstraction level: 'brief', 'standard' (default), or 'detailed'"
+          - "length (integer, optional): (Legacy) Desired summary length in words"
+          - "stream (boolean, optional): Stream the summary as it is generated, default False"
+      - title: "Outputs"
+        values:
+          - "Summary of the input text"
+
+  - title: "Dependencies and integration"
+    sections:
+      - title: "External dependencies"
+        values:
+          - "Inferencing endpoint compatible with OpenAI or similar AI APIs (required for LLM-based summarization capabilities)"
+
+  - title: "Content and format support"
+    sections:
+      - title: "Languages"
+        values:
+          - "English"
+
+  - title: "Expected resource consumption"
+    sections:
+      - title: "per 5 concurrent users"
+        values:
+          - title: "Compute"
+            value: "7 CPU cores"
+          - title: "Memory"
+            value: "101.00 GB"
+          - title: "Storage"
+            value: "60.00 GB"
+          - title: "Spyre acceleration cards"
+            value: 4
+
+  - title: "Assets"
+    sections:
+      - title: "Architectures"
+        values:
+          - "Digital assistant"
+      - title: "Source code"
+        ctaLabel: "View source code"
+        url: "https://github.com/IBM/project-ai-services"
+
+# Made with Bob

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -1368,6 +1368,7 @@ const docTemplate = `{
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture": {
             "type": "object",
             "properties": {
+                "about": {},
                 "certified_by": {
                     "type": "string"
                 },
@@ -1648,6 +1649,7 @@ const docTemplate = `{
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Service": {
             "type": "object",
             "properties": {
+                "about": {},
                 "architectures": {
                     "type": "array",
                     "items": {

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -1362,6 +1362,7 @@
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture": {
             "type": "object",
             "properties": {
+                "about": {},
                 "certified_by": {
                     "type": "string"
                 },
@@ -1642,6 +1643,7 @@
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Service": {
             "type": "object",
             "properties": {
+                "about": {},
                 "architectures": {
                     "type": "array",
                     "items": {

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -177,6 +177,7 @@ definitions:
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture:
     properties:
+      about: {}
       certified_by:
         type: string
       description:
@@ -361,6 +362,7 @@ definitions:
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Service:
     properties:
+      about: {}
       architectures:
         items:
           type: string

--- a/ai-services/internal/pkg/catalog/types/types.go
+++ b/ai-services/internal/pkg/catalog/types/types.go
@@ -12,6 +12,7 @@ type Architecture struct {
 	GlobalComponents []ComponentReference `yaml:"global_components,omitempty" json:"global_components,omitempty"`
 	Services         []ServiceReference   `yaml:"services" json:"services"`
 	Links            *ArchitectureLinks   `yaml:"links,omitempty" json:"links,omitempty"`
+	About            any                  `yaml:"about,omitempty" json:"about,omitempty"`
 }
 
 // ArchitectureSummary represents an architecture for list API responses.
@@ -65,6 +66,7 @@ type Service struct {
 	Architectures []string              `yaml:"architectures" json:"architectures"`
 	Dependencies  []DependencyReference `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
 	Standalone    bool                  `yaml:"standalone,omitempty" json:"standalone,omitempty"`
+	About         any                   `yaml:"about,omitempty" json:"about,omitempty"`
 }
 
 // ServiceSummary represents a service for list API responses.


### PR DESCRIPTION
Ref PR: https://github.com/IBM/project-ai-services/pull/870/changes#diff-6c851796ebe28a2a71bbb0b8e8d5225ba8325b01a20c6fcf67ceb7bd4877878aR1

- Add `about` section data in respective services metadata.
- Respond back as part of GET `/api/v1/services/{id}`
- Also `about` section for Digitial Assistant and respond back as part of GET `/api/v1/architectures/{id}`