### PR TITLE
Updated vLLM cpu image to v0.19.1

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.81
+TAG?=0.0.82
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -52,7 +52,7 @@ postgres:
 
 instruct:
   # @hidden
-  image: icr.io/ppc64le-oss/vllm-ppc64le:0.18.0
+  image: icr.io/ppc64le-oss/vllm-ppc64le:0.19.1
   # @description API key for vLLM instruct service authentication. If empty, authentication is disabled. Provide a key to enable authentication.
   apiKey: ""
   model:
@@ -67,7 +67,7 @@ instruct:
 
 embedding:
   # @hidden
-  image: icr.io/ppc64le-oss/vllm-ppc64le:0.18.0
+  image: icr.io/ppc64le-oss/vllm-ppc64le:0.19.1
   model:
     # @hidden
     name: ibm-granite/granite-embedding-278m-multilingual
@@ -76,7 +76,7 @@ embedding:
 
 reranker:
   # @hidden
-  image: icr.io/ppc64le-oss/vllm-ppc64le:0.18.0
+  image: icr.io/ppc64le-oss/vllm-ppc64le:0.19.1
   model:
     # @hidden
     name: BAAI/bge-reranker-v2-m3

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -65,7 +65,7 @@ instruct:
 
 embedding:
   # @hidden
-  image: icr.io/ppc64le-oss/vllm-ppc64le:0.9.1
+  image: icr.io/ppc64le-oss/vllm-ppc64le:0.19.1
   model:
     # @hidden
     name: ibm-granite/granite-embedding-278m-multilingual
@@ -74,7 +74,7 @@ embedding:
 
 reranker:
   # @hidden
-  image: icr.io/ppc64le-oss/vllm-ppc64le:0.9.1
+  image: icr.io/ppc64le-oss/vllm-ppc64le:0.19.1
   model:
     # @hidden
     name: BAAI/bge-reranker-v2-m3

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -65,7 +65,7 @@ instruct:
 
 embedding:
   # @hidden
-  image: icr.io/ppc64le-oss/vllm-ppc64le:0.9.1
+  image: icr.io/ppc64le-oss/vllm-ppc64le:0.19.1
   model:
     # @hidden
     name: ibm-granite/granite-embedding-278m-multilingual

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.81
+  image: icr.io/ai-services-cicd/ai-services:0.0.82
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/components/llm/vllm-cpu/podman/values.yaml
+++ b/ai-services/assets/components/llm/vllm-cpu/podman/values.yaml
@@ -1,4 +1,4 @@
-image: icr.io/ppc64le-oss/vllm-ppc64le:0.18.0
+image: icr.io/ppc64le-oss/vllm-ppc64le:0.19.1
 model: ""
 apiKey: ""
 maxNumBatchedTokens: 26208


### PR DESCRIPTION
- Updated vLLM cpu image to v0.19.1
- Tested overall functionality of deployment, ingesting the documents, querying chatbot with QnA(both backend and UI).
Observed below throughput for chat completion request, On an avg, seen throuput of 7 tokens per sec.
vLLM instruct logs:
```
(APIServer pid=1) INFO 06-12 05:47:17 [loggers.py:259] Engine 000: Avg prompt throughput: 2.5 tokens/s, Avg generation throughput: 0.4 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 38.1%
(APIServer pid=1) INFO:     127.0.0.1:45252 - "GET /health HTTP/1.1" 200 OK
(APIServer pid=1) INFO 06-12 05:47:27 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 7.2 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 38.1%
(APIServer pid=1) INFO 06-12 05:47:37 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 7.3 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.6%, Prefix cache hit rate: 38.1%
(APIServer pid=1) INFO 06-12 05:47:47 [loggers.py:259] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 7.3 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.6%, Prefix cache hit rate: 38.1%
(APIServer pid=1) INFO:     127.0.0.1:39484 - "GET /health HTTP/1.1" 200 OK
```