### PR TITLE
migrate create CLI cmd to use catalog API

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.94
+TAG?=v0.0.95
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.94
+  image: icr.io/ai-services-cicd/ai-services:v0.0.95
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -260,6 +260,12 @@ func buildFlagValidator() *flagvalidator.FlagValidator {
 
 // validateTemplateFlag validates the template flag.
 func validateTemplateFlag(cmd *cobra.Command) error {
+	// Skip template validation in experimental mode for podman runtime
+	// In experimental mode, templates are validated against catalog API
+	if experimentalCreate && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+		return nil
+	}
+
 	tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
 	if err := tp.AppTemplateExist(templateName); err != nil {
 		return err
@@ -395,7 +401,7 @@ func createApp(appName string) error {
 	if err != nil {
 		logger.Warningf("Failed to marshal payload for debugging: %v\n", err)
 	} else {
-		logger.Infof("=== CLI REQUEST PAYLOAD ===\n%s\n", string(payloadJSON))
+		logger.Infof("CLI REQUEST PAYLOAD:\n%s\n", string(payloadJSON))
 	}
 
 	// 7. Create application via catalog API
@@ -694,7 +700,7 @@ func selectProviderFromDeployOptions(compDeployOpt catalogTypes.DeployOptionsCom
 
 	// Special logic for LLM and reranker component types - prefer Spyre acceleration
 	if compDeployOpt.Type == "llm" || compDeployOpt.Type == "reranker" {
-		// Default to vllm-spyre for LLM/reranker if available (Spyre acceleration)
+		// Default to vllm-spyre for LLM/reranker if available
 		for _, p := range compDeployOpt.Providers {
 			if p.ID == "vllm-spyre" {
 				return p.ID, make(map[string]string)

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -2,7 +2,10 @@ package application
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"maps"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -12,12 +15,18 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/bootstrap"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
+	apiModels "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
+	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
+	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	appFlags "github.com/project-ai-services/ai-services/internal/pkg/cli/constants/application"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/flagvalidator"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
+	cliutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/image"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
@@ -35,6 +44,7 @@ var (
 	skipChecks            []string
 	valuesFiles           []string
 	rawArgImagePullPolicy string
+	experimentalCreate    bool
 
 	// openshift flags.
 	timeout time.Duration
@@ -75,8 +85,15 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
+		rt := vars.RuntimeFactory.GetRuntimeType()
+		// When experimentalCreate is true and runtime is podman, validate application name using catalog API
+		// For openshift runtime, always use the older/stable code path regardless of experimental flag
+		if experimentalCreate && rt == types.RuntimeTypePodman {
+			return createApp(appName)
+		}
+
 		// Create application instance using factory
-		appFactory := application.NewFactory(vars.RuntimeFactory.GetRuntimeType())
+		appFactory := application.NewFactory(rt)
 		app, err := appFactory.Create(appName)
 		if err != nil {
 			return fmt.Errorf("failed to create application instance: %w", err)
@@ -175,6 +192,7 @@ func initCreatePodmanFlags() {
 			"- If left false in air-gapped environments → download attempt will fail\n"+
 			"Note: Supported for podman runtime only.\n",
 	)
+	createCmd.Flags().BoolVar(&experimentalCreate, "experimental", false, "Include experimental application create")
 
 	initializeImagePullPolicyFlag()
 
@@ -262,7 +280,13 @@ func validateParamsFlag(cmd *cobra.Command) error {
 		return fmt.Errorf("invalid format: %w", err)
 	}
 
-	// Validate params against template values
+	// Skip template validation in experimental mode for podman runtime
+	// In experimental mode, params are validated against catalog API schemas
+	if experimentalCreate && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+		return nil
+	}
+
+	// Validate params against template values (non-experimental mode)
 	tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
 	_, err = tp.LoadValues(templateName, nil, argParams)
 	if err != nil {
@@ -322,6 +346,423 @@ func validateSkipChecksFlag(cmd *cobra.Command) error {
 	}
 
 	return nil
+}
+
+func createApp(appName string) error {
+	// 1. Initialize catalog client
+	appClient, err := catalogClient.NewApplicationClient()
+	if err != nil {
+		return fmt.Errorf("failed to create application client: %w", err)
+	}
+
+	// 2. Check if application already exists
+	existingApp, err := cliutils.GetAppByName(appClient, appName)
+	if err != nil && !strings.Contains(err.Error(), "not found") {
+		return err
+	}
+
+	if existingApp != nil {
+		return fmt.Errorf("application with name '%s' already exists", appName)
+	}
+
+	// 3. Initialize catalog provider
+	provider, err := catalog.NewCatalogProvider()
+	if err != nil {
+		return fmt.Errorf("failed to create catalog provider: %w", err)
+	}
+
+	// 4. Determine if template is architecture or service
+	isArchitecture := provider.ArchitectureExists(templateName)
+	isService := provider.ServiceExists(templateName)
+
+	if !isArchitecture && !isService {
+		return fmt.Errorf("template '%s' not found as architecture or service", templateName)
+	}
+
+	// 5. Build the catalog API payload
+	var payload *apiModels.CreateApplicationRequest
+	if isArchitecture {
+		payload, err = buildArchitecturePayload(provider, templateName, appName)
+	} else {
+		payload, err = buildServicePayload(templateName, appName)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to build payload: %w", err)
+	}
+
+	// 6. Debug: Print the payload being sent
+	payloadJSON, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		logger.Warningf("Failed to marshal payload for debugging: %v\n", err)
+	} else {
+		logger.Infof("=== CLI REQUEST PAYLOAD ===\n%s\n", string(payloadJSON))
+	}
+
+	// 7. Create application via catalog API
+	logger.Infof("Creating application '%s' using template '%s'...\n", appName, templateName)
+	resp, err := appClient.CreateApplication(payload)
+	if err != nil {
+		return fmt.Errorf("failed to create application: %w", err)
+	}
+
+	logger.Infof("Application creation initiated (ID: %s)\n", resp.ID)
+
+	// 8. Poll for application status
+	return pollApplicationStatus(appClient, appName)
+}
+
+// pollApplicationStatus polls the application status until it's ready or fails.
+func pollApplicationStatus(appClient *catalogClient.ApplicationClient, appName string) error {
+	logger.Infof("Waiting for application '%s' to be ready...\n", appName)
+
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	timeout := time.After(10 * time.Minute)
+
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timeout waiting for application '%s' to be ready", appName)
+
+		case <-ticker.C:
+			app, err := cliutils.GetAppByName(appClient, appName)
+			if err != nil {
+				return fmt.Errorf("failed to get application status: %w", err)
+			}
+
+			// Status values from ai-services/internal/pkg/catalog/db/models/application.go
+			switch app.Status {
+			case "Running":
+				logger.Infof("Application '%s' is ready!\n", appName)
+				return nil
+
+			case "Error":
+				if app.Message != "" {
+					return fmt.Errorf("application deployment failed: %s", app.Message)
+				}
+				return fmt.Errorf("application deployment failed")
+
+			case "Downloading", "Deploying":
+				// Still in progress, continue polling
+				logger.Infof("Deploying application: %s, Status: %s, Message: %s...\n", appName, app.Status, app.Message)
+
+			case "Deleting":
+				return fmt.Errorf("application is being deleted")
+
+			default:
+				logger.Infof("Status: %s\n", app.Status)
+			}
+		}
+	}
+}
+
+// buildArchitecturePayload builds the payload for an architecture deployment.
+func buildArchitecturePayload(provider *catalog.CatalogProvider, archID, appName string) (*apiModels.CreateApplicationRequest, error) {
+	// Load architecture metadata
+	arch, err := provider.LoadArchitecture(archID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load architecture: %w", err)
+	}
+
+	// Create application client for API calls
+	appClient, err := catalogClient.NewApplicationClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create application client: %w", err)
+	}
+
+	// Get deploy options for the architecture
+	deployOptions, err := appClient.GetArchitectureDeployOptions(archID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get deploy options: %w", err)
+	}
+
+	// Build services list using deploy options
+	services := make([]apiModels.Service, 0, len(arch.Services))
+	for _, svcRef := range arch.Services {
+		// Find the corresponding deploy options service
+		var svcDeployOpts *catalogTypes.DeployOptionsService
+		for i := range deployOptions.Services {
+			if deployOptions.Services[i].ID == svcRef.ID {
+				svcDeployOpts = &deployOptions.Services[i]
+				break
+			}
+		}
+
+		if svcDeployOpts == nil {
+			return nil, fmt.Errorf("deploy options not found for service '%s'", svcRef.ID)
+		}
+
+		svc, err := buildServiceEntryWithDeployOptions(appClient, svcRef.ID, svcDeployOpts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build service '%s': %w", svcRef.ID, err)
+		}
+		services = append(services, svc)
+	}
+
+	return &apiModels.CreateApplicationRequest{
+		CatalogID: archID,
+		Name:      appName,
+		Services:  services,
+		Version:   arch.Version,
+	}, nil
+}
+
+// buildServicePayload builds the payload for a standalone service deployment.
+func buildServicePayload(serviceID, appName string) (*apiModels.CreateApplicationRequest, error) {
+	// Create application client for API calls
+	appClient, err := catalogClient.NewApplicationClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create application client: %w", err)
+	}
+
+	// Get deploy options for the service
+	deployOptions, err := appClient.GetServiceDeployOptions(serviceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get deploy options: %w", err)
+	}
+
+	svc, err := buildServiceEntryWithDeployOptions(appClient, serviceID, deployOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build service: %w", err)
+	}
+
+	return &apiModels.CreateApplicationRequest{
+		CatalogID: serviceID,
+		Name:      appName,
+		Services:  []apiModels.Service{svc},
+		Version:   svc.Version,
+	}, nil
+}
+
+// buildServiceEntryWithDeployOptions builds a single service entry with its components using deploy options.
+func buildServiceEntryWithDeployOptions(appClient *catalogClient.ApplicationClient, serviceID string, deployOptions *catalogTypes.DeployOptionsService) (apiModels.Service, error) {
+	// Build components list from deploy options
+	components := make([]apiModels.Component, 0, len(deployOptions.Components))
+	for _, compDeployOpt := range deployOptions.Components {
+		// Get component configuration from argParams (provider-specific params)
+		providerParams := extractComponentParamsForService(serviceID, compDeployOpt.Type, argParams)
+
+		// Determine provider ID and get its params
+		providerID, userParams := selectProviderFromDeployOptions(compDeployOpt, providerParams)
+		if providerID == "" {
+			return apiModels.Service{}, fmt.Errorf("no provider found for component type '%s'", compDeployOpt.Type)
+		}
+
+		// Find the selected provider to get its version
+		var providerVersion string
+		var providerFound bool
+		for _, p := range compDeployOpt.Providers {
+			if p.ID == providerID {
+				providerVersion = p.Version
+				providerFound = true
+				break
+			}
+		}
+
+		// If provider not found in deploy options, return error
+		if !providerFound {
+			return apiModels.Service{}, fmt.Errorf("provider '%s' not found in deploy options for component type '%s'", providerID, compDeployOpt.Type)
+		}
+
+		// Fetch schema and apply defaults, merging with user params
+		componentParamsAny, err := applySchemaDefaults(appClient, compDeployOpt.Type, providerID, userParams)
+		if err != nil {
+			logger.Warningf("Failed to apply schema defaults for %s/%s: %v\n", compDeployOpt.Type, providerID, err)
+			// Continue with user-provided params only
+			componentParamsAny = make(map[string]any)
+			for k, v := range userParams {
+				componentParamsAny[k] = v
+			}
+		}
+
+		components = append(components, apiModels.Component{
+			ComponentType: compDeployOpt.Type,
+			ProviderID:    providerID,
+			Params:        componentParamsAny,
+			Version:       providerVersion,
+		})
+	}
+
+	// Extract service-level parameters (excluding component params)
+	serviceParams := extractServiceParams(serviceID, deployOptions.Components, argParams)
+
+	return apiModels.Service{
+		CatalogID:  serviceID,
+		Components: components,
+		Params:     serviceParams,
+		Version:    deployOptions.Version,
+	}, nil
+}
+
+// extractServiceParams extracts service-level parameters from argParams, excluding component params.
+// Format: {serviceID}.{param} -> {param}
+// Excludes: {serviceID}.{componentType}.{param} (those are component params)
+func extractServiceParams(serviceID string, components []catalogTypes.DeployOptionsComponent, allParams map[string]string) map[string]any {
+	serviceParams := make(map[string]any)
+	servicePrefix := serviceID + "."
+
+	// Build a set of component types for this service
+	componentTypes := make(map[string]bool)
+	for _, comp := range components {
+		componentTypes[comp.Type] = true
+	}
+
+	for key, value := range allParams {
+		if after, ok := strings.CutPrefix(key, servicePrefix); ok {
+			// Check if this is a component parameter (e.g., chat.llm.model)
+			// by seeing if it starts with a known component type
+			isComponentParam := false
+			for compType := range componentTypes {
+				if strings.HasPrefix(after, compType+".") {
+					isComponentParam = true
+					break
+				}
+			}
+
+			// Only add to service params if it's not a component param
+			if !isComponentParam {
+				serviceParams[after] = value
+			}
+		}
+	}
+
+	return serviceParams
+}
+
+// extractComponentParamsForService extracts parameters for a specific component type from argParams.
+// Supports provider-specific params:
+// - Global: {componentType}.{providerID}.{param} (e.g., llm.vllm-cpu.model)
+// - Service-specific: {serviceID}.{componentType}.{providerID}.{param} (e.g., chat.llm.vllm-cpu.model)
+// Returns a map with provider as key and params as value
+func extractComponentParamsForService(serviceID string, componentType string, allParams map[string]string) map[string]map[string]string {
+	providerParams := make(map[string]map[string]string)
+
+	// Extract global component params: {componentType}.{providerID}.{param}
+	globalPrefix := componentType + "."
+	for key, value := range allParams {
+		if after, ok := strings.CutPrefix(key, globalPrefix); ok {
+			// Split to get providerID and param
+			parts := strings.SplitN(after, ".", 2)
+			if len(parts) == 2 {
+				providerID := parts[0]
+				paramName := parts[1]
+				if providerParams[providerID] == nil {
+					providerParams[providerID] = make(map[string]string)
+				}
+				providerParams[providerID][paramName] = value
+			}
+		}
+	}
+
+	// Extract service-specific component params (these override global)
+	servicePrefix := serviceID + "." + componentType + "."
+	for key, value := range allParams {
+		if after, ok := strings.CutPrefix(key, servicePrefix); ok {
+			// Split to get providerID and param
+			parts := strings.SplitN(after, ".", 2)
+			if len(parts) == 2 {
+				providerID := parts[0]
+				paramName := parts[1]
+				if providerParams[providerID] == nil {
+					providerParams[providerID] = make(map[string]string)
+				}
+				providerParams[providerID][paramName] = value
+			}
+		}
+	}
+
+	return providerParams
+}
+
+// selectProviderFromDeployOptions determines the provider ID for a component using deploy options.
+// Priority:
+// 1. If user provided provider-specific params (e.g., llm.vllm-cpu.model), use that provider
+// 2. For LLM and reranker components: Use vllm-spyre by default
+// 3. Default provider marked in deploy options
+// 4. First available provider
+func selectProviderFromDeployOptions(compDeployOpt catalogTypes.DeployOptionsComponent, providerParams map[string]map[string]string) (string, map[string]string) {
+	// Check if user specified params for a specific provider
+	for providerID := range providerParams {
+		// Verify this provider exists in deploy options
+		for _, p := range compDeployOpt.Providers {
+			if p.ID == providerID {
+				return providerID, providerParams[providerID]
+			}
+		}
+	}
+
+	// Special logic for LLM and reranker component types - prefer Spyre acceleration
+	if compDeployOpt.Type == "llm" || compDeployOpt.Type == "reranker" {
+		// Default to vllm-spyre for LLM/reranker if available (Spyre acceleration)
+		for _, p := range compDeployOpt.Providers {
+			if p.ID == "vllm-spyre" {
+				return p.ID, make(map[string]string)
+			}
+		}
+	}
+
+	// Use default provider if marked
+	for _, p := range compDeployOpt.Providers {
+		if p.Default {
+			return p.ID, make(map[string]string)
+		}
+	}
+
+	// Fall back to first available provider
+	if len(compDeployOpt.Providers) > 0 {
+		return compDeployOpt.Providers[0].ID, make(map[string]string)
+	}
+
+	return "", make(map[string]string)
+}
+
+// applySchemaDefaults fetches the component provider schema and applies default values.
+// User-provided params override defaults.
+func applySchemaDefaults(appClient *catalogClient.ApplicationClient, componentType, providerID string, userParams map[string]string) (map[string]any, error) {
+	// Fetch schema from API
+	schema, err := appClient.GetComponentProviderParams(componentType, providerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch schema: %w", err)
+	}
+
+	// Extract defaults from schema
+	defaults := extractDefaultsFromSchema(schema)
+
+	// Merge: start with defaults, override with user params
+	result := make(map[string]any)
+	maps.Copy(result, defaults)
+
+	// Override with user-provided params (excluding 'provider' key)
+	for k, v := range userParams {
+		if k != "provider" {
+			result[k] = v
+		}
+	}
+
+	return result, nil
+}
+
+// extractDefaultsFromSchema extracts default values from a JSON schema.
+func extractDefaultsFromSchema(schema map[string]any) map[string]any {
+	defaults := make(map[string]any)
+
+	// Check if schema has properties
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return defaults
+	}
+
+	// Extract default value for each property
+	for propName, propValue := range properties {
+		if propMap, ok := propValue.(map[string]any); ok {
+			if defaultValue, hasDefault := propMap["default"]; hasDefault {
+				defaults[propName] = defaultValue
+			}
+		}
+	}
+
+	return defaults
 }
 
 // Made with Bob

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -389,7 +389,34 @@ func createApp(appName string) error {
 	logger.Infof("Application creation initiated (ID: %s)\n", resp.ID)
 
 	// 5. Poll for application status
-	return pollApplicationStatus(appClient, appName)
+	if err := pollApplicationStatus(appClient, appName); err != nil {
+		return err
+	}
+
+	// 6. Print next steps after successful deployment
+	return printNextSteps(appName)
+}
+
+// printNextSteps prints the next steps after successful application deployment.
+func printNextSteps(appName string) error {
+	// Create template provider
+	tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
+
+	// Get runtime instance
+	rt, err := vars.RuntimeFactory.Create(appName)
+	if err != nil {
+		logger.Infof("Unable to create runtime for next steps: %v\n", err)
+
+		return nil
+	}
+
+	// Print next steps
+	if err := helpers.PrintNextSteps(tp, rt, appName, templateName); err != nil {
+		// Don't fail the overall create if we cannot print next steps
+		logger.Infof("Failed to display next steps: %v\n", err)
+	}
+
+	return nil
 }
 
 // checkApplicationExists checks if an application with the given name already exists.
@@ -760,12 +787,8 @@ func findUserSpecifiedProvider(compDeployOpt catalogTypes.DeployOptionsComponent
 	return "", nil
 }
 
-// findSpyreProvider finds vllm-spyre provider for LLM and reranker components.
+// findSpyreProvider finds vllm-spyre provider if available for the component.
 func findSpyreProvider(compDeployOpt catalogTypes.DeployOptionsComponent) string {
-	if compDeployOpt.Type != "llm" && compDeployOpt.Type != "reranker" {
-		return ""
-	}
-
 	for _, p := range compDeployOpt.Providers {
 		if p.ID == "vllm-spyre" {
 			return p.ID

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -31,6 +31,14 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
+const (
+	// Polling configuration.
+	pollInterval       = 10 * time.Second
+	pollTimeout        = 10 * time.Minute
+	paramSplitParts    = 2
+	expectedParamParts = 2
+)
+
 // Variables for flags placeholder.
 var (
 	// common flags.
@@ -362,6 +370,34 @@ func createApp(appName string) error {
 	}
 
 	// 2. Check if application already exists
+	if err := checkApplicationExists(appClient, appName); err != nil {
+		return err
+	}
+
+	// 3. Build the catalog API payload
+	payload, err := buildCatalogPayload(appName)
+	if err != nil {
+		return err
+	}
+
+	// 4. Debug: Print the payload being sent
+	logPayload(payload)
+
+	// 5. Create application via catalog API
+	logger.Infof("Creating application '%s' using template '%s'...\n", appName, templateName)
+	resp, err := appClient.CreateApplication(payload)
+	if err != nil {
+		return fmt.Errorf("failed to create application: %w", err)
+	}
+
+	logger.Infof("Application creation initiated (ID: %s)\n", resp.ID)
+
+	// 6. Poll for application status
+	return pollApplicationStatus(appClient, appName)
+}
+
+// checkApplicationExists checks if an application with the given name already exists.
+func checkApplicationExists(appClient *catalogClient.ApplicationClient, appName string) error {
 	existingApp, err := cliutils.GetAppByName(appClient, appName)
 	if err != nil && !strings.Contains(err.Error(), "not found") {
 		return err
@@ -371,60 +407,51 @@ func createApp(appName string) error {
 		return fmt.Errorf("application with name '%s' already exists", appName)
 	}
 
-	// 3. Initialize catalog provider
+	return nil
+}
+
+// buildCatalogPayload builds the catalog API payload for the given template.
+func buildCatalogPayload(appName string) (*apiModels.CreateApplicationRequest, error) {
+	// Initialize catalog provider
 	provider, err := catalog.NewCatalogProvider()
 	if err != nil {
-		return fmt.Errorf("failed to create catalog provider: %w", err)
+		return nil, fmt.Errorf("failed to create catalog provider: %w", err)
 	}
 
-	// 4. Determine if template is architecture or service
+	// Determine if template is architecture or service
 	isArchitecture := provider.ArchitectureExists(templateName)
 	isService := provider.ServiceExists(templateName)
 
 	if !isArchitecture && !isService {
-		return fmt.Errorf("template '%s' not found as architecture or service", templateName)
+		return nil, fmt.Errorf("template '%s' not found as architecture or service", templateName)
 	}
 
-	// 5. Build the catalog API payload
-	var payload *apiModels.CreateApplicationRequest
+	// Build the payload
 	if isArchitecture {
-		payload, err = buildArchitecturePayload(provider, templateName, appName)
-	} else {
-		payload, err = buildServicePayload(templateName, appName)
-	}
-	if err != nil {
-		return fmt.Errorf("failed to build payload: %w", err)
+		return buildArchitecturePayload(provider, templateName, appName)
 	}
 
-	// 6. Debug: Print the payload being sent
+	return buildServicePayload(templateName, appName)
+}
+
+// logPayload logs the payload for debugging purposes.
+func logPayload(payload *apiModels.CreateApplicationRequest) {
 	payloadJSON, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
 		logger.Warningf("Failed to marshal payload for debugging: %v\n", err)
 	} else {
 		logger.Infof("CLI REQUEST PAYLOAD:\n%s\n", string(payloadJSON))
 	}
-
-	// 7. Create application via catalog API
-	logger.Infof("Creating application '%s' using template '%s'...\n", appName, templateName)
-	resp, err := appClient.CreateApplication(payload)
-	if err != nil {
-		return fmt.Errorf("failed to create application: %w", err)
-	}
-
-	logger.Infof("Application creation initiated (ID: %s)\n", resp.ID)
-
-	// 8. Poll for application status
-	return pollApplicationStatus(appClient, appName)
 }
 
 // pollApplicationStatus polls the application status until it's ready or fails.
 func pollApplicationStatus(appClient *catalogClient.ApplicationClient, appName string) error {
 	logger.Infof("Waiting for application '%s' to be ready...\n", appName)
 
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
-	timeout := time.After(10 * time.Minute)
+	timeout := time.After(pollTimeout)
 
 	for {
 		select {
@@ -437,29 +464,42 @@ func pollApplicationStatus(appClient *catalogClient.ApplicationClient, appName s
 				return fmt.Errorf("failed to get application status: %w", err)
 			}
 
-			// Status values from ai-services/internal/pkg/catalog/db/models/application.go
-			switch app.Status {
-			case "Running":
-				logger.Infof("Application '%s' is ready!\n", appName)
-				return nil
-
-			case "Error":
-				if app.Message != "" {
-					return fmt.Errorf("application deployment failed: %s", app.Message)
-				}
-				return fmt.Errorf("application deployment failed")
-
-			case "Downloading", "Deploying":
-				// Still in progress, continue polling
-				logger.Infof("Deploying application: %s, Status: %s, Message: %s...\n", appName, app.Status, app.Message)
-
-			case "Deleting":
-				return fmt.Errorf("application is being deleted")
-
-			default:
-				logger.Infof("Status: %s\n", app.Status)
+			if err := handleApplicationStatus(app, appName); err != nil {
+				return err
 			}
 		}
+	}
+}
+
+// handleApplicationStatus handles the application status and returns an error if deployment failed or completed.
+func handleApplicationStatus(app *catalogTypes.Application, appName string) error {
+	// Status values from ai-services/internal/pkg/catalog/db/models/application.go.
+	switch app.Status {
+	case "Running":
+		logger.Infof("Application '%s' is ready!\n", appName)
+
+		return nil
+
+	case "Error":
+		if app.Message != "" {
+			return fmt.Errorf("application deployment failed: %s", app.Message)
+		}
+
+		return fmt.Errorf("application deployment failed")
+
+	case "Downloading", "Deploying":
+		// Still in progress, continue polling.
+		logger.Infof("Deploying application: %s, Status: %s, Message: %s...\n", appName, app.Status, app.Message)
+
+		return nil
+
+	case "Deleting":
+		return fmt.Errorf("application is being deleted")
+
+	default:
+		logger.Infof("Status: %s\n", app.Status)
+
+		return nil
 	}
 }
 
@@ -491,6 +531,7 @@ func buildArchitecturePayload(provider *catalog.CatalogProvider, archID, appName
 		for i := range deployOptions.Services {
 			if deployOptions.Services[i].ID == svcRef.ID {
 				svcDeployOpts = &deployOptions.Services[i]
+
 				break
 			}
 		}
@@ -562,6 +603,7 @@ func buildServiceEntryWithDeployOptions(appClient *catalogClient.ApplicationClie
 			if p.ID == providerID {
 				providerVersion = p.Version
 				providerFound = true
+
 				break
 			}
 		}
@@ -602,102 +644,126 @@ func buildServiceEntryWithDeployOptions(appClient *catalogClient.ApplicationClie
 }
 
 // extractServiceParams extracts service-level parameters from argParams, excluding component params.
-// Format: {serviceID}.{param} -> {param}
-// Excludes: {serviceID}.{componentType}.{param} (those are component params)
+// Format: {serviceID}.{param} -> {param}.
+// Excludes: {serviceID}.{componentType}.{param} (those are component params).
 func extractServiceParams(serviceID string, components []catalogTypes.DeployOptionsComponent, allParams map[string]string) map[string]any {
 	serviceParams := make(map[string]any)
 	servicePrefix := serviceID + "."
 
-	// Build a set of component types for this service
+	// Build a set of component types for this service.
 	componentTypes := make(map[string]bool)
 	for _, comp := range components {
 		componentTypes[comp.Type] = true
 	}
 
 	for key, value := range allParams {
-		if after, ok := strings.CutPrefix(key, servicePrefix); ok {
-			// Check if this is a component parameter (e.g., chat.llm.model)
-			// by seeing if it starts with a known component type
-			isComponentParam := false
-			for compType := range componentTypes {
-				if strings.HasPrefix(after, compType+".") {
-					isComponentParam = true
-					break
-				}
-			}
+		after, ok := strings.CutPrefix(key, servicePrefix)
+		if !ok {
+			continue
+		}
 
-			// Only add to service params if it's not a component param
-			if !isComponentParam {
-				serviceParams[after] = value
-			}
+		// Check if this is a component parameter by seeing if it starts with a known component type.
+		isComponentParam := isComponentParameter(after, componentTypes)
+
+		// Only add to service params if it's not a component param.
+		if !isComponentParam {
+			serviceParams[after] = value
 		}
 	}
 
 	return serviceParams
 }
 
+// isComponentParameter checks if a parameter belongs to a component.
+func isComponentParameter(param string, componentTypes map[string]bool) bool {
+	for compType := range componentTypes {
+		if strings.HasPrefix(param, compType+".") {
+			return true
+		}
+	}
+
+	return false
+}
+
 // extractComponentParamsForService extracts parameters for a specific component type from argParams.
 // Supports provider-specific params:
-// - Provider only: {componentType}.{providerID} (e.g., llm.vllm-cpu) - selects provider with defaults
-// - Provider with params: {componentType}.{providerID}.{param} (e.g., llm.vllm-cpu.model)
-// - Service-specific: {serviceID}.{componentType}.{providerID}[.{param}] (e.g., chat.llm.vllm-cpu or chat.llm.vllm-cpu.model)
-// Returns a map with provider as key and params as value
+// - Provider only: {componentType}.{providerID} (e.g., llm.vllm-cpu) - selects provider with defaults.
+// - Provider with params: {componentType}.{providerID}.{param} (e.g., llm.vllm-cpu.model).
+// - Service-specific: {serviceID}.{componentType}.{providerID}[.{param}] (e.g., chat.llm.vllm-cpu or chat.llm.vllm-cpu.model).
+// Returns a map with provider as key and params as value.
 func extractComponentParamsForService(serviceID string, componentType string, allParams map[string]string) map[string]map[string]string {
 	providerParams := make(map[string]map[string]string)
 
-	// Extract global component params: {componentType}.{providerID}[.{param}]
-	globalPrefix := componentType + "."
-	for key, value := range allParams {
-		if after, ok := strings.CutPrefix(key, globalPrefix); ok {
-			// Split to get providerID and optional param
-			parts := strings.SplitN(after, ".", 2)
-			if len(parts) >= 1 {
-				providerID := parts[0]
-				if providerParams[providerID] == nil {
-					providerParams[providerID] = make(map[string]string)
-				}
-				// If there's a param name, add it; otherwise just mark provider as selected
-				if len(parts) == 2 {
-					paramName := parts[1]
-					providerParams[providerID][paramName] = value
-				}
-			}
-		}
-	}
+	// Extract global component params: {componentType}.{providerID}[.{param}].
+	extractProviderParams(componentType+".", allParams, providerParams)
 
-	// Extract service-specific component params (these override global)
-	servicePrefix := serviceID + "." + componentType + "."
-	for key, value := range allParams {
-		if after, ok := strings.CutPrefix(key, servicePrefix); ok {
-			// Split to get providerID and optional param
-			parts := strings.SplitN(after, ".", 2)
-			if len(parts) >= 1 {
-				providerID := parts[0]
-				if providerParams[providerID] == nil {
-					providerParams[providerID] = make(map[string]string)
-				}
-				// If there's a param name, add it; otherwise just mark provider as selected
-				if len(parts) == 2 {
-					paramName := parts[1]
-					providerParams[providerID][paramName] = value
-				}
-			}
-		}
-	}
+	// Extract service-specific component params (these override global).
+	extractProviderParams(serviceID+"."+componentType+".", allParams, providerParams)
 
 	return providerParams
 }
 
+// extractProviderParams extracts provider parameters from allParams with the given prefix.
+func extractProviderParams(prefix string, allParams map[string]string, providerParams map[string]map[string]string) {
+	for key, value := range allParams {
+		after, ok := strings.CutPrefix(key, prefix)
+		if !ok {
+			continue
+		}
+
+		// Split to get providerID and optional param.
+		parts := strings.SplitN(after, ".", paramSplitParts)
+		if len(parts) < 1 {
+			continue
+		}
+
+		providerID := parts[0]
+		if providerParams[providerID] == nil {
+			providerParams[providerID] = make(map[string]string)
+		}
+
+		// If there's a param name, add it; otherwise just mark provider as selected.
+		if len(parts) == expectedParamParts {
+			paramName := parts[1]
+			providerParams[providerID][paramName] = value
+		}
+	}
+}
+
 // selectProviderFromDeployOptions determines the provider ID for a component using deploy options.
 // Priority:
-// 1. If user provided provider-specific params (e.g., llm.vllm-cpu.model), use that provider
-// 2. For LLM and reranker components: Use vllm-spyre by default
-// 3. Default provider marked in deploy options
-// 4. First available provider
+// 1. If user provided provider-specific params (e.g., llm.vllm-cpu.model), use that provider.
+// 2. For LLM and reranker components: Use vllm-spyre by default.
+// 3. Default provider marked in deploy options.
+// 4. First available provider.
 func selectProviderFromDeployOptions(compDeployOpt catalogTypes.DeployOptionsComponent, providerParams map[string]map[string]string) (string, map[string]string) {
-	// Check if user specified params for a specific provider
+	// Check if user specified params for a specific provider.
+	if providerID, params := findUserSpecifiedProvider(compDeployOpt, providerParams); providerID != "" {
+		return providerID, params
+	}
+
+	// Special logic for LLM and reranker component types - prefer Spyre acceleration.
+	if providerID := findSpyreProvider(compDeployOpt); providerID != "" {
+		return providerID, make(map[string]string)
+	}
+
+	// Use default provider if marked.
+	if providerID := findDefaultProvider(compDeployOpt); providerID != "" {
+		return providerID, make(map[string]string)
+	}
+
+	// Fall back to first available provider.
+	if len(compDeployOpt.Providers) > 0 {
+		return compDeployOpt.Providers[0].ID, make(map[string]string)
+	}
+
+	return "", make(map[string]string)
+}
+
+// findUserSpecifiedProvider checks if user specified params for a specific provider.
+func findUserSpecifiedProvider(compDeployOpt catalogTypes.DeployOptionsComponent, providerParams map[string]map[string]string) (string, map[string]string) {
 	for providerID := range providerParams {
-		// Verify this provider exists in deploy options
+		// Verify this provider exists in deploy options.
 		for _, p := range compDeployOpt.Providers {
 			if p.ID == providerID {
 				return providerID, providerParams[providerID]
@@ -705,29 +771,33 @@ func selectProviderFromDeployOptions(compDeployOpt catalogTypes.DeployOptionsCom
 		}
 	}
 
-	// Special logic for LLM and reranker component types - prefer Spyre acceleration
-	if compDeployOpt.Type == "llm" || compDeployOpt.Type == "reranker" {
-		// Default to vllm-spyre for LLM/reranker if available
-		for _, p := range compDeployOpt.Providers {
-			if p.ID == "vllm-spyre" {
-				return p.ID, make(map[string]string)
-			}
+	return "", nil
+}
+
+// findSpyreProvider finds vllm-spyre provider for LLM and reranker components.
+func findSpyreProvider(compDeployOpt catalogTypes.DeployOptionsComponent) string {
+	if compDeployOpt.Type != "llm" && compDeployOpt.Type != "reranker" {
+		return ""
+	}
+
+	for _, p := range compDeployOpt.Providers {
+		if p.ID == "vllm-spyre" {
+			return p.ID
 		}
 	}
 
-	// Use default provider if marked
+	return ""
+}
+
+// findDefaultProvider finds the default provider marked in deploy options.
+func findDefaultProvider(compDeployOpt catalogTypes.DeployOptionsComponent) string {
 	for _, p := range compDeployOpt.Providers {
 		if p.Default {
-			return p.ID, make(map[string]string)
+			return p.ID
 		}
 	}
 
-	// Fall back to first available provider
-	if len(compDeployOpt.Providers) > 0 {
-		return compDeployOpt.Providers[0].ID, make(map[string]string)
-	}
-
-	return "", make(map[string]string)
+	return ""
 }
 
 // applySchemaDefaults fetches the component provider schema and applies default values.

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -638,25 +638,29 @@ func extractServiceParams(serviceID string, components []catalogTypes.DeployOpti
 
 // extractComponentParamsForService extracts parameters for a specific component type from argParams.
 // Supports provider-specific params:
-// - Global: {componentType}.{providerID}.{param} (e.g., llm.vllm-cpu.model)
-// - Service-specific: {serviceID}.{componentType}.{providerID}.{param} (e.g., chat.llm.vllm-cpu.model)
+// - Provider only: {componentType}.{providerID} (e.g., llm.vllm-cpu) - selects provider with defaults
+// - Provider with params: {componentType}.{providerID}.{param} (e.g., llm.vllm-cpu.model)
+// - Service-specific: {serviceID}.{componentType}.{providerID}[.{param}] (e.g., chat.llm.vllm-cpu or chat.llm.vllm-cpu.model)
 // Returns a map with provider as key and params as value
 func extractComponentParamsForService(serviceID string, componentType string, allParams map[string]string) map[string]map[string]string {
 	providerParams := make(map[string]map[string]string)
 
-	// Extract global component params: {componentType}.{providerID}.{param}
+	// Extract global component params: {componentType}.{providerID}[.{param}]
 	globalPrefix := componentType + "."
 	for key, value := range allParams {
 		if after, ok := strings.CutPrefix(key, globalPrefix); ok {
-			// Split to get providerID and param
+			// Split to get providerID and optional param
 			parts := strings.SplitN(after, ".", 2)
-			if len(parts) == 2 {
+			if len(parts) >= 1 {
 				providerID := parts[0]
-				paramName := parts[1]
 				if providerParams[providerID] == nil {
 					providerParams[providerID] = make(map[string]string)
 				}
-				providerParams[providerID][paramName] = value
+				// If there's a param name, add it; otherwise just mark provider as selected
+				if len(parts) == 2 {
+					paramName := parts[1]
+					providerParams[providerID][paramName] = value
+				}
 			}
 		}
 	}
@@ -665,15 +669,18 @@ func extractComponentParamsForService(serviceID string, componentType string, al
 	servicePrefix := serviceID + "." + componentType + "."
 	for key, value := range allParams {
 		if after, ok := strings.CutPrefix(key, servicePrefix); ok {
-			// Split to get providerID and param
+			// Split to get providerID and optional param
 			parts := strings.SplitN(after, ".", 2)
-			if len(parts) == 2 {
+			if len(parts) >= 1 {
 				providerID := parts[0]
-				paramName := parts[1]
 				if providerParams[providerID] == nil {
 					providerParams[providerID] = make(map[string]string)
 				}
-				providerParams[providerID][paramName] = value
+				// If there's a param name, add it; otherwise just mark provider as selected
+				if len(parts) == 2 {
+					paramName := parts[1]
+					providerParams[providerID][paramName] = value
+				}
 			}
 		}
 	}

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -2,7 +2,6 @@ package application
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"maps"
 	"strings"
@@ -33,8 +32,8 @@ import (
 
 const (
 	// Polling configuration.
-	pollInterval       = 10 * time.Second
-	pollTimeout        = 10 * time.Minute
+	pollInterval       = 20 * time.Second
+	pollTimeout        = 20 * time.Minute
 	paramSplitParts    = 2
 	expectedParamParts = 2
 )
@@ -380,10 +379,7 @@ func createApp(appName string) error {
 		return err
 	}
 
-	// 4. Debug: Print the payload being sent
-	logPayload(payload)
-
-	// 5. Create application via catalog API
+	// 4. Create application via catalog API
 	logger.Infof("Creating application '%s' using template '%s'...\n", appName, templateName)
 	resp, err := appClient.CreateApplication(payload)
 	if err != nil {
@@ -392,7 +388,7 @@ func createApp(appName string) error {
 
 	logger.Infof("Application creation initiated (ID: %s)\n", resp.ID)
 
-	// 6. Poll for application status
+	// 5. Poll for application status
 	return pollApplicationStatus(appClient, appName)
 }
 
@@ -432,16 +428,6 @@ func buildCatalogPayload(appName string) (*apiModels.CreateApplicationRequest, e
 	}
 
 	return buildServicePayload(templateName, appName)
-}
-
-// logPayload logs the payload for debugging purposes.
-func logPayload(payload *apiModels.CreateApplicationRequest) {
-	payloadJSON, err := json.MarshalIndent(payload, "", "  ")
-	if err != nil {
-		logger.Warningf("Failed to marshal payload for debugging: %v\n", err)
-	} else {
-		logger.Infof("CLI REQUEST PAYLOAD:\n%s\n", string(payloadJSON))
-	}
 }
 
 // pollApplicationStatus polls the application status until it's ready or fails.

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -61,8 +61,18 @@ var createCmd = &cobra.Command{
 	Use:   "create [name]",
 	Short: "Deploys an application",
 	Long: `Deploys an application with the provided application name based on the template
-		Arguments
-		- [name]: Application name (Required)
+Arguments
+- [name]: Application name (Required)
+
+Examples:
+# Deploy with experimental mode (5 Spyre cards)
+ai-services application create rag --template rag --runtime podman --experimental
+
+# Deploy with experimental mode (4 Spyre cards - reranker on CPU)
+ai-services application create rag --template rag --runtime podman --experimental --params reranker.vllm-cpu=true
+
+# Deploy with experimental mode (CPU mode)
+ai-services application create rag --template rag --runtime podman --experimental --params reranker.vllm-cpu=true,llm.vllm-cpu=true
 	`,
 	Args: cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -389,34 +399,7 @@ func createApp(appName string) error {
 	logger.Infof("Application creation initiated (ID: %s)\n", resp.ID)
 
 	// 5. Poll for application status
-	if err := pollApplicationStatus(appClient, appName); err != nil {
-		return err
-	}
-
-	// 6. Print next steps after successful deployment
-	return printNextSteps(appName)
-}
-
-// printNextSteps prints the next steps after successful application deployment.
-func printNextSteps(appName string) error {
-	// Create template provider
-	tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
-
-	// Get runtime instance
-	rt, err := vars.RuntimeFactory.Create(appName)
-	if err != nil {
-		logger.Infof("Unable to create runtime for next steps: %v\n", err)
-
-		return nil
-	}
-
-	// Print next steps
-	if err := helpers.PrintNextSteps(tp, rt, appName, templateName); err != nil {
-		// Don't fail the overall create if we cannot print next steps
-		logger.Infof("Failed to display next steps: %v\n", err)
-	}
-
-	return nil
+	return pollApplicationStatus(appClient, appName)
 }
 
 // checkApplicationExists checks if an application with the given name already exists.
@@ -477,42 +460,46 @@ func pollApplicationStatus(appClient *catalogClient.ApplicationClient, appName s
 				return fmt.Errorf("failed to get application status: %w", err)
 			}
 
-			if err := handleApplicationStatus(app, appName); err != nil {
+			done, err := handleApplicationStatus(app, appName)
+			if err != nil {
 				return err
+			}
+			if done {
+				return nil
 			}
 		}
 	}
 }
 
-// handleApplicationStatus handles the application status and returns an error if deployment failed or completed.
-func handleApplicationStatus(app *catalogTypes.Application, appName string) error {
+// handleApplicationStatus handles the application status and returns (done, error).
+func handleApplicationStatus(app *catalogTypes.Application, appName string) (bool, error) {
 	// Status values from ai-services/internal/pkg/catalog/db/models/application.go.
 	switch app.Status {
 	case "Running":
 		logger.Infof("Application '%s' is ready!\n", appName)
 
-		return nil
+		return true, nil
 
 	case "Error":
 		if app.Message != "" {
-			return fmt.Errorf("application deployment failed: %s", app.Message)
+			return false, fmt.Errorf("application deployment failed: %s", app.Message)
 		}
 
-		return fmt.Errorf("application deployment failed")
+		return false, fmt.Errorf("application deployment failed")
 
 	case "Downloading", "Deploying":
 		// Still in progress, continue polling.
-		logger.Infof("Deploying application: %s, Status: %s, Message: %s...\n", appName, app.Status, app.Message)
+		logger.Infof("Deploying application: %s, Status: %s, Message: %s\n", appName, app.Status, app.Message)
 
-		return nil
+		return false, nil
 
 	case "Deleting":
-		return fmt.Errorf("application is being deleted")
+		return false, fmt.Errorf("application is being deleted")
 
 	default:
 		logger.Infof("Status: %s\n", app.Status)
 
-		return nil
+		return false, nil
 	}
 }
 

--- a/ai-services/internal/pkg/catalog/client/application.go
+++ b/ai-services/internal/pkg/catalog/client/application.go
@@ -9,14 +9,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
-// HTTP header constants.
-const (
-	headerAuthorization = "Authorization"
-	headerContentType   = "Content-Type"
-	bearerPrefix        = "Bearer "
-	contentTypeJSON     = "application/json"
-)
-
 // API route constants for application endpoints.
 const (
 	applicationsRoute       = "/api/v1/applications"
@@ -158,9 +150,7 @@ func (c *ApplicationClient) GetApplication(id string) (*types.Application, error
 // It accepts a CreateApplicationRequest with catalog ID, name, services, and components configuration.
 func (c *ApplicationClient) CreateApplication(req *models.CreateApplicationRequest) (*models.CreateApplicationResponse, error) {
 	var result models.CreateApplicationResponse
-	resp, err := c.httpClient.R().
-		SetHeader(headerAuthorization, bearerPrefix+c.client.AccessToken()).
-		SetHeader(headerContentType, contentTypeJSON).
+	resp, err := c.client.HTTPClient().R().
 		SetBody(req).
 		SetResult(&result).
 		Post(applicationsRoute)
@@ -181,8 +171,7 @@ func (c *ApplicationClient) CreateApplication(req *models.CreateApplicationReque
 // It returns available providers and dependency rules for the service and its components.
 func (c *ApplicationClient) GetServiceDeployOptions(serviceID string) (*types.DeployOptionsService, error) {
 	var result types.DeployOptionsService
-	resp, err := c.httpClient.R().
-		SetHeader(headerAuthorization, bearerPrefix+c.client.AccessToken()).
+	resp, err := c.client.HTTPClient().R().
 		SetResult(&result).
 		Get(fmt.Sprintf(svcDeployOptionsRoute, serviceID))
 	if err != nil {
@@ -200,8 +189,7 @@ func (c *ApplicationClient) GetServiceDeployOptions(serviceID string) (*types.De
 // It returns available providers and dependency rules for all services in the architecture.
 func (c *ApplicationClient) GetArchitectureDeployOptions(architectureID string) (*types.DeployOptionsArchitecture, error) {
 	var result types.DeployOptionsArchitecture
-	resp, err := c.httpClient.R().
-		SetHeader(headerAuthorization, bearerPrefix+c.client.AccessToken()).
+	resp, err := c.client.HTTPClient().R().
 		SetResult(&result).
 		Get(fmt.Sprintf(archDeployOptionsRoute, architectureID))
 	if err != nil {
@@ -218,8 +206,7 @@ func (c *ApplicationClient) GetArchitectureDeployOptions(architectureID string) 
 // GetComponentProviderParams retrieves the parameter schema for a specific component provider.
 func (c *ApplicationClient) GetComponentProviderParams(componentType, providerID string) (map[string]any, error) {
 	var result map[string]any
-	resp, err := c.httpClient.R().
-		SetHeader(headerAuthorization, bearerPrefix+c.client.AccessToken()).
+	resp, err := c.client.HTTPClient().R().
 		SetResult(&result).
 		Get(fmt.Sprintf(compProviderParamsRoute, componentType, providerID))
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/client/application.go
+++ b/ai-services/internal/pkg/catalog/client/application.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
@@ -140,6 +141,85 @@ func (c *ApplicationClient) GetApplication(id string) (*types.Application, error
 	}
 
 	return &result, nil
+}
+
+// CreateApplication creates a new application deployment via catalog API.
+// It accepts a CreateApplicationRequest with catalog ID, name, services, and components configuration.
+func (c *ApplicationClient) CreateApplication(req *models.CreateApplicationRequest) (*models.CreateApplicationResponse, error) {
+	var result models.CreateApplicationResponse
+	resp, err := c.httpClient.R().
+		SetHeader("Authorization", "Bearer "+c.client.AccessToken()).
+		SetHeader("Content-Type", "application/json").
+		SetBody(req).
+		SetResult(&result).
+		Post("/api/v1/applications")
+
+	if err != nil {
+		return nil, fmt.Errorf("create application: %w", err)
+	}
+
+	if resp.IsError() {
+		return nil, fmt.Errorf("create application: server returned HTTP %d: %s",
+			resp.StatusCode(), utils.ParseErrorResponse(resp))
+	}
+
+	return &result, nil
+}
+
+// GetServiceDeployOptions retrieves deploy options for a specific service.
+// It returns available providers and dependency rules for the service and its components.
+func (c *ApplicationClient) GetServiceDeployOptions(serviceID string) (*types.DeployOptionsService, error) {
+	var result types.DeployOptionsService
+	resp, err := c.httpClient.R().
+		SetHeader("Authorization", "Bearer "+c.client.AccessToken()).
+		SetResult(&result).
+		Get(fmt.Sprintf("/api/v1/services/%s/deploy-options", serviceID))
+	if err != nil {
+		return nil, fmt.Errorf("get service deploy options: %w", err)
+	}
+
+	if resp.IsError() {
+		return nil, fmt.Errorf("get service deploy options: server returned HTTP %d: %s", resp.StatusCode(), utils.ParseErrorResponse(resp))
+	}
+
+	return &result, nil
+}
+
+// GetArchitectureDeployOptions retrieves deploy options for an architecture.
+// It returns available providers and dependency rules for all services in the architecture.
+func (c *ApplicationClient) GetArchitectureDeployOptions(architectureID string) (*types.DeployOptionsArchitecture, error) {
+	var result types.DeployOptionsArchitecture
+	resp, err := c.httpClient.R().
+		SetHeader("Authorization", "Bearer "+c.client.AccessToken()).
+		SetResult(&result).
+		Get(fmt.Sprintf("/api/v1/architectures/%s/deploy-options", architectureID))
+	if err != nil {
+		return nil, fmt.Errorf("get architecture deploy options: %w", err)
+	}
+
+	if resp.IsError() {
+		return nil, fmt.Errorf("get architecture deploy options: server returned HTTP %d: %s", resp.StatusCode(), utils.ParseErrorResponse(resp))
+	}
+
+	return &result, nil
+}
+
+// GetComponentProviderParams retrieves the parameter schema for a specific component provider.
+func (c *ApplicationClient) GetComponentProviderParams(componentType, providerID string) (map[string]any, error) {
+	var result map[string]any
+	resp, err := c.httpClient.R().
+		SetHeader("Authorization", "Bearer "+c.client.AccessToken()).
+		SetResult(&result).
+		Get(fmt.Sprintf("/api/v1/components/%s/providers/%s/params", componentType, providerID))
+	if err != nil {
+		return nil, fmt.Errorf("get component provider params: %w", err)
+	}
+
+	if resp.IsError() {
+		return nil, fmt.Errorf("get component provider params: server returned HTTP %d: %s", resp.StatusCode(), utils.ParseErrorResponse(resp))
+	}
+
+	return result, nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/client/application.go
+++ b/ai-services/internal/pkg/catalog/client/application.go
@@ -9,11 +9,22 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
+// HTTP header constants.
+const (
+	headerAuthorization = "Authorization"
+	headerContentType   = "Content-Type"
+	bearerPrefix        = "Bearer "
+	contentTypeJSON     = "application/json"
+)
+
 // API route constants for application endpoints.
 const (
-	listApplicationsRoute = "/api/v1/applications"
-	getApplicationPSRoute = "/api/v1/applications/%s/ps"
-	getApplicationRoute   = "/api/v1/applications/%s"
+	applicationsRoute       = "/api/v1/applications"
+	getApplicationPSRoute   = "/api/v1/applications/%s/ps"
+	getApplicationRoute     = "/api/v1/applications/%s"
+	svcDeployOptionsRoute   = "/api/v1/services/%s/deploy-options"
+	archDeployOptionsRoute  = "/api/v1/architectures/%s/deploy-options"
+	compProviderParamsRoute = "/api/v1/components/%s/providers/%s/params"
 )
 
 // ApplicationClient provides methods for interacting with the applications API.
@@ -65,7 +76,7 @@ func (c *ApplicationClient) ListApplications(params *ListApplicationsParams) (*t
 		}
 	}
 
-	resp, err := req.Get(listApplicationsRoute)
+	resp, err := req.Get(applicationsRoute)
 	if err != nil {
 		return nil, fmt.Errorf("list applications: %w", err)
 	}
@@ -148,11 +159,11 @@ func (c *ApplicationClient) GetApplication(id string) (*types.Application, error
 func (c *ApplicationClient) CreateApplication(req *models.CreateApplicationRequest) (*models.CreateApplicationResponse, error) {
 	var result models.CreateApplicationResponse
 	resp, err := c.httpClient.R().
-		SetHeader("Authorization", "Bearer "+c.client.AccessToken()).
-		SetHeader("Content-Type", "application/json").
+		SetHeader(headerAuthorization, bearerPrefix+c.client.AccessToken()).
+		SetHeader(headerContentType, contentTypeJSON).
 		SetBody(req).
 		SetResult(&result).
-		Post("/api/v1/applications")
+		Post(applicationsRoute)
 
 	if err != nil {
 		return nil, fmt.Errorf("create application: %w", err)
@@ -171,9 +182,9 @@ func (c *ApplicationClient) CreateApplication(req *models.CreateApplicationReque
 func (c *ApplicationClient) GetServiceDeployOptions(serviceID string) (*types.DeployOptionsService, error) {
 	var result types.DeployOptionsService
 	resp, err := c.httpClient.R().
-		SetHeader("Authorization", "Bearer "+c.client.AccessToken()).
+		SetHeader(headerAuthorization, bearerPrefix+c.client.AccessToken()).
 		SetResult(&result).
-		Get(fmt.Sprintf("/api/v1/services/%s/deploy-options", serviceID))
+		Get(fmt.Sprintf(svcDeployOptionsRoute, serviceID))
 	if err != nil {
 		return nil, fmt.Errorf("get service deploy options: %w", err)
 	}
@@ -190,9 +201,9 @@ func (c *ApplicationClient) GetServiceDeployOptions(serviceID string) (*types.De
 func (c *ApplicationClient) GetArchitectureDeployOptions(architectureID string) (*types.DeployOptionsArchitecture, error) {
 	var result types.DeployOptionsArchitecture
 	resp, err := c.httpClient.R().
-		SetHeader("Authorization", "Bearer "+c.client.AccessToken()).
+		SetHeader(headerAuthorization, bearerPrefix+c.client.AccessToken()).
 		SetResult(&result).
-		Get(fmt.Sprintf("/api/v1/architectures/%s/deploy-options", architectureID))
+		Get(fmt.Sprintf(archDeployOptionsRoute, architectureID))
 	if err != nil {
 		return nil, fmt.Errorf("get architecture deploy options: %w", err)
 	}
@@ -208,9 +219,9 @@ func (c *ApplicationClient) GetArchitectureDeployOptions(architectureID string) 
 func (c *ApplicationClient) GetComponentProviderParams(componentType, providerID string) (map[string]any, error) {
 	var result map[string]any
 	resp, err := c.httpClient.R().
-		SetHeader("Authorization", "Bearer "+c.client.AccessToken()).
+		SetHeader(headerAuthorization, bearerPrefix+c.client.AccessToken()).
 		SetResult(&result).
-		Get(fmt.Sprintf("/api/v1/components/%s/providers/%s/params", componentType, providerID))
+		Get(fmt.Sprintf(compProviderParamsRoute, componentType, providerID))
 	if err != nil {
 		return nil, fmt.Errorf("get component provider params: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/client/models.go
+++ b/ai-services/internal/pkg/catalog/client/models.go
@@ -17,3 +17,36 @@ type DeleteApplicationParams struct {
 	// KeepData preserves underlying data (volumes of databases/service resources) when true. Default: false
 	KeepData bool
 }
+
+// CreateApplicationRequest represents the payload for creating an application.
+type CreateApplicationRequest struct {
+	CatalogID string                     `json:"catalog_id"`
+	Name      string                     `json:"name"`
+	Services  []CreateApplicationService `json:"services"`
+	Version   string                     `json:"version,omitempty"`
+}
+
+// CreateApplicationService represents a service in the create application request.
+type CreateApplicationService struct {
+	CatalogID  string                       `json:"catalog_id"`
+	Components []CreateApplicationComponent `json:"components,omitempty"`
+	Params     map[string]interface{}       `json:"params,omitempty"`
+	Version    string                       `json:"version,omitempty"`
+}
+
+// CreateApplicationComponent represents a component in the create application request.
+type CreateApplicationComponent struct {
+	ComponentType string                 `json:"component_type"`
+	InstanceID    string                 `json:"instance_id,omitempty"`
+	Params        map[string]interface{} `json:"params,omitempty"`
+	ProviderID    string                 `json:"provider_id"`
+	Version       string                 `json:"version,omitempty"`
+}
+
+// CreateApplicationResponse represents the response after creating an application.
+type CreateApplicationResponse struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Message string `json:"message,omitempty"`
+}


### PR DESCRIPTION
Migrated ai-services application create command to use the Catalog API when `--experimental` flag is enabled for podman runtime.

1. Defaults to vllm-spyre for LLM/reranker (Spyre acceleration)
2. Switches to CPU when user provides provider-specific params: llm.vllm-cpu.model=...


