### PR TITLE
Add missing spec field in chatbot (rag template)

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.106
+TAG?=v0.0.107
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag/podman/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/chat-bot.yaml.tmpl
@@ -8,6 +8,7 @@ metadata:
     ai-services.io/version: "{{ .Version }}"
   annotations:
     ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"
+spec:
   containers:
     - name: ui
       image: "{{ .Values.ui.image }}"

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.106
+  image: icr.io/ai-services-cicd/ai-services:v0.0.107
   runtime: ""
   adminPasswordHash: ""
   podman:


### PR DESCRIPTION
As part of this PR: https://github.com/IBM/project-ai-services/pull/868/changes#diff-7af10d0cf73006d1592aadc63f879a96bab3fcefc583f84532a86dc03f9e18c6L12. The spec field got removed for rag-template due to which the deployments for `rag` is failing.