### PR TITLE
Enable deploy button in DA deploy flow

### DIFF
--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,6 +1,6 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.16
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.17
 
 backend:
   port: ""

--- a/ui/catalog/Makefile
+++ b/ui/catalog/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= catalog-ui
-TAG ?= v0.0.16
+TAG ?= v0.0.17
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/catalog/src/components/DeployFlow/DeployFlow.module.scss
+++ b/ui/catalog/src/components/DeployFlow/DeployFlow.module.scss
@@ -125,6 +125,16 @@
   color: $support-warning;
 }
 
+.iconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
 .resourceLoading {
   padding: $spacing-05 0;
 }

--- a/ui/catalog/src/components/DeployFlow/DeployFlow.tsx
+++ b/ui/catalog/src/components/DeployFlow/DeployFlow.tsx
@@ -299,10 +299,7 @@ export const DeployFlow = ({ open, onClose, onSubmit }: DeployFlowProps) => {
       kind: "primary" as const,
       onClick: isLastStep ? handleSubmit : handleNext,
       disabled:
-        state.isLoading ||
-        state.isDeploying ||
-        (isLastStep && state.isEditing) ||
-        (isLastStep && state.hasInsufficientResources),
+        state.isLoading || state.isDeploying || (isLastStep && state.isEditing),
     },
   ];
 

--- a/ui/catalog/src/components/DeployFlow/components/ResourceRequirements.tsx
+++ b/ui/catalog/src/components/DeployFlow/components/ResourceRequirements.tsx
@@ -5,6 +5,7 @@ import {
   ToggletipContent,
   InlineLoading,
   InlineNotification,
+  Tooltip,
 } from "@carbon/react";
 import { Help, CheckmarkFilled, WarningFilled } from "@carbon/icons-react";
 import styles from "../DeployFlow.module.scss";
@@ -81,7 +82,18 @@ export const ResourceRequirements: React.FC<ResourceRequirementsProps> = ({
                     <CheckmarkFilled size={16} className={styles.green} />
                   )}
                   {status === "insufficient" && (
-                    <WarningFilled size={16} className={styles.warning} />
+                    <Tooltip
+                      align="bottom"
+                      label="Insufficient resources available"
+                    >
+                      <button
+                        type="button"
+                        className={styles.iconButton}
+                        aria-label="Insufficient resources available"
+                      >
+                        <WarningFilled size={16} className={styles.warning} />
+                      </button>
+                    </Tooltip>
                   )}
                 </p>
                 <p className={styles.resourceValue}>


### PR DESCRIPTION
- Enabled the deploy button in the digital assistants even when the resources are insufficient and let backend manage the error handling.
- Added `Insufficient resources available` to the yellow warning symbol in the resources cards.

<img width="1916" height="943" alt="image" src="https://github.com/user-attachments/assets/5da5cc81-abdc-4149-a716-585d0cc133be" />
