### PR TITLE
refactor(catalog): remove obsolete --params flag from configure command

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.88
+TAG?=0.0.89
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.88
+  image: icr.io/ai-services-cicd/ai-services:0.0.89
   runtime: ""
   adminPasswordHash: ""
   podman:
@@ -25,7 +25,6 @@ db:
 
 caddy:
   image: icr.io/ai-services-cicd/caddy:v2.11.3-0
-  # @description admin port for caddy. If unspecified, a random available port is assigned
   adminPort: ""
   # @description HTTPS port for caddy. Set by configure command via --https-port flag.
   httpsPort: ""

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -25,7 +25,7 @@ db:
 
 caddy:
   image: icr.io/ai-services-cicd/caddy:v2.11.3-0
-  # @description admin port for caddy. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
+  # @description admin port for caddy. If unspecified, a random available port is assigned
   adminPort: ""
   # @description HTTPS port for caddy. Set by configure command via --https-port flag.
   httpsPort: ""

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -35,11 +35,6 @@ const defaultHTTPSPort = 443
 
 // NewConfigureCmd creates a new configure command for the catalog service.
 func NewConfigureCmd() *cobra.Command {
-	var (
-		rawArgParams []string
-		argParams    map[string]string
-	)
-
 	cmd := &cobra.Command{
 		Use:   "configure",
 		Short: "Configure the catalog service with initial configuration",
@@ -49,29 +44,26 @@ Examples:
 	 # Configure catalog service for podman
 	 ai-services catalog configure --runtime podman
 
-	 # Configure with custom UI port
-	 ai-services catalog configure --runtime podman --params ui.port=8081`,
+	 # Configure with custom HTTPS port
+	 ai-services catalog configure --runtime podman --https-port 8443`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 
-			var err error
-			argParams, err = validateConfigureFlags(rawArgParams)
-
-			return err
+			return validateConfigureFlags()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Prompt for admin password
-			return runConfigure(argParams)
+			return runConfigure()
 		},
 	}
 
-	configureConfigureFlags(cmd, &rawArgParams)
+	configureConfigureFlags(cmd)
 
 	return cmd
 }
 
 // runConfigure executes the catalog configuration process.
-func runConfigure(argParams map[string]string) error {
+func runConfigure() error {
 	// Prompt for admin password
 	adminPassword, err := promptForPassword()
 	if err != nil {
@@ -114,7 +106,6 @@ func runConfigure(argParams map[string]string) error {
 		AdminPassword: adminPassword,
 		Runtime:       vars.RuntimeFactory.GetRuntimeType(),
 		BaseDir:       aiServicesDir,
-		ArgParams:     argParams,
 		DomainName:    domainName,
 		SSLCertPath:   cleanCertPath,
 		SSLKeyPath:    cleanKeyPath,
@@ -123,11 +114,11 @@ func runConfigure(argParams map[string]string) error {
 }
 
 // validateConfigureFlags validates the configure command flags and initializes runtime.
-func validateConfigureFlags(rawArgParams []string) (map[string]string, error) {
+func validateConfigureFlags() error {
 	// Initialize runtime factory based on flag
 	rt := types.RuntimeType(runtimeType)
 	if !rt.Valid() {
-		return nil, fmt.Errorf("invalid runtime type: %s (must be 'podman' or 'openshift'). Please specify runtime using --runtime flag", runtimeType)
+		return fmt.Errorf("invalid runtime type: %s (must be 'podman' or 'openshift'). Please specify runtime using --runtime flag", runtimeType)
 	}
 
 	vars.RuntimeFactory = runtime.NewRuntimeFactory(rt)
@@ -135,30 +126,20 @@ func validateConfigureFlags(rawArgParams []string) (map[string]string, error) {
 
 	// Check if podman runtime is being used on unsupported platform
 	if err := utils.CheckPodmanPlatformSupport(vars.RuntimeFactory.GetRuntimeType()); err != nil {
-		return nil, err
+		return err
 	}
 
 	// Validate SSL flags
 	if err := validateSSLFlags(); err != nil {
-		return nil, err
+		return err
 	}
 
 	// Validate HTTPS port range
 	if httpsPort < 1 || httpsPort > 65535 {
-		return nil, fmt.Errorf("invalid HTTPS port %d: must be between 1 and 65535", httpsPort)
+		return fmt.Errorf("invalid HTTPS port %d: must be between 1 and 65535", httpsPort)
 	}
 
-	// Parse params if provided
-	var argParams map[string]string
-	if len(rawArgParams) > 0 {
-		var err error
-		argParams, err = utils.ParseKeyValues(rawArgParams)
-		if err != nil {
-			return nil, fmt.Errorf("invalid params format: %w", err)
-		}
-	}
-
-	return argParams, nil
+	return nil
 }
 
 // validateSSLFlags validates SSL certificate and key flags.
@@ -215,7 +196,7 @@ func validateSSLCertificates() error {
 }
 
 // configureConfigureFlags configures the flags for the configure command.
-func configureConfigureFlags(cmd *cobra.Command, rawArgParams *[]string) {
+func configureConfigureFlags(cmd *cobra.Command) {
 	// Add runtime flag as required
 	cmd.Flags().StringVarP(&runtimeType, "runtime", "r", "", fmt.Sprintf("runtime to use (options: %s, %s) (required)", types.RuntimeTypePodman, types.RuntimeTypeOpenShift))
 	_ = cmd.MarkFlagRequired("runtime")
@@ -236,19 +217,6 @@ func configureConfigureFlags(cmd *cobra.Command, rawArgParams *[]string) {
 		defaultHTTPSPort,
 		"Custom HTTPS port to expose the service endpoints externally (podman runtime only).\n"+
 			"Example: --https-port 8443\n",
-	)
-
-	cmd.Flags().StringSliceVar(
-		rawArgParams,
-		"params",
-		[]string{},
-		"Inline parameters to configure the catalog service.\n\n"+
-			"Format:\n"+
-			"- Comma-separated key=value pairs\n"+
-			"- Example: --params ui.port=8081,backend.port=8080\n\n"+
-			"Available parameters:\n"+
-			"- ui.port: Port for the catalog UI (default: random available port)\n"+
-			"- backend.port: Port for the catalog backend API (default: random available port)\n",
 	)
 
 	// SSL/TLS certificate configuration flags

--- a/ai-services/internal/pkg/catalog/cli/configure/common.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/common.go
@@ -24,7 +24,6 @@ type ConfigureOptions struct {
 	AdminPassword string
 	Runtime       types.RuntimeType
 	BaseDir       string
-	ArgParams     map[string]string
 	// SSL/TLS certificate configuration
 	DomainName  string // Custom domain name for self-signed certificates
 	SSLCertPath string // Path to user-provided SSL certificate
@@ -57,7 +56,7 @@ func Run(opts ConfigureOptions) error {
 			return fmt.Errorf("failed to get auth file path: %w", err)
 		}
 
-		return catalogPodman.DeployCatalog(ctx, podmanURI, authFilePath, passwordHash, opts.BaseDir, opts.ArgParams, opts.DomainName, opts.SSLCertPath, opts.SSLKeyPath, opts.HttpsPort)
+		return catalogPodman.DeployCatalog(ctx, podmanURI, authFilePath, passwordHash, opts.BaseDir, opts.DomainName, opts.SSLCertPath, opts.SSLKeyPath, opts.HttpsPort)
 
 	case types.RuntimeTypeOpenShift:
 		return fmt.Errorf("openshift runtime is not yet supported for catalog configure")

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -92,15 +92,15 @@ func (c *catalogDeploymentContext) getCaddyHostAdminURL(rt *podman.PodmanClient,
 }
 
 // DeployCatalog deploys the catalog service using the assets/catalog template for podman runtime.
-func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, baseDir string, argParams map[string]string, domainName string, sslCertPath, sslKeyPath string, httpsPort int) error {
+func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, baseDir string, domainName string, sslCertPath, sslKeyPath string, httpsPort int) error {
 	s := spinner.New("Deploying catalog service...")
 	s.Start(ctx)
 
 	// Initialize deployment context for caching
 	deployCtx := &catalogDeploymentContext{}
 
-	// Initialize and validate
-	rt, tp, appMetadata, tmpls, argParams, err := initializeCatalogDeployment(argParams, httpsPort, s)
+	// Initialize and validate - argParams is created internally
+	rt, tp, appMetadata, tmpls, argParams, err := initializeCatalogDeployment(httpsPort, s)
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,8 @@ func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, b
 }
 
 // initializeCatalogDeployment handles initialization and validation steps.
-func initializeCatalogDeployment(argParams map[string]string, httpsPort int, s *spinner.Spinner) (
+// Creates and returns argParams map internally for use throughout deployment.
+func initializeCatalogDeployment(httpsPort int, s *spinner.Spinner) (
 	*podman.PodmanClient,
 	templates.Template,
 	*templates.AppMetadata,
@@ -167,10 +168,8 @@ func initializeCatalogDeployment(argParams map[string]string, httpsPort int, s *
 		return nil, nil, nil, nil, nil, fmt.Errorf("failed to load catalog templates: %w", err)
 	}
 
-	// Set httpsPort in argParams
-	if argParams == nil {
-		argParams = make(map[string]string)
-	}
+	// Create argParams map for internal use
+	argParams := make(map[string]string)
 	argParams["caddy.httpsPort"] = fmt.Sprintf("%d", httpsPort)
 
 	return rt, tp, appMetadata, tmpls, argParams, nil


### PR DESCRIPTION
With Caddy handling routing, ui.port and backend.port parameters are no longer needed. Ports are now managed automatically by Podman/Caddy.