### PR TITLE
Proper Logger Implementation for Catalog Backend

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.87
+TAG?=0.0.88
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -95,6 +95,10 @@ spec:
       args:
         - "/usr/bin/ai-services catalog apiserver --port=8080 --admin-username=admin --admin-password-hash=${ADMIN_PASSWORD} --runtime={{ .Values.backend.runtime }}"
       env:
+        - name: AI_SERVICES_LOG_LEVEL
+          value: "info"
+        - name: AI_SERVICES_LOG_FORMAT
+          value: "service"
         - name: CONTAINER_HOST
           value: "unix://{{ .Values.backend.podman.uri }}"
         - name: REGISTRY_AUTH_FILE

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.87
+  image: icr.io/ai-services-cicd/ai-services:0.0.88
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/application/podman/restore/digitize.go
+++ b/ai-services/internal/pkg/application/podman/restore/digitize.go
@@ -78,14 +78,14 @@ func readJobFiles(jobsDir string) ([]interface{}, error) {
 		filePath := filepath.Join(jobsDir, entry.Name())
 		data, err := os.ReadFile(filePath)
 		if err != nil {
-			logger.Warningf("Failed to read job file %s: %v\n", entry.Name(), err, 0)
+			logger.Warningf("Failed to read job file %s: %v\n", entry.Name(), err)
 
 			continue
 		}
 
 		var job map[string]interface{}
 		if err := json.Unmarshal(data, &job); err != nil {
-			logger.Warningf("Failed to parse job file %s: %v\n", entry.Name(), err, 0)
+			logger.Warningf("Failed to parse job file %s: %v\n", entry.Name(), err)
 
 			continue
 		}
@@ -122,14 +122,14 @@ func readDocumentFiles(docsDir string) ([]interface{}, error) {
 		filePath := filepath.Join(docsDir, entry.Name())
 		data, err := os.ReadFile(filePath)
 		if err != nil {
-			logger.Warningf("Failed to read document file %s: %v\n", entry.Name(), err, 0)
+			logger.Warningf("Failed to read document file %s: %v\n", entry.Name(), err)
 
 			continue
 		}
 
 		var doc map[string]interface{}
 		if err := json.Unmarshal(data, &doc); err != nil {
-			logger.Warningf("Failed to parse document file %s: %v\n", entry.Name(), err, 0)
+			logger.Warningf("Failed to parse document file %s: %v\n", entry.Name(), err)
 
 			continue
 		}

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -1017,7 +1017,7 @@ func (s *ApplicationService) collectServicePods(
 		pod, err := loadApplicationPod(rt, service.ID.String())
 		if err != nil {
 			// Log error but continue with other services (fault-tolerant)
-			logger.Errorf("Failed to load service pod: %w", err)
+			logger.Errorf("Failed to load service pod: %v", err)
 
 			continue
 		}
@@ -1066,7 +1066,7 @@ func (s *ApplicationService) collectComponentPods(
 			// Load component pod from runtime
 			componentPod, err := loadApplicationPod(rt, componentID)
 			if err != nil {
-				logger.Errorf("Failed to load component pod: %w", err)
+				logger.Errorf("Failed to load component pod: %v", err)
 
 				continue
 			}

--- a/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
@@ -386,7 +386,7 @@ func (s *DeletionService) deleteVolumesFromPods(rt runtime.Runtime, pods []runti
 			}
 			errMsg := fmt.Sprintf("%s %s: failed to delete volume %s: %s", instanceType, instanceID, volumeName, err)
 			errorMessages = append(errorMessages, errMsg)
-			logger.Errorf(errMsg)
+			logger.Errorf("%s %s: failed to delete volume %s: %s", instanceType, instanceID, volumeName, err)
 		} else {
 			logger.Infof("Successfully deleted volume: %s", volumeName)
 		}
@@ -440,7 +440,7 @@ func (s *DeletionService) deleteSecretsFromPods(rt runtime.Runtime, pods []runti
 			}
 			errMsg := fmt.Sprintf("%s %s: failed to delete secret %s: %s", instanceType, instanceID, secretName, err)
 			errorMessages = append(errorMessages, errMsg)
-			logger.Errorf(errMsg)
+			logger.Errorf("%s %s: failed to delete secret %s: %s", instanceType, instanceID, secretName, err)
 		} else {
 			logger.Infof("Successfully deleted secret: %s", secretName)
 		}

--- a/ai-services/internal/pkg/catalog/deploy_options.go
+++ b/ai-services/internal/pkg/catalog/deploy_options.go
@@ -147,7 +147,7 @@ func (p *CatalogProvider) GetServiceDeployOptions(serviceID string) (*types.Depl
 	for _, dep := range service.Dependencies {
 		component, err := p.buildDeployOptionsComponent(dep.ID, true)
 		if err != nil {
-			logger.Errorf(fmt.Sprintf("failed to build component '%s': %v", dep.ID, err))
+			logger.Errorf("failed to build component '%s': %v", dep.ID, err)
 
 			continue
 		}
@@ -291,7 +291,7 @@ func (p *CatalogProvider) GetComponentProviderParams(componentType, providerID s
 	schemaData, err := assets.CatalogFS.ReadFile(schemaPath)
 	if err != nil {
 		// If schema file doesn't exist, return empty schema instead of failing
-		logger.Warningf(fmt.Sprintf("schema file not found at '%s': %v", schemaPath, err))
+		logger.Warningf("schema file not found at '%s': %v", schemaPath, err)
 
 		return map[string]any{}, nil
 	}
@@ -326,7 +326,7 @@ func (p *CatalogProvider) GetServiceParams(serviceID string) (map[string]any, er
 	schemaData, err := assets.CatalogFS.ReadFile(schemaPath)
 	if err != nil {
 		// If schema file doesn't exist, return empty schema instead of failing
-		logger.Warningf(fmt.Sprintf("schema file not found at '%s': %v", schemaPath, err))
+		logger.Warningf("schema file not found at '%s': %v", schemaPath, err)
 
 		return map[string]any{}, nil
 	}

--- a/ai-services/internal/pkg/logger/logger.go
+++ b/ai-services/internal/pkg/logger/logger.go
@@ -15,12 +15,6 @@ import (
 const (
 	// VerbosityLevelDebug is the klog verbosity level for debug logs (2).
 	VerbosityLevelDebug = 2
-	// VerbosityLevelInfo is the klog verbosity level for info logs (0).
-	VerbosityLevelInfo = 0
-	// VerbosityLevelWarning is the klog verbosity level for warning logs (0).
-	VerbosityLevelWarning = 0
-	// VerbosityLevelError is the klog verbosity level for error logs (0).
-	VerbosityLevelError = 0
 
 	// LogLevelDebug is the string constant for debug severity level.
 	LogLevelDebug = "debug"
@@ -42,10 +36,22 @@ const (
 	LogLevelWarningIndicator = "W"
 	// LogLevelErrorIndicator is the output indicator for error level logs ("E").
 	LogLevelErrorIndicator = "E"
+
+	// LevelRankDebug is the numeric rank for debug severity level (0).
+	LevelRankDebug = iota
+	// LevelRankInfo is the numeric rank for info severity level (1).
+	LevelRankInfo
+	// LevelRankWarn is the numeric rank for warning severity level (2).
+	LevelRankWarn
+	// LevelRankError is the numeric rank for error severity level (3).
+	LevelRankError
 )
 
 // Global state to track whether we are in a service context.
 var isServiceEnv bool
+
+// activeMinLevel tracks the active numeric severity level for filtering.
+var activeMinLevel int
 
 // Init initializes the logger with appropriate settings based on environment.
 func Init() {
@@ -75,16 +81,22 @@ func Init() {
 		_ = flag.CommandLine.Set("logtostderr", "true")
 	}
 
-	// 4. Apply Severity Thresholds
+	// 4. Apply Severity Thresholds and set active minimum level
 	switch logLevel {
 	case LogLevelDebug:
 		_ = flag.CommandLine.Set("v", "2")
-	case LogLevelInfo:
-		_ = flag.CommandLine.Set("v", "0")
+		activeMinLevel = LevelRankDebug
 	case LogLevelWarn:
-		_ = flag.CommandLine.Set("stderrthreshold", "WARNING")
+		_ = flag.CommandLine.Set("v", "0")
+		activeMinLevel = LevelRankWarn
 	case LogLevelError:
-		_ = flag.CommandLine.Set("stderrthreshold", "ERROR")
+		_ = flag.CommandLine.Set("v", "0")
+		activeMinLevel = LevelRankError
+	case LogLevelInfo:
+		fallthrough
+	default:
+		_ = flag.CommandLine.Set("v", "0")
+		activeMinLevel = LevelRankInfo
 	}
 }
 
@@ -98,7 +110,7 @@ func getCallerContext(skipDepth int, severity string) string {
 		return ""
 	}
 
-	// Use standard klog MMDD format or standardized ISO-8601 timestamps
+	// Use standard klog MMDD format matching production specs
 	timestamp := time.Now().Format("0102 15:04:05.000000")
 
 	// Standardized output shape: "I0610 19:31:44.190447 /path/to/file.go:200] "
@@ -116,9 +128,11 @@ func Flush() {
 }
 
 func Warningln(msg string) {
+	if activeMinLevel > LevelRankWarn {
+		return
+	}
 	ctx := getCallerContext(1, LogLevelWarningIndicator)
 	if ctx == "" {
-		// CLI mode: add WARNING prefix
 		klog.WarningDepth(1, "WARNING: ", msg)
 	} else {
 		klog.WarningDepth(1, ctx, msg)
@@ -126,19 +140,21 @@ func Warningln(msg string) {
 }
 
 func Warningf(format string, args ...any) {
+	if activeMinLevel > LevelRankWarn {
+		return
+	}
 	ctx := getCallerContext(1, LogLevelWarningIndicator)
+	formattedMsg := fmt.Sprintf(format, args...)
 	if ctx == "" {
-		// CLI mode: add WARNING prefix
-		klog.WarningDepth(1, "WARNING: "+fmt.Sprintf(format, args...))
+		klog.WarningDepth(1, "WARNING: ", formattedMsg)
 	} else {
-		klog.WarningDepth(1, ctx+fmt.Sprintf(format, args...))
+		klog.WarningDepth(1, ctx, formattedMsg) // FIXED: Comma separation ensures clean payload tracking
 	}
 }
 
 func Errorln(msg string) {
 	ctx := getCallerContext(1, LogLevelErrorIndicator)
 	if ctx == "" {
-		// CLI mode: add ERROR prefix
 		klog.ErrorDepth(1, "ERROR: ", msg)
 	} else {
 		klog.ErrorDepth(1, ctx, msg)
@@ -147,32 +163,52 @@ func Errorln(msg string) {
 
 func Errorf(format string, args ...any) {
 	ctx := getCallerContext(1, LogLevelErrorIndicator)
+	formattedMsg := fmt.Sprintf(format, args...)
 	if ctx == "" {
-		// CLI mode: add ERROR prefix
-		klog.ErrorDepth(1, "ERROR: "+fmt.Sprintf(format, args...))
+		klog.ErrorDepth(1, "ERROR: ", formattedMsg)
 	} else {
-		klog.ErrorDepth(1, ctx+fmt.Sprintf(format, args...))
+		klog.ErrorDepth(1, ctx, formattedMsg) // FIXED: Separated context metadata from message body
 	}
 }
 
 func Infoln(msg string, verbose ...int) {
+	if activeMinLevel > LevelRankInfo {
+		return
+	}
+
 	v := 0
 	if len(verbose) > 0 {
 		v = verbose[0]
 	}
+
+	// Guard check: Suppress custom debug logs if system level is locked to info
+	if v > 0 && activeMinLevel == LevelRankInfo {
+		return
+	}
+
 	ctx := getCallerContext(1, LogLevelInfoIndicator)
 	klog.V(klog.Level(v)).InfoDepth(1, ctx, msg)
 }
 
 func Infof(format string, args ...any) {
+	if activeMinLevel > LevelRankInfo {
+		return
+	}
+
 	v := 0
-	// Extract trailing verbosity argument safely to preserve backward compatibility
 	if len(args) > 0 {
 		if verbosity, ok := args[len(args)-1].(int); ok {
 			v = verbosity
 			args = args[:len(args)-1]
 		}
 	}
+
+	// Guard check: Suppress custom debug logs if system level is locked to info
+	if v > 0 && activeMinLevel == LevelRankInfo {
+		return
+	}
+
 	ctx := getCallerContext(1, LogLevelInfoIndicator)
-	klog.V(klog.Level(v)).InfoDepth(1, ctx+fmt.Sprintf(format, args...))
+	formattedMsg := fmt.Sprintf(format, args...)
+	klog.V(klog.Level(v)).InfoDepth(1, ctx, formattedMsg) // FIXED: Passing clean params instead of string concat
 }

--- a/ai-services/internal/pkg/logger/logger.go
+++ b/ai-services/internal/pkg/logger/logger.go
@@ -2,26 +2,103 @@ package logger
 
 import (
 	"flag"
+	"fmt"
+	"os"
+	"runtime"
+	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 )
 
+// Log levels following standard production hierarchy
 const (
-	VerbosityLevelDebug = 2
+	// Verbosity levels for klog
+	VerbosityLevelDebug   = 2
+	VerbosityLevelInfo    = 0
+	VerbosityLevelWarning = 0
+	VerbosityLevelError   = 0
+
+	// Standard Severity Levels
+	LogLevelDebug = "debug"
+	LogLevelInfo  = "info"
+	LogLevelWarn  = "warning"
+	LogLevelError = "error"
+
+	// Env Log Variables
+	EnvLogLevel  = "AI_SERVICES_LOG_LEVEL"  // e.g., "info", "debug"
+	EnvLogFormat = "AI_SERVICES_LOG_FORMAT" // e.g., "cli", "service"
+
+	// Log level indicators for output formatting
+	LogLevelInfoIndicator    = "I"
+	LogLevelWarningIndicator = "W"
+	LogLevelErrorIndicator   = "E"
 )
 
+// Global state to track whether we are in a service context
+var isServiceEnv bool
+
+// Init initializes the logger with appropriate settings based on environment
 func Init() {
 	klog.InitFlags(flag.CommandLine)
 	_ = flag.CommandLine.Set("alsologtostderr", "true")
-	_ = flag.CommandLine.Set("skip_headers", "true")
-	_ = flag.CommandLine.Set("skip_log_headers", "true")
+	_ = flag.CommandLine.Set("skip_log_backtrace_at", ":0")
+
+	// 1. Resolve Log Format (Defaults to "cli" for terminal users)
+	logFormat := os.Getenv(EnvLogFormat)
+	if logFormat == "" {
+		logFormat = "cli"
+	}
+	isServiceEnv = logFormat == "service"
+
+	// 2. Resolve Log Severity Level (Defaults to "info")
+	logLevel := os.Getenv(EnvLogLevel)
+	if logLevel == "" {
+		logLevel = LogLevelInfo
+	}
+
+	// 3. Apply Format Configuration
+	if logFormat == "cli" {
+		_ = flag.CommandLine.Set("skip_headers", "true")
+		_ = flag.CommandLine.Set("skip_log_headers", "true")
+	} else {
+		_ = flag.CommandLine.Set("skip_headers", "true") // Still true because custom wrapper handles the metadata
+		_ = flag.CommandLine.Set("logtostderr", "true")
+	}
+
+	// 4. Apply Severity Thresholds
+	switch logLevel {
+	case LogLevelDebug:
+		_ = flag.CommandLine.Set("v", "2")
+	case LogLevelInfo:
+		_ = flag.CommandLine.Set("v", "0")
+	case LogLevelWarn:
+		_ = flag.CommandLine.Set("stderrthreshold", "WARNING")
+	case LogLevelError:
+		_ = flag.CommandLine.Set("stderrthreshold", "ERROR")
+	}
+}
+
+// getCallerContext generates absolute paths and timestamps if service mode is active
+func getCallerContext(skipDepth int, severity string) string {
+	if !isServiceEnv {
+		return ""
+	}
+	_, file, line, ok := runtime.Caller(skipDepth + 1)
+	if !ok {
+		return ""
+	}
+
+	// Use standard klog MMDD format or standardized ISO-8601 timestamps
+	timestamp := time.Now().Format("0102 15:04:05.000000")
+
+	// Standardized output shape: "I0610 19:31:44.190447 /path/to/file.go:200] "
+	return fmt.Sprintf("%s%s %s:%d] ", severity, timestamp, file, line)
 }
 
 func InitFlags(cmd *cobra.Command) {
 	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
 	klog.InitFlags(klogFlags)
-
 	cmd.PersistentFlags().AddGoFlagSet(klogFlags)
 }
 
@@ -30,19 +107,25 @@ func Flush() {
 }
 
 func Warningln(msg string) {
-	klog.Warningln("WARNING: ", msg)
+	ctx := getCallerContext(1, LogLevelWarningIndicator)
+	klog.WarningDepth(1, ctx, msg)
 }
 
-func Warningf(msg string, args ...interface{}) {
-	klog.Warningf("WARNING: "+msg, args...)
+func Warningf(msg string, args ...any) {
+	ctx := getCallerContext(1, LogLevelWarningIndicator)
+	formattedMsg := fmt.Sprintf(msg, args...)
+	klog.WarningDepth(1, ctx+formattedMsg)
 }
 
 func Errorln(msg string) {
-	klog.Errorln("ERROR: ", msg)
+	ctx := getCallerContext(1, LogLevelErrorIndicator)
+	klog.ErrorDepth(1, ctx, msg)
 }
 
-func Errorf(msg string, args ...interface{}) {
-	klog.Errorf("ERROR: "+msg, args...)
+func Errorf(msg string, args ...any) {
+	ctx := getCallerContext(1, LogLevelErrorIndicator)
+	formattedMsg := fmt.Sprintf(msg, args...)
+	klog.ErrorDepth(1, ctx+formattedMsg)
 }
 
 func Infoln(msg string, verbose ...int) {
@@ -50,17 +133,20 @@ func Infoln(msg string, verbose ...int) {
 	if len(verbose) > 0 {
 		v = verbose[0]
 	}
-	klog.V(klog.Level(v)).Infoln(msg)
+	ctx := getCallerContext(1, LogLevelInfoIndicator)
+	klog.V(klog.Level(v)).InfoDepth(1, ctx, msg)
 }
 
-func Infof(msg string, args ...interface{}) {
+func Infof(msg string, args ...any) {
 	v := 0
-	// The last arg is an int, used for verbosity level
+	// Extract trailing verbosity argument safely to preserve backward compatibility
 	if len(args) > 0 {
 		if verbosity, ok := args[len(args)-1].(int); ok {
 			v = verbosity
-			args = args[:len(args)-1] // remove verbosity argument
+			args = args[:len(args)-1]
 		}
 	}
-	klog.V(klog.Level(v)).Infof(msg, args...)
+	ctx := getCallerContext(1, LogLevelInfoIndicator)
+	formattedMsg := fmt.Sprintf(msg, args...)
+	klog.V(klog.Level(v)).InfoDepth(1, ctx+formattedMsg)
 }

--- a/ai-services/internal/pkg/logger/logger.go
+++ b/ai-services/internal/pkg/logger/logger.go
@@ -11,34 +11,43 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// Log levels following standard production hierarchy
+// Log levels following standard production hierarchy.
 const (
-	// Verbosity levels for klog
-	VerbosityLevelDebug   = 2
-	VerbosityLevelInfo    = 0
+	// VerbosityLevelDebug is the klog verbosity level for debug logs (2).
+	VerbosityLevelDebug = 2
+	// VerbosityLevelInfo is the klog verbosity level for info logs (0).
+	VerbosityLevelInfo = 0
+	// VerbosityLevelWarning is the klog verbosity level for warning logs (0).
 	VerbosityLevelWarning = 0
-	VerbosityLevelError   = 0
+	// VerbosityLevelError is the klog verbosity level for error logs (0).
+	VerbosityLevelError = 0
 
-	// Standard Severity Levels
+	// LogLevelDebug is the string constant for debug severity level.
 	LogLevelDebug = "debug"
-	LogLevelInfo  = "info"
-	LogLevelWarn  = "warning"
+	// LogLevelInfo is the string constant for info severity level.
+	LogLevelInfo = "info"
+	// LogLevelWarn is the string constant for warning severity level.
+	LogLevelWarn = "warning"
+	// LogLevelError is the string constant for error severity level.
 	LogLevelError = "error"
 
-	// Env Log Variables
-	EnvLogLevel  = "AI_SERVICES_LOG_LEVEL"  // e.g., "info", "debug"
-	EnvLogFormat = "AI_SERVICES_LOG_FORMAT" // e.g., "cli", "service"
+	// EnvLogLevel is the environment variable name for log severity level (e.g., "info", "debug").
+	EnvLogLevel = "AI_SERVICES_LOG_LEVEL"
+	// EnvLogFormat is the environment variable name for log format (e.g., "cli", "service").
+	EnvLogFormat = "AI_SERVICES_LOG_FORMAT"
 
-	// Log level indicators for output formatting
-	LogLevelInfoIndicator    = "I"
+	// LogLevelInfoIndicator is the output indicator for info level logs ("I").
+	LogLevelInfoIndicator = "I"
+	// LogLevelWarningIndicator is the output indicator for warning level logs ("W").
 	LogLevelWarningIndicator = "W"
-	LogLevelErrorIndicator   = "E"
+	// LogLevelErrorIndicator is the output indicator for error level logs ("E").
+	LogLevelErrorIndicator = "E"
 )
 
-// Global state to track whether we are in a service context
+// Global state to track whether we are in a service context.
 var isServiceEnv bool
 
-// Init initializes the logger with appropriate settings based on environment
+// Init initializes the logger with appropriate settings based on environment.
 func Init() {
 	klog.InitFlags(flag.CommandLine)
 	_ = flag.CommandLine.Set("alsologtostderr", "true")
@@ -79,7 +88,7 @@ func Init() {
 	}
 }
 
-// getCallerContext generates absolute paths and timestamps if service mode is active
+// getCallerContext generates absolute paths and timestamps if service mode is active.
 func getCallerContext(skipDepth int, severity string) string {
 	if !isServiceEnv {
 		return ""
@@ -108,24 +117,42 @@ func Flush() {
 
 func Warningln(msg string) {
 	ctx := getCallerContext(1, LogLevelWarningIndicator)
-	klog.WarningDepth(1, ctx, msg)
+	if ctx == "" {
+		// CLI mode: add WARNING prefix
+		klog.WarningDepth(1, "WARNING: ", msg)
+	} else {
+		klog.WarningDepth(1, ctx, msg)
+	}
 }
 
-func Warningf(msg string, args ...any) {
+func Warningf(format string, args ...any) {
 	ctx := getCallerContext(1, LogLevelWarningIndicator)
-	formattedMsg := fmt.Sprintf(msg, args...)
-	klog.WarningDepth(1, ctx+formattedMsg)
+	if ctx == "" {
+		// CLI mode: add WARNING prefix
+		klog.WarningDepth(1, "WARNING: "+fmt.Sprintf(format, args...))
+	} else {
+		klog.WarningDepth(1, ctx+fmt.Sprintf(format, args...))
+	}
 }
 
 func Errorln(msg string) {
 	ctx := getCallerContext(1, LogLevelErrorIndicator)
-	klog.ErrorDepth(1, ctx, msg)
+	if ctx == "" {
+		// CLI mode: add ERROR prefix
+		klog.ErrorDepth(1, "ERROR: ", msg)
+	} else {
+		klog.ErrorDepth(1, ctx, msg)
+	}
 }
 
-func Errorf(msg string, args ...any) {
+func Errorf(format string, args ...any) {
 	ctx := getCallerContext(1, LogLevelErrorIndicator)
-	formattedMsg := fmt.Sprintf(msg, args...)
-	klog.ErrorDepth(1, ctx+formattedMsg)
+	if ctx == "" {
+		// CLI mode: add ERROR prefix
+		klog.ErrorDepth(1, "ERROR: "+fmt.Sprintf(format, args...))
+	} else {
+		klog.ErrorDepth(1, ctx+fmt.Sprintf(format, args...))
+	}
 }
 
 func Infoln(msg string, verbose ...int) {
@@ -137,7 +164,7 @@ func Infoln(msg string, verbose ...int) {
 	klog.V(klog.Level(v)).InfoDepth(1, ctx, msg)
 }
 
-func Infof(msg string, args ...any) {
+func Infof(format string, args ...any) {
 	v := 0
 	// Extract trailing verbosity argument safely to preserve backward compatibility
 	if len(args) > 0 {
@@ -147,6 +174,5 @@ func Infof(msg string, args ...any) {
 		}
 	}
 	ctx := getCallerContext(1, LogLevelInfoIndicator)
-	formattedMsg := fmt.Sprintf(msg, args...)
-	klog.V(klog.Level(v)).InfoDepth(1, ctx+formattedMsg)
+	klog.V(klog.Level(v)).InfoDepth(1, ctx+fmt.Sprintf(format, args...))
 }

--- a/ai-services/internal/pkg/logger/logger.go
+++ b/ai-services/internal/pkg/logger/logger.go
@@ -30,6 +30,11 @@ const (
 	// EnvLogFormat is the environment variable name for log format (e.g., "cli", "service").
 	EnvLogFormat = "AI_SERVICES_LOG_FORMAT"
 
+	// LogFormatCLI is the string constant for CLI format mode.
+	LogFormatCLI = "cli"
+	// LogFormatService is the string constant for service format mode.
+	LogFormatService = "service"
+
 	// LogLevelInfoIndicator is the output indicator for info level logs ("I").
 	LogLevelInfoIndicator = "I"
 	// LogLevelWarningIndicator is the output indicator for warning level logs ("W").
@@ -59,12 +64,12 @@ func Init() {
 	_ = flag.CommandLine.Set("alsologtostderr", "true")
 	_ = flag.CommandLine.Set("skip_log_backtrace_at", ":0")
 
-	// 1. Resolve Log Format (Defaults to "cli" for terminal users)
+	// 1. Resolve Log Format (Defaults to CLI for terminal users)
 	logFormat := os.Getenv(EnvLogFormat)
 	if logFormat == "" {
-		logFormat = "cli"
+		logFormat = LogFormatCLI
 	}
-	isServiceEnv = logFormat == "service"
+	isServiceEnv = logFormat == LogFormatService
 
 	// 2. Resolve Log Severity Level (Defaults to "info")
 	logLevel := os.Getenv(EnvLogLevel)
@@ -73,7 +78,7 @@ func Init() {
 	}
 
 	// 3. Apply Format Configuration
-	if logFormat == "cli" {
+	if logFormat == LogFormatCLI {
 		_ = flag.CommandLine.Set("skip_headers", "true")
 		_ = flag.CommandLine.Set("skip_log_headers", "true")
 	} else {
@@ -95,7 +100,7 @@ func Init() {
 	case LogLevelInfo:
 		fallthrough
 	default:
-		_ = flag.CommandLine.Set("v", "0")
+		_ = flag.CommandLine.Set("v", "2") // Setting this to 2 to ensure backward compatibility for cli
 		activeMinLevel = LevelRankInfo
 	}
 }
@@ -148,7 +153,7 @@ func Warningf(format string, args ...any) {
 	if ctx == "" {
 		klog.WarningDepth(1, "WARNING: ", formattedMsg)
 	} else {
-		klog.WarningDepth(1, ctx, formattedMsg) // FIXED: Comma separation ensures clean payload tracking
+		klog.WarningDepth(1, ctx, formattedMsg)
 	}
 }
 
@@ -167,11 +172,12 @@ func Errorf(format string, args ...any) {
 	if ctx == "" {
 		klog.ErrorDepth(1, "ERROR: ", formattedMsg)
 	} else {
-		klog.ErrorDepth(1, ctx, formattedMsg) // FIXED: Separated context metadata from message body
+		klog.ErrorDepth(1, ctx, formattedMsg)
 	}
 }
 
 func Infoln(msg string, verbose ...int) {
+	// 1. Drop logs early if the environment is explicitly set to warning or error
 	if activeMinLevel > LevelRankInfo {
 		return
 	}
@@ -181,21 +187,18 @@ func Infoln(msg string, verbose ...int) {
 		v = verbose[0]
 	}
 
-	// Guard check: Suppress custom debug logs if system level is locked to info
-	if v > 0 && activeMinLevel == LevelRankInfo {
-		return
-	}
-
 	ctx := getCallerContext(1, LogLevelInfoIndicator)
 	klog.V(klog.Level(v)).InfoDepth(1, ctx, msg)
 }
 
 func Infof(format string, args ...any) {
+	// 1. Drop logs early if the environment is explicitly set to warning or error
 	if activeMinLevel > LevelRankInfo {
 		return
 	}
 
 	v := 0
+	// 2. Extract trailing verbosity argument safely to preserve backward compatibility
 	if len(args) > 0 {
 		if verbosity, ok := args[len(args)-1].(int); ok {
 			v = verbosity
@@ -203,12 +206,7 @@ func Infof(format string, args ...any) {
 		}
 	}
 
-	// Guard check: Suppress custom debug logs if system level is locked to info
-	if v > 0 && activeMinLevel == LevelRankInfo {
-		return
-	}
-
 	ctx := getCallerContext(1, LogLevelInfoIndicator)
 	formattedMsg := fmt.Sprintf(format, args...)
-	klog.V(klog.Level(v)).InfoDepth(1, ctx, formattedMsg) // FIXED: Passing clean params instead of string concat
+	klog.V(klog.Level(v)).InfoDepth(1, ctx, formattedMsg)
 }

--- a/ai-services/internal/pkg/logger/logger.go
+++ b/ai-services/internal/pkg/logger/logger.go
@@ -100,7 +100,7 @@ func Init() {
 	case LogLevelInfo:
 		fallthrough
 	default:
-		_ = flag.CommandLine.Set("v", "2") // Setting this to 2 to ensure backward compatibility for cli
+		_ = flag.CommandLine.Set("v", "0")
 		activeMinLevel = LevelRankInfo
 	}
 }
@@ -116,7 +116,7 @@ func getCallerContext(skipDepth int, severity string) string {
 	}
 
 	// Use standard klog MMDD format matching production specs
-	timestamp := time.Now().Format("0102 15:04:05.000000")
+	timestamp := time.Now().UTC().Format("0102 15:04:05.000000")
 
 	// Standardized output shape: "I0610 19:31:44.190447 /path/to/file.go:200] "
 	return fmt.Sprintf("%s%s %s:%d] ", severity, timestamp, file, line)


### PR DESCRIPTION
- Implements a logging mechanism compatible for both CLI and Catalog service
- Introduces log levels
- Introduces env's so that same logger pkg can be used for both CLI and Catalog service. In case of Catalog service, it prints `Logging Level, TimeStamp and complete file path` along with the message for tracing unlike CLI which just prints the plain message.