### PR TITLE
fix: pass empty contents if podman auth file is not found

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.99
+TAG?=v0.0.100
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.99
+  image: icr.io/ai-services-cicd/ai-services:v0.0.100
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -168,13 +168,22 @@ func generateArgParams(passwordHash string, httpsPort int) (map[string]string, e
 
 	// Determine auth file path
 	// Read and encode auth file content for secret
+	// If auth file doesn't exist, use empty content
 	authFilePath, err := utils.GetAuthFilePath()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get auth file path: %w", err)
 	}
+
 	authFileContent, err := os.ReadFile(authFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read auth file from %s: %w", authFilePath, err)
+		if os.IsNotExist(err) {
+			// Auth file doesn't exist - user hasn't logged into podman
+			logger.Warningln("Podman auth file not found. Deployment may fail since deployment may require pulling images.")
+			logger.Warningln("Run 'podman login' to authenticate with container registries before deploying services.")
+			authFileContent = []byte{}
+		} else {
+			return nil, fmt.Errorf("failed to read auth file from %s: %w", authFilePath, err)
+		}
 	}
 
 	// Base64 encode the auth file content for Kubernetes secret

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -179,7 +179,7 @@ func generateArgParams(passwordHash string, httpsPort int) (map[string]string, e
 		if os.IsNotExist(err) {
 			// Auth file doesn't exist - user hasn't logged into podman
 			logger.Warningln("Podman auth file not found. Deployment may fail since deployment may require pulling images.")
-			logger.Warningln("Run 'podman login' to authenticate with container registries before deploying services.")
+			logger.Warningln("If you need to update registry credentials later, you can use the '--reset-podman-auth' flag after running 'podman login'.")
 			authFileContent = []byte{}
 		} else {
 			return nil, fmt.Errorf("failed to read auth file from %s: %w", authFilePath, err)


### PR DESCRIPTION
- We need to make sure that even if user does not login to podman, the `catalog configure` should still pass with empty contents in secret.
- We also log that deployment may fail as podman login is required for images to install.