### PR TITLE
[Catalog] Use common DB helper methods

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.103
+TAG?=v0.0.104
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.103
+  image: icr.io/ai-services-cicd/ai-services:v0.0.104
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -650,7 +650,7 @@ func (s *ApplicationService) DeleteApplication(ctx context.Context, id uuid.UUID
 		}
 	}
 
-	if err := s.appRepo.UpdateStatus(ctx, id, models.ApplicationStatusDeleting, "Deletion initiated"); err != nil {
+	if err := utils.UpdateApplicationStatus(ctx, s.appRepo, id, models.ApplicationStatusDeleting, "Deletion initiated"); err != nil {
 		return nil, err
 	}
 

--- a/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deletion/deletion.go
@@ -54,7 +54,7 @@ func (s *DeletionService) PerformDeletion(ctx context.Context, appID uuid.UUID, 
 	rt, err := vars.RuntimeFactory.Create("")
 	if err != nil {
 		logger.Errorf("failed to init runtime client for app %s: %s", appID, err)
-		_ = s.appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, "failed to init runtime client")
+		_ = catalogutils.UpdateApplicationStatus(ctx, s.appRepo, appID, models.ApplicationStatusError, "failed to init runtime client")
 
 		return
 	}
@@ -63,7 +63,7 @@ func (s *DeletionService) PerformDeletion(ctx context.Context, appID uuid.UUID, 
 	proxyManager, err := proxy.GetCaddyProxyManager()
 	if err != nil {
 		logger.Errorf("failed to get Caddy proxy manager for app %s: %s", appID, err)
-		_ = s.appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, fmt.Sprintf("failed to get Caddy proxy manager: %s", err))
+		_ = catalogutils.UpdateApplicationStatus(ctx, s.appRepo, appID, models.ApplicationStatusError, fmt.Sprintf("failed to get Caddy proxy manager: %s", err))
 
 		return
 	}
@@ -86,7 +86,7 @@ func (s *DeletionService) PerformDeletion(ctx context.Context, appID uuid.UUID, 
 	if err := s.appRepo.Delete(ctx, appID); err != nil {
 		errMsg := fmt.Sprintf("failed to delete application: %s", err)
 		logger.Errorf("application %s: %s", appID, errMsg)
-		_ = s.appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, errMsg)
+		_ = catalogutils.UpdateApplicationStatus(ctx, s.appRepo, appID, models.ApplicationStatusError, errMsg)
 
 		return
 	}
@@ -124,7 +124,7 @@ func (s *DeletionService) collectComponentCandidates(ctx context.Context, appID 
 		deps, err := s.serviceDependencyRepo.GetDependenciesByServiceID(ctx, svc.ID)
 		if err != nil {
 			logger.Errorf("failed to get dependencies for service %s: %s", svc.ID, err)
-			_ = s.appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, "failed to get service dependencies")
+			_ = catalogutils.UpdateApplicationStatus(ctx, s.appRepo, appID, models.ApplicationStatusError, "failed to get service dependencies")
 
 			return nil, err
 		}
@@ -184,7 +184,7 @@ func (s *DeletionService) unregisterServiceRoutes(ctx context.Context, proxyMana
 		svc.ID.String(),
 	); err != nil {
 		// Update DB status with route cleanup failure
-		_ = s.serviceRepo.UpdateStatus(ctx, svc.ID, models.ServiceStatusError,
+		_ = catalogutils.UpdateServiceStatus(ctx, s.serviceRepo, svc.ID, models.ServiceStatusError,
 			fmt.Sprintf("route unregistration failed: %v", err))
 
 		return err
@@ -208,7 +208,7 @@ func (s *DeletionService) deleteServices(ctx context.Context, rt runtime.Runtime
 		if err != nil {
 			errMsg := fmt.Sprintf("service %s: failed to list pods: %s", svc.ID, err)
 			errorMessages = append(errorMessages, errMsg)
-			_ = s.serviceRepo.UpdateStatus(ctx, svc.ID, models.ServiceStatusError, fmt.Sprintf("failed to list pods: %s", err))
+			_ = catalogutils.UpdateServiceStatus(ctx, s.serviceRepo, svc.ID, models.ServiceStatusError, fmt.Sprintf("failed to list pods: %s", err))
 
 			continue
 		}
@@ -233,7 +233,7 @@ func (s *DeletionService) deleteServices(ctx context.Context, rt runtime.Runtime
 			hasDeletionErrors = true
 			errMsg := fmt.Sprintf("service %s: failed to delete %d pod(s)", svc.ID, len(podErrors))
 			errorMessages = append(errorMessages, errMsg)
-			_ = s.serviceRepo.UpdateStatus(ctx, svc.ID, models.ServiceStatusError, fmt.Sprintf("failed to delete %d pod(s)", len(podErrors)))
+			_ = catalogutils.UpdateServiceStatus(ctx, s.serviceRepo, svc.ID, models.ServiceStatusError, fmt.Sprintf("failed to delete %d pod(s)", len(podErrors)))
 		}
 
 		// Delete volumes only after pods are deleted and only when keepData is false.
@@ -253,7 +253,7 @@ func (s *DeletionService) deleteServices(ctx context.Context, rt runtime.Runtime
 		if err := s.serviceRepo.Delete(ctx, svc.ID); err != nil {
 			errMsg := fmt.Sprintf("service %s: failed to delete from DB: %s", svc.ID, err)
 			errorMessages = append(errorMessages, errMsg)
-			_ = s.serviceRepo.UpdateStatus(ctx, svc.ID, models.ServiceStatusError, fmt.Sprintf("failed to delete from DB: %s", err))
+			_ = catalogutils.UpdateServiceStatus(ctx, s.serviceRepo, svc.ID, models.ServiceStatusError, fmt.Sprintf("failed to delete from DB: %s", err))
 		}
 	}
 
@@ -294,7 +294,7 @@ func (s *DeletionService) deleteOrphanedComponents(ctx context.Context, rt runti
 		if err != nil {
 			errMsg := fmt.Sprintf("component %s: failed to list pods: %s", componentID, err)
 			errorMessages = append(errorMessages, errMsg)
-			_ = s.componentRepo.UpdateStatus(ctx, componentID, models.ComponentStatusError, fmt.Sprintf("failed to list pods: %s", err))
+			_ = catalogutils.UpdateComponentStatus(ctx, s.componentRepo, componentID, models.ComponentStatusError, fmt.Sprintf("failed to list pods: %s", err))
 
 			continue
 		}
@@ -312,7 +312,7 @@ func (s *DeletionService) deleteOrphanedComponents(ctx context.Context, rt runti
 			hasDeletionErrors = true
 			errMsg := fmt.Sprintf("component %s: failed to delete %d pod(s)", componentID, len(podErrors))
 			errorMessages = append(errorMessages, errMsg)
-			_ = s.componentRepo.UpdateStatus(ctx, componentID, models.ComponentStatusError, fmt.Sprintf("failed to delete %d pod(s)", len(podErrors)))
+			_ = catalogutils.UpdateComponentStatus(ctx, s.componentRepo, componentID, models.ComponentStatusError, fmt.Sprintf("failed to delete %d pod(s)", len(podErrors)))
 		}
 
 		// Delete component volumes only after pods are deleted and only when keepData is false.
@@ -332,7 +332,7 @@ func (s *DeletionService) deleteOrphanedComponents(ctx context.Context, rt runti
 		if err := s.componentRepo.Delete(ctx, componentID); err != nil {
 			errMsg := fmt.Sprintf("component %s: failed to delete from DB: %s", componentID, err)
 			errorMessages = append(errorMessages, errMsg)
-			_ = s.componentRepo.UpdateStatus(ctx, componentID, models.ComponentStatusError, fmt.Sprintf("failed to delete from DB: %s", err))
+			_ = catalogutils.UpdateComponentStatus(ctx, s.componentRepo, componentID, models.ComponentStatusError, fmt.Sprintf("failed to delete from DB: %s", err))
 		}
 	}
 
@@ -343,7 +343,7 @@ func (s *DeletionService) deleteOrphanedComponents(ctx context.Context, rt runti
 func (s *DeletionService) handleDeletionFailure(ctx context.Context, appID uuid.UUID, errorMessages []string) {
 	errMsg := fmt.Sprintf("Application deletion failed with %d error(s), application not deleted", len(errorMessages))
 	logger.Errorf("application %s: %s", appID, errMsg)
-	_ = s.appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, errMsg)
+	_ = catalogutils.UpdateApplicationStatus(ctx, s.appRepo, appID, models.ApplicationStatusError, errMsg)
 }
 
 // deleteVolumesFromPods extracts volume names from pod labels and deletes them using the runtime client.

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -97,8 +97,8 @@ func (d *PodmanDeployer) ExecuteDeployment(
 
 	// Step 1.a: Pull container images for all components and services
 	if err := d.pullImagesForDeployment(plan); err != nil {
-		wrappedErr := fmt.Errorf("image pull failed: %w", err)
-		if updateErr := catalogutils.HandleApplicationDeploymentError(ctx, d.appRepo, plan.ApplicationID, wrappedErr); updateErr != nil {
+		errMsg := fmt.Sprintf("Image pull failed: %v", err)
+		if updateErr := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusError, errMsg); updateErr != nil {
 			logger.Errorf("Failed to update application status: %v\n", updateErr)
 		}
 
@@ -107,8 +107,8 @@ func (d *PodmanDeployer) ExecuteDeployment(
 
 	// Step 1.b: Download models specified in parameters
 	if err := d.downloadModelsForDeployment(plan); err != nil {
-		wrappedErr := fmt.Errorf("model download failed: %w", err)
-		if updateErr := catalogutils.HandleApplicationDeploymentError(ctx, d.appRepo, plan.ApplicationID, wrappedErr); updateErr != nil {
+		errMsg := fmt.Sprintf("Model download failed: %v", err)
+		if updateErr := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusError, errMsg); updateErr != nil {
 			logger.Errorf("Failed to update application status: %v\n", updateErr)
 		}
 
@@ -123,8 +123,8 @@ func (d *PodmanDeployer) ExecuteDeployment(
 	// Step 2: Deploy components if any
 	if len(plan.Components) > 0 {
 		if err := d.deployComponents(plan); err != nil {
-			wrappedErr := fmt.Errorf("component deployment failed: %w", err)
-			if updateErr := catalogutils.HandleApplicationDeploymentError(ctx, d.appRepo, plan.ApplicationID, wrappedErr); updateErr != nil {
+			errMsg := fmt.Sprintf("Component deployment failed: %v", err)
+			if updateErr := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusError, errMsg); updateErr != nil {
 				logger.Errorf("Failed to update application status: %v\n", updateErr)
 			}
 
@@ -135,8 +135,8 @@ func (d *PodmanDeployer) ExecuteDeployment(
 	// Step 4: Deploy services if any
 	if len(plan.Services) > 0 {
 		if err := d.deployServices(ctx, plan); err != nil {
-			wrappedErr := fmt.Errorf("service deployment failed: %w", err)
-			if updateErr := catalogutils.HandleApplicationDeploymentError(ctx, d.appRepo, plan.ApplicationID, wrappedErr); updateErr != nil {
+			errMsg := fmt.Sprintf("Service deployment failed: %v", err)
+			if updateErr := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusError, errMsg); updateErr != nil {
 				logger.Errorf("Failed to update application status: %v\n", updateErr)
 			}
 
@@ -146,8 +146,8 @@ func (d *PodmanDeployer) ExecuteDeployment(
 
 	// Step 5: Register routes with Caddy proxy
 	if err := d.registerApplicationRoutes(ctx, plan); err != nil {
-		wrappedErr := fmt.Errorf("failed to register application routes: %w", err)
-		if updateErr := catalogutils.HandleApplicationDeploymentError(ctx, d.appRepo, plan.ApplicationID, wrappedErr); updateErr != nil {
+		errMsg := fmt.Sprintf("Failed to register application routes: %v", err)
+		if updateErr := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusError, errMsg); updateErr != nil {
 			logger.Errorf("Failed to update application status: %v\n", updateErr)
 		}
 
@@ -360,7 +360,8 @@ func (d *PodmanDeployer) deployComponentsConcurrently(components map[string]*Com
 		go func(h string, c *ComponentPlan) {
 			defer wg.Done()
 			if err := d.deployComponent(h, c, plan, &mu); err != nil {
-				if updateErr := catalogutils.HandleComponentDeploymentError(context.Background(), d.componentRepo, c.DatabaseID, err); updateErr != nil {
+				errMsg := fmt.Sprintf("Component deployment failed: %v", err)
+				if updateErr := catalogutils.UpdateComponentStatus(context.Background(), d.componentRepo, c.DatabaseID, models.ComponentStatusError, errMsg); updateErr != nil {
 					logger.Errorf("Failed to update component %s status: %v\n", h, updateErr)
 				}
 				errChan <- fmt.Errorf("failed to deploy component %s: %w", h, err)
@@ -591,7 +592,8 @@ func (d *PodmanDeployer) deployServices(ctx context.Context, plan *DeploymentPla
 
 			if err := d.deployService(ctx, plan, sID, service); err != nil {
 				// Update service status to Error
-				if updateErr := catalogutils.HandleServiceDeploymentError(ctx, d.serviceRepo, service.DatabaseID, err); updateErr != nil {
+				errMsg := fmt.Sprintf("Service deployment failed: %v", err)
+				if updateErr := catalogutils.UpdateServiceStatus(ctx, d.serviceRepo, service.DatabaseID, models.ServiceStatusError, errMsg); updateErr != nil {
 					logger.Errorf("Failed to update service %s status: %v\n", sID, updateErr)
 				}
 				errCh <- fmt.Errorf("failed to deploy service %s: %w", sID, err)

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -97,26 +97,36 @@ func (d *PodmanDeployer) ExecuteDeployment(
 
 	// Step 1.a: Pull container images for all components and services
 	if err := d.pullImagesForDeployment(plan); err != nil {
-		d.handleDeploymentError(ctx, plan.ApplicationID, "Image pull failed", err)
+		wrappedErr := fmt.Errorf("image pull failed: %w", err)
+		if updateErr := catalogutils.HandleApplicationDeploymentError(ctx, d.appRepo, plan.ApplicationID, wrappedErr); updateErr != nil {
+			logger.Errorf("Failed to update application status: %v\n", updateErr)
+		}
 
 		return fmt.Errorf("failed to pull images: %w", err)
 	}
 
 	// Step 1.b: Download models specified in parameters
 	if err := d.downloadModelsForDeployment(plan); err != nil {
-		d.handleDeploymentError(ctx, plan.ApplicationID, "Model download failed", err)
+		wrappedErr := fmt.Errorf("model download failed: %w", err)
+		if updateErr := catalogutils.HandleApplicationDeploymentError(ctx, d.appRepo, plan.ApplicationID, wrappedErr); updateErr != nil {
+			logger.Errorf("Failed to update application status: %v\n", updateErr)
+		}
 
 		return fmt.Errorf("failed to download models: %w", err)
 	}
 
 	// Update application status to Deploying before starting deployment
-	deployMsg := "Deploying application"
-	d.updateStatusIgnoreError(ctx, plan.ApplicationID, models.ApplicationStatusDeploying, deployMsg)
+	if err := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusDeploying, "Deploying application"); err != nil {
+		logger.Errorf("Failed to update application status to Deploying: %v\n", err)
+	}
 
 	// Step 2: Deploy components if any
 	if len(plan.Components) > 0 {
 		if err := d.deployComponents(plan); err != nil {
-			d.handleDeploymentError(ctx, plan.ApplicationID, "Component deployment failed", err)
+			wrappedErr := fmt.Errorf("component deployment failed: %w", err)
+			if updateErr := catalogutils.HandleApplicationDeploymentError(ctx, d.appRepo, plan.ApplicationID, wrappedErr); updateErr != nil {
+				logger.Errorf("Failed to update application status: %v\n", updateErr)
+			}
 
 			return fmt.Errorf("failed to deploy components: %w", err)
 		}
@@ -125,7 +135,10 @@ func (d *PodmanDeployer) ExecuteDeployment(
 	// Step 4: Deploy services if any
 	if len(plan.Services) > 0 {
 		if err := d.deployServices(ctx, plan); err != nil {
-			d.handleDeploymentError(ctx, plan.ApplicationID, "Service deployment failed", err)
+			wrappedErr := fmt.Errorf("service deployment failed: %w", err)
+			if updateErr := catalogutils.HandleApplicationDeploymentError(ctx, d.appRepo, plan.ApplicationID, wrappedErr); updateErr != nil {
+				logger.Errorf("Failed to update application status: %v\n", updateErr)
+			}
 
 			return fmt.Errorf("failed to deploy services: %w", err)
 		}
@@ -133,32 +146,22 @@ func (d *PodmanDeployer) ExecuteDeployment(
 
 	// Step 5: Register routes with Caddy proxy
 	if err := d.registerApplicationRoutes(ctx, plan); err != nil {
-		d.handleDeploymentError(ctx, plan.ApplicationID, "Failed to register application routes", err)
+		wrappedErr := fmt.Errorf("failed to register application routes: %w", err)
+		if updateErr := catalogutils.HandleApplicationDeploymentError(ctx, d.appRepo, plan.ApplicationID, wrappedErr); updateErr != nil {
+			logger.Errorf("Failed to update application status: %v\n", updateErr)
+		}
 
 		return fmt.Errorf("failed to register application routes: %w", err)
 	}
 
 	// Step 6: Update application status to Running
-	d.updateStatusIgnoreError(ctx, plan.ApplicationID, models.ApplicationStatusRunning, "Deployment completed successfully")
+	if err := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusRunning, "Deployment completed successfully"); err != nil {
+		logger.Errorf("Failed to update application status to Running: %v\n", err)
+	}
 
 	logger.Infof("Deployment completed successfully for '%s'\n", plan.ApplicationName)
 
 	return nil
-}
-
-// handleDeploymentError updates application status on error and logs any update failures.
-func (d *PodmanDeployer) handleDeploymentError(ctx context.Context, appID uuid.UUID, message string, err error) {
-	fullMessage := fmt.Sprintf("%s: %v", message, err)
-	if updateErr := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, appID, models.ApplicationStatusError, fullMessage); updateErr != nil {
-		logger.Errorf("Failed to update application status: %v\n", updateErr)
-	}
-}
-
-// updateStatusIgnoreError updates application status and logs any failures without returning error.
-func (d *PodmanDeployer) updateStatusIgnoreError(ctx context.Context, appID uuid.UUID, status models.ApplicationStatus, message string) {
-	if err := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, appID, status, message); err != nil {
-		logger.Errorf("Failed to update application status: %v\n", err)
-	}
 }
 
 // downloadModelsForDeployment downloads all models specified in component and service parameters.
@@ -357,12 +360,17 @@ func (d *PodmanDeployer) deployComponentsConcurrently(components map[string]*Com
 		go func(h string, c *ComponentPlan) {
 			defer wg.Done()
 			if err := d.deployComponent(h, c, plan, &mu); err != nil {
-				d.handleComponentDeploymentError(h, c, err)
+				if updateErr := catalogutils.HandleComponentDeploymentError(context.Background(), d.componentRepo, c.DatabaseID, err); updateErr != nil {
+					logger.Errorf("Failed to update component %s status: %v\n", h, updateErr)
+				}
 				errChan <- fmt.Errorf("failed to deploy component %s: %w", h, err)
 
 				return
 			}
-			d.handleComponentDeploymentSuccess(h, c)
+			// Update component status to Running after successful deployment
+			if err := catalogutils.UpdateComponentStatus(context.Background(), d.componentRepo, c.DatabaseID, models.ComponentStatusRunning, "Component deployed successfully"); err != nil {
+				logger.Errorf("Failed to update component %s status to Running: %v\n", h, err)
+			}
 		}(hash, comp)
 	}
 
@@ -411,27 +419,6 @@ func (d *PodmanDeployer) deployComponent(hash string, comp *ComponentPlan, plan 
 	logger.Infof("Component %s deployed successfully\n", comp.ComponentType)
 
 	return nil
-}
-
-// handleComponentDeploymentError updates component status to Error when deployment fails.
-func (d *PodmanDeployer) handleComponentDeploymentError(hash string, comp *ComponentPlan, err error) {
-	if comp.DatabaseID == uuid.Nil {
-		return
-	}
-	errMsg := fmt.Sprintf("Component deployment failed: %v", err)
-	if updateErr := d.componentRepo.UpdateStatus(context.Background(), comp.DatabaseID, models.ComponentStatusError, errMsg); updateErr != nil {
-		logger.Errorf("Failed to update component %s status: %v\n", hash, updateErr)
-	}
-}
-
-// handleComponentDeploymentSuccess updates component status to Running after successful deployment.
-func (d *PodmanDeployer) handleComponentDeploymentSuccess(hash string, comp *ComponentPlan) {
-	if comp.DatabaseID == uuid.Nil {
-		return
-	}
-	if err := d.componentRepo.UpdateStatus(context.Background(), comp.DatabaseID, models.ComponentStatusRunning, "Component deployed successfully"); err != nil {
-		logger.Errorf("Failed to update component %s status to Running: %v\n", hash, err)
-	}
 }
 
 // loadComponentResources loads all necessary resources for a component.
@@ -604,11 +591,8 @@ func (d *PodmanDeployer) deployServices(ctx context.Context, plan *DeploymentPla
 
 			if err := d.deployService(ctx, plan, sID, service); err != nil {
 				// Update service status to Error
-				if service.DatabaseID != uuid.Nil {
-					errMsg := fmt.Sprintf("Service deployment failed: %v", err)
-					if updateErr := d.serviceRepo.UpdateStatus(ctx, service.DatabaseID, models.ServiceStatusError, errMsg); updateErr != nil {
-						logger.Errorf("Failed to update service %s status: %v\n", sID, updateErr)
-					}
+				if updateErr := catalogutils.HandleServiceDeploymentError(ctx, d.serviceRepo, service.DatabaseID, err); updateErr != nil {
+					logger.Errorf("Failed to update service %s status: %v\n", sID, updateErr)
 				}
 				errCh <- fmt.Errorf("failed to deploy service %s: %w", sID, err)
 
@@ -616,11 +600,9 @@ func (d *PodmanDeployer) deployServices(ctx context.Context, plan *DeploymentPla
 			}
 
 			// Update service status to Running after successful deployment
-			if service.DatabaseID != uuid.Nil {
-				if err := d.serviceRepo.UpdateStatus(ctx, service.DatabaseID, models.ServiceStatusRunning, "Service deployed successfully"); err != nil {
-					logger.Errorf("Failed to update service %s status to Running: %v\n", sID, err)
-					// Don't fail the deployment if status update fails
-				}
+			if err := catalogutils.UpdateServiceStatus(ctx, d.serviceRepo, service.DatabaseID, models.ServiceStatusRunning, "Service deployed successfully"); err != nil {
+				logger.Errorf("Failed to update service %s status to Running: %v\n", sID, err)
+				// Don't fail the deployment if status update fails
 			}
 		}(serviceID, svc)
 	}
@@ -648,7 +630,7 @@ func (d *PodmanDeployer) deployService(ctx context.Context, plan *DeploymentPlan
 	logger.Infof("Deploying service %s...\n", serviceID)
 
 	// Update service status to Initializing in database
-	if err := d.serviceRepo.UpdateStatus(ctx, svc.DatabaseID, models.ServiceStatusInitializing, "Deploying service"); err != nil {
+	if err := catalogutils.UpdateServiceStatus(ctx, d.serviceRepo, svc.DatabaseID, models.ServiceStatusInitializing, "Deploying service"); err != nil {
 		logger.Errorf("Failed to update service status to Initializing: %v\n", err)
 		// Don't fail the deployment if status update fails
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -97,20 +97,14 @@ func (d *PodmanDeployer) ExecuteDeployment(
 
 	// Step 1.a: Pull container images for all components and services
 	if err := d.pullImagesForDeployment(plan); err != nil {
-		errMsg := fmt.Sprintf("Image pull failed: %v", err)
-		if updateErr := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusError, errMsg); updateErr != nil {
-			logger.Errorf("Failed to update application status: %v\n", updateErr)
-		}
+		d.handleDeploymentStepError(ctx, plan.ApplicationID, "Image pull failed", err)
 
 		return fmt.Errorf("failed to pull images: %w", err)
 	}
 
 	// Step 1.b: Download models specified in parameters
 	if err := d.downloadModelsForDeployment(plan); err != nil {
-		errMsg := fmt.Sprintf("Model download failed: %v", err)
-		if updateErr := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusError, errMsg); updateErr != nil {
-			logger.Errorf("Failed to update application status: %v\n", updateErr)
-		}
+		d.handleDeploymentStepError(ctx, plan.ApplicationID, "Model download failed", err)
 
 		return fmt.Errorf("failed to download models: %w", err)
 	}
@@ -123,10 +117,7 @@ func (d *PodmanDeployer) ExecuteDeployment(
 	// Step 2: Deploy components if any
 	if len(plan.Components) > 0 {
 		if err := d.deployComponents(plan); err != nil {
-			errMsg := fmt.Sprintf("Component deployment failed: %v", err)
-			if updateErr := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusError, errMsg); updateErr != nil {
-				logger.Errorf("Failed to update application status: %v\n", updateErr)
-			}
+			d.handleDeploymentStepError(ctx, plan.ApplicationID, "Component deployment failed", err)
 
 			return fmt.Errorf("failed to deploy components: %w", err)
 		}
@@ -135,10 +126,7 @@ func (d *PodmanDeployer) ExecuteDeployment(
 	// Step 4: Deploy services if any
 	if len(plan.Services) > 0 {
 		if err := d.deployServices(ctx, plan); err != nil {
-			errMsg := fmt.Sprintf("Service deployment failed: %v", err)
-			if updateErr := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusError, errMsg); updateErr != nil {
-				logger.Errorf("Failed to update application status: %v\n", updateErr)
-			}
+			d.handleDeploymentStepError(ctx, plan.ApplicationID, "Service deployment failed", err)
 
 			return fmt.Errorf("failed to deploy services: %w", err)
 		}
@@ -146,10 +134,7 @@ func (d *PodmanDeployer) ExecuteDeployment(
 
 	// Step 5: Register routes with Caddy proxy
 	if err := d.registerApplicationRoutes(ctx, plan); err != nil {
-		errMsg := fmt.Sprintf("Failed to register application routes: %v", err)
-		if updateErr := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusError, errMsg); updateErr != nil {
-			logger.Errorf("Failed to update application status: %v\n", updateErr)
-		}
+		d.handleDeploymentStepError(ctx, plan.ApplicationID, "Failed to register application routes", err)
 
 		return fmt.Errorf("failed to register application routes: %w", err)
 	}
@@ -162,6 +147,14 @@ func (d *PodmanDeployer) ExecuteDeployment(
 	logger.Infof("Deployment completed successfully for '%s'\n", plan.ApplicationName)
 
 	return nil
+}
+
+// handleDeploymentStepError updates application status to Error and logs the failure.
+func (d *PodmanDeployer) handleDeploymentStepError(ctx context.Context, appID uuid.UUID, context string, err error) {
+	errMsg := fmt.Sprintf("%s: %v", context, err)
+	if updateErr := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, appID, models.ApplicationStatusError, errMsg); updateErr != nil {
+		logger.Errorf("Failed to update application status: %v\n", updateErr)
+	}
 }
 
 // downloadModelsForDeployment downloads all models specified in component and service parameters.

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
 	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
+	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
@@ -253,7 +254,7 @@ func (s *SyncService) syncServicePod(ctx context.Context, rt runtime.Runtime, se
 		message := fmt.Sprintf("Pod not found or error: %v", err)
 
 		if service.Status != newStatus {
-			if err := s.serviceRepo.UpdateStatus(ctx, service.ID, newStatus, message); err != nil {
+			if err := catalogutils.UpdateServiceStatus(ctx, s.serviceRepo, service.ID, newStatus, message); err != nil {
 				return "", fmt.Errorf("failed to update service status: %w", err)
 			}
 			logger.Infof("Updated service %s status to %s", service.ID, newStatus)
@@ -267,7 +268,7 @@ func (s *SyncService) syncServicePod(ctx context.Context, rt runtime.Runtime, se
 
 	// Update only if status changed
 	if service.Status != newStatus {
-		if err := s.serviceRepo.UpdateStatus(ctx, service.ID, newStatus, message); err != nil {
+		if err := catalogutils.UpdateServiceStatus(ctx, s.serviceRepo, service.ID, newStatus, message); err != nil {
 			return "", fmt.Errorf("failed to update service status: %w", err)
 		}
 		logger.Infof("Updated service %s status to %s", service.ID, newStatus)
@@ -301,7 +302,7 @@ func (s *SyncService) syncComponentPod(ctx context.Context, rt runtime.Runtime, 
 		message := fmt.Sprintf("Pod not found or error: %v", err)
 
 		if component.Status != newStatus {
-			if err := s.componentRepo.UpdateStatus(ctx, componentID, newStatus, message); err != nil {
+			if err := catalogutils.UpdateComponentStatus(ctx, s.componentRepo, componentID, newStatus, message); err != nil {
 				return newStatus, "", fmt.Errorf("failed to update component status: %w", err)
 			}
 			logger.Infof("Updated component %s status to %s", componentID, newStatus)
@@ -315,7 +316,7 @@ func (s *SyncService) syncComponentPod(ctx context.Context, rt runtime.Runtime, 
 
 	// Update only if status changed
 	if component.Status != newStatus {
-		if err := s.componentRepo.UpdateStatus(ctx, componentID, newStatus, message); err != nil {
+		if err := catalogutils.UpdateComponentStatus(ctx, s.componentRepo, componentID, newStatus, message); err != nil {
 			return newStatus, "", fmt.Errorf("failed to update component status: %w", err)
 		}
 		logger.Infof("Updated component %s status to %s", componentID, newStatus)
@@ -424,7 +425,7 @@ func (s *SyncService) updateApplicationStatus(ctx context.Context, app *models.A
 
 	// Update only if status changed
 	if app.Status != newStatus {
-		if err := s.appRepo.UpdateStatus(ctx, app.ID, newStatus, message); err != nil {
+		if err := catalogutils.UpdateApplicationStatus(ctx, s.appRepo, app.ID, newStatus, message); err != nil {
 			return fmt.Errorf("failed to update application status: %w", err)
 		}
 		logger.Infof("Updated application %s status to %s", app.Name, newStatus)

--- a/ai-services/internal/pkg/catalog/utils/application_utils.go
+++ b/ai-services/internal/pkg/catalog/utils/application_utils.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/google/uuid"
@@ -34,8 +33,6 @@ func UpdateApplicationStatus(ctx context.Context, appRepo dbrepo.ApplicationRepo
 	case string:
 		appUUID, err = uuid.Parse(id)
 		if err != nil {
-			log.Printf("Failed to parse application ID %s: %v", id, err)
-
 			return fmt.Errorf("invalid application ID: %w", err)
 		}
 	case uuid.UUID:
@@ -46,12 +43,34 @@ func UpdateApplicationStatus(ctx context.Context, appRepo dbrepo.ApplicationRepo
 
 	// Update the application status in the database
 	if err := appRepo.UpdateStatus(ctx, appUUID, status, message); err != nil {
-		log.Printf("Failed to update application %s status in database: %v", appUUID, err)
-
 		return fmt.Errorf("failed to update application status: %w", err)
 	}
 
-	log.Printf("Application %s status updated: %s - %s", appUUID, status, message)
+	return nil
+}
+
+// UpdateServiceStatus updates service status in the database.
+func UpdateServiceStatus(ctx context.Context, serviceRepo dbrepo.ServiceRepository, serviceID uuid.UUID, status models.ServiceStatus, message string) error {
+	if serviceID == uuid.Nil {
+		return nil
+	}
+
+	if err := serviceRepo.UpdateStatus(ctx, serviceID, status, message); err != nil {
+		return fmt.Errorf("failed to update service status: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateComponentStatus updates component status in the database.
+func UpdateComponentStatus(ctx context.Context, componentRepo dbrepo.ComponentRepository, componentID uuid.UUID, status models.ComponentStatus, message string) error {
+	if componentID == uuid.Nil {
+		return nil
+	}
+
+	if err := componentRepo.UpdateStatus(ctx, componentID, status, message); err != nil {
+		return fmt.Errorf("failed to update component status: %w", err)
+	}
 
 	return nil
 }
@@ -105,6 +124,48 @@ func CalculateComponentHash(componentType string, providerID string, params map[
 	hash := sha256.Sum256([]byte(hashInput))
 
 	return fmt.Sprintf("%x", hash[:16]) // Use first 16 bytes (32 hex chars)
+}
+
+// HandleApplicationDeploymentError updates application status to Error when deployment fails.
+func HandleApplicationDeploymentError(ctx context.Context, appRepo dbrepo.ApplicationRepository, appID uuid.UUID, err error) error {
+	if appID == uuid.Nil {
+		return nil
+	}
+
+	errMsg := fmt.Sprintf("Application deployment failed: %v", err)
+	if updateErr := appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, errMsg); updateErr != nil {
+		return fmt.Errorf("failed to update application status: %w", updateErr)
+	}
+
+	return nil
+}
+
+// HandleServiceDeploymentError updates service status to Error when deployment fails.
+func HandleServiceDeploymentError(ctx context.Context, serviceRepo dbrepo.ServiceRepository, serviceID uuid.UUID, err error) error {
+	if serviceID == uuid.Nil {
+		return nil
+	}
+
+	errMsg := fmt.Sprintf("Service deployment failed: %v", err)
+	if updateErr := serviceRepo.UpdateStatus(ctx, serviceID, models.ServiceStatusError, errMsg); updateErr != nil {
+		return fmt.Errorf("failed to update service status: %w", updateErr)
+	}
+
+	return nil
+}
+
+// HandleComponentDeploymentError updates component status to Error when deployment fails.
+func HandleComponentDeploymentError(ctx context.Context, componentRepo dbrepo.ComponentRepository, componentID uuid.UUID, err error) error {
+	if componentID == uuid.Nil {
+		return nil
+	}
+
+	errMsg := fmt.Sprintf("Component deployment failed: %v", err)
+	if updateErr := componentRepo.UpdateStatus(ctx, componentID, models.ComponentStatusError, errMsg); updateErr != nil {
+		return fmt.Errorf("failed to update component status: %w", updateErr)
+	}
+
+	return nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/utils/application_utils.go
+++ b/ai-services/internal/pkg/catalog/utils/application_utils.go
@@ -126,46 +126,4 @@ func CalculateComponentHash(componentType string, providerID string, params map[
 	return fmt.Sprintf("%x", hash[:16]) // Use first 16 bytes (32 hex chars)
 }
 
-// HandleApplicationDeploymentError updates application status to Error when deployment fails.
-func HandleApplicationDeploymentError(ctx context.Context, appRepo dbrepo.ApplicationRepository, appID uuid.UUID, err error) error {
-	if appID == uuid.Nil {
-		return nil
-	}
-
-	errMsg := fmt.Sprintf("Application deployment failed: %v", err)
-	if updateErr := appRepo.UpdateStatus(ctx, appID, models.ApplicationStatusError, errMsg); updateErr != nil {
-		return fmt.Errorf("failed to update application status: %w", updateErr)
-	}
-
-	return nil
-}
-
-// HandleServiceDeploymentError updates service status to Error when deployment fails.
-func HandleServiceDeploymentError(ctx context.Context, serviceRepo dbrepo.ServiceRepository, serviceID uuid.UUID, err error) error {
-	if serviceID == uuid.Nil {
-		return nil
-	}
-
-	errMsg := fmt.Sprintf("Service deployment failed: %v", err)
-	if updateErr := serviceRepo.UpdateStatus(ctx, serviceID, models.ServiceStatusError, errMsg); updateErr != nil {
-		return fmt.Errorf("failed to update service status: %w", updateErr)
-	}
-
-	return nil
-}
-
-// HandleComponentDeploymentError updates component status to Error when deployment fails.
-func HandleComponentDeploymentError(ctx context.Context, componentRepo dbrepo.ComponentRepository, componentID uuid.UUID, err error) error {
-	if componentID == uuid.Nil {
-		return nil
-	}
-
-	errMsg := fmt.Sprintf("Component deployment failed: %v", err)
-	if updateErr := componentRepo.UpdateStatus(ctx, componentID, models.ComponentStatusError, errMsg); updateErr != nil {
-		return fmt.Errorf("failed to update component status: %w", updateErr)
-	}
-
-	return nil
-}
-
 // Made with Bob


### PR DESCRIPTION
- Move DB helper methods to application_utils.go.
- Use it across the entire Application Flow where DB insert/update is done.
- Handle errors in deploy.go wherever not handled