### PR TITLE
feat: ensure catalog configure is idempotent wrt caddy certs and routing

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.102
+TAG?=v0.0.103
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.102
+  image: icr.io/ai-services-cicd/ai-services:v0.0.103
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
@@ -1,10 +1,7 @@
 package caddy
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -114,56 +111,6 @@ func stageCertificates(baseDir, sslCertPath, sslKeyPath string) (string, string,
 	}
 
 	return certFilename, keyFilename, nil
-}
-
-// CertificatesNeedUpdate checks if new certificates differ from existing staged certificates.
-// Returns true if certificates need to be updated, false if they are identical.
-// Assumes staged certificates exist (caller validates this).
-func CertificatesNeedUpdate(newCertPath, newKeyPath, stagedCertPath, stagedKeyPath string) (bool, error) {
-	// Compare certificate hashes
-	newCertHash, err := computeFileHash(newCertPath)
-	if err != nil {
-		return false, fmt.Errorf("failed to compute hash for new certificate: %w", err)
-	}
-
-	stagedCertHash, err := computeFileHash(stagedCertPath)
-	if err != nil {
-		return false, fmt.Errorf("failed to compute hash for staged certificate: %w", err)
-	}
-
-	// Compare key hashes
-	newKeyHash, err := computeFileHash(newKeyPath)
-	if err != nil {
-		return false, fmt.Errorf("failed to compute hash for new key: %w", err)
-	}
-
-	stagedKeyHash, err := computeFileHash(stagedKeyPath)
-	if err != nil {
-		return false, fmt.Errorf("failed to compute hash for staged key: %w", err)
-	}
-
-	// If either cert or key differs, need update
-	return newCertHash != stagedCertHash || newKeyHash != stagedKeyHash, nil
-}
-
-// computeFileHash computes SHA256 hash of a file.
-func computeFileHash(filePath string) (string, error) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to open file: %w", err)
-	}
-	defer func() {
-		if closeErr := file.Close(); closeErr != nil {
-			logger.Warningf("Failed to close file %s: %v", filePath, closeErr)
-		}
-	}()
-
-	hash := sha256.New()
-	if _, err := io.Copy(hash, file); err != nil {
-		return "", fmt.Errorf("failed to compute hash: %w", err)
-	}
-
-	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
@@ -21,20 +22,22 @@ const (
 
 // LoadSSLCertificates stages user-provided certificates for the Caddy pod and updates TLS config via Admin API.
 // Certificate validation is done in the CLI command's PreRunE hook before calling this function.
+// Uses timestamped filenames to ensure Caddy loads fresh certificates without requiring a restart.
 func (c *Context) LoadSSLCertificates(baseDir, sslCertPath, sslKeyPath string) error {
 	logger.Infoln("loading ssl certificate to caddy...", logger.VerbosityLevelDebug)
 	if sslCertPath == "" || sslKeyPath == "" {
 		return nil
 	}
 
-	// Define staged certificate paths
-	stagedCertPath := filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.crt")
-	stagedKeyPath := filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.key")
-
-	// Stage certificates
-	if err := stageCertificates(baseDir, sslCertPath, sslKeyPath); err != nil {
+	// Stage certificates with timestamped filenames (deletes old certificates)
+	certFilename, keyFilename, err := stageCertificates(baseDir, sslCertPath, sslKeyPath)
+	if err != nil {
 		return fmt.Errorf("failed to stage certificates for Caddy: %w", err)
 	}
+
+	// Define staged certificate paths with timestamped filenames
+	stagedCertPath := filepath.Join(baseDir, "common", "caddy", certsDirName, certFilename)
+	stagedKeyPath := filepath.Join(baseDir, "common", "caddy", certsDirName, keyFilename)
 
 	// Get admin URL
 	adminURL, err := c.GetHostAdminURL()
@@ -42,12 +45,12 @@ func (c *Context) LoadSSLCertificates(baseDir, sslCertPath, sslKeyPath string) e
 		return fmt.Errorf("failed to get Caddy admin URL: %w", err)
 	}
 
-	// Load certificates via Admin API
+	// Load certificates via Admin API with timestamped paths
 	if err := utils.LoadUserCertificates(
 		stagedCertPath,
 		stagedKeyPath,
-		filepath.Join(containerDataDir, certsDirName, "tls.crt"),
-		filepath.Join(containerDataDir, certsDirName, "tls.key"),
+		filepath.Join(containerDataDir, certsDirName, certFilename),
+		filepath.Join(containerDataDir, certsDirName, keyFilename),
 		adminURL,
 	); err != nil {
 		return fmt.Errorf("failed to load certificates via Admin API: %w", err)
@@ -58,36 +61,59 @@ func (c *Context) LoadSSLCertificates(baseDir, sslCertPath, sslKeyPath string) e
 	return nil
 }
 
-// stageCertificates stages SSL certificates for Caddy to use.
-func stageCertificates(baseDir, sslCertPath, sslKeyPath string) error {
+// stageCertificates stages SSL certificates for Caddy to use with timestamped filenames.
+// Deletes old certificate files before staging new ones to ensure only one set exists.
+// Returns the certificate and key filenames for use in loading.
+func stageCertificates(baseDir, sslCertPath, sslKeyPath string) (string, string, error) {
 	caddyDataDir := filepath.Join(baseDir, "common", "caddy")
 	certDir := filepath.Join(caddyDataDir, certsDirName)
 	if err := os.MkdirAll(certDir, dirPerm); err != nil {
-		return fmt.Errorf("failed to create Caddy cert directory: %w", err)
+		return "", "", fmt.Errorf("failed to create Caddy cert directory: %w", err)
 	}
 
-	stagedCertPath := filepath.Join(certDir, "tls.crt")
-	stagedKeyPath := filepath.Join(certDir, "tls.key")
+	// Delete old certificate files (tls-*.crt and tls-*.key)
+	oldCerts, _ := filepath.Glob(filepath.Join(certDir, "tls-*.crt"))
+	for _, oldCert := range oldCerts {
+		if err := os.Remove(oldCert); err != nil {
+			logger.Warningf("Failed to remove old certificate %s: %v", oldCert, err)
+		}
+	}
+	oldKeys, _ := filepath.Glob(filepath.Join(certDir, "tls-*.key"))
+	for _, oldKey := range oldKeys {
+		if err := os.Remove(oldKey); err != nil {
+			logger.Warningf("Failed to remove old key %s: %v", oldKey, err)
+		}
+	}
 
+	// Generate timestamped filenames
+	timestamp := time.Now().Unix()
+	certFilename := fmt.Sprintf("tls-%d.crt", timestamp)
+	keyFilename := fmt.Sprintf("tls-%d.key", timestamp)
+
+	stagedCertPath := filepath.Join(certDir, certFilename)
+	stagedKeyPath := filepath.Join(certDir, keyFilename)
+
+	// Read certificate and key files
 	certBytes, err := os.ReadFile(sslCertPath)
 	if err != nil {
-		return fmt.Errorf("failed to read certificate file: %w", err)
+		return "", "", fmt.Errorf("failed to read certificate file: %w", err)
 	}
 
 	keyBytes, err := os.ReadFile(sslKeyPath)
 	if err != nil {
-		return fmt.Errorf("failed to read key file: %w", err)
+		return "", "", fmt.Errorf("failed to read key file: %w", err)
 	}
 
+	// Write staged certificate and key with timestamped filenames
 	if err := os.WriteFile(stagedCertPath, certBytes, filePerm); err != nil {
-		return fmt.Errorf("failed to write staged certificate file: %w", err)
+		return "", "", fmt.Errorf("failed to write staged certificate file: %w", err)
 	}
 
 	if err := os.WriteFile(stagedKeyPath, keyBytes, filePerm); err != nil {
-		return fmt.Errorf("failed to write staged key file: %w", err)
+		return "", "", fmt.Errorf("failed to write staged key file: %w", err)
 	}
 
-	return nil
+	return certFilename, keyFilename, nil
 }
 
 // CertificatesNeedUpdate checks if new certificates differ from existing staged certificates.

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
@@ -1,7 +1,11 @@
 package caddy
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -16,11 +20,31 @@ const (
 	filePerm         = 0o644
 )
 
+// ErrCertificatesAlreadyLoaded is returned when certificates are identical and don't need reloading.
+var ErrCertificatesAlreadyLoaded = errors.New("certificates already loaded")
+
 // LoadSSLCertificates stages user-provided certificates for the Caddy pod and updates TLS config via Admin API.
+// It validates certificate changes and skips loading if certificates are identical to existing ones.
 func (c *Context) LoadSSLCertificates(baseDir, sslCertPath, sslKeyPath string) error {
 	logger.Infoln("loading ssl certificate to caddy...", logger.VerbosityLevelDebug)
 	if sslCertPath == "" || sslKeyPath == "" {
 		return nil
+	}
+
+	// Define staged certificate paths
+	stagedCertPath := filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.crt")
+	stagedKeyPath := filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.key")
+
+	// Validate certificate update (check if certificates changed)
+	err := validateCertificateUpdate(sslCertPath, sslKeyPath, stagedCertPath, stagedKeyPath)
+	if err != nil {
+		if errors.Is(err, ErrCertificatesAlreadyLoaded) {
+			// Certificates are identical, skip staging and loading
+			logger.Infoln("Certificates unchanged, skipping reload")
+			return nil
+		}
+		// Certificate content changed - block update
+		return err
 	}
 
 	// Stage certificates
@@ -36,8 +60,8 @@ func (c *Context) LoadSSLCertificates(baseDir, sslCertPath, sslKeyPath string) e
 
 	// Load certificates via Admin API
 	if err := utils.LoadUserCertificates(
-		filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.crt"),
-		filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.key"),
+		stagedCertPath,
+		stagedKeyPath,
 		filepath.Join(containerDataDir, certsDirName, "tls.crt"),
 		filepath.Join(containerDataDir, certsDirName, "tls.key"),
 		adminURL,
@@ -78,6 +102,84 @@ func stageCertificates(baseDir, sslCertPath, sslKeyPath string) error {
 	}
 
 	return nil
+}
+
+// validateCertificateUpdate validates certificate changes during reconfigure.
+// Returns an error if validation fails or if certificates should be skipped (with special error).
+// Returns nil if certificates can proceed with loading.
+func validateCertificateUpdate(newCertPath, newKeyPath, stagedCertPath, stagedKeyPath string) error {
+	// Check if staged certificates exist from previous successful deployment
+	_, certErr := os.Stat(stagedCertPath)
+	_, keyErr := os.Stat(stagedKeyPath)
+
+	if os.IsNotExist(certErr) || os.IsNotExist(keyErr) {
+		// No staged certificates found - either:
+		// 1. Previous deployment used auto-generated certs, OR
+		// 2. Previous custom cert deployment failed during staging
+		// In both cases, allow cert loading since domain is already validated
+		logger.Infof("No existing custom certificates found, loading new certificates\n")
+		return nil
+	}
+
+	// Staged certificates exist - compare content
+	needsUpdate, err := certificatesNeedUpdate(newCertPath, newKeyPath, stagedCertPath, stagedKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to check certificate status: %w", err)
+	}
+
+	if !needsUpdate {
+		// Certificates are identical - return special error to signal skip
+		return ErrCertificatesAlreadyLoaded
+	}
+
+	// Certificates differ - block update
+	return fmt.Errorf("certificate content change not allowed during reconfigure. Please reset cert")
+}
+
+// certificatesNeedUpdate checks if new certificates differ from existing staged certificates.
+// Returns true if certificates need to be updated, false if they are identical.
+// Assumes staged certificates exist (caller validates this).
+func certificatesNeedUpdate(newCertPath, newKeyPath, stagedCertPath, stagedKeyPath string) (bool, error) {
+	// Compare certificate hashes
+	newCertHash, err := computeFileHash(newCertPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to compute hash for new certificate: %w", err)
+	}
+
+	stagedCertHash, err := computeFileHash(stagedCertPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to compute hash for staged certificate: %w", err)
+	}
+
+	// Compare key hashes
+	newKeyHash, err := computeFileHash(newKeyPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to compute hash for new key: %w", err)
+	}
+
+	stagedKeyHash, err := computeFileHash(stagedKeyPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to compute hash for staged key: %w", err)
+	}
+
+	// If either cert or key differs, need update
+	return newCertHash != stagedCertHash || newKeyHash != stagedKeyHash, nil
+}
+
+// computeFileHash computes SHA256 hash of a file.
+func computeFileHash(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", fmt.Errorf("failed to compute hash: %w", err)
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
@@ -3,7 +3,6 @@ package caddy
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -20,11 +19,8 @@ const (
 	filePerm         = 0o644
 )
 
-// ErrCertificatesAlreadyLoaded is returned when certificates are identical and don't need reloading.
-var ErrCertificatesAlreadyLoaded = errors.New("certificates already loaded")
-
 // LoadSSLCertificates stages user-provided certificates for the Caddy pod and updates TLS config via Admin API.
-// It validates certificate changes and skips loading if certificates are identical to existing ones.
+// Certificate validation is done in the CLI command's PreRunE hook before calling this function.
 func (c *Context) LoadSSLCertificates(baseDir, sslCertPath, sslKeyPath string) error {
 	logger.Infoln("loading ssl certificate to caddy...", logger.VerbosityLevelDebug)
 	if sslCertPath == "" || sslKeyPath == "" {
@@ -34,18 +30,6 @@ func (c *Context) LoadSSLCertificates(baseDir, sslCertPath, sslKeyPath string) e
 	// Define staged certificate paths
 	stagedCertPath := filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.crt")
 	stagedKeyPath := filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.key")
-
-	// Validate certificate update (check if certificates changed)
-	err := validateCertificateUpdate(sslCertPath, sslKeyPath, stagedCertPath, stagedKeyPath)
-	if err != nil {
-		if errors.Is(err, ErrCertificatesAlreadyLoaded) {
-			// Certificates are identical, skip staging and loading
-			logger.Infoln("Certificates unchanged, skipping reload")
-			return nil
-		}
-		// Certificate content changed - block update
-		return err
-	}
 
 	// Stage certificates
 	if err := stageCertificates(baseDir, sslCertPath, sslKeyPath); err != nil {
@@ -68,6 +52,8 @@ func (c *Context) LoadSSLCertificates(baseDir, sslCertPath, sslKeyPath string) e
 	); err != nil {
 		return fmt.Errorf("failed to load certificates via Admin API: %w", err)
 	}
+
+	logger.Infoln("SSL certificates loaded successfully into Caddy")
 
 	return nil
 }
@@ -104,42 +90,10 @@ func stageCertificates(baseDir, sslCertPath, sslKeyPath string) error {
 	return nil
 }
 
-// validateCertificateUpdate validates certificate changes during reconfigure.
-// Returns an error if validation fails or if certificates should be skipped (with special error).
-// Returns nil if certificates can proceed with loading.
-func validateCertificateUpdate(newCertPath, newKeyPath, stagedCertPath, stagedKeyPath string) error {
-	// Check if staged certificates exist from previous successful deployment
-	_, certErr := os.Stat(stagedCertPath)
-	_, keyErr := os.Stat(stagedKeyPath)
-
-	if os.IsNotExist(certErr) || os.IsNotExist(keyErr) {
-		// No staged certificates found - either:
-		// 1. Previous deployment used auto-generated certs, OR
-		// 2. Previous custom cert deployment failed during staging
-		// In both cases, allow cert loading since domain is already validated
-		logger.Infof("No existing custom certificates found, loading new certificates\n")
-		return nil
-	}
-
-	// Staged certificates exist - compare content
-	needsUpdate, err := certificatesNeedUpdate(newCertPath, newKeyPath, stagedCertPath, stagedKeyPath)
-	if err != nil {
-		return fmt.Errorf("failed to check certificate status: %w", err)
-	}
-
-	if !needsUpdate {
-		// Certificates are identical - return special error to signal skip
-		return ErrCertificatesAlreadyLoaded
-	}
-
-	// Certificates differ - block update
-	return fmt.Errorf("certificate content change not allowed during reconfigure. Please reset cert")
-}
-
-// certificatesNeedUpdate checks if new certificates differ from existing staged certificates.
+// CertificatesNeedUpdate checks if new certificates differ from existing staged certificates.
 // Returns true if certificates need to be updated, false if they are identical.
 // Assumes staged certificates exist (caller validates this).
-func certificatesNeedUpdate(newCertPath, newKeyPath, stagedCertPath, stagedKeyPath string) (bool, error) {
+func CertificatesNeedUpdate(newCertPath, newKeyPath, stagedCertPath, stagedKeyPath string) (bool, error) {
 	// Compare certificate hashes
 	newCertHash, err := computeFileHash(newCertPath)
 	if err != nil {
@@ -172,7 +126,11 @@ func computeFileHash(filePath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to open file: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			logger.Warningf("Failed to close file %s: %v", filePath, closeErr)
+		}
+	}()
 
 	hash := sha256.New()
 	if _, err := io.Copy(hash, file); err != nil {

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
@@ -8,11 +8,18 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/containers/podman/v5/pkg/bindings/containers"
 	"github.com/project-ai-services/ai-services/assets"
 	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+)
+
+const (
+	domainSuffixEnvVar = "DOMAIN_SUFFIX"
+	httpsPortEnvVar    = "CADDY_HTTPS_PORT"
+	baseDirEnvVar      = "AI_SERVICES_BASE_DIR"
 )
 
 // ComputeDomainConfig computes the domain configuration from SSL certificates and domain name.
@@ -127,6 +134,93 @@ func GenerateCaddyfile(baseDir string) error {
 	caddyfilePath := filepath.Join(caddyDir, "Caddyfile")
 	if err := os.WriteFile(caddyfilePath, rendered.Bytes(), filePerm); err != nil {
 		return fmt.Errorf("failed to write Caddyfile: %w", err)
+	}
+
+	return nil
+}
+
+// GetExistingConfigFromCatalogBackend retrieves the domain, HTTPS port, and base directory from the catalog-backend container.
+// These values are used to validate that configuration hasn't changed during reconfigure operations.
+func GetExistingConfigFromCatalogBackend(rt *podman.PodmanClient) (domain string, httpsPort string, baseDir string, err error) {
+	// Construct the catalog-backend container name dynamically
+	// Pattern: {AppName}--catalog-backend (e.g., "ai-services--catalog-backend")
+	// This follows the Podman naming convention: {podName}-{containerName}
+	catalogBackendContainerName := fmt.Sprintf("%s--catalog-backend", catalogconstants.CatalogAppName)
+
+	// Inspect the catalog-backend container
+	stats, err := containers.Inspect(rt.Context, catalogBackendContainerName, nil)
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to inspect catalog-backend container '%s': %w", catalogBackendContainerName, err)
+	}
+
+	if stats == nil || stats.Config == nil || stats.Config.Env == nil {
+		return "", "", "", fmt.Errorf("invalid container stats when inspecting catalog-backend container")
+	}
+
+	// Extract DOMAIN_SUFFIX, HTTPS_PORT, and BASE_DIR from environment variables
+	for _, envVar := range stats.Config.Env {
+		// Environment variables are in format "KEY=VALUE"
+		parts := strings.SplitN(envVar, "=", 2)
+		if len(parts) == 2 {
+			switch parts[0] {
+			case domainSuffixEnvVar:
+				domain = parts[1]
+			case httpsPortEnvVar:
+				httpsPort = parts[1]
+			case baseDirEnvVar:
+				baseDir = parts[1]
+			}
+			// Early exit if all values found
+			if domain != "" && httpsPort != "" && baseDir != "" {
+				break
+			}
+		}
+	}
+
+	if domain == "" {
+		return "", "", "", fmt.Errorf("DOMAIN_SUFFIX environment variable not found in catalog-backend container")
+	}
+
+	if httpsPort == "" {
+		return "", "", "", fmt.Errorf("CADDY_HTTPS_PORT environment variable not found in catalog-backend container")
+	}
+
+	if baseDir == "" {
+		return "", "", "", fmt.Errorf("AI_SERVICES_BASE_DIR environment variable not found in catalog-backend container")
+	}
+
+	return domain, httpsPort, baseDir, nil
+}
+
+// ValidateReconfigureParameters validates that domain, HTTPS port, and base directory haven't changed during reconfigure.
+// Simplified validation: always check all parameters against existing configuration.
+func ValidateReconfigureParameters(rt *podman.PodmanClient, sslCertPath, sslKeyPath, domainName string, httpsPort int, baseDir string) error {
+	// Get existing configuration from catalog-backend pod
+	existingDomain, existingHTTPSPort, existingBaseDir, err := GetExistingConfigFromCatalogBackend(rt)
+	if err != nil {
+		return fmt.Errorf("failed to get existing configuration from catalog-backend: %w", err)
+	}
+
+	// Always validate domain during reconfigure
+	newDomain, err := ComputeDomainConfig(sslCertPath, sslKeyPath, domainName)
+	if err != nil {
+		return fmt.Errorf("failed to compute domain suffix: %w", err)
+	}
+
+	// Validate domain matches
+	if existingDomain != newDomain {
+		return fmt.Errorf("domain change not allowed during reconfigure: existing=%s, new=%s. Please delete the catalog deployment and reconfigure fresh to change domain", existingDomain, newDomain)
+	}
+
+	// Always validate HTTPS port
+	newPortStr := fmt.Sprintf("%d", httpsPort)
+	if existingHTTPSPort != newPortStr {
+		return fmt.Errorf("HTTPS port change not allowed during reconfigure: existing=%s, new=%s. Catalog is already configured with HTTPS port %s", existingHTTPSPort, newPortStr, existingHTTPSPort)
+	}
+
+	// Always validate base directory
+	if existingBaseDir != baseDir {
+		return fmt.Errorf("base directory change not allowed during reconfigure: existing=%s, new=%s. Please delete the catalog deployment and reconfigure fresh to change base directory", existingBaseDir, baseDir)
 	}
 
 	return nil

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
@@ -8,18 +8,11 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/containers/podman/v5/pkg/bindings/containers"
 	"github.com/project-ai-services/ai-services/assets"
 	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
-)
-
-const (
-	domainSuffixEnvVar = "DOMAIN_SUFFIX"
-	httpsPortEnvVar    = "CADDY_HTTPS_PORT"
-	baseDirEnvVar      = "AI_SERVICES_BASE_DIR"
 )
 
 // ComputeDomainConfig computes the domain configuration from SSL certificates and domain name.
@@ -134,93 +127,6 @@ func GenerateCaddyfile(baseDir string) error {
 	caddyfilePath := filepath.Join(caddyDir, "Caddyfile")
 	if err := os.WriteFile(caddyfilePath, rendered.Bytes(), filePerm); err != nil {
 		return fmt.Errorf("failed to write Caddyfile: %w", err)
-	}
-
-	return nil
-}
-
-// GetExistingConfigFromCatalogBackend retrieves the domain, HTTPS port, and base directory from the catalog-backend container.
-// These values are used to validate that configuration hasn't changed during reconfigure operations.
-func GetExistingConfigFromCatalogBackend(rt *podman.PodmanClient) (domain string, httpsPort string, baseDir string, err error) {
-	// Construct the catalog-backend container name dynamically
-	// Pattern: {AppName}--catalog-backend (e.g., "ai-services--catalog-backend")
-	// This follows the Podman naming convention: {podName}-{containerName}
-	catalogBackendContainerName := fmt.Sprintf("%s--catalog-backend", catalogconstants.CatalogAppName)
-
-	// Inspect the catalog-backend container
-	stats, err := containers.Inspect(rt.Context, catalogBackendContainerName, nil)
-	if err != nil {
-		return "", "", "", fmt.Errorf("failed to inspect catalog-backend container '%s': %w", catalogBackendContainerName, err)
-	}
-
-	if stats == nil || stats.Config == nil || stats.Config.Env == nil {
-		return "", "", "", fmt.Errorf("invalid container stats when inspecting catalog-backend container")
-	}
-
-	// Extract DOMAIN_SUFFIX, HTTPS_PORT, and BASE_DIR from environment variables
-	for _, envVar := range stats.Config.Env {
-		// Environment variables are in format "KEY=VALUE"
-		parts := strings.SplitN(envVar, "=", 2)
-		if len(parts) == 2 {
-			switch parts[0] {
-			case domainSuffixEnvVar:
-				domain = parts[1]
-			case httpsPortEnvVar:
-				httpsPort = parts[1]
-			case baseDirEnvVar:
-				baseDir = parts[1]
-			}
-			// Early exit if all values found
-			if domain != "" && httpsPort != "" && baseDir != "" {
-				break
-			}
-		}
-	}
-
-	if domain == "" {
-		return "", "", "", fmt.Errorf("DOMAIN_SUFFIX environment variable not found in catalog-backend container")
-	}
-
-	if httpsPort == "" {
-		return "", "", "", fmt.Errorf("CADDY_HTTPS_PORT environment variable not found in catalog-backend container")
-	}
-
-	if baseDir == "" {
-		return "", "", "", fmt.Errorf("AI_SERVICES_BASE_DIR environment variable not found in catalog-backend container")
-	}
-
-	return domain, httpsPort, baseDir, nil
-}
-
-// ValidateReconfigureParameters validates that domain, HTTPS port, and base directory haven't changed during reconfigure.
-// Simplified validation: always check all parameters against existing configuration.
-func ValidateReconfigureParameters(rt *podman.PodmanClient, sslCertPath, sslKeyPath, domainName string, httpsPort int, baseDir string) error {
-	// Get existing configuration from catalog-backend pod
-	existingDomain, existingHTTPSPort, existingBaseDir, err := GetExistingConfigFromCatalogBackend(rt)
-	if err != nil {
-		return fmt.Errorf("failed to get existing configuration from catalog-backend: %w", err)
-	}
-
-	// Always validate domain during reconfigure
-	newDomain, err := ComputeDomainConfig(sslCertPath, sslKeyPath, domainName)
-	if err != nil {
-		return fmt.Errorf("failed to compute domain suffix: %w", err)
-	}
-
-	// Validate domain matches
-	if existingDomain != newDomain {
-		return fmt.Errorf("domain change not allowed during reconfigure: existing=%s, new=%s. Please delete the catalog deployment and reconfigure fresh to change domain", existingDomain, newDomain)
-	}
-
-	// Always validate HTTPS port
-	newPortStr := fmt.Sprintf("%d", httpsPort)
-	if existingHTTPSPort != newPortStr {
-		return fmt.Errorf("HTTPS port change not allowed during reconfigure: existing=%s, new=%s. Catalog is already configured with HTTPS port %s", existingHTTPSPort, newPortStr, existingHTTPSPort)
-	}
-
-	// Always validate base directory
-	if existingBaseDir != baseDir {
-		return fmt.Errorf("base directory change not allowed during reconfigure: existing=%s, new=%s. Please delete the catalog deployment and reconfigure fresh to change base directory", existingBaseDir, baseDir)
 	}
 
 	return nil

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -63,21 +63,10 @@ func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployConte
 	s := spinner.New("Configuring catalog service...")
 	s.Start(ctx)
 
-	// Compute domain configuration early (needed for both validation and caddy context)
-	// Note: Certificate validation already done in CLI command's PreRunE hook
-	logger.Infoln("computing domain configuration...", logger.VerbosityLevelDebug)
-	domainSuffix, err := caddy.ComputeDomainConfig(opts.SSLCertPath, opts.SSLKeyPath, opts.DomainName)
-	if err != nil {
-		s.Fail("failed to calculate domain")
-
-		return err
-	}
-	logger.Infof("Using domain suffix: %s\n", domainSuffix, logger.VerbosityLevelDebug)
-
 	logger.Infoln("setting up caddy context...", logger.VerbosityLevelDebug)
 
-	// Setup Caddy context with pre-computed domain suffix and Caddyfile generation
-	caddyCtx, err := setupCaddyContext(deployCtx, opts, domainSuffix, s)
+	// Setup Caddy context with domain configuration and Caddyfile generation
+	caddyCtx, err := setupCaddyContext(deployCtx, opts, s)
 	if err != nil {
 		s.Fail("failed while setting up caddy context")
 
@@ -112,17 +101,19 @@ func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployConte
 
 		s.Stop("Catalog service deployed successfully")
 		logger.Infoln("-------")
+	} else {
+		s.Stop("Catalog service already deployed")
+		logger.Infof("Existing resources: %v\n", existingResources)
+		// Validate domain, HTTPS port, base directory, and certificates haven't changed
+		// Pass pre-computed domainSuffix to avoid recomputing
+		if err := ValidateReconfigureParameters(deployCtx.Runtime, caddyCtx.GetDomainSuffix(), opts.HttpsPort, opts.BaseDir, opts.SSLCertPath, opts.SSLKeyPath); err != nil {
+			s.Fail("validation failed during reconfigure")
+
+			return nil, fmt.Errorf("reconfigure validation failed: %w", err)
+		}
 	}
 
-	logger.Infof("Catalog pod already exists: %v\n", existingResources)
-
-	// Load SSL certificates if provided (validation already done above for reconfigure case)
-	if err := caddyCtx.LoadSSLCertificates(opts.BaseDir, opts.SSLCertPath, opts.SSLKeyPath); err != nil {
-		s.Fail("failed to load SSL certificates")
-		return err
-	}
-
-	return handlePostDeployment(caddyCtx, deployCtx)
+	return caddyCtx, nil
 }
 
 // handlePostDeployment handles route registration and next steps display after catalog deployment.
@@ -227,12 +218,13 @@ func generateArgParams(passwordHash string, httpsPort int) (map[string]string, e
 	return argParams, nil
 }
 
-// setupCaddyContext sets up the Caddy context with pre-computed domain suffix and Caddyfile generation.
+// setupCaddyContext sets up the Caddy context with domain configuration and Caddyfile generation.
 // This function:
 // 1. Gets the Caddy pod name from deployment context templates
-// 2. Creates Caddy context with pod name and pre-computed domain suffix
-// 3. Generates and writes Caddyfile.
-func setupCaddyContext(deployCtx *deploy.DeployContext, opts PodmanConfigureOptions, domainSuffix string, s *spinner.Spinner) (*caddy.Context, error) {
+// 2. Computes domain configuration (cert domain extraction + domain suffix resolution)
+// 3. Creates Caddy context with pod name and domain suffix
+// 4. Generates and writes Caddyfile.
+func setupCaddyContext(deployCtx *deploy.DeployContext, opts PodmanConfigureOptions, s *spinner.Spinner) (*caddy.Context, error) {
 	// Get Caddy pod name from deployment context (templates)
 	caddyPodName, err := deployCtx.GetCaddyPodName()
 	if err != nil {
@@ -241,7 +233,17 @@ func setupCaddyContext(deployCtx *deploy.DeployContext, opts PodmanConfigureOpti
 		return nil, fmt.Errorf("failed to find Caddy pod name: %w", err)
 	}
 
-	// Create Caddy context with pod name and pre-computed domain suffix (NO template dependencies)
+	// Compute domain configuration (cert domain extraction + domain suffix resolution)
+	domainSuffix, err := caddy.ComputeDomainConfig(opts.SSLCertPath, opts.SSLKeyPath, opts.DomainName)
+	if err != nil {
+		s.Fail("failed to calculate domain")
+
+		return nil, err
+	}
+
+	logger.Infof("Using domain suffix: %s\n", domainSuffix, logger.VerbosityLevelDebug)
+
+	// Create Caddy context with pod name and domain suffix (NO template dependencies)
 	caddyCtx := caddy.NewContext(caddyPodName, domainSuffix)
 
 	// Generate and write Caddyfile before deploying

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -105,7 +105,12 @@ func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployConte
 
 	logger.Infof("Catalog pod already exists: %v\n", existingResources)
 
-	return caddyCtx, nil
+	// Load SSL certificates if provided
+	if err := caddyCtx.LoadSSLCertificates(opts.BaseDir, opts.SSLCertPath, opts.SSLKeyPath); err != nil {
+		return err
+	}
+
+	return handlePostDeployment(caddyCtx, deployCtx)
 }
 
 // handlePostDeployment handles route registration and next steps display after catalog deployment.

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -63,10 +63,21 @@ func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployConte
 	s := spinner.New("Configuring catalog service...")
 	s.Start(ctx)
 
+	// Compute domain configuration early (needed for both validation and caddy context)
+	// Note: Certificate validation already done in CLI command's PreRunE hook
+	logger.Infoln("computing domain configuration...", logger.VerbosityLevelDebug)
+	domainSuffix, err := caddy.ComputeDomainConfig(opts.SSLCertPath, opts.SSLKeyPath, opts.DomainName)
+	if err != nil {
+		s.Fail("failed to calculate domain")
+
+		return err
+	}
+	logger.Infof("Using domain suffix: %s\n", domainSuffix, logger.VerbosityLevelDebug)
+
 	logger.Infoln("setting up caddy context...", logger.VerbosityLevelDebug)
 
-	// Setup Caddy context with domain configuration and Caddyfile generation
-	caddyCtx, err := setupCaddyContext(deployCtx, opts, s)
+	// Setup Caddy context with pre-computed domain suffix and Caddyfile generation
+	caddyCtx, err := setupCaddyContext(deployCtx, opts, domainSuffix, s)
 	if err != nil {
 		s.Fail("failed while setting up caddy context")
 
@@ -105,8 +116,9 @@ func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployConte
 
 	logger.Infof("Catalog pod already exists: %v\n", existingResources)
 
-	// Load SSL certificates if provided
+	// Load SSL certificates if provided (validation already done above for reconfigure case)
 	if err := caddyCtx.LoadSSLCertificates(opts.BaseDir, opts.SSLCertPath, opts.SSLKeyPath); err != nil {
+		s.Fail("failed to load SSL certificates")
 		return err
 	}
 
@@ -215,13 +227,12 @@ func generateArgParams(passwordHash string, httpsPort int) (map[string]string, e
 	return argParams, nil
 }
 
-// setupCaddyContext sets up the Caddy context with domain configuration and Caddyfile generation.
+// setupCaddyContext sets up the Caddy context with pre-computed domain suffix and Caddyfile generation.
 // This function:
 // 1. Gets the Caddy pod name from deployment context templates
-// 2. Computes domain configuration (cert domain extraction + domain suffix resolution)
-// 3. Creates Caddy context with pod name and domain suffix
-// 4. Generates and writes Caddyfile.
-func setupCaddyContext(deployCtx *deploy.DeployContext, opts PodmanConfigureOptions, s *spinner.Spinner) (*caddy.Context, error) {
+// 2. Creates Caddy context with pod name and pre-computed domain suffix
+// 3. Generates and writes Caddyfile.
+func setupCaddyContext(deployCtx *deploy.DeployContext, opts PodmanConfigureOptions, domainSuffix string, s *spinner.Spinner) (*caddy.Context, error) {
 	// Get Caddy pod name from deployment context (templates)
 	caddyPodName, err := deployCtx.GetCaddyPodName()
 	if err != nil {
@@ -230,17 +241,7 @@ func setupCaddyContext(deployCtx *deploy.DeployContext, opts PodmanConfigureOpti
 		return nil, fmt.Errorf("failed to find Caddy pod name: %w", err)
 	}
 
-	// Compute domain configuration (cert domain extraction + domain suffix resolution)
-	domainSuffix, err := caddy.ComputeDomainConfig(opts.SSLCertPath, opts.SSLKeyPath, opts.DomainName)
-	if err != nil {
-		s.Fail("failed to calculate domain")
-
-		return nil, err
-	}
-
-	logger.Infof("Using domain suffix: %s\n", domainSuffix, logger.VerbosityLevelDebug)
-
-	// Create Caddy context with pod name and domain suffix (NO template dependencies)
+	// Create Caddy context with pod name and pre-computed domain suffix (NO template dependencies)
 	caddyCtx := caddy.NewContext(caddyPodName, domainSuffix)
 
 	// Generate and write Caddyfile before deploying

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -105,8 +105,7 @@ func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployConte
 		s.Stop("Catalog service already deployed")
 		logger.Infof("Existing resources: %v\n", existingResources)
 		// Validate domain, HTTPS port, base directory, and certificates haven't changed
-		// Pass pre-computed domainSuffix to avoid recomputing
-		if err := ValidateReconfigureParameters(deployCtx.Runtime, caddyCtx.GetDomainSuffix(), opts.HttpsPort, opts.BaseDir, opts.SSLCertPath, opts.SSLKeyPath); err != nil {
+		if err := validateReconfigureParameters(deployCtx.Runtime, &opts, caddyCtx.GetDomainSuffix()); err != nil {
 			s.Fail("validation failed during reconfigure")
 
 			return nil, fmt.Errorf("reconfigure validation failed: %w", err)

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -59,7 +59,7 @@ func ValidateReconfigureParameters(rt runtime.Runtime, domainSuffix string, http
 	return validateCertificateChanges(baseDir, sslCertPath, sslKeyPath)
 }
 
-// validateConfigParameters validates domain, HTTPS port, and base directory haven't changed
+// validateConfigParameters validates domain, HTTPS port, and base directory haven't changed.
 func validateConfigParameters(existingDomain, domainSuffix, existingHTTPSPort string, httpsPort int, existingBaseDir, baseDir string) error {
 	if existingDomain != domainSuffix {
 		return fmt.Errorf("domain change not allowed during reconfigure: existing=%s, new=%s. Please uninstall the catalog deployment and re-run configure to change domain", existingDomain, domainSuffix)
@@ -77,7 +77,7 @@ func validateConfigParameters(existingDomain, domainSuffix, existingHTTPSPort st
 	return nil
 }
 
-// validateCertificateChanges checks if certificate content has changed during reconfigure
+// validateCertificateChanges checks if certificate content has changed during reconfigure.
 func validateCertificateChanges(baseDir, sslCertPath, sslKeyPath string) error {
 	if sslCertPath == "" || sslKeyPath == "" {
 		return nil

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -50,24 +50,31 @@ func ValidateReconfigureParameters(rt runtime.Runtime, domainSuffix string, http
 		return fmt.Errorf("failed to get existing configuration from catalog-backend: %w", err)
 	}
 
-	// Validate domain matches (using pre-computed domain suffix)
+	// Validate configuration parameters haven't changed
+	if err := validateConfigParameters(existingDomain, domainSuffix, existingHTTPSPort, httpsPort, existingBaseDir, baseDir); err != nil {
+		return err
+	}
+
+	// Validate certificate changes if SSL certificates are provided
+	return validateCertificateChanges(baseDir, sslCertPath, sslKeyPath)
+}
+
+// validateConfigParameters validates domain, HTTPS port, and base directory haven't changed
+func validateConfigParameters(existingDomain, domainSuffix, existingHTTPSPort string, httpsPort int, existingBaseDir, baseDir string) error {
 	if existingDomain != domainSuffix {
 		return fmt.Errorf("domain change not allowed during reconfigure: existing=%s, new=%s. Please uninstall the catalog deployment and re-run configure to change domain", existingDomain, domainSuffix)
 	}
 
-	// Always validate HTTPS port
 	newPortStr := fmt.Sprintf("%d", httpsPort)
 	if existingHTTPSPort != newPortStr {
 		return fmt.Errorf("HTTPS port change not allowed during reconfigure: existing=%s, new=%s. Please uninstall the catalog deployment and re-run configure to change https port", existingHTTPSPort, newPortStr)
 	}
 
-	// Always validate base directory
 	if existingBaseDir != baseDir {
 		return fmt.Errorf("base directory change not allowed during reconfigure: existing=%s, new=%s. Please uninstall the catalog deployment and re-run configure to change base directory", existingBaseDir, baseDir)
 	}
 
-	// Validate certificate changes if SSL certificates are provided
-	return validateCertificateChanges(baseDir, sslCertPath, sslKeyPath)
+	return nil
 }
 
 // validateCertificateChanges checks if certificate content has changed during reconfigure

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -2,7 +2,6 @@ package podman
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
@@ -78,25 +77,21 @@ func validateConfigParameters(existingOpts *PodmanConfigureOptions, newOpts *Pod
 
 // validateCertificateChanges prevents switching from custom certificates back to Caddy self-signed certificates.
 // Allows updating custom certificate content (e.g., for expiry or renewal).
+// Uses glob patterns to detect timestamped certificate files.
 func validateCertificateChanges(opts *PodmanConfigureOptions) error {
-	// Define staged certificate paths
-	stagedCertPath := filepath.Join(opts.BaseDir, "common", "caddy", certsDirName, "tls.crt")
-	stagedKeyPath := filepath.Join(opts.BaseDir, "common", "caddy", certsDirName, "tls.key")
+	// Define staged certificate directory
+	certDir := filepath.Join(opts.BaseDir, "common", "caddy", certsDirName)
 
-	// Check if staged certificates exist from previous deployment
-	stagedCertExists := false
-	stagedKeyExists := false
+	// Check if any timestamped certificates exist from previous deployment
+	stagedCerts, _ := filepath.Glob(filepath.Join(certDir, "tls-*.crt"))
+	stagedKeys, _ := filepath.Glob(filepath.Join(certDir, "tls-*.key"))
 
-	if _, err := os.Stat(stagedCertPath); err == nil {
-		stagedCertExists = true
-	}
-	if _, err := os.Stat(stagedKeyPath); err == nil {
-		stagedKeyExists = true
-	}
+	stagedCertExists := len(stagedCerts) > 0
+	stagedKeyExists := len(stagedKeys) > 0
 
 	// If no SSL paths provided in new config but staged certs exist, block cert type change
 	if (opts.SSLCertPath == "" || opts.SSLKeyPath == "") && stagedCertExists && stagedKeyExists {
-		return fmt.Errorf("certificate type change not allowed. Cannot switch to Caddy self-signed certificates during reconfigure. Please uninstall the catalog deployment and re-run configure to change certificate type")
+		return fmt.Errorf("certificate type change not allowed: custom certificates are already configured. Cannot switch to Caddy self-signed certificates during reconfigure. Please uninstall the catalog deployment and re-run configure to change certificate type")
 	}
 
 	// Allow all other scenarios:

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -10,12 +10,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 )
 
-const (
-	domainSuffixEnvVar = "DOMAIN_SUFFIX"
-	httpsPortEnvVar    = "CADDY_HTTPS_PORT"
-	baseDirEnvVar      = "AI_SERVICES_BASE_DIR"
-	certsDirName       = "certs"
-)
+const certsDirName = "certs"
 
 // GetExistingConfigFromCatalogBackend retrieves the domain, HTTPS port, and base directory from the catalog pod.
 // These values are used to validate that configuration hasn't changed during reconfigure operations.
@@ -72,30 +67,36 @@ func ValidateReconfigureParameters(rt runtime.Runtime, domainSuffix string, http
 	}
 
 	// Validate certificate changes if SSL certificates are provided
-	if sslCertPath != "" && sslKeyPath != "" {
-		// Define staged certificate paths
-		stagedCertPath := filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.crt")
-		stagedKeyPath := filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.key")
+	return validateCertificateChanges(baseDir, sslCertPath, sslKeyPath)
+}
 
-		// Check if staged certificates exist from previous successful deployment
-		_, certErr := os.Stat(stagedCertPath)
-		_, keyErr := os.Stat(stagedKeyPath)
+// validateCertificateChanges checks if certificate content has changed during reconfigure
+func validateCertificateChanges(baseDir, sslCertPath, sslKeyPath string) error {
+	if sslCertPath == "" || sslKeyPath == "" {
+		return nil
+	}
 
-		if os.IsNotExist(certErr) || os.IsNotExist(keyErr) {
-			// No staged certificates found - allow cert loading since domain is already validated
-			return nil
-		}
+	// Define staged certificate paths
+	stagedCertPath := filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.crt")
+	stagedKeyPath := filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.key")
 
-		// Staged certificates exist - compare content
-		needsUpdate, err := caddy.CertificatesNeedUpdate(sslCertPath, sslKeyPath, stagedCertPath, stagedKeyPath)
-		if err != nil {
-			return fmt.Errorf("failed to check certificate status: %w", err)
-		}
+	// Check if both staged certificates exist from previous successful deployment
+	if _, err := os.Stat(stagedCertPath); os.IsNotExist(err) {
+		return nil
+	}
+	if _, err := os.Stat(stagedKeyPath); os.IsNotExist(err) {
+		return nil
+	}
 
-		if needsUpdate {
-			// Certificates differ - block update
-			return fmt.Errorf("certificate content change not allowed during reconfigure. Please reset cert")
-		}
+	// Staged certificates exist - compare content
+	needsUpdate, err := caddy.CertificatesNeedUpdate(sslCertPath, sslKeyPath, stagedCertPath, stagedKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to check certificate status: %w", err)
+	}
+
+	if needsUpdate {
+		// Certificates differ - block update
+		return fmt.Errorf("certificate content change not allowed during reconfigure. Please reset cert")
 	}
 
 	return nil

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
+	"strconv"
 
-	"github.com/containers/podman/v5/pkg/bindings/containers"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
-	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 )
 
 const (
@@ -19,63 +17,38 @@ const (
 	certsDirName       = "certs"
 )
 
-// GetExistingConfigFromCatalogBackend retrieves the domain, HTTPS port, and base directory from the catalog-backend container.
+// GetExistingConfigFromCatalogBackend retrieves the domain, HTTPS port, and base directory from the catalog pod.
 // These values are used to validate that configuration hasn't changed during reconfigure operations.
-func GetExistingConfigFromCatalogBackend(rt *podman.PodmanClient) (domain string, httpsPort string, baseDir string, err error) {
-	// Construct the catalog-backend container name dynamically
-	// Pattern: {AppName}--catalog-backend (e.g., "ai-services--catalog-backend")
-	// This follows the Podman naming convention: {podName}-{containerName}
-	catalogBackendContainerName := fmt.Sprintf("%s--catalog-backend", catalogconstants.CatalogAppName)
-
-	// Inspect the catalog-backend container
-	stats, err := containers.Inspect(rt.Context, catalogBackendContainerName, nil)
+func GetExistingConfigFromCatalogBackend(rt runtime.Runtime) (domain string, httpsPort string, baseDir string, err error) {
+	// Use getCatalogPodDetails to retrieve configuration from the catalog pod
+	opts, _, err := getCatalogPodDetails(rt)
 	if err != nil {
-		return "", "", "", fmt.Errorf("failed to inspect catalog-backend container '%s': %w", catalogBackendContainerName, err)
+		return "", "", "", fmt.Errorf("failed to get catalog pod details: %w", err)
 	}
 
-	if stats == nil || stats.Config == nil || stats.Config.Env == nil {
-		return "", "", "", fmt.Errorf("invalid container stats when inspecting catalog-backend container")
+	// Validate that all required configuration values were found
+	if opts.DomainName == "" {
+		return "", "", "", fmt.Errorf("DOMAIN_SUFFIX environment variable not found in catalog pod")
 	}
 
-	// Extract DOMAIN_SUFFIX, HTTPS_PORT, and BASE_DIR from environment variables
-	for _, envVar := range stats.Config.Env {
-		// Environment variables are in format "KEY=VALUE"
-		parts := strings.SplitN(envVar, "=", 2)
-		if len(parts) == 2 {
-			switch parts[0] {
-			case domainSuffixEnvVar:
-				domain = parts[1]
-			case httpsPortEnvVar:
-				httpsPort = parts[1]
-			case baseDirEnvVar:
-				baseDir = parts[1]
-			}
-			// Early exit if all values found
-			if domain != "" && httpsPort != "" && baseDir != "" {
-				break
-			}
-		}
+	if opts.HttpsPort == 0 {
+		return "", "", "", fmt.Errorf("CADDY_HTTPS_PORT environment variable not found in catalog pod")
 	}
 
-	if domain == "" {
-		return "", "", "", fmt.Errorf("DOMAIN_SUFFIX environment variable not found in catalog-backend container")
+	if opts.BaseDir == "" {
+		return "", "", "", fmt.Errorf("AI_SERVICES_BASE_DIR environment variable not found in catalog pod")
 	}
 
-	if httpsPort == "" {
-		return "", "", "", fmt.Errorf("CADDY_HTTPS_PORT environment variable not found in catalog-backend container")
-	}
+	// Convert HttpsPort from int to string for return value
+	httpsPortStr := strconv.Itoa(opts.HttpsPort)
 
-	if baseDir == "" {
-		return "", "", "", fmt.Errorf("AI_SERVICES_BASE_DIR environment variable not found in catalog-backend container")
-	}
-
-	return domain, httpsPort, baseDir, nil
+	return opts.DomainName, httpsPortStr, opts.BaseDir, nil
 }
 
 // ValidateReconfigureParameters validates that domain, HTTPS port, base directory, and certificates haven't changed during reconfigure.
 // This function performs all validation checks including certificate validation.
 // Accepts pre-computed domainSuffix to avoid recomputing it.
-func ValidateReconfigureParameters(rt *podman.PodmanClient, domainSuffix string, httpsPort int, baseDir, sslCertPath, sslKeyPath string) error {
+func ValidateReconfigureParameters(rt runtime.Runtime, domainSuffix string, httpsPort int, baseDir, sslCertPath, sslKeyPath string) error {
 	// Get existing configuration from catalog-backend pod
 	existingDomain, existingHTTPSPort, existingBaseDir, err := GetExistingConfigFromCatalogBackend(rt)
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -1,0 +1,131 @@
+package podman
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containers/podman/v5/pkg/bindings/containers"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
+	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
+)
+
+const (
+	domainSuffixEnvVar = "DOMAIN_SUFFIX"
+	httpsPortEnvVar    = "CADDY_HTTPS_PORT"
+	baseDirEnvVar      = "AI_SERVICES_BASE_DIR"
+	certsDirName       = "certs"
+)
+
+// GetExistingConfigFromCatalogBackend retrieves the domain, HTTPS port, and base directory from the catalog-backend container.
+// These values are used to validate that configuration hasn't changed during reconfigure operations.
+func GetExistingConfigFromCatalogBackend(rt *podman.PodmanClient) (domain string, httpsPort string, baseDir string, err error) {
+	// Construct the catalog-backend container name dynamically
+	// Pattern: {AppName}--catalog-backend (e.g., "ai-services--catalog-backend")
+	// This follows the Podman naming convention: {podName}-{containerName}
+	catalogBackendContainerName := fmt.Sprintf("%s--catalog-backend", catalogconstants.CatalogAppName)
+
+	// Inspect the catalog-backend container
+	stats, err := containers.Inspect(rt.Context, catalogBackendContainerName, nil)
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to inspect catalog-backend container '%s': %w", catalogBackendContainerName, err)
+	}
+
+	if stats == nil || stats.Config == nil || stats.Config.Env == nil {
+		return "", "", "", fmt.Errorf("invalid container stats when inspecting catalog-backend container")
+	}
+
+	// Extract DOMAIN_SUFFIX, HTTPS_PORT, and BASE_DIR from environment variables
+	for _, envVar := range stats.Config.Env {
+		// Environment variables are in format "KEY=VALUE"
+		parts := strings.SplitN(envVar, "=", 2)
+		if len(parts) == 2 {
+			switch parts[0] {
+			case domainSuffixEnvVar:
+				domain = parts[1]
+			case httpsPortEnvVar:
+				httpsPort = parts[1]
+			case baseDirEnvVar:
+				baseDir = parts[1]
+			}
+			// Early exit if all values found
+			if domain != "" && httpsPort != "" && baseDir != "" {
+				break
+			}
+		}
+	}
+
+	if domain == "" {
+		return "", "", "", fmt.Errorf("DOMAIN_SUFFIX environment variable not found in catalog-backend container")
+	}
+
+	if httpsPort == "" {
+		return "", "", "", fmt.Errorf("CADDY_HTTPS_PORT environment variable not found in catalog-backend container")
+	}
+
+	if baseDir == "" {
+		return "", "", "", fmt.Errorf("AI_SERVICES_BASE_DIR environment variable not found in catalog-backend container")
+	}
+
+	return domain, httpsPort, baseDir, nil
+}
+
+// ValidateReconfigureParameters validates that domain, HTTPS port, base directory, and certificates haven't changed during reconfigure.
+// This function performs all validation checks including certificate validation.
+// Accepts pre-computed domainSuffix to avoid recomputing it.
+func ValidateReconfigureParameters(rt *podman.PodmanClient, domainSuffix string, httpsPort int, baseDir, sslCertPath, sslKeyPath string) error {
+	// Get existing configuration from catalog-backend pod
+	existingDomain, existingHTTPSPort, existingBaseDir, err := GetExistingConfigFromCatalogBackend(rt)
+	if err != nil {
+		return fmt.Errorf("failed to get existing configuration from catalog-backend: %w", err)
+	}
+
+	// Validate domain matches (using pre-computed domain suffix)
+	if existingDomain != domainSuffix {
+		return fmt.Errorf("domain change not allowed during reconfigure: existing=%s, new=%s. Please uninstall the catalog deployment and re-run configure to change domain", existingDomain, domainSuffix)
+	}
+
+	// Always validate HTTPS port
+	newPortStr := fmt.Sprintf("%d", httpsPort)
+	if existingHTTPSPort != newPortStr {
+		return fmt.Errorf("HTTPS port change not allowed during reconfigure: existing=%s, new=%s. Please uninstall the catalog deployment and re-run configure to change https port", existingHTTPSPort, newPortStr)
+	}
+
+	// Always validate base directory
+	if existingBaseDir != baseDir {
+		return fmt.Errorf("base directory change not allowed during reconfigure: existing=%s, new=%s. Please uninstall the catalog deployment and re-run configure to change base directory", existingBaseDir, baseDir)
+	}
+
+	// Validate certificate changes if SSL certificates are provided
+	if sslCertPath != "" && sslKeyPath != "" {
+		// Define staged certificate paths
+		stagedCertPath := filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.crt")
+		stagedKeyPath := filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.key")
+
+		// Check if staged certificates exist from previous successful deployment
+		_, certErr := os.Stat(stagedCertPath)
+		_, keyErr := os.Stat(stagedKeyPath)
+
+		if os.IsNotExist(certErr) || os.IsNotExist(keyErr) {
+			// No staged certificates found - allow cert loading since domain is already validated
+			return nil
+		}
+
+		// Staged certificates exist - compare content
+		needsUpdate, err := caddy.CertificatesNeedUpdate(sslCertPath, sslKeyPath, stagedCertPath, stagedKeyPath)
+		if err != nil {
+			return fmt.Errorf("failed to check certificate status: %w", err)
+		}
+
+		if needsUpdate {
+			// Certificates differ - block update
+			return fmt.Errorf("certificate content change not allowed during reconfigure. Please reset cert")
+		}
+	}
+
+	return nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 )
 
@@ -77,35 +76,35 @@ func validateConfigParameters(existingOpts *PodmanConfigureOptions, newOpts *Pod
 	return nil
 }
 
-// validateCertificateChanges checks if certificate content has changed during reconfigure.
+// validateCertificateChanges prevents switching from custom certificates back to Caddy self-signed certificates.
+// Allows updating custom certificate content (e.g., for expiry or renewal).
 func validateCertificateChanges(opts *PodmanConfigureOptions) error {
-	if opts.SSLCertPath == "" || opts.SSLKeyPath == "" {
-		return nil
-	}
-
 	// Define staged certificate paths
 	stagedCertPath := filepath.Join(opts.BaseDir, "common", "caddy", certsDirName, "tls.crt")
 	stagedKeyPath := filepath.Join(opts.BaseDir, "common", "caddy", certsDirName, "tls.key")
 
-	// Check if both staged certificates exist from previous successful deployment
-	if _, err := os.Stat(stagedCertPath); os.IsNotExist(err) {
-		return nil
+	// Check if staged certificates exist from previous deployment
+	stagedCertExists := false
+	stagedKeyExists := false
+
+	if _, err := os.Stat(stagedCertPath); err == nil {
+		stagedCertExists = true
 	}
-	if _, err := os.Stat(stagedKeyPath); os.IsNotExist(err) {
-		return nil
+	if _, err := os.Stat(stagedKeyPath); err == nil {
+		stagedKeyExists = true
 	}
 
-	// Staged certificates exist - compare content
-	needsUpdate, err := caddy.CertificatesNeedUpdate(opts.SSLCertPath, opts.SSLKeyPath, stagedCertPath, stagedKeyPath)
-	if err != nil {
-		return fmt.Errorf("failed to check certificate status: %w", err)
+	// If no SSL paths provided in new config but staged certs exist, block cert type change
+	if (opts.SSLCertPath == "" || opts.SSLKeyPath == "") && stagedCertExists && stagedKeyExists {
+		return fmt.Errorf("certificate type change not allowed. Cannot switch to Caddy self-signed certificates during reconfigure. Please uninstall the catalog deployment and re-run configure to change certificate type")
 	}
 
-	if needsUpdate {
-		// Certificates differ - block update
-		return fmt.Errorf("certificate content change not allowed during reconfigure. Please reset cert")
-	}
-
+	// Allow all other scenarios:
+	// - First run with Caddy certs (no SSL paths, no staged certs)
+	// - First run with custom certs (SSL paths provided, no staged certs)
+	// - Reconfigure with same custom certs (content matches)
+	// - Reconfigure with updated custom certs (content differs - allow for cert renewal/expiry)
+	// - Caddy self-signed to custom certs transition
 	return nil
 }
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
@@ -12,80 +11,81 @@ import (
 
 const certsDirName = "certs"
 
-// GetExistingConfigFromCatalogBackend retrieves the domain, HTTPS port, and base directory from the catalog pod.
+// getExistingConfigFromCatalogBackend retrieves the existing configuration from the catalog pod.
 // These values are used to validate that configuration hasn't changed during reconfigure operations.
-func GetExistingConfigFromCatalogBackend(rt runtime.Runtime) (domain string, httpsPort string, baseDir string, err error) {
-	// Use getCatalogPodDetails to retrieve configuration from the catalog pod
+func getExistingConfigFromCatalogBackend(rt runtime.Runtime) (*PodmanConfigureOptions, error) {
 	opts, _, err := getCatalogPodDetails(rt)
 	if err != nil {
-		return "", "", "", fmt.Errorf("failed to get catalog pod details: %w", err)
+		return nil, fmt.Errorf("failed to get catalog pod details: %w", err)
 	}
 
-	// Validate that all required configuration values were found
-	if opts.DomainName == "" {
-		return "", "", "", fmt.Errorf("DOMAIN_SUFFIX environment variable not found in catalog pod")
+	if err := validateRequiredFields(opts); err != nil {
+		return nil, err
 	}
 
-	if opts.HttpsPort == 0 {
-		return "", "", "", fmt.Errorf("CADDY_HTTPS_PORT environment variable not found in catalog pod")
-	}
-
-	if opts.BaseDir == "" {
-		return "", "", "", fmt.Errorf("AI_SERVICES_BASE_DIR environment variable not found in catalog pod")
-	}
-
-	// Convert HttpsPort from int to string for return value
-	httpsPortStr := strconv.Itoa(opts.HttpsPort)
-
-	return opts.DomainName, httpsPortStr, opts.BaseDir, nil
+	return opts, nil
 }
 
-// ValidateReconfigureParameters validates that domain, HTTPS port, base directory, and certificates haven't changed during reconfigure.
+// validateRequiredFields validates that all required configuration values are present.
+func validateRequiredFields(opts *PodmanConfigureOptions) error {
+	if opts.DomainName == "" {
+		return fmt.Errorf("DOMAIN_SUFFIX environment variable not found in catalog pod")
+	}
+	if opts.HttpsPort == 0 {
+		return fmt.Errorf("CADDY_HTTPS_PORT environment variable not found in catalog pod")
+	}
+	if opts.BaseDir == "" {
+		return fmt.Errorf("AI_SERVICES_BASE_DIR environment variable not found in catalog pod")
+	}
+
+	return nil
+}
+
+// validateReconfigureParameters validates that domain, HTTPS port, base directory, and certificates haven't changed during reconfigure.
 // This function performs all validation checks including certificate validation.
-// Accepts pre-computed domainSuffix to avoid recomputing it.
-func ValidateReconfigureParameters(rt runtime.Runtime, domainSuffix string, httpsPort int, baseDir, sslCertPath, sslKeyPath string) error {
+func validateReconfigureParameters(rt runtime.Runtime, newOpts *PodmanConfigureOptions, domainSuffix string) error {
 	// Get existing configuration from catalog-backend pod
-	existingDomain, existingHTTPSPort, existingBaseDir, err := GetExistingConfigFromCatalogBackend(rt)
+	existingOpts, err := getExistingConfigFromCatalogBackend(rt)
 	if err != nil {
 		return fmt.Errorf("failed to get existing configuration from catalog-backend: %w", err)
 	}
 
 	// Validate configuration parameters haven't changed
-	if err := validateConfigParameters(existingDomain, domainSuffix, existingHTTPSPort, httpsPort, existingBaseDir, baseDir); err != nil {
+	if err := validateConfigParameters(existingOpts, newOpts, domainSuffix); err != nil {
 		return err
 	}
 
 	// Validate certificate changes if SSL certificates are provided
-	return validateCertificateChanges(baseDir, sslCertPath, sslKeyPath)
+
+	return validateCertificateChanges(newOpts)
 }
 
 // validateConfigParameters validates domain, HTTPS port, and base directory haven't changed.
-func validateConfigParameters(existingDomain, domainSuffix, existingHTTPSPort string, httpsPort int, existingBaseDir, baseDir string) error {
-	if existingDomain != domainSuffix {
-		return fmt.Errorf("domain change not allowed during reconfigure: existing=%s, new=%s. Please uninstall the catalog deployment and re-run configure to change domain", existingDomain, domainSuffix)
+func validateConfigParameters(existingOpts *PodmanConfigureOptions, newOpts *PodmanConfigureOptions, domainSuffix string) error {
+	if existingOpts.DomainName != domainSuffix {
+		return fmt.Errorf("domain change not allowed during reconfigure: existing=%s, new=%s. Please uninstall the catalog deployment and re-run configure to change domain", existingOpts.DomainName, domainSuffix)
 	}
 
-	newPortStr := fmt.Sprintf("%d", httpsPort)
-	if existingHTTPSPort != newPortStr {
-		return fmt.Errorf("HTTPS port change not allowed during reconfigure: existing=%s, new=%s. Please uninstall the catalog deployment and re-run configure to change https port", existingHTTPSPort, newPortStr)
+	if existingOpts.HttpsPort != newOpts.HttpsPort {
+		return fmt.Errorf("HTTPS port change not allowed during reconfigure: existing=%d, new=%d. Please uninstall the catalog deployment and re-run configure to change https port", existingOpts.HttpsPort, newOpts.HttpsPort)
 	}
 
-	if existingBaseDir != baseDir {
-		return fmt.Errorf("base directory change not allowed during reconfigure: existing=%s, new=%s. Please uninstall the catalog deployment and re-run configure to change base directory", existingBaseDir, baseDir)
+	if existingOpts.BaseDir != newOpts.BaseDir {
+		return fmt.Errorf("base directory change not allowed during reconfigure: existing=%s, new=%s. Please uninstall the catalog deployment and re-run configure to change base directory", existingOpts.BaseDir, newOpts.BaseDir)
 	}
 
 	return nil
 }
 
 // validateCertificateChanges checks if certificate content has changed during reconfigure.
-func validateCertificateChanges(baseDir, sslCertPath, sslKeyPath string) error {
-	if sslCertPath == "" || sslKeyPath == "" {
+func validateCertificateChanges(opts *PodmanConfigureOptions) error {
+	if opts.SSLCertPath == "" || opts.SSLKeyPath == "" {
 		return nil
 	}
 
 	// Define staged certificate paths
-	stagedCertPath := filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.crt")
-	stagedKeyPath := filepath.Join(baseDir, "common", "caddy", certsDirName, "tls.key")
+	stagedCertPath := filepath.Join(opts.BaseDir, "common", "caddy", certsDirName, "tls.crt")
+	stagedKeyPath := filepath.Join(opts.BaseDir, "common", "caddy", certsDirName, "tls.key")
 
 	// Check if both staged certificates exist from previous successful deployment
 	if _, err := os.Stat(stagedCertPath); os.IsNotExist(err) {
@@ -96,7 +96,7 @@ func validateCertificateChanges(baseDir, sslCertPath, sslKeyPath string) error {
 	}
 
 	// Staged certificates exist - compare content
-	needsUpdate, err := caddy.CertificatesNeedUpdate(sslCertPath, sslKeyPath, stagedCertPath, stagedKeyPath)
+	needsUpdate, err := caddy.CertificatesNeedUpdate(opts.SSLCertPath, opts.SSLKeyPath, stagedCertPath, stagedKeyPath)
 	if err != nil {
 		return fmt.Errorf("failed to check certificate status: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
@@ -12,10 +12,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
-const (
-	catalogContainerName = "ai-services--catalog-backend"
-)
-
 func ResetCatalogPassword() error {
 	// Create deployment context without argParams for status check
 	deployCtx, err := deploy.NewDeployContext()
@@ -37,19 +33,12 @@ func ResetCatalogPassword() error {
 		return fmt.Errorf("failed to delete existing catalog secret: %w", err)
 	}
 
-	podEnv, err := getAndDeleteCatalogPod(deployCtx.Runtime)
+	opts, err := getAndDeleteCatalogPod(deployCtx.Runtime)
 	if err != nil {
 		return fmt.Errorf("failed to get existing catalog pod details: %w", err)
 	}
 
-	baseDir, domainName, httpsPort := getFlagValues(podEnv)
-	opts := PodmanConfigureOptions{
-		BaseDir:    baseDir,
-		DomainName: domainName,
-		HttpsPort:  httpsPort,
-	}
-
-	_, err = executeCatalogDeployment(context.Background(), deployCtx, opts, passwordHash)
+	_, err = executeCatalogDeployment(context.Background(), deployCtx, *opts, passwordHash)
 	if err != nil {
 		return fmt.Errorf("failed to deploy catalog pod: %w", err)
 	}
@@ -57,7 +46,23 @@ func ResetCatalogPassword() error {
 	return nil
 }
 
-func getAndDeleteCatalogPod(rt runtime.Runtime) (map[string]string, error) {
+func getAndDeleteCatalogPod(rt runtime.Runtime) (*PodmanConfigureOptions, error) {
+	opts, podID, err := getCatalogPodDetails(rt)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Infof("Deleting existing catalog pod %s", podID)
+	err = rt.DeletePod(podID, utils.BoolPtr(true))
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete existing catalog pod: %w", err)
+	}
+
+	return opts, nil
+}
+
+// getCatalogPodDetails retrieves catalog pod configuration by inspecting the running pod and its containers.
+func getCatalogPodDetails(rt runtime.Runtime) (*PodmanConfigureOptions, string, error) {
 	// Build filter to find all pods using the catalog secret via label
 	logger.Infof("Getting catalog pod details")
 	filter := map[string][]string{
@@ -71,61 +76,42 @@ func getAndDeleteCatalogPod(rt runtime.Runtime) (map[string]string, error) {
 	// List all pods that reference the catalog secret
 	pods, err := rt.ListPods(filter)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list pods: %w", err)
+		return nil, "", fmt.Errorf("failed to list pods: %w", err)
 	}
 	if len(pods) == 0 {
-		return nil, fmt.Errorf("no catalog pod found")
+		return nil, "", fmt.Errorf("no catalog pod found")
 	}
 
 	// Inspect catalog pod
 	pod := pods[0]
-	podID := ""
-	podEnv := map[string]string{}
 	pInfo, err := rt.InspectPod(pod.ID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to inspect pod %s: %w", pod.Name, err)
+		return nil, "", fmt.Errorf("failed to inspect pod %s: %w", pod.Name, err)
 	}
+
+	opts := &PodmanConfigureOptions{}
 
 	for _, container := range pInfo.Containers {
-		if container.Name == catalogContainerName {
-			// Inspect container for get hold of envs
-			cInfo, err := rt.InspectContainer(container.ID)
-			if err != nil {
-				return nil, fmt.Errorf("failed to inspect container %s: %w", container.Name, err)
-			}
-			podID = pod.ID
-			podEnv = cInfo.Env
-
-			break
+		// Inspect container for get hold of envs
+		cInfo, err := rt.InspectContainer(container.ID)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to inspect container %s: %w", container.Name, err)
 		}
+		getEnvValues(cInfo.Env, opts)
 	}
 
-	logger.Infof("Deleting existing catalog pod %s", podID)
-	err = rt.DeletePod(podID, utils.BoolPtr(true))
-	if err != nil {
-		return podEnv, fmt.Errorf("failed to delete existing catalog pod: %w", err)
-	}
-
-	return podEnv, nil
+	return opts, pod.ID, nil
 }
 
-func getFlagValues(podEnv map[string]string) (string, string, int) {
-	// Setting baseDir global variable
-	var baseDir, domainName string
-	var httpsPort int
+func getEnvValues(podEnv map[string]string, opts *PodmanConfigureOptions) {
+	// Setting required 3 envs
 	if value, ok := podEnv["AI_SERVICES_BASE_DIR"]; ok {
-		baseDir = value
+		opts.BaseDir = value
 	}
-
-	// Setting domainName global variable
 	if value, ok := podEnv["DOMAIN_SUFFIX"]; ok {
-		domainName = value
+		opts.DomainName = value
 	}
-
-	// Setting httpsPort global variable
 	if value, ok := podEnv["CADDY_HTTPS_PORT"]; ok {
-		httpsPort, _ = strconv.Atoi(value)
+		opts.HttpsPort, _ = strconv.Atoi(value)
 	}
-
-	return baseDir, domainName, httpsPort
 }

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -104,6 +104,7 @@ func (c *caddyManager) RegisterRoute(route Route) error {
 	if checkResp.StatusCode() == http.StatusOK {
 		// Route already exists, skip registration
 		logger.Infof("Route %s already exists, skipping registration\n", route.ID, logger.VerbosityLevelDebug)
+
 		return nil
 	}
 
@@ -160,13 +161,11 @@ func extractDomainFromRoute(rawRoute map[string]any) (string, error) {
 
 // GetRouteByID retrieves a specific route by its ID from Caddy.
 func (c *caddyManager) GetRouteByID(routeID string) (*Route, error) {
-	// Build URL to get specific route by ID
 	idURL, err := url.JoinPath(c.adminURL, "id", routeID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build route ID URL: %w", err)
 	}
 
-	// Query Caddy for the specific route
 	var rawRoute map[string]any
 	resp, err := c.httpClient.R().
 		SetResult(&rawRoute).
@@ -183,13 +182,11 @@ func (c *caddyManager) GetRouteByID(routeID string) (*Route, error) {
 		return nil, fmt.Errorf("caddy returned status %d for route %s", resp.StatusCode(), routeID)
 	}
 
-	// Extract domain using helper function
 	domain, err := extractDomainFromRoute(rawRoute)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract domain from route %s: %w", routeID, err)
 	}
 
-	// Build Route object with ID and Domain
 	return &Route{
 		ID:     routeID,
 		Domain: domain,
@@ -310,6 +307,10 @@ func UnregisterRoutesFromEndpoints(
 
 // extractRouteIDsFromEndpoints extracts unique route IDs from endpoints.
 func extractRouteIDsFromEndpoints(endpoints []map[string]any) map[string]bool {
+	if len(endpoints) == 0 {
+		return nil
+	}
+
 	routesToUnregister := make(map[string]bool)
 
 	for _, endpoint := range endpoints {

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -95,35 +95,20 @@ func (c *caddyManager) RegisterRoute(route Route) error {
 		return err
 	}
 
+	// Check if route already exists
 	checkResp, err := c.httpClient.R().Get(idURL)
 	if err != nil {
-		return fmt.Errorf("failed to check route: %w", err)
+		return fmt.Errorf("failed to check route existence: %w", err)
 	}
 
-	switch checkResp.StatusCode() {
-	case http.StatusOK:
-		return c.updateRoute(idURL, routeConfig)
-	case http.StatusNotFound:
-		return c.createRoute(routeConfig)
-	default:
-		return fmt.Errorf("unexpected status checking route: %d", checkResp.StatusCode())
-	}
-}
-
-// Helper to update an existing route via its specific ID URL.
-func (c *caddyManager) updateRoute(idURL string, routeConfig map[string]any) error {
-	resp, err := c.httpClient.R().
-		SetHeader("Content-Type", "application/json").
-		SetBody(routeConfig).
-		Put(idURL)
-	if err != nil {
-		return fmt.Errorf("failed to update route: %w", err)
-	}
-	if resp.StatusCode() != http.StatusOK && resp.StatusCode() != http.StatusCreated {
-		return fmt.Errorf("caddy returned status %d on update: %s", resp.StatusCode(), resp.String())
+	if checkResp.StatusCode() == http.StatusOK {
+		// Route already exists, skip registration
+		logger.Infof("Route %s already exists, skipping registration\n", route.ID, logger.VerbosityLevelDebug)
+		return nil
 	}
 
-	return nil
+	// Route doesn't exist, create it
+	return c.createRoute(routeConfig)
 }
 
 // Helper to append a new route to the server's route array.

--- a/ai-services/internal/pkg/utils/cert.go
+++ b/ai-services/internal/pkg/utils/cert.go
@@ -119,7 +119,8 @@ func ValidateWildcardCertificate(certPath string) error {
 
 // ExtractDomainFromCertificate extracts the base domain from a wildcard certificate.
 // For wildcard certificates (*.example.com), it returns the base domain (example.com).
-// This function requires a wildcard certificate to support multiple service subdomains.
+// This function assumes the certificate has already been validated (including wildcard check)
+// by ValidateWildcardCertificate before calling this function.
 func ExtractDomainFromCertificate(certPath string) (string, error) {
 	cert, err := LoadCertificate(certPath)
 	if err != nil {
@@ -127,6 +128,7 @@ func ExtractDomainFromCertificate(certPath string) (string, error) {
 	}
 
 	// Check Subject Alternative Names (SANs) for wildcard domains
+	// Certificate is pre-validated, so we know a wildcard exists
 	for _, san := range cert.DNSNames {
 		if strings.HasPrefix(san, wildcardPrefix) {
 			// Extract base domain from wildcard (*.example.com → example.com)
@@ -137,7 +139,7 @@ func ExtractDomainFromCertificate(certPath string) (string, error) {
 		}
 	}
 
-	// Check Common Name for wildcard
+	// Check Common Name for wildcard as fallback
 	if cert.Subject.CommonName != "" && strings.HasPrefix(cert.Subject.CommonName, wildcardPrefix) {
 		domain := strings.TrimPrefix(cert.Subject.CommonName, wildcardPrefix)
 		if domain != "" {
@@ -145,18 +147,8 @@ func ExtractDomainFromCertificate(certPath string) (string, error) {
 		}
 	}
 
-	// Build error message with available domains for debugging
-	var availableDomains []string
-	availableDomains = append(availableDomains, cert.DNSNames...)
-	if cert.Subject.CommonName != "" {
-		availableDomains = append(availableDomains, cert.Subject.CommonName)
-	}
-
-	if len(availableDomains) > 0 {
-		return "", fmt.Errorf("certificate must contain a wildcard domain (%sexample.com) to support multiple service subdomains. Found non-wildcard domains: %v", wildcardPrefix, availableDomains)
-	}
-
-	return "", fmt.Errorf("certificate must contain a wildcard domain (%sexample.com) to support multiple service subdomains. No domains found in certificate", wildcardPrefix)
+	// This should not happen if certificate was properly validated
+	return "", fmt.Errorf("failed to extract domain from certificate")
 }
 
 // LoadUserCertificates validates staged certificate files on the host and updates Caddy to load them from container-visible paths.


### PR DESCRIPTION
-Add HTTPS port,domain name, basedir immutability validation during reconfigure 
-Block certificate content changes (require reset-cert) 
-Skip certificate reload when identical
-Simplify route registration to check existence only