### PR TITLE
chore: whitelist Docker/Moby CVEs in Trivy scans

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,15 +1,27 @@
 # Trivy Vulnerability Whitelist
 # CVEs listed here will be ignored during security scans
 
-# CVE-2026-34040 - Moby Authorization Plugin Bypass
-# Severity: CRITICAL | Fixed in: v29.3.1 | Current: v28.5.2
-#
-# Cannot upgrade: Moby v29+ changed module path from github.com/docker/docker 
-# to github.com/moby/moby/v2, but Podman v5 still requires the old path.
-#
-# Risk: LOW - We don't use Docker daemon or client code. Docker is only imported 
-# for type definitions (events.Action, events.Type) via Podman. The vulnerable 
-# AuthZ plugin functionality is not accessible in our codebase.
-#
-# Action: Whitelist until Podman v6 migration (uses new module path)
+# Docker/Moby CVEs - All fixed in v29.3.1, Current: v28.5.2
+# Cannot upgrade: Module path changed from github.com/docker/docker to github.com/moby/moby/v2
+# Podman v5 still requires old path. Will resolve with Podman v6 migration.
+# Risk: LOW - We use Podman exclusively, not Docker daemon. Docker only imported for type definitions.
+
+# CVE-2026-34040 - Authorization Plugin Bypass (CRITICAL)
+# Vulnerable: Docker daemon AuthZ plugin system | Not used in our codebase
 CVE-2026-34040
+
+# CVE-2026-42306 - Docker CP Race Condition (HIGH)
+# Vulnerable: docker cp mount setup | We don't use docker cp command
+CVE-2026-42306
+
+# CVE-2026-41567 - Malicious Image Archive Upload (CRITICAL)
+# Vulnerable: Docker daemon archive upload | We don't use Docker daemon operations
+CVE-2026-41567
+
+# CVE-2026-33997 - Plugin Privilege Validation Bypass (HIGH)
+# Vulnerable: docker plugin install | We don't use Docker plugins
+CVE-2026-33997
+
+# CVE-2026-41568 - Docker CP Mountpoint Race (HIGH)
+# Vulnerable: docker cp mountpoint creation | We don't use docker cp command
+CVE-2026-41568


### PR DESCRIPTION
## Summary

This PR whitelists five Docker/Moby CVEs in Trivy vulnerability scans with proper justification.

## CVEs Whitelisted

All CVEs are fixed in Moby v29.3.1 but we cannot upgrade:

1. **CVE-2026-34040** (CRITICAL) - Authorization plugin bypass
2. **CVE-2026-42306** (HIGH) - Docker cp race condition  
3. **CVE-2026-41567** (CRITICAL) - Malicious image archive upload
4. **CVE-2026-33997** (HIGH) - Plugin privilege validation bypass
5. **CVE-2026-41568** (HIGH) - Docker cp mountpoint creation race

## Why We Cannot Upgrade

Moby v29+ changed the Go module path:
- **Old**: `github.com/docker/docker`
- **New**: `github.com/moby/moby/v2`

Our dependency chain:
```
github.com/project-ai-services/ai-services
  └─> github.com/containers/podman/v5@v5.8.2
      └─> github.com/docker/docker/api/types/events
```

Podman v5 still requires the old module path. Upgrading to Podman v6 requires significant code refactoring.

## Risk Assessment: LOW

Despite CRITICAL/HIGH severity ratings, actual risk is **LOW** because:

✅ **No Docker daemon usage** - We use Podman exclusively  
✅ **Only type definitions imported** - Docker imported for event types via Podman  
✅ **Vulnerable operations not used** - No AuthZ plugins, docker cp, archive uploads, or plugin installs  
✅ **Podman-based infrastructure** - All container operations use Podman bindings API

## Changes

- Optimized `.trivyignore` with concise documentation
- Added all five CVEs with clear justification
- Documented upgrade blocker and risk assessment
- Noted resolution path (Podman v6 migration)

## Future Action

This will be resolved when we migrate to Podman v6, which is planned as a separate initiative.