### PR TITLE
read about as yaml for maintaining the order

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=0.0.87
+TAG?=0.0.88
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:0.0.87
+  image: icr.io/ai-services-cicd/ai-services:0.0.88
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -1368,7 +1368,6 @@ const docTemplate = `{
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture": {
             "type": "object",
             "properties": {
-                "about": {},
                 "certified_by": {
                     "type": "string"
                 },
@@ -1649,7 +1648,6 @@ const docTemplate = `{
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Service": {
             "type": "object",
             "properties": {
-                "about": {},
                 "architectures": {
                     "type": "array",
                     "items": {

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -1362,7 +1362,6 @@
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture": {
             "type": "object",
             "properties": {
-                "about": {},
                 "certified_by": {
                     "type": "string"
                 },
@@ -1643,7 +1642,6 @@
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Service": {
             "type": "object",
             "properties": {
-                "about": {},
                 "architectures": {
                     "type": "array",
                     "items": {

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -177,7 +177,6 @@ definitions:
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Architecture:
     properties:
-      about: {}
       certified_by:
         type: string
       description:
@@ -362,7 +361,6 @@ definitions:
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Service:
     properties:
-      about: {}
       architectures:
         items:
           type: string

--- a/ai-services/go.mod
+++ b/ai-services/go.mod
@@ -30,6 +30,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.50.0
 	golang.org/x/term v0.42.0
+	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v4 v4.1.4
 	k8s.io/api v0.35.1
 	k8s.io/apimachinery v0.35.1
@@ -274,7 +275,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v1.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.1 // indirect
 	k8s.io/apiserver v0.35.1 // indirect

--- a/ai-services/internal/pkg/catalog/catalog.go
+++ b/ai-services/internal/pkg/catalog/catalog.go
@@ -16,7 +16,7 @@ import (
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
-	"go.yaml.in/yaml/v3"
+	"gopkg.in/yaml.v3"
 )
 
 // catalogItem represents a cached catalog item with its metadata and path.

--- a/ai-services/internal/pkg/catalog/types/types.go
+++ b/ai-services/internal/pkg/catalog/types/types.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	// yamlMappingKeyValuePairs represents that YAML mapping nodes store content as key-value pairs
+	// yamlMappingKeyValuePairs represents that YAML mapping nodes store content as key-value pairs.
 	yamlMappingKeyValuePairs = 2
 )
 

--- a/ai-services/internal/pkg/catalog/types/types.go
+++ b/ai-services/internal/pkg/catalog/types/types.go
@@ -6,6 +6,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	// yamlMappingKeyValuePairs represents that YAML mapping nodes store content as key-value pairs
+	yamlMappingKeyValuePairs = 2
+)
+
 // Architecture represents a complete AI solution template.
 type Architecture struct {
 	ID               string               `yaml:"id" json:"id"`
@@ -18,7 +23,7 @@ type Architecture struct {
 	GlobalComponents []ComponentReference `yaml:"global_components,omitempty" json:"global_components,omitempty"`
 	Services         []ServiceReference   `yaml:"services" json:"services"`
 	Links            *ArchitectureLinks   `yaml:"links,omitempty" json:"links,omitempty"`
-	About            yaml.Node            `yaml:"about,omitempty" json:"-"`
+	About            *yaml.Node           `yaml:"-" json:"-"`
 }
 
 // MarshalJSON implements custom JSON marshaling for Architecture to properly handle yaml.Node.
@@ -30,13 +35,30 @@ func (a Architecture) MarshalJSON() ([]byte, error) {
 	}{
 		Alias: (*Alias)(&a),
 	}
-
-	// Convert yaml.Node to interface{} preserving order
-	if a.About.Kind != 0 {
-		aux.About = yamlNodeToInterface(&a.About)
+	if a.About != nil && a.About.Kind != 0 {
+		aux.About = yamlNodeToInterface(a.About) // Uses your helper below
 	}
 
 	return json.Marshal(aux)
+}
+
+// UnmarshalYAML handles raw document maps to safely capture nested array/map structure nodes.
+func (a *Architecture) UnmarshalYAML(value *yaml.Node) error {
+	type Alias Architecture
+	aux := (*Alias)(a)
+
+	// Temporarily nil out About to prevent unmarshal errors
+	aux.About = nil
+
+	// Decode all fields except About
+	if err := value.Decode(aux); err != nil {
+		return err
+	}
+
+	// Extract About node manually
+	a.About = extractAboutNode(value)
+
+	return nil
 }
 
 // ArchitectureSummary represents an architecture for list API responses.
@@ -90,7 +112,26 @@ type Service struct {
 	Architectures []string              `yaml:"architectures" json:"architectures"`
 	Dependencies  []DependencyReference `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
 	Standalone    bool                  `yaml:"standalone,omitempty" json:"standalone,omitempty"`
-	About         yaml.Node             `yaml:"about,omitempty" json:"-"`
+	About         *yaml.Node            `yaml:"-" json:"-"`
+}
+
+// UnmarshalYAML extracts the 'about' node manually, insulating it from reflection errors.
+func (s *Service) UnmarshalYAML(value *yaml.Node) error {
+	type Alias Service
+	aux := (*Alias)(s)
+
+	// Temporarily nil out About to prevent unmarshal errors
+	aux.About = nil
+
+	// Decode all fields except About
+	if err := value.Decode(aux); err != nil {
+		return err
+	}
+
+	// Extract About node manually
+	s.About = extractAboutNode(value)
+
+	return nil
 }
 
 // MarshalJSON implements custom JSON marshaling for Service to properly handle yaml.Node.
@@ -102,10 +143,8 @@ func (s Service) MarshalJSON() ([]byte, error) {
 	}{
 		Alias: (*Alias)(&s),
 	}
-
-	// Convert yaml.Node to interface{} preserving order
-	if s.About.Kind != 0 {
-		aux.About = yamlNodeToInterface(&s.About)
+	if s.About != nil && s.About.Kind != 0 {
+		aux.About = yamlNodeToInterface(s.About)
 	}
 
 	return json.Marshal(aux)
@@ -182,6 +221,22 @@ type DeployOptionsArchitecture struct {
 	Services         []DeployOptionsService   `json:"services"`
 }
 
+// extractAboutNode finds and returns the 'about' field from a YAML node.
+func extractAboutNode(value *yaml.Node) *yaml.Node {
+	mapNode := value
+	if value.Kind == yaml.DocumentNode && len(value.Content) > 0 {
+		mapNode = value.Content[0]
+	}
+
+	for i := 0; i < len(mapNode.Content); i += 2 {
+		if mapNode.Content[i].Value == "about" && i+1 < len(mapNode.Content) {
+			return mapNode.Content[i+1]
+		}
+	}
+
+	return nil
+}
+
 // OrderedMap represents a map that preserves insertion order for JSON marshaling.
 type OrderedMap []OrderedMapEntry
 
@@ -193,18 +248,6 @@ type OrderedMapEntry struct {
 
 // MarshalJSON implements custom JSON marshaling for OrderedMap to preserve key order.
 func (om OrderedMap) MarshalJSON() ([]byte, error) {
-	// Build a map in the order of entries
-	result := make(map[string]interface{}, len(om))
-	keys := make([]string, 0, len(om))
-
-	for _, entry := range om {
-		result[entry.Key] = entry.Value
-		keys = append(keys, entry.Key)
-	}
-
-	// Use json.Marshal with a custom encoder that respects order
-	// Since Go 1.12+, json.Marshal preserves map key order for small maps
-	// For guaranteed order, we build JSON manually
 	if len(om) == 0 {
 		return []byte("{}"), nil
 	}
@@ -234,7 +277,6 @@ func (om OrderedMap) MarshalJSON() ([]byte, error) {
 }
 
 // yamlNodeToInterface converts a yaml.Node to a native Go interface{} while preserving order.
-// This is used for JSON marshaling to maintain the order of fields in YAML arrays and maps.
 func yamlNodeToInterface(node *yaml.Node) interface{} {
 	if node == nil {
 		return nil
@@ -242,41 +284,46 @@ func yamlNodeToInterface(node *yaml.Node) interface{} {
 
 	switch node.Kind {
 	case yaml.DocumentNode:
-		// Document nodes wrap the actual content
-		if len(node.Content) > 0 {
-			return yamlNodeToInterface(node.Content[0])
-		}
-		return nil
-
+		return yamlNodeToDocument(node)
 	case yaml.SequenceNode:
-		// Array/slice - preserve order
-		result := make([]interface{}, 0, len(node.Content))
-		for _, item := range node.Content {
-			result = append(result, yamlNodeToInterface(item))
-		}
-		return result
-
+		return yamlNodeToSequence(node)
 	case yaml.MappingNode:
-		// Map - preserve key order using OrderedMap
-		result := make(OrderedMap, 0, len(node.Content)/2)
-		for i := 0; i < len(node.Content); i += 2 {
-			key := node.Content[i].Value
-			value := yamlNodeToInterface(node.Content[i+1])
-			result = append(result, OrderedMapEntry{Key: key, Value: value})
-		}
-		return result
-
+		return yamlNodeToMapping(node)
 	case yaml.ScalarNode:
-		// Scalar value
 		return node.Value
-
 	case yaml.AliasNode:
-		// Alias to another node
 		return yamlNodeToInterface(node.Alias)
-
 	default:
 		return nil
 	}
+}
+
+func yamlNodeToDocument(node *yaml.Node) interface{} {
+	if len(node.Content) > 0 {
+		return yamlNodeToInterface(node.Content[0])
+	}
+
+	return nil
+}
+
+func yamlNodeToSequence(node *yaml.Node) []interface{} {
+	result := make([]interface{}, 0, len(node.Content))
+	for _, item := range node.Content {
+		result = append(result, yamlNodeToInterface(item))
+	}
+
+	return result
+}
+
+func yamlNodeToMapping(node *yaml.Node) OrderedMap {
+	result := make(OrderedMap, 0, len(node.Content)/yamlMappingKeyValuePairs)
+	for i := 0; i < len(node.Content); i += yamlMappingKeyValuePairs {
+		key := node.Content[i].Value
+		value := yamlNodeToInterface(node.Content[i+1])
+		result = append(result, OrderedMapEntry{Key: key, Value: value})
+	}
+
+	return result
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/types/types.go
+++ b/ai-services/internal/pkg/catalog/types/types.go
@@ -1,5 +1,11 @@
 package types
 
+import (
+	"encoding/json"
+
+	"gopkg.in/yaml.v3"
+)
+
 // Architecture represents a complete AI solution template.
 type Architecture struct {
 	ID               string               `yaml:"id" json:"id"`
@@ -12,7 +18,25 @@ type Architecture struct {
 	GlobalComponents []ComponentReference `yaml:"global_components,omitempty" json:"global_components,omitempty"`
 	Services         []ServiceReference   `yaml:"services" json:"services"`
 	Links            *ArchitectureLinks   `yaml:"links,omitempty" json:"links,omitempty"`
-	About            any                  `yaml:"about,omitempty" json:"about,omitempty"`
+	About            yaml.Node            `yaml:"about,omitempty" json:"-"`
+}
+
+// MarshalJSON implements custom JSON marshaling for Architecture to properly handle yaml.Node.
+func (a Architecture) MarshalJSON() ([]byte, error) {
+	type Alias Architecture
+	aux := &struct {
+		About interface{} `json:"about,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(&a),
+	}
+
+	// Convert yaml.Node to interface{} preserving order
+	if a.About.Kind != 0 {
+		aux.About = yamlNodeToInterface(&a.About)
+	}
+
+	return json.Marshal(aux)
 }
 
 // ArchitectureSummary represents an architecture for list API responses.
@@ -66,7 +90,25 @@ type Service struct {
 	Architectures []string              `yaml:"architectures" json:"architectures"`
 	Dependencies  []DependencyReference `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
 	Standalone    bool                  `yaml:"standalone,omitempty" json:"standalone,omitempty"`
-	About         any                   `yaml:"about,omitempty" json:"about,omitempty"`
+	About         yaml.Node             `yaml:"about,omitempty" json:"-"`
+}
+
+// MarshalJSON implements custom JSON marshaling for Service to properly handle yaml.Node.
+func (s Service) MarshalJSON() ([]byte, error) {
+	type Alias Service
+	aux := &struct {
+		About interface{} `json:"about,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(&s),
+	}
+
+	// Convert yaml.Node to interface{} preserving order
+	if s.About.Kind != 0 {
+		aux.About = yamlNodeToInterface(&s.About)
+	}
+
+	return json.Marshal(aux)
 }
 
 // ServiceSummary represents a service for list API responses.
@@ -138,6 +180,103 @@ type DeployOptionsArchitecture struct {
 	Version          string                   `json:"version,omitempty"`
 	GlobalComponents []DeployOptionsComponent `json:"global_components"`
 	Services         []DeployOptionsService   `json:"services"`
+}
+
+// OrderedMap represents a map that preserves insertion order for JSON marshaling.
+type OrderedMap []OrderedMapEntry
+
+// OrderedMapEntry represents a single key-value pair in an ordered map.
+type OrderedMapEntry struct {
+	Key   string      `json:"-"`
+	Value interface{} `json:"-"`
+}
+
+// MarshalJSON implements custom JSON marshaling for OrderedMap to preserve key order.
+func (om OrderedMap) MarshalJSON() ([]byte, error) {
+	// Build a map in the order of entries
+	result := make(map[string]interface{}, len(om))
+	keys := make([]string, 0, len(om))
+
+	for _, entry := range om {
+		result[entry.Key] = entry.Value
+		keys = append(keys, entry.Key)
+	}
+
+	// Use json.Marshal with a custom encoder that respects order
+	// Since Go 1.12+, json.Marshal preserves map key order for small maps
+	// For guaranteed order, we build JSON manually
+	if len(om) == 0 {
+		return []byte("{}"), nil
+	}
+
+	jsonBytes := []byte("{")
+	for i, entry := range om {
+		if i > 0 {
+			jsonBytes = append(jsonBytes, ',')
+		}
+
+		keyJSON, err := json.Marshal(entry.Key)
+		if err != nil {
+			return nil, err
+		}
+		jsonBytes = append(jsonBytes, keyJSON...)
+		jsonBytes = append(jsonBytes, ':')
+
+		valueJSON, err := json.Marshal(entry.Value)
+		if err != nil {
+			return nil, err
+		}
+		jsonBytes = append(jsonBytes, valueJSON...)
+	}
+	jsonBytes = append(jsonBytes, '}')
+
+	return jsonBytes, nil
+}
+
+// yamlNodeToInterface converts a yaml.Node to a native Go interface{} while preserving order.
+// This is used for JSON marshaling to maintain the order of fields in YAML arrays and maps.
+func yamlNodeToInterface(node *yaml.Node) interface{} {
+	if node == nil {
+		return nil
+	}
+
+	switch node.Kind {
+	case yaml.DocumentNode:
+		// Document nodes wrap the actual content
+		if len(node.Content) > 0 {
+			return yamlNodeToInterface(node.Content[0])
+		}
+		return nil
+
+	case yaml.SequenceNode:
+		// Array/slice - preserve order
+		result := make([]interface{}, 0, len(node.Content))
+		for _, item := range node.Content {
+			result = append(result, yamlNodeToInterface(item))
+		}
+		return result
+
+	case yaml.MappingNode:
+		// Map - preserve key order using OrderedMap
+		result := make(OrderedMap, 0, len(node.Content)/2)
+		for i := 0; i < len(node.Content); i += 2 {
+			key := node.Content[i].Value
+			value := yamlNodeToInterface(node.Content[i+1])
+			result = append(result, OrderedMapEntry{Key: key, Value: value})
+		}
+		return result
+
+	case yaml.ScalarNode:
+		// Scalar value
+		return node.Value
+
+	case yaml.AliasNode:
+		// Alias to another node
+		return yamlNodeToInterface(node.Alias)
+
+	default:
+		return nil
+	}
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/types/types_test.go
+++ b/ai-services/internal/pkg/catalog/types/types_test.go
@@ -1,0 +1,155 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestArchitectureAboutOrderPreservation(t *testing.T) {
+	// Sample YAML with ordered about field
+	yamlData := `
+id: test-arch
+name: Test Architecture
+description: Test
+version: 1.0.0
+type: architecture
+certified_by: IBM
+runtimes:
+  - podman
+services:
+  - id: test-service
+about:
+  - title: "First Section"
+    sections:
+      - title: "First Item"
+        value: "Value 1"
+      - title: "Second Item"
+        value: "Value 2"
+  - title: "Second Section"
+    sections:
+      - title: "Third Item"
+        value: "Value 3"
+`
+
+	var arch Architecture
+	err := yaml.Unmarshal([]byte(yamlData), &arch)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal YAML: %v", err)
+	}
+
+	// Marshal to JSON
+	jsonData, err := json.Marshal(arch)
+	if err != nil {
+		t.Fatalf("Failed to marshal to JSON: %v", err)
+	}
+
+	jsonStr := string(jsonData)
+	t.Logf("JSON output: %s", jsonStr)
+
+	// Verify that "First Section" appears before "Second Section"
+	firstSectionPos := findSubstring(jsonStr, "First Section")
+	secondSectionPos := findSubstring(jsonStr, "Second Section")
+
+	if firstSectionPos == -1 || secondSectionPos == -1 {
+		t.Fatal("Expected sections not found in JSON output")
+	}
+
+	if firstSectionPos >= secondSectionPos {
+		t.Errorf("Order not preserved: 'First Section' at position %d, 'Second Section' at position %d",
+			firstSectionPos, secondSectionPos)
+	}
+
+	// Verify that "First Item" appears before "Second Item"
+	firstItemPos := findSubstring(jsonStr, "First Item")
+	secondItemPos := findSubstring(jsonStr, "Second Item")
+
+	if firstItemPos == -1 || secondItemPos == -1 {
+		t.Fatal("Expected items not found in JSON output")
+	}
+
+	if firstItemPos >= secondItemPos {
+		t.Errorf("Order not preserved: 'First Item' at position %d, 'Second Item' at position %d",
+			firstItemPos, secondItemPos)
+	}
+}
+
+func TestServiceAboutOrderPreservation(t *testing.T) {
+	// Sample YAML with ordered about field
+	yamlData := `
+id: test-service
+name: Test Service
+description: Test
+type: service
+certified_by: IBM
+architectures:
+  - test-arch
+about:
+  - title: "Service details"
+    sections:
+      - title: "Version"
+        value: "1.0.0"
+      - title: "Model"
+        value: "test-model"
+  - title: "Inputs and outputs"
+    sections:
+      - title: "Inputs"
+        values:
+          - "Input 1"
+          - "Input 2"
+`
+
+	var svc Service
+	err := yaml.Unmarshal([]byte(yamlData), &svc)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal YAML: %v", err)
+	}
+
+	// Marshal to JSON
+	jsonData, err := json.Marshal(svc)
+	if err != nil {
+		t.Fatalf("Failed to marshal to JSON: %v", err)
+	}
+
+	jsonStr := string(jsonData)
+	t.Logf("JSON output: %s", jsonStr)
+
+	// Verify that "Service details" appears before "Inputs and outputs"
+	serviceDetailsPos := findSubstring(jsonStr, "Service details")
+	inputsOutputsPos := findSubstring(jsonStr, "Inputs and outputs")
+
+	if serviceDetailsPos == -1 || inputsOutputsPos == -1 {
+		t.Fatal("Expected sections not found in JSON output")
+	}
+
+	if serviceDetailsPos >= inputsOutputsPos {
+		t.Errorf("Order not preserved: 'Service details' at position %d, 'Inputs and outputs' at position %d",
+			serviceDetailsPos, inputsOutputsPos)
+	}
+
+	// Verify that "Version" appears before "Model"
+	versionPos := findSubstring(jsonStr, "Version")
+	modelPos := findSubstring(jsonStr, "Model")
+
+	if versionPos == -1 || modelPos == -1 {
+		t.Fatal("Expected items not found in JSON output")
+	}
+
+	if versionPos >= modelPos {
+		t.Errorf("Order not preserved: 'Version' at position %d, 'Model' at position %d",
+			versionPos, modelPos)
+	}
+}
+
+// Helper function to find substring position
+func findSubstring(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}
+
+// Made with Bob


### PR DESCRIPTION
Instead of using the standard gin JSON marshaller, use a custom JSON, yaml marshaller and unmarshaller to preserve order.