### PR TITLE
Disable chunked prefill since reranker model does not support it

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.117
+TAG?=v0.0.118
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag/openshift/templates/reranker-inferenceservice.yaml
+++ b/ai-services/assets/applications/rag/openshift/templates/reranker-inferenceservice.yaml
@@ -25,6 +25,8 @@ spec:
           value: "4"
         - name: VLLM_SPYRE_WARMUP_PROMPT_LENS
           value: "1024"
+        - name: VLLM_SPYRE_USE_CHUNKED_PREFILL
+          value: "0"
       resources:
         limits:
           cpu: "8"

--- a/ai-services/assets/applications/rag/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/vllm-server.yaml.tmpl
@@ -137,6 +137,8 @@ spec:
           value: "/models/{{ .Values.reranker.model.name }}"
         - name: AIU_WORLD_SIZE
           value: "1"
+        - name: VLLM_SPYRE_USE_CHUNKED_PREFILL
+          value: "0"
         - name: VLLM_SPYRE_WARMUP_BATCH_SIZES
           value: "4"
         - name: VLLM_SPYRE_WARMUP_PROMPT_LENS

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.117
+  image: icr.io/ai-services-cicd/ai-services:v0.0.118
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/components/reranker/vllm-spyre/podman/templates/reranker-server.yaml.tmpl
+++ b/ai-services/assets/components/reranker/vllm-spyre/podman/templates/reranker-server.yaml.tmpl
@@ -42,6 +42,8 @@ spec:
           value: "/models/{{ .Values.model }}"
         - name: AIU_WORLD_SIZE
           value: "1"
+        - name: VLLM_SPYRE_USE_CHUNKED_PREFILL
+          value: "0"
         - name: VLLM_SPYRE_WARMUP_BATCH_SIZES
           value: "4"
         - name: VLLM_SPYRE_WARMUP_PROMPT_LENS


### PR DESCRIPTION
- Chunked prefill is enabled on rhaiis image by default on rhaiis:3.4, need to disable it with `VLLM_SPYRE_USE_CHUNKED_PREFILL=0` since reranker model does not support it.