### PR TITLE
Update service-base image to v0.0.33 and increment dependent service versions

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.114
+TAG?=v0.0.115
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.18
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.19
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.25
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.26
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
@@ -85,7 +85,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.12
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.13
   # @hidden
   log_level: "INFO"
   database: "summarize_metadata"
@@ -94,7 +94,7 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.11
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.12
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.18
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.19
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.
@@ -12,7 +12,7 @@ backend:
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.12
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.13
   # @hidden
   log_level: "INFO"
   # @description Database name for the SUMMARIZE service. Default is "summarize_metadata".
@@ -20,13 +20,13 @@ summarize:
 
 similarity:
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.11
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.12
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.25
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.26
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.18
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.19
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.25
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.26
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
@@ -83,7 +83,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.12
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.13
   # @hidden
   log_level: "INFO"
   database: "summarize_metadata"
@@ -92,7 +92,7 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.11
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.12
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.18
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.19
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.
@@ -12,7 +12,7 @@ backend:
 
 summarize:
   # @hidden
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.12
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.13
   # @hidden
   log_level: "INFO"
   # @description Database name for the SUMMARIZE service. Default is "summarize_metadata".
@@ -20,13 +20,13 @@ summarize:
 
 similarity:
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.11
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.12
   # @hidden
   log_level: "INFO"
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.25
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.26
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.18
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.19
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.25
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.26
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
@@ -83,7 +83,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.12
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.13
   # @hidden
   log_level: "INFO"
   database: "summarize_metadata"
@@ -92,7 +92,7 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.11
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.12
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.114
+  image: icr.io/ai-services-cicd/ai-services:v0.0.115
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/chat/podman/values.yaml
+++ b/ai-services/assets/services/chat/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.18
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.19
   log_level: "INFO"
   chatbot:
     searchMode: "hybrid"

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,6 +1,6 @@
 digitize:
   port: ""
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.25
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.26
   log_level: "INFO"
   database: "digitize_metadata"
 

--- a/ai-services/assets/services/similarity/podman/values.yaml
+++ b/ai-services/assets/services/similarity/podman/values.yaml
@@ -1,6 +1,6 @@
 similarity:
   port: ""
-  image: icr.io/ai-services-cicd/similarity-service:v0.0.11
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.12
   log_level: "INFO"
 
 # Made with Bob

--- a/ai-services/assets/services/summarize/podman/values.yaml
+++ b/ai-services/assets/services/summarize/podman/values.yaml
@@ -1,6 +1,6 @@
 summarize:
   port: ""
-  image: icr.io/ai-services-cicd/summarize-service:v0.0.12
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.13
   log_level: "INFO"
   database: "summarize_metadata"
 

--- a/services/chatbot/Containerfile
+++ b/services/chatbot/Containerfile
@@ -1,4 +1,4 @@
-FROM icr.io/ai-services-cicd/service-base:v0.0.32
+FROM icr.io/ai-services-cicd/service-base:v0.0.33
 
 WORKDIR /opt/services/chatbot
 

--- a/services/chatbot/Makefile
+++ b/services/chatbot/Makefile
@@ -1,5 +1,5 @@
 IMAGE=chatbot-service
-TAG?=v0.0.18
+TAG?=v0.0.19
 
 run:
 	PORT=$${PORT:-5000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/Containerfile
+++ b/services/digitize/Containerfile
@@ -1,4 +1,4 @@
-FROM icr.io/ai-services-cicd/service-base:v0.0.32
+FROM icr.io/ai-services-cicd/service-base:v0.0.33
 
 WORKDIR /opt/services/digitize
 

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.25
+TAG?=v0.0.26
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/similarity/Containerfile
+++ b/services/similarity/Containerfile
@@ -1,4 +1,4 @@
-FROM icr.io/ai-services-cicd/service-base:v0.0.32
+FROM icr.io/ai-services-cicd/service-base:v0.0.33
 
 WORKDIR /opt/services/similarity
 

--- a/services/similarity/Makefile
+++ b/services/similarity/Makefile
@@ -1,5 +1,5 @@
 IMAGE=similarity-service
-TAG?=v0.0.11
+TAG?=v0.0.12
 
 run:
 	PORT=$${PORT:-7000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/summarize/Containerfile
+++ b/services/summarize/Containerfile
@@ -1,4 +1,4 @@
-FROM icr.io/ai-services-cicd/service-base:v0.0.32
+FROM icr.io/ai-services-cicd/service-base:v0.0.33
 
 WORKDIR /opt/services/summarize
 

--- a/services/summarize/Makefile
+++ b/services/summarize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=summarize-service
-TAG?=v0.0.12
+TAG?=v0.0.13
 
 run:
 	PORT=$${PORT:-6000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT


### PR DESCRIPTION
## Summary
This PR updates all services to use the latest service-base image (v0.0.33) and increments the version numbers of all dependent services accordingly.

## Changes
- Updated all service Containerfiles to use `service-base:v0.0.33` (from v0.0.32)
- Incremented service versions in Makefiles:
  - chatbot-service: v0.0.18 → v0.0.19
  - digitize-service: v0.0.25 → v0.0.26
  - similarity-service: v0.0.11 → v0.0.12
  - summarize-service: v0.0.12 → v0.0.13
- Updated all asset values.yaml files with new service versions across:
  - Individual service assets
  - RAG application assets (podman and openshift variants)

## Files Modified
- Service Containerfiles (4 files)
- Service Makefiles (4 files)
- Asset configuration files (9 files)

## Testing - expect to be covered by the test team during the test
- [ ] Build and test all services with updated base image
- [ ] Verify asset deployments with new versions