### PR TITLE
feat: reset caddy certificate

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.104
+TAG?=v0.0.105
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.104
+  image: icr.io/ai-services-cicd/ai-services:v0.0.105
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -62,7 +62,7 @@ Examples:
 			} else if resetPodmanAuthFlag {
 				return validateResetFlag(cmd, "reset-podman-auth")
 			} else if resetCertificateFlag {
-				return validateResetCertificateFlags(cmd)
+				return validateResetCertificateFlags(cmd, "reset-certificate")
 			}
 
 			return validateConfigureFlags()
@@ -122,7 +122,19 @@ func validateResetFlag(cmd *cobra.Command, flagName string) error {
 	}
 
 	// Check that no configuration parameters are provided with reset flag
-	return checkIncompatibleFlags(cmd, flagName)
+	var invalidFlags []string
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		if f.Name == flagName || f.Name == constants.RuntimeFlag {
+			// Skip reset flag and runtime parameter
+			return
+		}
+		invalidFlags = append(invalidFlags, "--"+f.Name)
+	})
+	if len(invalidFlags) > 0 {
+		return fmt.Errorf("the following flags cannot be used with --%s: %v", flagName, invalidFlags)
+	}
+
+	return nil
 }
 
 // validateConfigureFlags validates the configure command flags and initializes runtime.
@@ -215,7 +227,7 @@ func validateSSLCertificates() error {
 	return nil
 }
 
-func validateResetCertificateFlags(cmd *cobra.Command) error {
+func validateResetCertificateFlags(cmd *cobra.Command, flagName string) error {
 	if err := validateRuntimeFlag(); err != nil {
 		return err
 	}
@@ -232,28 +244,15 @@ func validateResetCertificateFlags(cmd *cobra.Command) error {
 
 	// Check that no other configuration parameters are provided with reset-certificate flag
 	// Allow ssl-cert and ssl-key since they are required for this operation
-	return checkIncompatibleFlags(cmd, "reset-certificate", "ssl-cert", "ssl-key")
-}
-
-// checkIncompatibleFlags validates that only allowed flags are used with a specific flag.
-// Returns an error if any incompatible flags are found, nil otherwise.
-func checkIncompatibleFlags(cmd *cobra.Command, flagName string, allowedFlags ...string) error {
-	// Create a map of allowed flags for quick lookup
-	allowed := make(map[string]bool)
-	allowed[flagName] = true
-	allowed["runtime"] = true // runtime is always allowed
-	for _, flag := range allowedFlags {
-		allowed[flag] = true
-	}
-
-	// Check that no configuration parameters are provided with the specified flag
 	var invalidFlags []string
 	cmd.Flags().Visit(func(f *pflag.Flag) {
-		if !allowed[f.Name] {
-			invalidFlags = append(invalidFlags, "--"+f.Name)
+		if f.Name == flagName || f.Name == constants.RuntimeFlag ||
+			f.Name == "ssl-cert" || f.Name == "ssl-key" {
+			// Skip reset flag, runtime parameter, and required SSL flags
+			return
 		}
+		invalidFlags = append(invalidFlags, "--"+f.Name)
 	})
-
 	if len(invalidFlags) > 0 {
 		return fmt.Errorf("the following flags cannot be used with --%s: %v", flagName, invalidFlags)
 	}

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -61,9 +61,7 @@ Examples:
 				return validateResetFlag(cmd, "reset-password")
 			} else if resetPodmanAuthFlag {
 				return validateResetFlag(cmd, "reset-podman-auth")
-			}
-
-			if resetCertificateFlag {
+			} else if resetCertificateFlag {
 				return validateResetCertificateFlags(cmd)
 			}
 
@@ -74,9 +72,7 @@ Examples:
 				return runResetPassword()
 			} else if resetPodmanAuthFlag {
 				return runResetPodmanAuth()
-			}
-
-			if resetCertificateFlag {
+			} else if resetCertificateFlag {
 				return runResetCertificate()
 			}
 
@@ -240,14 +236,6 @@ func validateResetCertificateFlags(cmd *cobra.Command) error {
 }
 
 // checkIncompatibleFlags validates that only allowed flags are used with a specific flag.
-// It checks all flags that were explicitly set by the user and returns an error if any
-// incompatible flags are found.
-//
-// Parameters:
-//   - cmd: The cobra command to check flags on
-//   - flagName: The name of the flag being validated (e.g., "reset-password")
-//   - allowedFlags: Optional list of flag names that are allowed to be used with flagName
-//
 // Returns an error if any incompatible flags are found, nil otherwise.
 func checkIncompatibleFlags(cmd *cobra.Command, flagName string, allowedFlags ...string) error {
 	// Create a map of allowed flags for quick lookup

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -33,6 +33,8 @@ var (
 	resetPasswordFlag bool
 	// Reset podman auth secret for catalog configure command.
 	resetPodmanAuthFlag bool
+	// Reset certificate flag for catalog configure command.
+	resetCertificateFlag bool
 )
 
 const (
@@ -61,6 +63,10 @@ Examples:
 				return validateResetFlag(cmd, "reset-podman-auth")
 			}
 
+			if resetCertificateFlag {
+				return validateResetCertificateFlags(cmd)
+			}
+
 			return validateConfigureFlags()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -68,6 +74,10 @@ Examples:
 				return runResetPassword()
 			} else if resetPodmanAuthFlag {
 				return runResetPodmanAuth()
+			}
+
+			if resetCertificateFlag {
+				return runResetCertificate()
 			}
 
 			return runConfigure()
@@ -105,15 +115,7 @@ func runConfigure() error {
 	}
 
 	// Sanitize SSL certificate paths to prevent path traversal attacks
-	// Only clean if paths are provided (filepath.Clean("") returns ".")
-	cleanCertPath := ""
-	cleanKeyPath := ""
-	if sslCertPath != "" {
-		cleanCertPath = filepath.Clean(sslCertPath)
-	}
-	if sslKeyPath != "" {
-		cleanKeyPath = filepath.Clean(sslKeyPath)
-	}
+	cleanCertPath, cleanKeyPath := sanitizeSSLPaths(sslCertPath, sslKeyPath)
 
 	return configure.Run(vars.RuntimeFactory.GetRuntimeType(), aiServicesDir, domainName, cleanCertPath, cleanKeyPath, httpsPort)
 }
@@ -124,20 +126,7 @@ func validateResetFlag(cmd *cobra.Command, flagName string) error {
 	}
 
 	// Check that no configuration parameters are provided with reset flag
-	// List of flags that cannot be used with reset flag
-	var invalidFlags []string
-	cmd.Flags().Visit(func(f *pflag.Flag) {
-		if f.Name == flagName || f.Name == constants.RuntimeFlag {
-			// Skip reset flag and runtime parameter
-			return
-		}
-		invalidFlags = append(invalidFlags, "--"+f.Name)
-	})
-	if len(invalidFlags) > 0 {
-		return fmt.Errorf("the following flags cannot be used with --%s: %v", flagName, invalidFlags)
-	}
-
-	return nil
+	return checkIncompatibleFlags(cmd, flagName)
 }
 
 // validateConfigureFlags validates the configure command flags and initializes runtime.
@@ -230,6 +219,70 @@ func validateSSLCertificates() error {
 	return nil
 }
 
+func validateResetCertificateFlags(cmd *cobra.Command) error {
+	if err := validateRuntimeFlag(); err != nil {
+		return err
+	}
+
+	// Require SSL certificate flags with reset-certificate
+	if sslCertPath == "" || sslKeyPath == "" {
+		return fmt.Errorf("--ssl-cert and --ssl-key are required when using --reset-certificate")
+	}
+
+	// Validate SSL certificate flags
+	if err := validateSSLFlags(); err != nil {
+		return err
+	}
+
+	// Check that no other configuration parameters are provided with reset-certificate flag
+	// Allow ssl-cert and ssl-key since they are required for this operation
+	return checkIncompatibleFlags(cmd, "reset-certificate", "ssl-cert", "ssl-key")
+}
+
+// checkIncompatibleFlags validates that only allowed flags are used with a specific flag.
+// It checks all flags that were explicitly set by the user and returns an error if any
+// incompatible flags are found.
+//
+// Parameters:
+//   - cmd: The cobra command to check flags on
+//   - flagName: The name of the flag being validated (e.g., "reset-password")
+//   - allowedFlags: Optional list of flag names that are allowed to be used with flagName
+//
+// Returns an error if any incompatible flags are found, nil otherwise.
+func checkIncompatibleFlags(cmd *cobra.Command, flagName string, allowedFlags ...string) error {
+	// Create a map of allowed flags for quick lookup
+	allowed := make(map[string]bool)
+	allowed[flagName] = true
+	allowed["runtime"] = true // runtime is always allowed
+	for _, flag := range allowedFlags {
+		allowed[flag] = true
+	}
+
+	// Check that no configuration parameters are provided with the specified flag
+	var invalidFlags []string
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		if !allowed[f.Name] {
+			invalidFlags = append(invalidFlags, "--"+f.Name)
+		}
+	})
+
+	if len(invalidFlags) > 0 {
+		return fmt.Errorf("the following flags cannot be used with --%s: %v", flagName, invalidFlags)
+	}
+
+	return nil
+}
+
+func runResetCertificate() error {
+	logger.Infof("Resetting certificates and reloading catalog pod...")
+
+	// Sanitize SSL certificate paths to prevent path traversal attacks
+	cleanCertPath, cleanKeyPath := sanitizeSSLPaths(sslCertPath, sslKeyPath)
+
+	// Call ResetCatalogCertificate with certificate paths
+	return catalogPodman.ResetCatalogCertificate(cleanCertPath, cleanKeyPath)
+}
+
 // configureConfigureFlags configures the flags for the configure command.
 func configureConfigureFlags(cmd *cobra.Command) {
 	// Add runtime flag as required
@@ -299,6 +352,17 @@ func configureResetFlags(cmd *cobra.Command) {
 		false,
 		"Reset podman authentication using the system's current auth.json.",
 	)
+
+	cmd.Flags().BoolVar(
+		&resetCertificateFlag,
+		"reset-certificate",
+		false,
+		"Reset the Caddy SSL certificates by loading new custom certificates.\n"+
+			"Requires --ssl-cert and --ssl-key flags to specify the new certificate files.\n"+
+			"This will reload the certificates in Caddy without restarting the pod.\n"+
+			"Example:\n"+
+			"  ai-services catalog configure --runtime podman --reset-certificate --ssl-cert /path/to/cert.pem --ssl-key /path/to/key.pem\n",
+	)
 }
 
 func runResetPassword() error {
@@ -333,6 +397,23 @@ func runResetPodmanAuth() error {
 	}
 
 	return catalogPodman.ResetPodmanAuth()
+}
+
+// sanitizeSSLPaths sanitizes SSL certificate and key paths to prevent path traversal attacks.
+// Only cleans if paths are provided (filepath.Clean("") returns ".").
+// Returns cleaned cert path and cleaned key path.
+func sanitizeSSLPaths(certPath, keyPath string) (string, string) {
+	cleanCertPath := ""
+	cleanKeyPath := ""
+
+	if certPath != "" {
+		cleanCertPath = filepath.Clean(certPath)
+	}
+	if keyPath != "" {
+		cleanKeyPath = filepath.Clean(keyPath)
+	}
+
+	return cleanCertPath, cleanKeyPath
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -37,11 +37,19 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 	}
 
 	// Create Caddy context for certificate operations
-	// The LoadSSLCertificates method will verify Caddy health internally when getting admin URL
 	caddyCtx := caddy.NewContext(caddyPodName, "")
 
-	// Load new SSL certificates to Caddy (this will check Caddy health via admin API)
-	logger.Infoln("loading new SSL certificates to Caddy...", logger.VerbosityLevelDebug)
+	// Check Caddy health before attempting to load certificates
+	proxyManager, err := caddyCtx.CreateProxyManager()
+	if err != nil {
+		return fmt.Errorf("failed to create proxy manager: %w", err)
+	}
+
+	if err := proxyManager.HealthCheck(); err != nil {
+		return fmt.Errorf("Caddy health check failed - Admin API is not accessible: %w", err)
+	}
+
+	// Load new SSL certificates to Caddy
 	if err := caddyCtx.LoadSSLCertificates(opts.BaseDir, sslCertPath, sslKeyPath); err != nil {
 		return fmt.Errorf("failed to load certificates: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -1,0 +1,61 @@
+package podman
+
+import (
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
+	catalogConstant "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+)
+
+// ResetCatalogCertificate resets the SSL certificates for the catalog service.
+// It stages new certificates and loads them into Caddy via the Admin API without pod restart.
+func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
+	logger.Infoln("resetting catalog SSL certificates...", logger.VerbosityLevelDebug)
+
+	// Create deployment context to get runtime
+	deployCtx, err := deploy.NewDeployContext()
+	if err != nil {
+		return fmt.Errorf("failed to create deployment context: %w", err)
+	}
+
+	// Get existing catalog pod details
+	opts, _, err := getCatalogPodDetails(deployCtx.Runtime)
+	if err != nil {
+		return fmt.Errorf("failed to get catalog pod details: %w", err)
+	}
+
+	if opts.BaseDir == "" {
+		return fmt.Errorf("AI_SERVICES_BASE_DIR not found in catalog configuration")
+	}
+
+	// Validate certificate files exist and are readable
+	if err := utils.ValidateCertificateFiles(sslCertPath, sslKeyPath); err != nil {
+		return fmt.Errorf("certificate validation failed: %w", err)
+	}
+
+	// Validate certificate and key match
+	if err := utils.ValidateCertificateKeyPair(sslCertPath, sslKeyPath); err != nil {
+		return fmt.Errorf("certificate and key validation failed: %w", err)
+	}
+
+	// Get pod name - construct it from the app name
+	podName := catalogConstant.CatalogAppName
+
+	// Create Caddy context
+	caddyCtx := caddy.NewContext(podName, "")
+
+	// Use the LoadSSLCertificates method which handles both staging and loading
+	logger.Infoln("loading SSL certificates to Caddy...", logger.VerbosityLevelDebug)
+	if err := caddyCtx.LoadSSLCertificates(opts.BaseDir, sslCertPath, sslKeyPath); err != nil {
+		return fmt.Errorf("failed to load certificates: %w", err)
+	}
+
+	logger.Infof("SSL certificates reset successfully")
+
+	return nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -46,7 +46,7 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 	}
 
 	if err := proxyManager.HealthCheck(); err != nil {
-		return fmt.Errorf("Caddy health check failed - Admin API is not accessible: %w", err)
+		return fmt.Errorf("caddy health check failed - admin API is not accessible: %w", err)
 	}
 
 	// Load new SSL certificates to Caddy

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -5,13 +5,12 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
-	catalogConstant "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 // ResetCatalogCertificate resets the SSL certificates for the catalog service.
 // It stages new certificates and loads them into Caddy via the Admin API without pod restart.
+// Caddy health is verified internally when connecting to the Admin API.
 func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 	logger.Infoln("resetting catalog SSL certificates...", logger.VerbosityLevelDebug)
 
@@ -31,24 +30,18 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 		return fmt.Errorf("AI_SERVICES_BASE_DIR not found in catalog configuration")
 	}
 
-	// Validate certificate files exist and are readable
-	if err := utils.ValidateCertificateFiles(sslCertPath, sslKeyPath); err != nil {
-		return fmt.Errorf("certificate validation failed: %w", err)
+	// Get Caddy pod name from templates
+	caddyPodName, err := deployCtx.GetCaddyPodName()
+	if err != nil {
+		return fmt.Errorf("failed to get Caddy pod name: %w", err)
 	}
 
-	// Validate certificate and key match
-	if err := utils.ValidateCertificateKeyPair(sslCertPath, sslKeyPath); err != nil {
-		return fmt.Errorf("certificate and key validation failed: %w", err)
-	}
+	// Create Caddy context for certificate operations
+	// The LoadSSLCertificates method will verify Caddy health internally when getting admin URL
+	caddyCtx := caddy.NewContext(caddyPodName, "")
 
-	// Get pod name - construct it from the app name
-	podName := catalogConstant.CatalogAppName
-
-	// Create Caddy context
-	caddyCtx := caddy.NewContext(podName, "")
-
-	// Use the LoadSSLCertificates method which handles both staging and loading
-	logger.Infoln("loading SSL certificates to Caddy...", logger.VerbosityLevelDebug)
+	// Load new SSL certificates to Caddy (this will check Caddy health via admin API)
+	logger.Infoln("loading new SSL certificates to Caddy...", logger.VerbosityLevelDebug)
 	if err := caddyCtx.LoadSSLCertificates(opts.BaseDir, sslCertPath, sslKeyPath); err != nil {
 		return fmt.Errorf("failed to load certificates: %w", err)
 	}


### PR DESCRIPTION
This PR supports --reset-certificate to allow users to load new certificate to caddy

Test results:

```
# ai-services catalog configure --runtime podman --reset-certificate  --ssl-cert rsa-cert.pem --ssl-key rsa-key.pem
Resetting certificates and reloading catalog pod...
Getting catalog pod details
SSL certificates loaded successfully into Caddy
SSL certificates reset successfully
```