### PR TITLE
Make catalog API implementation default, move old implementation behind --legacy flag

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.111
+TAG?=v0.0.112
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.111
+  image: icr.io/ai-services-cicd/ai-services:v0.0.112
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -53,7 +53,7 @@ var (
 	skipChecks            []string
 	valuesFiles           []string
 	rawArgImagePullPolicy string
-	experimentalCreate    bool
+	legacyCreate          bool
 
 	// openshift flags.
 	timeout time.Duration
@@ -67,14 +67,17 @@ Arguments
 - [name]: Application name (Required)
 
 Examples:
-# Deploy with experimental mode (5 Spyre cards)
-ai-services application create rag --template rag --runtime podman --experimental
+# Deploy with default mode (5 Spyre cards)
+ai-services application create rag --template rag --runtime podman
 
-# Deploy with experimental mode (4 Spyre cards - reranker on CPU)
-ai-services application create rag --template rag --runtime podman --experimental --params reranker.vllm-cpu=true
+# Deploy with default mode (4 Spyre cards - reranker on CPU)
+ai-services application create rag --template rag --runtime podman --params reranker.vllm-cpu=true
 
-# Deploy with experimental mode (CPU mode)
-ai-services application create rag --template rag --runtime podman --experimental --params reranker.vllm-cpu=true,llm.vllm-cpu=true
+# Deploy with default mode (CPU mode)
+ai-services application create rag --template rag --runtime podman --params reranker.vllm-cpu=true,llm.vllm-cpu=true
+
+# Deploy with legacy mode
+ai-services application create rag --template rag --runtime podman --legacy
 	`,
 	Args: cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -105,13 +108,37 @@ ai-services application create rag --template rag --runtime podman --experimenta
 		}
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
-		// When experimentalCreate is true and runtime is podman, validate application name using catalog API
-		// For openshift runtime, always use the older/stable code path regardless of experimental flag
-		if experimentalCreate && rt == types.RuntimeTypePodman {
+		// When legacyCreate is true and runtime is podman, use the older/stable code path
+		// For openshift runtime, always use the older/stable code path regardless of legacy flag
+		if legacyCreate && rt == types.RuntimeTypePodman {
+			// Create application instance using factory
+			appFactory := application.NewFactory(rt)
+			app, err := appFactory.Create(appName)
+			if err != nil {
+				return fmt.Errorf("failed to create application instance: %w", err)
+			}
+
+			opts := appTypes.CreateOptions{
+				Name:              appName,
+				TemplateName:      templateName,
+				SkipModelDownload: skipModelDownload,
+				SkipImageDownload: skipImageDownload,
+				ArgParams:         argParams,
+				ValuesFiles:       valuesFiles,
+				ImagePullPolicy:   image.ImagePullPolicy(rawArgImagePullPolicy),
+				Timeout:           timeout,
+			}
+
+			return app.Create(ctx, opts)
+		}
+
+		// Default: use catalog way of deploying application
+		// For openshift runtime, always use the older/stable code path
+		if rt == types.RuntimeTypePodman {
 			return createApp(appName)
 		}
 
-		// Create application instance using factory
+		// OpenShift runtime uses the older implementation
 		appFactory := application.NewFactory(rt)
 		app, err := appFactory.Create(appName)
 		if err != nil {
@@ -211,7 +238,7 @@ func initCreatePodmanFlags() {
 			"- If left false in air-gapped environments → download attempt will fail\n"+
 			"Note: Supported for podman runtime only.\n",
 	)
-	createCmd.Flags().BoolVar(&experimentalCreate, "experimental", false, "Include experimental application create")
+	createCmd.Flags().BoolVar(&legacyCreate, "legacy", false, "Use legacy application create implementation")
 
 	initializeImagePullPolicyFlag()
 
@@ -279,12 +306,23 @@ func buildFlagValidator() *flagvalidator.FlagValidator {
 
 // validateTemplateFlag validates the template flag.
 func validateTemplateFlag(cmd *cobra.Command) error {
-	// Skip template validation in experimental mode for podman runtime
-	// In experimental mode, templates are validated against catalog API
-	if experimentalCreate && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+	// do template validation in legacy mode for podman runtime
+	// In default mode, templates are validated against catalog API
+	if legacyCreate && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+		tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
+		if err := tp.AppTemplateExist(templateName); err != nil {
+			return err
+		}
+
 		return nil
 	}
 
+	// Default mode for podman: skip embedded template validation (uses catalog API)
+	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+		return nil
+	}
+
+	// OpenShift runtime: validate against embedded templates
 	tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
 	if err := tp.AppTemplateExist(templateName); err != nil {
 		return err
@@ -305,13 +343,25 @@ func validateParamsFlag(cmd *cobra.Command) error {
 		return fmt.Errorf("invalid format: %w", err)
 	}
 
-	// Skip template validation in experimental mode for podman runtime
-	// In experimental mode, params are validated against catalog API schemas
-	if experimentalCreate && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+	// do template validation in legacy mode for podman runtime
+	// In default mode, params are validated against catalog API schemas
+	if legacyCreate && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+		// Validate params against template values (legacy mode)
+		tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
+		_, err = tp.LoadValues(templateName, nil, argParams)
+		if err != nil {
+			return fmt.Errorf("failed to load params: %w", err)
+		}
+
 		return nil
 	}
 
-	// Validate params against template values (non-experimental mode)
+	// Default mode for podman: skip embedded template validation (uses catalog API)
+	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+		return nil
+	}
+
+	// OpenShift runtime: validate params against template values
 	tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
 	_, err = tp.LoadValues(templateName, nil, argParams)
 	if err != nil {

--- a/ai-services/cmd/ai-services/cmd/application/delete.go
+++ b/ai-services/cmd/ai-services/cmd/application/delete.go
@@ -21,9 +21,9 @@ import (
 )
 
 var (
-	skipCleanup        bool
-	deleteTimeout      time.Duration
-	experimentalDelete bool
+	skipCleanup   bool
+	deleteTimeout time.Duration
+	legacyDelete  bool
 )
 
 var deleteCmd = &cobra.Command{
@@ -42,7 +42,7 @@ Arguments
 		}
 
 		appName := args[0]
-		if !experimentalDelete {
+		if legacyDelete {
 			return utils.VerifyAppName(appName)
 		}
 
@@ -56,13 +56,33 @@ Arguments
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
-		// When experimentalDelete is true and runtime is podman, validate application name using catalog API
-		// For openshift runtime, always use the older/stable code path regardless of experimental flag
-		if experimentalDelete && rt == types.RuntimeTypePodman {
+		// When legacyDelete is true and runtime is podman, use the older/stable code path
+		// For openshift runtime, always use the older/stable code path regardless of legacy flag
+		if legacyDelete && rt == types.RuntimeTypePodman {
+			// Create application instance using factory
+			factory := application.NewFactory(rt)
+			app, err := factory.Create(applicationName)
+			if err != nil {
+				return fmt.Errorf("failed to create application instance: %w", err)
+			}
+
+			opts := appTypes.DeleteOptions{
+				Name:        applicationName,
+				AutoYes:     autoYes,
+				SkipCleanup: skipCleanup,
+				Timeout:     deleteTimeout,
+			}
+
+			return app.Delete(cmd.Context(), opts)
+		}
+
+		// Default: use new implementation (validate application name using catalog API)
+		// For openshift runtime, always use the older/stable code path
+		if rt == types.RuntimeTypePodman {
 			return deleteApplication(applicationName)
 		}
 
-		// Create application instance using factory
+		// OpenShift runtime uses the older implementation
 		factory := application.NewFactory(rt)
 		app, err := factory.Create(applicationName)
 		if err != nil {
@@ -89,7 +109,7 @@ func init() {
 func initDeleteCommonFlags() {
 	deleteCmd.Flags().BoolVar(&skipCleanup, appFlags.Delete.SkipCleanup, false, "Skip deleting application data (default=false)")
 	deleteCmd.Flags().BoolVarP(&autoYes, appFlags.Delete.AutoYes, "y", false, "Automatically accept all confirmation prompts (default=false)")
-	deleteCmd.Flags().BoolVar(&experimentalDelete, "experimental", false, "Include experimental application delete")
+	deleteCmd.Flags().BoolVar(&legacyDelete, "legacy", false, "Use legacy application delete implementation")
 }
 
 func initDeleteOpenShiftFlags() {

--- a/ai-services/cmd/ai-services/cmd/application/info.go
+++ b/ai-services/cmd/ai-services/cmd/application/info.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	experimentalInfo bool
+	legacyInfo bool
 )
 
 var infoCmd = &cobra.Command{
@@ -40,11 +40,30 @@ var infoCmd = &cobra.Command{
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
-		if experimentalInfo && rt == types.RuntimeTypePodman {
+		// When legacyInfo is true and runtime is podman, use the older/stable code path
+		// For openshift runtime, always use the older/stable code path regardless of legacy flag
+		if legacyInfo && rt == types.RuntimeTypePodman {
+			// Create application instance using factory
+			factory := application.NewFactory(rt)
+			app, err := factory.Create(applicationName)
+			if err != nil {
+				return fmt.Errorf("failed to create application instance: %w", err)
+			}
+
+			opts := appTypes.InfoOptions{
+				Name: applicationName,
+			}
+
+			return app.Info(opts)
+		}
+
+		// Default: use new implementation using catalog
+		// For openshift runtime, always use the older/stable code path
+		if rt == types.RuntimeTypePodman {
 			return renderApplicationInfo(applicationName)
 		}
 
-		// Create application instance using factory
+		// OpenShift runtime uses the older implementation
 		factory := application.NewFactory(rt)
 		app, err := factory.Create(applicationName)
 		if err != nil {
@@ -60,7 +79,7 @@ var infoCmd = &cobra.Command{
 }
 
 func init() {
-	infoCmd.Flags().BoolVar(&experimentalInfo, "experimental", false, "Include experimental application info")
+	infoCmd.Flags().BoolVar(&legacyInfo, "legacy", false, "Use legacy application info implementation")
 }
 
 func renderApplicationInfo(appName string) error {

--- a/ai-services/cmd/ai-services/cmd/application/logs.go
+++ b/ai-services/cmd/ai-services/cmd/application/logs.go
@@ -17,7 +17,7 @@ import (
 var (
 	podName           string
 	containerNameOrID string
-	experimentalLogs  bool
+	legacyLogs        bool
 )
 
 var logsCmd = &cobra.Command{
@@ -48,9 +48,27 @@ Arguments
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
-		// When experimentalLogs is true and runtime is podman, validate application name using catalog API
-		// For openshift runtime, always use the older/stable code path regardless of experimental flag
-		if experimentalLogs && rt == types.RuntimeTypePodman {
+		// When legacyLogs is true and runtime is podman, use the older/stable code path
+		// For openshift runtime, always use the older/stable code path regardless of legacy flag
+		if legacyLogs && rt == types.RuntimeTypePodman {
+			// Create application instance using factory
+			factory := application.NewFactory(rt)
+			app, err := factory.Create(applicationName)
+			if err != nil {
+				return fmt.Errorf("failed to create application instance: %w", err)
+			}
+
+			opts := appTypes.LogsOptions{
+				PodName:           podName,
+				ContainerNameOrID: containerNameOrID,
+			}
+
+			return app.Logs(opts)
+		}
+
+		// Default: use new implementation via catalog
+		// For openshift runtime, always use the older/stable code path
+		if rt == types.RuntimeTypePodman {
 			appClient, err := catalogClient.NewApplicationClient()
 			if err != nil {
 				return fmt.Errorf("failed to create application client: %w", err)
@@ -62,7 +80,7 @@ Arguments
 			return nil
 		}
 
-		// Create application instance using factory
+		// OpenShift runtime uses the older implementation
 		factory := application.NewFactory(rt)
 		app, err := factory.Create(applicationName)
 		if err != nil {
@@ -83,7 +101,7 @@ func init() {
 }
 
 func initLogsCommonFlags() {
-	logsCmd.Flags().BoolVar(&experimentalLogs, "experimental", false, "Include experimental application logs")
+	logsCmd.Flags().BoolVar(&legacyLogs, "legacy", false, "Use legacy application logs implementation")
 	logsCmd.Flags().StringVar(&podName, appFlags.Logs.Pod, "", "Pod name to show logs from (required)")
 	logsCmd.Flags().StringVar(&containerNameOrID, appFlags.Logs.Container, "", "Container logs to show logs from (Optional)")
 	_ = logsCmd.MarkFlagRequired(appFlags.Logs.Pod)

--- a/ai-services/cmd/ai-services/cmd/application/logs.go
+++ b/ai-services/cmd/ai-services/cmd/application/logs.go
@@ -48,27 +48,8 @@ Arguments
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
-		// When legacyLogs is true and runtime is podman, use the older/stable code path
-		// For openshift runtime, always use the older/stable code path regardless of legacy flag
-		if legacyLogs && rt == types.RuntimeTypePodman {
-			// Create application instance using factory
-			factory := application.NewFactory(rt)
-			app, err := factory.Create(applicationName)
-			if err != nil {
-				return fmt.Errorf("failed to create application instance: %w", err)
-			}
-
-			opts := appTypes.LogsOptions{
-				PodName:           podName,
-				ContainerNameOrID: containerNameOrID,
-			}
-
-			return app.Logs(opts)
-		}
-
-		// Default: use new implementation via catalog
-		// For openshift runtime, always use the older/stable code path
-		if rt == types.RuntimeTypePodman {
+		// For podman runtime with default mode
+		if !legacyLogs && rt == types.RuntimeTypePodman {
 			appClient, err := catalogClient.NewApplicationClient()
 			if err != nil {
 				return fmt.Errorf("failed to create application client: %w", err)
@@ -76,11 +57,9 @@ Arguments
 			if _, err := utils.GetAppByName(appClient, applicationName); err != nil {
 				return err
 			}
-
-			return nil
 		}
 
-		// OpenShift runtime uses the older implementation
+		// Create application instance using factory
 		factory := application.NewFactory(rt)
 		app, err := factory.Create(applicationName)
 		if err != nil {

--- a/ai-services/cmd/ai-services/cmd/application/ps.go
+++ b/ai-services/cmd/ai-services/cmd/application/ps.go
@@ -18,8 +18,8 @@ import (
 )
 
 var (
-	output         string
-	experimentalPs bool
+	output   string
+	legacyPs bool
 )
 
 func isOutputWide() bool {
@@ -56,13 +56,31 @@ Arguments
 			OutputWide:      isOutputWide(),
 		}
 
-		// When experimentalTemplates is true and runtime is podman, use experimental catalog ps api
-		// For openshift runtime, always use the older/stable code path regardless of experimental flag
-		if experimentalPs && rt == types.RuntimeTypePodman {
+		// When legacyPs is true and runtime is podman, use the older/stable code path
+		// For openshift runtime, always use the older/stable code path regardless of legacy flag
+		if legacyPs && rt == types.RuntimeTypePodman {
+			// Create application instance using factory
+			factory := application.NewFactory(rt)
+			app, err := factory.Create(applicationName)
+			if err != nil {
+				return fmt.Errorf("failed to create application instance: %w", err)
+			}
+
+			_, err = app.List(opts)
+			if err != nil {
+				return fmt.Errorf("failed to fetch application: %w", err)
+			}
+
+			return nil
+		}
+
+		// Default: use new implementation via catalog
+		// For openshift runtime, always use the older/stable code path
+		if rt == types.RuntimeTypePodman {
 			return renderApplicationPS(opts)
 		}
 
-		// Create application instance using factory
+		// OpenShift runtime uses the older implementation
 		factory := application.NewFactory(rt)
 		app, err := factory.Create(applicationName)
 		if err != nil {
@@ -84,10 +102,10 @@ func init() {
 
 func initPsCommonFlags() {
 	psCmd.Flags().BoolVar(
-		&experimentalPs,
-		"experimental",
+		&legacyPs,
+		"legacy",
 		false,
-		"Include experimental application templates",
+		"Use legacy application ps implementation",
 	)
 
 	psCmd.Flags().StringVarP(

--- a/ai-services/cmd/ai-services/cmd/application/start.go
+++ b/ai-services/cmd/ai-services/cmd/application/start.go
@@ -13,10 +13,10 @@ import (
 )
 
 var (
-	skipLogs          bool
-	startPodNames     []string
-	autoYes           bool
-	experimentalStart bool
+	skipLogs      bool
+	startPodNames []string
+	autoYes       bool
+	legacyStart   bool
 )
 
 var startCmd = &cobra.Command{
@@ -49,9 +49,8 @@ Note: Supported for podman runtime only.
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
-		// When experimentalStart is true and runtime is podman, validate application name using catalog API
-		// For openshift runtime, always use the older/stable code path regardless of experimental flag
-		if experimentalStart && rt == types.RuntimeTypePodman {
+		// For podman runtime with default mode, validate application name using catalog API
+		if !legacyStart && rt == types.RuntimeTypePodman {
 			appClient, err := catalogClient.NewApplicationClient()
 			if err != nil {
 				return fmt.Errorf("failed to create application client: %w", err)
@@ -72,11 +71,11 @@ Note: Supported for podman runtime only.
 
 		// start application with options
 		opts := appTypes.StartOptions{
-			Name:         applicationName,
-			PodNames:     startPodNames,
-			AutoYes:      autoYes,
-			SkipLogs:     skipLogs,
-			Experimental: experimentalStart,
+			Name:     applicationName,
+			PodNames: startPodNames,
+			AutoYes:  autoYes,
+			SkipLogs: skipLogs,
+			Legacy:   legacyStart,
 		}
 
 		return app.Start(opts)
@@ -84,7 +83,7 @@ Note: Supported for podman runtime only.
 }
 
 func init() {
-	startCmd.Flags().BoolVar(&experimentalStart, "experimental", false, "Include experimental application start")
+	startCmd.Flags().BoolVar(&legacyStart, "legacy", false, "Use legacy application start implementation")
 	startCmd.Flags().StringSlice("pod", []string{}, "Specific pod name(s) to start (optional)\nCan be specified multiple times: --pod pod1 --pod pod2\nOr comma-separated: --pod pod1,pod2")
 	startCmd.Flags().BoolVar(&skipLogs, "skip-logs", false, "Skip displaying logs after starting the pod")
 	startCmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "Automatically accept all confirmation prompts (default=false)")

--- a/ai-services/cmd/ai-services/cmd/application/start.go
+++ b/ai-services/cmd/ai-services/cmd/application/start.go
@@ -58,8 +58,6 @@ Note: Supported for podman runtime only.
 			if _, err := utils.GetAppByName(appClient, applicationName); err != nil {
 				return err
 			}
-
-			return nil
 		}
 
 		// Create application instance using factory

--- a/ai-services/cmd/ai-services/cmd/application/stop.go
+++ b/ai-services/cmd/ai-services/cmd/application/stop.go
@@ -54,8 +54,6 @@ Note: Supported for podman runtime only.
 			if _, err := utils.GetAppByName(appClient, applicationName); err != nil {
 				return err
 			}
-
-			return nil
 		}
 
 		// Create application instance using factory

--- a/ai-services/cmd/ai-services/cmd/application/stop.go
+++ b/ai-services/cmd/ai-services/cmd/application/stop.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	stopPodNames     []string
-	experimentalStop bool
+	stopPodNames []string
+	legacyStop   bool
 )
 
 var stopCmd = &cobra.Command{
@@ -45,9 +45,8 @@ Note: Supported for podman runtime only.
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
-		// When experimentalStop is true and runtime is podman, validate application name using catalog API
-		// For openshift runtime, always use the older/stable code path regardless of experimental flag
-		if experimentalStop && rt == types.RuntimeTypePodman {
+		// For podman runtime with default mode, validate application name using catalog API
+		if !legacyStop && rt == types.RuntimeTypePodman {
 			appClient, err := catalogClient.NewApplicationClient()
 			if err != nil {
 				return fmt.Errorf("failed to create application client: %w", err)
@@ -67,10 +66,10 @@ Note: Supported for podman runtime only.
 		}
 
 		opts := appTypes.StopOptions{
-			Name:         applicationName,
-			PodNames:     stopPodNames,
-			AutoYes:      autoYes,
-			Experimental: experimentalStop,
+			Name:     applicationName,
+			PodNames: stopPodNames,
+			AutoYes:  autoYes,
+			Legacy:   legacyStop,
 		}
 
 		return app.Stop(opts)
@@ -80,5 +79,5 @@ Note: Supported for podman runtime only.
 func init() {
 	stopCmd.Flags().StringSlice("pod", []string{}, "Specific pod name(s) to stop (optional)\nCan be specified multiple times: --pod pod1 --pod pod2\nOr comma-separated: --pod pod1,pod2")
 	stopCmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "Automatically accept all confirmation prompts (default=false)")
-	stopCmd.Flags().BoolVar(&experimentalStop, "experimental", false, "Include experimental application stop")
+	stopCmd.Flags().BoolVar(&legacyStop, "legacy", false, "Use legacy application stop implementation")
 }

--- a/ai-services/internal/pkg/application/podman/start.go
+++ b/ai-services/internal/pkg/application/podman/start.go
@@ -16,8 +16,8 @@ import (
 func (p *PodmanApplication) Start(opts appTypes.StartOptions) error {
 	var pods []types.Pod
 	var err error
-	// if experimental flag is set, get pods from applications-ps
-	if !opts.Experimental {
+	// if legacy flag is set, get pods from runtime; otherwise use catalog API
+	if opts.Legacy {
 		pods, err = p.fetchPodsFromRuntime(opts.Name)
 		if err != nil {
 			return err

--- a/ai-services/internal/pkg/application/podman/stop.go
+++ b/ai-services/internal/pkg/application/podman/stop.go
@@ -62,7 +62,8 @@ func (p *PodmanApplication) Stop(opts appTypes.StopOptions) error {
 
 // listApplicationPods retrieves pods for the given application.
 func (p *PodmanApplication) listApplicationPods(opts appTypes.StopOptions) ([]types.Pod, error) {
-	if !opts.Experimental {
+	// if legacy flag is set, get pods from runtime; otherwise use catalog API
+	if opts.Legacy {
 		pods, err := p.runtime.ListPods(map[string][]string{
 			"label": {fmt.Sprintf("ai-services.io/application=%s", opts.Name)},
 		})

--- a/ai-services/internal/pkg/application/types/types.go
+++ b/ai-services/internal/pkg/application/types/types.go
@@ -39,11 +39,11 @@ type DeleteOptions struct {
 
 // StartOptions contains parameters for starting an application.
 type StartOptions struct {
-	Name         string
-	PodNames     []string
-	SkipLogs     bool
-	AutoYes      bool
-	Experimental bool
+	Name     string
+	PodNames []string
+	SkipLogs bool
+	AutoYes  bool
+	Legacy   bool
 }
 
 // StopOptions contains parameters for stopping an application.

--- a/ai-services/internal/pkg/application/types/types.go
+++ b/ai-services/internal/pkg/application/types/types.go
@@ -48,10 +48,10 @@ type StartOptions struct {
 
 // StopOptions contains parameters for stopping an application.
 type StopOptions struct {
-	Name         string
-	PodNames     []string
-	AutoYes      bool
-	Experimental bool
+	Name     string
+	PodNames []string
+	AutoYes  bool
+	Legacy   bool
 }
 
 // ListOptions contains parameters for listing applications.


### PR DESCRIPTION
Replaced `--experimental` flag with --legacy flag across all application commands (create, delete, info, logs, ps, start, stop). The catalog API implementation is now the default for Podman runtime, with the previous implementation available via `--legacy` flag for backward compatibility.