### PR TITLE
Move catalog db data to volume

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.75
+TAG?=0.0.76
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/templates/catalog-db.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog-db.yaml.tmpl
@@ -8,21 +8,11 @@ metadata:
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/secret: "catalog-db-secret"
     ai-services.io/secret-skip-cleanup: "true"
+    ai-services.io/volume: "postgres-catalog"
+    ai-services.io/volume-skip-cleanup: "true"
+  annotations:
+    io.podman.annotations.pids-limit/postgresql: "4096"
 spec:
-  initContainers:
-  - name: fix-permissions
-    image: "{{ .Values.db.image }}"
-    command:
-    - /bin/sh
-    - -c
-    - |
-      chown -R 26:0 /var/lib/pgsql
-      chmod -R g=u /var/lib/pgsql
-    volumeMounts:
-    - name: postgres-data
-      mountPath: /var/lib/pgsql
-    securityContext:
-      runAsUser: 0
   containers:
   - name: postgresql
     image: "{{ .Values.db.image }}"
@@ -41,9 +31,12 @@ spec:
       value: "{{ .Values.db.database }}"
     - name: PGDATA
       value: "/var/lib/pgsql/data"
+    securityContext:
+      runAsUser: 26
+      fsGroup: 26
     volumeMounts:
     - name: postgres-data
-      mountPath: /var/lib/pgsql
+      mountPath: /var/lib/pgsql:z
     livenessProbe:
       exec:
         command:
@@ -54,6 +47,16 @@ spec:
       periodSeconds: 10
       timeoutSeconds: 5
       failureThreshold: 3
+    readinessProbe:
+      exec:
+        command:
+        - /bin/sh
+        - -c
+        - pg_isready -U {{ .Values.db.user }} -d {{ .Values.db.database }}
+      initialDelaySeconds: 10
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 3
     resources:
       requests:
         memory: "{{ .Values.db.resources.requests.memory }}"
@@ -61,6 +64,5 @@ spec:
         memory: "{{ .Values.db.resources.limits.memory }}"
   volumes:
   - name: postgres-data
-    hostPath:
-      path: "{{ .BaseDir }}/db"
-      type: DirectoryOrCreate
+    persistentVolumeClaim:
+      claimName: "postgres-catalog"

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.75
+  image: icr.io/ai-services-cicd/ai-services:0.0.76
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -271,8 +271,7 @@ func dataDeletion(dataPath string) error {
 // deleteVolumes removes the specified volumes.
 func deleteVolumes(rt *podman.PodmanClient, volumeNames []string) error {
 	if len(volumeNames) == 0 {
-		logger.Infoln("No volumes to delete")
-
+		// Just return if there are no volumes to delete.
 		return nil
 	}
 

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
@@ -90,6 +91,8 @@ func performCleanup(rt *podman.PodmanClient, pods []types.Pod, skipCleanup bool)
 	secretsToDelete, secretsToSkip := fetchSecretsToDelete(pods)
 	secretsToDelete = append(secretsToDelete, catalogConstants.PodmanAuthSecret)
 
+	volumesToDelete, volumesToSkip := fetchVolumesToDelete(pods)
+
 	// Delete catalog pods
 	if err := podsDeletion(rt, pods); err != nil {
 		return err
@@ -100,6 +103,11 @@ func performCleanup(rt *podman.PodmanClient, pods []types.Pod, skipCleanup bool)
 		return err
 	}
 
+	// Delete volumes (only those without skip-cleanup label)
+	if err := deleteVolumes(rt, volumesToDelete); err != nil {
+		return err
+	}
+
 	// Delete caddy data
 	caddyDataPath := getDataPath(baseDir, "common")
 	if err := dataDeletion(caddyDataPath); err != nil {
@@ -107,7 +115,7 @@ func performCleanup(rt *podman.PodmanClient, pods []types.Pod, skipCleanup bool)
 	}
 
 	// Delete database data and secrets
-	if err := cleanupDatabaseResources(rt, baseDir, secretsToSkip, skipCleanup); err != nil {
+	if err := cleanupDatabaseResources(rt, secretsToSkip, volumesToSkip, skipCleanup); err != nil {
 		return err
 	}
 
@@ -137,8 +145,8 @@ func getDataPath(baseDir, subDir string) string {
 	return filepath.Join(baseDir, "ai-services", subDir)
 }
 
-// cleanupDatabaseResources handles database data and secret cleanup.
-func cleanupDatabaseResources(rt *podman.PodmanClient, baseDir string, secretsToSkip []string, skipCleanup bool) error {
+// cleanupDatabaseResources handles database volume and secret cleanup.
+func cleanupDatabaseResources(rt *podman.PodmanClient, secretsToSkip []string, volumesToSkip []string, skipCleanup bool) error {
 	if skipCleanup {
 		logger.Infoln("Skipping database data cleanup (--skip-cleanup flag set)")
 
@@ -150,10 +158,8 @@ func cleanupDatabaseResources(rt *podman.PodmanClient, baseDir string, secretsTo
 		return err
 	}
 
-	// Delete database data
-	dbDataPath := getDataPath(baseDir, "db")
-
-	return dataDeletion(dbDataPath)
+	// Delete volumes with skip-cleanup label (only when --skip-cleanup is not set)
+	return deleteVolumes(rt, volumesToSkip)
 }
 
 // podsDeletion removes all catalog pods.
@@ -200,6 +206,47 @@ func fetchSecretsToDelete(pods []types.Pod) ([]string, []string) {
 	return secretsToDelete, secretsToSkip
 }
 
+// fetchVolumesToDelete extracts volume names from pod labels and separates them based on skip-cleanup label.
+// Returns two lists: volumes to delete immediately, and volumes to skip (only deleted when --skip-cleanup is not set).
+func fetchVolumesToDelete(pods []types.Pod) ([]string, []string) {
+	volumeMapToDelete := make(map[string]bool) // Use map to avoid duplicates
+	volumeMapToSkip := make(map[string]bool)
+
+	for _, pod := range pods {
+		// fetch volume names from pod labels
+		if volumeNames, ok := pod.Labels[catalogConstants.CatalogVolumeLabel]; ok && volumeNames != "" {
+			// Check if this pod has skip-cleanup label for volumes
+			_, hasSkipLabel := pod.Labels[catalogConstants.CatalogVolumeSkipLabel]
+
+			// Split comma-separated volume names (in case a pod has multiple volumes)
+			volumes := strings.Split(volumeNames, ",")
+			for _, volumeName := range volumes {
+				volumeName = strings.TrimSpace(volumeName)
+				if volumeName != "" {
+					if hasSkipLabel {
+						volumeMapToSkip[volumeName] = true
+					} else {
+						volumeMapToDelete[volumeName] = true
+					}
+				}
+			}
+		}
+	}
+
+	// Convert maps to slices
+	volumesToDelete := make([]string, 0, len(volumeMapToDelete))
+	for volumeName := range volumeMapToDelete {
+		volumesToDelete = append(volumesToDelete, volumeName)
+	}
+
+	volumesToSkip := make([]string, 0, len(volumeMapToSkip))
+	for volumeName := range volumeMapToSkip {
+		volumesToSkip = append(volumesToSkip, volumeName)
+	}
+
+	return volumesToDelete, volumesToSkip
+}
+
 // dataDeletion removes the specified data directory.
 func dataDeletion(dataPath string) error {
 	// Check if data directory exists
@@ -217,6 +264,41 @@ func dataDeletion(dataPath string) error {
 	}
 
 	logger.Infof("Successfully removed data at: %s\n", dataPath)
+
+	return nil
+}
+
+// deleteVolumes removes the specified volumes.
+func deleteVolumes(rt *podman.PodmanClient, volumeNames []string) error {
+	if len(volumeNames) == 0 {
+		logger.Infoln("No volumes to delete")
+		return nil
+	}
+
+	logger.Infof("Deleting %d volume(s)\n", len(volumeNames))
+
+	var errors []string
+	for _, volumeName := range volumeNames {
+		logger.Infof("Deleting volume: %s\n", volumeName)
+
+		if err := rt.DeleteVolume(volumeName); err != nil {
+			// Ignore "not found" errors - volume already deleted or never existed
+			if catalogUtils.IsNotFoundError(err) {
+				logger.Infof("Volume %s already deleted or does not exist\n", volumeName)
+				continue
+			}
+
+			errors = append(errors, fmt.Sprintf("volume %s: %v", volumeName, err))
+			continue
+		}
+
+		logger.Infof("Successfully deleted volume: %s\n", volumeName)
+	}
+
+	// Aggregate errors at the end
+	if len(errors) > 0 {
+		return fmt.Errorf("failed to remove volumes: \n%s", strings.Join(errors, "\n"))
+	}
 
 	return nil
 }

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -272,6 +272,7 @@ func dataDeletion(dataPath string) error {
 func deleteVolumes(rt *podman.PodmanClient, volumeNames []string) error {
 	if len(volumeNames) == 0 {
 		logger.Infoln("No volumes to delete")
+
 		return nil
 	}
 
@@ -285,10 +286,12 @@ func deleteVolumes(rt *podman.PodmanClient, volumeNames []string) error {
 			// Ignore "not found" errors - volume already deleted or never existed
 			if catalogUtils.IsNotFoundError(err) {
 				logger.Infof("Volume %s already deleted or does not exist\n", volumeName)
+
 				continue
 			}
 
 			errors = append(errors, fmt.Sprintf("volume %s: %v", volumeName, err))
+
 			continue
 		}
 

--- a/ai-services/internal/pkg/catalog/constants/catalog.go
+++ b/ai-services/internal/pkg/catalog/constants/catalog.go
@@ -30,6 +30,8 @@ const (
 	CatalogSecretSkipLabel = "ai-services.io/secret-skip-cleanup"
 	// CatalogVolumeLabel represents the catalog volume name associated with Catalog Pod.
 	CatalogVolumeLabel = "ai-services.io/volume"
+	// CatalogVolumeSkipLabel represents if catalog volume associated with pod should be skipped while deletion.
+	CatalogVolumeSkipLabel = "ai-services.io/volume-skip-cleanup"
 	// PodmanAuthSecret represents podman auth secret name.
 	PodmanAuthSecret = "podman-auth-secret"
 )


### PR DESCRIPTION
In manifests:
- Migrated from hostPath to persistentVolumeClaim.
- Added volume tracking and skip-cleanup labels

In uninstall:
- Implemented dynamic volume extraction from pod labels with volume-skip-cleanup support