### PR TITLE
fix: modify duplicate app check to return proper error

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.85
+TAG?=0.0.86
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.85
+  image: icr.io/ai-services-cicd/ai-services:0.0.86
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -265,7 +265,7 @@ func (s *ApplicationService) UpdateApplication(ctx context.Context, id uuid.UUID
 func (s *ApplicationService) CreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest) (*apimodels.CreateApplicationResponse, error) {
 	// Phase 1: Validate request and check for duplicate application name
 	existingApp, err := s.appRepo.GetByName(ctx, req.Name)
-	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+	if err != nil {
 		return nil, fmt.Errorf("failed to check for existing application: %w", err)
 	}
 	if existingApp != nil {

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	apimodels "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/deletion"
@@ -229,26 +228,24 @@ func ValidatePaginationParams(page, pageSize int) (int, int, error) {
 func (s *ApplicationService) UpdateApplication(ctx context.Context, id uuid.UUID, userID, newName string) (*types.Application, error) {
 	app, err := s.appRepo.GetByID(ctx, id)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrApplicationNotFound
-		}
-
 		return nil, fmt.Errorf("failed to get application: %w", err)
+	}
+	if app == nil {
+		return nil, ErrApplicationNotFound
 	}
 	if app.CreatedBy != userID {
 		return nil, ErrUnauthorized
 	}
 	err = s.appRepo.UpdateDeploymentName(ctx, id, newName)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrApplicationNotFound
-		}
-
 		return nil, fmt.Errorf("failed to update application name: %w", err)
 	}
 	updatedApp, err := s.appRepo.GetByID(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch updated application %w", err)
+	}
+	if updatedApp == nil {
+		return nil, ErrApplicationNotFound
 	}
 
 	appData, err := s.buildApplication(*updatedApp)
@@ -491,11 +488,10 @@ func (s *ApplicationService) GetApplicationByID(ctx context.Context, id uuid.UUI
 	// Fetch application from database
 	app, err := s.appRepo.GetByID(ctx, id)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrApplicationNotFound
-		}
-
 		return nil, fmt.Errorf("failed to get application: %w", err)
+	}
+	if app == nil {
+		return nil, ErrApplicationNotFound
 	}
 	// Build complete response with services and components
 	return s.buildGetApplicationResponse(ctx, app)
@@ -573,6 +569,9 @@ func (s *ApplicationService) loadServiceComponents(ctx context.Context, sd []mod
 			if err != nil {
 				return nil, fmt.Errorf("failed to get component: %w", err)
 			}
+			if component == nil {
+				continue
+			}
 
 			// Transform to response object
 			temp := types.ServiceComponentResp{
@@ -599,11 +598,10 @@ type DeleteApplicationResponse struct {
 func (s *ApplicationService) DeleteApplication(ctx context.Context, id uuid.UUID, user string, keepData bool) (*DeleteApplicationResponse, error) {
 	app, err := s.appRepo.GetByID(ctx, id)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, fmt.Errorf("not found: application does not exist")
-		}
-
-		return nil, fmt.Errorf("not found: %w", err)
+		return nil, fmt.Errorf("failed to get application: %w", err)
+	}
+	if app == nil {
+		return nil, fmt.Errorf("not found: application does not exist")
 	}
 
 	if app.CreatedBy != user {
@@ -703,7 +701,10 @@ func (s *ApplicationService) GetApplicationResources(ctx context.Context, id uui
 	// Fetch application from database
 	app, err := s.appRepo.GetByID(ctx, id)
 	if err != nil {
-		return nil, handleGetApplicationError(err)
+		return nil, fmt.Errorf("failed to get application: %w", err)
+	}
+	if app == nil {
+		return nil, ErrApplicationNotFound
 	}
 
 	// Create runtime client
@@ -726,15 +727,6 @@ func (s *ApplicationService) GetApplicationResources(ctx context.Context, id uui
 
 	// Build and return response
 	return buildResourcesResponse(resourceTotals), nil
-}
-
-// handleGetApplicationError handles errors from GetByID.
-func handleGetApplicationError(err error) error {
-	if errors.Is(err, pgx.ErrNoRows) {
-		return ErrApplicationNotFound
-	}
-
-	return fmt.Errorf("failed to get application: %w", err)
 }
 
 // resourceTotals holds aggregated resource information.
@@ -975,11 +967,10 @@ func buildResourcesResponse(totals *resourceTotals) *types.ApplicationResourcesR
 func (s *ApplicationService) ApplicationsPs(ctx context.Context, appID uuid.UUID) (*types.ApplicationPSResponse, error) {
 	app, err := s.appRepo.GetByID(ctx, appID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrApplicationNotFound
-		}
-
 		return nil, fmt.Errorf("failed to get application: %w", err)
+	}
+	if app == nil {
+		return nil, ErrApplicationNotFound
 	}
 
 	// Initialize runtime client for pod operations

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
@@ -264,8 +265,15 @@ func (s *ApplicationService) UpdateApplication(ctx context.Context, id uuid.UUID
 func (s *ApplicationService) CreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest) (*apimodels.CreateApplicationResponse, error) {
 	// Phase 1: Validate request and check for duplicate application name
 	existingApp, err := s.appRepo.GetByName(ctx, req.Name)
-	if err == nil && existingApp != nil {
-		return nil, fmt.Errorf("application with name '%s' already exists", req.Name)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return nil, fmt.Errorf("failed to check for existing application: %w", err)
+	}
+	if existingApp != nil {
+		// Application with this name already exists - return conflict error
+		return nil, &ValidationError{
+			Code:    http.StatusConflict,
+			Message: fmt.Sprintf("application with name '%s' already exists", req.Name),
+		}
 	}
 
 	// Phase 2: Validate request payload

--- a/ai-services/internal/pkg/catalog/db/repository/application_repo.go
+++ b/ai-services/internal/pkg/catalog/db/repository/application_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -338,7 +339,12 @@ func (r *applicationRepo) GetByName(ctx context.Context, name string) (*models.A
 	}
 	defer rows.Close()
 
-	return collectApplication(rows)
+	app, err := collectApplication(rows)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return nil, err
+	}
+
+	return app, nil
 }
 
 // Insert creates a new application in the database.

--- a/ai-services/internal/pkg/catalog/db/repository/application_repo.go
+++ b/ai-services/internal/pkg/catalog/db/repository/application_repo.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -294,7 +293,7 @@ func collectApplication(rows pgx.Rows) (*models.Application, error) {
 	}
 
 	if app == nil {
-		return nil, pgx.ErrNoRows
+		return nil, nil
 	}
 
 	return app, nil
@@ -339,12 +338,7 @@ func (r *applicationRepo) GetByName(ctx context.Context, name string) (*models.A
 	}
 	defer rows.Close()
 
-	app, err := collectApplication(rows)
-	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-		return nil, err
-	}
-
-	return app, nil
+	return collectApplication(rows)
 }
 
 // Insert creates a new application in the database.
@@ -388,13 +382,9 @@ func (r *applicationRepo) UpdateDeploymentName(ctx context.Context, id uuid.UUID
 		WHERE id = $2
 	`
 
-	result, err := r.pool.Exec(ctx, query, name, id)
+	_, err := r.pool.Exec(ctx, query, name, id)
 	if err != nil {
 		return fmt.Errorf("failed to update application name: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return pgx.ErrNoRows
 	}
 
 	return nil
@@ -408,13 +398,9 @@ func (r *applicationRepo) UpdateStatus(ctx context.Context, id uuid.UUID, status
 		WHERE id = $3
 	`
 
-	result, err := r.pool.Exec(ctx, query, status, sql.NullString{String: message, Valid: message != ""}, id)
+	_, err := r.pool.Exec(ctx, query, status, sql.NullString{String: message, Valid: message != ""}, id)
 	if err != nil {
 		return fmt.Errorf("failed to update application status: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return pgx.ErrNoRows
 	}
 
 	return nil
@@ -425,13 +411,9 @@ func (r *applicationRepo) UpdateStatus(ctx context.Context, id uuid.UUID, status
 func (r *applicationRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	query := `DELETE FROM applications WHERE id = $1`
 
-	result, err := r.pool.Exec(ctx, query, id)
+	_, err := r.pool.Exec(ctx, query, id)
 	if err != nil {
 		return fmt.Errorf("failed to delete application: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return pgx.ErrNoRows
 	}
 
 	return nil

--- a/ai-services/internal/pkg/catalog/db/repository/component_repo.go
+++ b/ai-services/internal/pkg/catalog/db/repository/component_repo.go
@@ -125,7 +125,7 @@ func (r *componentRepo) GetByID(ctx context.Context, id uuid.UUID) (*models.Comp
 
 	if err != nil {
 		if err == pgx.ErrNoRows {
-			return nil, pgx.ErrNoRows
+			return nil, nil
 		}
 
 		return nil, fmt.Errorf("failed to get component: %w", err)
@@ -303,7 +303,7 @@ func (r *componentRepo) Update(ctx context.Context, component *models.Component)
 
 	if err != nil {
 		if err == pgx.ErrNoRows {
-			return pgx.ErrNoRows
+			return nil
 		}
 
 		return fmt.Errorf("failed to update component: %w", err)
@@ -320,13 +320,9 @@ func (r *componentRepo) UpdateStatus(ctx context.Context, id uuid.UUID, status m
 		WHERE id = $3
 	`
 
-	result, err := r.pool.Exec(ctx, query, status, sql.NullString{String: message, Valid: message != ""}, id)
+	_, err := r.pool.Exec(ctx, query, status, sql.NullString{String: message, Valid: message != ""}, id)
 	if err != nil {
 		return fmt.Errorf("failed to update component status: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return pgx.ErrNoRows
 	}
 
 	return nil
@@ -350,13 +346,9 @@ func (r *componentRepo) UpdateEndpoints(ctx context.Context, id uuid.UUID, endpo
 		}
 	}
 
-	result, err := r.pool.Exec(ctx, query, endpointsJSON, id)
+	_, err = r.pool.Exec(ctx, query, endpointsJSON, id)
 	if err != nil {
 		return fmt.Errorf("failed to update component endpoints: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return pgx.ErrNoRows
 	}
 
 	return nil
@@ -366,13 +358,9 @@ func (r *componentRepo) UpdateEndpoints(ctx context.Context, id uuid.UUID, endpo
 func (r *componentRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	query := `DELETE FROM components WHERE id = $1`
 
-	result, err := r.pool.Exec(ctx, query, id)
+	_, err := r.pool.Exec(ctx, query, id)
 	if err != nil {
 		return fmt.Errorf("failed to delete component: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return pgx.ErrNoRows
 	}
 
 	return nil

--- a/ai-services/internal/pkg/catalog/db/repository/service_dependency_repo.go
+++ b/ai-services/internal/pkg/catalog/db/repository/service_dependency_repo.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
 )
@@ -58,13 +57,9 @@ func (r *serviceDependencyRepo) RemoveDependency(ctx context.Context, serviceID,
 		WHERE service_id = $1 AND dependency_id = $2
 	`
 
-	result, err := r.pool.Exec(ctx, query, serviceID, dependencyID)
+	_, err := r.pool.Exec(ctx, query, serviceID, dependencyID)
 	if err != nil {
 		return fmt.Errorf("failed to remove service dependency: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return pgx.ErrNoRows
 	}
 
 	return nil

--- a/ai-services/internal/pkg/catalog/db/repository/service_repo.go
+++ b/ai-services/internal/pkg/catalog/db/repository/service_repo.go
@@ -84,13 +84,9 @@ func (r *serviceRepo) Insert(ctx context.Context, service *models.Service) error
 func (r *serviceRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	query := `DELETE FROM services WHERE id = $1`
 
-	result, err := r.pool.Exec(ctx, query, id)
+	_, err := r.pool.Exec(ctx, query, id)
 	if err != nil {
 		return fmt.Errorf("failed to delete service: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return pgx.ErrNoRows
 	}
 
 	return nil
@@ -201,7 +197,7 @@ func (r *serviceRepo) Update(ctx context.Context, service *models.Service) error
 
 	if err != nil {
 		if err == pgx.ErrNoRows {
-			return pgx.ErrNoRows
+			return nil
 		}
 
 		return fmt.Errorf("failed to update service: %w", err)
@@ -218,13 +214,9 @@ func (r *serviceRepo) UpdateStatus(ctx context.Context, id uuid.UUID, status mod
 		WHERE id = $3
 	`
 
-	result, err := r.pool.Exec(ctx, query, status, sql.NullString{String: message, Valid: message != ""}, id)
+	_, err := r.pool.Exec(ctx, query, status, sql.NullString{String: message, Valid: message != ""}, id)
 	if err != nil {
 		return fmt.Errorf("failed to update service status: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return pgx.ErrNoRows
 	}
 
 	return nil
@@ -248,13 +240,9 @@ func (r *serviceRepo) UpdateEndpoints(ctx context.Context, id uuid.UUID, endpoin
 		}
 	}
 
-	result, err := r.pool.Exec(ctx, query, endpointsJSON, id)
+	_, err = r.pool.Exec(ctx, query, endpointsJSON, id)
 	if err != nil {
 		return fmt.Errorf("failed to update service endpoints: %w", err)
-	}
-
-	if result.RowsAffected() == 0 {
-		return pgx.ErrNoRows
 	}
 
 	return nil


### PR DESCRIPTION
1. The condition `if err == nil && existingApp != nil` would bypass the duplicate check when GetByName returned an error, allowing applications with duplicate names to be created.
2. Duplicate names returned a generic 500 error instead of the appropriate 409 Conflict status.