### PR TITLE
[Catalog-CMD]: Adding reset podman auth flag for catalog configure cmd

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.103
+TAG?=v0.0.104
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.103
+  image: icr.io/ai-services-cicd/ai-services:v0.0.104
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -122,27 +122,7 @@ func validateResetPasswordFlags(cmd *cobra.Command) error {
 		return err
 	}
 
-	// Check if basedir was explicitly setn
-	if baseDir != "" {
-		return fmt.Errorf("--base-dir cannot be used with --reset-password")
-	}
-
-	// Check if domain-name was explicitly set
-	if domainName != "" {
-		return fmt.Errorf("--domain-name cannot be used with --reset-password")
-	}
-
-	// Check if https-port was explicitly set by the user
-	if cmd.Flags().Changed("https-port") {
-		return fmt.Errorf("--https-port cannot be used with --reset-password")
-	}
-
-	// Check if SSL certificate flags were set
-	if sslCertPath != "" || sslKeyPath != "" {
-		return fmt.Errorf("--ssl-cert and --ssl-key cannot be used with --reset-password")
-	}
-
-	return nil
+	return validateResetFlag(cmd, "reset-password")
 }
 
 func validateResetAuthFlags(cmd *cobra.Command) error {

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -134,12 +134,12 @@ func validateResetAuthFlags(cmd *cobra.Command) error {
 }
 
 func validateResetFlag(cmd *cobra.Command, flagName string) error {
-	// Check that no configuration parameters are provided with --reset-password
-	// List of flags that cannot be used with --reset-password
+	// Check that no configuration parameters are provided with reset flag
+	// List of flags that cannot be used with reset flag
 	var invalidFlags []string
 	cmd.Flags().Visit(func(f *pflag.Flag) {
 		if f.Name == flagName || f.Name == "runtime" {
-			// Skip valid flags
+			// Skip reset flag and runtime parameter
 			return
 		}
 		invalidFlags = append(invalidFlags, "--"+f.Name)

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -330,7 +330,7 @@ func runResetPassword() error {
 func runResetPodmanAuth() error {
 	logger.Warningf("Resetting podman auth will reload catalog pod!")
 	// Confirm deletion
-	confirmed, err := utils.ConfirmAction("\nDo you want to continue, with auth reset?")
+	confirmed, err := utils.ConfirmAction("\nDo you want to continue, with podman auth reset?")
 	if err != nil {
 		return fmt.Errorf("failed to get confirmation: %w", err)
 	}

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -56,9 +56,9 @@ Examples:
 			cmd.SilenceUsage = true
 
 			if resetPasswordFlag {
-				return validateResetPasswordFlags(cmd)
+				return validateResetFlag(cmd, "reset-password")
 			} else if resetPodmanAuthFlag {
-				return validateResetAuthFlags(cmd)
+				return validateResetFlag(cmd, "reset-podman-auth")
 			}
 
 			return validateConfigureFlags()
@@ -75,6 +75,7 @@ Examples:
 	}
 
 	configureConfigureFlags(cmd)
+	configureResetFlags(cmd)
 
 	return cmd
 }
@@ -117,23 +118,11 @@ func runConfigure() error {
 	return configure.Run(vars.RuntimeFactory.GetRuntimeType(), aiServicesDir, domainName, cleanCertPath, cleanKeyPath, httpsPort)
 }
 
-func validateResetPasswordFlags(cmd *cobra.Command) error {
-	if err := validateRuntimeFlag(); err != nil {
-		return err
-	}
-
-	return validateResetFlag(cmd, "reset-password")
-}
-
-func validateResetAuthFlags(cmd *cobra.Command) error {
-	if err := validateRuntimeFlag(); err != nil {
-		return err
-	}
-
-	return validateResetFlag(cmd, "reset-podman-auth")
-}
-
 func validateResetFlag(cmd *cobra.Command, flagName string) error {
+	if err := validateRuntimeFlag(); err != nil {
+		return err
+	}
+
 	// Check that no configuration parameters are provided with reset flag
 	// List of flags that cannot be used with reset flag
 	var invalidFlags []string
@@ -294,7 +283,9 @@ func configureConfigureFlags(cmd *cobra.Command) {
 			"Must be used together with --ssl-cert.\n"+
 			"Example: --ssl-key /path/to/key.pem\n",
 	)
+}
 
+func configureResetFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(
 		&resetPasswordFlag,
 		"reset-password",

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure"
 	catalogPodman "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure/podman"
@@ -30,6 +31,8 @@ var (
 	httpsPort int
 	// Reset password flag for catalog configure command.
 	resetPasswordFlag bool
+	// Reset podman auth secret for catalog configure command.
+	resetPodmanAuthFlag bool
 )
 
 const (
@@ -53,7 +56,9 @@ Examples:
 			cmd.SilenceUsage = true
 
 			if resetPasswordFlag {
-				return validateResetFlags(cmd)
+				return validateResetPasswordFlags(cmd)
+			} else if resetPodmanAuthFlag {
+				return validateResetAuthFlags(cmd)
 			}
 
 			return validateConfigureFlags()
@@ -61,6 +66,8 @@ Examples:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if resetPasswordFlag {
 				return runResetPassword()
+			} else if resetPodmanAuthFlag {
+				return runResetPodmanAuth()
 			}
 
 			return runConfigure()
@@ -110,7 +117,7 @@ func runConfigure() error {
 	return configure.Run(vars.RuntimeFactory.GetRuntimeType(), aiServicesDir, domainName, cleanCertPath, cleanKeyPath, httpsPort)
 }
 
-func validateResetFlags(cmd *cobra.Command) error {
+func validateResetPasswordFlags(cmd *cobra.Command) error {
 	if err := validateRuntimeFlag(); err != nil {
 		return err
 	}
@@ -133,6 +140,32 @@ func validateResetFlags(cmd *cobra.Command) error {
 	// Check if SSL certificate flags were set
 	if sslCertPath != "" || sslKeyPath != "" {
 		return fmt.Errorf("--ssl-cert and --ssl-key cannot be used with --reset-password")
+	}
+
+	return nil
+}
+
+func validateResetAuthFlags(cmd *cobra.Command) error {
+	if err := validateRuntimeFlag(); err != nil {
+		return err
+	}
+
+	return validateResetFlag(cmd, "reset-podman-auth")
+}
+
+func validateResetFlag(cmd *cobra.Command, flagName string) error {
+	// Check that no configuration parameters are provided with --reset-password
+	// List of flags that cannot be used with --reset-password
+	var invalidFlags []string
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		if f.Name == flagName || f.Name == "runtime" {
+			// Skip valid flags
+			return
+		}
+		invalidFlags = append(invalidFlags, "--"+f.Name)
+	})
+	if len(invalidFlags) > 0 {
+		return fmt.Errorf("the following flags cannot be used with --%s: %v", flagName, invalidFlags)
 	}
 
 	return nil
@@ -288,6 +321,13 @@ func configureConfigureFlags(cmd *cobra.Command) {
 		false,
 		"Reset the password for the admin user",
 	)
+
+	cmd.Flags().BoolVar(
+		&resetPodmanAuthFlag,
+		"reset-podman-auth",
+		false,
+		"Reset podman authentication using the system's current auth.json.",
+	)
 }
 
 func runResetPassword() error {
@@ -305,6 +345,23 @@ func runResetPassword() error {
 	}
 
 	return catalogPodman.ResetCatalogPassword()
+}
+
+func runResetPodmanAuth() error {
+	logger.Warningf("Resetting podman auth will reload catalog pod!")
+	// Confirm deletion
+	confirmed, err := utils.ConfirmAction("\nDo you want to continue, with auth reset?")
+	if err != nil {
+		return fmt.Errorf("failed to get confirmation: %w", err)
+	}
+
+	if !confirmed {
+		logger.Infoln("Catalog podman auth reset cancelled")
+
+		return nil
+	}
+
+	return catalogPodman.ResetPodmanAuth()
 }
 
 // Made with Bob

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -127,7 +127,7 @@ func validateResetFlag(cmd *cobra.Command, flagName string) error {
 	// List of flags that cannot be used with reset flag
 	var invalidFlags []string
 	cmd.Flags().Visit(func(f *pflag.Flag) {
-		if f.Name == flagName || f.Name == "runtime" {
+		if f.Name == flagName || f.Name == constants.RuntimeFlag {
 			// Skip reset flag and runtime parameter
 			return
 		}
@@ -233,8 +233,8 @@ func validateSSLCertificates() error {
 // configureConfigureFlags configures the flags for the configure command.
 func configureConfigureFlags(cmd *cobra.Command) {
 	// Add runtime flag as required
-	cmd.Flags().StringVarP(&runtimeType, "runtime", "r", "", fmt.Sprintf("runtime to use (options: %s, %s) (required)", types.RuntimeTypePodman, types.RuntimeTypeOpenShift))
-	_ = cmd.MarkFlagRequired("runtime")
+	cmd.Flags().StringVarP(&runtimeType, constants.RuntimeFlag, "r", "", fmt.Sprintf("runtime to use (options: %s, %s) (required)", types.RuntimeTypePodman, types.RuntimeTypeOpenShift))
+	_ = cmd.MarkFlagRequired(constants.RuntimeFlag)
 
 	// Add basedir flag
 	cmd.Flags().StringVar(

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -302,7 +302,7 @@ func configureResetFlags(cmd *cobra.Command) {
 }
 
 func runResetPassword() error {
-	logger.Warningf("Resetting password will reload catalog pod!")
+	logger.Warningf("Resetting password will reload the catalog pod, catalog service will be temporarily unavailable during this time!")
 	// Confirm deletion
 	confirmed, err := utils.ConfirmAction("\nDo you want to continue, with password reset?")
 	if err != nil {
@@ -319,7 +319,7 @@ func runResetPassword() error {
 }
 
 func runResetPodmanAuth() error {
-	logger.Warningf("Resetting podman auth will reload catalog pod!")
+	logger.Warningf("Resetting Podman auth will reload the catalog pod, catalog service will be temporarily unavailable during this time!")
 	// Confirm deletion
 	confirmed, err := utils.ConfirmAction("\nDo you want to continue, with podman auth reset?")
 	if err != nil {

--- a/ai-services/go.mod
+++ b/ai-services/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
@@ -232,7 +233,6 @@ require (
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/smallstep/pkcs7 v0.1.1 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6 // indirect
 	github.com/sylabs/sif/v2 v2.22.0 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.3 // indirect

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
@@ -97,13 +97,13 @@ func getCatalogPodDetails(rt runtime.Runtime) (*PodmanConfigureOptions, string, 
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to inspect container %s: %w", container.Name, err)
 		}
-		getEnvValues(cInfo.Env, opts)
+		setConfigureOptions(cInfo.Env, opts)
 	}
 
 	return opts, pod.ID, nil
 }
 
-func getEnvValues(podEnv map[string]string, opts *PodmanConfigureOptions) {
+func setConfigureOptions(podEnv map[string]string, opts *PodmanConfigureOptions) {
 	// Setting required 3 envs
 	if value, ok := podEnv["AI_SERVICES_BASE_DIR"]; ok {
 		opts.BaseDir = value

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
@@ -3,7 +3,6 @@ package podman
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
 	catalogConstant "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
@@ -17,7 +17,7 @@ func ResetPodmanAuth() error {
 		return err
 	}
 
-	// Verify auth file path before deleting secret
+	// Verify auth file path exists before deleting secret
 	_, err = utils.GetAuthFilePath()
 	if err != nil {
 		return err
@@ -30,19 +30,12 @@ func ResetPodmanAuth() error {
 		return fmt.Errorf("failed to delete existing catalog podman auth secret: %w", err)
 	}
 
-	podEnv, err := getAndDeleteCatalogPod(deployCtx.Runtime)
+	opts, err := getAndDeleteCatalogPod(deployCtx.Runtime)
 	if err != nil {
 		return fmt.Errorf("failed to get existing catalog pod details: %w", err)
 	}
-
-	baseDir, domainName, httpsPort := getFlagValues(podEnv)
-	opts := PodmanConfigureOptions{
-		BaseDir:    baseDir,
-		DomainName: domainName,
-		HttpsPort:  httpsPort,
-	}
-
-	_, err = executeCatalogDeployment(context.Background(), deployCtx, opts, "")
+	
+	_, err = executeCatalogDeployment(context.Background(), deployCtx, *opts, "")
 	if err != nil {
 		return fmt.Errorf("failed to deploy catalog pod: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
@@ -34,7 +34,7 @@ func ResetPodmanAuth() error {
 	if err != nil {
 		return fmt.Errorf("failed to get existing catalog pod details: %w", err)
 	}
-	
+
 	_, err = executeCatalogDeployment(context.Background(), deployCtx, *opts, "")
 	if err != nil {
 		return fmt.Errorf("failed to deploy catalog pod: %w", err)

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
@@ -1,0 +1,51 @@
+package podman
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
+	catalogConstant "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+)
+
+func ResetPodmanAuth() error {
+	// Create deployment context without argParams for status check
+	deployCtx, err := deploy.NewDeployContext()
+	if err != nil {
+		return err
+	}
+
+	// Verify auth file path before deleting secret
+	_, err = utils.GetAuthFilePath()
+	if err != nil {
+		return err
+	}
+
+	// Delete podman auth secret.
+	logger.Infof("Deleting catalog podman auth secret %s", catalogConstant.CatalogPodmanAuthSecretName)
+	err = deployCtx.Runtime.DeleteSecret(catalogConstant.CatalogSecretName)
+	if err != nil {
+		return fmt.Errorf("failed to delete existing catalog podman auth secret: %w", err)
+	}
+
+	podEnv, err := getAndDeleteCatalogPod(deployCtx.Runtime)
+	if err != nil {
+		return fmt.Errorf("failed to get existing catalog pod details: %w", err)
+	}
+
+	baseDir, domainName, httpsPort := getFlagValues(podEnv)
+	opts := PodmanConfigureOptions{
+		BaseDir:    baseDir,
+		DomainName: domainName,
+		HttpsPort:  httpsPort,
+	}
+
+	_, err = executeCatalogDeployment(context.Background(), deployCtx, opts, "")
+	if err != nil {
+		return fmt.Errorf("failed to deploy catalog pod: %w", err)
+	}
+
+	return nil
+}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
@@ -25,7 +25,7 @@ func ResetPodmanAuth() error {
 
 	// Delete podman auth secret.
 	logger.Infof("Deleting catalog podman auth secret %s", catalogConstant.CatalogPodmanAuthSecretName)
-	err = deployCtx.Runtime.DeleteSecret(catalogConstant.CatalogSecretName)
+	err = deployCtx.Runtime.DeleteSecret(catalogConstant.CatalogPodmanAuthSecretName)
 	if err != nil {
 		return fmt.Errorf("failed to delete existing catalog podman auth secret: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
@@ -3,6 +3,7 @@ package podman
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
 	catalogConstant "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
@@ -7,18 +7,11 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
 	catalogConstant "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 func ResetPodmanAuth() error {
 	// Create deployment context without argParams for status check
 	deployCtx, err := deploy.NewDeployContext()
-	if err != nil {
-		return err
-	}
-
-	// Verify auth file path exists before deleting secret
-	_, err = utils.GetAuthFilePath()
 	if err != nil {
 		return err
 	}

--- a/ai-services/internal/pkg/catalog/constants/catalog.go
+++ b/ai-services/internal/pkg/catalog/constants/catalog.go
@@ -36,6 +36,8 @@ const (
 	PodmanAuthSecret = "podman-auth-secret"
 	// CatalogSecretName represents the catalog secret name.
 	CatalogSecretName = "catalog-secret"
+	// CatalogPodmanAuthSecretName represent the podman auth secret name.
+	CatalogPodmanAuthSecretName = "podman-auth-secret"
 )
 
 // Pagination constants.

--- a/ai-services/internal/pkg/constants/flags.go
+++ b/ai-services/internal/pkg/constants/flags.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	RuntimeFlag string = "runtime"
+)


### PR DESCRIPTION
Added `--reset-podman-auth` flag to the `catalog configure` command, allowing users to reset the podman auth secret for the catalog service using the system's existing `auth.json`.