### PR TITLE
Fix digitize UI duration and timestamps

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.113
+TAG?=v0.0.114
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.24
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.25
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.24
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.25
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.24
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.25
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.24
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.25
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.24
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.25
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.113
+  image: icr.io/ai-services-cicd/ai-services:v0.0.114
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,6 +1,6 @@
 digitize:
   port: ""
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.24
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.25
   log_level: "INFO"
   database: "digitize_metadata"
 

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.24
+TAG?=v0.0.25
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/db/scripts/init_schema.sql
+++ b/services/digitize/db/scripts/init_schema.sql
@@ -6,11 +6,11 @@ CREATE TABLE IF NOT EXISTS jobs (
     job_name VARCHAR(500),
     operation VARCHAR(50) NOT NULL,
     status VARCHAR(50) NOT NULL,
-    submitted_at TIMESTAMP NOT NULL,  -- When user submitted the job
-    completed_at TIMESTAMP,           -- When job finished processing
+    submitted_at TIMESTAMP WITH TIME ZONE NOT NULL,  -- When user submitted the job (UTC)
+    completed_at TIMESTAMP WITH TIME ZONE,           -- When job finished processing (UTC)
     error TEXT,
     stats JSONB NOT NULL DEFAULT '{"total_documents": 0, "completed": 0, "failed": 0, "in_progress": 0}',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,  -- Last modification time
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,  -- Last modification time (UTC)
     CONSTRAINT chk_job_status CHECK (status IN ('accepted', 'in_progress', 'completed', 'failed')),
     CONSTRAINT chk_job_operation CHECK (operation IN ('ingestion', 'digitization'))
 );
@@ -22,11 +22,11 @@ CREATE TABLE IF NOT EXISTS documents (
     type VARCHAR(50) NOT NULL,
     status VARCHAR(50) NOT NULL,
     output_format VARCHAR(10) NOT NULL,
-    submitted_at TIMESTAMP NOT NULL,  -- When user submitted the document as part of job
-    completed_at TIMESTAMP,           -- When document finished processing
+    submitted_at TIMESTAMP WITH TIME ZONE NOT NULL,  -- When user submitted the document as part of job (UTC)
+    completed_at TIMESTAMP WITH TIME ZONE,           -- When document finished processing (UTC)
     error TEXT,
     metadata JSONB NOT NULL DEFAULT '{}',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,  -- Last modification time
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,  -- Last modification time (UTC)
     CONSTRAINT chk_doc_status CHECK (status IN ('accepted', 'in_progress', 'digitized', 'processed', 'chunked', 'completed', 'failed')),
     CONSTRAINT chk_doc_type CHECK (type IN ('ingestion', 'digitization')),
     CONSTRAINT chk_output_format CHECK (output_format IN ('txt', 'md', 'json'))


### PR DESCRIPTION
The database schema used TIMESTAMP (without WITH TIME ZONE) for all timestamp columns. When timezone-aware datetime objects were stored in PostgreSQL:

1. PostgreSQL stripped the timezone information and stored timestamps as local time
2. Upon retrieval, SQLAlchemy returned timezone-naive datetime objects
3. When serialized to ISO 8601 format, these timestamps lacked the Z (UTC) suffix
4. JavaScript in the frontend interpreted these timestamps as local timezone instead of UTC
5. This caused incorrect duration calculations, off by the timezone offset (e.g., 5.5 hours for IST)

The full issue is briefed here: https://jsw.ibm.com/browse/AISERVICES-1249

<img width="1920" height="631" alt="Screenshot 2026-06-17 at 5 24 16 PM" src="https://github.com/user-attachments/assets/80eb34b1-71a4-44d3-b4e0-4da2f2bbfc17" />
