### PR TITLE
Refactor catlog configure flow including caddy

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.91
+TAG?=v0.0.92
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.91
+  image: icr.io/ai-services-cicd/ai-services:v0.0.92
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
@@ -31,7 +29,9 @@ var (
 	httpsPort int
 )
 
-const defaultHTTPSPort = 443
+const (
+	defaultHTTPSPort = 443
+)
 
 // NewConfigureCmd creates a new configure command for the catalog service.
 func NewConfigureCmd() *cobra.Command {
@@ -52,7 +52,6 @@ Examples:
 			return validateConfigureFlags()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Prompt for admin password
 			return runConfigure()
 		},
 	}
@@ -64,13 +63,8 @@ Examples:
 
 // runConfigure executes the catalog configuration process.
 func runConfigure() error {
-	// Prompt for admin password
-	adminPassword, err := promptForPassword()
-	if err != nil {
-		return fmt.Errorf("failed to read admin password: %w", err)
-	}
-
 	var aiServicesDir string
+	var err error
 
 	// Use default base directory if not specified, otherwise validate
 	if baseDir == "" {
@@ -102,15 +96,7 @@ func runConfigure() error {
 		cleanKeyPath = filepath.Clean(sslKeyPath)
 	}
 
-	return configure.Run(configure.ConfigureOptions{
-		AdminPassword: adminPassword,
-		Runtime:       vars.RuntimeFactory.GetRuntimeType(),
-		BaseDir:       aiServicesDir,
-		DomainName:    domainName,
-		SSLCertPath:   cleanCertPath,
-		SSLKeyPath:    cleanKeyPath,
-		HttpsPort:     httpsPort,
-	})
+	return configure.Run(vars.RuntimeFactory.GetRuntimeType(), aiServicesDir, domainName, cleanCertPath, cleanKeyPath, httpsPort)
 }
 
 // validateConfigureFlags validates the configure command flags and initializes runtime.
@@ -248,36 +234,6 @@ func configureConfigureFlags(cmd *cobra.Command) {
 			"Must be used together with --ssl-cert.\n"+
 			"Example: --ssl-key /path/to/key.pem\n",
 	)
-}
-
-// promptForPassword prompts the user to enter a password securely.
-func promptForPassword() (string, error) {
-	fmt.Print("Enter admin password: ")
-	passwordBytes, err := term.ReadPassword(int(syscall.Stdin))
-	fmt.Println() // Print newline after password input
-	if err != nil {
-		return "", err
-	}
-
-	password := string(passwordBytes)
-	if password == "" {
-		return "", fmt.Errorf("password cannot be empty")
-	}
-
-	// Prompt for confirmation
-	fmt.Print("Confirm admin password: ")
-	confirmBytes, err := term.ReadPassword(int(syscall.Stdin))
-	fmt.Println() // Print newline after password input
-	if err != nil {
-		return "", err
-	}
-
-	confirm := string(confirmBytes)
-	if password != confirm {
-		return "", fmt.Errorf("passwords do not match")
-	}
-
-	return password, nil
 }
 
 // Made with Bob

--- a/ai-services/cmd/ai-services/cmd/catalog/hashpw.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/hashpw.go
@@ -1,9 +1,6 @@
 package catalog
 
 import (
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -11,11 +8,9 @@ import (
 	"strings"
 	"syscall"
 
+	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/pbkdf2"
 	"golang.org/x/term"
-
-	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 )
 
 const (
@@ -52,7 +47,7 @@ Tip: Avoid passing plain passwords as CLI args (they can leak via process list).
 				return err
 			}
 
-			hash, err := hashPasswordPBKDF2(pw, iterations)
+			hash, err := catalogutils.HashPasswordPBKDF2(pw, iterations)
 			if err != nil {
 				return fmt.Errorf("pbkdf2: %w", err)
 			}
@@ -134,21 +129,4 @@ func readHidden(prompt string) (string, error) {
 	}
 
 	return strings.TrimSpace(string(b)), nil
-}
-
-func hashPasswordPBKDF2(password string, iteration int) (string, error) {
-	salt := make([]byte, constants.Pbkdf2SaltLen)
-	if _, err := rand.Read(salt); err != nil {
-		return "", err
-	}
-
-	hash := pbkdf2.Key([]byte(password), salt, iteration, constants.Pbkdf2KeyLen, sha256.New)
-
-	// Format: iterations.salt.hash (base64 encoded)
-	encoded := fmt.Sprintf("%d.%s.%s",
-		iteration,
-		base64.RawStdEncoding.EncodeToString(salt),
-		base64.RawStdEncoding.EncodeToString(hash))
-
-	return encoded, nil
 }

--- a/ai-services/go.mod
+++ b/ai-services/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/huh v0.7.0
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/term v0.2.1
 	github.com/containers/podman/v5 v5.8.2
 	github.com/gin-gonic/gin v1.11.0
 	github.com/go-resty/resty/v2 v2.17.2
@@ -69,7 +70,6 @@ require (
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
-	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -1181,7 +1181,6 @@ func (d *PodmanDeployer) registerServiceRoutes(
 	// Register routes for each pod in the service
 	for podName, routesAnnotation := range svc.Routes {
 		registeredRoutes, err := proxy.RegisterRoutesForAppAndReturn(
-			d.runtime,
 			catalogconstants.CatalogAppName,
 			proxyManager,
 			routesAnnotation,

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
@@ -1,0 +1,81 @@
+package caddy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+)
+
+const (
+	certsDirName     = "certs"
+	containerDataDir = "/data/caddy"
+	dirPerm          = 0o755
+	filePerm         = 0o644
+)
+
+// LoadSSLCertificates stages user-provided certificates for the Caddy pod and updates TLS config via Admin API.
+func (c *Context) LoadSSLCertificates(baseDir, sslCertPath, sslKeyPath string) error {
+	if sslCertPath == "" || sslKeyPath == "" {
+		return nil
+	}
+
+	// Stage certificates
+	if err := stageCertificates(baseDir, sslCertPath, sslKeyPath); err != nil {
+		return fmt.Errorf("failed to stage certificates for Caddy: %w", err)
+	}
+
+	// Get admin URL
+	adminURL, err := c.GetHostAdminURL()
+	if err != nil {
+		return fmt.Errorf("failed to get Caddy admin URL: %w", err)
+	}
+
+	// Load certificates via Admin API
+	if err := utils.LoadUserCertificates(
+		filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.crt"),
+		filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.key"),
+		filepath.Join(containerDataDir, certsDirName, "tls.crt"),
+		filepath.Join(containerDataDir, certsDirName, "tls.key"),
+		adminURL,
+	); err != nil {
+		return fmt.Errorf("failed to load certificates via Admin API: %w", err)
+	}
+
+	return nil
+}
+
+// stageCertificates stages SSL certificates for Caddy to use.
+func stageCertificates(baseDir, sslCertPath, sslKeyPath string) error {
+	caddyDataDir := filepath.Join(baseDir, "common", "caddy")
+	certDir := filepath.Join(caddyDataDir, certsDirName)
+	if err := os.MkdirAll(certDir, dirPerm); err != nil {
+		return fmt.Errorf("failed to create Caddy cert directory: %w", err)
+	}
+
+	stagedCertPath := filepath.Join(certDir, "tls.crt")
+	stagedKeyPath := filepath.Join(certDir, "tls.key")
+
+	certBytes, err := os.ReadFile(sslCertPath)
+	if err != nil {
+		return fmt.Errorf("failed to read certificate file: %w", err)
+	}
+
+	keyBytes, err := os.ReadFile(sslKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to read key file: %w", err)
+	}
+
+	if err := os.WriteFile(stagedCertPath, certBytes, filePerm); err != nil {
+		return fmt.Errorf("failed to write staged certificate file: %w", err)
+	}
+
+	if err := os.WriteFile(stagedKeyPath, keyBytes, filePerm); err != nil {
+		return fmt.Errorf("failed to write staged key file: %w", err)
+	}
+
+	return nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
@@ -17,6 +18,7 @@ const (
 
 // LoadSSLCertificates stages user-provided certificates for the Caddy pod and updates TLS config via Admin API.
 func (c *Context) LoadSSLCertificates(baseDir, sslCertPath, sslKeyPath string) error {
+	logger.Infoln("loading ssl certificate to caddy...", logger.VerbosityLevelDebug)
 	if sslCertPath == "" || sslKeyPath == "" {
 		return nil
 	}

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/context.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/context.go
@@ -60,6 +60,7 @@ func (c *Context) GetContainerAdminURL() string {
 	}
 
 	c.containerAdminURL = fmt.Sprintf("http://%s:2019", c.podName)
+
 	return c.containerAdminURL
 }
 

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/context.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/context.go
@@ -1,0 +1,86 @@
+// Package caddy provides Caddy-specific operations for catalog deployment.
+// This package handles Caddy proxy operations WITHOUT any template dependencies.
+package caddy
+
+import (
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/proxy"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
+)
+
+// Context holds Caddy-specific configuration and cached values during catalog deployment.
+// NOTE: This context does NOT handle templates - that's the responsibility of deployContext.
+type Context struct {
+	// Pod identification
+	podName string
+	// Network configuration
+	domainSuffix string
+
+	// Admin API access
+	containerAdminURL string // http://<podName>:2019 (for container use in templates)
+	hostAdminURL      string // http://localhost:<port> (for host VM use in post-deployment)
+}
+
+// NewContext creates a new Caddy context with the pod name provided by configure.go.
+// The pod name should be obtained from deployContext, not looked up here.
+func NewContext(podName string, domainSuffix string) *Context {
+	return &Context{
+		podName:      podName,
+		domainSuffix: domainSuffix,
+	}
+}
+
+// GetHostAdminURL retrieves the Caddy admin URL for host VM use, caching the result.
+func (c *Context) GetHostAdminURL() (string, error) {
+	if c.hostAdminURL != "" {
+		return c.hostAdminURL, nil
+	}
+
+	rt, err := podman.NewPodmanClient()
+	if err != nil {
+		return "", fmt.Errorf("failed to initialize podman client: %w", err)
+	}
+
+	adminPort, err := getCaddyAdminPort(rt, c.podName)
+	if err != nil {
+		return "", fmt.Errorf("failed to get Caddy admin port: %w", err)
+	}
+
+	c.hostAdminURL = fmt.Sprintf("http://localhost:%s", adminPort)
+
+	return c.hostAdminURL, nil
+}
+
+// GetContainerAdminURL returns the Caddy admin URL for container use.
+func (c *Context) GetContainerAdminURL() string {
+	if c.containerAdminURL != "" {
+		return c.containerAdminURL
+	}
+
+	c.containerAdminURL = fmt.Sprintf("http://%s:2019", c.podName)
+	return c.containerAdminURL
+}
+
+// GetHTTPSPort retrieves the Caddy HTTPS port.
+func (c *Context) GetHTTPSPort(rt *podman.PodmanClient) (string, error) {
+	return getHTTPSPort(rt, c.podName)
+}
+
+// CreateProxyManager creates a Caddy proxy manager.
+func (c *Context) CreateProxyManager() (proxy.ProxyManager, error) {
+	adminURL, err := c.GetHostAdminURL()
+	if err != nil {
+		return nil, err
+	}
+
+	return proxy.NewCaddyManager(adminURL, constants.CaddyServerName), nil
+}
+
+// GetDomainSuffix returns the domain suffix.
+func (c *Context) GetDomainSuffix() string {
+	return c.domainSuffix
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
@@ -16,7 +16,7 @@ import (
 )
 
 // ComputeDomainConfig computes the domain configuration from SSL certificates and domain name.
-// Priority: certDomain > customDomain > hostIP.nip.io
+// Priority: certDomain > customDomain > hostIP.nip.io.
 func ComputeDomainConfig(sslCertPath, sslKeyPath, domainName string) (string, error) {
 	var domainSuffix string
 

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
@@ -1,0 +1,135 @@
+package caddy
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/project-ai-services/ai-services/assets"
+	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+)
+
+// ComputeDomainConfig computes the domain configuration from SSL certificates and domain name.
+// Priority: certDomain > customDomain > hostIP.nip.io
+func ComputeDomainConfig(sslCertPath, sslKeyPath, domainName string) (string, error) {
+	var domainSuffix string
+
+	// If SSL certificate is provided, extract domain from it
+	if sslCertPath != "" && sslKeyPath != "" {
+		extractedDomain, err := utils.ExtractDomainFromCertificate(sslCertPath)
+		if err != nil {
+			return "", fmt.Errorf("failed to extract domain from certificate: %w", err)
+		}
+		domainSuffix = extractedDomain
+	} else if domainName != "" {
+		// Use provided domain name
+		domainSuffix = domainName
+	} else {
+		// Default to hostIP.nip.io when no configuration is provided
+		hostIP, err := utils.GetHostIP()
+		if err != nil {
+			return "", fmt.Errorf("failed to get host IP for domain suffix: %w", err)
+		}
+		domainSuffix = fmt.Sprintf("%s.nip.io", hostIP)
+	}
+
+	return domainSuffix, nil
+}
+
+// getCaddyAdminPort retrieves the host port mapped to Caddy's admin API (container port 2019).
+func getCaddyAdminPort(runtime *podman.PodmanClient, podName string) (string, error) {
+	pod, err := runtime.InspectPod(podName)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect Caddy pod: %w", err)
+	}
+
+	// Get port mappings from the Ports field
+	// Ports is a map[string][]string where key is "containerPort/protocol" and value is list of host ports
+	// Example: {"2019/tcp": ["37249"], "443/tcp": ["39341"]}
+	for containerPort, hostPorts := range pod.Ports {
+		// Check if this is the admin API port (2019)
+		if strings.HasPrefix(containerPort, "2019/") && len(hostPorts) > 0 {
+			return hostPorts[0], nil
+		}
+	}
+
+	return "", fmt.Errorf("admin port mapping not found in pod ports")
+}
+
+// getHTTPSPort retrieves the HTTPS port from the Caddy pod.
+func getHTTPSPort(runtime *podman.PodmanClient, caddyPodName string) (string, error) {
+	// Get pod details
+	pod, err := runtime.InspectPod(caddyPodName)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect Caddy pod: %w", err)
+	}
+
+	// Look for the HTTPS port mapping
+	// Ports is a map[string][]string where key is "containerPort/protocol" (e.g., "443/tcp")
+	// and value is list of host ports
+	httpsPortKey := catalogconstants.DefaultHTTPSPort + "/tcp"
+	if hostPorts, ok := pod.Ports[httpsPortKey]; ok && len(hostPorts) > 0 {
+		return hostPorts[0], nil
+	}
+
+	// Also check without protocol suffix for compatibility
+	if hostPorts, ok := pod.Ports[catalogconstants.DefaultHTTPSPort]; ok && len(hostPorts) > 0 {
+		return hostPorts[0], nil
+	}
+
+	// Fallback: search through all port mappings
+	for portKey, hostPorts := range pod.Ports {
+		if strings.HasPrefix(portKey, catalogconstants.DefaultHTTPSPort+"/") && len(hostPorts) > 0 {
+			return hostPorts[0], nil
+		}
+	}
+
+	return "", fmt.Errorf("HTTPS port not found in Caddy pod")
+}
+
+// GenerateCaddyfile copies the static Caddyfile to the caddy directory.
+func GenerateCaddyfile(baseDir string) error {
+	// Read the Caddyfile template
+	caddyfileContent, err := assets.CatalogFS.ReadFile("catalog/podman/Caddyfile.tmpl")
+	if err != nil {
+		return fmt.Errorf("failed to read Caddyfile template: %w", err)
+	}
+
+	// Parse the Caddyfile as a template
+	tmpl, err := template.New("Caddyfile.tmpl").Parse(string(caddyfileContent))
+	if err != nil {
+		return fmt.Errorf("failed to parse Caddyfile template: %w", err)
+	}
+
+	// Prepare template data with the server name constant
+	templateData := map[string]any{
+		"CaddyServerName": constants.CaddyServerName,
+	}
+
+	// Execute the template
+	var rendered bytes.Buffer
+	if err := tmpl.Execute(&rendered, templateData); err != nil {
+		return fmt.Errorf("failed to execute Caddyfile template: %w", err)
+	}
+
+	// Ensure directory exists and write Caddyfile
+	caddyDir := filepath.Join(baseDir, "common", "caddy")
+	if err := os.MkdirAll(caddyDir, dirPerm); err != nil {
+		return fmt.Errorf("failed to create caddy directory: %w", err)
+	}
+
+	caddyfilePath := filepath.Join(caddyDir, "Caddyfile")
+	if err := os.WriteFile(caddyfilePath, rendered.Bytes(), filePerm); err != nil {
+		return fmt.Errorf("failed to write Caddyfile: %w", err)
+	}
+
+	return nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/routes.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/routes.go
@@ -22,6 +22,7 @@ type TemplateRouteInfo struct {
 func RegisterCatalogRoutes(runtime *podman.PodmanClient, caddyCtx *Context, routeInfos []TemplateRouteInfo) (map[string]string, error) {
 	if len(routeInfos) == 0 {
 		logger.Infof("No templates found with routes annotation, skipping route registration\n")
+
 		return nil, nil
 	}
 
@@ -43,6 +44,7 @@ func RegisterCatalogRoutes(runtime *podman.PodmanClient, caddyCtx *Context, rout
 		routes, err := proxy.RegisterRoutesForAppAndReturn(constants.CatalogAppName, proxyManager, info.RoutesAnnotation, caddyCtx.GetDomainSuffix(), info.PodName)
 		if err != nil {
 			registrationErrors = append(registrationErrors, fmt.Errorf("pod %s: %w", info.PodName, err))
+
 			continue
 		}
 
@@ -89,6 +91,7 @@ func GetCatalogRouteInfo(caddyCtx *Context, runtime *podman.PodmanClient, routeI
 // Converts "catalog-ui" to "CATALOG_UI_DOMAIN".
 func createRouteVariableName(subdomain string) string {
 	sanitized := strings.ReplaceAll(subdomain, "-", "_")
+
 	return strings.ToUpper(fmt.Sprintf("%s_DOMAIN", sanitized))
 }
 
@@ -99,6 +102,7 @@ func extractSubdomainFromDomain(domain string) string {
 	if len(parts) > 0 {
 		return parts[0]
 	}
+
 	return ""
 }
 
@@ -120,8 +124,10 @@ func parseRouteEntry(routeEntry, podName string) string {
 	parts, err := proxy.ParseRouteEntry(routeEntry)
 	if err != nil {
 		logger.Warningf("Invalid route format '%s' in pod %s: %v", routeEntry, podName, err)
+
 		return ""
 	}
+
 	return parts.Subdomain
 }
 
@@ -142,6 +148,7 @@ func processRouteInfo(info TemplateRouteInfo, proxyManager proxy.ProxyManager, r
 		if err != nil {
 			// Log warning but continue - route might not exist yet
 			logger.Warningf("Failed to query route %s from Caddy: %v", subdomain, err)
+
 			continue
 		}
 

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/routes.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/routes.go
@@ -1,0 +1,154 @@
+package caddy
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/proxy"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
+)
+
+// TemplateRouteInfo contains route information extracted from a template.
+type TemplateRouteInfo struct {
+	PodName          string
+	RoutesAnnotation string
+}
+
+// RegisterCatalogRoutes registers routes with Caddy and returns route domains.
+// Accepts pre-extracted route infos from templates.
+func RegisterCatalogRoutes(runtime *podman.PodmanClient, caddyCtx *Context, routeInfos []TemplateRouteInfo) (map[string]string, error) {
+	if len(routeInfos) == 0 {
+		logger.Infof("No templates found with routes annotation, skipping route registration\n")
+		return nil, nil
+	}
+
+	// Create proxy manager using Caddy context
+	proxyManager, err := caddyCtx.CreateProxyManager()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create proxy manager: %w", err)
+	}
+
+	// Build route domains map
+	routeDomains := make(map[string]string)
+
+	// Register routes for each template that has them
+	var registrationErrors []error
+	for _, info := range routeInfos {
+		logger.Infof("Registering routes for pod: %s\n", info.PodName, logger.VerbosityLevelDebug)
+
+		// Register routes and get the built routes back
+		routes, err := proxy.RegisterRoutesForAppAndReturn(constants.CatalogAppName, proxyManager, info.RoutesAnnotation, caddyCtx.GetDomainSuffix(), info.PodName)
+		if err != nil {
+			registrationErrors = append(registrationErrors, fmt.Errorf("pod %s: %w", info.PodName, err))
+			continue
+		}
+
+		addRoutesToDomainMap(routes, routeDomains)
+	}
+
+	// Return error if any routes failed to register
+	if len(registrationErrors) > 0 {
+		return nil, fmt.Errorf("failed to register routes for %d pod(s): %w", len(registrationErrors), errors.Join(registrationErrors...))
+	}
+
+	logger.Infof("Successfully registered routes for %d pod(s)\n", len(routeInfos))
+
+	return routeDomains, nil
+}
+
+// GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service.
+// Accepts pre-extracted route infos from templates.
+func GetCatalogRouteInfo(caddyCtx *Context, runtime *podman.PodmanClient, routeInfos []TemplateRouteInfo) (map[string]string, string, error) {
+	// Create proxy manager
+	proxyManager, err := caddyCtx.CreateProxyManager()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create proxy manager: %w", err)
+	}
+
+	// Build route domains map by querying Caddy
+	routeDomains := make(map[string]string)
+	for _, info := range routeInfos {
+		processRouteInfo(info, proxyManager, routeDomains)
+	}
+
+	// Get Caddy HTTPS port
+	httpsPort, err := caddyCtx.GetHTTPSPort(runtime)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get Caddy HTTPS port: %w", err)
+	}
+
+	return routeDomains, httpsPort, nil
+}
+
+// Helper functions for route processing
+
+// createRouteVariableName creates a standardized environment variable name from a subdomain.
+// Converts "catalog-ui" to "CATALOG_UI_DOMAIN".
+func createRouteVariableName(subdomain string) string {
+	sanitized := strings.ReplaceAll(subdomain, "-", "_")
+	return strings.ToUpper(fmt.Sprintf("%s_DOMAIN", sanitized))
+}
+
+// extractSubdomainFromDomain extracts the subdomain from a full domain.
+// For "catalog-ui.example.com", returns "catalog-ui".
+func extractSubdomainFromDomain(domain string) string {
+	parts := strings.Split(domain, ".")
+	if len(parts) > 0 {
+		return parts[0]
+	}
+	return ""
+}
+
+// addRoutesToDomainMap adds routes to the domain map with standardized variable names.
+func addRoutesToDomainMap(routes []proxy.Route, routeDomains map[string]string) {
+	for _, route := range routes {
+		subdomain := extractSubdomainFromDomain(route.Domain)
+		if subdomain != "" {
+			varName := createRouteVariableName(subdomain)
+			routeDomains[varName] = route.Domain
+		}
+	}
+}
+
+// parseRouteEntry parses a single route entry and returns the subdomain.
+// Route format: "port:subdomain:type"
+// Returns empty string if the entry is invalid.
+func parseRouteEntry(routeEntry, podName string) string {
+	parts, err := proxy.ParseRouteEntry(routeEntry)
+	if err != nil {
+		logger.Warningf("Invalid route format '%s' in pod %s: %v", routeEntry, podName, err)
+		return ""
+	}
+	return parts.Subdomain
+}
+
+// processRouteInfo processes route information and populates the routeDomains map.
+// Queries Caddy for each route and adds it to the map with a standardized variable name.
+func processRouteInfo(info TemplateRouteInfo, proxyManager proxy.ProxyManager, routeDomains map[string]string) {
+	// Parse routes annotation to extract subdomains
+	// Format: "port:subdomain:type, port:subdomain:type, ..."
+	// Example: "8081:catalog-ui:ui, 8080:catalog-api:api"
+	for _, routeEntry := range strings.Split(info.RoutesAnnotation, ",") {
+		subdomain := parseRouteEntry(strings.TrimSpace(routeEntry), info.PodName)
+		if subdomain == "" {
+			continue
+		}
+
+		// Query Caddy for this route (route ID is the subdomain)
+		actualRoute, err := proxyManager.GetRouteByID(subdomain)
+		if err != nil {
+			// Log warning but continue - route might not exist yet
+			logger.Warningf("Failed to query route %s from Caddy: %v", subdomain, err)
+			continue
+		}
+
+		// Use standardized variable name creation
+		varName := createRouteVariableName(subdomain)
+		routeDomains[varName] = actualRoute.Domain
+	}
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/common/podman/deploy/deploy_context.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/deploy/deploy_context.go
@@ -1,0 +1,207 @@
+package deploy
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+	"text/template"
+
+	"github.com/project-ai-services/ai-services/assets"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
+	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
+	clipodman "github.com/project-ai-services/ai-services/internal/pkg/cli/podman"
+	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
+	"github.com/project-ai-services/ai-services/internal/pkg/specs"
+)
+
+// DeployContext encapsulates catalog deployment context.
+// Provides template access, runtime client, and deployment operations.
+type DeployContext struct {
+	// Core components - exported for external access
+	Runtime          *podman.PodmanClient
+	TemplateProvider templates.Template
+	argParams        map[string]string
+	values           map[string]interface{}
+	appMetadata      *templates.AppMetadata
+	templates        map[string]*template.Template
+}
+
+// NewDeployContext creates and initializes a new deployment context.
+// This is a factory method that handles all initialization including loading templates.
+func NewDeployContext() (*DeployContext, error) {
+	// Initialize runtime
+	rt, err := podman.NewPodmanClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize podman client: %w", err)
+	}
+
+	// Create template provider
+	tp := templates.NewEmbedTemplateProvider(&assets.CatalogFS, "")
+
+	// Load metadata from templates
+	var appMetadata templates.AppMetadata
+	if err := tp.LoadMetadata(catalogconstants.CatalogAppTemplate, true, &appMetadata); err != nil {
+		return nil, fmt.Errorf("failed to load catalog metadata: %w", err)
+	}
+
+	// Load all templates
+	tmpls, err := tp.LoadAllTemplates(catalogconstants.CatalogAppTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load catalog templates: %w", err)
+	}
+
+	return &DeployContext{
+		Runtime:          rt,
+		TemplateProvider: tp,
+		argParams:        nil,
+		appMetadata:      &appMetadata,
+		templates:        tmpls,
+	}, nil
+}
+
+// PrepareValues sets the application argument params and loads values.
+func (d *DeployContext) PrepareValues(argParams map[string]string) error {
+	// Set argParams first so it can be used in LoadValues
+	d.argParams = argParams
+
+	values, err := d.TemplateProvider.LoadValues(catalogconstants.CatalogAppTemplate, nil, d.argParams)
+	if err != nil {
+		return err
+	}
+
+	d.values = values
+
+	return nil
+}
+
+// checkStatus checks if the catalog is already deployed.
+func (d *DeployContext) CheckStatus() (bool, []string, error) {
+	catalogSecrets, err := collectSecretNames(d.TemplateProvider, d.argParams)
+	if err != nil {
+		return false, nil, err
+	}
+
+	existingResources, err := helpers.CheckExistingResourcesForApplication(d.Runtime, catalogconstants.CatalogAppName, catalogSecrets)
+	if err != nil {
+		return false, nil, err
+	}
+
+	return len(existingResources) == len(d.templates), existingResources, nil
+}
+
+// GetCaddyPodName extracts the Caddy pod name from templates.
+func (d *DeployContext) GetCaddyPodName() (string, error) {
+	return findCaddyPodNameFromTemplates(d.TemplateProvider, d.argParams)
+}
+
+// ExtractRouteInfos extracts route information from all templates.
+func (d *DeployContext) ExtractRouteInfos() ([]caddy.TemplateRouteInfo, error) {
+	return extractAllRoutesFromTemplates(d.TemplateProvider, d.argParams)
+}
+
+// ExecutePodLayers executes all pod template layers.
+func (d *DeployContext) ExecutePodLayers(baseDir string, caddyCtx *caddy.Context,
+	existingResources []string) error {
+	for i, layer := range d.appMetadata.PodTemplateExecutions {
+		logger.Infof("\n Executing Layer %d/%d: %v\n", i+1, len(d.appMetadata.PodTemplateExecutions), layer)
+		logger.Infoln("-------")
+
+		if err := d.executeLayer(layer, baseDir, caddyCtx, i, existingResources); err != nil {
+			return err
+		}
+
+		logger.Infof("Layer %d completed\n", i+1)
+	}
+
+	return nil
+}
+
+// executeLayer executes a single layer of pod templates.
+func (d *DeployContext) executeLayer(layer []string, baseDir string, caddyCtx *caddy.Context,
+	layerIndex int, existingResources []string) error {
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(layer))
+
+	// for each layer, fetch all the pod Template Names and do the pod deploy
+	for _, podTemplateName := range layer {
+		wg.Add(1)
+		go func(t string) {
+			defer wg.Done()
+			if err := d.executePodTemplate(t, baseDir, caddyCtx, existingResources); err != nil {
+				errCh <- err
+			}
+		}(podTemplateName)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	// collect all errors for this layer
+	errs := make([]error, 0, len(layer))
+	for e := range errCh {
+		errs = append(errs, fmt.Errorf("layer %d: %w", layerIndex+1, e))
+	}
+
+	// If an error exist for a given layer, then return (do not process further layers)
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+// executePodTemplate executes a single pod template.
+func (d *DeployContext) executePodTemplate(podTemplateName string,
+	baseDir string, caddyCtx *caddy.Context, existingResources []string) error {
+	logger.Infof("Processing template: %s\n", catalogconstants.CatalogAppTemplate)
+
+	// Fetch pod spec
+	podSpec, err := d.TemplateProvider.LoadPodTemplateWithValues(catalogconstants.CatalogAppTemplate, podTemplateName, catalogconstants.CatalogAppName, nil, d.argParams)
+	if err != nil {
+		return fmt.Errorf("failed to load pod template: %w", err)
+	}
+
+	// Generate template parameters
+	params := map[string]any{
+		"AppName":         catalogconstants.CatalogAppName,
+		"AppTemplateName": catalogconstants.CatalogAppTemplate,
+		"Version":         d.appMetadata.Version,
+		"BaseDir":         baseDir,
+		"CaddyAdminURL":   caddyCtx.GetContainerAdminURL(),
+		"DomainSuffix":    caddyCtx.GetDomainSuffix(),
+		"Values":          d.values,
+		"env":             map[string]map[string]string{},
+	}
+
+	// filter out resources
+	if slices.Contains(existingResources, podSpec.Name) {
+		logger.Infof("%s: Skipping resource deploy as '%s' it already exists", podTemplateName, podSpec.Name)
+		return nil
+	}
+
+	// Get the template
+	podTemplate := d.templates[podTemplateName]
+
+	// Render template
+	var rendered bytes.Buffer
+	if err := podTemplate.Execute(&rendered, params); err != nil {
+		return fmt.Errorf("failed to render pod template: %w", err)
+	}
+
+	// Deploy the pod with readiness checks
+	reader := bytes.NewReader(rendered.Bytes())
+	podDeployOptions := clipodman.ConstructPodDeployOptions(specs.FetchPodAnnotations(*podSpec))
+
+	if err := clipodman.DeployPodAndReadinessCheck(d.Runtime, podSpec, podTemplateName, reader, podDeployOptions); err != nil {
+		return fmt.Errorf("failed to deploy pod: %w", err)
+	}
+
+	return nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/common/podman/deploy/deploy_context.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/deploy/deploy_context.go
@@ -107,6 +107,8 @@ func (d *DeployContext) ExtractRouteInfos() ([]caddy.TemplateRouteInfo, error) {
 // ExecutePodLayers executes all pod template layers.
 func (d *DeployContext) ExecutePodLayers(baseDir string, caddyCtx *caddy.Context,
 	existingResources []string) error {
+	logger.Infoln("executing catalog service resources...", logger.VerbosityLevelDebug)
+
 	for i, layer := range d.appMetadata.PodTemplateExecutions {
 		logger.Infof("\n Executing Layer %d/%d: %v\n", i+1, len(d.appMetadata.PodTemplateExecutions), layer)
 		logger.Infoln("-------")

--- a/ai-services/internal/pkg/catalog/cli/common/podman/deploy/deploy_context.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/deploy/deploy_context.go
@@ -79,7 +79,7 @@ func (d *DeployContext) PrepareValues(argParams map[string]string) error {
 	return nil
 }
 
-// checkStatus checks if the catalog is already deployed.
+// CheckStatus checks if the catalog is already deployed.
 func (d *DeployContext) CheckStatus() (bool, []string, error) {
 	catalogSecrets, err := collectSecretNames(d.TemplateProvider, d.argParams)
 	if err != nil {
@@ -181,6 +181,7 @@ func (d *DeployContext) executePodTemplate(podTemplateName string,
 	// filter out resources
 	if slices.Contains(existingResources, podSpec.Name) {
 		logger.Infof("%s: Skipping resource deploy as '%s' it already exists", podTemplateName, podSpec.Name)
+
 		return nil
 	}
 

--- a/ai-services/internal/pkg/catalog/cli/common/podman/deploy/template_helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/deploy/template_helpers.go
@@ -1,0 +1,107 @@
+package deploy
+
+import (
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
+	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/models"
+)
+
+const (
+	kindSecret = "Secret"
+)
+
+// processPodTemplates loads all templates and processes each pod spec with the provided callback.
+// This helper function eliminates duplicate template loading and iteration logic.
+func processPodTemplates(tp templates.Template, argParams map[string]string,
+	processor func(podSpec *models.PodSpec) error) error {
+	// Load all templates once
+	tmpls, err := tp.LoadAllTemplates(catalogconstants.CatalogAppTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to load templates: %w", err)
+	}
+
+	// Iterate through templates and process each pod spec
+	for templateName := range tmpls {
+		podSpec, err := tp.LoadPodTemplateWithValues(catalogconstants.CatalogAppTemplate, templateName,
+			catalogconstants.CatalogAppName, nil, argParams)
+		if err != nil {
+			return fmt.Errorf("failed to load template %s: %w", templateName, err)
+		}
+
+		if err := processor(podSpec); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// collectSecretNames collects all secret names from templates.
+func collectSecretNames(tp templates.Template, argParams map[string]string) ([]string, error) {
+	var secretNames []string
+
+	err := processPodTemplates(tp, argParams, func(podSpec *models.PodSpec) error {
+		if podSpec.Kind == kindSecret {
+			secretNames = append(secretNames, podSpec.Name)
+		}
+		return nil
+	})
+
+	return secretNames, err
+}
+
+// extractAllRoutesFromTemplates extracts routes annotations from all templates that have them.
+// Returns a slice of caddy.TemplateRouteInfo containing pod name and routes for each template.
+func extractAllRoutesFromTemplates(tp templates.Template, argParams map[string]string) ([]caddy.TemplateRouteInfo, error) {
+	var routeInfos []caddy.TemplateRouteInfo
+
+	err := processPodTemplates(tp, argParams, func(podSpec *models.PodSpec) error {
+		// Check if this template has the routes annotation
+		if podSpec.Annotations != nil {
+			if routes, ok := podSpec.Annotations[constants.PodRoutesAnnotationKey]; ok {
+				routeInfos = append(routeInfos, caddy.TemplateRouteInfo{
+					PodName:          podSpec.Name,
+					RoutesAnnotation: routes,
+				})
+			}
+		}
+
+		return nil
+	})
+
+	return routeInfos, err
+}
+
+// findCaddyPodNameFromTemplates finds the Caddy pod name by looking for the pod with component=proxy label in templates.
+func findCaddyPodNameFromTemplates(tp templates.Template, argParams map[string]string) (string, error) {
+	var caddyPodName string
+
+	err := processPodTemplates(tp, argParams, func(podSpec *models.PodSpec) error {
+		// Check if this is the Caddy pod (component=proxy label)
+		if podSpec.Labels != nil {
+			if component, ok := podSpec.Labels["ai-services.io/component"]; ok && component == "proxy" {
+				caddyPodName = podSpec.Name
+			}
+		}
+
+		return nil
+	})
+
+	// Check if we found the Caddy pod (err will be "found" sentinel)
+	if caddyPodName != "" {
+		return caddyPodName, nil
+	}
+
+	// If err is not nil and we didn't find the pod, it's a real error
+	if err != nil {
+		return "", err
+	}
+
+	return "", fmt.Errorf("no Caddy pod found with component=proxy label in templates")
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/common/podman/deploy/template_helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/deploy/template_helpers.go
@@ -48,6 +48,7 @@ func collectSecretNames(tp templates.Template, argParams map[string]string) ([]s
 		if podSpec.Kind == kindSecret {
 			secretNames = append(secretNames, podSpec.Name)
 		}
+
 		return nil
 	})
 

--- a/ai-services/internal/pkg/catalog/cli/configure/common.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/common.go
@@ -2,95 +2,34 @@ package configure
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
-	"os"
 
 	catalogPodman "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure/podman"
-	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
-	"github.com/project-ai-services/ai-services/internal/pkg/utils"
-	"golang.org/x/crypto/pbkdf2"
 )
-
-const (
-	defaultPasswordIterations = 100000
-)
-
-// ConfigureOptions contains the configuration for configuring the catalog service.
-type ConfigureOptions struct {
-	AdminPassword string
-	Runtime       types.RuntimeType
-	BaseDir       string
-	// SSL/TLS certificate configuration
-	DomainName  string // Custom domain name for self-signed certificates
-	SSLCertPath string // Path to user-provided SSL certificate
-	SSLKeyPath  string // Path to user-provided SSL private key
-	HttpsPort   int
-}
 
 // Run executes the configure process for the catalog service.
-func Run(opts ConfigureOptions) error {
+// It creates runtime-specific options and calls the appropriate runtime implementation.
+func Run(runtime types.RuntimeType, baseDir, domainName, sslCertPath, sslKeyPath string, httpsPort int) error {
 	ctx := context.Background()
-
-	// Generate password hash using PBKDF2
-	passwordHash, err := hashPasswordPBKDF2(opts.AdminPassword, defaultPasswordIterations)
-	if err != nil {
-		return fmt.Errorf("failed to hash password: %w", err)
-	}
-
 	// Deploy catalog service based on runtime
-	switch opts.Runtime {
+	switch runtime {
 	case types.RuntimeTypePodman:
-		// Determine Podman URI
-		podmanURI, err := utils.ResolvePodmanURI()
-		if err != nil {
-			return fmt.Errorf("failed to generate podman uri: %w", err)
+		opts := catalogPodman.PodmanConfigureOptions{
+			BaseDir:     baseDir,
+			DomainName:  domainName,
+			SSLCertPath: sslCertPath,
+			SSLKeyPath:  sslKeyPath,
+			HttpsPort:   httpsPort,
 		}
-
-		// Determine auth file path
-		authFilePath, err := getAuthFilePath()
-		if err != nil {
-			return fmt.Errorf("failed to get auth file path: %w", err)
-		}
-
-		return catalogPodman.DeployCatalog(ctx, podmanURI, authFilePath, passwordHash, opts.BaseDir, opts.DomainName, opts.SSLCertPath, opts.SSLKeyPath, opts.HttpsPort)
+		return catalogPodman.DeployCatalog(ctx, opts)
 
 	case types.RuntimeTypeOpenShift:
 		return fmt.Errorf("openshift runtime is not yet supported for catalog configure")
 
 	default:
-		return fmt.Errorf("unsupported runtime type: %s", opts.Runtime)
+		return fmt.Errorf("unsupported runtime type: %s", runtime)
 	}
-}
-
-// getAuthFilePath determines the auth.json file path.
-func getAuthFilePath() (string, error) {
-	if os.Geteuid() == 0 {
-		return "/run/user/0/containers/auth.json", nil
-	}
-
-	return fmt.Sprintf("/run/user/%d/containers/auth.json", os.Getuid()), nil
-}
-
-// hashPasswordPBKDF2 generates a PBKDF2 hash of the password with a random salt.
-func hashPasswordPBKDF2(password string, iteration int) (string, error) {
-	salt := make([]byte, constants.Pbkdf2SaltLen)
-	if _, err := rand.Read(salt); err != nil {
-		return "", err
-	}
-
-	hash := pbkdf2.Key([]byte(password), salt, iteration, constants.Pbkdf2KeyLen, sha256.New)
-
-	// Format: iterations.salt.hash (base64 encoded)
-	encoded := fmt.Sprintf("%d.%s.%s",
-		iteration,
-		base64.RawStdEncoding.EncodeToString(salt),
-		base64.RawStdEncoding.EncodeToString(hash))
-
-	return encoded, nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/configure/common.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/common.go
@@ -22,6 +22,7 @@ func Run(runtime types.RuntimeType, baseDir, domainName, sslCertPath, sslKeyPath
 			SSLKeyPath:  sslKeyPath,
 			HttpsPort:   httpsPort,
 		}
+
 		return catalogPodman.DeployCatalog(ctx, opts)
 
 	case types.RuntimeTypeOpenShift:

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -31,7 +31,6 @@ type PodmanConfigureOptions struct {
 
 // DeployCatalog deploys the catalog service using the assets/catalog template for podman runtime.
 func DeployCatalog(ctx context.Context, opts PodmanConfigureOptions) error {
-
 	logger.Infoln("started configuring catalog service...", logger.VerbosityLevelDebug)
 
 	// Create deployment context without argParams for status check
@@ -71,8 +70,6 @@ func DeployCatalog(ctx context.Context, opts PodmanConfigureOptions) error {
 	}
 
 	if !isDeployed {
-		logger.Infoln("loading catalog service param values...", logger.VerbosityLevelDebug)
-
 		// Prepare deployment with domain suffix computation and create Caddy context
 		err = loadCatalogParamValues(deployCtx, passwordHash, opts.HttpsPort)
 		if err != nil {
@@ -80,8 +77,6 @@ func DeployCatalog(ctx context.Context, opts PodmanConfigureOptions) error {
 
 			return err
 		}
-
-		logger.Infoln("executing catalog service resources...", logger.VerbosityLevelDebug)
 
 		// Execute pod templates
 		if err := deployCtx.ExecutePodLayers(opts.BaseDir, caddyCtx, existingResources); err != nil {
@@ -96,20 +91,18 @@ func DeployCatalog(ctx context.Context, opts PodmanConfigureOptions) error {
 
 	logger.Infof("Catalog pod already exists: %v\n", existingResources)
 
-	logger.Infoln("loding ssl certificate to caddy...", logger.VerbosityLevelDebug)
-
 	// Load SSL certificates if provided
 	if err := caddyCtx.LoadSSLCertificates(opts.BaseDir, opts.SSLCertPath, opts.SSLKeyPath); err != nil {
 		return err
 	}
-
-	logger.Infoln("handling post deployment steps...", logger.VerbosityLevelDebug)
 
 	return handlePostDeployment(caddyCtx, deployCtx)
 }
 
 // handlePostDeployment handles route registration and next steps display after catalog deployment.
 func handlePostDeployment(caddyCtx *caddy.Context, deployCtx *deploy.DeployContext) error {
+	logger.Infoln("handling post deployment steps...", logger.VerbosityLevelDebug)
+
 	// Extract route infos from deployment context
 	routeInfos, err := deployCtx.ExtractRouteInfos()
 	if err != nil {
@@ -139,6 +132,8 @@ func handlePostDeployment(caddyCtx *caddy.Context, deployCtx *deploy.DeployConte
 
 // prepareCatalogDeployment prepares all necessary data for deployment including domain suffix computation.
 func loadCatalogParamValues(deployCtx *deploy.DeployContext, passwordHash string, httpsPort int) error {
+	logger.Infoln("loading catalog service param values...", logger.VerbosityLevelDebug)
+
 	// Generate argument parameters
 	argParams, err := generateArgParams(passwordHash, httpsPort)
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -1,205 +1,133 @@
 package podman
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
-	"slices"
 	"strings"
-	"sync"
-	"text/template"
 
-	"github.com/project-ai-services/ai-services/assets"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
 	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
-	clipodman "github.com/project-ai-services/ai-services/internal/pkg/cli/podman"
-	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
-	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/models"
-	"github.com/project-ai-services/ai-services/internal/pkg/proxy"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
-	"github.com/project-ai-services/ai-services/internal/pkg/specs"
 	"github.com/project-ai-services/ai-services/internal/pkg/spinner"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 const (
-	catalogAppTemplate    = "catalog"
-	dirPerm               = 0o755
-	filePerm              = 0o644
-	kindSecret            = "Secret"
-	caddyCertsDirName     = "certs"
-	caddyContainerDataDir = "/data/caddy"
+	defaultPasswordIterations = 100000
 )
 
-// catalogDeploymentContext holds cached values during catalog deployment to avoid redundant lookups.
-type catalogDeploymentContext struct {
-	// Pod identification
-	caddyPodName string
-
-	// Admin API access
-	caddyAdminPort         string // Dynamic port assigned by Podman
-	caddyContainerAdminURL string // http://<podName>:2019 (for container use in templates)
-	caddyHostAdminURL      string // http://localhost:<port> (for host VM use in post-deployment)
-
-	// Network configuration
-	domainSuffix string
-}
-
-// getCaddyPodName retrieves the Caddy pod name, using cache if available.
-func (c *catalogDeploymentContext) getCaddyPodName(tp templates.Template, appTemplateName string, argParams map[string]string) (string, error) {
-	if c.caddyPodName != "" {
-		return c.caddyPodName, nil
-	}
-
-	name, err := findCaddyPodNameFromTemplates(tp, appTemplateName, argParams)
-	if err != nil {
-		return "", err
-	}
-
-	c.caddyPodName = name
-
-	return name, nil
-}
-
-// getCaddyHostAdminURL retrieves the Caddy admin URL for host VM use, using cache if available.
-func (c *catalogDeploymentContext) getCaddyHostAdminURL(rt *podman.PodmanClient, tp templates.Template, appTemplateName string, argParams map[string]string) (string, error) {
-	if c.caddyHostAdminURL != "" {
-		return c.caddyHostAdminURL, nil
-	}
-
-	// Get pod name (will use cache if available)
-	podName, err := c.getCaddyPodName(tp, appTemplateName, argParams)
-	if err != nil {
-		return "", err
-	}
-
-	// Get admin port
-	adminPort, err := proxy.GetCaddyAdminPort(rt, podName)
-	if err != nil {
-		return "", err
-	}
-
-	c.caddyAdminPort = adminPort
-	c.caddyHostAdminURL = fmt.Sprintf("http://localhost:%s", adminPort)
-
-	return c.caddyHostAdminURL, nil
+// PodmanConfigureOptions contains the configuration for configuring the catalog service on Podman runtime.
+type PodmanConfigureOptions struct {
+	BaseDir     string
+	DomainName  string // Custom domain name for self-signed certificates
+	SSLCertPath string // Path to user-provided SSL certificate
+	SSLKeyPath  string // Path to user-provided SSL private key
+	HttpsPort   int
 }
 
 // DeployCatalog deploys the catalog service using the assets/catalog template for podman runtime.
-func DeployCatalog(ctx context.Context, podmanURI, authFilePath, passwordHash, baseDir string, domainName string, sslCertPath, sslKeyPath string, httpsPort int) error {
-	s := spinner.New("Deploying catalog service...")
-	s.Start(ctx)
+func DeployCatalog(ctx context.Context, opts PodmanConfigureOptions) error {
 
-	// Initialize deployment context for caching
-	deployCtx := &catalogDeploymentContext{}
+	logger.Infoln("started configuring catalog service...", logger.VerbosityLevelDebug)
 
-	// Initialize and validate - argParams is created internally
-	rt, tp, appMetadata, tmpls, argParams, err := initializeCatalogDeployment(httpsPort, s)
+	// Create deployment context without argParams for status check
+	deployCtx, err := deploy.NewDeployContext()
 	if err != nil {
 		return err
 	}
 
+	// Collect and hash password
+	// If secret exist passwordHash will be empty
+	passwordHash, err := collectAndHashPassword(deployCtx.Runtime)
+	if err != nil {
+		return err
+	}
+
+	s := spinner.New("Configuring catalog service...")
+	s.Start(ctx)
+
+	logger.Infoln("setting up caddy context...", logger.VerbosityLevelDebug)
+
+	// Setup Caddy context with domain configuration and Caddyfile generation
+	caddyCtx, err := setupCaddyContext(deployCtx, opts, s)
+	if err != nil {
+		s.Fail("failed while setting up caddy context")
+		return err
+	}
+
+	logger.Infoln("checking for existing resources...", logger.VerbosityLevelDebug)
+
 	// Check existing deployment status
-	isDeployed, existingResources, err := checkCatalogStatus(rt, tp, tmpls, argParams)
+	isDeployed, existingResources, err := deployCtx.CheckStatus()
 	if err != nil {
 		s.Fail("failed to check existing resources")
-
 		return fmt.Errorf("failed to check existing resources: %w", err)
 	}
 
-	if isDeployed {
-		s.Stop("Catalog service already deployed")
-		logger.Infof("Catalog pod already exists: %v\n", existingResources)
+	if !isDeployed {
 
-		return nil
+		logger.Infoln("loading catalog service param values...", logger.VerbosityLevelDebug)
+
+		// Prepare deployment with domain suffix computation and create Caddy context
+		err = loadCatalogParamValues(deployCtx, passwordHash, opts.HttpsPort)
+		if err != nil {
+			s.Fail("failed to load param values")
+			return err
+		}
+
+		logger.Infoln("executing catalog service resources...", logger.VerbosityLevelDebug)
+
+		// Execute pod templates
+		if err := deployCtx.ExecutePodLayers(opts.BaseDir, caddyCtx, existingResources); err != nil {
+			s.Fail("failed to deploy catalog pod")
+
+			return err
+		}
+
+		s.Stop("Catalog service deployed successfully")
+		logger.Infoln("-------")
 	}
 
-	// Prepare deployment with domain suffix computation
-	values, err := prepareCatalogDeployment(deployCtx, tp, podmanURI, authFilePath, passwordHash, baseDir, domainName, sslCertPath, sslKeyPath, argParams, s)
-	if err != nil {
-		return err
-	}
+	logger.Infof("Catalog pod already exists: %v\n", existingResources)
 
-	// Execute pod templates (using cached values from context)
-	if err := executePodLayers(rt, tp, tmpls, appMetadata, values, baseDir, deployCtx.caddyContainerAdminURL, deployCtx.domainSuffix, argParams, s, existingResources); err != nil {
-		return err
-	}
-
-	s.Stop("Catalog service deployed successfully")
-	logger.Infoln("-------")
+	logger.Infoln("loding ssl certificate to caddy...", logger.VerbosityLevelDebug)
 
 	// Load SSL certificates if provided
-	if err := loadSSLCertificatesIfProvided(deployCtx, rt, tp, baseDir, sslCertPath, sslKeyPath, argParams); err != nil {
+	if err := caddyCtx.LoadSSLCertificates(opts.BaseDir, opts.SSLCertPath, opts.SSLKeyPath); err != nil {
 		return err
 	}
 
-	return handlePostDeployment(deployCtx, rt, tp, argParams)
-}
+	logger.Infoln("handling post deployment steps...", logger.VerbosityLevelDebug)
 
-// initializeCatalogDeployment handles initialization and validation steps.
-// Creates and returns argParams map internally for use throughout deployment.
-func initializeCatalogDeployment(httpsPort int, s *spinner.Spinner) (
-	*podman.PodmanClient,
-	templates.Template,
-	*templates.AppMetadata,
-	map[string]*template.Template,
-	map[string]string,
-	error,
-) {
-	// Initialize runtime
-	rt, err := podman.NewPodmanClient()
-	if err != nil {
-		s.Fail("failed to initialize podman client")
-
-		return nil, nil, nil, nil, nil, fmt.Errorf("failed to initialize podman client: %w", err)
-	}
-
-	// Load template provider and metadata
-	tp, appMetadata, tmpls, err := loadCatalogTemplates(s)
-	if err != nil {
-		s.Fail("failed to load catalog templates")
-
-		return nil, nil, nil, nil, nil, fmt.Errorf("failed to load catalog templates: %w", err)
-	}
-
-	// Create argParams map for internal use
-	argParams := make(map[string]string)
-	argParams["caddy.httpsPort"] = fmt.Sprintf("%d", httpsPort)
-
-	return rt, tp, appMetadata, tmpls, argParams, nil
+	return handlePostDeployment(caddyCtx, deployCtx)
 }
 
 // handlePostDeployment handles route registration and next steps display after catalog deployment.
-func handlePostDeployment(deployCtx *catalogDeploymentContext, rt *podman.PodmanClient, tp templates.Template, argParams map[string]string) error {
-	// Get Caddy admin URL from cache (will fetch and cache if not already cached)
-	adminURL, err := deployCtx.getCaddyHostAdminURL(rt, tp, catalogAppTemplate, argParams)
+func handlePostDeployment(caddyCtx *caddy.Context, deployCtx *deploy.DeployContext) error {
+	// Extract route infos from deployment context
+	routeInfos, err := deployCtx.ExtractRouteInfos()
 	if err != nil {
-		return fmt.Errorf("failed to get Caddy admin URL: %w", err)
+		return fmt.Errorf("failed to extract route infos: %w", err)
 	}
 
-	// Get Caddy pod name from cache
-	caddyPodName := deployCtx.caddyPodName
-
 	// Register routes with Caddy and get the registered route domains
-	routeDomains, err := registerCatalogRoutes(rt, tp, catalogAppTemplate, argParams, deployCtx.domainSuffix, adminURL)
+	routeDomains, err := caddy.RegisterCatalogRoutes(deployCtx.Runtime, caddyCtx, routeInfos)
 	if err != nil {
 		return fmt.Errorf("route registration failed: %w", err)
 	}
 
 	// Get Caddy HTTPS port for next steps display
-	httpsPort, err := getCaddyHTTPSPort(rt, caddyPodName)
+	httpsPort, err := caddyCtx.GetHTTPSPort(deployCtx.Runtime)
 	if err != nil {
 		return fmt.Errorf("failed to get Caddy HTTPS port: %w", err)
 	}
 
 	// Print next steps with proxy route information
-	if err := helpers.PrintNextStepsWithProxy(tp, rt, catalogconstants.CatalogAppName, catalogAppTemplate, routeDomains, httpsPort); err != nil {
+	if err := helpers.PrintNextStepsWithProxy(deployCtx.TemplateProvider, deployCtx.Runtime, catalogconstants.CatalogAppName, catalogconstants.CatalogAppTemplate, routeDomains, httpsPort); err != nil {
 		// do not want to fail the overall configure if we cannot print next steps
 		logger.Infof("failed to display next steps: %v\n", err)
 	}
@@ -207,174 +135,26 @@ func handlePostDeployment(deployCtx *catalogDeploymentContext, rt *podman.Podman
 	return nil
 }
 
-// extractCertDomainIfProvided extracts domain from certificate if SSL cert/key are provided.
-func extractCertDomainIfProvided(sslCertPath, sslKeyPath string, s *spinner.Spinner) (string, error) {
-	if sslCertPath == "" || sslKeyPath == "" {
-		return "", nil
-	}
-
-	certDomain, err := utils.ExtractDomainFromCertificate(sslCertPath)
-	if err != nil {
-		s.Fail("failed to extract domain from certificate")
-
-		return "", fmt.Errorf("failed to extract domain from certificate: %w", err)
-	}
-
-	logger.Infof("Extracted domain from certificate: %s\n", certDomain, logger.VerbosityLevelDebug)
-
-	return certDomain, nil
-}
-
 // prepareCatalogDeployment prepares all necessary data for deployment including domain suffix computation.
-func prepareCatalogDeployment(deployCtx *catalogDeploymentContext, tp templates.Template, podmanURI, authFilePath, passwordHash, baseDir, domainName, sslCertPath, sslKeyPath string, argParams map[string]string, s *spinner.Spinner) (map[string]any, error) {
-	// Extract domain from certificate if provided
-	certDomain, err := extractCertDomainIfProvided(sslCertPath, sslKeyPath, s)
+func loadCatalogParamValues(deployCtx *deploy.DeployContext, passwordHash string, httpsPort int) error {
+
+	// Generate argument parameters
+	argParams, err := generateArgParams(passwordHash, httpsPort)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("failed to generate arg params: %w", err)
 	}
-
-	// Compute domain suffix using priority: certDomain > customDomain > hostIP.nip.io
-	domainSuffix, err := computeDomainSuffix(certDomain, domainName)
-	if err != nil {
-		s.Fail("failed to compute domain suffix")
-
-		return nil, fmt.Errorf("failed to compute domain suffix: %w", err)
-	}
-	deployCtx.domainSuffix = domainSuffix
-
-	logger.Infof("Using domain suffix: %s\n", domainSuffix, logger.VerbosityLevelDebug)
-
-	// Get Caddy pod name from cache (will be cached for subsequent calls)
-	caddyPodName, err := deployCtx.getCaddyPodName(tp, catalogAppTemplate, argParams)
-	if err != nil {
-		s.Fail("failed to find Caddy pod name")
-
-		return nil, fmt.Errorf("failed to find Caddy pod name: %w", err)
-	}
-
-	// Build admin URL for container (uses internal port 2019) and cache it
-	deployCtx.caddyContainerAdminURL = fmt.Sprintf("http://%s:2019", caddyPodName)
 
 	// Prepare values with configure-specific configuration
-	values, err := prepareCatalogValues(tp, podmanURI, authFilePath, passwordHash, argParams)
+	err = deployCtx.PrepareValues(argParams)
 	if err != nil {
-		s.Fail("failed to load values")
-
-		return nil, fmt.Errorf("failed to load values: %w", err)
-	}
-
-	// Generate and write Caddyfile before deploying
-	if err := generateCaddyfile(baseDir); err != nil {
-		s.Fail("failed to generate Caddyfile")
-
-		return nil, fmt.Errorf("failed to generate Caddyfile: %w", err)
-	}
-
-	return values, nil
-}
-
-// loadSSLCertificatesIfProvided stages user-provided certificates for the Caddy pod and updates TLS config via Admin API.
-func loadSSLCertificatesIfProvided(deployCtx *catalogDeploymentContext, rt *podman.PodmanClient, tp templates.Template, baseDir, sslCertPath, sslKeyPath string, argParams map[string]string) error {
-	if sslCertPath == "" || sslKeyPath == "" {
-		return nil
-	}
-
-	// Get Caddy admin URL from cache (will fetch and cache if not already cached)
-	adminURL, err := deployCtx.getCaddyHostAdminURL(rt, tp, catalogAppTemplate, argParams)
-	if err != nil {
-		return fmt.Errorf("failed to get Caddy admin URL: %w", err)
-	}
-
-	if err := stageCertificatesForCaddy(baseDir, sslCertPath, sslKeyPath); err != nil {
-		return fmt.Errorf("failed to stage certificates for Caddy: %w", err)
-	}
-
-	if err := utils.LoadUserCertificates(
-		filepath.Join(baseDir, "common", "caddy", caddyCertsDirName, "tls.crt"),
-		filepath.Join(baseDir, "common", "caddy", caddyCertsDirName, "tls.key"),
-		filepath.Join(caddyContainerDataDir, caddyCertsDirName, "tls.crt"),
-		filepath.Join(caddyContainerDataDir, caddyCertsDirName, "tls.key"),
-		adminURL,
-	); err != nil {
-		return fmt.Errorf("failed to load certificates via Admin API: %w", err)
+		return fmt.Errorf("failed to load values: %w", err)
 	}
 
 	return nil
 }
 
-func stageCertificatesForCaddy(baseDir, sslCertPath, sslKeyPath string) error {
-	caddyDataDir := filepath.Join(baseDir, "common", "caddy")
-	certDir := filepath.Join(caddyDataDir, caddyCertsDirName)
-	if err := os.MkdirAll(certDir, dirPerm); err != nil {
-		return fmt.Errorf("failed to create Caddy cert directory: %w", err)
-	}
-
-	stagedCertPath := filepath.Join(certDir, "tls.crt")
-	stagedKeyPath := filepath.Join(certDir, "tls.key")
-
-	certBytes, err := os.ReadFile(sslCertPath)
-	if err != nil {
-		return fmt.Errorf("failed to read certificate file: %w", err)
-	}
-
-	keyBytes, err := os.ReadFile(sslKeyPath)
-	if err != nil {
-		return fmt.Errorf("failed to read key file: %w", err)
-	}
-
-	if err := os.WriteFile(stagedCertPath, certBytes, filePerm); err != nil {
-		return fmt.Errorf("failed to write staged certificate file: %w", err)
-	}
-
-	if err := os.WriteFile(stagedKeyPath, keyBytes, filePerm); err != nil {
-		return fmt.Errorf("failed to write staged key file: %w", err)
-	}
-
-	return nil
-}
-
-func checkCatalogStatus(rt *podman.PodmanClient, tp templates.Template, tmpls map[string]*template.Template, argParams map[string]string) (bool, []string, error) {
-	catalogSecrets, err := collectSecretNames(tp, tmpls, argParams)
-	if err != nil {
-		return false, nil, err
-	}
-
-	existingResources, err := helpers.CheckExistingResourcesForApplication(rt, catalogconstants.CatalogAppName, catalogSecrets)
-	if err != nil {
-		return false, nil, err
-	}
-
-	return len(existingResources) == len(tmpls), existingResources, nil
-}
-
-// loadCatalogTemplates loads the catalog template provider, metadata, and templates.
-func loadCatalogTemplates(s *spinner.Spinner) (templates.Template, *templates.AppMetadata, map[string]*template.Template, error) {
-	tp := templates.NewEmbedTemplateProvider(&assets.CatalogFS, "")
-
-	// Load metadata from catalog/podman
-	var appMetadata templates.AppMetadata
-	if err := tp.LoadMetadata(catalogAppTemplate, true, &appMetadata); err != nil {
-		s.Fail("failed to load catalog metadata")
-
-		return nil, nil, nil, fmt.Errorf("failed to load catalog metadata: %w", err)
-	}
-
-	// Load all templates from catalog
-	tmpls, err := tp.LoadAllTemplates(catalogAppTemplate)
-	if err != nil {
-		s.Fail("failed to load catalog templates")
-
-		return nil, nil, nil, fmt.Errorf("failed to load catalog templates: %w", err)
-	}
-
-	return tp, &appMetadata, tmpls, nil
-}
-
-// prepareCatalogValues prepares the values map with configure-specific configuration.
-func prepareCatalogValues(tp templates.Template, podmanURI, authFilePath, passwordHash string, argParams map[string]string) (map[string]any, error) {
-	if argParams == nil {
-		argParams = make(map[string]string)
-	}
+// generateArgParams generates the argument parameters for template rendering.
+func generateArgParams(passwordHash string, httpsPort int) (map[string]string, error) {
 
 	// Generate database password
 	dbPassword, err := utils.GenerateRandomPassword()
@@ -382,7 +162,12 @@ func prepareCatalogValues(tp templates.Template, podmanURI, authFilePath, passwo
 		return nil, fmt.Errorf("failed to generate database password: %w", err)
 	}
 
+	// Determine auth file path
 	// Read and encode auth file content for secret
+	authFilePath, err := utils.GetAuthFilePath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get auth file path: %w", err)
+	}
 	authFileContent, err := os.ReadFile(authFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read auth file from %s: %w", authFilePath, err)
@@ -391,446 +176,60 @@ func prepareCatalogValues(tp templates.Template, podmanURI, authFilePath, passwo
 	// Base64 encode the auth file content for Kubernetes secret
 	authFileBase64 := base64.StdEncoding.EncodeToString(authFileContent)
 
+	// Determine the podman URI
 	// Strip unix:// prefix from podmanURI for hostPath volume mount
 	// The CONTAINER_HOST env var needs the full URI, but the hostPath needs just the file path
+	podmanURI, err := utils.ResolvePodmanURI()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate podman uri: %w", err)
+	}
 	podmanSocketPath := strings.TrimPrefix(podmanURI, "unix://")
 
 	// Set configure-specific values
+	argParams := make(map[string]string)
 	argParams["backend.adminPasswordHash"] = passwordHash
 	argParams["backend.runtime"] = "podman"
 	argParams["backend.podman.authFileContent"] = authFileBase64
 	argParams["backend.podman.uri"] = podmanSocketPath
 	argParams["db.password"] = dbPassword
+	argParams["caddy.httpsPort"] = fmt.Sprintf("%d", httpsPort)
 
-	// Load values from catalog
-	return tp.LoadValues(catalogAppTemplate, nil, argParams)
+	return argParams, nil
 }
 
-// executePodLayers executes all pod template layers.
-func executePodLayers(rt *podman.PodmanClient, tp templates.Template, tmpls map[string]*template.Template,
-	appMetadata *templates.AppMetadata, values map[string]any, baseDir, caddyAdminURL, domainSuffix string, argParams map[string]string,
-	s *spinner.Spinner, existingResources []string) error {
-	for i, layer := range appMetadata.PodTemplateExecutions {
-		logger.Infof("\n Executing Layer %d/%d: %v\n", i+1, len(appMetadata.PodTemplateExecutions), layer)
-		logger.Infoln("-------")
-
-		if err := executeLayer(rt, tp, tmpls, layer, appMetadata.Version, values, baseDir, caddyAdminURL, domainSuffix, argParams, i, existingResources); err != nil {
-			s.Fail("failed to deploy catalog pod")
-
-			return err
-		}
-
-		logger.Infof("Layer %d completed\n", i+1)
-	}
-
-	return nil
-}
-
-// executeLayer executes a single layer of pod templates.
-func executeLayer(rt *podman.PodmanClient, tp templates.Template, tmpls map[string]*template.Template,
-	layer []string, version string, values map[string]any, baseDir, caddyAdminURL, domainSuffix string, argParams map[string]string,
-	layerIndex int, existingResources []string) error {
-	var wg sync.WaitGroup
-	errCh := make(chan error, len(layer))
-
-	// for each layer, fetch all the pod Template Names and do the pod deploy
-	for _, podTemplateName := range layer {
-		wg.Add(1)
-		go func(t string) {
-			defer wg.Done()
-			if err := executePodTemplate(rt, tp, tmpls, t, catalogAppTemplate, catalogconstants.CatalogAppName, values, version, nil, baseDir, caddyAdminURL, domainSuffix, argParams, existingResources); err != nil {
-				errCh <- err
-			}
-		}(podTemplateName)
-	}
-
-	wg.Wait()
-	close(errCh)
-
-	// collect all errors for this layer
-	errs := make([]error, 0, len(layer))
-	for e := range errCh {
-		errs = append(errs, fmt.Errorf("layer %d: %w", layerIndex+1, e))
-	}
-
-	// If an error exist for a given layer, then return (do not process further layers)
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
-}
-
-// executePodTemplate executes a single pod template.
-func executePodTemplate(rt *podman.PodmanClient, tp templates.Template, tmpls map[string]*template.Template,
-	podTemplateName, appTemplateName, appName string, values map[string]any, version string,
-	valuesFiles []string, baseDir, caddyAdminURL, domainSuffix string, argParams map[string]string, existingResources []string) error {
-	logger.Infof("Processing template: %s\n", podTemplateName)
-
-	// Fetch pod spec
-	podSpec, err := tp.LoadPodTemplateWithValues(appTemplateName, podTemplateName, appName, valuesFiles, argParams)
+// setupCaddyContext sets up the Caddy context with domain configuration and Caddyfile generation.
+// This function:
+// 1. Gets the Caddy pod name from deployment context templates
+// 2. Computes domain configuration (cert domain extraction + domain suffix resolution)
+// 3. Creates Caddy context with pod name and domain suffix
+// 4. Generates and writes Caddyfile
+func setupCaddyContext(deployCtx *deploy.DeployContext, opts PodmanConfigureOptions, s *spinner.Spinner) (*caddy.Context, error) {
+	// Get Caddy pod name from deployment context (templates)
+	caddyPodName, err := deployCtx.GetCaddyPodName()
 	if err != nil {
-		return fmt.Errorf("failed to load pod template: %w", err)
+		s.Fail("failed to find Caddy pod name")
+		return nil, fmt.Errorf("failed to find Caddy pod name: %w", err)
 	}
 
-	// Prepare template parameters
-	params := map[string]any{
-		"AppName":         appName,
-		"AppTemplateName": appTemplateName,
-		"Version":         version,
-		"BaseDir":         baseDir,
-		"CaddyAdminURL":   caddyAdminURL,
-		"DomainSuffix":    domainSuffix,
-		"Values":          values,
-		"env":             map[string]map[string]string{},
-	}
-
-	// filter out resources
-	if slices.Contains(existingResources, podSpec.Name) {
-		logger.Infof("%s: Skipping resource deploy as '%s' it already exists", podTemplateName, podSpec.Name)
-
-		return nil
-	}
-
-	// Get the template
-	podTemplate := tmpls[podTemplateName]
-
-	// Render template
-	var rendered bytes.Buffer
-	if err := podTemplate.Execute(&rendered, params); err != nil {
-		return fmt.Errorf("failed to render pod template: %w", err)
-	}
-
-	// Deploy the pod with readiness checks
-	reader := bytes.NewReader(rendered.Bytes())
-	podDeployOptions := clipodman.ConstructPodDeployOptions(specs.FetchPodAnnotations(*podSpec))
-
-	if err := clipodman.DeployPodAndReadinessCheck(rt, podSpec, podTemplateName, reader, podDeployOptions); err != nil {
-		return fmt.Errorf("failed to deploy pod: %w", err)
-	}
-
-	return nil
-}
-
-// generateCaddyfile copies the static Caddyfile to the caddy directory.
-func generateCaddyfile(baseDir string) error {
-	// Read the Caddyfile template
-	caddyfileContent, err := assets.CatalogFS.ReadFile("catalog/podman/Caddyfile.tmpl")
+	// Compute domain configuration (cert domain extraction + domain suffix resolution)
+	domainSuffix, err := caddy.ComputeDomainConfig(opts.SSLCertPath, opts.SSLKeyPath, opts.DomainName)
 	if err != nil {
-		return fmt.Errorf("failed to read Caddyfile template: %w", err)
+		s.Fail("failed to calculate domain")
+		return nil, err
 	}
 
-	// Parse the Caddyfile as a template
-	tmpl, err := template.New("Caddyfile.tmpl").Parse(string(caddyfileContent))
-	if err != nil {
-		return fmt.Errorf("failed to parse Caddyfile template: %w", err)
+	logger.Infof("Using domain suffix: %s\n", domainSuffix, logger.VerbosityLevelDebug)
+
+	// Create Caddy context with pod name and domain suffix (NO template dependencies)
+	caddyCtx := caddy.NewContext(caddyPodName, domainSuffix)
+
+	// Generate and write Caddyfile before deploying
+	if err := caddy.GenerateCaddyfile(opts.BaseDir); err != nil {
+		s.Fail("failed to generate Caddyfile")
+		return nil, fmt.Errorf("failed to generate Caddyfile: %w", err)
 	}
 
-	// Prepare template data with the server name constant
-	templateData := map[string]any{
-		"CaddyServerName": constants.CaddyServerName,
-	}
-
-	// Execute the template
-	var rendered bytes.Buffer
-	if err := tmpl.Execute(&rendered, templateData); err != nil {
-		return fmt.Errorf("failed to execute Caddyfile template: %w", err)
-	}
-
-	// Ensure directory exists and write Caddyfile
-	caddyDir := filepath.Join(baseDir, "common", "caddy")
-	if err := os.MkdirAll(caddyDir, dirPerm); err != nil {
-		return fmt.Errorf("failed to create caddy directory: %w", err)
-	}
-
-	caddyfilePath := filepath.Join(caddyDir, "Caddyfile")
-	if err := os.WriteFile(caddyfilePath, rendered.Bytes(), filePerm); err != nil {
-		return fmt.Errorf("failed to write Caddyfile: %w", err)
-	}
-
-	return nil
-}
-
-func collectSecretNames(tp templates.Template, tmpls map[string]*template.Template, argParams map[string]string) ([]string, error) {
-	secretNames := make([]string, 0)
-
-	for podTemplateName := range tmpls {
-		podSpec, err := tp.LoadPodTemplateWithValues(catalogAppTemplate, podTemplateName, catalogconstants.CatalogAppName, nil, argParams)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load pod template %s: %w", podTemplateName, err)
-		}
-
-		if podSpec.Kind == kindSecret {
-			secretNames = append(secretNames, podSpec.Name)
-		}
-	}
-
-	return secretNames, nil
-}
-
-// TemplateRouteInfo holds route information extracted from a template.
-type TemplateRouteInfo struct {
-	PodName          string
-	RoutesAnnotation string
-}
-
-// processPodTemplates loads all templates and processes each pod spec with the provided callback.
-// This helper function eliminates duplicate template loading and iteration logic.
-func processPodTemplates(tp templates.Template, appTemplateName string, argParams map[string]string,
-	processor func(templateName string, podSpec *models.PodSpec) error) error {
-	// Load all templates once
-	tmpls, err := tp.LoadAllTemplates(appTemplateName)
-	if err != nil {
-		return fmt.Errorf("failed to load templates: %w", err)
-	}
-
-	// Iterate through templates and process each pod spec
-	for templateName := range tmpls {
-		podSpec, err := tp.LoadPodTemplateWithValues(appTemplateName, templateName,
-			catalogconstants.CatalogAppName, nil, argParams)
-		if err != nil {
-			return fmt.Errorf("failed to load template %s: %w", templateName, err)
-		}
-
-		if err := processor(templateName, podSpec); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// extractAllRoutesFromTemplates extracts routes annotations from all templates that have them.
-// Returns a slice of TemplateRouteInfo containing pod name and routes for each template.
-func extractAllRoutesFromTemplates(tp templates.Template, appTemplateName string, argParams map[string]string) ([]TemplateRouteInfo, error) {
-	var routeInfos []TemplateRouteInfo
-
-	err := processPodTemplates(tp, appTemplateName, argParams, func(templateName string, podSpec *models.PodSpec) error {
-		// Check if this template has the routes annotation
-		if podSpec.Annotations != nil {
-			if routes, ok := podSpec.Annotations[constants.PodRoutesAnnotationKey]; ok {
-				routeInfos = append(routeInfos, TemplateRouteInfo{
-					PodName:          podSpec.Name,
-					RoutesAnnotation: routes,
-				})
-			}
-		}
-
-		return nil
-	})
-
-	return routeInfos, err
-}
-
-// findCaddyPodNameFromTemplates finds the Caddy pod name by looking for the pod with component=proxy label in templates.
-func findCaddyPodNameFromTemplates(tp templates.Template, appTemplateName string, argParams map[string]string) (string, error) {
-	var caddyPodName string
-
-	err := processPodTemplates(tp, appTemplateName, argParams, func(templateName string, podSpec *models.PodSpec) error {
-		// Check if this is the Caddy pod (component=proxy label)
-		if podSpec.Labels != nil {
-			if component, ok := podSpec.Labels["ai-services.io/component"]; ok && component == "proxy" {
-				caddyPodName = podSpec.Name
-				// Return a sentinel error to stop iteration early
-				return fmt.Errorf("found")
-			}
-		}
-
-		return nil
-	})
-
-	// Check if we found the Caddy pod (err will be "found" sentinel)
-	if caddyPodName != "" {
-		return caddyPodName, nil
-	}
-
-	// If err is not nil and we didn't find the pod, it's a real error
-	if err != nil && err.Error() != "found" {
-		return "", err
-	}
-
-	return "", fmt.Errorf("no Caddy pod found with component=proxy label in templates")
-}
-
-// registerCatalogRoutes registers routes with Caddy and returns route domains.
-func registerCatalogRoutes(rt *podman.PodmanClient, tp templates.Template, appTemplateName string, argParams map[string]string, domainSuffix, adminURL string) (map[string]string, error) {
-	// Extract routes from all templates
-	routeInfos, err := extractAllRoutesFromTemplates(tp, appTemplateName, argParams)
-	if err != nil {
-		return nil, fmt.Errorf("failed to extract routes from templates: %w", err)
-	}
-
-	if len(routeInfos) == 0 {
-		logger.Infof("No templates found with routes annotation, skipping route registration\n")
-
-		return nil, nil
-	}
-
-	// Create proxy manager once before registering routes
-	proxyManager := proxy.NewCaddyManager(adminURL, constants.CaddyServerName)
-
-	// Build route domains map
-	routeDomains := make(map[string]string)
-
-	// Register routes for each template that has them
-	var registrationErrors []error
-	for _, info := range routeInfos {
-		logger.Infof("Registering routes for pod: %s\n", info.PodName, logger.VerbosityLevelDebug)
-
-		// Register routes and get the built routes back
-		routes, err := proxy.RegisterRoutesForAppAndReturn(rt, catalogconstants.CatalogAppName, proxyManager, info.RoutesAnnotation, domainSuffix, info.PodName)
-		if err != nil {
-			registrationErrors = append(registrationErrors, fmt.Errorf("pod %s: %w", info.PodName, err))
-
-			continue
-		}
-
-		addRoutesToDomainMap(routes, routeDomains)
-	}
-
-	// Return error if any routes failed to register
-	if len(registrationErrors) > 0 {
-		return nil, fmt.Errorf("failed to register routes for %d pod(s): %w", len(registrationErrors), errors.Join(registrationErrors...))
-	}
-
-	logger.Infof("Successfully registered routes for %d pod(s)\n", len(routeInfos))
-
-	return routeDomains, nil
-}
-
-// computeDomainSuffix computes the domain suffix using priority: certDomain > customDomain > hostIP.nip.io.
-func computeDomainSuffix(certDomain, customDomain string) (string, error) {
-	if certDomain != "" {
-		return certDomain, nil
-	}
-	if customDomain != "" {
-		return customDomain, nil
-	}
-
-	// Only get hostIP if we actually need it (when both cert and custom domains are absent)
-	hostIP, err := utils.GetHostIP()
-	if err != nil {
-		return "", fmt.Errorf("failed to get host IP: %w", err)
-	}
-	if hostIP == "" {
-		return "", fmt.Errorf("no non-loopback IPv4 address found")
-	}
-
-	return fmt.Sprintf("%s.nip.io", hostIP), nil
-}
-
-// addRoutesToDomainMap adds routes to the domain map with sanitized variable names.
-func addRoutesToDomainMap(routes []proxy.Route, routeDomains map[string]string) {
-	for _, route := range routes {
-		parts := strings.Split(route.Domain, ".")
-		if len(parts) > 0 {
-			subdomain := parts[0]
-			sanitizedSubdomain := strings.ReplaceAll(subdomain, "-", "_")
-			varName := strings.ToUpper(fmt.Sprintf("%s_DOMAIN", sanitizedSubdomain))
-			routeDomains[varName] = route.Domain
-		}
-	}
-}
-
-// getCaddyHTTPSPort retrieves the host port mapped to Caddy's HTTPS port (container port 443).
-func getCaddyHTTPSPort(rt *podman.PodmanClient, caddyPodName string) (string, error) {
-	pod, err := rt.InspectPod(caddyPodName)
-	if err != nil {
-		return "", fmt.Errorf("failed to inspect Caddy pod: %w", err)
-	}
-
-	// Get port mappings from the Ports field
-	// Ports is a map[string][]string where key is "containerPort/protocol" and value is list of host ports
-	// Example: {"443/tcp": ["39341"], "2019/tcp": ["37249"]}
-	for containerPort, hostPorts := range pod.Ports {
-		// Check if this is the HTTPS port (443)
-		if strings.HasPrefix(containerPort, "443/") && len(hostPorts) > 0 {
-			return hostPorts[0], nil
-		}
-	}
-
-	return "", fmt.Errorf("HTTPS port mapping not found in pod ports")
-}
-
-// parseRouteEntry parses a single route entry and returns the subdomain.
-// Route format: "port:subdomain:type"
-// Returns empty string if the entry is invalid.
-func parseRouteEntry(routeEntry, podName string) string {
-	// Use shared helper from proxy package
-	parts, err := proxy.ParseRouteEntry(routeEntry)
-	if err != nil {
-		logger.Warningf("Invalid route format '%s' in pod %s: %v", routeEntry, podName, err)
-
-		return ""
-	}
-
-	return parts.Subdomain
-}
-
-// processRouteInfo processes route information and populates the routeDomains map.
-func processRouteInfo(info TemplateRouteInfo, proxyManager proxy.ProxyManager, routeDomains map[string]string) {
-	// Parse routes annotation directly to extract subdomains
-	// Format: "port:subdomain:type, port:subdomain:type, ..."
-	// Example: "8081:catalog-ui:ui, 8080:catalog-api:api"
-	for _, routeEntry := range strings.Split(info.RoutesAnnotation, ",") {
-		subdomain := parseRouteEntry(routeEntry, info.PodName)
-		if subdomain == "" {
-			continue
-		}
-
-		// Query Caddy for this route (route ID is just the subdomain)
-		actualRoute, err := proxyManager.GetRouteByID(subdomain)
-		if err != nil {
-			// Log warning but continue - route might not exist yet
-			logger.Warningf("Failed to query route %s from Caddy: %v", subdomain, err)
-
-			continue
-		}
-
-		// Create variable name from subdomain
-		sanitizedSubdomain := strings.ReplaceAll(subdomain, "-", "_")
-		varName := strings.ToUpper(fmt.Sprintf("%s_DOMAIN", sanitizedSubdomain))
-		routeDomains[varName] = actualRoute.Domain
-	}
-}
-
-// GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service.
-func GetCatalogRouteInfo(rt *podman.PodmanClient, tp templates.Template, appTemplateName string, argParams map[string]string) (map[string]string, string, error) {
-	// Find Caddy pod from templates
-	caddyPodName, err := findCaddyPodNameFromTemplates(tp, appTemplateName, argParams)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to find Caddy pod: %w", err)
-	}
-
-	// Get Caddy admin URL for querying specific routes
-	caddyAdminPort, err := proxy.GetCaddyAdminPort(rt, caddyPodName)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Caddy admin port: %w", err)
-	}
-	caddyAdminURL := fmt.Sprintf("http://localhost:%s", caddyAdminPort)
-
-	// Extract routes from all templates (same as during registration)
-	routeInfos, err := extractAllRoutesFromTemplates(tp, appTemplateName, argParams)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to extract routes from templates: %w", err)
-	}
-
-	// Create proxy manager
-	proxyManager := proxy.NewCaddyManager(caddyAdminURL, constants.CaddyServerName)
-
-	// Build route domains map by querying Caddy for each route
-	routeDomains := make(map[string]string)
-	for _, info := range routeInfos {
-		processRouteInfo(info, proxyManager, routeDomains)
-	}
-
-	// Get Caddy HTTPS port
-	httpsPort, err := getCaddyHTTPSPort(rt, caddyPodName)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Caddy HTTPS port: %w", err)
-	}
-
-	return routeDomains, httpsPort, nil
+	return caddyCtx, nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -56,6 +56,7 @@ func DeployCatalog(ctx context.Context, opts PodmanConfigureOptions) error {
 	caddyCtx, err := setupCaddyContext(deployCtx, opts, s)
 	if err != nil {
 		s.Fail("failed while setting up caddy context")
+
 		return err
 	}
 
@@ -65,17 +66,18 @@ func DeployCatalog(ctx context.Context, opts PodmanConfigureOptions) error {
 	isDeployed, existingResources, err := deployCtx.CheckStatus()
 	if err != nil {
 		s.Fail("failed to check existing resources")
+
 		return fmt.Errorf("failed to check existing resources: %w", err)
 	}
 
 	if !isDeployed {
-
 		logger.Infoln("loading catalog service param values...", logger.VerbosityLevelDebug)
 
 		// Prepare deployment with domain suffix computation and create Caddy context
 		err = loadCatalogParamValues(deployCtx, passwordHash, opts.HttpsPort)
 		if err != nil {
 			s.Fail("failed to load param values")
+
 			return err
 		}
 
@@ -137,7 +139,6 @@ func handlePostDeployment(caddyCtx *caddy.Context, deployCtx *deploy.DeployConte
 
 // prepareCatalogDeployment prepares all necessary data for deployment including domain suffix computation.
 func loadCatalogParamValues(deployCtx *deploy.DeployContext, passwordHash string, httpsPort int) error {
-
 	// Generate argument parameters
 	argParams, err := generateArgParams(passwordHash, httpsPort)
 	if err != nil {
@@ -155,7 +156,6 @@ func loadCatalogParamValues(deployCtx *deploy.DeployContext, passwordHash string
 
 // generateArgParams generates the argument parameters for template rendering.
 func generateArgParams(passwordHash string, httpsPort int) (map[string]string, error) {
-
 	// Generate database password
 	dbPassword, err := utils.GenerateRandomPassword()
 	if err != nil {
@@ -202,12 +202,13 @@ func generateArgParams(passwordHash string, httpsPort int) (map[string]string, e
 // 1. Gets the Caddy pod name from deployment context templates
 // 2. Computes domain configuration (cert domain extraction + domain suffix resolution)
 // 3. Creates Caddy context with pod name and domain suffix
-// 4. Generates and writes Caddyfile
+// 4. Generates and writes Caddyfile.
 func setupCaddyContext(deployCtx *deploy.DeployContext, opts PodmanConfigureOptions, s *spinner.Spinner) (*caddy.Context, error) {
 	// Get Caddy pod name from deployment context (templates)
 	caddyPodName, err := deployCtx.GetCaddyPodName()
 	if err != nil {
 		s.Fail("failed to find Caddy pod name")
+
 		return nil, fmt.Errorf("failed to find Caddy pod name: %w", err)
 	}
 
@@ -215,6 +216,7 @@ func setupCaddyContext(deployCtx *deploy.DeployContext, opts PodmanConfigureOpti
 	domainSuffix, err := caddy.ComputeDomainConfig(opts.SSLCertPath, opts.SSLKeyPath, opts.DomainName)
 	if err != nil {
 		s.Fail("failed to calculate domain")
+
 		return nil, err
 	}
 
@@ -226,6 +228,7 @@ func setupCaddyContext(deployCtx *deploy.DeployContext, opts PodmanConfigureOpti
 	// Generate and write Caddyfile before deploying
 	if err := caddy.GenerateCaddyfile(opts.BaseDir); err != nil {
 		s.Fail("failed to generate Caddyfile")
+
 		return nil, fmt.Errorf("failed to generate Caddyfile: %w", err)
 	}
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/password_helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/password_helpers.go
@@ -69,6 +69,7 @@ func readPasswordFromTerminal(prompt string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return string(passwordBytes), nil
 }
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/password_helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/password_helpers.go
@@ -1,0 +1,75 @@
+package podman
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/charmbracelet/x/term"
+	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+)
+
+// collectAndHashPassword collects the password from user and returns the hashed password.
+// Returns empty string if the secret already exists (no password needed).
+func collectAndHashPassword(rt runtime.Runtime) (string, error) {
+	secretExists, err := rt.SecretExists(catalogconstants.CatalogSecretName)
+	if err != nil {
+		return "", fmt.Errorf("failed to check existing secrets: %w", err)
+	}
+
+	if secretExists {
+		return "", nil
+	}
+
+	// Prompt for admin password if secret doesn't exist
+	adminPassword, err := promptForPassword()
+	if err != nil {
+		return "", fmt.Errorf("failed to read admin password: %w", err)
+	}
+
+	// Hash the password immediately after collection
+	passwordHash, err := catalogutils.HashPasswordPBKDF2(adminPassword, defaultPasswordIterations)
+	if err != nil {
+		return "", fmt.Errorf("failed to hash password: %w", err)
+	}
+
+	return passwordHash, nil
+}
+
+// promptForPassword prompts the user to enter a password securely with confirmation.
+func promptForPassword() (string, error) {
+	password, err := readPasswordFromTerminal("Enter admin password: ")
+	if err != nil {
+		return "", err
+	}
+
+	if password == "" {
+		return "", fmt.Errorf("password cannot be empty")
+	}
+
+	// Prompt for confirmation
+	confirm, err := readPasswordFromTerminal("Confirm admin password: ")
+	if err != nil {
+		return "", err
+	}
+
+	if password != confirm {
+		return "", fmt.Errorf("passwords do not match")
+	}
+
+	return password, nil
+}
+
+// readPasswordFromTerminal reads a password from the terminal without echoing.
+func readPasswordFromTerminal(prompt string) (string, error) {
+	fmt.Print(prompt)
+	passwordBytes, err := term.ReadPassword(uintptr(syscall.Stdin))
+	fmt.Println() // Print newline after password input
+	if err != nil {
+		return "", err
+	}
+	return string(passwordBytes), nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/info/podman/info.go
+++ b/ai-services/internal/pkg/catalog/cli/info/podman/info.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/assets"
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure/podman"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
@@ -50,7 +51,7 @@ func DisplayCatalogInfo() error {
 
 	// Step 3: Fetch route information
 	tp := templates.NewEmbedTemplateProvider(&assets.CatalogFS, "")
-	routeDomains, httpsPort, err := podman.GetCatalogRouteInfo(runtime, tp, catalogTemplate, nil)
+	routeDomains, httpsPort, err := GetCatalogRouteInfo(runtime)
 	if err != nil {
 		logger.Errorf("failed to get route info: %v\n", err)
 		// Continue with basic info display
@@ -70,6 +71,35 @@ func DisplayCatalogInfo() error {
 	}
 
 	return nil
+}
+
+// GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service.
+// This orchestrates: deployContext gets pod name and route info from templates,
+// caddy.Context queries Caddy for route domains and HTTPS port.
+func GetCatalogRouteInfo(rt *rt.PodmanClient) (map[string]string, string, error) {
+	// Create deployment context to access templates
+	deployCtx, err := deploy.NewDeployContext()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create deployment context: %w", err)
+	}
+
+	// Get Caddy pod name from templates
+	caddyPodName, err := deployCtx.GetCaddyPodName()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get Caddy pod name: %w", err)
+	}
+
+	// Extract route infos from deployment context
+	routeInfos, err := deployCtx.ExtractRouteInfos()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to extract route infos: %w", err)
+	}
+
+	// Create Caddy context (domain suffix not needed for querying existing routes)
+	caddyCtx := caddy.NewContext(caddyPodName, "")
+
+	// Use caddy package to get route info
+	return caddy.GetCatalogRouteInfo(caddyCtx, rt, routeInfos)
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/constants/catalog.go
+++ b/ai-services/internal/pkg/catalog/constants/catalog.go
@@ -34,6 +34,8 @@ const (
 	CatalogVolumeSkipLabel = "ai-services.io/volume-skip-cleanup"
 	// PodmanAuthSecret represents podman auth secret name.
 	PodmanAuthSecret = "podman-auth-secret"
+	// CatalogSecretName represents the catalog secret name.
+	CatalogSecretName = "catalog-secret"
 )
 
 // Pagination constants.

--- a/ai-services/internal/pkg/catalog/utils/password.go
+++ b/ai-services/internal/pkg/catalog/utils/password.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// HashPasswordPBKDF2 generates a PBKDF2 hash of the password with a random salt.
+// The hash is returned in the format: iterations.salt.hash (base64 encoded).
+func HashPasswordPBKDF2(password string, iteration int) (string, error) {
+	salt := make([]byte, constants.Pbkdf2SaltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return "", err
+	}
+
+	hash := pbkdf2.Key([]byte(password), salt, iteration, constants.Pbkdf2KeyLen, sha256.New)
+
+	// Format: iterations.salt.hash (base64 encoded)
+	encoded := fmt.Sprintf("%d.%s.%s",
+		iteration,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(hash))
+
+	return encoded, nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/cli/helpers/helper.go
+++ b/ai-services/internal/pkg/cli/helpers/helper.go
@@ -143,8 +143,7 @@ func existingPods(runtime runtime.Runtime, appName string) ([]string, error) {
 	}
 
 	if len(pods) == 0 {
-		logger.Infof("No existing pods found for application: %s\n", appName)
-
+		// No existing pods found for application
 		return nil, nil
 	}
 

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
@@ -254,7 +253,6 @@ func (c *caddyManager) UnregisterRoute(routeID string) error {
 //   - []Route: List of successfully built and registered routes
 //   - error: nil if routes were registered successfully, error otherwise
 func RegisterRoutesForAppAndReturn(
-	rt runtime.Runtime,
 	appName string,
 	proxyManager ProxyManager,
 	routesAnnotation string,

--- a/ai-services/internal/pkg/runtime/interface.go
+++ b/ai-services/internal/pkg/runtime/interface.go
@@ -26,6 +26,7 @@ type Runtime interface {
 	// Secret operations
 	ListSecrets(filters map[string][]string) ([]string, error)
 	DeleteSecret(name string) error
+	SecretExists(nameOrID string) (bool, error)
 
 	// Volume operations
 	DeleteVolume(name string) error

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -436,6 +436,12 @@ func (kc *OpenshiftClient) DeleteSecret(name string) error {
 	return nil
 }
 
+func (kc *OpenshiftClient) SecretExists(nameOrID string) (bool, error) {
+	logger.Warningln("Not implemented")
+
+	return false, nil
+}
+
 func (kc *OpenshiftClient) DeleteVolume(name string) error {
 	logger.Warningln("Not implemented")
 

--- a/ai-services/internal/pkg/runtime/podman/mapper.go
+++ b/ai-services/internal/pkg/runtime/podman/mapper.go
@@ -1,6 +1,8 @@
 package podman
 
 import (
+	"strings"
+
 	"github.com/containers/podman/v5/libpod/define"
 	podmanTypes "github.com/containers/podman/v5/pkg/domain/entities/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
@@ -146,6 +148,16 @@ func toInspectContainer(input *define.InspectContainerData) *types.Container {
 	if input.Config != nil && input.Config.Healthcheck != nil {
 		container.HealthcheckStartPeriod = input.Config.Healthcheck.StartPeriod
 	}
+
+	envMap := make(map[string]string)
+	const envLen = 2
+	for _, env := range input.Config.Env {
+		values := strings.Split(env, "=")
+		if len(values) == envLen {
+			envMap[values[0]] = values[1]
+		}
+	}
+	container.Env = envMap
 
 	return container
 }

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -421,6 +421,10 @@ func (pc *PodmanClient) ListSecrets(filters map[string][]string) ([]string, erro
 	return secretIDorNames, nil
 }
 
+func (pc *PodmanClient) SecretExists(nameOrID string) (bool, error) {
+	return secrets.Exists(pc.Context, nameOrID)
+}
+
 // Type returns the runtime type for PodmanClient.
 func (pc *PodmanClient) Type() types.RuntimeType {
 	return types.RuntimeTypePodman

--- a/ai-services/internal/pkg/runtime/types/types.go
+++ b/ai-services/internal/pkg/runtime/types/types.go
@@ -44,6 +44,7 @@ type Container struct {
 	Status                 string
 	Health                 string
 	Annotations            map[string]string
+	Env                    map[string]string
 	HealthcheckStartPeriod time.Duration
 }
 

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -579,6 +579,16 @@ func getPodmanURIAsRoot() (string, error) {
 	), nil
 }
 
+// GetAuthFilePath determines the auth.json file path based on the current user.
+// Returns the path to the Podman auth.json file for container registry authentication.
+func GetAuthFilePath() (string, error) {
+	if os.Geteuid() == 0 {
+		return "/run/user/0/containers/auth.json", nil
+	}
+
+	return fmt.Sprintf("/run/user/%d/containers/auth.json", os.Getuid()), nil
+}
+
 // ExtractTarGz extracts a tar.gz file to a destination directory.
 func ExtractTarGz(srcFile, destDir string) error {
 	file, err := os.Open(srcFile)
@@ -618,7 +628,19 @@ func ExtractTarGz(srcFile, destDir string) error {
 
 // extractTarEntry extracts a single tar entry.
 func extractTarEntry(tr *tar.Reader, header *tar.Header, destDir string) error {
-	target := filepath.Join(destDir, header.Name)
+	// Get the absolute path of the destination directory
+	destPath, err := filepath.Abs(destDir)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path for destination: %w", err)
+	}
+
+	// Join the paths. filepath.Join automatically calls filepath.Clean
+	target := filepath.Join(destPath, header.Name)
+
+	// ZIP SLIP FIX: Check if the resolved target path falls outside the destination directory
+	if !strings.HasPrefix(target, destPath+string(os.PathSeparator)) && target != destPath {
+		return fmt.Errorf("illegal file path in archive: %s", header.Name)
+	}
 
 	switch header.Typeflag {
 	case tar.TypeDir:


### PR DESCRIPTION
This PR implements architectural refactoring of the catalog configure flow, focusing on the separation of concerns and improved code organization.

- `caddy/` package: Handles all Caddy-specific operations (routes, certificates, domain config)
- `deploy/` package: Manages deployment context and template operations
- `configure/podman/` package: Orchestrates the configuration flow
- Password collection moved to where it's actually used
- Password hashing extracted to reusable utility
- Smart check for existing secrets before prompting
- caddy.Context: Caches Caddy-specific values (admin URLs, domain suffix)
- deploy.DeployContext: Encapsulates deployment operations
- processPodTemplates helper eliminates duplicate template iteration
- Standardized route variable naming
- Shared domain configuration logic