### PR TITLE
fix: clean up auth-secret volume during uninstall 

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.76
+TAG?=0.0.77
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -7,6 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/secret: "catalog-secret"
+    ai-services.io/volume: "podman-auth-secret"
   annotations:
     run.oci.keep_original_groups: "1"
     ai-services.io/routes: "8081:catalog-ui:ui, 8080:catalog-api:api"

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.76
+  image: icr.io/ai-services-cicd/ai-services:0.0.77
   runtime: ""
   adminPasswordHash: ""
   podman:


### PR DESCRIPTION
After uninstall `podman-auth-secret` was left out.
Added the missing label to cleanup volumes properly.