### PR TITLE
Get Reference Doc is broken if Similarity Search Pod restarts

### DIFF
--- a/ui/chatbot/Containerfile
+++ b/ui/chatbot/Containerfile
@@ -18,4 +18,4 @@ COPY --from=build /app/build /usr/share/nginx/html
 EXPOSE 3000
 
 # Render nginx.conf.tmpl with backend server details and start the nginx server
-CMD /bin/bash -c "envsubst '\$BACKEND_HOST \$BACKEND_PORT \$SIMILARITY_SEARCH_HOST \$SIMILARITY_SEARCH_PORT \$CHATBOT_SEARCH_MODE \$CHATBOT_NUM_CHUNKS_POST_RERANKER \$CHATBOT_RERANK' < /etc/nginx.conf.tmpl > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
+CMD /bin/bash -c "export PODMAN_DNS=\$(awk '/nameserver/ {print \$2; exit}' /etc/resolv.conf) && envsubst '\$BACKEND_HOST \$BACKEND_PORT \$SIMILARITY_SEARCH_HOST \$SIMILARITY_SEARCH_PORT \$CHATBOT_SEARCH_MODE \$CHATBOT_NUM_CHUNKS_POST_RERANKER \$CHATBOT_RERANK \$PODMAN_DNS' < /etc/nginx.conf.tmpl > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"

--- a/ui/chatbot/nginx.conf.tmpl
+++ b/ui/chatbot/nginx.conf.tmpl
@@ -44,7 +44,11 @@ http {
 
         # Proxy API requests
         location /v1/similarity-search {
-          proxy_pass http://${SIMILARITY_SEARCH_HOST}:${SIMILARITY_SEARCH_PORT};
+          resolver ${PODMAN_DNS} valid=5s;
+
+          set $similarity_backend "http://${SIMILARITY_SEARCH_HOST}:${SIMILARITY_SEARCH_PORT}";
+          proxy_pass $similarity_backend;
+
           proxy_http_version 1.1;
           proxy_set_header Upgrade $http_upgrade;
           proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
[AISERVICES-1251](https://jsw.ibm.com/browse/AISERVICES-1251)

-When similarity search pod restarts, nginx stores a cached IP for the resolved hostname which is invalid when the pod restarts. 
-Passing PODMAN_DNS as env which is used to resolve to an IP which is valid for just 5 seconds (to resolve on every request - only for similarity search)
-These changes should not affect the OpenShift env as /etc/resolv.conf points to the Cluster DNS IP and does the same (just for ss call)