### PR TITLE
Code cleanup on digitize service wrt to the new docx content support

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.112
+TAG?=v0.0.113
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.23
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.24
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.23
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.24
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.23
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.24
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.23
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.24
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.23
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.24
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.112
+  image: icr.io/ai-services-cicd/ai-services:v0.0.113
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,6 +1,6 @@
 digitize:
   port: ""
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.23
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.24
   log_level: "INFO"
   database: "digitize_metadata"
 

--- a/services/common/llm_utils.py
+++ b/services/common/llm_utils.py
@@ -117,7 +117,7 @@ def summarize_and_classify_single_table(prompt, gen_model, llm_endpoint, max_tok
         logger.error(f"Error summarizing/classifying table: {e}")
         return "No summary.", False
 
-def summarize_and_classify_tables(table_mds, gen_model, llm_endpoint, pdf_path, prompt_template: str, max_tokens: int = 1024, max_workers=32):
+def summarize_and_classify_tables(table_mds, gen_model, llm_endpoint, doc_path, prompt_template: str, max_tokens: int = 1024, max_workers=32):
     """
     Combined function to summarize and classify tables using a single prompt.
     Returns tuple: (summaries, decisions)
@@ -132,7 +132,7 @@ def summarize_and_classify_tables(table_mds, gen_model, llm_endpoint, pdf_path, 
             for idx, prompt in enumerate(all_prompts)
         }
         for future in tqdm_wrapper(as_completed(futures), total=len(all_prompts),
-                                   desc=f"Summarizing and classifying tables of '{pdf_path}'"):
+                                   desc=f"Summarizing and classifying tables of '{doc_path}'"):
             idx = futures[future]
             results[idx] = future.result()
 

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.23
+TAG?=v0.0.24
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/digitize_core.py
+++ b/services/digitize/digitize_core.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from common.misc_utils import get_utc_timestamp
 from digitize.models import JobStatus, DocStatus, OutputFormat
 from digitize.pdf_utils import get_pdf_page_count, get_document_page_count
-from digitize.doc_utils import convert_document_format
+from digitize.docling_utils import convert_document_format
 from digitize.db_operations import get_status_manager
 from concurrent.futures import ProcessPoolExecutor
 

--- a/services/digitize/doc_utils.py
+++ b/services/digitize/doc_utils.py
@@ -10,7 +10,6 @@ import random
 os.environ['GRPC_VERBOSITY'] = 'ERROR'
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
 
-from tqdm import tqdm
 from pathlib import Path
 from docling_core.types.doc.document import DoclingDocument
 from concurrent.futures import as_completed, ProcessPoolExecutor
@@ -22,11 +21,11 @@ logging.getLogger('docling').setLevel(logging.CRITICAL)
 
 # Import project modules after setting log levels
 from common.thread_utils import ContextAwareThreadPoolExecutor
-from common.llm_utils import summarize_and_classify_tables, tokenize_with_llm
+from common.llm_utils import summarize_and_classify_tables, tokenize_with_llm, tqdm_wrapper
 from common.misc_utils import get_logger, text_suffix, table_suffix, text_chunk_suffix, table_chunk_suffix, get_utc_timestamp
 from common.lang_utils import detect_language, get_prompt_for_language, to_sentence_splitter_lang, LanguageCodes
-from digitize.pdf_utils import get_toc, get_matching_header_lvl, load_pdf_pages, find_text_font_size, get_pdf_page_count, convert_doc
-from digitize.docx_utils import get_docx_toc, estimate_docx_page_count
+from digitize.pdf_utils import get_toc, get_matching_header_lvl, load_pdf_pages, find_text_font_size, convert_doc, get_document_page_count
+from digitize.docx_utils import get_docx_toc, estimate_docx_page_count, recover_table_caption_from_body_context
 from digitize.models import DocStatus, JobStatus, OutputFormat
 from digitize.settings import settings
 from digitize.db_operations import get_status_manager
@@ -35,289 +34,16 @@ logger = get_logger("doc_utils")
 
 # Load configuration from settings modules
 WORKER_SIZE = settings.digitize.doc_worker_size
-HEAVY_PDF_CONVERT_WORKER_SIZE = settings.digitize.heavy_pdf_convert_worker_size
-HEAVY_PDF_PAGE_THRESHOLD = settings.digitize.heavy_pdf_page_threshold
+HEAVY_DOC_CONVERT_WORKER_SIZE = settings.digitize.heavy_doc_convert_worker_size
+HEAVY_DOC_PAGE_THRESHOLD = settings.digitize.heavy_doc_page_threshold
 POOL_SIZE = settings.common.llm.max_batch_size
 
 is_debug = logger.isEnabledFor(logging.DEBUG)
 
-TABLE_CAPTION_PATTERN = re.compile(
-    r"^\s*table\s+\d+(?:[.-]\d+)*\s*[:.-]?\s+.+$",
-    re.IGNORECASE
-)
-
-
-def _parse_ref_index(ref: str, prefix: str) -> int | None:
-    """
-    Parse a Docling ref like '#/texts/616' or '#/tables/2' into its integer index.
-    """
-    try:
-        expected_prefix = f"#/{prefix}/"
-        if not isinstance(ref, str) or not ref.startswith(expected_prefix):
-            logger.debug(f"_parse_ref_index: ref '{ref}' does not match expected prefix '{expected_prefix}'")
-            return None
-        parsed_idx = int(ref[len(expected_prefix):])
-        logger.debug(f"_parse_ref_index: parsed ref '{ref}' with prefix '{prefix}' to index {parsed_idx}")
-        return parsed_idx
-    except Exception as e:
-        logger.debug(f"_parse_ref_index: failed to parse ref '{ref}' with prefix '{prefix}': {e}")
-        return None
-
-
-def _get_body_children_refs(converted_doc) -> list[str]:
-    """
-    Return top-level body child refs in document order.
-    """
-    try:
-        children = getattr(converted_doc.body, "children", []) or []
-        refs = []
-        logger.debug(f"_get_body_children_refs: found {len(children)} top-level body children")
-        for idx, child in enumerate(children):
-            if isinstance(child, dict) and "$ref" in child:
-                refs.append(child["$ref"])
-            else:
-                child_ref = (
-                    getattr(child, "ref", None)
-                    or getattr(child, "$ref", None)
-                    or getattr(child, "cref", None)
-                    or getattr(child, "self_ref", None)
-                )
-                if not child_ref and hasattr(child, "__dict__"):
-                    logger.debug(
-                        f"_get_body_children_refs: child[{idx}] available attrs={list(vars(child).keys())}, type={type(child)}"
-                    )
-                if child_ref:
-                    refs.append(child_ref)
-        logger.debug(f"_get_body_children_refs: extracted {len(refs)} refs")
-        return refs
-    except Exception as e:
-        logger.debug(f"_get_body_children_refs: failed to extract body children refs: {e}", exc_info=True)
-        return []
-
-
-def _get_text_value_by_ref(converted_doc, ref: str) -> str:
-    """
-    Resolve a '#/texts/<n>' ref to its text content.
-    """
-    idx = _parse_ref_index(ref, "texts")
-    if idx is None:
-        logger.debug(f"_get_text_value_by_ref: could not parse text ref '{ref}'")
-        return ""
-
-    try:
-        text_obj = converted_doc.texts[idx]
-        text = getattr(text_obj, "text", None)
-        if text:
-            resolved_text = str(text).strip()
-            logger.debug(f"_get_text_value_by_ref: resolved '{ref}' from text field -> '{resolved_text}'")
-            return resolved_text
-
-        orig = getattr(text_obj, "orig", None)
-        if orig:
-            resolved_orig = str(orig).strip()
-            logger.debug(f"_get_text_value_by_ref: resolved '{ref}' from orig field -> '{resolved_orig}'")
-            return resolved_orig
-
-        logger.debug(f"_get_text_value_by_ref: ref '{ref}' resolved to empty text/orig")
-    except Exception as e:
-        logger.debug(f"_get_text_value_by_ref: failed to resolve ref '{ref}': {e}", exc_info=True)
-
-    return ""
-
-
-def _looks_like_table_caption(text: str) -> bool:
-    """
-    Heuristic check for real table captions such as:
-    'Table 1-1 VIOS release schedule'
-    """
-    if not text:
-        logger.debug("_looks_like_table_caption: empty text -> False")
-        return False
-    text_stripped = text.strip()
-    is_match = bool(TABLE_CAPTION_PATTERN.match(text_stripped))
-    logger.debug(f"_looks_like_table_caption: text='{text_stripped}' match={is_match}")
-    return is_match
-
-
-def _get_ref_value(ref_obj) -> str | None:
-    """
-    Extract a Docling ref string from dict-like or object-like refs.
-    """
-    if isinstance(ref_obj, dict):
-        return ref_obj.get("$ref")
-    return (
-        getattr(ref_obj, "ref", None)
-        or getattr(ref_obj, "$ref", None)
-        or getattr(ref_obj, "cref", None)
-        or getattr(ref_obj, "self_ref", None)
-    )
-
-
-def _get_doc_item_by_ref(converted_doc, ref: str):
-    """
-    Resolve a Docling ref to the underlying object when possible.
-    """
-    for prefix in ("texts", "tables", "groups", "pictures"):
-        idx = _parse_ref_index(ref, prefix)
-        if idx is None:
-            continue
-        try:
-            collection = getattr(converted_doc, prefix, None)
-            if collection is not None:
-                return collection[idx]
-        except Exception as e:
-            logger.debug(f"_get_doc_item_by_ref: failed to resolve '{ref}' in '{prefix}': {e}", exc_info=True)
-            return None
-    logger.debug(f"_get_doc_item_by_ref: unsupported or unresolved ref '{ref}'")
-    return None
-
-
-def _get_parent_ref_for_table(converted_doc, table_ix: int) -> str:
-    """
-    Resolve the parent ref for a table, if any.
-    """
-    try:
-        table_obj = converted_doc.tables[table_ix]
-        parent = getattr(table_obj, "parent", None)
-        parent_ref = _get_ref_value(parent) if parent is not None else None
-        logger.debug(f"_get_parent_ref_for_table: table_ix={table_ix}, parent_ref={parent_ref}")
-        return parent_ref or ""
-    except Exception as e:
-        logger.debug(f"_get_parent_ref_for_table: failed for table_ix={table_ix}: {e}", exc_info=True)
-        return ""
-
-
-def _get_child_refs(item) -> list[str]:
-    """
-    Return child refs for a Docling item in document order.
-    """
-    try:
-        children = getattr(item, "children", []) or []
-        refs = []
-        for child in children:
-            child_ref = _get_ref_value(child)
-            if child_ref:
-                refs.append(child_ref)
-        return refs
-    except Exception as e:
-        logger.debug(f"_get_child_refs: failed to extract child refs: {e}", exc_info=True)
-        return []
-
-
-def _find_matching_caption_near_refs(converted_doc, ordered_refs: list[str], target_ref: str, search_window: int) -> str:
-    """
-    Look for a caption-like text node near the target ref inside an ordered ref list.
-    """
-    if not ordered_refs:
-        logger.debug("_find_matching_caption_near_refs: ordered_refs empty")
-        return ""
-
-    try:
-        target_pos = ordered_refs.index(target_ref)
-        logger.debug(f"_find_matching_caption_near_refs: found {target_ref} at pos={target_pos}")
-    except ValueError:
-        logger.debug(f"_find_matching_caption_near_refs: target_ref {target_ref} not found in ordered refs")
-        return ""
-
-    candidate_positions = list(range(max(0, target_pos - search_window), target_pos))
-    candidate_positions.reverse()
-    candidate_positions.extend(range(target_pos + 1, min(len(ordered_refs), target_pos + 1 + search_window)))
-
-    candidate_refs = [(pos, ordered_refs[pos]) for pos in candidate_positions]
-    logger.debug(f"_find_matching_caption_near_refs: candidate positions/refs={candidate_refs}")
-
-    for pos in candidate_positions:
-        ref = ordered_refs[pos]
-
-        if not ref.startswith("#/texts/"):
-            logger.debug(f"_find_matching_caption_near_refs: skipping non-text ref {ref}")
-            continue
-
-        text = _get_text_value_by_ref(converted_doc, ref)
-        logger.debug(f"_find_matching_caption_near_refs: resolved ref {ref} to text='{text}'")
-
-        if _looks_like_table_caption(text):
-            logger.debug(f"_find_matching_caption_near_refs: matched caption '{text}' near {target_ref}")
-            return text
-
-    logger.debug(f"_find_matching_caption_near_refs: no caption match found near {target_ref}")
-    return ""
-
-
-def _get_enclosing_section_header_for_table(converted_doc, table_ix: int) -> str:
-    """
-    Secondary fallback for DOCX-like structures where a table is nested under
-    a section/container node but has no explicit caption paragraph.
-    """
-    parent_ref = _get_parent_ref_for_table(converted_doc, table_ix)
-    if not parent_ref:
-        logger.debug(f"_get_enclosing_section_header_for_table: no parent ref for table_ix={table_ix}")
-        return ""
-
-    parent_item = _get_doc_item_by_ref(converted_doc, parent_ref)
-    if parent_item is None:
-        logger.debug(f"_get_enclosing_section_header_for_table: could not resolve parent item for {parent_ref}")
-        return ""
-
-    label = getattr(parent_item, "label", None)
-    text = (getattr(parent_item, "text", None) or getattr(parent_item, "orig", None) or "").strip()
-    logger.debug(
-        f"_get_enclosing_section_header_for_table: table_ix={table_ix}, parent_ref={parent_ref}, "
-        f"label={label}, text='{text}'"
-    )
-
-    if label == "section_header" and text:
-        return text
-
-    return ""
-
-
-def recover_table_caption_from_body_context(converted_doc, table_ix: int, search_window: int = 3) -> str:
-    """
-    Recover a table caption using layered fallbacks:
-    1. nearby caption paragraph in top-level body order
-    2. nearby caption paragraph within the enclosing parent/container children
-    3. enclosing section header text as semantic fallback
-    """
-    target_ref = f"#/tables/{table_ix}"
-    logger.debug(f"recover_table_caption_from_body_context: looking for caption near {target_ref} with search_window={search_window}")
-
-    body_refs = _get_body_children_refs(converted_doc)
-    caption = _find_matching_caption_near_refs(converted_doc, body_refs, target_ref, search_window)
-    if caption:
-        logger.debug(f"recover_table_caption_from_body_context: using body-level caption '{caption}' for {target_ref}")
-        return caption
-
-    parent_ref = _get_parent_ref_for_table(converted_doc, table_ix)
-    if parent_ref:
-        parent_item = _get_doc_item_by_ref(converted_doc, parent_ref)
-        if parent_item is not None:
-            parent_child_refs = _get_child_refs(parent_item)
-            caption = _find_matching_caption_near_refs(converted_doc, parent_child_refs, target_ref, search_window)
-            if caption:
-                logger.debug(
-                    f"recover_table_caption_from_body_context: using parent-level nearby caption '{caption}' "
-                    f"for {target_ref} within parent {parent_ref}"
-                )
-                return caption
-
-    section_header = _get_enclosing_section_header_for_table(converted_doc, table_ix)
-    if section_header:
-        logger.debug(
-            f"recover_table_caption_from_body_context: using enclosing section header '{section_header}' "
-            f"as secondary fallback for {target_ref}"
-        )
-        return section_header
-
-    logger.debug(f"recover_table_caption_from_body_context: no caption match found for {target_ref}")
-    return ""
-tqdm_wrapper = tqdm if is_debug else (lambda x, **kwargs: x)
 
 excluded_labels = {
     'page_header', 'page_footer', 'caption', 'reference', 'footnote'
 }
-
-
 def process_text_docx(converted_doc, docx_path, out_path):
     """
     Process text content from DOCX files.
@@ -393,7 +119,8 @@ def process_text_docx(converted_doc, docx_path, out_path):
     return page_count, process_time
 
 
-def process_text(converted_doc, pdf_path, out_path):
+
+def process_text(converted_doc, doc_path, out_path):
     page_count = 0
     process_time = 0.0
 
@@ -402,25 +129,25 @@ def process_text(converted_doc, pdf_path, out_path):
     
     toc_headers = None
     try:
-        toc_headers, page_count = get_toc(pdf_path)
+        toc_headers, page_count = get_toc(doc_path)
     except Exception as e:
         logger.debug(f"No TOC found or failed to load TOC: {e}")
 
     # Load pdf pages one time when TOC headers not found for retrieving the font size of header texts
     pdf_pages = None
     if not toc_headers:
-        pdf_pages = load_pdf_pages(pdf_path)
+        pdf_pages = load_pdf_pages(doc_path)
         page_count = len(pdf_pages)
 
     # --- Text Extraction ---
     if not converted_doc.texts:
-        logger.debug(f"No text content found in '{pdf_path}'")
+        logger.debug(f"No text content found in '{doc_path}'")
         out_path.write_text(json.dumps([], indent=2), encoding="utf-8")
         return page_count, process_time
 
     structured_output = []
     last_header_level = 0
-    for text_obj in tqdm_wrapper(converted_doc.texts, desc=f"Processing text content of '{pdf_path}'"):
+    for text_obj in tqdm_wrapper(converted_doc.texts, desc=f"Processing text content of '{doc_path}'"):
         label = text_obj.label
         if label in excluded_labels:
             continue
@@ -660,24 +387,24 @@ def merge_consecutive_tables(table_dict: dict) -> dict:
 
     return merged_dict
 
-def process_table(converted_doc, pdf_path, out_path, gen_model, gen_endpoint, document_language=LanguageCodes.ENGLISH):
+def process_table(converted_doc, doc_path, out_path, gen_model, gen_endpoint, document_language=LanguageCodes.ENGLISH):
     table_count = 0
     process_time = 0.0
     filtered_table_dicts = {}
     t0 = time.time()
     # --- Table Extraction ---
     if not converted_doc.tables:
-        logger.debug(f"No tables found in '{pdf_path}'")
+        logger.debug(f"No tables found in '{doc_path}'")
         out_path.write_text(json.dumps({}, indent=2), encoding="utf-8")
         return table_count, process_time
 
     # Determine if this is a DOCX file
     from pathlib import Path
-    file_ext = Path(pdf_path).suffix.lower()
+    file_ext = Path(doc_path).suffix.lower()
     is_docx = file_ext == '.docx'
     
     table_dict = {}
-    for table_ix, table in enumerate(tqdm_wrapper(converted_doc.tables, desc=f"Processing table content of '{pdf_path}'")):
+    for table_ix, table in enumerate(tqdm_wrapper(converted_doc.tables, desc=f"Processing table content of '{doc_path}'")):
         table_dict[table_ix] = {}
         # Use Markdown format for better LLM understanding
         table_dict[table_ix]["markdown"] = table.export_to_markdown(doc=converted_doc)
@@ -701,7 +428,7 @@ def process_table(converted_doc, pdf_path, out_path, gen_model, gen_endpoint, do
             table_dict[table_ix]["page_number"] = None
 
     # Merge tables that span multiple consecutive pages with matching headers
-    logger.debug(f"Merging tables spanning multiple pages for '{pdf_path}'")
+    logger.debug(f"Merging tables spanning multiple pages for '{doc_path}'")
     merged_table_dict = merge_consecutive_tables(table_dict)
 
     table_markdowns = [merged_table_dict[key]["markdown"] for key in sorted(merged_table_dict)]
@@ -735,7 +462,7 @@ def process_table(converted_doc, pdf_path, out_path, gen_model, gen_endpoint, do
 
     # Summarize and classify tables - use markdown directly
     table_summaries, decisions = summarize_and_classify_tables(
-        table_markdowns, gen_model, gen_endpoint, pdf_path,
+        table_markdowns, gen_model, gen_endpoint, doc_path,
         prompt_template=selected_prompt,
         max_tokens=selected_max_tokens,
     )
@@ -754,7 +481,7 @@ def process_table(converted_doc, pdf_path, out_path, gen_model, gen_endpoint, do
 
     return table_count, process_time
 
-def process_converted_document(converted_json_path, pdf_path, out_path, gen_model, gen_endpoint, emb_endpoint, max_tokens, doc_id):
+def process_converted_document(converted_json_path, doc_path, out_path, gen_model, gen_endpoint, emb_endpoint, max_tokens, doc_id):
     """
     Process converted document to extract text and tables.
     No caching - always process fresh.
@@ -777,11 +504,11 @@ def process_converted_document(converted_json_path, pdf_path, out_path, gen_mode
             raise Exception(f"failed to load converted json into Docling Document")
 
         # Check file type and route to appropriate processing function
-        file_ext = Path(pdf_path).suffix.lower()
+        file_ext = Path(doc_path).suffix.lower()
         if file_ext == '.docx':
-            page_count, process_time = process_text_docx(converted_doc, pdf_path, processed_text_json_path)
+            page_count, process_time = process_text_docx(converted_doc, doc_path, processed_text_json_path)
         else:
-            page_count, process_time = process_text(converted_doc, pdf_path, processed_text_json_path)
+            page_count, process_time = process_text(converted_doc, doc_path, processed_text_json_path)
         timings["process_text"] = process_time
 
         # Detect document language early using the processed text
@@ -794,35 +521,35 @@ def process_converted_document(converted_json_path, pdf_path, out_path, gen_mode
         except Exception as e:
             logger.warning(f"Failed to detect document language, using default {LanguageCodes.ENGLISH}: {e}")
 
-        table_count, process_time = process_table(converted_doc, pdf_path, processed_table_json_path, gen_model, gen_endpoint, document_language)
+        table_count, process_time = process_table(converted_doc, doc_path, processed_table_json_path, gen_model, gen_endpoint, document_language)
         timings["process_tables"] = process_time
 
         return processed_text_json_path, processed_table_json_path, page_count, table_count, timings, document_language
     except Exception as e:
-        logger.error(f"Error processing converted document for PDF: {pdf_path}. Details: {e}", exc_info=True)
+        logger.error(f"Error processing converted document: {doc_path}. Details: {e}", exc_info=True)
 
         return None, None, None, None, None, None
 
-def convert_document(pdf_path, out_path, file_name):
+def convert_document(doc_path, out_path, file_name):
     """
     Convert a single document to JSON format.
     This function runs in a separate process via ProcessPoolExecutor.
     """
     try:
-        logger.info(f"Processing '{pdf_path}'")
+        logger.info(f"Processing '{doc_path}'")
         converted_json = (Path(out_path) / f"{file_name}.json")
         converted_json_f = str(converted_json)
-        logger.debug(f"Converting '{pdf_path}'")
+        logger.debug(f"Converting '{doc_path}'")
         t0 = time.time()
 
-        converted_doc: DoclingDocument = convert_doc(pdf_path, cache_dir=out_path / file_name)
+        converted_doc: DoclingDocument = convert_doc(doc_path, cache_dir=out_path / file_name)
         converted_doc.save_as_json(str(converted_json_f))
 
         conversion_time = time.time() - t0
-        logger.debug(f"'{pdf_path}' converted")
+        logger.debug(f"'{doc_path}' converted")
         return converted_json_f, conversion_time
     except Exception as e:
-        logger.error(f"Error converting '{pdf_path}': {e}")
+        logger.error(f"Error converting '{doc_path}': {e}")
     return None, None
 
 def clean_intermediate_files(doc_id, out_path):
@@ -858,8 +585,8 @@ def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoi
     # Partition files into light and heavy based on page count
     light_files, heavy_files = [], []
     for path in input_paths:
-        pg_count = get_pdf_page_count(path)
-        if pg_count >= HEAVY_PDF_PAGE_THRESHOLD:
+        pg_count = get_document_page_count(path)
+        if pg_count >= HEAVY_DOC_PAGE_THRESHOLD:
             heavy_files.append(path)
         else:
             light_files.append(path)
@@ -1066,7 +793,7 @@ def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoi
 
         # Process Heavy Batch
         h_worker = min(WORKER_SIZE, len(heavy_files)) if heavy_files else 0
-        h_conv_worker = min(HEAVY_PDF_CONVERT_WORKER_SIZE, len(heavy_files)) if heavy_files else 0
+        h_conv_worker = min(HEAVY_DOC_CONVERT_WORKER_SIZE, len(heavy_files)) if heavy_files else 0
         h_stats = _run_batch(
             heavy_files, convert_worker=h_conv_worker, max_worker=h_worker, doc_id_dict=doc_id_dict,
             indexing_callback=indexing_callback
@@ -1596,16 +1323,16 @@ def merge_chunked_documents(in_txt_chunk_f, in_tab_chunk_f, orig_fn):
 
     return combined_docs
 
-def convert_document_format(pdf_path: str, out_path: Path, doc_id: str, output_format: OutputFormat):
-    logger.info(f"Processing '{pdf_path}'")
+def convert_document_format(doc_path: str, out_path: Path, doc_id: str, output_format: OutputFormat):
+    logger.info(f"Processing '{doc_path}'")
 
     out_dir = Path(out_path)
     out_dir.mkdir(parents=True, exist_ok=True)
 
     t0 = time.time()
 
-    # Convert PDF → DoclingDocument
-    doc_obj = convert_doc(pdf_path, cache_dir=out_path / doc_id)
+    # Convert document → DoclingDocument
+    doc_obj = convert_doc(doc_path, cache_dir=out_path / doc_id)
 
     conversion_time = time.time() - t0
 

--- a/services/digitize/doc_utils.py
+++ b/services/digitize/doc_utils.py
@@ -2,7 +2,6 @@ import json
 import time
 import logging
 import os
-import re
 import shutil
 import random
 
@@ -24,9 +23,10 @@ from common.thread_utils import ContextAwareThreadPoolExecutor
 from common.llm_utils import summarize_and_classify_tables, tokenize_with_llm, tqdm_wrapper
 from common.misc_utils import get_logger, text_suffix, table_suffix, text_chunk_suffix, table_chunk_suffix, get_utc_timestamp
 from common.lang_utils import detect_language, get_prompt_for_language, to_sentence_splitter_lang, LanguageCodes
-from digitize.pdf_utils import get_toc, get_matching_header_lvl, load_pdf_pages, find_text_font_size, convert_doc, get_document_page_count
+from digitize.pdf_utils import get_toc, get_matching_header_lvl, load_pdf_pages, find_text_font_size, get_document_page_count
 from digitize.docx_utils import get_docx_toc, estimate_docx_page_count, recover_table_caption_from_body_context
-from digitize.models import DocStatus, JobStatus, OutputFormat
+from digitize.docling_utils import convert_document
+from digitize.models import DocStatus, JobStatus
 from digitize.settings import settings
 from digitize.db_operations import get_status_manager
 
@@ -529,28 +529,6 @@ def process_converted_document(converted_json_path, doc_path, out_path, gen_mode
         logger.error(f"Error processing converted document: {doc_path}. Details: {e}", exc_info=True)
 
         return None, None, None, None, None, None
-
-def convert_document(doc_path, out_path, file_name):
-    """
-    Convert a single document to JSON format.
-    This function runs in a separate process via ProcessPoolExecutor.
-    """
-    try:
-        logger.info(f"Processing '{doc_path}'")
-        converted_json = (Path(out_path) / f"{file_name}.json")
-        converted_json_f = str(converted_json)
-        logger.debug(f"Converting '{doc_path}'")
-        t0 = time.time()
-
-        converted_doc: DoclingDocument = convert_doc(doc_path, cache_dir=out_path / file_name)
-        converted_doc.save_as_json(str(converted_json_f))
-
-        conversion_time = time.time() - t0
-        logger.debug(f"'{doc_path}' converted")
-        return converted_json_f, conversion_time
-    except Exception as e:
-        logger.error(f"Error converting '{doc_path}': {e}")
-    return None, None
 
 def clean_intermediate_files(doc_id, out_path):
     # Remove intermediate files but keep <doc_id>.json
@@ -1323,31 +1301,3 @@ def merge_chunked_documents(in_txt_chunk_f, in_tab_chunk_f, orig_fn):
 
     return combined_docs
 
-def convert_document_format(doc_path: str, out_path: Path, doc_id: str, output_format: OutputFormat):
-    logger.info(f"Processing '{doc_path}'")
-
-    out_dir = Path(out_path)
-    out_dir.mkdir(parents=True, exist_ok=True)
-
-    t0 = time.time()
-
-    # Convert document → DoclingDocument
-    doc_obj = convert_doc(doc_path, cache_dir=out_path / doc_id)
-
-    conversion_time = time.time() - t0
-
-    # Save requested format
-    if output_format == OutputFormat.JSON:
-        out_file = out_dir / f"{doc_id}.json"
-        doc_obj.save_as_json(str(out_file))
-
-    elif output_format == OutputFormat.MD:
-        out_file = out_dir / f"{doc_id}.md"
-        out_file.write_text(doc_obj.export_to_markdown(), encoding="utf-8")
-
-    elif output_format == OutputFormat.TEXT:
-        out_file = out_dir / f"{doc_id}.txt"
-        out_file.write_text(doc_obj.export_to_text(), encoding="utf-8")
-
-    logger.debug(f"Saved converted file to '{out_file}'")
-    return str(out_file), conversion_time

--- a/services/digitize/docling_utils.py
+++ b/services/digitize/docling_utils.py
@@ -1,0 +1,224 @@
+import logging
+import shutil
+import tempfile
+import time
+from pathlib import Path
+from typing import Optional
+
+# Local application imports
+from common.misc_utils import get_logger, DoclingConversionError
+from common.retry_utils import retry_on_transient_error
+from digitize.settings import settings
+from digitize.pdf_utils import get_document_page_count
+from digitize.models import OutputFormat
+
+# Docling document conversion libraries
+from docling.datamodel.document import ConversionResult
+from docling.document_converter import DocumentConverter
+from docling_core.types.doc.document import DoclingDocument
+
+logger = get_logger("docling_utils")
+
+@retry_on_transient_error(max_retries=3, initial_delay=1.0, backoff_multiplier=2.0)
+def convert_chunk(doc_converter: DocumentConverter, path: Path, chunk_num: int, start_page: int, end_page: int, chunk_cache_dir: Path):
+    """Convert a single chunk of a document.
+
+    Args:
+        doc_converter: DocumentConverter instance
+        path: Path to the file
+        chunk_num: Chunk number for logging
+        start_page: Starting page number (1-based)
+        end_page: Ending page number (1-based, inclusive)
+        chunk_cache_dir: Directory to save chunk results
+
+    Returns:
+        Path to the saved chunk JSON file
+
+    Raises:
+        DoclingConversionError: If conversion or saving fails
+    """
+    try:
+        # Convert this chunk
+        conv_res: ConversionResult = doc_converter.convert(source=path, page_range=(start_page, end_page))
+
+        # Save chunk result to cache
+        chunk_filename = chunk_cache_dir / f"chunk_{chunk_num:04d}.json"
+        conv_res.document.save_as_json(str(chunk_filename))
+        logger.debug(f"Saved chunk of {path}'s chunk {chunk_num} to {chunk_filename}")
+
+        return chunk_filename
+    except Exception as e:
+        # Wrap any exception in DoclingConversionError for retry handling
+        error_msg = f"Failed to convert chunk {chunk_num} (pages {start_page}-{end_page}) of {path}: {str(e)}"
+        logger.error(error_msg)
+        raise DoclingConversionError(error_msg) from e
+
+def convert_doc(path: str | Path, cache_dir: Optional[Path] = None) -> DoclingDocument:
+    """
+    Convert a document to DoclingDocument, processing in 100-page chunks.
+
+    Args:
+        path: Path to the document file to convert
+        cache_dir: Optional cache directory for storing chunk results.
+                   Will be cleaned up after processing.
+
+    Returns:
+        DoclingDocument containing the concatenated result
+    """
+
+    # Input validation
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Document not found: {path}")
+
+    doc_converter: DocumentConverter = get_doc_converter()
+
+    # Get total page count
+    total_pages = get_document_page_count(str(path))
+
+    # If document has configured chunk size pages or fewer, convert normally
+    if total_pages <= settings.digitize.doc_chunk_size:
+        logger.debug(f"Converting {path} document with {total_pages} pages in single pass")
+
+        @retry_on_transient_error(max_retries=3, initial_delay=1.0, backoff_multiplier=2.0)
+        def _convert_single_doc():
+            try:
+                return doc_converter.convert(source=path).document
+            except Exception as e:
+                error_msg = f"Failed to convert document {path}: {str(e)}"
+                logger.error(error_msg)
+                raise DoclingConversionError(error_msg) from e
+
+        return _convert_single_doc()
+
+    # Process in chunks
+    # Calculate total chunks using ceiling division for the configured PDF chunk size.
+    # This ensures all pages are covered even if the last chunk is smaller.
+    total_chunks = (total_pages + settings.digitize.doc_chunk_size - 1) // settings.digitize.doc_chunk_size
+    logger.debug(
+        f"Converting {path} document with {total_pages} pages in {total_chunks} "
+        f"chunks of {settings.digitize.doc_chunk_size}"
+    )
+
+    # Determine cache directory for storing chunk results
+    if cache_dir is None:
+        chunk_cache_dir = Path(tempfile.mkdtemp(prefix="docling_chunks_"))
+    else:
+        chunk_cache_dir = Path(cache_dir)
+
+    chunk_cache_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        # Process document in chunks and save each chunk
+        chunk_files = []
+
+        for start_page in range(1, total_pages + 1, settings.digitize.doc_chunk_size):
+            end_page = min(start_page + settings.digitize.doc_chunk_size - 1, total_pages)
+            chunk_num = (start_page - 1) // settings.digitize.doc_chunk_size + 1
+
+            logger.debug(f"Processing {path}'s chunk {chunk_num}/{total_chunks} (pages {start_page}-{end_page})")
+            chunk_file = convert_chunk(doc_converter, path, chunk_num, start_page, end_page, chunk_cache_dir)
+            chunk_files.append(chunk_file)
+
+        # Load all chunk documents and concatenate
+        docs = [DoclingDocument.load_from_json(filename=f) for f in chunk_files]
+        concatenated_doc = DoclingDocument.concatenate(docs=docs)
+
+        logger.debug(f"Successfully concatenated {path}'s {len(docs)} chunks into single document")
+        
+        return concatenated_doc
+
+    finally:
+        # Always cleanup cache directory
+        try:
+            shutil.rmtree(chunk_cache_dir)
+            logger.debug(f"Cleaned up cache directory: {chunk_cache_dir}")
+        except Exception as e:
+            logger.warning(f"Failed to cleanup cache directory {chunk_cache_dir}: {e}")
+
+def get_doc_converter():
+    import os
+    from pathlib import Path
+    from docling.datamodel.base_models import InputFormat
+    from docling.datamodel.pipeline_options import PdfPipelineOptions
+    from docling.document_converter import DocumentConverter, PdfFormatOption
+
+    # Accelerator & pipeline options
+    pipeline_options = PdfPipelineOptions()
+    
+    # Only set artifacts_path if DOCLING_MODELS_PATH environment variable is set
+    docling_models_path = os.environ.get('DOCLING_MODELS_PATH')
+    if docling_models_path:
+        artifacts_path = Path(docling_models_path)
+        if artifacts_path.exists():
+            pipeline_options.artifacts_path = artifacts_path
+            logger.debug(f"Using docling models from: {artifacts_path}")
+        else:
+            logger.warning(f"DOCLING_MODELS_PATH set to {artifacts_path} but directory does not exist")
+    else:
+        logger.debug("DOCLING_MODELS_PATH not set. Docling will use default model loading behavior.")
+    
+    pipeline_options.do_table_structure = True
+    pipeline_options.table_structure_options.do_cell_matching = True
+    pipeline_options.do_ocr = False
+
+    doc_converter = DocumentConverter(
+        allowed_formats=[
+            InputFormat.PDF,
+            InputFormat.DOCX
+        ],
+        format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)}
+    )
+
+    return doc_converter
+
+def convert_document_format(doc_path: str, out_path: Path, doc_id: str, output_format: OutputFormat):
+    logger.info(f"Processing '{doc_path}'")
+
+    out_dir = Path(out_path)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    t0 = time.time()
+
+    # Convert document → DoclingDocument
+    doc_obj = convert_doc(doc_path, cache_dir=out_path / doc_id)
+
+    conversion_time = time.time() - t0
+
+    # Save requested format
+    if output_format == OutputFormat.JSON:
+        out_file = out_dir / f"{doc_id}.json"
+        doc_obj.save_as_json(str(out_file))
+
+    elif output_format == OutputFormat.MD:
+        out_file = out_dir / f"{doc_id}.md"
+        out_file.write_text(doc_obj.export_to_markdown(), encoding="utf-8")
+
+    elif output_format == OutputFormat.TEXT:
+        out_file = out_dir / f"{doc_id}.txt"
+        out_file.write_text(doc_obj.export_to_text(), encoding="utf-8")
+
+    logger.debug(f"Saved converted file to '{out_file}'")
+    return str(out_file), conversion_time
+
+def convert_document(doc_path, out_path, file_name):
+    """
+    Convert a single document to JSON format.
+    This function runs in a separate process via ProcessPoolExecutor.
+    """
+    try:
+        logger.info(f"Processing '{doc_path}'")
+        converted_json = (Path(out_path) / f"{file_name}.json")
+        converted_json_f = str(converted_json)
+        logger.debug(f"Converting '{doc_path}'")
+        t0 = time.time()
+
+        converted_doc: DoclingDocument = convert_doc(doc_path, cache_dir=out_path / file_name)
+        converted_doc.save_as_json(str(converted_json_f))
+
+        conversion_time = time.time() - t0
+        logger.debug(f"'{doc_path}' converted")
+        return converted_json_f, conversion_time
+    except Exception as e:
+        logger.error(f"Error converting '{doc_path}': {e}")
+    return None, None

--- a/services/digitize/docx_utils.py
+++ b/services/digitize/docx_utils.py
@@ -3,12 +3,14 @@ Utilities for processing DOCX files, providing page count estimation and TOC ext
 This module provides DOCX-specific functionality parallel to PDF utilities.
 """
 import json
+import time
 import re
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional
 from docx import Document
 
 from common.misc_utils import get_logger
+from common.llm_utils import tqdm_wrapper
 
 logger = get_logger("docx_utils")
 
@@ -16,6 +18,275 @@ logger = get_logger("docx_utils")
 CHARS_PER_PAGE = 3000  # Approximate characters per page
 WORDS_PER_PAGE = 450   # Approximate words per page
 
+TABLE_CAPTION_PATTERN = re.compile(
+    r"^\s*table\s+\d+(?:[.-]\d+)*\s*[:.-]?\s+.+$",
+    re.IGNORECASE
+)
+
+
+def _parse_ref_index(ref: str, prefix: str) -> int | None:
+    """
+    Parse a Docling ref like '#/texts/616' or '#/tables/2' into its integer index.
+    """
+    try:
+        expected_prefix = f"#/{prefix}/"
+        if not isinstance(ref, str) or not ref.startswith(expected_prefix):
+            logger.debug(f"_parse_ref_index: ref '{ref}' does not match expected prefix '{expected_prefix}'")
+            return None
+        parsed_idx = int(ref[len(expected_prefix):])
+        logger.debug(f"_parse_ref_index: parsed ref '{ref}' with prefix '{prefix}' to index {parsed_idx}")
+        return parsed_idx
+    except Exception as e:
+        logger.debug(f"_parse_ref_index: failed to parse ref '{ref}' with prefix '{prefix}': {e}")
+        return None
+
+
+def _get_body_children_refs(converted_doc) -> list[str]:
+    """
+    Return top-level body child refs in document order.
+    """
+    try:
+        children = getattr(converted_doc.body, "children", []) or []
+        refs = []
+        logger.debug(f"_get_body_children_refs: found {len(children)} top-level body children")
+        for idx, child in enumerate(children):
+            if isinstance(child, dict) and "$ref" in child:
+                refs.append(child["$ref"])
+            else:
+                child_ref = (
+                    getattr(child, "ref", None)
+                    or getattr(child, "$ref", None)
+                    or getattr(child, "cref", None)
+                    or getattr(child, "self_ref", None)
+                )
+                if not child_ref and hasattr(child, "__dict__"):
+                    logger.debug(
+                        f"_get_body_children_refs: child[{idx}] available attrs={list(vars(child).keys())}, type={type(child)}"
+                    )
+                if child_ref:
+                    refs.append(child_ref)
+        logger.debug(f"_get_body_children_refs: extracted {len(refs)} refs")
+        return refs
+    except Exception as e:
+        logger.debug(f"_get_body_children_refs: failed to extract body children refs: {e}", exc_info=True)
+        return []
+
+
+def _get_text_value_by_ref(converted_doc, ref: str) -> str:
+    """
+    Resolve a '#/texts/<n>' ref to its text content.
+    """
+    idx = _parse_ref_index(ref, "texts")
+    if idx is None:
+        logger.debug(f"_get_text_value_by_ref: could not parse text ref '{ref}'")
+        return ""
+
+    try:
+        text_obj = converted_doc.texts[idx]
+        text = getattr(text_obj, "text", None)
+        if text:
+            resolved_text = str(text).strip()
+            logger.debug(f"_get_text_value_by_ref: resolved '{ref}' from text field -> '{resolved_text}'")
+            return resolved_text
+
+        orig = getattr(text_obj, "orig", None)
+        if orig:
+            resolved_orig = str(orig).strip()
+            logger.debug(f"_get_text_value_by_ref: resolved '{ref}' from orig field -> '{resolved_orig}'")
+            return resolved_orig
+
+        logger.debug(f"_get_text_value_by_ref: ref '{ref}' resolved to empty text/orig")
+    except Exception as e:
+        logger.debug(f"_get_text_value_by_ref: failed to resolve ref '{ref}': {e}", exc_info=True)
+
+    return ""
+
+
+def _looks_like_table_caption(text: str) -> bool:
+    """
+    Heuristic check for real table captions such as:
+    'Table 1-1 VIOS release schedule'
+    """
+    if not text:
+        logger.debug("_looks_like_table_caption: empty text -> False")
+        return False
+    text_stripped = text.strip()
+    is_match = bool(TABLE_CAPTION_PATTERN.match(text_stripped))
+    logger.debug(f"_looks_like_table_caption: text='{text_stripped}' match={is_match}")
+    return is_match
+
+
+def _get_ref_value(ref_obj) -> str | None:
+    """
+    Extract a Docling ref string from dict-like or object-like refs.
+    """
+    if isinstance(ref_obj, dict):
+        return ref_obj.get("$ref")
+    return (
+        getattr(ref_obj, "ref", None)
+        or getattr(ref_obj, "$ref", None)
+        or getattr(ref_obj, "cref", None)
+        or getattr(ref_obj, "self_ref", None)
+    )
+
+
+def _get_doc_item_by_ref(converted_doc, ref: str):
+    """
+    Resolve a Docling ref to the underlying object when possible.
+    """
+    for prefix in ("texts", "tables", "groups", "pictures"):
+        idx = _parse_ref_index(ref, prefix)
+        if idx is None:
+            continue
+        try:
+            collection = getattr(converted_doc, prefix, None)
+            if collection is not None:
+                return collection[idx]
+        except Exception as e:
+            logger.debug(f"_get_doc_item_by_ref: failed to resolve '{ref}' in '{prefix}': {e}", exc_info=True)
+            return None
+    logger.debug(f"_get_doc_item_by_ref: unsupported or unresolved ref '{ref}'")
+    return None
+
+
+def _get_parent_ref_for_table(converted_doc, table_ix: int) -> str:
+    """
+    Resolve the parent ref for a table, if any.
+    """
+    try:
+        table_obj = converted_doc.tables[table_ix]
+        parent = getattr(table_obj, "parent", None)
+        parent_ref = _get_ref_value(parent) if parent is not None else None
+        logger.debug(f"_get_parent_ref_for_table: table_ix={table_ix}, parent_ref={parent_ref}")
+        return parent_ref or ""
+    except Exception as e:
+        logger.debug(f"_get_parent_ref_for_table: failed for table_ix={table_ix}: {e}", exc_info=True)
+        return ""
+
+
+def _get_child_refs(item) -> list[str]:
+    """
+    Return child refs for a Docling item in document order.
+    """
+    try:
+        children = getattr(item, "children", []) or []
+        refs = []
+        for child in children:
+            child_ref = _get_ref_value(child)
+            if child_ref:
+                refs.append(child_ref)
+        return refs
+    except Exception as e:
+        logger.debug(f"_get_child_refs: failed to extract child refs: {e}", exc_info=True)
+        return []
+
+
+def _find_matching_caption_near_refs(converted_doc, ordered_refs: list[str], target_ref: str, search_window: int) -> str:
+    """
+    Look for a caption-like text node near the target ref inside an ordered ref list.
+    """
+    if not ordered_refs:
+        logger.debug("_find_matching_caption_near_refs: ordered_refs empty")
+        return ""
+
+    try:
+        target_pos = ordered_refs.index(target_ref)
+        logger.debug(f"_find_matching_caption_near_refs: found {target_ref} at pos={target_pos}")
+    except ValueError:
+        logger.debug(f"_find_matching_caption_near_refs: target_ref {target_ref} not found in ordered refs")
+        return ""
+
+    candidate_positions = list(range(max(0, target_pos - search_window), target_pos))
+    candidate_positions.reverse()
+    candidate_positions.extend(range(target_pos + 1, min(len(ordered_refs), target_pos + 1 + search_window)))
+
+    candidate_refs = [(pos, ordered_refs[pos]) for pos in candidate_positions]
+    logger.debug(f"_find_matching_caption_near_refs: candidate positions/refs={candidate_refs}")
+
+    for pos in candidate_positions:
+        ref = ordered_refs[pos]
+
+        if not ref.startswith("#/texts/"):
+            logger.debug(f"_find_matching_caption_near_refs: skipping non-text ref {ref}")
+            continue
+
+        text = _get_text_value_by_ref(converted_doc, ref)
+        logger.debug(f"_find_matching_caption_near_refs: resolved ref {ref} to text='{text}'")
+
+        if _looks_like_table_caption(text):
+            logger.debug(f"_find_matching_caption_near_refs: matched caption '{text}' near {target_ref}")
+            return text
+
+    logger.debug(f"_find_matching_caption_near_refs: no caption match found near {target_ref}")
+    return ""
+
+def _get_enclosing_section_header_for_table(converted_doc, table_ix: int) -> str:
+    """
+    Secondary fallback for DOCX-like structures where a table is nested under
+    a section/container node but has no explicit caption paragraph.
+    """
+    parent_ref = _get_parent_ref_for_table(converted_doc, table_ix)
+    if not parent_ref:
+        logger.debug(f"_get_enclosing_section_header_for_table: no parent ref for table_ix={table_ix}")
+        return ""
+
+    parent_item = _get_doc_item_by_ref(converted_doc, parent_ref)
+    if parent_item is None:
+        logger.debug(f"_get_enclosing_section_header_for_table: could not resolve parent item for {parent_ref}")
+        return ""
+
+    label = getattr(parent_item, "label", None)
+    text = (getattr(parent_item, "text", None) or getattr(parent_item, "orig", None) or "").strip()
+    logger.debug(
+        f"_get_enclosing_section_header_for_table: table_ix={table_ix}, parent_ref={parent_ref}, "
+        f"label={label}, text='{text}'"
+    )
+
+    if label == "section_header" and text:
+        return text
+
+    return ""
+
+
+def recover_table_caption_from_body_context(converted_doc, table_ix: int, search_window: int = 3) -> str:
+    """
+    Recover a table caption using layered fallbacks:
+    1. nearby caption paragraph in top-level body order
+    2. nearby caption paragraph within the enclosing parent/container children
+    3. enclosing section header text as semantic fallback
+    """
+    target_ref = f"#/tables/{table_ix}"
+    logger.debug(f"recover_table_caption_from_body_context: looking for caption near {target_ref} with search_window={search_window}")
+
+    body_refs = _get_body_children_refs(converted_doc)
+    caption = _find_matching_caption_near_refs(converted_doc, body_refs, target_ref, search_window)
+    if caption:
+        logger.debug(f"recover_table_caption_from_body_context: using body-level caption '{caption}' for {target_ref}")
+        return caption
+
+    parent_ref = _get_parent_ref_for_table(converted_doc, table_ix)
+    if parent_ref:
+        parent_item = _get_doc_item_by_ref(converted_doc, parent_ref)
+        if parent_item is not None:
+            parent_child_refs = _get_child_refs(parent_item)
+            caption = _find_matching_caption_near_refs(converted_doc, parent_child_refs, target_ref, search_window)
+            if caption:
+                logger.debug(
+                    f"recover_table_caption_from_body_context: using parent-level nearby caption '{caption}' "
+                    f"for {target_ref} within parent {parent_ref}"
+                )
+                return caption
+
+    section_header = _get_enclosing_section_header_for_table(converted_doc, table_ix)
+    if section_header:
+        logger.debug(
+            f"recover_table_caption_from_body_context: using enclosing section header '{section_header}' "
+            f"as secondary fallback for {target_ref}"
+        )
+        return section_header
+
+    logger.debug(f"recover_table_caption_from_body_context: no caption match found for {target_ref}")
+    return ""
 
 def estimate_docx_page_count(docx_path: str) -> int:
     """
@@ -112,7 +383,6 @@ def get_docx_toc(docx_path: str) -> Dict[str, int]:
     except Exception as e:
         logger.error(f"Error extracting TOC from {docx_path}: {e}")
         return {}
-
 
 # ============================================================================
 # NEW: TOC Style-Based Extraction Functions

--- a/services/digitize/pdf_utils.py
+++ b/services/digitize/pdf_utils.py
@@ -1,10 +1,8 @@
 # Standard library imports
 import logging
-import shutil
-import tempfile
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 # Third-party PDF processing libraries
 import pdfplumber
@@ -14,15 +12,8 @@ from pdfminer.pdfpage import PDFPage
 from pdfminer.pdfparser import PDFParser, PDFSyntaxError
 from rapidfuzz import fuzz
 
-# Docling document conversion libraries
-from docling.datamodel.document import ConversionResult
-from docling.document_converter import DocumentConverter
-from docling_core.types.doc.document import DoclingDocument
-
 # Local application imports
-from common.misc_utils import get_logger, DoclingConversionError
-from common.retry_utils import retry_on_transient_error
-from digitize.settings import settings
+from common.misc_utils import get_logger
 
 # To suppress the warnings raised from pdfminer package while extracting the font size
 logging.getLogger("pdfminer").propagate = False
@@ -52,7 +43,6 @@ def get_document_page_count(file_path: str) -> int:
     Returns:
         Page count (int), or 0 if unable to determine
     """
-    from pathlib import Path
     from digitize.docx_utils import estimate_docx_page_count
 
     try:
@@ -118,7 +108,6 @@ def load_pdf_pages(pdf_path):
     Load PDF pages for text extraction.
     Returns empty list for non-PDF files (e.g., DOCX).
     """
-    from pathlib import Path
     
     # Check if file is actually a PDF
     file_ext = Path(pdf_path).suffix.lower()
@@ -201,156 +190,3 @@ def find_text_font_size(
         logger.error(f"Error extracting font size: {e}")
 
     return matches
-
-@retry_on_transient_error(max_retries=3, initial_delay=1.0, backoff_multiplier=2.0)
-def convert_chunk(doc_converter: DocumentConverter, path: Path, chunk_num: int, start_page: int, end_page: int, chunk_cache_dir: Path):
-    """Convert a single chunk of a PDF document.
-
-    Args:
-        doc_converter: DocumentConverter instance
-        path: Path to the PDF file
-        chunk_num: Chunk number for logging
-        start_page: Starting page number (1-based)
-        end_page: Ending page number (1-based, inclusive)
-        chunk_cache_dir: Directory to save chunk results
-
-    Returns:
-        Path to the saved chunk JSON file
-
-    Raises:
-        DoclingConversionError: If conversion or saving fails
-    """
-    try:
-        # Convert this chunk
-        conv_res: ConversionResult = doc_converter.convert(source=path, page_range=(start_page, end_page))
-
-        # Save chunk result to cache
-        chunk_filename = chunk_cache_dir / f"chunk_{chunk_num:04d}.json"
-        conv_res.document.save_as_json(str(chunk_filename))
-        logger.debug(f"Saved chunk of {path}'s chunk {chunk_num} to {chunk_filename}")
-
-        return chunk_filename
-    except Exception as e:
-        # Wrap any exception in DoclingConversionError for retry handling
-        error_msg = f"Failed to convert chunk {chunk_num} (pages {start_page}-{end_page}) of {path}: {str(e)}"
-        logger.error(error_msg)
-        raise DoclingConversionError(error_msg) from e
-
-def convert_doc(path: str | Path, cache_dir: Optional[Path] = None) -> DoclingDocument:
-    """
-    Convert a document to DoclingDocument, processing in 100-page chunks.
-
-    Args:
-        path: Path to the document file to convert
-        cache_dir: Optional cache directory for storing chunk results.
-                   Will be cleaned up after processing.
-
-    Returns:
-        DoclingDocument containing the concatenated result
-    """
-
-    # Input validation
-    path = Path(path)
-    if not path.exists():
-        raise FileNotFoundError(f"Document not found: {path}")
-
-    doc_converter: DocumentConverter = get_doc_converter()
-
-    # Get total page count
-    total_pages = get_document_page_count(str(path))
-
-    # If document has configured chunk size pages or fewer, convert normally
-    if total_pages <= settings.digitize.doc_chunk_size:
-        logger.debug(f"Converting {path} document with {total_pages} pages in single pass")
-
-        @retry_on_transient_error(max_retries=3, initial_delay=1.0, backoff_multiplier=2.0)
-        def _convert_single_doc():
-            try:
-                return doc_converter.convert(source=path).document
-            except Exception as e:
-                error_msg = f"Failed to convert document {path}: {str(e)}"
-                logger.error(error_msg)
-                raise DoclingConversionError(error_msg) from e
-
-        return _convert_single_doc()
-
-    # Process in chunks
-    # Calculate total chunks using ceiling division for the configured PDF chunk size.
-    # This ensures all pages are covered even if the last chunk is smaller.
-    total_chunks = (total_pages + settings.digitize.doc_chunk_size - 1) // settings.digitize.doc_chunk_size
-    logger.debug(
-        f"Converting {path} document with {total_pages} pages in {total_chunks} "
-        f"chunks of {settings.digitize.doc_chunk_size}"
-    )
-
-    # Determine cache directory for storing chunk results
-    if cache_dir is None:
-        chunk_cache_dir = Path(tempfile.mkdtemp(prefix="docling_chunks_"))
-    else:
-        chunk_cache_dir = Path(cache_dir)
-
-    chunk_cache_dir.mkdir(parents=True, exist_ok=True)
-
-    try:
-        # Process document in chunks and save each chunk
-        chunk_files = []
-
-        for start_page in range(1, total_pages + 1, settings.digitize.doc_chunk_size):
-            end_page = min(start_page + settings.digitize.doc_chunk_size - 1, total_pages)
-            chunk_num = (start_page - 1) // settings.digitize.doc_chunk_size + 1
-
-            logger.debug(f"Processing {path}'s chunk {chunk_num}/{total_chunks} (pages {start_page}-{end_page})")
-            chunk_file = convert_chunk(doc_converter, path, chunk_num, start_page, end_page, chunk_cache_dir)
-            chunk_files.append(chunk_file)
-
-        # Load all chunk documents and concatenate
-        docs = [DoclingDocument.load_from_json(filename=f) for f in chunk_files]
-        concatenated_doc = DoclingDocument.concatenate(docs=docs)
-
-        logger.debug(f"Successfully concatenated {path}'s {len(docs)} chunks into single document")
-        
-        return concatenated_doc
-
-    finally:
-        # Always cleanup cache directory
-        try:
-            shutil.rmtree(chunk_cache_dir)
-            logger.debug(f"Cleaned up cache directory: {chunk_cache_dir}")
-        except Exception as e:
-            logger.warning(f"Failed to cleanup cache directory {chunk_cache_dir}: {e}")
-
-def get_doc_converter():
-    import os
-    from pathlib import Path
-    from docling.datamodel.base_models import InputFormat
-    from docling.datamodel.pipeline_options import PdfPipelineOptions
-    from docling.document_converter import DocumentConverter, PdfFormatOption
-
-    # Accelerator & pipeline options
-    pipeline_options = PdfPipelineOptions()
-    
-    # Only set artifacts_path if DOCLING_MODELS_PATH environment variable is set
-    docling_models_path = os.environ.get('DOCLING_MODELS_PATH')
-    if docling_models_path:
-        artifacts_path = Path(docling_models_path)
-        if artifacts_path.exists():
-            pipeline_options.artifacts_path = artifacts_path
-            logger.debug(f"Using docling models from: {artifacts_path}")
-        else:
-            logger.warning(f"DOCLING_MODELS_PATH set to {artifacts_path} but directory does not exist")
-    else:
-        logger.debug("DOCLING_MODELS_PATH not set. Docling will use default model loading behavior.")
-    
-    pipeline_options.do_table_structure = True
-    pipeline_options.table_structure_options.do_cell_matching = True
-    pipeline_options.do_ocr = False
-
-    doc_converter = DocumentConverter(
-        allowed_formats=[
-            InputFormat.PDF,
-            InputFormat.DOCX
-        ],
-        format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)}
-    )
-
-    return doc_converter

--- a/services/digitize/pdf_utils.py
+++ b/services/digitize/pdf_utils.py
@@ -241,7 +241,7 @@ def convert_doc(path: str | Path, cache_dir: Optional[Path] = None) -> DoclingDo
     Convert a document to DoclingDocument, processing in 100-page chunks.
 
     Args:
-        path: Path to the PDF file to convert
+        path: Path to the document file to convert
         cache_dir: Optional cache directory for storing chunk results.
                    Will be cleaned up after processing.
 
@@ -257,10 +257,10 @@ def convert_doc(path: str | Path, cache_dir: Optional[Path] = None) -> DoclingDo
     doc_converter: DocumentConverter = get_doc_converter()
 
     # Get total page count
-    total_pages = get_pdf_page_count(path)
+    total_pages = get_document_page_count(str(path))
 
     # If document has configured chunk size pages or fewer, convert normally
-    if total_pages <= settings.digitize.pdf_chunk_size:
+    if total_pages <= settings.digitize.doc_chunk_size:
         logger.debug(f"Converting {path} document with {total_pages} pages in single pass")
 
         @retry_on_transient_error(max_retries=3, initial_delay=1.0, backoff_multiplier=2.0)
@@ -277,10 +277,10 @@ def convert_doc(path: str | Path, cache_dir: Optional[Path] = None) -> DoclingDo
     # Process in chunks
     # Calculate total chunks using ceiling division for the configured PDF chunk size.
     # This ensures all pages are covered even if the last chunk is smaller.
-    total_chunks = (total_pages + settings.digitize.pdf_chunk_size - 1) // settings.digitize.pdf_chunk_size
+    total_chunks = (total_pages + settings.digitize.doc_chunk_size - 1) // settings.digitize.doc_chunk_size
     logger.debug(
         f"Converting {path} document with {total_pages} pages in {total_chunks} "
-        f"chunks of {settings.digitize.pdf_chunk_size}"
+        f"chunks of {settings.digitize.doc_chunk_size}"
     )
 
     # Determine cache directory for storing chunk results
@@ -295,9 +295,9 @@ def convert_doc(path: str | Path, cache_dir: Optional[Path] = None) -> DoclingDo
         # Process document in chunks and save each chunk
         chunk_files = []
 
-        for start_page in range(1, total_pages + 1, settings.digitize.pdf_chunk_size):
-            end_page = min(start_page + settings.digitize.pdf_chunk_size - 1, total_pages)
-            chunk_num = (start_page - 1) // settings.digitize.pdf_chunk_size + 1
+        for start_page in range(1, total_pages + 1, settings.digitize.doc_chunk_size):
+            end_page = min(start_page + settings.digitize.doc_chunk_size - 1, total_pages)
+            chunk_num = (start_page - 1) // settings.digitize.doc_chunk_size + 1
 
             logger.debug(f"Processing {path}'s chunk {chunk_num}/{total_chunks} (pages {start_page}-{end_page})")
             chunk_file = convert_chunk(doc_converter, path, chunk_num, start_page, end_page, chunk_cache_dir)

--- a/services/digitize/settings.py
+++ b/services/digitize/settings.py
@@ -24,16 +24,16 @@ class DigitizeConfig(BaseSettings):
         description="Number of workers for document processing",
     )
 
-    heavy_pdf_convert_worker_size: int = Field(
+    heavy_doc_convert_worker_size: int = Field(
         default=2,
         ge=1,
-        description="Number of workers for heavy PDF conversion",
+        description="Number of workers for heavy document conversion",
     )
 
-    heavy_pdf_page_threshold: int = Field(
+    heavy_doc_page_threshold: int = Field(
         default=500,
         ge=1,
-        description="Page count threshold for heavy PDF classification",
+        description="Page count threshold for heavy document classification",
     )
 
     # API concurrency limits
@@ -63,10 +63,10 @@ class DigitizeConfig(BaseSettings):
     )
 
     # Document conversion parameters
-    pdf_chunk_size: int = Field(
+    doc_chunk_size: int = Field(
         default=100,
         ge=1,
-        description="Pages per chunk for large PDF processing",
+        description="Pages per chunk for large document processing",
     )
 
     # Batch processing

--- a/services/digitize/tests/test_doc_utils.py
+++ b/services/digitize/tests/test_doc_utils.py
@@ -403,7 +403,7 @@ class TestProcessTableLanguageSelection:
         with patch.object(Path, 'write_text'):
             process_table(
                 converted_doc=converted_doc,
-                pdf_path="sample.pdf",
+                doc_path="sample.pdf",
                 out_path=Path("/tmp/out.json"),
                 gen_model="test-model",
                 gen_endpoint="http://llm",
@@ -475,7 +475,7 @@ class TestProcessTableLanguageSelection:
         with patch.object(Path, 'write_text'):
             process_table(
                 converted_doc=converted_doc,
-                pdf_path="sample.pdf",
+                doc_path="sample.pdf",
                 out_path=Path("/tmp/out.json"),
                 gen_model="test-model",
                 gen_endpoint="http://llm",
@@ -548,7 +548,7 @@ class TestProcessTableLanguageSelection:
         with patch.object(Path, 'write_text'):
             process_table(
                 converted_doc=converted_doc,
-                pdf_path="sample.pdf",
+                doc_path="sample.pdf",
                 out_path=Path("/tmp/out.json"),
                 gen_model="test-model",
                 gen_endpoint="http://llm",
@@ -622,7 +622,7 @@ class TestProcessTableLanguageSelection:
         with patch.object(Path, 'write_text'):
             process_table(
                 converted_doc=converted_doc,
-                pdf_path="sample.pdf",
+                doc_path="sample.pdf",
                 out_path=Path("/tmp/out.json"),
                 gen_model="test-model",
                 gen_endpoint="http://llm",


### PR DESCRIPTION
This PR handles code cleanup of digitize service. 

- Replaced "pdf" to "doc" in the variables across the files to make it generic for both file formats (.docx and .pdf)
- Removed [duplicate](https://github.com/IBM/project-ai-services/pull/979/changes#diff-5264f94ed648806fe67159bc113a69e5c61217f7886984f943ec1697699bf89aL314) tqdm_wrapper initiation in doc_utils.py and used the [tqdm_wrapper](https://github.com/IBM/project-ai-services/pull/979/changes#diff-210e0ca9f16a1c7c9f7155da895816dcef0ce2a3bca66090645c1fde02687550R13) thats in llm_utils.py
- Moved all docx code related functions to docx_utils.py specifically all the functions related to fetching captions and section headers.
- Created a new file docling_utils.py and moved all docling related methods(convert_chunk, convert_doc,get_doc_converter,convert_document_format, convert_document) there
