### PR TITLE
chore: whitelist CVE-2026-34040 in Trivy scans

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,15 @@
+# Trivy Vulnerability Whitelist
+# CVEs listed here will be ignored during security scans
+
+# CVE-2026-34040 - Moby Authorization Plugin Bypass
+# Severity: CRITICAL | Fixed in: v29.3.1 | Current: v28.5.2
+#
+# Cannot upgrade: Moby v29+ changed module path from github.com/docker/docker 
+# to github.com/moby/moby/v2, but Podman v5 still requires the old path.
+#
+# Risk: LOW - We don't use Docker daemon or client code. Docker is only imported 
+# for type definitions (events.Action, events.Type) via Podman. The vulnerable 
+# AuthZ plugin functionality is not accessible in our codebase.
+#
+# Action: Whitelist until Podman v6 migration (uses new module path)
+CVE-2026-34040


### PR DESCRIPTION
## Summary

This PR whitelists CVE-2026-34040 in Trivy vulnerability scans with proper justification.

## CVE Details

- **CVE ID**: CVE-2026-34040
- **Severity**: CRITICAL
- **Component**: Moby (Docker Engine)
- **Vulnerability**: Authorization plugin bypass
- **Fixed in**: v29.3.1 (released 2026-03-25)
- **Current version**: v28.5.2

## Why We Cannot Upgrade

The fix exists in Moby v29.3.1, but we cannot upgrade due to a **breaking module path change**:

- **Old path** (v28 and below): `github.com/docker/docker`
- **New path** (v29 and above): `github.com/moby/moby/v2`

Our dependency chain:
```
github.com/project-ai-services/ai-services
  └─> github.com/containers/podman/v5@v5.8.2
      └─> github.com/docker/docker/api/types/events
```

Podman v5 still requires the old module path. Upgrading to Podman v6 (which uses the new path) requires significant code refactoring.

## Why the Risk is Low

Despite the CRITICAL severity rating, the actual risk to our application is **LOW**:

1. ✅ **No Docker daemon or client usage** - We use Podman exclusively
2. ✅ **Only type definitions imported** - Docker is imported only for event types via Podman
3. ✅ **Vulnerable functionality not accessible** - The AuthZ plugin system is not used in our codebase
4. ✅ **Build verification passed** - Code compiles and runs correctly

## Changes

- Updated `.trivyignore` to whitelist CVE-2026-34040 with detailed justification
- Documented why upgrade is blocked and why risk is acceptable
- Added action item to resolve when migrating to Podman v6

## Future Action

This will be resolved when we migrate to Podman v6, which is planned as a separate initiative.