### PR TITLE
Add tar to the tools image

### DIFF
--- a/ai-services/internal/pkg/vars/var.go
+++ b/ai-services/internal/pkg/vars/var.go
@@ -15,7 +15,7 @@ var (
 var (
 	// SpyreCardAnnotationRegex -> ai-services.io/<containerName>--spyre-cards.
 	SpyreCardAnnotationRegex = regexp.MustCompile(`^ai-services\.io\/([A-Za-z0-9][-A-Za-z0-9_.]*)--spyre-cards$`)
-	ToolImage                = "icr.io/ai-services-cicd/tools:0.9"
+	ToolImage                = "icr.io/ai-services-cicd/tools:0.10"
 )
 
 type Label string

--- a/images/tools/Containerfile
+++ b/images/tools/Containerfile
@@ -50,7 +50,7 @@ COPY --from=tools_builder /opt/venv /opt/venv
 COPY --from=servicereport_builder /rpms/ /tmp/rpms/
 
 RUN microdnf update ${DNF_FLAGS} -y && \
-  microdnf install ${DNF_FLAGS} -y python3.12 jq && \
+  microdnf install ${DNF_FLAGS} -y python3.12 jq tar && \
   ARCH=$(uname -m) && \
   if [ "$ARCH" = "ppc64le" ]; then \
   echo "Installing ServiceReport for ppc64le..." && \

--- a/images/tools/Makefile
+++ b/images/tools/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=tools
-TAG?=0.9
+TAG?=0.10
 SR_COMMIT=2a57a3a4b14d23981b4add77670bcea90cf69d77
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 


### PR DESCRIPTION
This is needed for openshift restore command, since it uses oc cp which internally requires tar to be installed.