### PR TITLE
Add retry mechanism to similarity service while connecting to opensearch

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.93
+TAG?=v0.0.94
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -94,7 +94,7 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.10
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.11
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -20,7 +20,7 @@ summarize:
 
 similarity:
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.10
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.11
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -92,7 +92,7 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.10
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.11
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -20,7 +20,7 @@ summarize:
 
 similarity:
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.10
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.11
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -92,7 +92,7 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.10
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.11
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.93
+  image: icr.io/ai-services-cicd/ai-services:v0.0.94
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/similarity/podman/values.yaml
+++ b/ai-services/assets/services/similarity/podman/values.yaml
@@ -1,6 +1,6 @@
 similarity:
   port: ""
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.10
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.11
   log_level: "INFO"
 
 # Made with Bob

--- a/services/similarity/Makefile
+++ b/services/similarity/Makefile
@@ -1,5 +1,5 @@
 IMAGE=similarity-service
-TAG?=v0.0.10
+TAG?=v0.0.11
 
 run:
 	PORT=$${PORT:-7000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/similarity/app.py
+++ b/services/similarity/app.py
@@ -24,6 +24,7 @@ import common.db_utils as db
 from common.misc_utils import get_embedding_endpoint, get_reranker_endpoint, set_request_id, create_llm_session
 from common.error_utils import APIError, ErrorCode, http_error_responses, http_exception_handler
 from common.validation_utils import validate_query_length as _validate_query_length
+from common.retry_utils import retry_on_transient_error
 from similarity.settings import settings
 from similarity.similarity_utils import (
     SimilaritySearchRequest,
@@ -43,9 +44,16 @@ def _initialize_models():
     reranker_model_dict = get_reranker_endpoint()
 
 
+@retry_on_transient_error(max_retries=5, initial_delay=2.0, backoff_multiplier=2.0, max_delay=30.0)
 def _initialize_vectorstore():
+    """
+    Initialize the vector store with retry logic for OpenSearch connection.
+    Uses the common retry mechanism to handle cases where OpenSearch is not ready during service startup.
+    Retries up to 5 times with exponential backoff (2s, 4s, 8s, 16s, 30s).
+    """
     global vectorstore
     vectorstore = db.get_vector_store()
+    logging.info("Successfully initialized vector store connection")
 
 
 @asynccontextmanager


### PR DESCRIPTION
- Sometimes there are failures due to delayed opensearch startup, which leads to similarity service startup getting crashed.
Added retry mechanism while connecting to openseach vector db.