### PR TITLE
remove experimental flags and use new way of deploying application

### DIFF
--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -1,12 +1,8 @@
 package application
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"maps"
-	"strings"
-	"text/template"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -16,28 +12,15 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/bootstrap"
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
-	apiModels "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
-	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
-	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	appFlags "github.com/project-ai-services/ai-services/internal/pkg/cli/constants/application"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/flagvalidator"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
-	cliutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/image"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
-)
-
-const (
-	// Polling configuration.
-	pollInterval       = 20 * time.Second
-	pollTimeout        = 20 * time.Minute
-	paramSplitParts    = 2
-	expectedParamParts = 2
 )
 
 // Variables for flags placeholder.
@@ -53,7 +36,6 @@ var (
 	skipChecks            []string
 	valuesFiles           []string
 	rawArgImagePullPolicy string
-	experimentalCreate    bool
 
 	// openshift flags.
 	timeout time.Duration
@@ -67,14 +49,14 @@ Arguments
 - [name]: Application name (Required)
 
 Examples:
-# Deploy with experimental mode (5 Spyre cards)
-ai-services application create rag --template rag --runtime podman --experimental
+# Deploy application (5 Spyre cards)
+ai-services application create rag --template rag --runtime podman
 
-# Deploy with experimental mode (4 Spyre cards - reranker on CPU)
-ai-services application create rag --template rag --runtime podman --experimental --params reranker.vllm-cpu=true
+# Deploy application (4 Spyre cards - reranker on CPU)
+ai-services application create rag --template rag --runtime podman --params reranker.vllm-cpu=true
 
-# Deploy with experimental mode (CPU mode)
-ai-services application create rag --template rag --runtime podman --experimental --params reranker.vllm-cpu=true,llm.vllm-cpu=true
+# Deploy application (CPU mode)
+ai-services application create rag --template rag --runtime podman --params reranker.vllm-cpu=true,llm.vllm-cpu=true
 	`,
 	Args: cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -95,7 +77,6 @@ ai-services application create rag --template rag --runtime podman --experimenta
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		appName := args[0]
-		ctx := context.Background()
 
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true
@@ -105,11 +86,6 @@ ai-services application create rag --template rag --runtime podman --experimenta
 		}
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
-		// When experimentalCreate is true and runtime is podman, validate application name using catalog API
-		// For openshift runtime, always use the older/stable code path regardless of experimental flag
-		if experimentalCreate && rt == types.RuntimeTypePodman {
-			return createApp(appName)
-		}
 
 		// Create application instance using factory
 		appFactory := application.NewFactory(rt)
@@ -129,7 +105,7 @@ ai-services application create rag --template rag --runtime podman --experimenta
 			Timeout:           timeout,
 		}
 
-		return app.Create(ctx, opts)
+		return app.Create(context.Background(), opts)
 	},
 }
 
@@ -211,7 +187,6 @@ func initCreatePodmanFlags() {
 			"- If left false in air-gapped environments → download attempt will fail\n"+
 			"Note: Supported for podman runtime only.\n",
 	)
-	createCmd.Flags().BoolVar(&experimentalCreate, "experimental", false, "Include experimental application create")
 
 	initializeImagePullPolicyFlag()
 
@@ -279,12 +254,12 @@ func buildFlagValidator() *flagvalidator.FlagValidator {
 
 // validateTemplateFlag validates the template flag.
 func validateTemplateFlag(cmd *cobra.Command) error {
-	// Skip template validation in experimental mode for podman runtime
-	// In experimental mode, templates are validated against catalog API
-	if experimentalCreate && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+	// For Podman runtime, templates are validated against catalog API
+	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
 		return nil
 	}
 
+	// For OpenShift runtime, validate against embedded templates
 	tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
 	if err := tp.AppTemplateExist(templateName); err != nil {
 		return err
@@ -305,13 +280,12 @@ func validateParamsFlag(cmd *cobra.Command) error {
 		return fmt.Errorf("invalid format: %w", err)
 	}
 
-	// Skip template validation in experimental mode for podman runtime
-	// In experimental mode, params are validated against catalog API schemas
-	if experimentalCreate && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+	// For Podman runtime, params are validated against catalog API schemas
+	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
 		return nil
 	}
 
-	// Validate params against template values (non-experimental mode)
+	// For OpenShift runtime, validate params against template values
 	tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
 	_, err = tp.LoadValues(templateName, nil, argParams)
 	if err != nil {
@@ -371,581 +345,6 @@ func validateSkipChecksFlag(cmd *cobra.Command) error {
 	}
 
 	return nil
-}
-
-func createApp(appName string) error {
-	// 1. Initialize catalog client
-	appClient, err := catalogClient.NewApplicationClient()
-	if err != nil {
-		return fmt.Errorf("failed to create application client: %w", err)
-	}
-
-	// 2. Check if application already exists
-	if err := checkApplicationExists(appClient, appName); err != nil {
-		return err
-	}
-
-	// 3. Build the catalog API payload
-	payload, err := buildCatalogPayload(appName)
-	if err != nil {
-		return err
-	}
-
-	// 4. Create application via catalog API
-	logger.Infof("Creating application '%s' using template '%s'...\n", appName, templateName)
-	resp, err := appClient.CreateApplication(payload)
-	if err != nil {
-		return fmt.Errorf("failed to create application: %w", err)
-	}
-
-	logger.Infof("Application creation initiated (ID: %s)\n", resp.ID)
-
-	// 5. Poll for application status
-	return pollApplicationStatus(appClient, appName)
-}
-
-// checkApplicationExists checks if an application with the given name already exists.
-func checkApplicationExists(appClient *catalogClient.ApplicationClient, appName string) error {
-	existingApp, err := cliutils.GetAppByName(appClient, appName)
-	if err != nil && !strings.Contains(err.Error(), "not found") {
-		return err
-	}
-
-	if existingApp != nil {
-		return fmt.Errorf("application with name '%s' already exists", appName)
-	}
-
-	return nil
-}
-
-// buildCatalogPayload builds the catalog API payload for the given template.
-func buildCatalogPayload(appName string) (*apiModels.CreateApplicationRequest, error) {
-	// Initialize catalog provider
-	provider, err := catalog.NewCatalogProvider()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create catalog provider: %w", err)
-	}
-
-	// Determine if template is architecture or service
-	isArchitecture := provider.ArchitectureExists(templateName)
-	isService := provider.ServiceExists(templateName)
-
-	if !isArchitecture && !isService {
-		return nil, fmt.Errorf("template '%s' not found as architecture or service", templateName)
-	}
-
-	// Build the payload
-	if isArchitecture {
-		return buildArchitecturePayload(provider, templateName, appName)
-	}
-
-	return buildServicePayload(templateName, appName)
-}
-
-// pollApplicationStatus polls the application status until it's ready or fails.
-func pollApplicationStatus(appClient *catalogClient.ApplicationClient, appName string) error {
-	logger.Infof("Waiting for application '%s' to be ready...\n", appName)
-
-	ticker := time.NewTicker(pollInterval)
-	defer ticker.Stop()
-
-	timeout := time.After(pollTimeout)
-
-	for {
-		select {
-		case <-timeout:
-			return fmt.Errorf("timeout waiting for application '%s' to be ready", appName)
-
-		case <-ticker.C:
-			app, err := cliutils.GetAppByName(appClient, appName)
-			if err != nil {
-				return fmt.Errorf("failed to get application status: %w", err)
-			}
-
-			done, err := handleApplicationStatus(app, appName)
-			if err != nil {
-				return err
-			}
-			if done {
-				return nil
-			}
-		}
-	}
-}
-
-// handleApplicationStatus handles the application status and returns (done, error).
-func handleApplicationStatus(app *catalogTypes.Application, appName string) (bool, error) {
-	// Status values from ai-services/internal/pkg/catalog/db/models/application.go.
-	switch app.Status {
-	case "Running":
-		logger.Infof("Application '%s' is ready!\n", appName)
-
-		// Print next steps after successful deployment
-		if err := printNextSteps(app); err != nil {
-			logger.Warningf("Failed to display next steps: %v\n", err)
-		}
-
-		return true, nil
-
-	case "Error":
-		if app.Message != "" {
-			return false, fmt.Errorf("application deployment failed: %s", app.Message)
-		}
-
-		return false, fmt.Errorf("application deployment failed")
-
-	case "Downloading", "Deploying":
-		// Still in progress, continue polling.
-		logger.Infof("Deploying application: %s, Status: %s, Message: %s\n", appName, app.Status, app.Message)
-
-		return false, nil
-
-	case "Deleting":
-		return false, fmt.Errorf("application is being deleted")
-
-	default:
-		logger.Infof("Status: %s\n", app.Status)
-
-		return false, nil
-	}
-}
-
-// printNextSteps prints the next steps for the deployed application.
-func printNextSteps(app *catalogTypes.Application) error {
-	appClient, err := catalogClient.NewApplicationClient()
-	if err != nil {
-		return fmt.Errorf("failed to create application client: %w", err)
-	}
-
-	// Get full application details with services
-	application, err := appClient.GetApplication(app.ID)
-	if err != nil {
-		return fmt.Errorf("failed to get application: %w", err)
-	}
-
-	catalogProvider, err := catalog.NewCatalogProvider()
-	if err != nil {
-		return fmt.Errorf("failed to create catalog provider: %w", err)
-	}
-
-	logger.Infoln("\nNext Steps:")
-	logger.Infoln("-------")
-
-	for _, service := range application.Services {
-		params := map[string]string{}
-		params["SERVICE_NAME"] = service.Type
-
-		// Add endpoint URLs to params
-		for _, endpoint := range service.Endpoints {
-			urlType, urlTypeOk := endpoint["type"].(string)
-			url, urlOk := endpoint["url"].(string)
-			if urlTypeOk && urlOk {
-				params[strings.ToUpper(urlType)+"_URL"] = url
-			}
-		}
-
-		tmpls, err := catalogProvider.LoadServicesMD(service.CatalogID)
-		if err != nil {
-			logger.Warningf("Failed to load next steps for service '%s': %v\n", service.CatalogID, err)
-
-			continue
-		}
-
-		err = printNextStepsMD(tmpls, params, application.Name)
-		if err != nil {
-			logger.Warningf("Failed to render next steps for service '%s': %v\n", service.CatalogID, err)
-		}
-	}
-
-	return nil
-}
-
-// printNextStepsMD renders and prints the next.md template for a service.
-func printNextStepsMD(tmpls map[string]*template.Template, params map[string]string, appName string) error {
-	tmpl, ok := tmpls["next.md"]
-	if !ok {
-		// next.md doesn't exist for this service, return nil
-		return nil
-	}
-
-	var rendered bytes.Buffer
-	if err := tmpl.Execute(&rendered, params); err != nil {
-		return fmt.Errorf("failed to execute next.md: %w", err)
-	}
-
-	value := rendered.String()
-
-	// Print the template content if available
-	if strings.TrimSpace(value) != "" {
-		logger.Infof(value)
-	}
-
-	// Print the info command for all services
-	logger.Infof("\n- For detailed endpoint information, use: `ai-services application info %s --runtime podman`\n", appName)
-
-	return nil
-}
-
-// buildArchitecturePayload builds the payload for an architecture deployment.
-func buildArchitecturePayload(provider *catalog.CatalogProvider, archID, appName string) (*apiModels.CreateApplicationRequest, error) {
-	// Load architecture metadata
-	arch, err := provider.LoadArchitecture(archID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load architecture: %w", err)
-	}
-
-	// Create application client for API calls
-	appClient, err := catalogClient.NewApplicationClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create application client: %w", err)
-	}
-
-	// Get deploy options for the architecture
-	deployOptions, err := appClient.GetArchitectureDeployOptions(archID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get deploy options: %w", err)
-	}
-
-	// Build services list using deploy options
-	services := make([]apiModels.Service, 0, len(arch.Services))
-	for _, svcRef := range arch.Services {
-		// Find the corresponding deploy options service
-		var svcDeployOpts *catalogTypes.DeployOptionsService
-		for i := range deployOptions.Services {
-			if deployOptions.Services[i].ID == svcRef.ID {
-				svcDeployOpts = &deployOptions.Services[i]
-
-				break
-			}
-		}
-
-		if svcDeployOpts == nil {
-			return nil, fmt.Errorf("deploy options not found for service '%s'", svcRef.ID)
-		}
-
-		svc, err := buildServiceEntryWithDeployOptions(appClient, svcRef.ID, svcDeployOpts)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build service '%s': %w", svcRef.ID, err)
-		}
-		services = append(services, svc)
-	}
-
-	return &apiModels.CreateApplicationRequest{
-		CatalogID: archID,
-		Name:      appName,
-		Services:  services,
-		Version:   arch.Version,
-	}, nil
-}
-
-// buildServicePayload builds the payload for a standalone service deployment.
-func buildServicePayload(serviceID, appName string) (*apiModels.CreateApplicationRequest, error) {
-	// Create application client for API calls
-	appClient, err := catalogClient.NewApplicationClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create application client: %w", err)
-	}
-
-	// Get deploy options for the service
-	deployOptions, err := appClient.GetServiceDeployOptions(serviceID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get deploy options: %w", err)
-	}
-
-	svc, err := buildServiceEntryWithDeployOptions(appClient, serviceID, deployOptions)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build service: %w", err)
-	}
-
-	return &apiModels.CreateApplicationRequest{
-		CatalogID: serviceID,
-		Name:      appName,
-		Services:  []apiModels.Service{svc},
-		Version:   svc.Version,
-	}, nil
-}
-
-// buildServiceEntryWithDeployOptions builds a single service entry with its components using deploy options.
-func buildServiceEntryWithDeployOptions(appClient *catalogClient.ApplicationClient, serviceID string, deployOptions *catalogTypes.DeployOptionsService) (apiModels.Service, error) {
-	// Build components list from deploy options
-	components := make([]apiModels.Component, 0, len(deployOptions.Components))
-	for _, compDeployOpt := range deployOptions.Components {
-		// Get component configuration from argParams (provider-specific params)
-		providerParams := extractComponentParamsForService(serviceID, compDeployOpt.Type, argParams)
-
-		// Determine provider ID and get its params
-		providerID, userParams := selectProviderFromDeployOptions(compDeployOpt, providerParams)
-		if providerID == "" {
-			return apiModels.Service{}, fmt.Errorf("no provider found for component type '%s'", compDeployOpt.Type)
-		}
-
-		// Find the selected provider to get its version
-		var providerVersion string
-		var providerFound bool
-		for _, p := range compDeployOpt.Providers {
-			if p.ID == providerID {
-				providerVersion = p.Version
-				providerFound = true
-
-				break
-			}
-		}
-
-		// If provider not found in deploy options, return error
-		if !providerFound {
-			return apiModels.Service{}, fmt.Errorf("provider '%s' not found in deploy options for component type '%s'", providerID, compDeployOpt.Type)
-		}
-
-		// Fetch schema and apply defaults, merging with user params
-		componentParamsAny, err := applySchemaDefaults(appClient, compDeployOpt.Type, providerID, userParams)
-		if err != nil {
-			logger.Warningf("Failed to apply schema defaults for %s/%s: %v\n", compDeployOpt.Type, providerID, err)
-			// Continue with user-provided params only
-			componentParamsAny = make(map[string]any)
-			for k, v := range userParams {
-				componentParamsAny[k] = v
-			}
-		}
-
-		components = append(components, apiModels.Component{
-			ComponentType: compDeployOpt.Type,
-			ProviderID:    providerID,
-			Params:        componentParamsAny,
-			Version:       providerVersion,
-		})
-	}
-
-	// Extract service-level parameters (excluding component params)
-	serviceParams := extractServiceParams(serviceID, deployOptions.Components, argParams)
-
-	return apiModels.Service{
-		CatalogID:  serviceID,
-		Components: components,
-		Params:     serviceParams,
-		Version:    deployOptions.Version,
-	}, nil
-}
-
-// extractServiceParams extracts service-level parameters from argParams, excluding component params.
-// Format: {serviceID}.{param} -> {param}.
-// Excludes: {serviceID}.{componentType}.{param} (those are component params).
-// Nested dot-notation keys (e.g. backend.systemPrompt) are expanded into nested maps.
-func extractServiceParams(serviceID string, components []catalogTypes.DeployOptionsComponent, allParams map[string]string) map[string]any {
-	serviceParams := make(map[string]any)
-	servicePrefix := serviceID + "."
-
-	// Build a set of component types for this service.
-	componentTypes := make(map[string]bool)
-	for _, comp := range components {
-		componentTypes[comp.Type] = true
-	}
-
-	for key, value := range allParams {
-		after, ok := strings.CutPrefix(key, servicePrefix)
-		if !ok {
-			continue
-		}
-
-		// Check if this is a component parameter by seeing if it starts with a known component type.
-		isComponentParam := isComponentParameter(after, componentTypes)
-
-		// Only add to service params if it's not a component param.
-		if !isComponentParam {
-			setNestedParam(serviceParams, after, value)
-		}
-	}
-
-	return serviceParams
-}
-
-// setNestedParam sets a value in a nested map using a dot-notation key.
-// e.g. setNestedParam(m, "backend.systemPrompt", "hello") → m["backend"]["systemPrompt"] = "hello".
-func setNestedParam(m map[string]any, dotKey string, value string) {
-	parts := strings.SplitN(dotKey, ".", paramSplitParts)
-	if len(parts) == 1 {
-		m[dotKey] = value
-
-		return
-	}
-
-	nested, ok := m[parts[0]].(map[string]any)
-	if !ok {
-		nested = make(map[string]any)
-		m[parts[0]] = nested
-	}
-
-	setNestedParam(nested, parts[1], value)
-}
-
-// isComponentParameter checks if a parameter belongs to a component.
-func isComponentParameter(param string, componentTypes map[string]bool) bool {
-	for compType := range componentTypes {
-		if strings.HasPrefix(param, compType+".") {
-			return true
-		}
-	}
-
-	return false
-}
-
-// extractComponentParamsForService extracts parameters for a specific component type from argParams.
-// Supports provider-specific params:
-// - Provider only: {componentType}.{providerID} (e.g., llm.vllm-cpu) - selects provider with defaults.
-// - Provider with params: {componentType}.{providerID}.{param} (e.g., llm.vllm-cpu.model).
-// - Service-specific: {serviceID}.{componentType}.{providerID}[.{param}] (e.g., chat.llm.vllm-cpu or chat.llm.vllm-cpu.model).
-// Returns a map with provider as key and params as value.
-func extractComponentParamsForService(serviceID string, componentType string, allParams map[string]string) map[string]map[string]string {
-	providerParams := make(map[string]map[string]string)
-
-	// Extract global component params: {componentType}.{providerID}[.{param}].
-	extractProviderParams(componentType+".", allParams, providerParams)
-
-	// Extract service-specific component params (these override global).
-	extractProviderParams(serviceID+"."+componentType+".", allParams, providerParams)
-
-	return providerParams
-}
-
-// extractProviderParams extracts provider parameters from allParams with the given prefix.
-func extractProviderParams(prefix string, allParams map[string]string, providerParams map[string]map[string]string) {
-	for key, value := range allParams {
-		after, ok := strings.CutPrefix(key, prefix)
-		if !ok {
-			continue
-		}
-
-		// Split to get providerID and optional param.
-		parts := strings.SplitN(after, ".", paramSplitParts)
-		if len(parts) < 1 {
-			continue
-		}
-
-		providerID := parts[0]
-		if providerParams[providerID] == nil {
-			providerParams[providerID] = make(map[string]string)
-		}
-
-		// If there's a param name, add it; otherwise just mark provider as selected.
-		if len(parts) == expectedParamParts {
-			paramName := parts[1]
-			providerParams[providerID][paramName] = value
-		}
-	}
-}
-
-// selectProviderFromDeployOptions determines the provider ID for a component using deploy options.
-// Priority:
-// 1. If user provided provider-specific params (e.g., llm.vllm-cpu.model), use that provider.
-// 2. For LLM and reranker components: Use vllm-spyre by default.
-// 3. Default provider marked in deploy options.
-// 4. First available provider.
-func selectProviderFromDeployOptions(compDeployOpt catalogTypes.DeployOptionsComponent, providerParams map[string]map[string]string) (string, map[string]string) {
-	// Check if user specified params for a specific provider.
-	if providerID, params := findUserSpecifiedProvider(compDeployOpt, providerParams); providerID != "" {
-		return providerID, params
-	}
-
-	// Special logic for LLM and reranker component types - prefer Spyre acceleration.
-	if providerID := findSpyreProvider(compDeployOpt); providerID != "" {
-		return providerID, make(map[string]string)
-	}
-
-	// Use default provider if marked.
-	if providerID := findDefaultProvider(compDeployOpt); providerID != "" {
-		return providerID, make(map[string]string)
-	}
-
-	// Fall back to first available provider.
-	if len(compDeployOpt.Providers) > 0 {
-		return compDeployOpt.Providers[0].ID, make(map[string]string)
-	}
-
-	return "", make(map[string]string)
-}
-
-// findUserSpecifiedProvider checks if user specified params for a specific provider.
-func findUserSpecifiedProvider(compDeployOpt catalogTypes.DeployOptionsComponent, providerParams map[string]map[string]string) (string, map[string]string) {
-	for providerID := range providerParams {
-		// Verify this provider exists in deploy options.
-		for _, p := range compDeployOpt.Providers {
-			if p.ID == providerID {
-				return providerID, providerParams[providerID]
-			}
-		}
-	}
-
-	return "", nil
-}
-
-// findSpyreProvider finds vllm-spyre provider if available for the component.
-func findSpyreProvider(compDeployOpt catalogTypes.DeployOptionsComponent) string {
-	for _, p := range compDeployOpt.Providers {
-		if p.ID == "vllm-spyre" {
-			return p.ID
-		}
-	}
-
-	return ""
-}
-
-// findDefaultProvider finds the default provider marked in deploy options.
-func findDefaultProvider(compDeployOpt catalogTypes.DeployOptionsComponent) string {
-	for _, p := range compDeployOpt.Providers {
-		if p.Default {
-			return p.ID
-		}
-	}
-
-	return ""
-}
-
-// applySchemaDefaults fetches the component provider schema and applies default values.
-// User-provided params override defaults.
-func applySchemaDefaults(appClient *catalogClient.ApplicationClient, componentType, providerID string, userParams map[string]string) (map[string]any, error) {
-	// Fetch schema from API
-	schema, err := appClient.GetComponentProviderParams(componentType, providerID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch schema: %w", err)
-	}
-
-	// Extract defaults from schema
-	defaults := extractDefaultsFromSchema(schema)
-
-	// Merge: start with defaults, override with user params
-	result := make(map[string]any)
-	maps.Copy(result, defaults)
-
-	// Override with user-provided params (excluding 'provider' key)
-	// Support nested parameters using dot notation (e.g., auth.password)
-	for k, v := range userParams {
-		if k != "provider" {
-			setNestedParam(result, k, v)
-		}
-	}
-
-	return result, nil
-}
-
-// extractDefaultsFromSchema extracts default values from a JSON schema.
-func extractDefaultsFromSchema(schema map[string]any) map[string]any {
-	defaults := make(map[string]any)
-
-	// Check if schema has properties
-	properties, ok := schema["properties"].(map[string]any)
-	if !ok {
-		return defaults
-	}
-
-	// Extract default value for each property
-	for propName, propValue := range properties {
-		if propMap, ok := propValue.(map[string]any); ok {
-			if defaultValue, hasDefault := propMap["default"]; hasDefault {
-				defaults[propName] = defaultValue
-			}
-		}
-	}
-
-	return defaults
 }
 
 // Made with Bob

--- a/ai-services/cmd/ai-services/cmd/application/delete.go
+++ b/ai-services/cmd/ai-services/cmd/application/delete.go
@@ -1,29 +1,21 @@
 package application
 
 import (
-	"errors"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
-	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	appFlags "github.com/project-ai-services/ai-services/internal/pkg/cli/constants/application"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/flagvalidator"
-	cliUtils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
-	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
-	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 var (
-	skipCleanup        bool
-	deleteTimeout      time.Duration
-	experimentalDelete bool
+	skipCleanup   bool
+	deleteTimeout time.Duration
 )
 
 var deleteCmd = &cobra.Command{
@@ -37,16 +29,8 @@ Arguments
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// Build and run flag validator
 		flagValidator := buildDeleteFlagValidator()
-		if err := flagValidator.Validate(cmd); err != nil {
-			return err
-		}
 
-		appName := args[0]
-		if !experimentalDelete {
-			return utils.VerifyAppName(appName)
-		}
-
-		return nil
+		return flagValidator.Validate(cmd)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		applicationName := args[0]
@@ -55,12 +39,6 @@ Arguments
 		cmd.SilenceUsage = true
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
-
-		// When experimentalDelete is true and runtime is podman, validate application name using catalog API
-		// For openshift runtime, always use the older/stable code path regardless of experimental flag
-		if experimentalDelete && rt == types.RuntimeTypePodman {
-			return deleteApplication(applicationName)
-		}
 
 		// Create application instance using factory
 		factory := application.NewFactory(rt)
@@ -77,7 +55,6 @@ Arguments
 		}
 
 		return app.Delete(cmd.Context(), opts)
-
 	},
 }
 
@@ -89,7 +66,6 @@ func init() {
 func initDeleteCommonFlags() {
 	deleteCmd.Flags().BoolVar(&skipCleanup, appFlags.Delete.SkipCleanup, false, "Skip deleting application data (default=false)")
 	deleteCmd.Flags().BoolVarP(&autoYes, appFlags.Delete.AutoYes, "y", false, "Automatically accept all confirmation prompts (default=false)")
-	deleteCmd.Flags().BoolVar(&experimentalDelete, "experimental", false, "Include experimental application delete")
 }
 
 func initDeleteOpenShiftFlags() {
@@ -118,92 +94,4 @@ func buildDeleteFlagValidator() *flagvalidator.FlagValidator {
 		AddOpenShiftFlag(appFlags.Delete.Timeout, nil)
 
 	return builder.Build()
-}
-
-func deleteApplication(appName string) error {
-	appClient, err := catalogClient.NewApplicationClient()
-	if err != nil {
-		return fmt.Errorf("failed to create application client: %w", err)
-	}
-	app, err := cliUtils.GetAppByName(appClient, appName)
-	if err != nil {
-		return err
-	}
-	if app == nil {
-		return fmt.Errorf("application not found: %s", appName)
-	}
-
-	if !autoYes {
-		confirmDelete, err := deleteConfirmation()
-		if err != nil {
-			return err
-		}
-		if !confirmDelete {
-			logger.Infoln("Deletion cancelled")
-
-			return nil
-		}
-	}
-
-	deleteParams := catalogClient.DeleteApplicationParams{
-		KeepData: skipCleanup,
-	}
-
-	if err := appClient.DeleteApplication(app.ID, &deleteParams); err != nil {
-		return fmt.Errorf("failed to delete application: %w", err)
-	}
-
-	// Poll to verify deletion is complete
-	logger.Infof("Waiting for application %s to be deleted...\n", appName)
-	if err := waitForApplicationDeletion(appClient, app.ID); err != nil {
-		return fmt.Errorf("failed to verify application deletion: %w", err)
-	}
-
-	logger.Infof("Application %s deleted successfully.", appName)
-
-	return nil
-}
-
-// waitForApplicationDeletion polls the application status until it's fully deleted.
-func waitForApplicationDeletion(appClient *catalogClient.ApplicationClient, appID string) error {
-	const (
-		pollInterval = 5 * time.Second
-		maxAttempts  = 12
-	)
-
-	for range maxAttempts {
-		// Check if application still exists via API
-		app, err := appClient.GetApplication(appID)
-		if err != nil {
-			// Check if it's an HTTPError with 404 status code
-			var httpErr *catalogClient.HTTPError
-			if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-				// Application not found (HTTP 404) - successfully deleted
-				return nil
-			}
-
-			return fmt.Errorf("failed to fetch application: %w", err)
-		}
-
-		// If application exists, check its status
-		if app != nil {
-			logger.Infof("Application status: %s, message: %s\n", app.Status, app.Message)
-			// Application still exists, continue polling
-		}
-
-		// Wait before next poll
-		time.Sleep(pollInterval)
-	}
-
-	return fmt.Errorf("timeout waiting for application deletion after %v", maxAttempts*pollInterval)
-}
-
-func deleteConfirmation() (bool, error) {
-	confirmActionPrompt := "Are you sure you want to delete the application? "
-	confirmDelete, err := utils.ConfirmAction(confirmActionPrompt)
-	if err != nil {
-		return confirmDelete, fmt.Errorf("failed to take user input: %w", err)
-	}
-
-	return confirmDelete, nil
 }

--- a/ai-services/cmd/ai-services/cmd/application/info.go
+++ b/ai-services/cmd/ai-services/cmd/application/info.go
@@ -1,26 +1,13 @@
 package application
 
 import (
-	"bytes"
 	"fmt"
-	"strings"
-	"text/template"
 
 	"github.com/spf13/cobra"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
-	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
-	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
-	cliUtils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
-	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
-)
-
-var (
-	experimentalInfo bool
 )
 
 var infoCmd = &cobra.Command{
@@ -40,10 +27,6 @@ var infoCmd = &cobra.Command{
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
-		if experimentalInfo && rt == types.RuntimeTypePodman {
-			return renderApplicationInfo(applicationName)
-		}
-
 		// Create application instance using factory
 		factory := application.NewFactory(rt)
 		app, err := factory.Create(applicationName)
@@ -59,127 +42,4 @@ var infoCmd = &cobra.Command{
 	},
 }
 
-func init() {
-	infoCmd.Flags().BoolVar(&experimentalInfo, "experimental", false, "Include experimental application info")
-}
-
-func renderApplicationInfo(appName string) error {
-	appClient, err := catalogClient.NewApplicationClient()
-	if err != nil {
-		return fmt.Errorf("failed to create application client: %w", err)
-	}
-
-	app, err := cliUtils.GetAppByName(appClient, appName)
-	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			logger.Warningf("Application: '%s' does not exist", appName)
-
-			return nil
-		}
-
-		return err
-	}
-
-	application, err := appClient.GetApplication(app.ID)
-	if err != nil {
-		return fmt.Errorf("failed to get application: %w", err)
-	}
-
-	appPS, err := appClient.GetApplicationPS(app.ID)
-	if err != nil {
-		return fmt.Errorf("failed to get application pods: %w", err)
-	}
-
-	logger.Infoln("Application Name: " + application.Name)
-	logger.Infoln("Application Template: " + application.CatalogID)
-	logger.Infof("Application Version: " + application.Version)
-
-	return printServicesInfo(application.Services, appPS)
-}
-
-func printServicesInfo(services []catalogTypes.ApplicationService, appPS *catalogTypes.ApplicationPSResponse) error {
-	catalogProvider, err := catalog.NewCatalogProvider()
-	if err != nil {
-		return fmt.Errorf("failed to create catalog provider: %w", err)
-	}
-
-	logger.Infoln("Info:")
-	logger.Infoln("-------")
-	logger.Infoln("Day N: ")
-
-	for _, service := range services {
-		params := map[string]string{}
-		params["SERVICE_NAME"] = service.Type
-
-		uiStatus, apiSatatus := getContainerStatus(appPS.Services, service.CatalogID)
-		params["UI_STATUS"] = uiStatus
-		params["API_STATUS"] = apiSatatus
-
-		for _, endpoint := range service.Endpoints {
-			urlType, urlTypeOk := endpoint["type"].(string)
-			url, urlOk := endpoint["url"].(string)
-			if urlTypeOk && urlOk {
-				params[strings.ToUpper(urlType)+"_URL"] = url
-			}
-		}
-
-		tmpls, err := catalogProvider.LoadServicesMD(service.CatalogID)
-		if err != nil {
-			return fmt.Errorf("failed to load service md files: %w", err)
-		}
-
-		err = printInfo(tmpls, params, service.CatalogID)
-		if err != nil {
-			return fmt.Errorf("failed to load application info: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func getContainerStatus(services []catalogTypes.Pod, catalogID string) (string, string) {
-	uiStatus, apiStatus := "", ""
-
-	for _, servicePod := range services {
-		if strings.HasPrefix(servicePod.PodName, catalogID) {
-			for _, podContainer := range servicePod.Containers {
-				// TODO: Set the container status in info.md generically
-				uiContainerName := fmt.Sprintf("%s-ui", servicePod.PodName)
-				apiContainerName := ""
-				if strings.Contains(podContainer.Name, "backend-server") {
-					apiContainerName = podContainer.Name
-				} else {
-					apiContainerName = fmt.Sprintf("%s-%s-api", servicePod.PodName, catalogID)
-				}
-
-				if podContainer.Name == uiContainerName && podContainer.Healthy {
-					uiStatus = "running"
-				}
-				if podContainer.Name == apiContainerName && podContainer.Healthy {
-					apiStatus = "running"
-				}
-			}
-		}
-	}
-
-	return uiStatus, apiStatus
-}
-
-func printInfo(tmpls map[string]*template.Template, params map[string]string, appTemplate string) error {
-	tmpl, ok := tmpls["info.md"]
-	if !ok {
-		logger.Warningf("failed to find info.md template")
-
-		return nil
-	}
-
-	var rendered bytes.Buffer
-	if err := tmpl.Execute(&rendered, params); err != nil {
-		return fmt.Errorf("failed to execute info.md: %w", err)
-	}
-	value := rendered.String()
-	value = strings.ReplaceAll(value, "Day N:\n", "")
-	logger.Infof(value)
-
-	return nil
-}
+// Made with Bob

--- a/ai-services/cmd/ai-services/cmd/application/logs.go
+++ b/ai-services/cmd/ai-services/cmd/application/logs.go
@@ -5,11 +5,8 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
-	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	appFlags "github.com/project-ai-services/ai-services/internal/pkg/cli/constants/application"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/flagvalidator"
-	"github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	"github.com/spf13/cobra"
 )
@@ -17,7 +14,6 @@ import (
 var (
 	podName           string
 	containerNameOrID string
-	experimentalLogs  bool
 )
 
 var logsCmd = &cobra.Command{
@@ -48,20 +44,6 @@ Arguments
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
-		// When experimentalLogs is true and runtime is podman, validate application name using catalog API
-		// For openshift runtime, always use the older/stable code path regardless of experimental flag
-		if experimentalLogs && rt == types.RuntimeTypePodman {
-			appClient, err := catalogClient.NewApplicationClient()
-			if err != nil {
-				return fmt.Errorf("failed to create application client: %w", err)
-			}
-			if _, err := utils.GetAppByName(appClient, applicationName); err != nil {
-				return err
-			}
-
-			return nil
-		}
-
 		// Create application instance using factory
 		factory := application.NewFactory(rt)
 		app, err := factory.Create(applicationName)
@@ -70,6 +52,7 @@ Arguments
 		}
 
 		opts := appTypes.LogsOptions{
+			ApplicationName:   applicationName,
 			PodName:           podName,
 			ContainerNameOrID: containerNameOrID,
 		}
@@ -83,7 +66,6 @@ func init() {
 }
 
 func initLogsCommonFlags() {
-	logsCmd.Flags().BoolVar(&experimentalLogs, "experimental", false, "Include experimental application logs")
 	logsCmd.Flags().StringVar(&podName, appFlags.Logs.Pod, "", "Pod name to show logs from (required)")
 	logsCmd.Flags().StringVar(&containerNameOrID, appFlags.Logs.Container, "", "Container logs to show logs from (Optional)")
 	_ = logsCmd.MarkFlagRequired(appFlags.Logs.Pod)

--- a/ai-services/cmd/ai-services/cmd/application/ps.go
+++ b/ai-services/cmd/ai-services/cmd/application/ps.go
@@ -6,21 +6,13 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
-	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	appFlags "github.com/project-ai-services/ai-services/internal/pkg/cli/constants/application"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/flagvalidator"
-	cliUtils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
-	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
-	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	"github.com/spf13/cobra"
 )
 
-var (
-	output         string
-	experimentalPs bool
-)
+var output string
 
 func isOutputWide() bool {
 	return strings.ToLower(output) == "wide"
@@ -56,12 +48,6 @@ Arguments
 			OutputWide:      isOutputWide(),
 		}
 
-		// When experimentalTemplates is true and runtime is podman, use experimental catalog ps api
-		// For openshift runtime, always use the older/stable code path regardless of experimental flag
-		if experimentalPs && rt == types.RuntimeTypePodman {
-			return renderApplicationPS(opts)
-		}
-
 		// Create application instance using factory
 		factory := application.NewFactory(rt)
 		app, err := factory.Create(applicationName)
@@ -83,13 +69,6 @@ func init() {
 }
 
 func initPsCommonFlags() {
-	psCmd.Flags().BoolVar(
-		&experimentalPs,
-		"experimental",
-		false,
-		"Include experimental application templates",
-	)
-
 	psCmd.Flags().StringVarP(
 		&output,
 		appFlags.Ps.Output,
@@ -112,61 +91,3 @@ func buildPsFlagValidator() *flagvalidator.FlagValidator {
 	return builder.Build()
 }
 
-// renderApplicationPS retrieves and processes the PS information for multiple application IDs.
-// It fetches the process status for each application using the catalog API and prints the results in tabular format.
-func renderApplicationPS(opts appTypes.ListOptions) error {
-	appClient, err := catalogClient.NewApplicationClient()
-	if err != nil {
-		return fmt.Errorf("failed to create application client: %w", err)
-	}
-
-	applicationList, err := cliUtils.FetchApplications(appClient, opts.ApplicationName)
-	if err != nil {
-		return err
-	}
-
-	if len(applicationList) == 0 {
-		logger.Warningln("No Application found")
-
-		return nil
-	}
-
-	// Create table writer
-	printer := utils.NewTableWriter()
-	defer printer.CloseTableWriter()
-
-	// Set table headers based on output format
-	setApplicationPSTableHeaders(printer, opts.OutputWide)
-
-	// Process each application ID
-	for _, app := range applicationList {
-		// Get PS information for the application
-		psResp, err := appClient.GetApplicationPS(app.ID)
-		if err != nil {
-			return fmt.Errorf("failed to fetch application: %w", err)
-		}
-
-		// Process services pods
-		for _, pod := range psResp.Services {
-			rows := cliUtils.BuildPodRowFromAPI(psResp.Name, pod, opts.OutputWide)
-			printer.AppendRow(rows...)
-		}
-
-		// Process components pods
-		for _, pod := range psResp.Components {
-			rows := cliUtils.BuildPodRowFromAPI(psResp.Name, pod, opts.OutputWide)
-			printer.AppendRow(rows...)
-		}
-	}
-
-	return nil
-}
-
-// setApplicationPSTableHeaders sets the table headers based on output format.
-func setApplicationPSTableHeaders(printer *utils.Printer, outputWide bool) {
-	if outputWide {
-		printer.SetHeaders("APPLICATION NAME", "POD ID", "POD NAME", "STATUS", "CREATED", "CONTAINERS")
-	} else {
-		printer.SetHeaders("APPLICATION NAME", "POD NAME", "STATUS")
-	}
-}

--- a/ai-services/cmd/ai-services/cmd/application/start.go
+++ b/ai-services/cmd/ai-services/cmd/application/start.go
@@ -5,18 +5,14 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
-	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
-	"github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	"github.com/spf13/cobra"
 )
 
 var (
-	skipLogs          bool
-	startPodNames     []string
-	autoYes           bool
-	experimentalStart bool
+	skipLogs      bool
+	startPodNames []string
+	autoYes       bool
 )
 
 var startCmd = &cobra.Command{
@@ -49,20 +45,6 @@ Note: Supported for podman runtime only.
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
-		// When experimentalStart is true and runtime is podman, validate application name using catalog API
-		// For openshift runtime, always use the older/stable code path regardless of experimental flag
-		if experimentalStart && rt == types.RuntimeTypePodman {
-			appClient, err := catalogClient.NewApplicationClient()
-			if err != nil {
-				return fmt.Errorf("failed to create application client: %w", err)
-			}
-			if _, err := utils.GetAppByName(appClient, applicationName); err != nil {
-				return err
-			}
-
-			return nil
-		}
-
 		// Create application instance using factory
 		factory := application.NewFactory(rt)
 		app, err := factory.Create(applicationName)
@@ -72,11 +54,10 @@ Note: Supported for podman runtime only.
 
 		// start application with options
 		opts := appTypes.StartOptions{
-			Name:         applicationName,
-			PodNames:     startPodNames,
-			AutoYes:      autoYes,
-			SkipLogs:     skipLogs,
-			Experimental: experimentalStart,
+			Name:     applicationName,
+			PodNames: startPodNames,
+			AutoYes:  autoYes,
+			SkipLogs: skipLogs,
 		}
 
 		return app.Start(opts)
@@ -84,7 +65,6 @@ Note: Supported for podman runtime only.
 }
 
 func init() {
-	startCmd.Flags().BoolVar(&experimentalStart, "experimental", false, "Include experimental application start")
 	startCmd.Flags().StringSlice("pod", []string{}, "Specific pod name(s) to start (optional)\nCan be specified multiple times: --pod pod1 --pod pod2\nOr comma-separated: --pod pod1,pod2")
 	startCmd.Flags().BoolVar(&skipLogs, "skip-logs", false, "Skip displaying logs after starting the pod")
 	startCmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "Automatically accept all confirmation prompts (default=false)")

--- a/ai-services/cmd/ai-services/cmd/application/stop.go
+++ b/ai-services/cmd/ai-services/cmd/application/stop.go
@@ -5,17 +5,11 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
-	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
-	"github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	"github.com/spf13/cobra"
 )
 
-var (
-	stopPodNames     []string
-	experimentalStop bool
-)
+var stopPodNames []string
 
 var stopCmd = &cobra.Command{
 	Use:   "stop [name]",
@@ -45,20 +39,6 @@ Note: Supported for podman runtime only.
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
-		// When experimentalStop is true and runtime is podman, validate application name using catalog API
-		// For openshift runtime, always use the older/stable code path regardless of experimental flag
-		if experimentalStop && rt == types.RuntimeTypePodman {
-			appClient, err := catalogClient.NewApplicationClient()
-			if err != nil {
-				return fmt.Errorf("failed to create application client: %w", err)
-			}
-			if _, err := utils.GetAppByName(appClient, applicationName); err != nil {
-				return err
-			}
-
-			return nil
-		}
-
 		// Create application instance using factory
 		factory := application.NewFactory(rt)
 		app, err := factory.Create(applicationName)
@@ -67,10 +47,9 @@ Note: Supported for podman runtime only.
 		}
 
 		opts := appTypes.StopOptions{
-			Name:         applicationName,
-			PodNames:     stopPodNames,
-			AutoYes:      autoYes,
-			Experimental: experimentalStop,
+			Name:     applicationName,
+			PodNames: stopPodNames,
+			AutoYes:  autoYes,
 		}
 
 		return app.Stop(opts)
@@ -80,5 +59,4 @@ Note: Supported for podman runtime only.
 func init() {
 	stopCmd.Flags().StringSlice("pod", []string{}, "Specific pod name(s) to stop (optional)\nCan be specified multiple times: --pod pod1 --pod pod2\nOr comma-separated: --pod pod1,pod2")
 	stopCmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "Automatically accept all confirmation prompts (default=false)")
-	stopCmd.Flags().BoolVar(&experimentalStop, "experimental", false, "Include experimental application stop")
 }

--- a/ai-services/cmd/ai-services/cmd/application/templates.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates.go
@@ -18,10 +18,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
-var (
-	experimentalTemplates bool
-)
-
 var templatesCmd = &cobra.Command{
 	Use:   "templates",
 	Short: "Lists the offered application templates and their supported parameters",
@@ -30,13 +26,12 @@ var templatesCmd = &cobra.Command{
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true
 
-		// When experimentalTemplates is true and runtime is podman, use experimental catalog templates
-		// For openshift runtime, always use the older/stable code path regardless of experimental flag
-		if experimentalTemplates && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
-			// Use experimental catalog templates listing (architectures and services)
+		// For Podman runtime, use catalog templates
+		if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
 			return listCatalogTemplates(cmd)
 		}
 
+		// For OpenShift runtime, use embedded templates
 		tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
 
 		appTemplateNames, err := tp.ListApplications(hiddenTemplates)
@@ -93,8 +88,6 @@ var templatesCmd = &cobra.Command{
 }
 
 func init() {
-	templatesCmd.Flags().BoolVar(&experimentalTemplates, "experimental", false, "Include experimental application templates")
-
 	// Add parameters subcommand
 	templatesCmd.AddCommand(appTemplates.NewParametersCmd())
 }

--- a/ai-services/internal/pkg/application/podman/create.go
+++ b/ai-services/internal/pkg/application/podman/create.go
@@ -3,439 +3,604 @@ package podman
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
-	"slices"
-	"strconv"
-	"sync"
+	"maps"
+	"strings"
 	"text/template"
+	"time"
 
-	"github.com/project-ai-services/ai-services/assets"
-	"github.com/project-ai-services/ai-services/internal/pkg/application/types"
-	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
-	clipodman "github.com/project-ai-services/ai-services/internal/pkg/cli/podman"
-	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
-	"github.com/project-ai-services/ai-services/internal/pkg/constants"
-	"github.com/project-ai-services/ai-services/internal/pkg/image"
+	apiModels "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
+	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
+	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+	cliutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/models"
-	"github.com/project-ai-services/ai-services/internal/pkg/specs"
-	"github.com/project-ai-services/ai-services/internal/pkg/spinner"
-	"github.com/project-ai-services/ai-services/internal/pkg/utils"
-	"github.com/project-ai-services/ai-services/internal/pkg/vars"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/application/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 )
 
-var (
-	envMutex sync.Mutex
+const (
+	// Polling configuration.
+	pollInterval       = 20 * time.Second
+	pollTimeout        = 20 * time.Minute
+	paramSplitParts    = 2
+	expectedParamParts = 2
 )
 
-// Create deploys a new application based on a template.
+// Create deploys a new application using catalog API.
 func (p *PodmanApplication) Create(ctx context.Context, opts types.CreateOptions) error {
-	// Proceed to create application
-	logger.Infof("Creating application '%s' using template '%s'\n", opts.Name, opts.TemplateName)
-	tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
+	// 1. Initialize catalog client
+	appClient, err := catalogClient.NewApplicationClient()
+	if err != nil {
+		return fmt.Errorf("failed to create application client: %w", err)
+	}
 
-	// validate whether the provided template name is correct
-	if err := tp.AppTemplateExist(opts.TemplateName); err != nil {
+	// 2. Check if application already exists
+	if err := p.checkApplicationExists(appClient, opts.Name); err != nil {
 		return err
 	}
 
-	tmpls, err := tp.LoadAllTemplates(opts.TemplateName)
-	if err != nil {
-		return fmt.Errorf("failed to parse the templates: %w", err)
-	}
-
-	// load metadata.yml to read the app metadata
-	var appMetadata templates.AppMetadata
-	if err := tp.LoadMetadata(opts.TemplateName, true, &appMetadata); err != nil {
-		return fmt.Errorf("failed to read the app metadata: %w", err)
-	}
-
-	if err := p.verifyPodTemplateExists(tmpls, &appMetadata); err != nil {
-		return fmt.Errorf("failed to verify pod template: %w", err)
-	}
-
-	// Check if resources already exists with the given application name
-	existingResources, err := helpers.CheckExistingResourcesForApplication(p.runtime, opts.Name, nil)
-	if err != nil {
-		return fmt.Errorf("failed while checking existing pods for application: %w", err)
-	}
-
-	// if all the pods for given application are already deployed, just log and do not proceed further
-	if len(existingResources) == len(tmpls) {
-		logger.Infof("Pods for given app: %s are already deployed. Please use 'ai-services application ps %s' to see the pods deployed\n", opts.Name, opts.Name)
-
-		return nil
-	}
-
-	// ---- Validate Spyre card Requirements ----
-	pciAddresses, err := p.validateAndAllocateSpyreCards(opts.TemplateName, opts.Name, tmpls)
+	// 3. Build the catalog API payload
+	payload, err := p.buildCatalogPayload(opts.Name, opts.TemplateName, opts.ArgParams)
 	if err != nil {
 		return err
 	}
 
-	if err := p.prepareApplicationArtifacts(ctx, opts); err != nil {
-		return err
+	// 4. Create application via catalog API
+	logger.Infof("Creating application '%s' using template '%s'...\n", opts.Name, opts.TemplateName)
+	resp, err := appClient.CreateApplication(payload)
+	if err != nil {
+		return fmt.Errorf("failed to create application: %w", err)
 	}
 
-	// Loop through all pod templates, render and run kube play
-	logger.Infof("Total Pod Templates to be processed: %d\n", len(tmpls))
+	logger.Infof("Application creation initiated (ID: %s)\n", resp.ID)
 
-	return p.deployApplication(ctx, opts, tmpls, &appMetadata, pciAddresses, existingResources)
+	// 5. Poll for application status
+	return p.pollApplicationStatus(appClient, opts.Name)
 }
 
-func (p *PodmanApplication) validateAndAllocateSpyreCards(templateName, appName string, tmpls map[string]*template.Template) ([]string, error) {
-	tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
-
-	reqSpyreCardsCount, err := p.calculateReqSpyreCards(tp, utils.ExtractMapKeys(tmpls), templateName, appName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to calculateReqSpyreCards: %w", err)
-	}
-
-	if reqSpyreCardsCount == 0 {
-		return nil, nil
-	}
-
-	// calculate the actual available spyre cards
-	pciAddresses, err := helpers.FindFreeSpyreCards()
-	if err != nil {
-		return nil, fmt.Errorf("failed to find free Spyre Cards: %w", err)
-	}
-
-	actualSpyreCardsCount := len(pciAddresses)
-
-	// validate spyre card requirements
-	if err := p.validateSpyreCardRequirements(reqSpyreCardsCount, actualSpyreCardsCount); err != nil {
-		return nil, err
-	}
-
-	return pciAddresses, nil
-}
-
-func (p *PodmanApplication) prepareApplicationArtifacts(ctx context.Context, opts types.CreateOptions) error {
-	// Download Container Images
-	if err := p.downloadImagesForTemplate(opts.TemplateName, opts.Name, opts.ImagePullPolicy); err != nil {
+// checkApplicationExists checks if an application with the given name already exists.
+func (p *PodmanApplication) checkApplicationExists(appClient *catalogClient.ApplicationClient, appName string) error {
+	existingApp, err := cliutils.GetAppByName(appClient, appName)
+	if err != nil && !strings.Contains(err.Error(), "not found") {
 		return err
 	}
 
-	// Download models if flag is set to true(default: true)
-	if !opts.SkipModelDownload {
-		if err := p.downloadModels(ctx, opts.TemplateName, opts.Name); err != nil {
-			return err
-		}
+	if existingApp != nil {
+		return fmt.Errorf("application with name '%s' already exists", appName)
 	}
 
 	return nil
 }
 
-func (p *PodmanApplication) deployApplication(ctx context.Context, opts types.CreateOptions, tmpls map[string]*template.Template,
-	appMetadata *templates.AppMetadata, pciAddresses []string, existingResources []string) error {
-	logger.Infof("Total Pod Templates to be processed: %d\n", len(tmpls))
-
-	s := spinner.New("Deploying application '" + opts.Name + "'...")
-	s.Start(ctx)
-
-	tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
-
-	// execute the pod Templates
-	if err := p.executePodTemplates(tp, opts.Name, appMetadata, tmpls, pciAddresses, existingResources, opts.ValuesFiles, opts.ArgParams); err != nil {
-		return err
+// buildCatalogPayload builds the catalog API payload for the given template.
+func (p *PodmanApplication) buildCatalogPayload(appName, templateName string, argParams map[string]string) (*apiModels.CreateApplicationRequest, error) {
+	// Initialize catalog provider
+	provider, err := catalog.NewCatalogProvider()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create catalog provider: %w", err)
 	}
 
-	s.Stop("Application '" + opts.Name + "' deployed successfully")
+	// Determine if template is architecture or service
+	isArchitecture := provider.ArchitectureExists(templateName)
+	isService := provider.ServiceExists(templateName)
 
+	if !isArchitecture && !isService {
+		return nil, fmt.Errorf("template '%s' not found as architecture or service", templateName)
+	}
+
+	// Build the payload
+	if isArchitecture {
+		return p.buildArchitecturePayload(provider, templateName, appName, argParams)
+	}
+
+	return p.buildServicePayload(templateName, appName, argParams)
+}
+
+// pollApplicationStatus polls the application status until it's ready or fails.
+func (p *PodmanApplication) pollApplicationStatus(appClient *catalogClient.ApplicationClient, appName string) error {
+	logger.Infof("Waiting for application '%s' to be ready...\n", appName)
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	timeout := time.After(pollTimeout)
+
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timeout waiting for application '%s' to be ready", appName)
+
+		case <-ticker.C:
+			app, err := cliutils.GetAppByName(appClient, appName)
+			if err != nil {
+				return fmt.Errorf("failed to get application status: %w", err)
+			}
+
+			done, err := p.handleApplicationStatus(app, appName)
+			if err != nil {
+				return err
+			}
+			if done {
+				return nil
+			}
+		}
+	}
+}
+
+// handleApplicationStatus handles the application status and returns (done, error).
+func (p *PodmanApplication) handleApplicationStatus(app *catalogTypes.Application, appName string) (bool, error) {
+	// Status values from ai-services/internal/pkg/catalog/db/models/application.go.
+	switch app.Status {
+	case "Running":
+		logger.Infof("Application '%s' is ready!\n", appName)
+
+		// Print next steps after successful deployment
+		if err := p.printNextSteps(app); err != nil {
+			logger.Warningf("Failed to display next steps: %v\n", err)
+		}
+
+		return true, nil
+
+	case "Error":
+		if app.Message != "" {
+			return false, fmt.Errorf("application deployment failed: %s", app.Message)
+		}
+
+		return false, fmt.Errorf("application deployment failed")
+
+	case "Downloading", "Deploying":
+		// Still in progress, continue polling.
+		logger.Infof("Deploying application: %s, Status: %s, Message: %s\n", appName, app.Status, app.Message)
+
+		return false, nil
+
+	case "Deleting":
+		return false, fmt.Errorf("application is being deleted")
+
+	default:
+		logger.Infof("Status: %s\n", app.Status)
+
+		return false, nil
+	}
+}
+
+// printNextSteps prints the next steps for the deployed application.
+func (p *PodmanApplication) printNextSteps(app *catalogTypes.Application) error {
+	appClient, err := catalogClient.NewApplicationClient()
+	if err != nil {
+		return fmt.Errorf("failed to create application client: %w", err)
+	}
+
+	// Get full application details with services
+	application, err := appClient.GetApplication(app.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get application: %w", err)
+	}
+
+	catalogProvider, err := catalog.NewCatalogProvider()
+	if err != nil {
+		return fmt.Errorf("failed to create catalog provider: %w", err)
+	}
+
+	logger.Infoln("\nNext Steps:")
 	logger.Infoln("-------")
 
-	// print the next steps to be performed at the end of create
-	if err := helpers.PrintNextSteps(tp, p.runtime, opts.Name, opts.TemplateName); err != nil {
-		// do not want to fail the overall create if we cannot print next steps
-		logger.Infof("failed to display next steps: %v\n", err)
+	for _, service := range application.Services {
+		params := map[string]string{}
+		params["SERVICE_NAME"] = service.Type
 
-		return nil //nolint:nilerr // intentionally swallow error for non-critical step
-	}
+		// Add endpoint URLs to params
+		for _, endpoint := range service.Endpoints {
+			urlType, urlTypeOk := endpoint["type"].(string)
+			url, urlOk := endpoint["url"].(string)
+			if urlTypeOk && urlOk {
+				params[strings.ToUpper(urlType)+"_URL"] = url
+			}
+		}
 
-	return nil
-}
-
-func (p *PodmanApplication) downloadModels(ctx context.Context, templateName, appName string) error {
-	s := spinner.New("Downloading models as part of application creation...")
-	s.Start(ctx)
-
-	models, err := helpers.ListModels(templateName, appName)
-	if err != nil {
-		s.Fail("failed to list models")
-
-		return err
-	}
-
-	logger.Infoln("Downloading models required for application template " + templateName + ":")
-
-	for _, model := range models {
-		s.UpdateMessage("Downloading model: " + model + "...")
-		err = utils.Retry(vars.RetryCount, vars.RetryInterval, nil, func() error {
-			return helpers.DownloadModel(model, utils.GetModelsPath())
-		})
+		tmpls, err := catalogProvider.LoadServicesMD(service.CatalogID)
 		if err != nil {
-			s.Fail("failed to download model: " + model)
-
-			return fmt.Errorf("failed to download model: %w", err)
-		}
-	}
-
-	s.Stop("Model download completed.")
-
-	return nil
-}
-
-func (p *PodmanApplication) verifyPodTemplateExists(tmpls map[string]*template.Template, appMetadata *templates.AppMetadata) error {
-	flattenPodTemplateExecutions := utils.FlattenArray(appMetadata.PodTemplateExecutions)
-
-	if len(flattenPodTemplateExecutions) != len(tmpls) {
-		return errors.New("number of values specified in podTemplateExecutions under metadata.yml is mismatched. Please ensure all the pod template file names are specified")
-	}
-
-	// Make sure the podTemplateExecution mentioned in metadata.yaml is valid (corresponding pod template is present)
-	for _, podTemplate := range flattenPodTemplateExecutions {
-		if _, ok := tmpls[podTemplate]; !ok {
-			return fmt.Errorf("value: %s specified in podTemplateExecutions under metadata.yml is invalid. Please ensure corresponding template file exists", podTemplate)
-		}
-	}
-
-	return nil
-}
-
-func (p *PodmanApplication) validateSpyreCardRequirements(req int, actual int) error {
-	if actual < req {
-		return fmt.Errorf("insufficient spyre cards. Require: %d spyre cards to proceed", req)
-	}
-
-	return nil
-}
-
-func (p *PodmanApplication) calculateReqSpyreCards(tp templates.Template, podTemplateFileNames []string, appTemplateName, appName string) (int, error) {
-	totalReqSpyreCounts := 0
-
-	// Calculate Req Spyre Counts
-	for _, podTemplateFileName := range podTemplateFileNames {
-		// fetch pod spec
-		podSpec, err := p.fetchPodSpec(tp, appTemplateName, podTemplateFileName, appName, nil, nil)
-		if err != nil {
-			return totalReqSpyreCounts, fmt.Errorf("failed to load pod Template: '%s' for appTemplate: '%s' with error: %w", podTemplateFileName, appTemplateName, err)
-		}
-
-		// check if pod already exists and skip counting if it does exists
-		exists, err := p.runtime.PodExists(podSpec.Name)
-		if err != nil {
-			return totalReqSpyreCounts, fmt.Errorf("failed to check pod status: %w", err)
-		}
-
-		if exists {
-			logger.Infof("Pod %s already exists, skipping spyre cards calculation", podSpec.Name, logger.VerbosityLevelDebug)
+			logger.Warningf("Failed to load next steps for service '%s': %v\n", service.CatalogID, err)
 
 			continue
 		}
 
-		// fetch the spyreCount for all containers from the annotations
-		spyreCount, _, err := p.fetchSpyreCardsFromPodAnnotations(podSpec.Annotations)
+		err = p.printNextStepsMD(tmpls, params, application.Name)
 		if err != nil {
-			return totalReqSpyreCounts, err
+			logger.Warningf("Failed to render next steps for service '%s': %v\n", service.CatalogID, err)
 		}
-
-		totalReqSpyreCounts += spyreCount
-	}
-
-	return totalReqSpyreCounts, nil
-}
-
-func (p *PodmanApplication) fetchPodSpec(tp templates.Template, appTemplateName, podTemplateFileName, appName string, valuesFiles []string, argParams map[string]string) (*models.PodSpec, error) {
-	podSpec, err := tp.LoadPodTemplateWithValues(appTemplateName, podTemplateFileName, appName, valuesFiles, argParams)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load pod Template: '%s' for appTemplate: '%s' with error: %w", podTemplateFileName, appTemplateName, err)
-	}
-
-	return podSpec, nil
-}
-
-func (p *PodmanApplication) fetchSpyreCardsFromPodAnnotations(annotations map[string]string) (int, map[string]int, error) {
-	var spyreCards int
-	// spyreCardContainerMap: Key -> containerName, Value -> SpyreCardCounts
-	spyreCardContainerMap := map[string]int{}
-
-	isSpyreCardAnnotation := func(annotation string) (string, bool) {
-		matches := vars.SpyreCardAnnotationRegex.FindStringSubmatch(annotation)
-		if matches == nil {
-			return "", false
-		}
-
-		return matches[1], true
-	}
-
-	for annotationKey, val := range annotations {
-		if containerName, ok := isSpyreCardAnnotation(annotationKey); ok {
-			valInt, err := strconv.Atoi(val)
-			if err != nil {
-				return 0, spyreCardContainerMap, fmt.Errorf("failed to convert to int. Provided val: %s is not of int type", val)
-			}
-			// Replace with container name
-			spyreCardContainerMap[containerName] = valInt
-			spyreCards += valInt
-		}
-	}
-
-	return spyreCards, spyreCardContainerMap, nil
-}
-
-func (p *PodmanApplication) downloadImagesForTemplate(templateName, appName string, imagePullPolicy image.ImagePullPolicy) error {
-	// create Images struct and run with the specified policy
-	img := &image.Images{
-		Runtime:     p.runtime,
-		App:         appName,
-		AppTemplate: templateName,
-	}
-
-	return img.Run(imagePullPolicy)
-}
-
-func (p *PodmanApplication) executePodTemplates(tp templates.Template,
-	appName string, appMetadata *templates.AppMetadata,
-	tmpls map[string]*template.Template, pciAddresses []string, existingPods []string,
-	valuesFiles []string, argParams map[string]string) error {
-	// Load values for template rendering
-	values, err := tp.LoadValues(appMetadata.Name, valuesFiles, argParams)
-	if err != nil {
-		return fmt.Errorf("failed to load params for application: %w", err)
-	}
-
-	globalParams := map[string]any{
-		"AppName":         appName,
-		"AppTemplateName": appMetadata.Name,
-		"Version":         appMetadata.Version,
-		"BaseDir":         utils.GetBaseDir(),
-		"Values":          values,
-		// Key -> container name
-		// Value -> range of key-value env pairs
-		"env": map[string]map[string]string{},
-	}
-
-	// looping over each layer of podTemplateExecutions
-	for i, layer := range appMetadata.PodTemplateExecutions {
-		logger.Infof("\n Executing Layer %d/%d: %v\n", i+1, len(appMetadata.PodTemplateExecutions), layer)
-		logger.Infoln("-------")
-		var wg sync.WaitGroup
-		errCh := make(chan error, len(layer))
-
-		// for each layer, fetch all the pod Template Names and do the pod deploy
-		for _, podTemplateName := range layer {
-			wg.Add(1)
-			go func(t string) {
-				defer wg.Done()
-				if err := p.executePodTemplateLayer(tp, tmpls, globalParams, pciAddresses, existingPods, podTemplateName, appName, valuesFiles, argParams); err != nil {
-					errCh <- err
-				}
-			}(podTemplateName)
-		}
-
-		wg.Wait()
-		close(errCh)
-
-		// collect all errors for this layer
-		var errs []error
-		for e := range errCh {
-			errs = append(errs, fmt.Errorf("layer %d: %w", i+1, e))
-		}
-
-		// If an error exist for a given layer, then return (do not process further layers)
-		if len(errs) > 0 {
-			return errors.Join(errs...)
-		}
-
-		logger.Infof("Layer %d completed\n", i+1)
 	}
 
 	return nil
 }
 
-func (p *PodmanApplication) executePodTemplateLayer(tp templates.Template, tmpls map[string]*template.Template,
-	globalParams map[string]any, pciAddresses []string, existingPods []string, podTemplateName, appName string,
-	valuesFiles []string, argParams map[string]string) error {
-	logger.Infof("'%s': Processing template...\n", podTemplateName)
-
-	// Shallow Copy globalParams Map
-	params := utils.CopyMap(globalParams)
-
-	// fetch pod Spec
-	podSpec, err := p.fetchPodSpec(tp, globalParams["AppTemplateName"].(string), podTemplateName, appName, valuesFiles, argParams)
-	if err != nil {
-		return err
-	}
-
-	if slices.Contains(existingPods, podSpec.Name) {
-		logger.Infof("%s: Skipping pod deploy as '%s' it already exists", podTemplateName, podSpec.Name)
-
+// printNextStepsMD renders and prints the next.md template for a service.
+func (p *PodmanApplication) printNextStepsMD(tmpls map[string]*template.Template, params map[string]string, appName string) error {
+	tmpl, ok := tmpls["next.md"]
+	if !ok {
+		// next.md doesn't exist for this service, return nil
 		return nil
 	}
 
-	// fetch annotations from pod Spec
-	podAnnotations := p.fetchPodAnnotations(podSpec)
-
-	// get the env params for a given pod
-	env, err := p.returnEnvParamsForPod(podSpec, podAnnotations, &pciAddresses)
-	if err != nil {
-		return fmt.Errorf("'%s': Failed to fetch env params: %w", podTemplateName, err)
-	}
-	params["env"] = env
-
-	podTemplate := tmpls[podTemplateName]
-
 	var rendered bytes.Buffer
-	if err := podTemplate.Execute(&rendered, params); err != nil {
-		return fmt.Errorf("'%s': Failed to parse pod template: %w", podTemplateName, err)
+	if err := tmpl.Execute(&rendered, params); err != nil {
+		return fmt.Errorf("failed to execute next.md: %w", err)
 	}
 
-	// Wrap the bytes in a bytes.Reader
-	reader := bytes.NewReader(rendered.Bytes())
+	value := rendered.String()
 
-	// Deploy the Pod and do Readiness check
-	if err := clipodman.DeployPodAndReadinessCheck(p.runtime, podSpec, podTemplateName, reader, clipodman.ConstructPodDeployOptions(podAnnotations)); err != nil {
-		return fmt.Errorf("'%s': Failed to deploy pod and do readiness check: %w", podTemplateName, err)
+	// Print the template content if available
+	if strings.TrimSpace(value) != "" {
+		logger.Infof(value)
 	}
+
+	// Print the info command for all services
+	logger.Infof("\n- For detailed endpoint information, use: `ai-services application info %s --runtime podman`\n", appName)
 
 	return nil
 }
 
-func (p *PodmanApplication) fetchPodAnnotations(podSpec *models.PodSpec) map[string]string {
-	return specs.FetchPodAnnotations(*podSpec)
+// buildArchitecturePayload builds the payload for an architecture deployment.
+func (p *PodmanApplication) buildArchitecturePayload(provider *catalog.CatalogProvider, archID, appName string, argParams map[string]string) (*apiModels.CreateApplicationRequest, error) {
+	// Load architecture metadata
+	arch, err := provider.LoadArchitecture(archID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load architecture: %w", err)
+	}
+
+	// Create application client for API calls
+	appClient, err := catalogClient.NewApplicationClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create application client: %w", err)
+	}
+
+	// Get deploy options for the architecture
+	deployOptions, err := appClient.GetArchitectureDeployOptions(archID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get deploy options: %w", err)
+	}
+
+	// Build services list using deploy options
+	services := make([]apiModels.Service, 0, len(arch.Services))
+	for _, svcRef := range arch.Services {
+		// Find the corresponding deploy options service
+		var svcDeployOpts *catalogTypes.DeployOptionsService
+		for i := range deployOptions.Services {
+			if deployOptions.Services[i].ID == svcRef.ID {
+				svcDeployOpts = &deployOptions.Services[i]
+
+				break
+			}
+		}
+
+		if svcDeployOpts == nil {
+			return nil, fmt.Errorf("deploy options not found for service '%s'", svcRef.ID)
+		}
+
+		svc, err := p.buildServiceEntryWithDeployOptions(appClient, svcRef.ID, svcDeployOpts, argParams)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build service '%s': %w", svcRef.ID, err)
+		}
+		services = append(services, svc)
+	}
+
+	return &apiModels.CreateApplicationRequest{
+		CatalogID: archID,
+		Name:      appName,
+		Services:  services,
+		Version:   arch.Version,
+	}, nil
 }
 
-func (p *PodmanApplication) returnEnvParamsForPod(podSpec *models.PodSpec, podAnnotations map[string]string, pciAddresses *[]string) (map[string]map[string]string, error) {
-	env := map[string]map[string]string{}
-	podContainerNames := specs.FetchContainerNames(*podSpec)
-
-	// populate env with empty map
-	for _, containerName := range podContainerNames {
-		env[containerName] = map[string]string{}
-	}
-
-	// fetch the spyre cards and spyre card count required for each container in a pod
-	spyreCards, spyreCardContainerMap, err := p.fetchSpyreCardsFromPodAnnotations(podAnnotations)
+// buildServicePayload builds the payload for a standalone service deployment.
+func (p *PodmanApplication) buildServicePayload(serviceID, appName string, argParams map[string]string) (*apiModels.CreateApplicationRequest, error) {
+	// Create application client for API calls
+	appClient, err := catalogClient.NewApplicationClient()
 	if err != nil {
-		return env, err
+		return nil, fmt.Errorf("failed to create application client: %w", err)
 	}
 
-	if spyreCards == 0 {
-		// The pod doesn't require any spyre cards. // populate the given container with empty map
-		return env, nil
+	// Get deploy options for the service
+	deployOptions, err := appClient.GetServiceDeployOptions(serviceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get deploy options: %w", err)
 	}
 
-	// Construct env for a given pod
-	// Since this is a critical section as both requires pciAddresses and modifies -> wrap it in mutex
-	envMutex.Lock()
-	for container, spyreCount := range spyreCardContainerMap {
-		if spyreCount != 0 {
-			env[container] = map[string]string{string(constants.PCIAddressKey): utils.JoinAndRemove(pciAddresses, spyreCount, " ")}
+	svc, err := p.buildServiceEntryWithDeployOptions(appClient, serviceID, deployOptions, argParams)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build service: %w", err)
+	}
+
+	return &apiModels.CreateApplicationRequest{
+		CatalogID: serviceID,
+		Name:      appName,
+		Services:  []apiModels.Service{svc},
+		Version:   svc.Version,
+	}, nil
+}
+
+// buildServiceEntryWithDeployOptions builds a single service entry with its components using deploy options.
+func (p *PodmanApplication) buildServiceEntryWithDeployOptions(appClient *catalogClient.ApplicationClient, serviceID string, deployOptions *catalogTypes.DeployOptionsService, argParams map[string]string) (apiModels.Service, error) {
+	// Build components list from deploy options
+	components := make([]apiModels.Component, 0, len(deployOptions.Components))
+	for _, compDeployOpt := range deployOptions.Components {
+		// Get component configuration from argParams (provider-specific params)
+		providerParams := extractComponentParamsForService(serviceID, compDeployOpt.Type, argParams)
+
+		// Determine provider ID and get its params
+		providerID, userParams := selectProviderFromDeployOptions(compDeployOpt, providerParams)
+		if providerID == "" {
+			return apiModels.Service{}, fmt.Errorf("no provider found for component type '%s'", compDeployOpt.Type)
+		}
+
+		// Find the selected provider to get its version
+		var providerVersion string
+		var providerFound bool
+		for _, prov := range compDeployOpt.Providers {
+			if prov.ID == providerID {
+				providerVersion = prov.Version
+				providerFound = true
+
+				break
+			}
+		}
+
+		// If provider not found in deploy options, return error
+		if !providerFound {
+			return apiModels.Service{}, fmt.Errorf("provider '%s' not found in deploy options for component type '%s'", providerID, compDeployOpt.Type)
+		}
+
+		// Fetch schema and apply defaults, merging with user params
+		componentParamsAny, err := p.applySchemaDefaults(appClient, compDeployOpt.Type, providerID, userParams)
+		if err != nil {
+			logger.Warningf("Failed to apply schema defaults for %s/%s: %v\n", compDeployOpt.Type, providerID, err)
+			// Continue with user-provided params only
+			componentParamsAny = make(map[string]any)
+			for k, v := range userParams {
+				componentParamsAny[k] = v
+			}
+		}
+
+		components = append(components, apiModels.Component{
+			ComponentType: compDeployOpt.Type,
+			ProviderID:    providerID,
+			Params:        componentParamsAny,
+			Version:       providerVersion,
+		})
+	}
+
+	// Extract service-level parameters (excluding component params)
+	serviceParams := extractServiceParams(serviceID, deployOptions.Components, argParams)
+
+	return apiModels.Service{
+		CatalogID:  serviceID,
+		Components: components,
+		Params:     serviceParams,
+		Version:    deployOptions.Version,
+	}, nil
+}
+
+// extractServiceParams extracts service-level parameters from argParams, excluding component params.
+// Format: {serviceID}.{param} -> {param}.
+// Excludes: {serviceID}.{componentType}.{param} (those are component params).
+// Nested dot-notation keys (e.g. backend.systemPrompt) are expanded into nested maps.
+func extractServiceParams(serviceID string, components []catalogTypes.DeployOptionsComponent, allParams map[string]string) map[string]any {
+	serviceParams := make(map[string]any)
+	servicePrefix := serviceID + "."
+
+	// Build a set of component types for this service.
+	componentTypes := make(map[string]bool)
+	for _, comp := range components {
+		componentTypes[comp.Type] = true
+	}
+
+	for key, value := range allParams {
+		after, ok := strings.CutPrefix(key, servicePrefix)
+		if !ok {
+			continue
+		}
+
+		// Check if this is a component parameter by seeing if it starts with a known component type.
+		isComponentParam := isComponentParameter(after, componentTypes)
+
+		// Only add to service params if it's not a component param.
+		if !isComponentParam {
+			setNestedParam(serviceParams, after, value)
 		}
 	}
-	envMutex.Unlock()
 
-	return env, nil
+	return serviceParams
 }
+
+// setNestedParam sets a value in a nested map using a dot-notation key.
+// e.g. setNestedParam(m, "backend.systemPrompt", "hello") → m["backend"]["systemPrompt"] = "hello".
+func setNestedParam(m map[string]any, dotKey string, value string) {
+	parts := strings.SplitN(dotKey, ".", paramSplitParts)
+	if len(parts) == 1 {
+		m[dotKey] = value
+
+		return
+	}
+
+	nested, ok := m[parts[0]].(map[string]any)
+	if !ok {
+		nested = make(map[string]any)
+		m[parts[0]] = nested
+	}
+
+	setNestedParam(nested, parts[1], value)
+}
+
+// isComponentParameter checks if a parameter belongs to a component.
+func isComponentParameter(param string, componentTypes map[string]bool) bool {
+	for compType := range componentTypes {
+		if strings.HasPrefix(param, compType+".") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// extractComponentParamsForService extracts parameters for a specific component type from argParams.
+// Supports provider-specific params:
+// - Provider only: {componentType}.{providerID} (e.g., llm.vllm-cpu) - selects provider with defaults.
+// - Provider with params: {componentType}.{providerID}.{param} (e.g., llm.vllm-cpu.model).
+// - Service-specific: {serviceID}.{componentType}.{providerID}[.{param}] (e.g., chat.llm.vllm-cpu or chat.llm.vllm-cpu.model).
+// Returns a map with provider as key and params as value.
+func extractComponentParamsForService(serviceID string, componentType string, allParams map[string]string) map[string]map[string]string {
+	providerParams := make(map[string]map[string]string)
+
+	// Extract global component params: {componentType}.{providerID}[.{param}].
+	extractProviderParams(componentType+".", allParams, providerParams)
+
+	// Extract service-specific component params (these override global).
+	extractProviderParams(serviceID+"."+componentType+".", allParams, providerParams)
+
+	return providerParams
+}
+
+// extractProviderParams extracts provider parameters from allParams with the given prefix.
+func extractProviderParams(prefix string, allParams map[string]string, providerParams map[string]map[string]string) {
+	for key, value := range allParams {
+		after, ok := strings.CutPrefix(key, prefix)
+		if !ok {
+			continue
+		}
+
+		// Split to get providerID and optional param.
+		parts := strings.SplitN(after, ".", paramSplitParts)
+		if len(parts) < 1 {
+			continue
+		}
+
+		providerID := parts[0]
+		if providerParams[providerID] == nil {
+			providerParams[providerID] = make(map[string]string)
+		}
+
+		// If there's a param name, add it; otherwise just mark provider as selected.
+		if len(parts) == expectedParamParts {
+			paramName := parts[1]
+			providerParams[providerID][paramName] = value
+		}
+	}
+}
+
+// selectProviderFromDeployOptions determines the provider ID for a component using deploy options.
+// Priority:
+// 1. If user provided provider-specific params (e.g., llm.vllm-cpu.model), use that provider.
+// 2. For LLM and reranker components: Use vllm-spyre by default.
+// 3. Default provider marked in deploy options.
+// 4. First available provider.
+func selectProviderFromDeployOptions(compDeployOpt catalogTypes.DeployOptionsComponent, providerParams map[string]map[string]string) (string, map[string]string) {
+	// Check if user specified params for a specific provider.
+	if providerID, params := findUserSpecifiedProvider(compDeployOpt, providerParams); providerID != "" {
+		return providerID, params
+	}
+
+	// Special logic for LLM and reranker component types - prefer Spyre acceleration.
+	if providerID := findSpyreProvider(compDeployOpt); providerID != "" {
+		return providerID, make(map[string]string)
+	}
+
+	// Use default provider if marked.
+	if providerID := findDefaultProvider(compDeployOpt); providerID != "" {
+		return providerID, make(map[string]string)
+	}
+
+	// Fall back to first available provider.
+	if len(compDeployOpt.Providers) > 0 {
+		return compDeployOpt.Providers[0].ID, make(map[string]string)
+	}
+
+	return "", make(map[string]string)
+}
+
+// findUserSpecifiedProvider checks if user specified params for a specific provider.
+func findUserSpecifiedProvider(compDeployOpt catalogTypes.DeployOptionsComponent, providerParams map[string]map[string]string) (string, map[string]string) {
+	for providerID := range providerParams {
+		// Verify this provider exists in deploy options.
+		for _, prov := range compDeployOpt.Providers {
+			if prov.ID == providerID {
+				return providerID, providerParams[providerID]
+			}
+		}
+	}
+
+	return "", nil
+}
+
+// findSpyreProvider finds vllm-spyre provider if available for the component.
+func findSpyreProvider(compDeployOpt catalogTypes.DeployOptionsComponent) string {
+	for _, prov := range compDeployOpt.Providers {
+		if prov.ID == "vllm-spyre" {
+			return prov.ID
+		}
+	}
+
+	return ""
+}
+
+// findDefaultProvider finds the default provider marked in deploy options.
+func findDefaultProvider(compDeployOpt catalogTypes.DeployOptionsComponent) string {
+	for _, prov := range compDeployOpt.Providers {
+		if prov.Default {
+			return prov.ID
+		}
+	}
+
+	return ""
+}
+
+// applySchemaDefaults fetches the component provider schema and applies default values.
+// User-provided params override defaults.
+func (p *PodmanApplication) applySchemaDefaults(appClient *catalogClient.ApplicationClient, componentType, providerID string, userParams map[string]string) (map[string]any, error) {
+	// Fetch schema from API
+	schema, err := appClient.GetComponentProviderParams(componentType, providerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch schema: %w", err)
+	}
+
+	// Extract defaults from schema
+	defaults := extractDefaultsFromSchema(schema)
+
+	// Merge: start with defaults, override with user params
+	result := make(map[string]any)
+	maps.Copy(result, defaults)
+
+	// Override with user-provided params (excluding 'provider' key)
+	// Support nested parameters using dot notation (e.g., auth.password)
+	for k, v := range userParams {
+		if k != "provider" {
+			setNestedParam(result, k, v)
+		}
+	}
+
+	return result, nil
+}
+
+// extractDefaultsFromSchema extracts default values from a JSON schema.
+func extractDefaultsFromSchema(schema map[string]any) map[string]any {
+	defaults := make(map[string]any)
+
+	// Check if schema has properties
+	properties, ok := schema["properties"].(map[string]any)
+	if !ok {
+		return defaults
+	}
+
+	// Extract default value for each property
+	for propName, propValue := range properties {
+		if propMap, ok := propValue.(map[string]any); ok {
+			if defaultValue, hasDefault := propMap["default"]; hasDefault {
+				defaults[propName] = defaultValue
+			}
+		}
+	}
+
+	return defaults
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/application/podman/delete.go
+++ b/ai-services/internal/pkg/application/podman/delete.go
@@ -2,41 +2,35 @@ package podman
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
+	"net/http"
+	"time"
 
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
+	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
+	cliUtils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 // Delete removes an application and its associated resources.
 func (p *PodmanApplication) Delete(_ context.Context, opts appTypes.DeleteOptions) error {
-	appDir := filepath.Join(utils.GetApplicationsPath(), filepath.Base(opts.Name))
-	appExists := utils.FileExists(appDir)
-
-	pods, err := p.runtime.ListPods(map[string][]string{
-		"label": {fmt.Sprintf("ai-services.io/application=%s", opts.Name)},
-	})
+	appClient, err := catalogClient.NewApplicationClient()
 	if err != nil {
-		return fmt.Errorf("failed to list pods: %w", err)
-	}
-	podsExists := len(pods) != 0
-
-	if !podsExists {
-		logger.Infof("No pods found for application: %s\n", opts.Name)
-
-		return nil
+		return fmt.Errorf("failed to create application client: %w", err)
 	}
 
-	// print relevant app pod status
-	p.logPodsToBeDeleted(opts.Name, pods)
+	app, err := cliUtils.GetAppByName(appClient, opts.Name)
+	if err != nil {
+		return err
+	}
+	if app == nil {
+		return fmt.Errorf("application not found: %s", opts.Name)
+	}
 
 	if !opts.AutoYes {
-		confirmDelete, err := p.deleteConfirmation(opts.Name, podsExists, appExists, opts.SkipCleanup)
+		confirmDelete, err := p.deleteConfirmation()
 		if err != nil {
 			return err
 		}
@@ -47,43 +41,28 @@ func (p *PodmanApplication) Delete(_ context.Context, opts appTypes.DeleteOption
 		}
 	}
 
-	logger.Infoln("Proceeding with deletion...")
-
-	if err := p.podsDeletion(pods); err != nil {
-		return err
+	deleteParams := catalogClient.DeleteApplicationParams{
+		KeepData: opts.SkipCleanup,
 	}
 
-	if appExists && !opts.SkipCleanup {
-		if err := p.appDataDeletion(appDir); err != nil {
-			return err
-		}
+	if err := appClient.DeleteApplication(app.ID, &deleteParams); err != nil {
+		return fmt.Errorf("failed to delete application: %w", err)
 	}
+
+	// Poll to verify deletion is complete
+	logger.Infof("Waiting for application %s to be deleted...\n", opts.Name)
+	if err := p.waitForApplicationDeletion(appClient, app.ID); err != nil {
+		return fmt.Errorf("failed to verify application deletion: %w", err)
+	}
+
+	logger.Infof("Application %s deleted successfully.", opts.Name)
 
 	return nil
 }
 
-func (p *PodmanApplication) logPodsToBeDeleted(appName string, pods []types.Pod) {
-	logger.Infof("Found %d pods for given applicationName: %s.\n", len(pods), appName)
-	logger.Infoln("Below are the list of pods to be deleted")
-	for _, pod := range pods {
-		logger.Infof("\t-> %s\n", pod.Name)
-	}
-}
-
-func (p *PodmanApplication) deleteConfirmation(appName string, podsExists, appExists, skipCleanup bool) (bool, error) {
-	var confirmActionPrompt string
-	if podsExists && appExists && !skipCleanup {
-		confirmActionPrompt = "Are you sure you want to delete the above pods and application data? "
-	} else if podsExists {
-		confirmActionPrompt = "Are you sure you want to delete the above pods? "
-	} else if appExists && !skipCleanup {
-		confirmActionPrompt = "Are you sure you want to delete the application data? "
-	} else {
-		logger.Infof("Application %s does not exist", appName)
-
-		return false, nil
-	}
-
+// deleteConfirmation prompts the user to confirm deletion.
+func (p *PodmanApplication) deleteConfirmation() (bool, error) {
+	confirmActionPrompt := "Are you sure you want to delete the application? "
 	confirmDelete, err := utils.ConfirmAction(confirmActionPrompt)
 	if err != nil {
 		return confirmDelete, fmt.Errorf("failed to take user input: %w", err)
@@ -92,37 +71,36 @@ func (p *PodmanApplication) deleteConfirmation(appName string, podsExists, appEx
 	return confirmDelete, nil
 }
 
-func (p *PodmanApplication) podsDeletion(pods []types.Pod) error {
-	var errors []string
+// waitForApplicationDeletion polls the application status until it's fully deleted.
+func (p *PodmanApplication) waitForApplicationDeletion(appClient *catalogClient.ApplicationClient, appID string) error {
+	const (
+		pollInterval = 5 * time.Second
+		maxAttempts  = 12
+	)
 
-	for _, pod := range pods {
-		logger.Infof("Deleting pod: %s\n", pod.Name)
+	for range maxAttempts {
+		// Check if application still exists via API
+		app, err := appClient.GetApplication(appID)
+		if err != nil {
+			// Check if it's an HTTPError with 404 status code
+			var httpErr *catalogClient.HTTPError
+			if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+				// Application not found (HTTP 404) - successfully deleted
+				return nil
+			}
 
-		if err := p.runtime.DeletePod(pod.ID, utils.BoolPtr(true)); err != nil {
-			errors = append(errors, fmt.Sprintf("pod %s: %v", pod.Name, err))
-
-			continue
+			return fmt.Errorf("failed to fetch application: %w", err)
 		}
 
-		logger.Infof("Successfully removed pod: %s\n", pod.Name)
+		// If application exists, check its status
+		if app != nil {
+			logger.Infof("Application status: %s, message: %s\n", app.Status, app.Message)
+			// Application still exists, continue polling
+		}
+
+		// Wait before next poll
+		time.Sleep(pollInterval)
 	}
 
-	// Aggregate errors at the end
-	if len(errors) > 0 {
-		return fmt.Errorf("failed to remove pods: \n%s", strings.Join(errors, "\n"))
-	}
-
-	return nil
-}
-
-func (p *PodmanApplication) appDataDeletion(appDir string) error {
-	logger.Infoln("Cleaning up application data")
-
-	if err := os.RemoveAll(appDir); err != nil {
-		return fmt.Errorf("failed to delete application data: %w", err)
-	}
-
-	logger.Infoln("Application data cleaned up successfully")
-
-	return nil
+	return fmt.Errorf("timeout waiting for application deletion after %v", maxAttempts*pollInterval)
 }

--- a/ai-services/internal/pkg/application/podman/info.go
+++ b/ai-services/internal/pkg/application/podman/info.go
@@ -1,56 +1,139 @@
 package podman
 
 import (
+	"bytes"
 	"fmt"
+	"strings"
+	"text/template"
 
-	"github.com/project-ai-services/ai-services/assets"
 	"github.com/project-ai-services/ai-services/internal/pkg/application/types"
-	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
-	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
+	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
+	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+	cliUtils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // Info displays detailed information about an application.
 func (p *PodmanApplication) Info(opts types.InfoOptions) error {
-	// Step1: Do List pods and filter for given application name
-
-	listFilters := map[string][]string{}
-	if opts.Name != "" {
-		listFilters["label"] = []string{fmt.Sprintf("ai-services.io/application=%s", opts.Name)}
-	}
-
-	pods, err := p.runtime.ListPods(listFilters)
+	appClient, err := catalogClient.NewApplicationClient()
 	if err != nil {
-		return fmt.Errorf("failed to list pods: %w", err)
+		return fmt.Errorf("failed to create application client: %w", err)
 	}
 
-	// If there exists no pod for given application name, then fail saying application for given application name doesnt exist
-	if len(pods) == 0 {
-		logger.Infof("Application: '%s' does not exist.", opts.Name)
+	app, err := cliUtils.GetAppByName(appClient, opts.Name)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			logger.Warningf("Application: '%s' does not exist", opts.Name)
 
-		return nil
+			return nil
+		}
+
+		return err
 	}
 
-	logger.Infoln("Application Name: " + opts.Name)
+	application, err := appClient.GetApplication(app.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get application: %w", err)
+	}
 
-	// Step2: From one of the pod, fetch and print the template and version label values
+	appPS, err := appClient.GetApplicationPS(app.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get application pods: %w", err)
+	}
 
-	appTemplate := pods[0].Labels[string(vars.TemplateLabel)]
-	logger.Infoln("Application Template: " + appTemplate)
+	logger.Infoln("Application Name: " + application.Name)
+	logger.Infoln("Application Template: " + application.CatalogID)
+	logger.Infof("Application Version: " + application.Version)
 
-	version := pods[0].Labels[string(vars.VersionLabel)]
-	logger.Infoln("Version: " + version)
+	return printServicesInfo(application.Services, appPS)
+}
 
-	// Step3: Read and print the info.md file
-	tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
+func printServicesInfo(services []catalogTypes.ApplicationService, appPS *catalogTypes.ApplicationPSResponse) error {
+	catalogProvider, err := catalog.NewCatalogProvider()
+	if err != nil {
+		return fmt.Errorf("failed to create catalog provider: %w", err)
+	}
 
-	if err := helpers.PrintInfo(tp, p.runtime, opts.Name, appTemplate); err != nil {
-		// not failing if overall info command, if we cannot display Info
-		logger.Errorf("failed to display info: %v\n", err)
+	logger.Infoln("Info:")
+	logger.Infoln("-------")
+	logger.Infoln("Day N: ")
 
-		return nil
+	for _, service := range services {
+		params := map[string]string{}
+		params["SERVICE_NAME"] = service.Type
+
+		uiStatus, apiSatatus := getContainerStatus(appPS.Services, service.CatalogID)
+		params["UI_STATUS"] = uiStatus
+		params["API_STATUS"] = apiSatatus
+
+		for _, endpoint := range service.Endpoints {
+			urlType, urlTypeOk := endpoint["type"].(string)
+			url, urlOk := endpoint["url"].(string)
+			if urlTypeOk && urlOk {
+				params[strings.ToUpper(urlType)+"_URL"] = url
+			}
+		}
+
+		tmpls, err := catalogProvider.LoadServicesMD(service.CatalogID)
+		if err != nil {
+			return fmt.Errorf("failed to load service md files: %w", err)
+		}
+
+		err = printInfo(tmpls, params, service.CatalogID)
+		if err != nil {
+			return fmt.Errorf("failed to load application info: %w", err)
+		}
 	}
 
 	return nil
 }
+
+func getContainerStatus(services []catalogTypes.Pod, catalogID string) (string, string) {
+	uiStatus, apiStatus := "", ""
+
+	for _, servicePod := range services {
+		if strings.HasPrefix(servicePod.PodName, catalogID) {
+			for _, podContainer := range servicePod.Containers {
+				// TODO: Set the container status in info.md generically
+				uiContainerName := fmt.Sprintf("%s-ui", servicePod.PodName)
+				apiContainerName := ""
+				if strings.Contains(podContainer.Name, "backend-server") {
+					apiContainerName = podContainer.Name
+				} else {
+					apiContainerName = fmt.Sprintf("%s-%s-api", servicePod.PodName, catalogID)
+				}
+
+				if podContainer.Name == uiContainerName && podContainer.Healthy {
+					uiStatus = "running"
+				}
+				if podContainer.Name == apiContainerName && podContainer.Healthy {
+					apiStatus = "running"
+				}
+			}
+		}
+	}
+
+	return uiStatus, apiStatus
+}
+
+func printInfo(tmpls map[string]*template.Template, params map[string]string, appTemplate string) error {
+	tmpl, ok := tmpls["info.md"]
+	if !ok {
+		logger.Warningf("failed to find info.md template")
+
+		return nil
+	}
+
+	var rendered bytes.Buffer
+	if err := tmpl.Execute(&rendered, params); err != nil {
+		return fmt.Errorf("failed to execute info.md: %w", err)
+	}
+	value := rendered.String()
+	value = strings.ReplaceAll(value, "Day N:\n", "")
+	logger.Infof(value)
+
+	return nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/application/podman/logs.go
+++ b/ai-services/internal/pkg/application/podman/logs.go
@@ -4,11 +4,23 @@ import (
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application/types"
+	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
+	cliUtils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 )
 
 // Logs displays logs from an application pod.
 func (p *PodmanApplication) Logs(opts types.LogsOptions) error {
+	// Validate application exists via catalog API
+	appClient, err := catalogClient.NewApplicationClient()
+	if err != nil {
+		return fmt.Errorf("failed to create application client: %w", err)
+	}
+
+	if _, err := cliUtils.GetAppByName(appClient, opts.ApplicationName); err != nil {
+		return err
+	}
+
 	logger.Warningln("Press Ctrl+C to exit the logs and return to the terminal.")
 	logger.Infof("Fetching logs for application pod: %s", opts.PodName)
 

--- a/ai-services/internal/pkg/application/podman/ps.go
+++ b/ai-services/internal/pkg/application/podman/ps.go
@@ -1,33 +1,71 @@
 package podman
 
 import (
-	"github.com/project-ai-services/ai-services/internal/pkg/application/common"
+	"fmt"
+
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
+	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
+	cliUtils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 // List returns information about running applications.
 func (p *PodmanApplication) List(opts appTypes.ListOptions) ([]appTypes.ApplicationInfo, error) {
-	// filter and fetch pods based on appName
-	pods, err := common.FetchFilteredPods(p.runtime, opts.ApplicationName)
+	appClient, err := catalogClient.NewApplicationClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create application client: %w", err)
+	}
+
+	applicationList, err := cliUtils.FetchApplications(appClient, opts.ApplicationName)
 	if err != nil {
 		return nil, err
 	}
 
-	// if no pods are present and also if appName is provided then simply log and return
-	if len(pods) == 0 && opts.ApplicationName != "" {
-		logger.Infof("No Pods found for the given application name: %s", opts.ApplicationName)
+	if len(applicationList) == 0 {
+		logger.Warningln("No Application found")
 
 		return nil, nil
 	}
 
-	// fetch the table writer object
+	// Create table writer
 	printer := utils.NewTableWriter()
 	defer printer.CloseTableWriter()
 
-	// set table headers and rows
-	common.PopulateTable(p.runtime, opts, pods)
+	// Set table headers based on output format
+	setApplicationPSTableHeaders(printer, opts.OutputWide)
+
+	// Process each application ID
+	for _, app := range applicationList {
+		// Get PS information for the application
+		psResp, err := appClient.GetApplicationPS(app.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch application: %w", err)
+		}
+
+		// Process services pods
+		for _, pod := range psResp.Services {
+			rows := cliUtils.BuildPodRowFromAPI(psResp.Name, pod, opts.OutputWide)
+			printer.AppendRow(rows...)
+		}
+
+		// Process components pods
+		for _, pod := range psResp.Components {
+			rows := cliUtils.BuildPodRowFromAPI(psResp.Name, pod, opts.OutputWide)
+			printer.AppendRow(rows...)
+		}
+	}
 
 	return nil, nil
 }
+
+// setApplicationPSTableHeaders sets the table headers based on output format.
+func setApplicationPSTableHeaders(printer *utils.Printer, outputWide bool) {
+	if outputWide {
+		printer.SetHeaders("APPLICATION NAME", "POD ID", "POD NAME", "STATUS", "CREATED", "CONTAINERS")
+	} else {
+		printer.SetHeaders("APPLICATION NAME", "POD NAME", "STATUS")
+	}
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/application/podman/start.go
+++ b/ai-services/internal/pkg/application/podman/start.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
+	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	cliutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
@@ -14,19 +15,19 @@ import (
 
 // Start starts a stopped application.
 func (p *PodmanApplication) Start(opts appTypes.StartOptions) error {
-	var pods []types.Pod
-	var err error
-	// if experimental flag is set, get pods from applications-ps
-	if !opts.Experimental {
-		pods, err = p.fetchPodsFromRuntime(opts.Name)
-		if err != nil {
-			return err
-		}
-	} else {
-		pods, err = cliutils.GetPodsFromApplicationsPS(opts.Name)
-		if err != nil {
-			return err
-		}
+	// Validate application exists
+	appClient, err := catalogClient.NewApplicationClient()
+	if err != nil {
+		return fmt.Errorf("failed to create application client: %w", err)
+	}
+	if _, err := cliutils.GetAppByName(appClient, opts.Name); err != nil {
+		return err
+	}
+
+	// Get pods from application ps
+	pods, err := cliutils.GetPodsFromApplicationsPS(opts.Name)
+	if err != nil {
+		return err
 	}
 
 	if len(pods) == 0 {
@@ -50,17 +51,6 @@ func (p *PodmanApplication) Start(opts appTypes.StartOptions) error {
 }
 
 // Start implementation helper methods.
-func (p *PodmanApplication) fetchPodsFromRuntime(appName string) ([]types.Pod, error) {
-	pods, err := p.runtime.ListPods(map[string][]string{
-		"label": {fmt.Sprintf("ai-services.io/application=%s", appName)},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list pods: %w", err)
-	}
-
-	return pods, nil
-}
-
 func (p *PodmanApplication) fetchPodsToStart(pods []types.Pod, podNames []string) ([]types.Pod, error) {
 	if len(podNames) > 0 {
 		return p.filterPodsByNameForStart(pods, podNames)

--- a/ai-services/internal/pkg/application/podman/stop.go
+++ b/ai-services/internal/pkg/application/podman/stop.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
+	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	cliutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
@@ -13,7 +14,17 @@ import (
 
 // Stop stops a running application.
 func (p *PodmanApplication) Stop(opts appTypes.StopOptions) error {
-	pods, err := p.listApplicationPods(opts)
+	// Validate application exists
+	appClient, err := catalogClient.NewApplicationClient()
+	if err != nil {
+		return fmt.Errorf("failed to create application client: %w", err)
+	}
+	if _, err := cliutils.GetAppByName(appClient, opts.Name); err != nil {
+		return err
+	}
+
+	// Get pods from applications ps
+	pods, err := cliutils.GetPodsFromApplicationsPS(opts.Name)
 	if err != nil {
 		return err
 	}
@@ -58,22 +69,6 @@ func (p *PodmanApplication) Stop(opts appTypes.StopOptions) error {
 	logger.Infof("Proceeding to stop pods...\n")
 
 	return p.stopPods(podsToStop)
-}
-
-// listApplicationPods retrieves pods for the given application.
-func (p *PodmanApplication) listApplicationPods(opts appTypes.StopOptions) ([]types.Pod, error) {
-	if !opts.Experimental {
-		pods, err := p.runtime.ListPods(map[string][]string{
-			"label": {fmt.Sprintf("ai-services.io/application=%s", opts.Name)},
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to list pods: %w", err)
-		}
-
-		return pods, nil
-	}
-
-	return cliutils.GetPodsFromApplicationsPS(opts.Name)
 }
 
 func (p *PodmanApplication) fetchPodsToStop(pods []types.Pod, podNames []string, appName string) ([]types.Pod, error) {

--- a/ai-services/internal/pkg/application/types/types.go
+++ b/ai-services/internal/pkg/application/types/types.go
@@ -47,10 +47,9 @@ type StartOptions struct {
 
 // StopOptions contains parameters for stopping an application.
 type StopOptions struct {
-	Name         string
-	PodNames     []string
-	AutoYes      bool
-	Experimental bool
+	Name     string
+	PodNames []string
+	AutoYes  bool
 }
 
 // ListOptions contains parameters for listing applications.

--- a/ai-services/internal/pkg/application/types/types.go
+++ b/ai-services/internal/pkg/application/types/types.go
@@ -39,11 +39,10 @@ type DeleteOptions struct {
 
 // StartOptions contains parameters for starting an application.
 type StartOptions struct {
-	Name         string
-	PodNames     []string
-	SkipLogs     bool
-	AutoYes      bool
-	Experimental bool
+	Name     string
+	PodNames []string
+	SkipLogs bool
+	AutoYes  bool
 }
 
 // StopOptions contains parameters for stopping an application.

--- a/ai-services/internal/pkg/application/types/types.go
+++ b/ai-services/internal/pkg/application/types/types.go
@@ -67,6 +67,7 @@ type InfoOptions struct {
 
 // LogsOptions contains parameters for displaying application logs.
 type LogsOptions struct {
+	ApplicationName   string
 	PodName           string
 	ContainerNameOrID string
 }


### PR DESCRIPTION
This PR removes all experimental flags from application commands and migrates catalog API logic to the implementation layer, making it the default behavior for Podman runtime.