### PR TITLE
[Catalog] Values schema updates

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.97
+TAG?=v0.0.98
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.98
+TAG?=v0.0.97
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.96
+TAG?=v0.0.97
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.98
+  image: icr.io/ai-services-cicd/ai-services:v0.0.97
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.97
+  image: icr.io/ai-services-cicd/ai-services:v0.0.98
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.96
+  image: icr.io/ai-services-cicd/ai-services:v0.0.97
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/components/embedding/vllm-cpu/metadata.yaml
+++ b/ai-services/assets/components/embedding/vllm-cpu/metadata.yaml
@@ -7,3 +7,4 @@ description: "Deploy embedding models on vLLM inference engine (CPU-only)"
 # Component type this provider belongs to
 component_type: embedding
 component_name: "Embedding model"
+default: true

--- a/ai-services/assets/components/embedding/vllm-cpu/podman/values.schema.json
+++ b/ai-services/assets/components/embedding/vllm-cpu/podman/values.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
     "model": {
       "type": "string",

--- a/ai-services/assets/components/llm/vllm-cpu/metadata.yaml
+++ b/ai-services/assets/components/llm/vllm-cpu/metadata.yaml
@@ -6,4 +6,4 @@ description: "Deploy instruct models on vLLM inference engine (CPU-only)"
 
 # Component type this provider belongs to
 component_type: llm
-component_name: "Large Language Model (LLM)"
+component_name: "Large language model (LLM)"

--- a/ai-services/assets/components/llm/vllm-cpu/podman/values.schema.json
+++ b/ai-services/assets/components/llm/vllm-cpu/podman/values.schema.json
@@ -4,8 +4,8 @@
   "properties": {
     "model": {
       "type": "string",
-      "title": "Large Language Model (LLM)",
-      "description": "Large Language Model (LLM)",
+      "title": "Large language model (LLM)",
+      "description": "Large language model (LLM)",
       "oneOf": [
         {
           "const": "ibm-granite/granite-3.3-8b-instruct",

--- a/ai-services/assets/components/llm/vllm-cpu/podman/values.schema.json
+++ b/ai-services/assets/components/llm/vllm-cpu/podman/values.schema.json
@@ -10,7 +10,7 @@
         {
           "const": "ibm-granite/granite-3.3-8b-instruct",
           "title": "granite-3.3-8b-instruct",
-          "description": "**Languages:** English, with multilingual capabilities\n\n**Use Cases:** General-purpose instruction following, Question answering and reasoning, Code generation and explanation, Content creation and summarization\n\n**Strengths:** Balanced performance and efficiency with 8B parameters, Strong instruction following capabilities, Optimized for CPU inference, Suitable for enterprise applications"
+          "description": "An 8-parameter instruction-tuned LLM used for natural language understanding and generation tasks. In this project, it powers tasks such as prompt-based reasoning, summarization, answer generation, and other LLM-driven functionalities.\n\n**Model strengths**: reliable instruction-following, natural conversation, strong reasoning, and enterprise-grade accuracy.\n\n**Supported Languages**: English (primary), Spanish, French, German, Portuguese, Italian, Japanese, Korean, Chinese, Arabic, and 100+ more."
         }
       ],
       "default": "ibm-granite/granite-3.3-8b-instruct"

--- a/ai-services/assets/components/llm/vllm-cpu/podman/values.schema.json
+++ b/ai-services/assets/components/llm/vllm-cpu/podman/values.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
     "model": {
       "type": "string",

--- a/ai-services/assets/components/llm/vllm-cpu/podman/values.schema.json
+++ b/ai-services/assets/components/llm/vllm-cpu/podman/values.schema.json
@@ -20,7 +20,7 @@
       "type": "string",
       "title": "API Key",
       "format": "password",
-      "description": "API key for vLLM instruct service authentication. If empty, authentication is disabled. Provide a key to enable authentication."
+      "description": "Optional API key for securing the vLLM service. If provided, **store it securely**—you will need to enter this key when accessing the Question and Answer service. Leave empty to disable authentication."
     }
   }
 }

--- a/ai-services/assets/components/llm/vllm-spyre/metadata.yaml
+++ b/ai-services/assets/components/llm/vllm-spyre/metadata.yaml
@@ -7,3 +7,4 @@ description: "Deploy instruct models on vLLM inference engine with Spyre acceler
 # Component type this provider belongs to
 component_type: llm
 component_name: "Large language model (LLM)"
+default: true

--- a/ai-services/assets/components/llm/vllm-spyre/metadata.yaml
+++ b/ai-services/assets/components/llm/vllm-spyre/metadata.yaml
@@ -6,4 +6,4 @@ description: "Deploy instruct models on vLLM inference engine with Spyre acceler
 
 # Component type this provider belongs to
 component_type: llm
-component_name: "Large Language Model (LLM)"
+component_name: "Large language model (LLM)"

--- a/ai-services/assets/components/llm/vllm-spyre/podman/values.schema.json
+++ b/ai-services/assets/components/llm/vllm-spyre/podman/values.schema.json
@@ -4,8 +4,8 @@
   "properties": {
     "model": {
       "type": "string",
-      "title": "Large Language Model (LLM)",
-      "description": "Large Language Model (LLM)",
+      "title": "Large language model (LLM)",
+      "description": "Large language model (LLM)",
       "oneOf": [
         {
           "const": "ibm-granite/granite-3.3-8b-instruct",

--- a/ai-services/assets/components/llm/vllm-spyre/podman/values.schema.json
+++ b/ai-services/assets/components/llm/vllm-spyre/podman/values.schema.json
@@ -10,7 +10,7 @@
         {
           "const": "ibm-granite/granite-3.3-8b-instruct",
           "title": "granite-3.3-8b-instruct",
-          "description": "**Languages:** English, with multilingual capabilities\n\n**Use Cases:** General-purpose instruction following, Question answering and reasoning, Code generation and explanation, Content creation and summarization\n\n**Strengths:** Balanced performance and efficiency with 8B parameters, Strong instruction following capabilities, Optimized for GPU inference with Spyre acceleration, Suitable for enterprise applications"
+          "description": "An 8-parameter instruction-tuned LLM used for natural language understanding and generation tasks. In this project, it powers tasks such as prompt-based reasoning, summarization, answer generation, and other LLM-driven functionalities.\n\n**Model strengths**: reliable instruction-following, natural conversation, strong reasoning, and enterprise-grade accuracy.\n\n**Supported Languages**: English (primary), Spanish, French, German, Portuguese, Italian, Japanese, Korean, Chinese, Arabic, and 100+ more."
         }
       ],
       "default": "ibm-granite/granite-3.3-8b-instruct"

--- a/ai-services/assets/components/llm/vllm-spyre/podman/values.schema.json
+++ b/ai-services/assets/components/llm/vllm-spyre/podman/values.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
     "model": {
       "type": "string",

--- a/ai-services/assets/components/llm/vllm-spyre/podman/values.schema.json
+++ b/ai-services/assets/components/llm/vllm-spyre/podman/values.schema.json
@@ -20,7 +20,7 @@
       "type": "string",
       "title": "API Key",
       "format": "password",
-      "description": "API key for vLLM instruct service authentication. If empty, authentication is disabled. Provide a key to enable authentication."
+      "description": "Optional API key for securing the vLLM service. If provided, **store it securely**—you will need to enter this key when accessing the Question and Answer service. Leave empty to disable authentication."
     }
   }
 }

--- a/ai-services/assets/components/llm/watsonx/metadata.yaml
+++ b/ai-services/assets/components/llm/watsonx/metadata.yaml
@@ -6,6 +6,6 @@ description: "Deploy llm models using watsonx"
 
 # Component type this provider belongs to
 component_type: llm
-component_name: "Large Language Model (LLM)"
+component_name: "Large language model (LLM)"
 
 # Made with Bob

--- a/ai-services/assets/components/llm/watsonx/podman/values.schema.json
+++ b/ai-services/assets/components/llm/watsonx/podman/values.schema.json
@@ -11,7 +11,7 @@
         {
           "const": "ibm/granite-4-h-small",
           "title": "granite-4-h-small",
-          "description": "IBM Granite 4 H Small model on Watsonx for chat and instruct workloads"
+          "description": "An 8-parameter instruction-tuned LLM used for natural language understanding and generation tasks. In this project, it powers tasks such as prompt-based reasoning, summarization, answer generation, and other LLM-driven functionalities.\n\n**Model strengths**: reliable instruction-following, natural conversation, strong reasoning, and enterprise-grade accuracy.\n\n**Supported Languages**: English (primary), Spanish, French, German, Portuguese, Italian, Japanese, Korean, Chinese, Arabic, and 100+ more."
         }
       ],
       "default": "ibm/granite-4-h-small"

--- a/ai-services/assets/components/llm/watsonx/podman/values.schema.json
+++ b/ai-services/assets/components/llm/watsonx/podman/values.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": false,
   "required": ["watsonxApiKey", "watsonxProjectId", "watsonxUrl"],
   "properties": {
     "model": {

--- a/ai-services/assets/components/llm/watsonx/podman/values.schema.json
+++ b/ai-services/assets/components/llm/watsonx/podman/values.schema.json
@@ -18,19 +18,19 @@
     },
     "watsonxApiKey": {
       "type": "string",
-      "title": "watsonx API Key",
+      "title": "API Key",
       "format": "password",
-      "description": "watsonx API Key for LiteLLM integration"
+      "description": "API key for accessing watsonx"
     },
     "watsonxProjectId": {
       "type": "string",
-      "title": "watsonx Project ID",
-      "description": "watsonx Project ID for LiteLLM integration"
+      "title": "Project ID",
+      "description": "Find your ID on the watsonx cloud site when you create a project\n\n[Open project](https://dataplatform.cloud.ibm.com/projects/?context=wx)"
     },
     "watsonxUrl": {
       "type": "string",
-      "title": "watsonx Base URL",
-      "description": "watsonx Base URL for LiteLLM integration"
+      "title": "API Endpoint",
+      "description": "API Endpoint for accessing watsonx"
     }
   }
 }

--- a/ai-services/assets/components/llm/watsonx/podman/values.schema.json
+++ b/ai-services/assets/components/llm/watsonx/podman/values.schema.json
@@ -5,7 +5,7 @@
   "properties": {
     "model": {
       "type": "string",
-      "title": "Large Language Model (LLM)",
+      "title": "Large language model (LLM)",
       "description": "Chat/Instruct model name for WatsonX",
       "oneOf": [
         {

--- a/ai-services/assets/components/reranker/vllm-cpu/podman/values.schema.json
+++ b/ai-services/assets/components/reranker/vllm-cpu/podman/values.schema.json
@@ -11,7 +11,7 @@
         {
           "const": "BAAI/bge-reranker-v2-m3",
           "title": "bge-reranker-v2-m3",
-          "description": "A multilingual, cross‑encoder–based reranker model used to improve retrieval quality by scoring and ranking candidate documents. It enhances search relevance by providing high‑accuracy reranking on top of initial vector retrieval."
+          "description": "A multilingual, cross‑encoder–based reranker model used to improve retrieval quality by scoring and ranking candidate documents. It enhances search relevance by providing high‑accuracy reranking on top of initial vector retrieval.\n\n**Model strengths**: Reliable instruction-following, contextual reasoning, and accurate response generation across a wide range of natural language tasks from summarization and question answering to prompt-driven workflows.\n\n**Supported Languages**: English (primary), Spanish, French, German, Portuguese, Italian, Japanese, Korean, Chinese, Arabic, and 90+ more"
         }
       ],
       "default": "BAAI/bge-reranker-v2-m3"

--- a/ai-services/assets/components/reranker/vllm-cpu/podman/values.schema.json
+++ b/ai-services/assets/components/reranker/vllm-cpu/podman/values.schema.json
@@ -10,7 +10,7 @@
         {
           "const": "BAAI/bge-reranker-v2-m3",
           "title": "bge-reranker-v2-m3",
-          "description": "**Languages:** Multilingual (100+ languages)\n\n**Use Cases:** Search result reranking, Document relevance scoring, Query-document matching refinement, RAG pipeline optimization\n\n**Strengths:** State-of-the-art reranking performance, Excellent multilingual support, Efficient inference on CPU, Improved retrieval accuracy for RAG applications"
+          "description": "A multilingual, cross‑encoder–based reranker model used to improve retrieval quality by scoring and ranking candidate documents. It enhances search relevance by providing high‑accuracy reranking on top of initial vector retrieval."
         }
       ],
       "default": "BAAI/bge-reranker-v2-m3"

--- a/ai-services/assets/components/reranker/vllm-cpu/podman/values.schema.json
+++ b/ai-services/assets/components/reranker/vllm-cpu/podman/values.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
     "model": {
       "type": "string",

--- a/ai-services/assets/components/reranker/vllm-spyre/metadata.yaml
+++ b/ai-services/assets/components/reranker/vllm-spyre/metadata.yaml
@@ -7,3 +7,4 @@ description: "Deploy reranker models on vLLM inference engine"
 # Component type this provider belongs to
 component_type: reranker
 component_name: "Reranker model"
+default: true

--- a/ai-services/assets/components/reranker/vllm-spyre/podman/values.schema.json
+++ b/ai-services/assets/components/reranker/vllm-spyre/podman/values.schema.json
@@ -11,7 +11,7 @@
         {
           "const": "BAAI/bge-reranker-v2-m3",
           "title": "bge-reranker-v2-m3",
-          "description": "A multilingual, cross‑encoder–based reranker model used to improve retrieval quality by scoring and ranking candidate documents. It enhances search relevance by providing high‑accuracy reranking on top of initial vector retrieval."
+          "description": "A multilingual, cross‑encoder–based reranker model used to improve retrieval quality by scoring and ranking candidate documents. It enhances search relevance by providing high‑accuracy reranking on top of initial vector retrieval.\n\n**Model strengths**: Reliable instruction-following, contextual reasoning, and accurate response generation across a wide range of natural language tasks from summarization and question answering to prompt-driven workflows.\n\n**Supported Languages**: English (primary), Spanish, French, German, Portuguese, Italian, Japanese, Korean, Chinese, Arabic, and 90+ more."
         }
       ],
       "default": "BAAI/bge-reranker-v2-m3"

--- a/ai-services/assets/components/reranker/vllm-spyre/podman/values.schema.json
+++ b/ai-services/assets/components/reranker/vllm-spyre/podman/values.schema.json
@@ -10,7 +10,7 @@
         {
           "const": "BAAI/bge-reranker-v2-m3",
           "title": "bge-reranker-v2-m3",
-          "description": "**Languages:** Multilingual (100+ languages)\n\n**Use Cases:** Search result reranking, Document relevance scoring, Query-document matching refinement, RAG pipeline optimization\n\n**Strengths:** State-of-the-art reranking performance, Excellent multilingual support, GPU-accelerated inference with Spyre, Improved retrieval accuracy for RAG applications"
+          "description": "A multilingual, cross‑encoder–based reranker model used to improve retrieval quality by scoring and ranking candidate documents. It enhances search relevance by providing high‑accuracy reranking on top of initial vector retrieval."
         }
       ],
       "default": "BAAI/bge-reranker-v2-m3"

--- a/ai-services/assets/components/reranker/vllm-spyre/podman/values.schema.json
+++ b/ai-services/assets/components/reranker/vllm-spyre/podman/values.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
     "model": {
       "type": "string",

--- a/ai-services/assets/components/vector_db/opensearch/metadata.yaml
+++ b/ai-services/assets/components/vector_db/opensearch/metadata.yaml
@@ -7,3 +7,4 @@ description: "Distributed search and analytics engine for vector storage"
 # Component type this provider belongs to
 component_type: vector_store
 component_name: "Vector store"
+default: true

--- a/ai-services/assets/components/vector_db/opensearch/metadata.yaml
+++ b/ai-services/assets/components/vector_db/opensearch/metadata.yaml
@@ -6,4 +6,4 @@ description: "Distributed search and analytics engine for vector storage"
 
 # Component type this provider belongs to
 component_type: vector_store
-component_name: "Vector Store"
+component_name: "Vector store"

--- a/ai-services/assets/components/vector_db/opensearch/podman/values.schema.json
+++ b/ai-services/assets/components/vector_db/opensearch/podman/values.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
-  "properties": {}
+  "properties": {},
+  "additionalProperties": false
 }

--- a/ai-services/assets/services/chat/metadata.yaml
+++ b/ai-services/assets/services/chat/metadata.yaml
@@ -25,18 +25,18 @@ about:
     sections:
       - title: "Version"
         value: "1.0.0"
-      - title: "Large Language Model (LLM)"
+      - title: "Large language model (LLM)"
         value: "granite-3.3-8b-instruct"
       - title: "Inference backend"
         values:
           - "RedHat AI Inference with Spyre"
           - "AI Inference on CPU"
           - "IBM watsonx.ai on IBM Cloud"
-      - title: "Embedding Model"
+      - title: "Embedding model"
         value: "granite-embedding-278m-multilingual"
-      - title: "Reranker Model"
+      - title: "Reranker model"
         value: "bge-reranker-v2-m3"
-      - title: "Vector Store"
+      - title: "Vector store"
         value: "OpenSearch"
 
   - title: "Inputs and outputs"

--- a/ai-services/assets/services/chat/podman/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/services/chat/podman/templates/chat-bot.yaml.tmpl
@@ -104,6 +104,8 @@ spec:
           value: "{{ .Values.backend.chatbot.rerank }}"
         - name: CHATBOT_SIMILARITY_SERVICE_URL
           value: "http://similarity-api-{{ .InstanceSlug }}:7000"
+        - name: CHATBOT_SYSTEM_PROMPT
+          value: "{{ .Values.backend.systemPrompt }}"
       ports:
         - containerPort: 5000
           protocol: TCP

--- a/ai-services/assets/services/chat/podman/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/services/chat/podman/templates/chat-bot.yaml.tmpl
@@ -31,8 +31,6 @@ spec:
           value: "{{ .Values.backend.chatbot.numChunksPostReranker }}"
         - name: CHATBOT_RERANK
           value: "{{ .Values.backend.chatbot.rerank }}"
-        - name: CHATBOT_SYSTEM_PROMPT
-          value: "{{ .Values.backend.systemPrompt }}"
       ports:
         - containerPort: 3000
           protocol: TCP

--- a/ai-services/assets/services/chat/podman/values.schema.json
+++ b/ai-services/assets/services/chat/podman/values.schema.json
@@ -21,7 +21,7 @@
           "description": "Custom initial system prompt for conversational RAG",
           "default": "You are a helpful, conversational AI assistant. Engage naturally with users across multiple turns of conversation. Provide clear, accurate, and contextually relevant responses. Reference previous exchanges when appropriate to maintain conversation flow.",
           "minLength": 10,
-          "maxLength": 2500,
+          "maxLength": 5000,
           "x-ui-controlled-by": "editSystemPrompt"
         }
       }

--- a/ai-services/assets/services/chat/podman/values.schema.json
+++ b/ai-services/assets/services/chat/podman/values.schema.json
@@ -12,37 +12,19 @@
           "title": "Edit system prompt for queries",
           "description": "Enable editing of the system prompt used for conversational queries",
           "default": false,
-          "x-ui-only": true
+          "x-ui-only": true,
+          "x-ui-controls": "systemPrompt"
         },
-        "systemPrompt": {}
-      },
-      "oneOf": [
-        {
-          "properties": {
-            "editSystemPrompt": { 
-              "type": "boolean",
-              "const": false 
-            }
-          }
-        },
-        {
-          "properties": {
-            "editSystemPrompt": { 
-              "type": "boolean",
-              "const": true 
-            },
-            "systemPrompt": {
-              "type": "string",
-              "title": "Prompt text",
-              "description": "Custom initial system prompt for conversational RAG",
-              "default": "You are a helpful, conversational AI assistant. Engage naturally with users across multiple turns of conversation. Provide clear, accurate, and contextually relevant responses. Reference previous exchanges when appropriate to maintain conversation flow.",
-              "minLength": 10,
-              "maxLength": 2500
-            }
-          },
-          "required": ["systemPrompt"]
+        "systemPrompt": {
+          "type": "string",
+          "title": "Prompt text",
+          "description": "Custom initial system prompt for conversational RAG",
+          "default": "You are a helpful, conversational AI assistant. Engage naturally with users across multiple turns of conversation. Provide clear, accurate, and contextually relevant responses. Reference previous exchanges when appropriate to maintain conversation flow.",
+          "minLength": 10,
+          "maxLength": 2500,
+          "x-ui-controlled-by": "editSystemPrompt"
         }
-      ]
+      }
     }
   }
 }

--- a/ai-services/assets/services/chat/podman/values.schema.json
+++ b/ai-services/assets/services/chat/podman/values.schema.json
@@ -1,45 +1,48 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
     "backend": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "editSystemPrompt": {
           "type": "boolean",
           "title": "Edit system prompt for queries",
           "description": "Enable editing of the system prompt used for conversational queries",
-          "default": false
-        }
+          "default": false,
+          "x-ui-only": true
+        },
+        "systemPrompt": {}
       },
-      "dependencies": {
-        "editSystemPrompt": {
-          "oneOf": [
-            {
-              "properties": {
-                "editSystemPrompt": {
-                  "enum": [false]
-                }
-              }
-            },
-            {
-              "properties": {
-                "editSystemPrompt": {
-                  "enum": [true]
-                },
-                "systemPrompt": {
-                  "type": "string",
-                  "title": "Prompt text",
-                  "description": "Custom initial system prompt for conversational RAG",
-                  "default": "You are a helpful, conversational AI assistant. Engage naturally with users across multiple turns of conversation. Provide clear, accurate, and contextually relevant responses. Reference previous exchanges when appropriate to maintain conversation flow.",
-                  "minLength": 10,
-                  "maxLength": 2500
-                }
-              }
+      "oneOf": [
+        {
+          "properties": {
+            "editSystemPrompt": { 
+              "type": "boolean",
+              "const": false 
             }
-          ]
+          }
+        },
+        {
+          "properties": {
+            "editSystemPrompt": { 
+              "type": "boolean",
+              "const": true 
+            },
+            "systemPrompt": {
+              "type": "string",
+              "title": "Prompt text",
+              "description": "Custom initial system prompt for conversational RAG",
+              "default": "You are a helpful, conversational AI assistant. Engage naturally with users across multiple turns of conversation. Provide clear, accurate, and contextually relevant responses. Reference previous exchanges when appropriate to maintain conversation flow.",
+              "minLength": 10,
+              "maxLength": 2500
+            }
+          },
+          "required": ["systemPrompt"]
         }
-      }
+      ]
     }
   }
 }

--- a/ai-services/assets/services/chat/podman/values.schema.json
+++ b/ai-services/assets/services/chat/podman/values.schema.json
@@ -5,13 +5,39 @@
     "backend": {
       "type": "object",
       "properties": {
-        "systemPrompt": {
-          "type": "string",
-          "title": "System Prompt",
-          "description": "Custom initial system prompt for conversational RAG. Leave empty to use default.",
-          "default": "",
-          "minLength": 10,
-          "maxLength": 5000
+        "editSystemPrompt": {
+          "type": "boolean",
+          "title": "Edit system prompt for queries",
+          "description": "Enable editing of the system prompt used for conversational queries",
+          "default": false
+        }
+      },
+      "dependencies": {
+        "editSystemPrompt": {
+          "oneOf": [
+            {
+              "properties": {
+                "editSystemPrompt": {
+                  "enum": [false]
+                }
+              }
+            },
+            {
+              "properties": {
+                "editSystemPrompt": {
+                  "enum": [true]
+                },
+                "systemPrompt": {
+                  "type": "string",
+                  "title": "Prompt text",
+                  "description": "Custom initial system prompt for conversational RAG",
+                  "default": "You are a helpful, conversational AI assistant. Engage naturally with users across multiple turns of conversation. Provide clear, accurate, and contextually relevant responses. Reference previous exchanges when appropriate to maintain conversation flow.",
+                  "minLength": 10,
+                  "maxLength": 2500
+                }
+              }
+            }
+          ]
         }
       }
     }

--- a/ai-services/assets/services/digitize/metadata.yaml
+++ b/ai-services/assets/services/digitize/metadata.yaml
@@ -25,16 +25,16 @@ about:
     sections:
       - title: "Version"
         value: "1.0.0"
-      - title: "Large Language Model (LLM)"
+      - title: "Large language model (LLM)"
         value: "granite-3.3-8b-instruct"
       - title: "Inference backend"
         values:
           - "RedHat AI Inference with Spyre"
           - "AI Inference on CPU"
           - "IBM watsonx.ai on IBM Cloud"
-      - title: "Embedding Model"
+      - title: "Embedding model"
         value: "granite-embedding-278m-multilingual"
-      - title: "Vector Store"
+      - title: "Vector store"
         value: "OpenSearch"
 
   - title: "Inputs and outputs"

--- a/ai-services/assets/services/digitize/podman/values.schema.json
+++ b/ai-services/assets/services/digitize/podman/values.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
-  "properties": {}
+  "properties": {},
+  "additionalProperties": false
 }

--- a/ai-services/assets/services/similarity/metadata.yaml
+++ b/ai-services/assets/services/similarity/metadata.yaml
@@ -29,11 +29,11 @@ about:
         values:
           - "RedHat AI Inference with Spyre"
           - "AI Inference on CPU"
-      - title: "Embedding Model"
+      - title: "Embedding model"
         value: "granite-embedding-278m-multilingual"
-      - title: "Reranker Model"
+      - title: "Reranker model"
         value: "bge-reranker-v2-m3"
-      - title: "Vector Store"
+      - title: "Vector store"
         value: "OpenSearch"
 
   - title: "Inputs and outputs"

--- a/ai-services/assets/services/similarity/podman/values.schema.json
+++ b/ai-services/assets/services/similarity/podman/values.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
-  "properties": {}
+  "properties": {},
+  "additionalProperties": false
 }

--- a/ai-services/assets/services/summarize/metadata.yaml
+++ b/ai-services/assets/services/summarize/metadata.yaml
@@ -23,7 +23,7 @@ about:
     sections:
       - title: "Version"
         value: "1.0.0"
-      - title: "Large Language Model (LLM)"
+      - title: "Large language model (LLM)"
         value: "granite-3.3-8b-instruct"
       - title: "Inference backend"
         values:

--- a/ai-services/assets/services/summarize/podman/values.schema.json
+++ b/ai-services/assets/services/summarize/podman/values.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
-  "properties": {}
+  "properties": {},
+  "additionalProperties": false
 }

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -676,7 +676,7 @@ func extractServiceParams(serviceID string, components []catalogTypes.DeployOpti
 }
 
 // setNestedParam sets a value in a nested map using a dot-notation key.
-// e.g. setNestedParam(m, "backend.systemPrompt", "hello") → m["backend"]["systemPrompt"] = "hello"
+// e.g. setNestedParam(m, "backend.systemPrompt", "hello") → m["backend"]["systemPrompt"] = "hello".
 func setNestedParam(m map[string]any, dotKey string, value string) {
 	parts := strings.SplitN(dotKey, ".", paramSplitParts)
 	if len(parts) == 1 {

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -833,9 +833,10 @@ func applySchemaDefaults(appClient *catalogClient.ApplicationClient, componentTy
 	maps.Copy(result, defaults)
 
 	// Override with user-provided params (excluding 'provider' key)
+	// Support nested parameters using dot notation (e.g., auth.password)
 	for k, v := range userParams {
 		if k != "provider" {
-			result[k] = v
+			setNestedParam(result, k, v)
 		}
 	}
 

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -646,6 +646,7 @@ func buildServiceEntryWithDeployOptions(appClient *catalogClient.ApplicationClie
 // extractServiceParams extracts service-level parameters from argParams, excluding component params.
 // Format: {serviceID}.{param} -> {param}.
 // Excludes: {serviceID}.{componentType}.{param} (those are component params).
+// Nested dot-notation keys (e.g. backend.systemPrompt) are expanded into nested maps.
 func extractServiceParams(serviceID string, components []catalogTypes.DeployOptionsComponent, allParams map[string]string) map[string]any {
 	serviceParams := make(map[string]any)
 	servicePrefix := serviceID + "."
@@ -667,11 +668,30 @@ func extractServiceParams(serviceID string, components []catalogTypes.DeployOpti
 
 		// Only add to service params if it's not a component param.
 		if !isComponentParam {
-			serviceParams[after] = value
+			setNestedParam(serviceParams, after, value)
 		}
 	}
 
 	return serviceParams
+}
+
+// setNestedParam sets a value in a nested map using a dot-notation key.
+// e.g. setNestedParam(m, "backend.systemPrompt", "hello") → m["backend"]["systemPrompt"] = "hello"
+func setNestedParam(m map[string]any, dotKey string, value string) {
+	parts := strings.SplitN(dotKey, ".", paramSplitParts)
+	if len(parts) == 1 {
+		m[dotKey] = value
+
+		return
+	}
+
+	nested, ok := m[parts[0]].(map[string]any)
+	if !ok {
+		nested = make(map[string]any)
+		m[parts[0]] = nested
+	}
+
+	setNestedParam(nested, parts[1], value)
 }
 
 // isComponentParameter checks if a parameter belongs to a component.

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -191,6 +191,7 @@ func displayPropertiesRecursive(parentSchema map[string]any, properties map[stri
 		if propType == "object" {
 			if nestedProps, ok := prop["properties"].(map[string]any); ok {
 				displayPropertiesRecursive(prop, nestedProps, fmt.Sprintf("%s.%s", prefix, paramName))
+
 				continue
 			}
 		}
@@ -208,67 +209,116 @@ func displayPropertiesRecursive(parentSchema map[string]any, properties map[stri
 // in conditional branches (oneOf, anyOf, allOf, dependencies, if/then/else).
 // It merges properties from all branches, with later definitions taking precedence.
 func collectAllProperties(parentSchema map[string]any, baseProperties map[string]any) map[string]any {
-	result := make(map[string]any)
+	result := initializeBaseProperties(baseProperties)
 
-	// Start with base properties, skipping empty placeholders
+	// Collect from conditional branches at current schema level
+	collectConditionalBranches(parentSchema, result)
+
+	// Check dependencies (legacy pattern)
+	collectDependencyBranches(parentSchema, result)
+
+	// Check if/then/else
+	collectIfThenElseBranches(parentSchema, result)
+
+	return result
+}
+
+// initializeBaseProperties creates the initial result map with base properties,
+// skipping empty placeholders.
+func initializeBaseProperties(baseProperties map[string]any) map[string]any {
+	result := make(map[string]any)
 	for name, prop := range baseProperties {
-		if propMap, ok := prop.(map[string]any); ok && len(propMap) > 0 {
+		if isValidProperty(prop) {
 			result[name] = prop
 		}
 	}
 
-	// Collect from conditional branches at current level
-	collectFromBranches := func(branches []any) {
-		for _, branch := range branches {
-			if branchMap, ok := branch.(map[string]any); ok {
-				if branchProps, ok := branchMap["properties"].(map[string]any); ok {
-					for name, prop := range branchProps {
-						// Only add if not already present or if this has more detail
-						if existing, exists := result[name]; !exists {
-							result[name] = prop
-						} else if existingMap, ok := existing.(map[string]any); ok {
-							if propMap, ok := prop.(map[string]any); ok && len(propMap) > len(existingMap) {
-								result[name] = prop
-							}
-						}
-					}
-				}
-			}
-		}
-	}
+	return result
+}
 
-	// Check oneOf/anyOf/allOf at current schema level
+// isValidProperty checks if a property is valid (non-empty map).
+func isValidProperty(prop any) bool {
+	propMap, ok := prop.(map[string]any)
+
+	return ok && len(propMap) > 0
+}
+
+// collectConditionalBranches collects properties from oneOf/anyOf/allOf branches.
+func collectConditionalBranches(parentSchema map[string]any, result map[string]any) {
 	for _, keyword := range []string{"oneOf", "anyOf", "allOf"} {
 		if branches, ok := parentSchema[keyword].([]any); ok {
-			collectFromBranches(branches)
+			mergePropertiesFromBranches(branches, result)
 		}
 	}
+}
 
-	// Check dependencies (legacy pattern)
-	if deps, ok := parentSchema["dependencies"].(map[string]any); ok {
-		for _, depValue := range deps {
-			if depSchema, ok := depValue.(map[string]any); ok {
-				for _, keyword := range []string{"oneOf", "anyOf", "allOf"} {
-					if branches, ok := depSchema[keyword].([]any); ok {
-						collectFromBranches(branches)
-					}
-				}
-			}
-		}
+// collectDependencyBranches collects properties from dependency schemas.
+func collectDependencyBranches(parentSchema map[string]any, result map[string]any) {
+	deps, ok := parentSchema["dependencies"].(map[string]any)
+	if !ok {
+		return
 	}
 
-	// Check if/then/else
+	for _, depValue := range deps {
+		depSchema, ok := depValue.(map[string]any)
+		if !ok {
+			continue
+		}
+		collectConditionalBranches(depSchema, result)
+	}
+}
+
+// collectIfThenElseBranches collects properties from if/then/else branches.
+func collectIfThenElseBranches(parentSchema map[string]any, result map[string]any) {
 	for _, keyword := range []string{"then", "else"} {
 		if branch, ok := parentSchema[keyword].(map[string]any); ok {
-			if branchProps, ok := branch["properties"].(map[string]any); ok {
-				for name, prop := range branchProps {
-					if _, exists := result[name]; !exists {
-						result[name] = prop
-					}
-				}
-			}
+			mergePropertiesFromBranch(branch, result)
 		}
 	}
+}
 
-	return result
+// mergePropertiesFromBranches merges properties from multiple branches into result.
+func mergePropertiesFromBranches(branches []any, result map[string]any) {
+	for _, branch := range branches {
+		branchMap, ok := branch.(map[string]any)
+		if !ok {
+			continue
+		}
+		mergePropertiesFromBranch(branchMap, result)
+	}
+}
+
+// mergePropertiesFromBranch merges properties from a single branch into result.
+func mergePropertiesFromBranch(branchMap map[string]any, result map[string]any) {
+	branchProps, ok := branchMap["properties"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	for name, prop := range branchProps {
+		mergeProperty(name, prop, result)
+	}
+}
+
+// mergeProperty merges a single property into result, preferring more detailed definitions.
+func mergeProperty(name string, prop any, result map[string]any) {
+	existing, exists := result[name]
+	if !exists {
+		result[name] = prop
+
+		return
+	}
+
+	// Replace if new property has more detail
+	if shouldReplaceProperty(existing, prop) {
+		result[name] = prop
+	}
+}
+
+// shouldReplaceProperty determines if an existing property should be replaced
+// with a new one based on detail level (map size).
+func shouldReplaceProperty(existing, new any) bool {
+	existingMap, existingOk := existing.(map[string]any)
+	newMap, newOk := new.(map[string]any)
+	return existingOk && newOk && len(newMap) > len(existingMap)
 }

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -162,14 +162,25 @@ func displaySchemaParameters(schema map[string]any, prefix string) {
 		return
 	}
 
-	displayPropertiesRecursive(properties, prefix)
+	displayPropertiesRecursive(schema, properties, prefix)
 }
 
 // displayPropertiesRecursive recursively displays properties, handling nested objects.
-func displayPropertiesRecursive(properties map[string]any, prefix string) {
-	for paramName, propValue := range properties {
+// It skips fields marked with "x-ui-only": true (UI-only fields with no CLI meaning)
+// and collects all properties from the schema including those in conditional branches.
+func displayPropertiesRecursive(parentSchema map[string]any, properties map[string]any, prefix string) {
+	// Collect all properties including those from conditional branches
+	allProperties := collectAllProperties(parentSchema, properties)
+
+	// Display each property
+	for paramName, propValue := range allProperties {
 		prop, ok := propValue.(map[string]any)
 		if !ok {
+			continue
+		}
+
+		// Skip fields explicitly marked as UI-only
+		if uiOnly, _ := prop["x-ui-only"].(bool); uiOnly {
 			continue
 		}
 
@@ -179,17 +190,85 @@ func displayPropertiesRecursive(properties map[string]any, prefix string) {
 		// If this is an object type with nested properties, recurse into it
 		if propType == "object" {
 			if nestedProps, ok := prop["properties"].(map[string]any); ok {
-				displayPropertiesRecursive(nestedProps, fmt.Sprintf("%s.%s", prefix, paramName))
-
+				displayPropertiesRecursive(prop, nestedProps, fmt.Sprintf("%s.%s", prefix, paramName))
 				continue
 			}
 		}
 
-		// Append default value if present and not empty
+		// Display the parameter with its description and default value
 		if defaultValue, hasDefault := prop["default"]; hasDefault && defaultValue != nil && defaultValue != "" {
 			logger.Infof("  %s.%s: %s (Default: %v)", prefix, paramName, description, defaultValue)
 		} else {
 			logger.Infof("  %s.%s: %s", prefix, paramName, description)
 		}
 	}
+}
+
+// collectAllProperties gathers all properties from a schema, including those defined
+// in conditional branches (oneOf, anyOf, allOf, dependencies, if/then/else).
+// It merges properties from all branches, with later definitions taking precedence.
+func collectAllProperties(parentSchema map[string]any, baseProperties map[string]any) map[string]any {
+	result := make(map[string]any)
+
+	// Start with base properties, skipping empty placeholders
+	for name, prop := range baseProperties {
+		if propMap, ok := prop.(map[string]any); ok && len(propMap) > 0 {
+			result[name] = prop
+		}
+	}
+
+	// Collect from conditional branches at current level
+	collectFromBranches := func(branches []any) {
+		for _, branch := range branches {
+			if branchMap, ok := branch.(map[string]any); ok {
+				if branchProps, ok := branchMap["properties"].(map[string]any); ok {
+					for name, prop := range branchProps {
+						// Only add if not already present or if this has more detail
+						if existing, exists := result[name]; !exists {
+							result[name] = prop
+						} else if existingMap, ok := existing.(map[string]any); ok {
+							if propMap, ok := prop.(map[string]any); ok && len(propMap) > len(existingMap) {
+								result[name] = prop
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Check oneOf/anyOf/allOf at current schema level
+	for _, keyword := range []string{"oneOf", "anyOf", "allOf"} {
+		if branches, ok := parentSchema[keyword].([]any); ok {
+			collectFromBranches(branches)
+		}
+	}
+
+	// Check dependencies (legacy pattern)
+	if deps, ok := parentSchema["dependencies"].(map[string]any); ok {
+		for _, depValue := range deps {
+			if depSchema, ok := depValue.(map[string]any); ok {
+				for _, keyword := range []string{"oneOf", "anyOf", "allOf"} {
+					if branches, ok := depSchema[keyword].([]any); ok {
+						collectFromBranches(branches)
+					}
+				}
+			}
+		}
+	}
+
+	// Check if/then/else
+	for _, keyword := range []string{"then", "else"} {
+		if branch, ok := parentSchema[keyword].(map[string]any); ok {
+			if branchProps, ok := branch["properties"].(map[string]any); ok {
+				for name, prop := range branchProps {
+					if _, exists := result[name]; !exists {
+						result[name] = prop
+					}
+				}
+			}
+		}
+	}
+
+	return result
 }

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -162,18 +162,13 @@ func displaySchemaParameters(schema map[string]any, prefix string) {
 		return
 	}
 
-	displayPropertiesRecursive(schema, properties, prefix)
+	displayPropertiesRecursive(properties, prefix)
 }
 
 // displayPropertiesRecursive recursively displays properties, handling nested objects.
-// It skips fields marked with "x-ui-only": true (UI-only fields with no CLI meaning)
-// and collects all properties from the schema including those in conditional branches.
-func displayPropertiesRecursive(parentSchema map[string]any, properties map[string]any, prefix string) {
-	// Collect all properties including those from conditional branches
-	allProperties := collectAllProperties(parentSchema, properties)
-
-	// Display each property
-	for paramName, propValue := range allProperties {
+// It skips fields marked with "x-ui-only": true (UI-only fields with no CLI meaning).
+func displayPropertiesRecursive(properties map[string]any, prefix string) {
+	for paramName, propValue := range properties {
 		prop, ok := propValue.(map[string]any)
 		if !ok {
 			continue
@@ -190,135 +185,17 @@ func displayPropertiesRecursive(parentSchema map[string]any, properties map[stri
 		// If this is an object type with nested properties, recurse into it
 		if propType == "object" {
 			if nestedProps, ok := prop["properties"].(map[string]any); ok {
-				displayPropertiesRecursive(prop, nestedProps, fmt.Sprintf("%s.%s", prefix, paramName))
+				displayPropertiesRecursive(nestedProps, fmt.Sprintf("%s.%s", prefix, paramName))
 
 				continue
 			}
 		}
 
-		// Display the parameter with its description and default value
+		// Append default value if present and not empty
 		if defaultValue, hasDefault := prop["default"]; hasDefault && defaultValue != nil && defaultValue != "" {
 			logger.Infof("  %s.%s: %s (Default: %v)", prefix, paramName, description, defaultValue)
 		} else {
 			logger.Infof("  %s.%s: %s", prefix, paramName, description)
 		}
 	}
-}
-
-// collectAllProperties gathers all properties from a schema, including those defined
-// in conditional branches (oneOf, anyOf, allOf, dependencies, if/then/else).
-// It merges properties from all branches, with later definitions taking precedence.
-func collectAllProperties(parentSchema map[string]any, baseProperties map[string]any) map[string]any {
-	result := initializeBaseProperties(baseProperties)
-
-	// Collect from conditional branches at current schema level
-	collectConditionalBranches(parentSchema, result)
-
-	// Check dependencies (legacy pattern)
-	collectDependencyBranches(parentSchema, result)
-
-	// Check if/then/else
-	collectIfThenElseBranches(parentSchema, result)
-
-	return result
-}
-
-// initializeBaseProperties creates the initial result map with base properties,
-// skipping empty placeholders.
-func initializeBaseProperties(baseProperties map[string]any) map[string]any {
-	result := make(map[string]any)
-	for name, prop := range baseProperties {
-		if isValidProperty(prop) {
-			result[name] = prop
-		}
-	}
-
-	return result
-}
-
-// isValidProperty checks if a property is valid (non-empty map).
-func isValidProperty(prop any) bool {
-	propMap, ok := prop.(map[string]any)
-
-	return ok && len(propMap) > 0
-}
-
-// collectConditionalBranches collects properties from oneOf/anyOf/allOf branches.
-func collectConditionalBranches(parentSchema map[string]any, result map[string]any) {
-	for _, keyword := range []string{"oneOf", "anyOf", "allOf"} {
-		if branches, ok := parentSchema[keyword].([]any); ok {
-			mergePropertiesFromBranches(branches, result)
-		}
-	}
-}
-
-// collectDependencyBranches collects properties from dependency schemas.
-func collectDependencyBranches(parentSchema map[string]any, result map[string]any) {
-	deps, ok := parentSchema["dependencies"].(map[string]any)
-	if !ok {
-		return
-	}
-
-	for _, depValue := range deps {
-		depSchema, ok := depValue.(map[string]any)
-		if !ok {
-			continue
-		}
-		collectConditionalBranches(depSchema, result)
-	}
-}
-
-// collectIfThenElseBranches collects properties from if/then/else branches.
-func collectIfThenElseBranches(parentSchema map[string]any, result map[string]any) {
-	for _, keyword := range []string{"then", "else"} {
-		if branch, ok := parentSchema[keyword].(map[string]any); ok {
-			mergePropertiesFromBranch(branch, result)
-		}
-	}
-}
-
-// mergePropertiesFromBranches merges properties from multiple branches into result.
-func mergePropertiesFromBranches(branches []any, result map[string]any) {
-	for _, branch := range branches {
-		branchMap, ok := branch.(map[string]any)
-		if !ok {
-			continue
-		}
-		mergePropertiesFromBranch(branchMap, result)
-	}
-}
-
-// mergePropertiesFromBranch merges properties from a single branch into result.
-func mergePropertiesFromBranch(branchMap map[string]any, result map[string]any) {
-	branchProps, ok := branchMap["properties"].(map[string]any)
-	if !ok {
-		return
-	}
-
-	for name, prop := range branchProps {
-		mergeProperty(name, prop, result)
-	}
-}
-
-// mergeProperty merges a single property into result, preferring more detailed definitions.
-func mergeProperty(name string, prop any, result map[string]any) {
-	existing, exists := result[name]
-	if !exists {
-		result[name] = prop
-
-		return
-	}
-
-	// Replace if new property has more detail
-	if shouldReplaceProperty(existing, prop) {
-		result[name] = prop
-	}
-}
-
-// shouldReplaceProperty determines if an existing property should be replaced
-// with a new one based on detail level (map size).
-func shouldReplaceProperty(existing, new any) bool {
-	existingMap, existingOk := existing.(map[string]any)
-	newMap, newOk := new.(map[string]any)
-	return existingOk && newOk && len(newMap) > len(existingMap)
 }

--- a/ai-services/internal/pkg/catalog/deploy_options.go
+++ b/ai-services/internal/pkg/catalog/deploy_options.go
@@ -248,6 +248,7 @@ func (p *CatalogProvider) buildProvider(comp types.Component, componentType stri
 		Name:        comp.Name,
 		Description: comp.Description,
 		Version:     providerVersion,
+		Default:     comp.Default,
 		Resources:   resources,
 	}
 

--- a/ai-services/internal/pkg/catalog/types/types.go
+++ b/ai-services/internal/pkg/catalog/types/types.go
@@ -165,9 +165,10 @@ type Component struct {
 	ID            string `yaml:"id" json:"id"`
 	Name          string `yaml:"name" json:"name"`
 	Description   string `yaml:"description" json:"description"`
-	Type          string `yaml:"type" json:"type"`                     // "component"
-	ComponentType string `yaml:"component_type" json:"component_type"` // "vector_store", "embedding", "llm", etc.
-	ComponentName string `yaml:"component_name" json:"component_name"` // Display name for component type (e.g., "Vector store", "Large language model")
+	Type          string `yaml:"type" json:"type"`                           // "component"
+	ComponentType string `yaml:"component_type" json:"component_type"`       // "vector_store", "embedding", "llm", etc.
+	ComponentName string `yaml:"component_name" json:"component_name"`       // Display name for component type (e.g., "Vector store", "Large language model")
+	Default       bool   `yaml:"default,omitempty" json:"default,omitempty"` // Whether this is the default provider for this component type
 }
 
 // ComponentSummary represents a component for list API responses.

--- a/ai-services/internal/pkg/catalog/types/types.go
+++ b/ai-services/internal/pkg/catalog/types/types.go
@@ -167,7 +167,7 @@ type Component struct {
 	Description   string `yaml:"description" json:"description"`
 	Type          string `yaml:"type" json:"type"`                     // "component"
 	ComponentType string `yaml:"component_type" json:"component_type"` // "vector_store", "embedding", "llm", etc.
-	ComponentName string `yaml:"component_name" json:"component_name"` // Display name for component type (e.g., "Vector Store", "LLM Model")
+	ComponentName string `yaml:"component_name" json:"component_name"` // Display name for component type (e.g., "Vector store", "Large language model")
 }
 
 // ComponentSummary represents a component for list API responses.

--- a/ai-services/internal/pkg/catalog/validators/schema.go
+++ b/ai-services/internal/pkg/catalog/validators/schema.go
@@ -11,24 +11,27 @@ import (
 )
 
 // ValidateParams validates parameters against a JSON schema.
+// This function relies entirely on the JSON Schema validator to handle all validation logic,
+// including parameter existence, types, constraints, and conditional requirements.
 func ValidateParams(params map[string]any, schema map[string]any, contextName string) error {
 	// If no params provided or schema is empty, skip validation
 	if len(params) == 0 || len(schema) == 0 {
 		return nil
 	}
 
-	// First, validate that all provided params are supported by the schema
-	if err := ValidateSupportedParams(params, schema, contextName); err != nil {
-		return err
-	}
-
 	// Compile and validate against JSON schema
+	// The JSON Schema validator handles everything:
+	// - Parameter existence (via additionalProperties: false in schema)
+	// - Required/optional fields
+	// - Conditional requirements (dependencies, oneOf, anyOf, allOf, if/then/else)
+	// - Type validation
+	// - Format validation
+	// - Constraint validation (minLength, maxLength, min, max, pattern, etc.)
 	compiledSchema, err := compileJSONSchema(schema, contextName)
 	if err != nil {
 		return err
 	}
 
-	// Validate params against schema
 	return validateAgainstSchema(compiledSchema, params, contextName)
 }
 
@@ -83,84 +86,6 @@ func validateAgainstSchema(compiledSchema *jsonschema.Schema, params map[string]
 		return &ValidationError{
 			Code:    http.StatusBadRequest,
 			Message: fmt.Sprintf("Parameter validation failed for %s: %s", contextName, strings.Join(errorMessages, "; ")),
-		}
-	}
-
-	return nil
-}
-
-// ValidateSupportedParams checks if all provided parameters are defined in the schema.
-// This ensures users don't provide unsupported parameters that would be silently ignored.
-func ValidateSupportedParams(params map[string]any, schema map[string]any, contextName string) error {
-	// Extract the properties defined in the schema
-	properties, ok := schema["properties"].(map[string]any)
-	if !ok || len(properties) == 0 {
-		// If no properties defined in schema, no params should be provided
-		if len(params) > 0 {
-			paramKeys := make([]string, 0, len(params))
-			for key := range params {
-				paramKeys = append(paramKeys, key)
-			}
-
-			return &ValidationError{
-				Code:    http.StatusBadRequest,
-				Message: fmt.Sprintf("Unsupported parameters for %s: %s. No parameters are supported for this resource.", contextName, strings.Join(paramKeys, ", ")),
-			}
-		}
-
-		return nil
-	}
-
-	// Check each provided parameter against the schema properties
-	var unsupportedParams []string
-	for paramKey := range params {
-		if err := ValidateNestedParam(paramKey, params[paramKey], properties); err != nil {
-			unsupportedParams = append(unsupportedParams, paramKey)
-		}
-	}
-
-	if len(unsupportedParams) > 0 {
-		// Get list of supported parameters for helpful error message
-		supportedParams := make([]string, 0, len(properties))
-		for key := range properties {
-			supportedParams = append(supportedParams, key)
-		}
-
-		return &ValidationError{
-			Code:    http.StatusBadRequest,
-			Message: fmt.Sprintf("Unsupported parameters for %s: %s. Supported parameters are: %s", contextName, strings.Join(unsupportedParams, ", "), strings.Join(supportedParams, ", ")),
-		}
-	}
-
-	return nil
-}
-
-// ValidateNestedParam validates a parameter key against schema properties, handling nested objects.
-func ValidateNestedParam(paramKey string, paramValue any, properties map[string]any) error {
-	// Check if the parameter exists in the schema properties
-	propSchema, exists := properties[paramKey]
-	if !exists {
-		return fmt.Errorf("parameter '%s' not found in schema", paramKey)
-	}
-
-	// If the parameter value is a map (nested object), validate its nested properties
-	if nestedParams, ok := paramValue.(map[string]any); ok {
-		propSchemaMap, ok := propSchema.(map[string]any)
-		if !ok {
-			return nil // Schema doesn't define nested structure, let JSON schema validator handle it
-		}
-
-		// Check if the property schema defines nested properties
-		nestedProperties, ok := propSchemaMap["properties"].(map[string]any)
-		if !ok || len(nestedProperties) == 0 {
-			return nil // No nested properties defined, let JSON schema validator handle it
-		}
-
-		// Validate each nested parameter
-		for nestedKey := range nestedParams {
-			if _, exists := nestedProperties[nestedKey]; !exists {
-				return fmt.Errorf("nested parameter '%s.%s' not found in schema", paramKey, nestedKey)
-			}
 		}
 	}
 


### PR DESCRIPTION
- Update model description (for known ones) based on Figma
- Update description for watsonx project ID
- Update/modify watsonx params titles
- Return default: true for providers in deploy-options
- Update `chat` values.schema to support `Edit prompt` checkbox
- Avoid unnecessary manual schema validation but rather rely on `jsonschema` pkg

**BUG Fixes**
---
- Fix on create.go CLI where it was not populating nested params! (systemPrompt is nested and it wasnt getting populated)