### PR TITLE
feat: Integrate AI deployment name

### DIFF
--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,6 +1,6 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.14
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.15
 
 backend:
   port: ""

--- a/ui/catalog/Makefile
+++ b/ui/catalog/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= catalog-ui
-TAG ?= v0.0.14
+TAG ?= v0.0.15
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/catalog/src/components/DeploymentDetails/DeploymentDetails.module.scss
+++ b/ui/catalog/src/components/DeploymentDetails/DeploymentDetails.module.scss
@@ -251,6 +251,11 @@
   justify-content: flex-start;
 }
 
+.saveError {
+  margin-bottom: $spacing-05;
+  color: $support-error;
+}
+
 .placeholderContent {
   padding: $spacing-07;
   text-align: center;

--- a/ui/catalog/src/components/DeploymentDetails/DeploymentDetails.tsx
+++ b/ui/catalog/src/components/DeploymentDetails/DeploymentDetails.tsx
@@ -37,12 +37,14 @@ interface DeploymentDetailsProps {
   deployment: DeploymentDetailsType;
   onBack: () => void;
   deploymentSource: string;
+  onNameUpdate?: (newName: string) => void;
 }
 
 const DeploymentDetails = ({
   deployment,
   onBack,
   deploymentSource,
+  onNameUpdate,
 }: DeploymentDetailsProps) => {
   const [activeSection, setActiveSection] = useState("details");
   const [resources, setResources] = useState<
@@ -53,8 +55,15 @@ const DeploymentDetails = ({
   const [integrationEndpoints, setIntegrationEndpoints] = useState<
     DeployIntegrationEndpoints[]
   >([]);
-
+  const [editedName, setEditedName] = useState(deployment.name);
+  const [isSaving, setIsSaving]     = useState(false);
+  const [saveError, setSaveError]   = useState(""); 
   useEffect(() => {
+    setEditedName(deployment.name);
+    setSaveError("");
+  }, [deployment.name]);
+
+  useEffect(() => { 
     const fetchResources = async () => {
       setIsLoadingResources(true);
       setResources([]);
@@ -284,6 +293,43 @@ const DeploymentDetails = ({
     return Math.round((used / allocated) * 100);
   };
 
+  const handleSave = async () => {
+    // Validate name
+    if (editedName.length < 3 || editedName.length > 100) {
+      setSaveError("Name must be between 3 and 100 characters");
+      return;
+    }
+
+    // Check if name actually changed
+    if (editedName === deployment.name) {
+      return;
+    }
+
+    setIsSaving(true);
+    setSaveError("");
+
+    try {
+      await api.put(
+        APPLICATION_ENDPOINTS.UPDATE_APPLICATION(deployment.id),
+        { name: editedName }
+      );
+      onNameUpdate?.(editedName);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "Failed to update deployment name";
+      setSaveError(errorMessage);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setEditedName(deployment.name);
+    setSaveError("");
+  };
+
   return (
     <>
       <div>
@@ -390,9 +436,18 @@ const DeploymentDetails = ({
                             className={styles.labelColor}
                             id="deployment-name"
                             labelText="Name"
-                            value={deployment.name}
-                            invalid={false}
-                            invalidText=""
+                            value={editedName}
+                            onChange={(e) => {
+                              setEditedName(e.target.value);
+                              setSaveError("");
+                            }}
+                            invalid={editedName.length < 3 || editedName.length > 100}
+                            invalidText={
+                              editedName.length < 3
+                                ? "Name must be at least 3 characters"
+                                : "Name must be at most 100 characters"
+                            }
+                            disabled={isSaving}
                           />
                         )}
                       </Column>
@@ -489,9 +544,31 @@ const DeploymentDetails = ({
 
               <Grid className={styles.actionsGrid}>
                 <Column sm={4} md={8} lg={16}>
+                  {saveError && (
+                    <div style={{ marginBottom: "1rem", color: "#da1e28" }}>
+                      {saveError}
+                    </div>
+                  )}
                   <div className={styles.actionButtons}>
-                    <Button kind="secondary">Cancel</Button>
-                    <Button kind="primary">Save</Button>
+                    <Button
+                      kind="secondary"
+                      onClick={handleCancel}
+                      disabled={isSaving}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      kind="primary"
+                      onClick={handleSave}
+                      disabled={
+                        isSaving ||
+                        editedName === deployment.name ||
+                        editedName.length < 3 ||
+                        editedName.length > 100
+                      }
+                    >
+                      {isSaving ? "Saving..." : "Save"}
+                    </Button>
                   </div>
                 </Column>
               </Grid>

--- a/ui/catalog/src/components/DeploymentDetails/DeploymentDetails.tsx
+++ b/ui/catalog/src/components/DeploymentDetails/DeploymentDetails.tsx
@@ -56,14 +56,14 @@ const DeploymentDetails = ({
     DeployIntegrationEndpoints[]
   >([]);
   const [editedName, setEditedName] = useState(deployment.name);
-  const [isSaving, setIsSaving]     = useState(false);
-  const [saveError, setSaveError]   = useState(""); 
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState("");
   useEffect(() => {
     setEditedName(deployment.name);
     setSaveError("");
   }, [deployment.name]);
 
-  useEffect(() => { 
+  useEffect(() => {
     const fetchResources = async () => {
       setIsLoadingResources(true);
       setResources([]);
@@ -309,10 +309,9 @@ const DeploymentDetails = ({
     setSaveError("");
 
     try {
-      await api.put(
-        APPLICATION_ENDPOINTS.UPDATE_APPLICATION(deployment.id),
-        { name: editedName }
-      );
+      await api.put(APPLICATION_ENDPOINTS.UPDATE_APPLICATION(deployment.id), {
+        name: editedName,
+      });
       onNameUpdate?.(editedName);
     } catch (error) {
       const errorMessage =
@@ -441,7 +440,9 @@ const DeploymentDetails = ({
                               setEditedName(e.target.value);
                               setSaveError("");
                             }}
-                            invalid={editedName.length < 3 || editedName.length > 100}
+                            invalid={
+                              editedName.length < 3 || editedName.length > 100
+                            }
                             invalidText={
                               editedName.length < 3
                                 ? "Name must be at least 3 characters"
@@ -545,9 +546,7 @@ const DeploymentDetails = ({
               <Grid className={styles.actionsGrid}>
                 <Column sm={4} md={8} lg={16}>
                   {saveError && (
-                    <div style={{ marginBottom: "1rem", color: "#da1e28" }}>
-                      {saveError}
-                    </div>
+                    <div className={styles.saveError}>{saveError}</div>
                   )}
                   <div className={styles.actionButtons}>
                     <Button

--- a/ui/catalog/src/constants/api-endpoints.constants.ts
+++ b/ui/catalog/src/constants/api-endpoints.constants.ts
@@ -27,4 +27,5 @@ export const APPLICATION_ENDPOINTS = {
   DELETE_APPLICATION: (id: string) => `/applications/${id}`,
   GET_APPLICATION_DETAILS: (id: string) => `/applications/${id}`,
   GET_APPLICATION_RESOURCES: (id: string) => `/applications/${id}/resources`,
+  UPDATE_APPLICATION: (id: string) => `/applications/${id}`,
 };

--- a/ui/catalog/src/pages/DigitalAssistants/DigitalAssistants.tsx
+++ b/ui/catalog/src/pages/DigitalAssistants/DigitalAssistants.tsx
@@ -244,6 +244,9 @@ const DigitalAssistantsPage = () => {
         deployment={state.selectedDeployment}
         onBack={() => dispatch({ type: ACTION_TYPES.HIDE_DEPLOYMENT_DETAILS })}
         deploymentSource="Digital assistants"
+        onNameUpdate={(newName) =>
+          dispatch({ type: ACTION_TYPES.UPDATE_DEPLOYMENT_NAME, payload: newName })
+        }
       />
     );
   }

--- a/ui/catalog/src/pages/DigitalAssistants/DigitalAssistants.tsx
+++ b/ui/catalog/src/pages/DigitalAssistants/DigitalAssistants.tsx
@@ -245,7 +245,10 @@ const DigitalAssistantsPage = () => {
         onBack={() => dispatch({ type: ACTION_TYPES.HIDE_DEPLOYMENT_DETAILS })}
         deploymentSource="Digital assistants"
         onNameUpdate={(newName) =>
-          dispatch({ type: ACTION_TYPES.UPDATE_DEPLOYMENT_NAME, payload: newName })
+          dispatch({
+            type: ACTION_TYPES.UPDATE_DEPLOYMENT_NAME,
+            payload: newName,
+          })
         }
       />
     );

--- a/ui/catalog/src/pages/DigitalAssistants/types.ts
+++ b/ui/catalog/src/pages/DigitalAssistants/types.ts
@@ -73,6 +73,7 @@ export const ACTION_TYPES = {
   // DeploymentDetails actions
   SHOW_DEPLOYMENT_DETAILS: "SHOW_DEPLOYMENT_DETAILS",
   HIDE_DEPLOYMENT_DETAILS: "HIDE_DEPLOYMENT_DETAILS",
+  UPDATE_DEPLOYMENT_NAME: "UPDATE_DEPLOYMENT_NAME",
 } as const;
 
 export type AppAction =
@@ -116,7 +117,8 @@ export type AppAction =
       type: typeof ACTION_TYPES.SHOW_DEPLOYMENT_DETAILS;
       payload: DeploymentDetails;
     }
-  | { type: typeof ACTION_TYPES.HIDE_DEPLOYMENT_DETAILS };
+  | { type: typeof ACTION_TYPES.HIDE_DEPLOYMENT_DETAILS }
+  | { type: typeof ACTION_TYPES.UPDATE_DEPLOYMENT_NAME; payload: string };
 
 // Table headers
 export const HEADERS: DataTableHeader[] = [
@@ -301,6 +303,13 @@ export const appReducer = (state: AppState, action: AppAction): AppState => {
         ...state,
         selectedDeployment: null,
         showDeploymentDetails: false,
+      };
+    case ACTION_TYPES.UPDATE_DEPLOYMENT_NAME:
+      return {
+        ...state,
+        selectedDeployment: state.selectedDeployment
+          ? { ...state.selectedDeployment, name: action.payload }
+          : null,
       };
     default:
       return state;


### PR DESCRIPTION
This PR wires up the AI deployment name field in the deployment details page so users can actually edit and save it

Added the UPDATE_APPLICATION endpoint constant and hooked up the Name text input so it is editable

- When a user types a new name and clicks Save it fires a PUT call to /applications/{id} with the update d  n ame 
- The Save button stays disabled until the name is valid (3-100 chars) and different from the original
- Cancel resets the field back to the original name. Any API errors show inline in red above the buttons
- Also bumped the catalog-ui version to v0.0.14 in the Makefile and values.yaml
- Also added the UPDATE_DEPLOYMENT_NAME action so the page header updates too


tested in swagger with isolated backend 
also tested e2e with UI, should be g2g 