### PR TITLE
fix: move sentient group and ulimit values to configure

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.119
+TAG?=v0.0.120
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.119
+  image: icr.io/ai-services-cicd/ai-services:v0.0.120
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/components/llm/watsonx/podman/templates/watsonx-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/watsonx/podman/templates/watsonx-server.yaml.tmpl
@@ -49,10 +49,8 @@ spec:
       resources:
         requests:
           memory: "2Gi"
-          cpu: "1"
         limits:
           memory: "4Gi"
-          cpu: "2"
       ports:
         - containerPort: 8000
           protocol: TCP

--- a/ai-services/internal/pkg/bootstrap/podman/configure.go
+++ b/ai-services/internal/pkg/bootstrap/podman/configure.go
@@ -37,12 +37,17 @@ func (p *PodmanBootstrap) Configure() error {
 		return err
 	}
 
-	// 3. Configure SMT level to 2 and persist via systemd
+	// 3. Configure user groups (sentient group)
+	if err := ensureUsergroupConfigured(ctx); err != nil {
+		return err
+	}
+
+	// 4. Configure SMT level to 2 and persist via systemd
 	if err := ensureSMTConfigured(ctx); err != nil {
 		return err
 	}
 
-	// 4. Configure SELinux policy for Podman socket access
+	// 5. Configure SELinux policy for Podman socket access
 	if err := ensureSELinuxPolicyConfigured(ctx); err != nil {
 		return err
 	}

--- a/ai-services/internal/pkg/bootstrap/podman/configure.go
+++ b/ai-services/internal/pkg/bootstrap/podman/configure.go
@@ -47,12 +47,17 @@ func (p *PodmanBootstrap) Configure() error {
 		return err
 	}
 
-	// 5. Configure SMT level to 2 and persist via systemd
+	// 5. Configure systemd user slice limits for rootless podman
+	if err := ensureSystemdSliceLimitsConfigured(ctx); err != nil {
+		return err
+	}
+
+	// 6. Configure SMT level to 2 and persist via systemd
 	if err := ensureSMTConfigured(ctx); err != nil {
 		return err
 	}
 
-	// 6. Configure SELinux policy for Podman socket access
+	// 7. Configure SELinux policy for Podman socket access
 	if err := ensureSELinuxPolicyConfigured(ctx); err != nil {
 		return err
 	}

--- a/ai-services/internal/pkg/bootstrap/podman/configure.go
+++ b/ai-services/internal/pkg/bootstrap/podman/configure.go
@@ -42,12 +42,17 @@ func (p *PodmanBootstrap) Configure() error {
 		return err
 	}
 
-	// 4. Configure SMT level to 2 and persist via systemd
+	// 4. Configure ulimits (memlock and nofile)
+	if err := ensureUlimitsConfigured(ctx); err != nil {
+		return err
+	}
+
+	// 5. Configure SMT level to 2 and persist via systemd
 	if err := ensureSMTConfigured(ctx); err != nil {
 		return err
 	}
 
-	// 5. Configure SELinux policy for Podman socket access
+	// 6. Configure SELinux policy for Podman socket access
 	if err := ensureSELinuxPolicyConfigured(ctx); err != nil {
 		return err
 	}

--- a/ai-services/internal/pkg/bootstrap/podman/helper.go
+++ b/ai-services/internal/pkg/bootstrap/podman/helper.go
@@ -146,20 +146,20 @@ func ensureSentientGroupExists() error {
 	cmd := exec.Command("getent", "group", "sentient")
 	if err := cmd.Run(); err == nil {
 		// Group already exists
-		logger.Infoln("sentient group already exists", logger.VerbosityLevelDebug)
+		logger.Debugln("sentient group already exists")
 
 		return nil
 	}
 
 	// Create the sentient group
-	logger.Infoln("Creating sentient group", logger.VerbosityLevelDebug)
+	logger.Debugln("Creating sentient group")
 	cmd = exec.Command("groupadd", "sentient")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to create sentient group: %w, output: %s", err, string(out))
 	}
 
-	logger.Infoln("sentient group created successfully", logger.VerbosityLevelDebug)
+	logger.Debugln("sentient group created successfully")
 
 	return nil
 }
@@ -177,34 +177,129 @@ func configureUlimits() error {
 	return nil
 }
 
+// configureSystemdUserSliceLimits configures systemd user slice limits for rootless podman.
+// This ensures that containers started by non-root users have proper ulimits.
+func configureSystemdUserSliceLimits() error {
+	sudoUser := os.Getenv("SUDO_USER")
+	if sudoUser == "" {
+		// Not running via sudo, skip this configuration
+		logger.Debugln("Not running via sudo, skipping systemd user slice limits configuration")
+
+		return nil
+	}
+
+	userID, err := getUserID(sudoUser)
+	if err != nil {
+		return fmt.Errorf("failed to get user ID for %s: %w", sudoUser, err)
+	}
+
+	// Skip if user is root (UID 0)
+	// Systemd user slice limits only apply to non-root users running rootless podman
+	if userID == "0" {
+		logger.Debugln("User is root, skipping systemd user slice limits configuration")
+
+		return nil
+	}
+
+	sliceDir := fmt.Sprintf("/etc/systemd/system/user-%s.slice.d", userID)
+	limitsFile := fmt.Sprintf("%s/limits.conf", sliceDir)
+
+	// Check if already configured
+	if isSystemdSliceLimitsConfigured(limitsFile) {
+		logger.Debugln("Systemd user slice limits already configured")
+
+		return nil
+	}
+
+	// Create directory if it doesn't exist
+	if err := os.MkdirAll(sliceDir, constants.DirPerm); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", sliceDir, err)
+	}
+
+	// Write limits configuration
+	limitsContent := fmt.Sprintf(`[Slice]
+LimitNOFILE=%d
+LimitMEMLOCK=infinity
+`, constants.MinNofileLimit)
+	if err := os.WriteFile(limitsFile, []byte(limitsContent), constants.FilePerm); err != nil {
+		return fmt.Errorf("failed to write systemd slice limits file: %w", err)
+	}
+
+	// Reload systemd daemon
+	cmd := exec.Command("systemctl", "daemon-reload")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to reload systemd daemon: %w, output: %s", err, string(out))
+	}
+
+	logger.Infof("Systemd user slice limits configured for user %s (UID: %s)", sudoUser, userID)
+
+	return nil
+}
+
+// getUserID gets the user ID for the specified user.
+func getUserID(username string) (string, error) {
+	cmd := exec.Command("id", "-u", username)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user ID: %w", err)
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+// isSystemdSliceLimitsConfigured checks if systemd slice limits are already configured.
+func isSystemdSliceLimitsConfigured(limitsFile string) bool {
+	if !utils.FileExists(limitsFile) {
+		return false
+	}
+
+	lines, err := utils.ReadFileLines(limitsFile)
+	if err != nil {
+		return false
+	}
+
+	hasNofile := false
+	hasMemlock := false
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if after, ok := strings.CutPrefix(line, "LimitNOFILE="); ok {
+			if value, err := strconv.Atoi(after); err == nil && value >= constants.MinNofileLimit {
+				hasNofile = true
+			}
+		}
+		if after, ok := strings.CutPrefix(line, "LimitMEMLOCK="); ok {
+			if after == "infinity" {
+				hasMemlock = true
+			}
+		}
+	}
+
+	return hasNofile && hasMemlock
+}
+
 // configureMemlockLimit configures memlock ulimit for the sentient group.
 func configureMemlockLimit() error {
-	const (
-		memlockConfFile    = "/etc/security/limits.d/memlock.conf"
-		memlockConfContent = "@sentient - memlock unlimited\n"
-		filePermissions    = 0644
-	)
-
 	// Check if configuration already exists and is valid
-	if isMemlockConfigValid(memlockConfFile) {
-		logger.Infoln("memlock configuration already exists", logger.VerbosityLevelDebug)
+	if isMemlockConfigValid(constants.MemlockConfFile) {
+		logger.Debugln("memlock configuration already exists")
 
 		return nil
 	}
 
 	// Read and filter existing content
-	existingContent, err := getFilteredMemlockContent(memlockConfFile)
+	existingContent, err := getFilteredMemlockContent(constants.MemlockConfFile)
 	if err != nil {
 		return err
 	}
 
 	// Write configuration
-	content := existingContent + memlockConfContent
-	if err := os.WriteFile(memlockConfFile, []byte(content), filePermissions); err != nil {
+	content := existingContent + constants.MemlockConfContent
+	if err := os.WriteFile(constants.MemlockConfFile, []byte(content), constants.FilePerm); err != nil {
 		return fmt.Errorf("failed to write memlock configuration: %w", err)
 	}
 
-	logger.Infoln("memlock configuration created successfully", logger.VerbosityLevelDebug)
+	logger.Debugln("memlock configuration created successfully")
 
 	return nil
 }
@@ -221,7 +316,7 @@ func isMemlockConfigValid(confFile string) bool {
 	}
 
 	for _, line := range lines {
-		if strings.TrimSpace(line) == "@sentient - memlock unlimited" {
+		if strings.TrimSpace(line) == constants.ExpectedMemlockConfig {
 			return true
 		}
 	}
@@ -242,7 +337,7 @@ func getFilteredMemlockContent(confFile string) (string, error) {
 
 	var filteredLines []string
 	for _, line := range lines {
-		if !strings.HasPrefix(strings.TrimSpace(line), "@sentient") {
+		if !strings.HasPrefix(strings.TrimSpace(line), "@"+constants.SentientGroupName) {
 			filteredLines = append(filteredLines, line)
 		}
 	}
@@ -256,35 +351,27 @@ func getFilteredMemlockContent(confFile string) (string, error) {
 
 // configureNofileLimit configures nofile ulimit for the sentient group.
 func configureNofileLimit() error {
-	const (
-		nofileConfFile     = "/etc/security/limits.conf"
-		minNofileLimit     = 134217728
-		nofileConfTemplate = "@sentient hard nofile %d\n"
-		filePermissions    = 0644
-		nofileFieldCount   = 4
-	)
-
 	// Check if configuration already exists and is valid
-	if isNofileConfigValid(nofileConfFile, minNofileLimit) {
-		logger.Infoln("nofile configuration already exists with sufficient limit", logger.VerbosityLevelDebug)
+	if isNofileConfigValid(constants.NofileConfFile, constants.MinNofileLimit) {
+		logger.Debugln("nofile configuration already exists with sufficient limit")
 
 		return nil
 	}
 
 	// Read and filter existing content
-	existingContent, err := getFilteredNofileContent(nofileConfFile)
+	existingContent, err := getFilteredNofileContent(constants.NofileConfFile)
 	if err != nil {
 		return err
 	}
 
 	// Write configuration
-	nofileConf := fmt.Sprintf(nofileConfTemplate, minNofileLimit)
+	nofileConf := fmt.Sprintf(constants.NofileConfTemplate, constants.MinNofileLimit)
 	content := existingContent + nofileConf
-	if err := os.WriteFile(nofileConfFile, []byte(content), filePermissions); err != nil {
+	if err := os.WriteFile(constants.NofileConfFile, []byte(content), constants.FilePerm); err != nil {
 		return fmt.Errorf("failed to write nofile configuration: %w", err)
 	}
 
-	logger.Infoln("nofile configuration created successfully", logger.VerbosityLevelDebug)
+	logger.Debugln("nofile configuration created successfully")
 
 	return nil
 }
@@ -311,14 +398,14 @@ func isNofileConfigValid(confFile string, minLimit int) bool {
 
 // isValidNofileLine checks if a line contains valid nofile configuration.
 func isValidNofileLine(line string, minLimit int) bool {
-	const nofileFieldCount = 4
+	sentientPrefix := "@" + constants.SentientGroupName
 
-	if !strings.HasPrefix(line, "@sentient") || !strings.Contains(line, "nofile") {
+	if !strings.HasPrefix(line, sentientPrefix) || !strings.Contains(line, "nofile") {
 		return false
 	}
 
 	parts := strings.Fields(line)
-	if len(parts) < nofileFieldCount {
+	if len(parts) < constants.NofileFieldCount {
 		return false
 	}
 
@@ -338,10 +425,11 @@ func getFilteredNofileContent(confFile string) (string, error) {
 		return "", fmt.Errorf("failed to read existing limits.conf: %w", err)
 	}
 
+	sentientPrefix := "@" + constants.SentientGroupName
 	var filteredLines []string
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "@sentient") && strings.Contains(trimmed, "nofile") {
+		if strings.HasPrefix(trimmed, sentientPrefix) && strings.Contains(trimmed, "nofile") {
 			continue
 		}
 		filteredLines = append(filteredLines, line)
@@ -606,6 +694,22 @@ func ensureUlimitsConfigured(ctx context.Context) error {
 		return err
 	}
 	s.Stop("Ulimits configured successfully")
+
+	return nil
+}
+
+// ensureSystemdSliceLimitsConfigured configures systemd user slice limits for rootless podman.
+// This is required for both Spyre and non-Spyre setups to ensure proper ulimits for non-root users.
+func ensureSystemdSliceLimitsConfigured(ctx context.Context) error {
+	s := spinner.New("Configuring systemd user slice limits")
+	s.Start(ctx)
+
+	if err := configureSystemdUserSliceLimits(); err != nil {
+		s.Fail("failed to configure systemd user slice limits")
+
+		return err
+	}
+	s.Stop("Systemd user slice limits configured successfully")
 
 	return nil
 }

--- a/ai-services/internal/pkg/bootstrap/podman/helper.go
+++ b/ai-services/internal/pkg/bootstrap/podman/helper.go
@@ -35,11 +35,6 @@ func configureSpyre() error {
 	// Run validation and repair
 	allPassed := runValidationAndRepair()
 
-	// Add current user to sentient group
-	if err := configureUsergroup(); err != nil {
-		return err
-	}
-
 	if !allPassed {
 		return fmt.Errorf("some Spyre configuration checks still failed after repair")
 	}
@@ -118,6 +113,11 @@ func logRepairResults(results []spyre.RepairResult) {
 }
 
 func configureUsergroup() error {
+	// Ensure sentient group exists first
+	if err := ensureSentientGroupExists(); err != nil {
+		return err
+	}
+
 	username := os.Getenv("SUDO_USER")
 	if username == "" {
 		// Fallback to current user if not running via sudo
@@ -134,8 +134,32 @@ func configureUsergroup() error {
 	cmd := exec.Command("bash", "-c", cmd_str)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to create sentient group and add current user to the sentient group. Error: %w, output: %s", err, string(out))
+		return fmt.Errorf("failed to add current user to the sentient group. Error: %w, output: %s", err, string(out))
 	}
+
+	return nil
+}
+
+// ensureSentientGroupExists creates the sentient group if it doesn't exist.
+func ensureSentientGroupExists() error {
+	// Check if sentient group already exists
+	cmd := exec.Command("getent", "group", "sentient")
+	if err := cmd.Run(); err == nil {
+		// Group already exists
+		logger.Infoln("sentient group already exists", logger.VerbosityLevelDebug)
+
+		return nil
+	}
+
+	// Create the sentient group
+	logger.Infoln("Creating sentient group", logger.VerbosityLevelDebug)
+	cmd = exec.Command("groupadd", "sentient")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to create sentient group: %w, output: %s", err, string(out))
+	}
+
+	logger.Infoln("sentient group created successfully", logger.VerbosityLevelDebug)
 
 	return nil
 }
@@ -360,6 +384,22 @@ func ensureSpyreConfigured(ctx context.Context) error {
 		return err
 	}
 	s.Stop("Spyre cards configuration validated successfully.")
+
+	return nil
+}
+
+// ensureUsergroupConfigured ensures sentient group exists and adds current user to it.
+// This is required for both Spyre and non-Spyre setups to handle ulimit configurations.
+func ensureUsergroupConfigured(ctx context.Context) error {
+	s := spinner.New("Configuring user groups")
+	s.Start(ctx)
+
+	if err := configureUsergroup(); err != nil {
+		s.Fail("failed to configure user groups")
+
+		return err
+	}
+	s.Stop("User groups configured successfully")
 
 	return nil
 }

--- a/ai-services/internal/pkg/bootstrap/podman/helper.go
+++ b/ai-services/internal/pkg/bootstrap/podman/helper.go
@@ -164,6 +164,196 @@ func ensureSentientGroupExists() error {
 	return nil
 }
 
+// configureUlimits configures both memlock and nofile ulimits for the sentient group.
+func configureUlimits() error {
+	if err := configureMemlockLimit(); err != nil {
+		return err
+	}
+
+	if err := configureNofileLimit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// configureMemlockLimit configures memlock ulimit for the sentient group.
+func configureMemlockLimit() error {
+	const (
+		memlockConfFile    = "/etc/security/limits.d/memlock.conf"
+		memlockConfContent = "@sentient - memlock unlimited\n"
+		filePermissions    = 0644
+	)
+
+	// Check if configuration already exists and is valid
+	if isMemlockConfigValid(memlockConfFile) {
+		logger.Infoln("memlock configuration already exists", logger.VerbosityLevelDebug)
+
+		return nil
+	}
+
+	// Read and filter existing content
+	existingContent, err := getFilteredMemlockContent(memlockConfFile)
+	if err != nil {
+		return err
+	}
+
+	// Write configuration
+	content := existingContent + memlockConfContent
+	if err := os.WriteFile(memlockConfFile, []byte(content), filePermissions); err != nil {
+		return fmt.Errorf("failed to write memlock configuration: %w", err)
+	}
+
+	logger.Infoln("memlock configuration created successfully", logger.VerbosityLevelDebug)
+
+	return nil
+}
+
+// isMemlockConfigValid checks if memlock configuration already exists.
+func isMemlockConfigValid(confFile string) bool {
+	if !utils.FileExists(confFile) {
+		return false
+	}
+
+	lines, err := utils.ReadFileLines(confFile)
+	if err != nil {
+		return false
+	}
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "@sentient - memlock unlimited" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// getFilteredMemlockContent reads and filters existing memlock configuration.
+func getFilteredMemlockContent(confFile string) (string, error) {
+	if !utils.FileExists(confFile) {
+		return "", nil
+	}
+
+	lines, err := utils.ReadFileLines(confFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to read existing memlock.conf: %w", err)
+	}
+
+	var filteredLines []string
+	for _, line := range lines {
+		if !strings.HasPrefix(strings.TrimSpace(line), "@sentient") {
+			filteredLines = append(filteredLines, line)
+		}
+	}
+
+	if len(filteredLines) > 0 {
+		return strings.Join(filteredLines, "\n") + "\n", nil
+	}
+
+	return "", nil
+}
+
+// configureNofileLimit configures nofile ulimit for the sentient group.
+func configureNofileLimit() error {
+	const (
+		nofileConfFile     = "/etc/security/limits.conf"
+		minNofileLimit     = 134217728
+		nofileConfTemplate = "@sentient hard nofile %d\n"
+		filePermissions    = 0644
+		nofileFieldCount   = 4
+	)
+
+	// Check if configuration already exists and is valid
+	if isNofileConfigValid(nofileConfFile, minNofileLimit) {
+		logger.Infoln("nofile configuration already exists with sufficient limit", logger.VerbosityLevelDebug)
+
+		return nil
+	}
+
+	// Read and filter existing content
+	existingContent, err := getFilteredNofileContent(nofileConfFile)
+	if err != nil {
+		return err
+	}
+
+	// Write configuration
+	nofileConf := fmt.Sprintf(nofileConfTemplate, minNofileLimit)
+	content := existingContent + nofileConf
+	if err := os.WriteFile(nofileConfFile, []byte(content), filePermissions); err != nil {
+		return fmt.Errorf("failed to write nofile configuration: %w", err)
+	}
+
+	logger.Infoln("nofile configuration created successfully", logger.VerbosityLevelDebug)
+
+	return nil
+}
+
+// isNofileConfigValid checks if nofile configuration already exists with sufficient limit.
+func isNofileConfigValid(confFile string, minLimit int) bool {
+	if !utils.FileExists(confFile) {
+		return false
+	}
+
+	lines, err := utils.ReadFileLines(confFile)
+	if err != nil {
+		return false
+	}
+
+	for _, line := range lines {
+		if isValidNofileLine(strings.TrimSpace(line), minLimit) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isValidNofileLine checks if a line contains valid nofile configuration.
+func isValidNofileLine(line string, minLimit int) bool {
+	const nofileFieldCount = 4
+
+	if !strings.HasPrefix(line, "@sentient") || !strings.Contains(line, "nofile") {
+		return false
+	}
+
+	parts := strings.Fields(line)
+	if len(parts) < nofileFieldCount {
+		return false
+	}
+
+	value, err := strconv.Atoi(parts[3])
+
+	return err == nil && value >= minLimit
+}
+
+// getFilteredNofileContent reads and filters existing nofile configuration.
+func getFilteredNofileContent(confFile string) (string, error) {
+	if !utils.FileExists(confFile) {
+		return "", nil
+	}
+
+	lines, err := utils.ReadFileLines(confFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to read existing limits.conf: %w", err)
+	}
+
+	var filteredLines []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "@sentient") && strings.Contains(trimmed, "nofile") {
+			continue
+		}
+		filteredLines = append(filteredLines, line)
+	}
+
+	if len(filteredLines) > 0 {
+		return strings.Join(filteredLines, "\n") + "\n", nil
+	}
+
+	return "", nil
+}
+
 func installPodman() error {
 	cmd := exec.Command("dnf", "-y", "install", "podman")
 	out, err := cmd.CombinedOutput()
@@ -400,6 +590,22 @@ func ensureUsergroupConfigured(ctx context.Context) error {
 		return err
 	}
 	s.Stop("User groups configured successfully")
+
+	return nil
+}
+
+// ensureUlimitsConfigured configures ulimits (memlock and nofile) for the sentient group.
+// This is required for both Spyre and non-Spyre setups to allow pods to run properly.
+func ensureUlimitsConfigured(ctx context.Context) error {
+	s := spinner.New("Configuring ulimits")
+	s.Start(ctx)
+
+	if err := configureUlimits(); err != nil {
+		s.Fail("failed to configure ulimits")
+
+		return err
+	}
+	s.Stop("Ulimits configured successfully")
 
 	return nil
 }

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
@@ -42,7 +42,7 @@ type RepairResult struct {
 
 // Repair attempts to fix all failed Spyre checks.
 func Repair(checks []check.CheckResult) []RepairResult {
-	const checkResultsLen = 8
+	const checkResultsLen = 7
 	results := make([]RepairResult, 0, checkResultsLen)
 
 	// Create a map for easy lookup.
@@ -52,13 +52,12 @@ func Repair(checks []check.CheckResult) []RepairResult {
 	}
 
 	// Fix checks in dependency order.
-	// Note: User group and ulimit configurations moved to generic bootstrap flow
+	// Note: User group, ulimit, and systemd slice limit configurations moved to generic bootstrap flow
 	results = append(results, fixVFIODriverConfig(checkMap))
 	results = append(results, fixUdevRule(checkMap))
 	results = append(results, fixVFIOPCIConf(checkMap))
 	results = append(results, fixVFIOModule(checkMap))
 	results = append(results, fixVFIOPermissions(checkMap, RepairResult{}))
-	results = append(results, fixSystemdUserSliceLimits(checkMap))
 	results = append(results, fixSELinuxVFIOPolicy())
 	results = append(results, fixPodmanServiceSupplementaryGroups(checkMap))
 
@@ -286,82 +285,6 @@ func fixVFIOPermissions(checkMap map[string]check.CheckResult, userGroupResult R
 	}
 
 	return RepairResult{CheckName: checkName, Status: StatusFixed}
-}
-
-// reloadSystemdDaemon reloads the systemd daemon configuration.
-func reloadSystemdDaemon() error {
-	exitCode, _, stderr, err := utils.ExecuteCommand("systemctl", "daemon-reload")
-	if err != nil || exitCode != 0 {
-		return fmt.Errorf("failed to reload systemd: %v, stderr: %s", err, stderr)
-	}
-
-	return nil
-}
-
-// getUserIDForSlice gets the user ID for the SUDO_USER.
-func getUserIDForSlice(sudoUser string) (string, error) {
-	exitCode, stdout, stderr, err := utils.ExecuteCommand("id", "-u", sudoUser)
-	if err != nil || exitCode != 0 {
-		return "", fmt.Errorf("failed to get user ID: %v, stderr: %s", err, stderr)
-	}
-
-	return strings.TrimSpace(stdout), nil
-}
-
-// writeSystemdSliceLimits writes the systemd slice limits configuration file.
-func writeSystemdSliceLimits(sliceDir, limitsFile string) error {
-	if err := os.MkdirAll(sliceDir, dirPermissions); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", sliceDir, err)
-	}
-
-	limitsContent := `[Slice]
-LimitNOFILE=134217728
-LimitMEMLOCK=infinity
-`
-	if err := utils.WriteToFile(limitsFile, limitsContent); err != nil {
-		return fmt.Errorf("failed to write limits file: %w", err)
-	}
-
-	return nil
-}
-
-// fixSystemdUserSliceLimits configures systemd user slice limits for rootless podman.
-// This ensures that containers started by non-root users have proper ulimits.
-func fixSystemdUserSliceLimits(checkMap map[string]check.CheckResult) RepairResult {
-	checkName := "Systemd user slice limits configuration"
-	chk, ok := getCheckFromMap(checkMap, checkName)
-	if !ok {
-		return RepairResult{CheckName: checkName, Status: StatusSkipped}
-	}
-
-	if chk.GetStatus() {
-		return RepairResult{CheckName: checkName, Status: StatusSkipped}
-	}
-
-	sudoUser := os.Getenv("SUDO_USER")
-	if sudoUser == "" {
-		return RepairResult{CheckName: checkName, Status: StatusNotFixable,
-			Message: "Not running via sudo, cannot configure user slice"}
-	}
-
-	userID, err := getUserIDForSlice(sudoUser)
-	if err != nil {
-		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
-	}
-
-	sliceDir := fmt.Sprintf("/etc/systemd/system/user-%s.slice.d", userID)
-	limitsFile := fmt.Sprintf("%s/limits.conf", sliceDir)
-
-	if err := writeSystemdSliceLimits(sliceDir, limitsFile); err != nil {
-		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
-	}
-
-	if err := reloadSystemdDaemon(); err != nil {
-		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
-	}
-
-	return RepairResult{CheckName: checkName, Status: StatusFixed,
-		Message: fmt.Sprintf("Configured systemd slice limits for user %s (UID: %s)", sudoUser, userID)}
 }
 
 // isSELinuxEnabledAndActive checks if SELinux is enabled and active.

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
@@ -42,7 +42,7 @@ type RepairResult struct {
 
 // Repair attempts to fix all failed Spyre checks.
 func Repair(checks []check.CheckResult) []RepairResult {
-	const checkResultsLen = 11
+	const checkResultsLen = 10
 	results := make([]RepairResult, 0, checkResultsLen)
 
 	// Create a map for easy lookup.
@@ -57,10 +57,10 @@ func Repair(checks []check.CheckResult) []RepairResult {
 	results = append(results, fixNofileConf(checkMap))
 	results = append(results, fixUdevRule(checkMap))
 	results = append(results, fixVFIOPCIConf(checkMap))
-	userGroupResult := fixUserGroup(checkMap)
-	results = append(results, userGroupResult)
 	results = append(results, fixVFIOModule(checkMap))
-	results = append(results, fixVFIOPermissions(checkMap, userGroupResult))
+	// Note: User group configuration moved to generic bootstrap flow
+	// fixVFIOPermissions no longer depends on userGroupResult
+	results = append(results, fixVFIOPermissions(checkMap, RepairResult{}))
 	results = append(results, fixSystemdUserSliceLimits(checkMap))
 	results = append(results, fixSELinuxVFIOPolicy())
 	results = append(results, fixPodmanServiceSupplementaryGroups(checkMap))
@@ -346,31 +346,6 @@ func appendMissingModules(confCheck *check.ConfigurationFileCheck, checkName str
 	for key, attr := range confCheck.Attributes {
 		if !attr.Status {
 			if err := utils.AppendToFile(confCheck.FilePath, "\n"+key); err != nil {
-				return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
-			}
-		}
-	}
-
-	return RepairResult{CheckName: checkName, Status: StatusFixed}
-}
-
-// fixUserGroup repairs user group configuration.
-func fixUserGroup(checkMap map[string]check.CheckResult) RepairResult {
-	checkName := "User group configuration"
-	chk, ok := getCheckFromMap(checkMap, checkName)
-	if !ok {
-		return RepairResult{CheckName: checkName, Status: StatusSkipped}
-	}
-
-	configCheck, ok := chk.(*check.ConfigCheck)
-	if !ok {
-		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Message: "Invalid check type"}
-	}
-
-	// Create missing groups.
-	for groupName, status := range configCheck.Configs {
-		if !status {
-			if err := utils.CreateGroup(groupName); err != nil {
 				return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
 			}
 		}

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
@@ -42,7 +42,7 @@ type RepairResult struct {
 
 // Repair attempts to fix all failed Spyre checks.
 func Repair(checks []check.CheckResult) []RepairResult {
-	const checkResultsLen = 10
+	const checkResultsLen = 8
 	results := make([]RepairResult, 0, checkResultsLen)
 
 	// Create a map for easy lookup.
@@ -52,14 +52,11 @@ func Repair(checks []check.CheckResult) []RepairResult {
 	}
 
 	// Fix checks in dependency order.
+	// Note: User group and ulimit configurations moved to generic bootstrap flow
 	results = append(results, fixVFIODriverConfig(checkMap))
-	results = append(results, fixMemlockConf(checkMap))
-	results = append(results, fixNofileConf(checkMap))
 	results = append(results, fixUdevRule(checkMap))
 	results = append(results, fixVFIOPCIConf(checkMap))
 	results = append(results, fixVFIOModule(checkMap))
-	// Note: User group configuration moved to generic bootstrap flow
-	// fixVFIOPermissions no longer depends on userGroupResult
 	results = append(results, fixVFIOPermissions(checkMap, RepairResult{}))
 	results = append(results, fixSystemdUserSliceLimits(checkMap))
 	results = append(results, fixSELinuxVFIOPolicy())
@@ -136,106 +133,6 @@ func fixVFIODriverConfig(checkMap map[string]check.CheckResult) RepairResult {
 	}
 
 	return RepairResult{CheckName: checkName, Status: StatusFixed}
-}
-
-// fixMemlockConf repairs user memlock configuration.
-func fixMemlockConf(checkMap map[string]check.CheckResult) RepairResult {
-	checkName := "User memlock configuration"
-	chk, ok := getCheckFromMap(checkMap, checkName)
-	if !ok {
-		return RepairResult{CheckName: checkName, Status: StatusSkipped}
-	}
-
-	confCheck, ok := chk.(*check.ConfigurationFileCheck)
-	if !ok {
-		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Message: "Invalid check type"}
-	}
-
-	// Read existing file.
-	lines, err := utils.ReadFileLines(confCheck.FilePath)
-	if err != nil && !os.IsNotExist(err) {
-		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
-	}
-
-	// Remove old @sentient lines.
-	var updatedLines []string
-	for _, line := range lines {
-		if !strings.HasPrefix(strings.TrimSpace(line), "@sentient") {
-			updatedLines = append(updatedLines, line)
-		}
-	}
-
-	// Add new configuration.
-	for key, attr := range confCheck.Attributes {
-		if !attr.Status {
-			updatedLines = append(updatedLines, key)
-		}
-	}
-
-	// Write back.
-	content := strings.Join(updatedLines, "\n")
-	if err := utils.WriteToFile(confCheck.FilePath, content); err != nil {
-		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
-	}
-
-	msg := "Memlock limit set. User must be in sentient group: sudo usermod -aG sentient <user>"
-
-	return RepairResult{CheckName: checkName, Status: StatusFixed, Message: msg}
-}
-
-// filterNofileLinesForSentient filters out old @sentient nofile configuration lines.
-func filterNofileLinesForSentient(lines []string) []string {
-	updatedLines := make([]string, 0, len(lines))
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		// Skip lines that configure nofile for @sentient group
-		if strings.HasPrefix(trimmed, "@sentient") && strings.Contains(trimmed, "nofile") {
-			continue
-		}
-		updatedLines = append(updatedLines, line)
-	}
-
-	return updatedLines
-}
-
-// fixNofileConf repairs user nofile limit configuration.
-func fixNofileConf(checkMap map[string]check.CheckResult) RepairResult {
-	checkName := "User nofile limit configuration"
-	chk, ok := getCheckFromMap(checkMap, checkName)
-	if !ok {
-		return RepairResult{CheckName: checkName, Status: StatusSkipped}
-	}
-
-	confCheck, ok := chk.(*check.ConfigurationFileCheck)
-	if !ok {
-		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Message: "Invalid check type"}
-	}
-
-	// Read existing file.
-	lines, err := utils.ReadFileLines(confCheck.FilePath)
-	if err != nil && !os.IsNotExist(err) {
-		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
-	}
-
-	// Remove old @sentient nofile lines.
-	updatedLines := filterNofileLinesForSentient(lines)
-
-	// Add new configuration.
-	for key, attr := range confCheck.Attributes {
-		if !attr.Status {
-			updatedLines = append(updatedLines, key)
-		}
-	}
-
-	// Write back.
-	content := strings.Join(updatedLines, "\n")
-	if err := utils.WriteToFile(confCheck.FilePath, content); err != nil {
-		return RepairResult{CheckName: checkName, Status: StatusFailedToFix, Error: err}
-	}
-
-	msg := "File descriptor limit set. User must be in sentient group and re-login for changes to take effect"
-
-	return RepairResult{CheckName: checkName, Status: StatusFixed, Message: msg}
 }
 
 // fixUdevRule repairs VFIO udev rules.

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
@@ -73,7 +73,6 @@ func RunChecks() []check.CheckResult {
 		checkMemlockConf(),
 		checkNofileConf(),
 		checkVfioPciConf(),
-		checkUserGroup(),
 		checkVfioModule(),
 		checkVfioAccessPermission(),
 		checkSELinuxVFIOPolicy(),
@@ -416,16 +415,6 @@ func checkVfioPciConf() *check.ConfigurationFileCheck {
 	return confCheck
 }
 
-// checkUserGroup validates user group configuration.
-func checkUserGroup() *check.ConfigCheck {
-	userGroupCheck := check.NewConfigCheck("User group configuration")
-
-	status := utils.GroupExists(sentientGroup)
-	userGroupCheck.AddConfig(sentientGroup, status)
-	userGroupCheck.SetStatus(status)
-
-	return userGroupCheck
-}
 
 // checkVfioModule validates VFIO kernel module is loaded.
 func checkVfioModule() *check.Check {

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
@@ -72,7 +72,6 @@ func RunChecks() []check.CheckResult {
 		checkVfioModule(),
 		checkVfioAccessPermission(),
 		checkSELinuxVFIOPolicy(),
-		checkSystemdUserSliceLimits(),
 		checkPodmanServiceSupplementaryGroups(),
 	}
 }
@@ -489,100 +488,6 @@ func setCheckResult(confCheck *check.ConfigurationFileCheck, found, correctValue
 		confCheck.AddAttribute("SupplementaryGroups=sentient", false, "not found", sentientGroup)
 		confCheck.SetStatus(false)
 	}
-}
-
-// getUserIDForSliceCheck retrieves the user ID for the SUDO_USER.
-// Returns userID and ok status. If ok is false, the check should be skipped or failed.
-func getUserIDForSliceCheck() (userID string, shouldSkip bool, shouldFail bool) {
-	sudoUser := os.Getenv("SUDO_USER")
-	if sudoUser == "" {
-		// Not running via sudo, skip this check
-		return "", true, false
-	}
-
-	exitCode, stdout, stderr, err := utils.ExecuteCommand("id", "-u", sudoUser)
-	if err != nil || exitCode != 0 {
-		log.Printf("Failed to get user ID for %s: %v, stderr: %s", sudoUser, err, stderr)
-
-		return "", false, true
-	}
-
-	userID = strings.TrimSpace(stdout)
-
-	// Skip this check if the user is root (UID 0).
-	// Systemd user slice limits (LimitMEMLOCK and LimitNOFILE) only apply to non-root users
-	// running rootless podman. root users don't need to re-login to shell after configuration changes,
-	// as these values can be picked up from podman yaml annotations at runtime.
-	if userID == "0" {
-		return "", true, false
-	}
-
-	return userID, false, false
-}
-
-// validateSystemdLimitsFile reads and validates the systemd limits file for required values.
-func validateSystemdLimitsFile(limitsFile string) (hasNofile, hasMemlock bool, err error) {
-	lines, err := utils.ReadFileLines(limitsFile)
-	if err != nil {
-		return false, false, err
-	}
-
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if after, ok := strings.CutPrefix(line, "LimitNOFILE="); ok {
-			hasNofile = after == "134217728"
-		}
-		if after, ok := strings.CutPrefix(line, "LimitMEMLOCK="); ok {
-			hasMemlock = after == "infinity"
-		}
-	}
-
-	return hasNofile, hasMemlock, nil
-}
-
-// checkSystemdUserSliceLimits validates that systemd user slice limits are configured for rootless podman.
-func checkSystemdUserSliceLimits() *check.ConfigurationFileCheck {
-	checkName := "Systemd user slice limits configuration"
-	confCheck := check.NewConfigurationFileCheck(checkName, "")
-
-	userID, shouldSkip, shouldFail := getUserIDForSliceCheck()
-	if shouldSkip {
-		confCheck.SetStatus(true)
-
-		return confCheck
-	}
-	if shouldFail {
-		confCheck.SetStatus(false)
-
-		return confCheck
-	}
-
-	limitsFile := fmt.Sprintf("/etc/systemd/system/user-%s.slice.d/limits.conf", userID)
-	confCheck.FilePath = limitsFile
-
-	// Check if limits file exists
-	if !utils.FileExists(limitsFile) {
-		confCheck.AddAttribute("LimitNOFILE=134217728", false, "not found", "134217728")
-		confCheck.AddAttribute("LimitMEMLOCK=infinity", false, "not found", "infinity")
-		confCheck.SetStatus(false)
-
-		return confCheck
-	}
-
-	// Read and validate limits file
-	hasNofile, hasMemlock, err := validateSystemdLimitsFile(limitsFile)
-	if err != nil {
-		log.Printf("Failed to read %s: %v", limitsFile, err)
-		confCheck.SetStatus(false)
-
-		return confCheck
-	}
-
-	confCheck.AddAttribute("LimitNOFILE=134217728", hasNofile, "", "134217728")
-	confCheck.AddAttribute("LimitMEMLOCK=infinity", hasMemlock, "", "infinity")
-	confCheck.SetStatus(hasNofile && hasMemlock)
-
-	return confCheck
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/jaypipes/ghw"
@@ -27,7 +26,6 @@ const (
 var (
 	vfioOptionsPattern = regexp.MustCompile(`^options\s+(\S+)\s+(.+)$`)
 	vfioConfigPattern  = regexp.MustCompile(`(\w+)=([^=\s]+)`)
-	memLimitPattern    = regexp.MustCompile(`^(@sentient.+)\s+(unlimited|\d+)$`)
 )
 
 // GetNumberOfSpyreCards returns the number of Spyre cards in the system.
@@ -70,8 +68,6 @@ func RunChecks() []check.CheckResult {
 	return []check.CheckResult{
 		checkDriverConfig(),
 		checkUdevRule(),
-		checkMemlockConf(),
-		checkNofileConf(),
 		checkVfioPciConf(),
 		checkVfioModule(),
 		checkVfioAccessPermission(),
@@ -231,155 +227,6 @@ func checkUdevRule() *check.ConfigurationFileCheck {
 	return confCheck
 }
 
-// parseMemLimitLine extracts the group pattern and value from a memlock config line.
-func parseMemLimitLine(line string, pattern *regexp.Regexp) (groupPattern, value string, ok bool) {
-	matches := pattern.FindStringSubmatch(line)
-	if matches == nil {
-		return "", "", false
-	}
-
-	return matches[1], matches[2], true
-}
-
-// isMemLimitValid checks if a line's memlock value satisfies the expected limit.
-func isMemLimitValid(lineValue, expectedValue string) bool {
-	// If line has unlimited, it satisfies any requirement
-	if lineValue == "unlimited" {
-		return true
-	}
-
-	// If expected is unlimited but line isn't, it doesn't satisfy.
-	if expectedValue == "unlimited" {
-		return false
-	}
-
-	// Both are numeric - compare values.
-	lineInt, err1 := strconv.Atoi(lineValue)
-	expectedInt, err2 := strconv.Atoi(expectedValue)
-	if err1 != nil || err2 != nil {
-		return false
-	}
-
-	return lineInt >= expectedInt
-}
-
-// isMemLimitConfigValid checks if memlock configuration is valid.
-func isMemLimitConfigValid(configFile, expectedConf string) bool {
-	lines, err := utils.ReadFileLines(configFile)
-	if err != nil {
-		log.Printf("Error reading %s: %v", configFile, err)
-
-		return false
-	}
-
-	// Parse expected configuration once.
-	expectedGroup, expectedValue, ok := parseMemLimitLine(expectedConf, memLimitPattern)
-	if !ok {
-		return false
-	}
-
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-
-		// Skip empty lines.
-		if line == "" {
-			continue
-		}
-
-		// Check for exact match first.
-		if line == expectedConf {
-			return true
-		}
-
-		// Parse current line.
-		lineGroup, lineValue, ok := parseMemLimitLine(line, memLimitPattern)
-		if !ok {
-			continue
-		}
-
-		// Check if this line matches the expected group pattern.
-		if lineGroup == expectedGroup {
-			return isMemLimitValid(lineValue, expectedValue)
-		}
-	}
-
-	return false
-}
-
-// checkMemlockConf validates user memlock configuration.
-func checkMemlockConf() *check.ConfigurationFileCheck {
-	expectedConf := "@sentient - memlock unlimited"
-	configFile := "/etc/security/limits.d/memlock.conf"
-
-	confCheck := check.NewConfigurationFileCheck("User memlock configuration", configFile)
-
-	status := isMemLimitConfigValid(configFile, expectedConf)
-	confCheck.AddAttribute(expectedConf, status, "", "")
-	confCheck.SetStatus(status)
-
-	return confCheck
-}
-
-// checkNofileConf validates user nofile limit configuration.
-func checkNofileConf() *check.ConfigurationFileCheck {
-	expectedConf := "@sentient hard nofile 134217728"
-	configFile := "/etc/security/limits.conf"
-
-	confCheck := check.NewConfigurationFileCheck("User nofile limit configuration", configFile)
-
-	status := isNofileLimitConfigValid(configFile, expectedConf)
-	confCheck.AddAttribute(expectedConf, status, "", "")
-	confCheck.SetStatus(status)
-
-	return confCheck
-}
-
-// isNofileLimitConfigValid checks if nofile limit configuration is valid.
-func isNofileLimitConfigValid(configFile, expectedConf string) bool {
-	lines, err := utils.ReadFileLines(configFile)
-	if err != nil {
-		log.Printf("Error reading %s: %v", configFile, err)
-
-		return false
-	}
-
-	// Pattern to match: @sentient hard nofile <value>
-	nofilePattern := regexp.MustCompile(`^@sentient\s+hard\s+nofile\s+(\d+)$`)
-
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-
-		// Skip empty lines and comments
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		// Check for exact match first
-		if line == expectedConf {
-			return true
-		}
-
-		// Parse current line
-		matches := nofilePattern.FindStringSubmatch(line)
-		if matches != nil {
-			// Found a nofile config for @sentient group
-			lineValue := matches[1]
-			lineInt, err := strconv.Atoi(lineValue)
-			if err != nil {
-				continue
-			}
-
-			// Check if the value meets or exceeds the expected value (134217728)
-			expectedInt, _ := strconv.Atoi("134217728")
-			if lineInt >= expectedInt {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
 // checkVfioPciConf validates VFIO module dep configuration.
 func checkVfioPciConf() *check.ConfigurationFileCheck {
 	configFile := "/etc/modules-load.d/vfio-pci.conf"
@@ -414,7 +261,6 @@ func checkVfioPciConf() *check.ConfigurationFileCheck {
 
 	return confCheck
 }
-
 
 // checkVfioModule validates VFIO kernel module is loaded.
 func checkVfioModule() *check.Check {

--- a/ai-services/internal/pkg/constants/common.go
+++ b/ai-services/internal/pkg/constants/common.go
@@ -21,6 +21,19 @@ const (
 	FilePerm = 0644
 )
 
+// Ulimit configuration constants.
+const (
+	MinNofileLimit        = 134217728
+	NofileFieldCount      = 4
+	MemlockConfFile       = "/etc/security/limits.d/memlock.conf"
+	NofileConfFile        = "/etc/security/limits.conf"
+	MemlockConfContent    = "@sentient - memlock unlimited\n"
+	NofileConfTemplate    = "@sentient hard nofile %d\n"
+	SentientGroupName     = "sentient"
+	ExpectedMemlockConfig = "@sentient - memlock unlimited"
+	ExpectedNofileConfig  = "@sentient hard nofile 134217728"
+)
+
 const (
 	PercentageDivisor = 100.0
 )

--- a/ai-services/internal/pkg/validators/podman/slicelimits/slicelimits.go
+++ b/ai-services/internal/pkg/validators/podman/slicelimits/slicelimits.go
@@ -1,0 +1,139 @@
+package slicelimits
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/bootstrap/spyreconfig/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+)
+
+type SliceLimitsRule struct{}
+
+func NewSliceLimitsRule() *SliceLimitsRule {
+	return &SliceLimitsRule{}
+}
+
+func (r *SliceLimitsRule) Name() string {
+	return "slicelimits"
+}
+
+func (r *SliceLimitsRule) Description() string {
+	return "Validates that systemd user slice limits are configured for rootless podman."
+}
+
+func (r *SliceLimitsRule) Verify() error {
+	logger.Debugln("Validating systemd user slice limits")
+
+	sudoUser := os.Getenv("SUDO_USER")
+	if sudoUser == "" {
+		// Not running via sudo, skip this check
+		logger.Debugln("Not running via sudo, skipping systemd slice limits check")
+
+		return nil
+	}
+
+	userID, err := r.getUserID(sudoUser)
+	if err != nil {
+		return fmt.Errorf("failed to get user ID for %s: %w", sudoUser, err)
+	}
+
+	// Skip if user is root (UID 0)
+	if userID == "0" {
+		logger.Debugln("User is root, skipping systemd slice limits check")
+
+		return nil
+	}
+
+	limitsFile := fmt.Sprintf("/etc/systemd/system/user-%s.slice.d/limits.conf", userID)
+
+	if err := r.validateLimitsFile(limitsFile); err != nil {
+		return err
+	}
+
+	logger.Debugln("✓ systemd user slice limits are valid")
+
+	return nil
+}
+
+func (r *SliceLimitsRule) getUserID(username string) (string, error) {
+	cmd := exec.Command("id", "-u", username)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user ID: %w", err)
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (r *SliceLimitsRule) validateLimitsFile(limitsFile string) error {
+	lines, err := utils.ReadFileLines(limitsFile)
+	if err != nil {
+		return r.handleReadError(err, limitsFile)
+	}
+
+	hasNofile, hasMemlock := r.checkLimits(lines)
+
+	return r.validateLimits(hasNofile, hasMemlock, limitsFile)
+}
+
+func (r *SliceLimitsRule) handleReadError(err error, limitsFile string) error {
+	if os.IsNotExist(err) {
+		return fmt.Errorf("systemd slice limits file does not exist: %s", limitsFile)
+	}
+
+	return fmt.Errorf("failed to read systemd slice limits file: %w", err)
+}
+
+func (r *SliceLimitsRule) checkLimits(lines []string) (bool, bool) {
+	hasNofile := false
+	hasMemlock := false
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		if after, ok := strings.CutPrefix(line, "LimitNOFILE="); ok {
+			if value, err := strconv.Atoi(after); err == nil && value >= constants.MinNofileLimit {
+				hasNofile = true
+			}
+		}
+
+		if after, ok := strings.CutPrefix(line, "LimitMEMLOCK="); ok {
+			if after == "infinity" {
+				hasMemlock = true
+			}
+		}
+	}
+
+	return hasNofile, hasMemlock
+}
+
+func (r *SliceLimitsRule) validateLimits(hasNofile, hasMemlock bool, limitsFile string) error {
+	if !hasNofile {
+		return fmt.Errorf("LimitNOFILE not configured or below minimum (%d) in %s", constants.MinNofileLimit, limitsFile)
+	}
+
+	if !hasMemlock {
+		return fmt.Errorf("LimitMEMLOCK not configured to infinity in %s", limitsFile)
+	}
+
+	return nil
+}
+
+func (r *SliceLimitsRule) Message() string {
+	return "Systemd user slice limits are properly configured"
+}
+
+func (r *SliceLimitsRule) Level() constants.ValidationLevel {
+	return constants.ValidationLevelWarning
+}
+
+func (r *SliceLimitsRule) Hint() string {
+	return "Systemd user slice limits are required for rootless podman to have proper ulimits. Run 'ai-services bootstrap configure' to set up the required limits."
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/validators/podman/ulimits/ulimits.go
+++ b/ai-services/internal/pkg/validators/podman/ulimits/ulimits.go
@@ -26,7 +26,7 @@ func (r *UlimitsRule) Description() string {
 }
 
 func (r *UlimitsRule) Verify() error {
-	logger.Infoln("Validating ulimit configurations", logger.VerbosityLevelDebug)
+	logger.Debugln("Validating ulimit configurations")
 
 	// Validate memlock configuration
 	if err := r.validateMemlockConf(); err != nil {
@@ -38,21 +38,16 @@ func (r *UlimitsRule) Verify() error {
 		return err
 	}
 
-	logger.Infoln("✓ ulimit configurations are valid", logger.VerbosityLevelDebug)
+	logger.Debugln("✓ ulimit configurations are valid")
 
 	return nil
 }
 
 func (r *UlimitsRule) validateMemlockConf() error {
-	const (
-		memlockConfFile = "/etc/security/limits.d/memlock.conf"
-		expectedConf    = "@sentient - memlock unlimited"
-	)
-
-	lines, err := utils.ReadFileLines(memlockConfFile)
+	lines, err := utils.ReadFileLines(constants.MemlockConfFile)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("memlock configuration file does not exist: %s", memlockConfFile)
+			return fmt.Errorf("memlock configuration file does not exist: %s", constants.MemlockConfFile)
 		}
 
 		return fmt.Errorf("failed to read memlock configuration: %w", err)
@@ -60,27 +55,21 @@ func (r *UlimitsRule) validateMemlockConf() error {
 
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
-		if line == expectedConf {
-			logger.Infoln("✓ memlock configuration is valid", logger.VerbosityLevelDebug)
+		if line == constants.ExpectedMemlockConfig {
+			logger.Debugln("✓ memlock configuration is valid")
 
 			return nil
 		}
 	}
 
-	return fmt.Errorf("memlock configuration not found or invalid in %s", memlockConfFile)
+	return fmt.Errorf("memlock configuration not found or invalid in %s", constants.MemlockConfFile)
 }
 
 func (r *UlimitsRule) validateNofileConf() error {
-	const (
-		nofileConfFile   = "/etc/security/limits.conf"
-		minNofileLimit   = 134217728
-		nofileFieldCount = 4
-	)
-
-	lines, err := utils.ReadFileLines(nofileConfFile)
+	lines, err := utils.ReadFileLines(constants.NofileConfFile)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("nofile configuration file does not exist: %s", nofileConfFile)
+			return fmt.Errorf("nofile configuration file does not exist: %s", constants.NofileConfFile)
 		}
 
 		return fmt.Errorf("failed to read nofile configuration: %w", err)
@@ -95,8 +84,8 @@ func (r *UlimitsRule) validateNofileConf() error {
 		}
 
 		// Check for @sentient hard nofile configuration
-		if err := r.checkNofileLine(line, minNofileLimit, nofileFieldCount); err == nil {
-			logger.Infoln("✓ nofile configuration is valid", logger.VerbosityLevelDebug)
+		if err := r.checkNofileLine(line); err == nil {
+			logger.Debugln("✓ nofile configuration is valid")
 
 			return nil
 		} else if err.Error() != "not a nofile line" {
@@ -104,17 +93,18 @@ func (r *UlimitsRule) validateNofileConf() error {
 		}
 	}
 
-	return fmt.Errorf("nofile configuration not found or invalid in %s", nofileConfFile)
+	return fmt.Errorf("nofile configuration not found or invalid in %s", constants.NofileConfFile)
 }
 
 // checkNofileLine validates a single nofile configuration line.
-func (r *UlimitsRule) checkNofileLine(line string, minLimit, fieldCount int) error {
-	if !strings.HasPrefix(line, "@sentient") || !strings.Contains(line, "nofile") {
+func (r *UlimitsRule) checkNofileLine(line string) error {
+	sentientPrefix := "@" + constants.SentientGroupName
+	if !strings.HasPrefix(line, sentientPrefix) || !strings.Contains(line, "nofile") {
 		return fmt.Errorf("not a nofile line")
 	}
 
 	parts := strings.Fields(line)
-	if len(parts) < fieldCount || parts[1] != "hard" || parts[2] != "nofile" {
+	if len(parts) < constants.NofileFieldCount || parts[1] != "hard" || parts[2] != "nofile" {
 		return fmt.Errorf("not a nofile line")
 	}
 
@@ -123,8 +113,8 @@ func (r *UlimitsRule) checkNofileLine(line string, minLimit, fieldCount int) err
 		return fmt.Errorf("not a nofile line")
 	}
 
-	if value < minLimit {
-		return fmt.Errorf("nofile limit (%d) is below minimum required (%d)", value, minLimit)
+	if value < constants.MinNofileLimit {
+		return fmt.Errorf("nofile limit (%d) is below minimum required (%d)", value, constants.MinNofileLimit)
 	}
 
 	return nil

--- a/ai-services/internal/pkg/validators/podman/ulimits/ulimits.go
+++ b/ai-services/internal/pkg/validators/podman/ulimits/ulimits.go
@@ -1,0 +1,145 @@
+package ulimits
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/bootstrap/spyreconfig/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+)
+
+type UlimitsRule struct{}
+
+func NewUlimitsRule() *UlimitsRule {
+	return &UlimitsRule{}
+}
+
+func (r *UlimitsRule) Name() string {
+	return "ulimits"
+}
+
+func (r *UlimitsRule) Description() string {
+	return "Validates that memlock and nofile ulimits are properly configured for the sentient group."
+}
+
+func (r *UlimitsRule) Verify() error {
+	logger.Infoln("Validating ulimit configurations", logger.VerbosityLevelDebug)
+
+	// Validate memlock configuration
+	if err := r.validateMemlockConf(); err != nil {
+		return err
+	}
+
+	// Validate nofile configuration
+	if err := r.validateNofileConf(); err != nil {
+		return err
+	}
+
+	logger.Infoln("✓ ulimit configurations are valid", logger.VerbosityLevelDebug)
+
+	return nil
+}
+
+func (r *UlimitsRule) validateMemlockConf() error {
+	const (
+		memlockConfFile = "/etc/security/limits.d/memlock.conf"
+		expectedConf    = "@sentient - memlock unlimited"
+	)
+
+	lines, err := utils.ReadFileLines(memlockConfFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("memlock configuration file does not exist: %s", memlockConfFile)
+		}
+
+		return fmt.Errorf("failed to read memlock configuration: %w", err)
+	}
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == expectedConf {
+			logger.Infoln("✓ memlock configuration is valid", logger.VerbosityLevelDebug)
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("memlock configuration not found or invalid in %s", memlockConfFile)
+}
+
+func (r *UlimitsRule) validateNofileConf() error {
+	const (
+		nofileConfFile   = "/etc/security/limits.conf"
+		minNofileLimit   = 134217728
+		nofileFieldCount = 4
+	)
+
+	lines, err := utils.ReadFileLines(nofileConfFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("nofile configuration file does not exist: %s", nofileConfFile)
+		}
+
+		return fmt.Errorf("failed to read nofile configuration: %w", err)
+	}
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Check for @sentient hard nofile configuration
+		if err := r.checkNofileLine(line, minNofileLimit, nofileFieldCount); err == nil {
+			logger.Infoln("✓ nofile configuration is valid", logger.VerbosityLevelDebug)
+
+			return nil
+		} else if err.Error() != "not a nofile line" {
+			return err
+		}
+	}
+
+	return fmt.Errorf("nofile configuration not found or invalid in %s", nofileConfFile)
+}
+
+// checkNofileLine validates a single nofile configuration line.
+func (r *UlimitsRule) checkNofileLine(line string, minLimit, fieldCount int) error {
+	if !strings.HasPrefix(line, "@sentient") || !strings.Contains(line, "nofile") {
+		return fmt.Errorf("not a nofile line")
+	}
+
+	parts := strings.Fields(line)
+	if len(parts) < fieldCount || parts[1] != "hard" || parts[2] != "nofile" {
+		return fmt.Errorf("not a nofile line")
+	}
+
+	value, err := strconv.Atoi(parts[3])
+	if err != nil {
+		return fmt.Errorf("not a nofile line")
+	}
+
+	if value < minLimit {
+		return fmt.Errorf("nofile limit (%d) is below minimum required (%d)", value, minLimit)
+	}
+
+	return nil
+}
+
+func (r *UlimitsRule) Message() string {
+	return "Ulimits (memlock and nofile) are properly configured"
+}
+
+func (r *UlimitsRule) Level() constants.ValidationLevel {
+	return constants.ValidationLevelError
+}
+
+func (r *UlimitsRule) Hint() string {
+	return "Ulimit configurations are required for pods to run properly. Run 'ai-services bootstrap configure' to set up the required ulimits."
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/validators/podman/usergroup/usergroup.go
+++ b/ai-services/internal/pkg/validators/podman/usergroup/usergroup.go
@@ -23,21 +23,21 @@ func (r *UsergroupRule) Description() string {
 }
 
 func (r *UsergroupRule) Verify() error {
-	logger.Infoln("Validating sentient group exists", logger.VerbosityLevelDebug)
+	logger.Debugln("Validating sentient group exists")
 
 	// Check if sentient group exists using getent
-	cmd := exec.Command("getent", "group", "sentient")
+	cmd := exec.Command("getent", "group", constants.SentientGroupName)
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("sentient group does not exist")
+		return fmt.Errorf("%s group does not exist", constants.SentientGroupName)
 	}
 
-	logger.Infoln("✓ sentient group exists", logger.VerbosityLevelDebug)
+	logger.Debugf("✓ %s group exists", constants.SentientGroupName)
 
 	return nil
 }
 
 func (r *UsergroupRule) Message() string {
-	return "Sentient group exists"
+	return fmt.Sprintf("%s group exists", constants.SentientGroupName)
 }
 
 func (r *UsergroupRule) Level() constants.ValidationLevel {

--- a/ai-services/internal/pkg/validators/podman/usergroup/usergroup.go
+++ b/ai-services/internal/pkg/validators/podman/usergroup/usergroup.go
@@ -1,0 +1,51 @@
+package usergroup
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+)
+
+type UsergroupRule struct{}
+
+func NewUsergroupRule() *UsergroupRule {
+	return &UsergroupRule{}
+}
+
+func (r *UsergroupRule) Name() string {
+	return "usergroup"
+}
+
+func (r *UsergroupRule) Description() string {
+	return "Validates that the sentient group exists for ulimit configurations."
+}
+
+func (r *UsergroupRule) Verify() error {
+	logger.Infoln("Validating sentient group exists", logger.VerbosityLevelDebug)
+
+	// Check if sentient group exists using getent
+	cmd := exec.Command("getent", "group", "sentient")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("sentient group does not exist")
+	}
+
+	logger.Infoln("✓ sentient group exists", logger.VerbosityLevelDebug)
+
+	return nil
+}
+
+func (r *UsergroupRule) Message() string {
+	return "Sentient group exists"
+}
+
+func (r *UsergroupRule) Level() constants.ValidationLevel {
+	return constants.ValidationLevelError
+}
+
+func (r *UsergroupRule) Hint() string {
+	return "The sentient group is required for ulimit configurations. Run 'ai-services bootstrap configure' to create the group."
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/validators/validators.go
+++ b/ai-services/internal/pkg/validators/validators.go
@@ -14,6 +14,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/validators/podman/platform"
 	"github.com/project-ai-services/ai-services/internal/pkg/validators/podman/power"
 	"github.com/project-ai-services/ai-services/internal/pkg/validators/podman/rhn"
+	"github.com/project-ai-services/ai-services/internal/pkg/validators/podman/slicelimits"
 	"github.com/project-ai-services/ai-services/internal/pkg/validators/podman/spyre"
 	"github.com/project-ai-services/ai-services/internal/pkg/validators/podman/ulimits"
 	"github.com/project-ai-services/ai-services/internal/pkg/validators/podman/usergroup"
@@ -29,6 +30,7 @@ func init() {
 	PodmanRegistry.Register(spyre.NewSpyreRule())
 	PodmanRegistry.Register(usergroup.NewUsergroupRule())
 	PodmanRegistry.Register(ulimits.NewUlimitsRule())
+	PodmanRegistry.Register(slicelimits.NewSliceLimitsRule())
 
 	// OpenshiftChecks
 	OpenshiftRegistry.Register(kubeconfig.NewKubeconfigRule())

--- a/ai-services/internal/pkg/validators/validators.go
+++ b/ai-services/internal/pkg/validators/validators.go
@@ -15,6 +15,8 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/validators/podman/power"
 	"github.com/project-ai-services/ai-services/internal/pkg/validators/podman/rhn"
 	"github.com/project-ai-services/ai-services/internal/pkg/validators/podman/spyre"
+	"github.com/project-ai-services/ai-services/internal/pkg/validators/podman/ulimits"
+	"github.com/project-ai-services/ai-services/internal/pkg/validators/podman/usergroup"
 )
 
 // Initialize the default registry with built-in rules.
@@ -25,6 +27,8 @@ func init() {
 	PodmanRegistry.Register(power.NewPowerRule())
 	PodmanRegistry.Register(rhn.NewRHNRule())
 	PodmanRegistry.Register(spyre.NewSpyreRule())
+	PodmanRegistry.Register(usergroup.NewUsergroupRule())
+	PodmanRegistry.Register(ulimits.NewUlimitsRule())
 
 	// OpenshiftChecks
 	OpenshiftRegistry.Register(kubeconfig.NewKubeconfigRule())


### PR DESCRIPTION
LLM, reranker, and embedding pods were failing to start with errors:
```
crun: controller 'cpu' is not available (cgroup error)
crun: setrlimit 'RLIMIT_NOFILE': Operation not permitted (ulimit error)
```

**Root Cause:** The sentient group and ulimit configurations were only created during Spyre-specific setups causing failures in non-Spyre setups.

**Solution:** Moved sentient group creation and ulimit configurations from spyre.gpo code to the podman configure, ensuring they're configured for both spyre and non-spyre environments.