### PR TITLE
Deploy flow options bug fix

### DIFF
--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,6 +1,6 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.21
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.22
 
 backend:
   port: ""

--- a/ui/catalog/Makefile
+++ b/ui/catalog/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= catalog-ui
-TAG ?= v0.0.21
+TAG ?= v0.0.22
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/catalog/src/components/DeployFlow/DeployFlow.tsx
+++ b/ui/catalog/src/components/DeployFlow/DeployFlow.tsx
@@ -92,17 +92,13 @@ export const DeployFlow = ({ open, onClose, onSubmit }: DeployFlowProps) => {
     setServiceSummaries,
     setServiceSummariesLoading,
     setServiceSummariesError,
-    isServiceSummariesStale,
     providerParams,
     serviceParams,
   } = useDeployStore();
 
   useEffect(() => {
-    // Fetch service summaries if not in store or if cache is stale (older than 15 minutes)
-    const shouldFetch =
-      serviceSummaries.length === 0 || isServiceSummariesStale();
-
-    if (open && shouldFetch) {
+    // Fetch service summaries if not in store
+    if (open && serviceSummaries.length === 0) {
       setServiceSummariesLoading(true);
       fetchServices()
         .then((data) => {
@@ -120,7 +116,6 @@ export const DeployFlow = ({ open, onClose, onSubmit }: DeployFlowProps) => {
   }, [
     open,
     serviceSummaries.length,
-    isServiceSummariesStale,
     setServiceSummaries,
     setServiceSummariesLoading,
     setServiceSummariesError,

--- a/ui/catalog/src/components/DeployFlow/DeployFlow.tsx
+++ b/ui/catalog/src/components/DeployFlow/DeployFlow.tsx
@@ -20,6 +20,7 @@ import { StepTwo } from "./steps/StepTwo";
 import { useDeployOptions } from "@/hooks/useDeployOptions";
 import { useDeployStore } from "@/store/deploy.store";
 import { initializeFormData } from "@/utils/formDataInitializer";
+import { dedupe } from "@/utils/requestManager";
 import styles from "./DeployFlow.module.scss";
 
 const getInitialState = (formData: DeployFormData): DeployFlowState => ({
@@ -92,15 +93,27 @@ export const DeployFlow = ({ open, onClose, onSubmit }: DeployFlowProps) => {
     setServiceSummaries,
     setServiceSummariesLoading,
     setServiceSummariesError,
+    isServiceSummariesStale,
     providerParams,
     serviceParams,
+    initialize,
   } = useDeployStore();
 
+  // Initialize store and validate cache version on mount
   useEffect(() => {
-    // Fetch service summaries if not in store
-    if (open && serviceSummaries.length === 0) {
+    initialize();
+  }, [initialize]);
+
+  useEffect(() => {
+    // Check if cache is stale
+    const isStale = isServiceSummariesStale();
+
+    // Fetch service summaries if not in store or stale
+    // dedupe() handles preventing duplicate in-flight requests
+    if (open && (serviceSummaries.length === 0 || isStale)) {
       setServiceSummariesLoading(true);
-      fetchServices()
+
+      dedupe("serviceSummaries", () => fetchServices())
         .then((data) => {
           setServiceSummaries(data);
         })
@@ -119,6 +132,7 @@ export const DeployFlow = ({ open, onClose, onSubmit }: DeployFlowProps) => {
     setServiceSummaries,
     setServiceSummariesLoading,
     setServiceSummariesError,
+    isServiceSummariesStale,
   ]);
 
   const initialState = useMemo(() => {

--- a/ui/catalog/src/components/DeployFlow/components/ServiceConfigCard.tsx
+++ b/ui/catalog/src/components/DeployFlow/components/ServiceConfigCard.tsx
@@ -696,8 +696,12 @@ export const ServiceConfigCard: React.FC<ServiceConfigCardProps> = ({
                           if (hasValidationError) {
                             setHasValidationError(false);
                           }
+                          // Merge provider params with existing params to preserve service-level params
                           onUpdateConfig({
-                            params,
+                            params: {
+                              ...currentConfig?.params,
+                              ...params,
+                            },
                           });
                         }}
                         providerParamsMap={
@@ -726,8 +730,12 @@ export const ServiceConfigCard: React.FC<ServiceConfigCardProps> = ({
                     if (hasValidationError) {
                       setHasValidationError(false);
                     }
+                    // Merge service-level params with existing params to preserve provider params
                     onUpdateConfig({
-                      params,
+                      params: {
+                        ...currentConfig?.params,
+                        ...params,
+                      },
                     });
                   }}
                   providerParamsMap={{

--- a/ui/catalog/src/components/DeployFlow/components/ServiceConfigCard.tsx
+++ b/ui/catalog/src/components/DeployFlow/components/ServiceConfigCard.tsx
@@ -696,12 +696,34 @@ export const ServiceConfigCard: React.FC<ServiceConfigCardProps> = ({
                           if (hasValidationError) {
                             setHasValidationError(false);
                           }
-                          // Merge provider params with existing params to preserve service-level params
-                          onUpdateConfig({
-                            params: {
-                              ...currentConfig?.params,
-                              ...params,
+                          // Get provider schema keys to know which params belong to provider
+                          const providerSchema =
+                            providerParamsByType[componentType]?.paramsMap?.[
+                              fieldValue || ""
+                            ];
+                          const providerKeys = new Set(
+                            providerSchema?.properties
+                              ? Object.keys(providerSchema.properties)
+                              : [],
+                          );
+
+                          // Preserve service-level params, update only provider params
+                          const mergedParams: Record<string, unknown> = {};
+                          Object.entries(currentConfig?.params || {}).forEach(
+                            ([key, value]) => {
+                              // Keep service-level params (not in provider schema)
+                              if (!providerKeys.has(key)) {
+                                mergedParams[key] = value;
+                              }
                             },
+                          );
+                          // Add/update provider params from DynamicSchemaFields
+                          Object.entries(params).forEach(([key, value]) => {
+                            mergedParams[key] = value;
+                          });
+
+                          onUpdateConfig({
+                            params: mergedParams,
                           });
                         }}
                         providerParamsMap={
@@ -730,12 +752,32 @@ export const ServiceConfigCard: React.FC<ServiceConfigCardProps> = ({
                     if (hasValidationError) {
                       setHasValidationError(false);
                     }
-                    // Merge service-level params with existing params to preserve provider params
-                    onUpdateConfig({
-                      params: {
-                        ...currentConfig?.params,
-                        ...params,
+                    // Get service schema keys to know which params belong to service
+                    const serviceSchemaTyped =
+                      serviceSchema as import("@/utils/schemaParser").JSONSchema;
+                    const serviceKeys = new Set(
+                      serviceSchemaTyped?.properties
+                        ? Object.keys(serviceSchemaTyped.properties)
+                        : [],
+                    );
+
+                    // Preserve provider params, update only service-level params
+                    const mergedParams: Record<string, unknown> = {};
+                    Object.entries(currentConfig?.params || {}).forEach(
+                      ([key, value]) => {
+                        // Keep provider params (not in service schema)
+                        if (!serviceKeys.has(key)) {
+                          mergedParams[key] = value;
+                        }
                       },
+                    );
+                    // Add/update service params from DynamicSchemaFields
+                    Object.entries(params).forEach(([key, value]) => {
+                      mergedParams[key] = value;
+                    });
+
+                    onUpdateConfig({
+                      params: mergedParams,
                     });
                   }}
                   providerParamsMap={{

--- a/ui/catalog/src/components/DeployFlow/components/ServiceConfigCard.tsx
+++ b/ui/catalog/src/components/DeployFlow/components/ServiceConfigCard.tsx
@@ -17,6 +17,7 @@ import { DynamicSchemaFields } from "./DynamicSchemaFields";
 import type { Component } from "@/types/digitalAssistants";
 import { parseSchema, validateField } from "@/utils/schemaParser";
 import { useServiceParams } from "@/hooks/useServiceParams";
+import { shouldShowParam } from "@/utils/paramFilter";
 
 interface ServiceConfigCardProps {
   serviceId: string;
@@ -342,7 +343,7 @@ export const ServiceConfigCard: React.FC<ServiceConfigCardProps> = ({
             if (!schema?.properties) return null;
 
             return Object.entries(componentConfig.params)
-              .filter(([key]) => key !== "model")
+              .filter(([key, value]) => shouldShowParam(key, value, schema))
               .map(([key, value]) => {
                 const property = (
                   schema.properties as Record<
@@ -414,9 +415,10 @@ export const ServiceConfigCard: React.FC<ServiceConfigCardProps> = ({
               // Filter out params that are already shown in service-level schema fields
               const serviceFieldKeys = new Set(serviceFields.map((f) => f.key));
 
+              const excludeKeys = new Set(["model", ...serviceFieldKeys]);
               return Object.entries(config.params)
-                .filter(
-                  ([key]) => key !== "model" && !serviceFieldKeys.has(key),
+                .filter(([key, value]) =>
+                  shouldShowParam(key, value, schema, excludeKeys),
                 )
                 .map(([key, value]) => {
                   const property = (
@@ -659,8 +661,26 @@ export const ServiceConfigCard: React.FC<ServiceConfigCardProps> = ({
                         itemToString={(item) => (item ? item.text : "")}
                         selectedItem={selectedItem}
                         onChange={({ selectedItem }) => {
+                          // Get service-level param keys to preserve (dynamic, backend-driven)
+                          const serviceFieldKeys = new Set(
+                            serviceFields.map((f) => f.key),
+                          );
+
+                          // Preserve only service-level params, clear provider-specific params
+                          const preservedParams: Record<string, unknown> = {};
+                          if (currentConfig?.params) {
+                            Object.entries(currentConfig.params).forEach(
+                              ([key, value]) => {
+                                if (serviceFieldKeys.has(key)) {
+                                  preservedParams[key] = value;
+                                }
+                              },
+                            );
+                          }
+
                           onUpdateConfig({
                             inferenceBackend: selectedItem?.id || "",
+                            params: preservedParams, // Keep service-level, clear provider params
                           });
                         }}
                       />
@@ -677,10 +697,7 @@ export const ServiceConfigCard: React.FC<ServiceConfigCardProps> = ({
                             setHasValidationError(false);
                           }
                           onUpdateConfig({
-                            params: {
-                              ...currentConfig?.params,
-                              ...params,
-                            },
+                            params,
                           });
                         }}
                         providerParamsMap={

--- a/ui/catalog/src/hooks/useDeployOptions.ts
+++ b/ui/catalog/src/hooks/useDeployOptions.ts
@@ -1,11 +1,15 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { useDeployStore } from "@/store/deploy.store";
 import { fetchDeployOptions } from "@/api/digitalAssistants";
+import { dedupe } from "@/utils/requestManager";
 
 /**
  * Custom hook to fetch and cache deploy options
  * Uses Zustand store with 15-minute cache expiration
  * Deploy options can change when service versions or component providers are updated
+ *
+ * Uses request de-duping to prevent race conditions when multiple components
+ * request the same data simultaneously
  */
 export const useDeployOptions = () => {
   const {
@@ -18,8 +22,6 @@ export const useDeployOptions = () => {
     setDeployOptionsLoading,
     setDeployOptionsError,
   } = useDeployStore();
-
-  const hasFetched = useRef(false);
 
   // Determine if we should be in loading state
   // Loading if: no data AND no error AND not currently loading (will start loading in useEffect)
@@ -35,17 +37,15 @@ export const useDeployOptions = () => {
     // Check if cache is stale (older than 15 minutes)
     const isStale = isDeployOptionsStale();
 
-    // Fetch if we don't have data or if cache is stale, and we haven't already started fetching
-    if (
-      (!deployOptions || isStale) &&
-      !hasFetched.current &&
-      !deployOptionsLoading
-    ) {
-      hasFetched.current = true;
+    // Fetch if we don't have data or if cache is stale
+    // dedupe() handles preventing duplicate in-flight requests
+    if ((!deployOptions || isStale) && !deployOptionsLoading) {
       setDeployOptionsLoading(true);
       setDeployOptionsError(null);
 
-      fetchDeployOptions(selectedArchitectureId)
+      // Use dedupe to prevent simultaneous requests
+      const requestKey = `deployOptions:${selectedArchitectureId}`;
+      dedupe(requestKey, () => fetchDeployOptions(selectedArchitectureId))
         .then((data) => {
           setDeployOptions(data);
         })
@@ -55,9 +55,6 @@ export const useDeployOptions = () => {
               ? err.message
               : "Failed to load deploy options";
           setDeployOptionsError(errorMessage);
-        })
-        .finally(() => {
-          hasFetched.current = false;
         });
     }
   }, [

--- a/ui/catalog/src/hooks/useDeployOptions.ts
+++ b/ui/catalog/src/hooks/useDeployOptions.ts
@@ -4,9 +4,12 @@ import { fetchDeployOptions } from "@/api/digitalAssistants";
 import { dedupe } from "@/utils/requestManager";
 
 /**
- * Custom hook to fetch and cache deploy options
- * Uses Zustand store with 15-minute cache expiration
+ * Custom hook to fetch and cache deploy options per architecture
+ * Uses Zustand store with 15-minute cache expiration, keyed by architecture ID
  * Deploy options can change when service versions or component providers are updated
+ *
+ * Cache is architecture-specific: switching architectures will fetch new options
+ * if not already cached or if the cache is stale (>15 minutes old)
  *
  * Uses request de-duping to prevent race conditions when multiple components
  * request the same data simultaneously
@@ -14,7 +17,7 @@ import { dedupe } from "@/utils/requestManager";
 export const useDeployOptions = () => {
   const {
     selectedArchitectureId,
-    deployOptions,
+    getDeployOptions,
     deployOptionsLoading,
     deployOptionsError,
     isDeployOptionsStale,
@@ -22,6 +25,11 @@ export const useDeployOptions = () => {
     setDeployOptionsLoading,
     setDeployOptionsError,
   } = useDeployStore();
+
+  // Get deploy options for the selected architecture
+  const deployOptions = selectedArchitectureId
+    ? getDeployOptions(selectedArchitectureId)
+    : null;
 
   // Determine if we should be in loading state
   // Loading if: no data AND no error AND not currently loading (will start loading in useEffect)
@@ -34,8 +42,8 @@ export const useDeployOptions = () => {
       return;
     }
 
-    // Check if cache is stale (older than 15 minutes)
-    const isStale = isDeployOptionsStale();
+    // Check if cache is stale (older than 15 minutes) for this specific architecture
+    const isStale = isDeployOptionsStale(selectedArchitectureId);
 
     // Fetch if we don't have data or if cache is stale
     // dedupe() handles preventing duplicate in-flight requests
@@ -47,7 +55,7 @@ export const useDeployOptions = () => {
       const requestKey = `deployOptions:${selectedArchitectureId}`;
       dedupe(requestKey, () => fetchDeployOptions(selectedArchitectureId))
         .then((data) => {
-          setDeployOptions(data);
+          setDeployOptions(selectedArchitectureId, data);
         })
         .catch((err) => {
           const errorMessage =
@@ -65,6 +73,7 @@ export const useDeployOptions = () => {
     setDeployOptions,
     setDeployOptionsLoading,
     setDeployOptionsError,
+    getDeployOptions,
   ]);
 
   return {

--- a/ui/catalog/src/hooks/useProviderParams.ts
+++ b/ui/catalog/src/hooks/useProviderParams.ts
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useDeployStore } from "@/store/deploy.store";
 import { fetchProviderParams } from "@/api/digitalAssistants";
+import { dedupe } from "@/utils/requestManager";
 
 interface UseProviderParamsResult {
   params: Record<string, unknown> | null;
@@ -10,7 +11,8 @@ interface UseProviderParamsResult {
 
 /**
  * Hook to fetch and cache provider parameters
- * Uses Zustand store (no cache expiration - fetches only if not in cache)
+ * Uses Zustand store with 1-hour cache expiration
+ * Uses request de-duping to prevent race conditions
  */
 export function useProviderParams(
   componentType: string,
@@ -18,51 +20,61 @@ export function useProviderParams(
 ): UseProviderParamsResult {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const hasFetched = useRef(false);
 
-  const { getProviderParams, setProviderParams } = useDeployStore();
+  const { getProviderParams, setProviderParams, isProviderParamsStale } =
+    useDeployStore();
 
   const params = getProviderParams(componentType, providerId);
 
   useEffect(() => {
-    // Fetch only if we don't have data and haven't already started fetching
-    if (params || hasFetched.current) {
-      return;
+    // Check if cache is stale
+    const isStale = isProviderParamsStale(componentType, providerId);
+
+    // Fetch only if we don't have data or cache is stale
+    // dedupe() handles preventing duplicate in-flight requests per key
+    if (!params || isStale) {
+      const fetchParams = async () => {
+        setIsLoading(true);
+        setError(null);
+
+        try {
+          const requestKey = `providerParams:${componentType}:${providerId}`;
+          const response = await dedupe(requestKey, () =>
+            fetchProviderParams(componentType, providerId),
+          );
+          setProviderParams(componentType, providerId, response);
+        } catch (err) {
+          const errorMessage =
+            err instanceof Error
+              ? err.message
+              : "Failed to fetch provider params";
+          setError(errorMessage);
+          console.error(
+            `Error fetching params for ${componentType}/${providerId}:`,
+            err,
+          );
+        } finally {
+          setIsLoading(false);
+        }
+      };
+
+      fetchParams();
     }
-
-    const fetchParams = async () => {
-      hasFetched.current = true;
-      setIsLoading(true);
-      setError(null);
-
-      try {
-        const response = await fetchProviderParams(componentType, providerId);
-        setProviderParams(componentType, providerId, response);
-      } catch (err) {
-        const errorMessage =
-          err instanceof Error
-            ? err.message
-            : "Failed to fetch provider params";
-        setError(errorMessage);
-        console.error(
-          `Error fetching params for ${componentType}/${providerId}:`,
-          err,
-        );
-      } finally {
-        setIsLoading(false);
-        hasFetched.current = false;
-      }
-    };
-
-    fetchParams();
-  }, [componentType, providerId, params, setProviderParams]);
+  }, [
+    componentType,
+    providerId,
+    params,
+    setProviderParams,
+    isProviderParamsStale,
+  ]);
 
   return { params, isLoading, error };
 }
 
 /**
  * Hook to fetch provider params for multiple providers at once
- * Uses Zustand store (no cache expiration - fetches only if not in cache)
+ * Uses Zustand store with 1-hour cache expiration
+ * Uses request de-duping to prevent race conditions
  */
 export function useBatchProviderParams(
   componentType: string,
@@ -74,9 +86,9 @@ export function useBatchProviderParams(
 } {
   const [isLoading, setIsLoading] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
-  const hasFetched = useRef(false);
 
-  const { getProviderParams, setProviderParams } = useDeployStore();
+  const { getProviderParams, setProviderParams, isProviderParamsStale } =
+    useDeployStore();
 
   // Build params map from cache
   const paramsMap: Record<string, Record<string, unknown>> = {};
@@ -88,13 +100,15 @@ export function useBatchProviderParams(
   }
 
   useEffect(() => {
-    if (hasFetched.current || providerIds.length === 0) {
+    if (providerIds.length === 0) {
       return;
     }
 
-    // Find providers that need fetching (not cached)
+    // Find providers that need fetching (not cached or stale)
     const providersToFetch = providerIds.filter((providerId) => {
-      return !getProviderParams(componentType, providerId);
+      const cached = getProviderParams(componentType, providerId);
+      const isStale = isProviderParamsStale(componentType, providerId);
+      return !cached || isStale;
     });
 
     if (providersToFetch.length === 0) {
@@ -102,13 +116,15 @@ export function useBatchProviderParams(
     }
 
     const fetchAllParams = async () => {
-      hasFetched.current = true;
       setIsLoading(true);
       setErrors({});
 
       const results = await Promise.allSettled(
         providersToFetch.map(async (providerId) => {
-          const response = await fetchProviderParams(componentType, providerId);
+          const requestKey = `providerParams:${componentType}:${providerId}`;
+          const response = await dedupe(requestKey, () =>
+            fetchProviderParams(componentType, providerId),
+          );
           return { providerId, response };
         }),
       );
@@ -134,11 +150,16 @@ export function useBatchProviderParams(
 
       setErrors(newErrors);
       setIsLoading(false);
-      hasFetched.current = false;
     };
 
     fetchAllParams();
-  }, [componentType, providerIds, getProviderParams, setProviderParams]);
+  }, [
+    componentType,
+    providerIds,
+    getProviderParams,
+    setProviderParams,
+    isProviderParamsStale,
+  ]);
 
   return { paramsMap, isLoading, errors };
 }
@@ -146,7 +167,8 @@ export function useBatchProviderParams(
 /**
  * Hook to fetch provider params for multiple component types at once
  * This is the truly dynamic solution that respects Rules of Hooks
- * Uses Zustand store (no cache expiration - fetches only if not in cache)
+ * Uses Zustand store with 1-hour cache expiration
+ * Uses request de-duping to prevent race conditions
  */
 export function useMultiTypeProviderParams(
   componentTypesWithIds: Record<string, string[]>,
@@ -159,9 +181,9 @@ export function useMultiTypeProviderParams(
   const [errorsByType, setErrorsByType] = useState<
     Record<string, Record<string, string>>
   >({});
-  const hasFetched = useRef(false);
 
-  const { getProviderParams, setProviderParams } = useDeployStore();
+  const { getProviderParams, setProviderParams, isProviderParamsStale } =
+    useDeployStore();
 
   // Build params map from cache for all component types
   const paramsByType: Record<
@@ -181,11 +203,11 @@ export function useMultiTypeProviderParams(
   }
 
   useEffect(() => {
-    if (hasFetched.current || Object.keys(componentTypesWithIds).length === 0) {
+    if (Object.keys(componentTypesWithIds).length === 0) {
       return;
     }
 
-    // Find all providers that need fetching (not cached) across all component types
+    // Find all providers that need fetching (not cached or stale) across all component types
     const providersToFetch: Array<{
       componentType: string;
       providerId: string;
@@ -195,7 +217,9 @@ export function useMultiTypeProviderParams(
       componentTypesWithIds,
     )) {
       for (const providerId of providerIds) {
-        if (!getProviderParams(componentType, providerId)) {
+        const cached = getProviderParams(componentType, providerId);
+        const isStale = isProviderParamsStale(componentType, providerId);
+        if (!cached || isStale) {
           providersToFetch.push({ componentType, providerId });
         }
       }
@@ -206,14 +230,15 @@ export function useMultiTypeProviderParams(
     }
 
     const fetchAllParams = async () => {
-      hasFetched.current = true;
       setIsLoading(true);
       setErrorsByType({});
 
-      // Fetch all params in parallel
       const results = await Promise.allSettled(
         providersToFetch.map(async ({ componentType, providerId }) => {
-          const response = await fetchProviderParams(componentType, providerId);
+          const requestKey = `providerParams:${componentType}:${providerId}`;
+          const response = await dedupe(requestKey, () =>
+            fetchProviderParams(componentType, providerId),
+          );
           return { componentType, providerId, response };
         }),
       );
@@ -245,11 +270,15 @@ export function useMultiTypeProviderParams(
 
       setErrorsByType(newErrorsByType);
       setIsLoading(false);
-      hasFetched.current = false;
     };
 
     fetchAllParams();
-  }, [componentTypesWithIds, getProviderParams, setProviderParams]);
+  }, [
+    componentTypesWithIds,
+    getProviderParams,
+    setProviderParams,
+    isProviderParamsStale,
+  ]);
 
   return { paramsByType, isLoading, errorsByType };
 }

--- a/ui/catalog/src/hooks/useProviderParams.ts
+++ b/ui/catalog/src/hooks/useProviderParams.ts
@@ -10,8 +10,7 @@ interface UseProviderParamsResult {
 
 /**
  * Hook to fetch and cache provider parameters
- * Uses Zustand store with 15-minute cache expiration
- * Provider params can change when provider definitions are updated
+ * Uses Zustand store (no cache expiration - fetches only if not in cache)
  */
 export function useProviderParams(
   componentType: string,
@@ -21,25 +20,13 @@ export function useProviderParams(
   const [error, setError] = useState<string | null>(null);
   const hasFetched = useRef(false);
 
-  const { getProviderParams, setProviderParams, isProviderParamsStale } =
-    useDeployStore();
+  const { getProviderParams, setProviderParams } = useDeployStore();
 
   const params = getProviderParams(componentType, providerId);
-  const isStale = isProviderParamsStale(componentType, providerId);
 
   useEffect(() => {
-    // Fetch if we don't have data or if cache is stale, and we haven't already started fetching
-    if ((!params && !isStale) || hasFetched.current) {
-      return;
-    }
-
-    // Only fetch if stale or missing
-    if (!params || isStale) {
-      // Skip if already fetching
-      if (hasFetched.current) {
-        return;
-      }
-    } else {
+    // Fetch only if we don't have data and haven't already started fetching
+    if (params || hasFetched.current) {
       return;
     }
 
@@ -68,15 +55,14 @@ export function useProviderParams(
     };
 
     fetchParams();
-  }, [componentType, providerId, params, isStale, setProviderParams]);
+  }, [componentType, providerId, params, setProviderParams]);
 
   return { params, isLoading, error };
 }
 
 /**
  * Hook to fetch provider params for multiple providers at once
- * Uses Zustand store with 15-minute cache expiration
- * Provider params can change when provider definitions are updated
+ * Uses Zustand store (no cache expiration - fetches only if not in cache)
  */
 export function useBatchProviderParams(
   componentType: string,
@@ -90,8 +76,7 @@ export function useBatchProviderParams(
   const [errors, setErrors] = useState<Record<string, string>>({});
   const hasFetched = useRef(false);
 
-  const { getProviderParams, setProviderParams, isProviderParamsStale } =
-    useDeployStore();
+  const { getProviderParams, setProviderParams } = useDeployStore();
 
   // Build params map from cache
   const paramsMap: Record<string, Record<string, unknown>> = {};
@@ -107,9 +92,9 @@ export function useBatchProviderParams(
       return;
     }
 
-    // Find providers that need fetching (not cached or stale)
+    // Find providers that need fetching (not cached)
     const providersToFetch = providerIds.filter((providerId) => {
-      return isProviderParamsStale(componentType, providerId);
+      return !getProviderParams(componentType, providerId);
     });
 
     if (providersToFetch.length === 0) {
@@ -153,13 +138,7 @@ export function useBatchProviderParams(
     };
 
     fetchAllParams();
-  }, [
-    componentType,
-    providerIds,
-    getProviderParams,
-    setProviderParams,
-    isProviderParamsStale,
-  ]);
+  }, [componentType, providerIds, getProviderParams, setProviderParams]);
 
   return { paramsMap, isLoading, errors };
 }
@@ -167,8 +146,7 @@ export function useBatchProviderParams(
 /**
  * Hook to fetch provider params for multiple component types at once
  * This is the truly dynamic solution that respects Rules of Hooks
- * Uses Zustand store with 15-minute cache expiration
- * Provider params can change when provider definitions are updated
+ * Uses Zustand store (no cache expiration - fetches only if not in cache)
  */
 export function useMultiTypeProviderParams(
   componentTypesWithIds: Record<string, string[]>,
@@ -183,8 +161,7 @@ export function useMultiTypeProviderParams(
   >({});
   const hasFetched = useRef(false);
 
-  const { getProviderParams, setProviderParams, isProviderParamsStale } =
-    useDeployStore();
+  const { getProviderParams, setProviderParams } = useDeployStore();
 
   // Build params map from cache for all component types
   const paramsByType: Record<
@@ -208,7 +185,7 @@ export function useMultiTypeProviderParams(
       return;
     }
 
-    // Find all providers that need fetching (not cached or stale) across all component types
+    // Find all providers that need fetching (not cached) across all component types
     const providersToFetch: Array<{
       componentType: string;
       providerId: string;
@@ -218,7 +195,7 @@ export function useMultiTypeProviderParams(
       componentTypesWithIds,
     )) {
       for (const providerId of providerIds) {
-        if (isProviderParamsStale(componentType, providerId)) {
+        if (!getProviderParams(componentType, providerId)) {
           providersToFetch.push({ componentType, providerId });
         }
       }
@@ -272,12 +249,7 @@ export function useMultiTypeProviderParams(
     };
 
     fetchAllParams();
-  }, [
-    componentTypesWithIds,
-    getProviderParams,
-    setProviderParams,
-    isProviderParamsStale,
-  ]);
+  }, [componentTypesWithIds, getProviderParams, setProviderParams]);
 
   return { paramsByType, isLoading, errorsByType };
 }

--- a/ui/catalog/src/hooks/useServiceParams.ts
+++ b/ui/catalog/src/hooks/useServiceParams.ts
@@ -10,19 +10,16 @@ interface UseServiceParamsResult {
 
 /**
  * Hook to fetch and cache service-level parameters
- * Uses Zustand store with 15-minute cache expiration
- * Service params can change when service definitions are updated
+ * Uses Zustand store (no cache expiration - fetches only if not in cache)
  */
 export function useServiceParams(serviceId: string): UseServiceParamsResult {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const hasFetched = useRef(false);
 
-  const { getServiceParams, setServiceParams, isServiceParamsStale } =
-    useDeployStore();
+  const { getServiceParams, setServiceParams } = useDeployStore();
 
   const params = getServiceParams(serviceId);
-  const isStale = isServiceParamsStale(serviceId);
 
   useEffect(() => {
     // Don't fetch if no serviceId
@@ -30,8 +27,8 @@ export function useServiceParams(serviceId: string): UseServiceParamsResult {
       return;
     }
 
-    // Fetch if we don't have data or if cache is stale, and we haven't already started fetching
-    if ((params && !isStale) || hasFetched.current) {
+    // Fetch only if we don't have data and haven't already started fetching
+    if (params || hasFetched.current) {
       return;
     }
 
@@ -55,7 +52,7 @@ export function useServiceParams(serviceId: string): UseServiceParamsResult {
     };
 
     fetchParams();
-  }, [serviceId, params, isStale, setServiceParams]);
+  }, [serviceId, params, setServiceParams]);
 
   return { params, isLoading, error };
 }

--- a/ui/catalog/src/hooks/useServiceParams.ts
+++ b/ui/catalog/src/hooks/useServiceParams.ts
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useDeployStore } from "@/store/deploy.store";
 import { fetchServiceParams } from "@/api/digitalAssistants";
+import { dedupe } from "@/utils/requestManager";
 
 interface UseServiceParamsResult {
   params: Record<string, unknown> | null;
@@ -10,14 +11,15 @@ interface UseServiceParamsResult {
 
 /**
  * Hook to fetch and cache service-level parameters
- * Uses Zustand store (no cache expiration - fetches only if not in cache)
+ * Uses Zustand store with 1-hour cache expiration
+ * Uses request de-duping to prevent race conditions
  */
 export function useServiceParams(serviceId: string): UseServiceParamsResult {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const hasFetched = useRef(false);
 
-  const { getServiceParams, setServiceParams } = useDeployStore();
+  const { getServiceParams, setServiceParams, isServiceParamsStale } =
+    useDeployStore();
 
   const params = getServiceParams(serviceId);
 
@@ -27,32 +29,37 @@ export function useServiceParams(serviceId: string): UseServiceParamsResult {
       return;
     }
 
-    // Fetch only if we don't have data and haven't already started fetching
-    if (params || hasFetched.current) {
-      return;
+    // Check if cache is stale
+    const isStale = isServiceParamsStale(serviceId);
+
+    // Fetch only if we don't have data or cache is stale
+    // dedupe() handles preventing duplicate in-flight requests
+    if (!params || isStale) {
+      const fetchParams = async () => {
+        setIsLoading(true);
+        setError(null);
+
+        try {
+          const requestKey = `serviceParams:${serviceId}`;
+          const response = await dedupe(requestKey, () =>
+            fetchServiceParams(serviceId),
+          );
+          setServiceParams(serviceId, response);
+        } catch (err) {
+          const errorMessage =
+            err instanceof Error
+              ? err.message
+              : "Failed to fetch service params";
+          setError(errorMessage);
+          console.error(`Error fetching params for service ${serviceId}:`, err);
+        } finally {
+          setIsLoading(false);
+        }
+      };
+
+      fetchParams();
     }
-
-    const fetchParams = async () => {
-      hasFetched.current = true;
-      setIsLoading(true);
-      setError(null);
-
-      try {
-        const response = await fetchServiceParams(serviceId);
-        setServiceParams(serviceId, response);
-      } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : "Failed to fetch service params";
-        setError(errorMessage);
-        console.error(`Error fetching params for service ${serviceId}:`, err);
-      } finally {
-        setIsLoading(false);
-        hasFetched.current = false;
-      }
-    };
-
-    fetchParams();
-  }, [serviceId, params, setServiceParams]);
+  }, [serviceId, params, setServiceParams, isServiceParamsStale]);
 
   return { params, isLoading, error };
 }

--- a/ui/catalog/src/pages/DigitalAssistants/DigitalAssistants.tsx
+++ b/ui/catalog/src/pages/DigitalAssistants/DigitalAssistants.tsx
@@ -563,7 +563,7 @@ const DigitalAssistantsPage = () => {
                             {noApplications && (
                               <NoDataEmptyState
                                 title="Start by adding a digital assistant"
-                                subtitle="To deploy a digital assistant using a template, click Deploy."
+                                subtitle="To deploy a digital assistant, click Deploy."
                                 className={styles.noDataContent}
                               />
                             )}
@@ -620,7 +620,7 @@ const DigitalAssistantsPage = () => {
                     onRequestSubmit={handleDelete}
                   >
                     <p>
-                      Deleting an digital assistant deployment permanently
+                      Deleting a digital assistant deployment permanently
                       deletes all associated components, including connected
                       services, runtime metadata, and configurations will be
                       permanently deleted, and it cannot be undone.

--- a/ui/catalog/src/pages/DigitalAssistants/components/AboutTab.tsx
+++ b/ui/catalog/src/pages/DigitalAssistants/components/AboutTab.tsx
@@ -4,6 +4,7 @@ import { Deploy, Code, PlayOutline } from "@carbon/icons-react";
 import styles from "../DigitalAssistants.module.scss";
 import { useDeployStore } from "@/store/deploy.store";
 import { fetchArchitectureDetails } from "@/api/digitalAssistants";
+import { dedupe } from "@/utils/requestManager";
 import type { AboutSection } from "@/types/digitalAssistants";
 
 interface AboutTabProps {
@@ -32,6 +33,9 @@ export const AboutTab: React.FC<AboutTabProps> = ({ onDeployClick }) => {
   const setArchitectureDetailsError = useDeployStore(
     (state) => state.setArchitectureDetailsError,
   );
+  const isArchitectureDetailsStale = useDeployStore(
+    (state) => state.isArchitectureDetailsStale,
+  );
 
   useEffect(() => {
     const loadArchitectureDetails = async () => {
@@ -42,11 +46,18 @@ export const AboutTab: React.FC<AboutTabProps> = ({ onDeployClick }) => {
         architectureDetails &&
         architectureDetails.id === selectedArchitectureId;
 
-      // Fetch if we don't have data for this architecture
-      if (!hasCorrectData) {
+      // Check if cache is stale
+      const isStale = isArchitectureDetailsStale();
+
+      // Fetch if we don't have data for this architecture or cache is stale
+      // dedupe() handles preventing duplicate in-flight requests
+      if (!hasCorrectData || isStale) {
         setArchitectureDetailsLoading(true);
         try {
-          const data = await fetchArchitectureDetails(selectedArchitectureId);
+          const requestKey = `architectureDetails:${selectedArchitectureId}`;
+          const data = await dedupe(requestKey, () =>
+            fetchArchitectureDetails(selectedArchitectureId),
+          );
           setArchitectureDetails(data);
         } catch (error) {
           const errorMessage =
@@ -65,6 +76,7 @@ export const AboutTab: React.FC<AboutTabProps> = ({ onDeployClick }) => {
     setArchitectureDetails,
     setArchitectureDetailsLoading,
     setArchitectureDetailsError,
+    isArchitectureDetailsStale,
   ]);
 
   // Generic section renderer - renders sections based on their structure

--- a/ui/catalog/src/pages/DigitalAssistants/components/AboutTab.tsx
+++ b/ui/catalog/src/pages/DigitalAssistants/components/AboutTab.tsx
@@ -32,22 +32,18 @@ export const AboutTab: React.FC<AboutTabProps> = ({ onDeployClick }) => {
   const setArchitectureDetailsError = useDeployStore(
     (state) => state.setArchitectureDetailsError,
   );
-  const isArchitectureDetailsStale = useDeployStore(
-    (state) => state.isArchitectureDetailsStale,
-  );
 
   useEffect(() => {
     const loadArchitectureDetails = async () => {
       if (!selectedArchitectureId) return;
 
-      // Check if we have data for this architecture and if it's stale
+      // Check if we have data for this architecture
       const hasCorrectData =
         architectureDetails &&
         architectureDetails.id === selectedArchitectureId;
-      const isStale = isArchitectureDetailsStale();
 
-      // Fetch if we don't have data for this architecture or if cache is stale (older than 15 minutes)
-      if (!hasCorrectData || isStale) {
+      // Fetch if we don't have data for this architecture
+      if (!hasCorrectData) {
         setArchitectureDetailsLoading(true);
         try {
           const data = await fetchArchitectureDetails(selectedArchitectureId);
@@ -66,7 +62,6 @@ export const AboutTab: React.FC<AboutTabProps> = ({ onDeployClick }) => {
   }, [
     selectedArchitectureId,
     architectureDetails,
-    isArchitectureDetailsStale,
     setArchitectureDetails,
     setArchitectureDetailsLoading,
     setArchitectureDetailsError,

--- a/ui/catalog/src/services/auth.ts
+++ b/ui/catalog/src/services/auth.ts
@@ -11,13 +11,10 @@ export const login = async (payload: LoginRequest): Promise<LoginResponse> => {
   const refreshToken = response.data.refresh_token;
   useAuthStore.getState().setTokens(accessToken, refreshToken);
 
-  // Fetch architectures if not in store or if cache is stale (older than 15 minutes)
+  // Fetch architectures if not in store
   const deployStore = useDeployStore.getState();
-  const shouldFetchArchitectures =
-    deployStore.architectures.length === 0 ||
-    deployStore.isArchitecturesStale();
 
-  if (shouldFetchArchitectures) {
+  if (deployStore.architectures.length === 0) {
     try {
       deployStore.setArchitecturesLoading(true);
       const architectures = await fetchArchitectures();

--- a/ui/catalog/src/store/deploy.store.ts
+++ b/ui/catalog/src/store/deploy.store.ts
@@ -10,24 +10,31 @@ import type {
 
 interface ProviderParamsCache {
   data: Record<string, unknown>;
+  fetchedAt: number;
 }
 
 interface DeployState {
-  // Architectures - persisted (no cache expiration)
+  // Cache version for invalidating stale schemas
+  cacheVersion: string;
+
+  // Architectures - persisted with 30-minute cache
   architectures: ArchitectureSummary[];
   selectedArchitectureId: string | null;
   architecturesLoading: boolean;
   architecturesError: string | null;
+  architecturesFetchedAt: number | null;
 
-  // Services - persisted (no cache expiration)
+  // Services - persisted with 30-minute cache
   serviceSummaries: ServiceSummary[];
   serviceSummariesLoading: boolean;
   serviceSummariesError: string | null;
+  serviceSummariesFetchedAt: number | null;
 
-  // Architecture details - persisted (no cache expiration)
+  // Architecture details - persisted with 30-minute cache
   architectureDetails: ArchitectureDetailsResponse | null;
   architectureDetailsLoading: boolean;
   architectureDetailsError: string | null;
+  architectureDetailsFetchedAt: number | null;
 
   // Deploy options - persisted with 15-minute cache
   deployOptions: DeployOptionsResponse | null;
@@ -41,10 +48,10 @@ interface DeployState {
   resourcesError: string | null;
   resourcesFetchedAt: number | null;
 
-  // Provider params cache - persisted (no cache expiration)
+  // Provider params cache - persisted with 1-hour cache
   providerParams: Record<string, ProviderParamsCache>;
 
-  // Service params cache - persisted (no cache expiration)
+  // Service params cache - persisted with 1-hour cache
   serviceParams: Record<string, ProviderParamsCache>;
 
   // Architecture actions
@@ -96,35 +103,55 @@ interface DeployState {
   getServiceParams: (serviceId: string) => Record<string, unknown> | null;
   clearServiceParams: () => void;
 
-  // Check if cache is stale (only for deployOptions and resources)
+  // Check if cache is stale
+  isArchitecturesStale: () => boolean;
+  isServiceSummariesStale: () => boolean;
+  isArchitectureDetailsStale: () => boolean;
   isDeployOptionsStale: () => boolean;
   isResourcesStale: () => boolean;
+  isProviderParamsStale: (componentType: string, providerId: string) => boolean;
+  isServiceParamsStale: (serviceId: string) => boolean;
 
   // Clear all deploy store data
   clearAll: () => void;
+
+  // Initialize store and validate cache version
+  initialize: () => void;
 }
 
-const CACHE_DURATION = 15 * 60 * 1000; // 15 minutes
+// Cache version - increment when making breaking changes to cached data structure
+const CACHE_VERSION = "1.0.0";
+
+// Cache durations
+const CATALOG_CACHE_DURATION = 30 * 60 * 1000; // 30 minutes for catalog metadata
+const DEPLOY_OPTIONS_CACHE_DURATION = 15 * 60 * 1000; // 15 minutes for deploy options
+const PARAMS_CACHE_DURATION = 60 * 60 * 1000; // 1 hour for provider/service params
 const RESOURCES_CACHE_DURATION = 5 * 60 * 1000; // 5 minutes for resources (dynamic data)
 
 export const useDeployStore = create<DeployState>()(
   persist(
     (set, get) => ({
+      // Cache version
+      cacheVersion: CACHE_VERSION,
+
       // Architectures state
       architectures: [],
       selectedArchitectureId: null,
       architecturesLoading: false,
       architecturesError: null,
+      architecturesFetchedAt: null,
 
       // Service summaries state
       serviceSummaries: [],
       serviceSummariesLoading: false,
       serviceSummariesError: null,
+      serviceSummariesFetchedAt: null,
 
       // Architecture details state
       architectureDetails: null,
       architectureDetailsLoading: false,
       architectureDetailsError: null,
+      architectureDetailsFetchedAt: null,
 
       // Deploy options state
       deployOptions: null,
@@ -151,6 +178,7 @@ export const useDeployStore = create<DeployState>()(
           selectedArchitectureId: data.length > 0 ? data[0].id : null,
           architecturesError: null,
           architecturesLoading: false,
+          architecturesFetchedAt: Date.now(),
         }),
 
       setSelectedArchitectureId: (id) => set({ selectedArchitectureId: id }),
@@ -174,6 +202,7 @@ export const useDeployStore = create<DeployState>()(
           serviceSummaries: data,
           serviceSummariesError: null,
           serviceSummariesLoading: false,
+          serviceSummariesFetchedAt: Date.now(),
         }),
 
       setServiceSummariesLoading: (loading) =>
@@ -191,6 +220,7 @@ export const useDeployStore = create<DeployState>()(
         set({
           serviceSummaries: [],
           serviceSummariesError: null,
+          serviceSummariesFetchedAt: null,
         }),
 
       // Architecture details actions
@@ -199,6 +229,7 @@ export const useDeployStore = create<DeployState>()(
           architectureDetails: data,
           architectureDetailsError: null,
           architectureDetailsLoading: false,
+          architectureDetailsFetchedAt: Date.now(),
         }),
 
       setArchitectureDetailsLoading: (loading) =>
@@ -214,6 +245,7 @@ export const useDeployStore = create<DeployState>()(
         set({
           architectureDetails: null,
           architectureDetailsError: null,
+          architectureDetailsFetchedAt: null,
         }),
 
       // Deploy options actions
@@ -267,6 +299,7 @@ export const useDeployStore = create<DeployState>()(
             ...state.providerParams,
             [key]: {
               data,
+              fetchedAt: Date.now(),
             },
           },
         }));
@@ -287,6 +320,7 @@ export const useDeployStore = create<DeployState>()(
             ...state.serviceParams,
             [serviceId]: {
               data,
+              fetchedAt: Date.now(),
             },
           },
         }));
@@ -299,12 +333,34 @@ export const useDeployStore = create<DeployState>()(
 
       clearServiceParams: () => set({ serviceParams: {} }),
 
-      // Cache staleness checks (only for deployOptions and resources)
+      // Cache staleness checks
+
+      isArchitecturesStale: () => {
+        const { architecturesFetchedAt } = get();
+        if (!architecturesFetchedAt) return true;
+        return Date.now() - architecturesFetchedAt > CATALOG_CACHE_DURATION;
+      },
+
+      isServiceSummariesStale: () => {
+        const { serviceSummariesFetchedAt } = get();
+        if (!serviceSummariesFetchedAt) return true;
+        return Date.now() - serviceSummariesFetchedAt > CATALOG_CACHE_DURATION;
+      },
+
+      isArchitectureDetailsStale: () => {
+        const { architectureDetailsFetchedAt } = get();
+        if (!architectureDetailsFetchedAt) return true;
+        return (
+          Date.now() - architectureDetailsFetchedAt > CATALOG_CACHE_DURATION
+        );
+      },
 
       isDeployOptionsStale: () => {
         const { deployOptionsFetchedAt } = get();
         if (!deployOptionsFetchedAt) return true;
-        return Date.now() - deployOptionsFetchedAt > CACHE_DURATION;
+        return (
+          Date.now() - deployOptionsFetchedAt > DEPLOY_OPTIONS_CACHE_DURATION
+        );
       },
 
       isResourcesStale: () => {
@@ -313,16 +369,33 @@ export const useDeployStore = create<DeployState>()(
         return Date.now() - resourcesFetchedAt > RESOURCES_CACHE_DURATION;
       },
 
+      isProviderParamsStale: (componentType, providerId) => {
+        const key = `${componentType}:${providerId}`;
+        const cached = get().providerParams[key];
+        if (!cached || !cached.fetchedAt) return true;
+        return Date.now() - cached.fetchedAt > PARAMS_CACHE_DURATION;
+      },
+
+      isServiceParamsStale: (serviceId) => {
+        const cached = get().serviceParams[serviceId];
+        if (!cached || !cached.fetchedAt) return true;
+        return Date.now() - cached.fetchedAt > PARAMS_CACHE_DURATION;
+      },
+
       // Clear all deploy store data
       clearAll: () => {
         set({
+          cacheVersion: CACHE_VERSION,
           architectures: [],
           selectedArchitectureId: null,
           architecturesError: null,
+          architecturesFetchedAt: null,
           serviceSummaries: [],
           serviceSummariesError: null,
+          serviceSummariesFetchedAt: null,
           architectureDetails: null,
           architectureDetailsError: null,
+          architectureDetailsFetchedAt: null,
           deployOptions: null,
           deployOptionsError: null,
           deployOptionsFetchedAt: null,
@@ -333,21 +406,61 @@ export const useDeployStore = create<DeployState>()(
           serviceParams: {},
         });
       },
+
+      // Initialize store and validate cache version at runtime
+      initialize: () => {
+        const state = get();
+        // If cache version doesn't match current version, clear all cached data
+        // This handles cases where the app is updated without a page reload
+        if (state.cacheVersion !== CACHE_VERSION) {
+          console.warn(
+            `Cache version mismatch: expected ${CACHE_VERSION}, found ${state.cacheVersion}. Clearing cache.`,
+          );
+          get().clearAll();
+        }
+      },
     }),
     {
       name: "deploy-storage",
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
-        // Persist configuration data (only deployOptions has cache expiration)
+        // Persist configuration data with timestamps for cache invalidation
+        cacheVersion: state.cacheVersion,
         architectures: state.architectures,
         selectedArchitectureId: state.selectedArchitectureId,
+        architecturesFetchedAt: state.architecturesFetchedAt,
         serviceSummaries: state.serviceSummaries,
+        serviceSummariesFetchedAt: state.serviceSummariesFetchedAt,
         architectureDetails: state.architectureDetails,
+        architectureDetailsFetchedAt: state.architectureDetailsFetchedAt,
         deployOptions: state.deployOptions,
         deployOptionsFetchedAt: state.deployOptionsFetchedAt,
         providerParams: state.providerParams,
         serviceParams: state.serviceParams,
       }),
+      // Version check: clear cache if version mismatch
+      version: 1,
+      migrate: (persistedState: unknown) => {
+        // If cache version doesn't match, clear all cached data
+        const state = persistedState as { cacheVersion?: string } | null;
+        if (state?.cacheVersion !== CACHE_VERSION) {
+          return {
+            cacheVersion: CACHE_VERSION,
+            architectures: [],
+            selectedArchitectureId: null,
+            architecturesFetchedAt: null,
+            serviceSummaries: [],
+            serviceSummariesFetchedAt: null,
+            architectureDetails: null,
+            architectureDetailsFetchedAt: null,
+            deployOptions: null,
+            deployOptionsFetchedAt: null,
+            providerParams: {},
+            serviceParams: {},
+          };
+        }
+        return persistedState;
+      },
     },
   ),
 );

--- a/ui/catalog/src/store/deploy.store.ts
+++ b/ui/catalog/src/store/deploy.store.ts
@@ -13,6 +13,11 @@ interface ProviderParamsCache {
   fetchedAt: number;
 }
 
+interface DeployOptionsCache {
+  data: DeployOptionsResponse;
+  fetchedAt: number;
+}
+
 interface DeployState {
   // Cache version for invalidating stale schemas
   cacheVersion: string;
@@ -36,11 +41,10 @@ interface DeployState {
   architectureDetailsError: string | null;
   architectureDetailsFetchedAt: number | null;
 
-  // Deploy options - persisted with 15-minute cache
-  deployOptions: DeployOptionsResponse | null;
+  // Deploy options - persisted with 15-minute cache, keyed by architecture ID
+  deployOptions: Record<string, DeployOptionsCache>;
   deployOptionsLoading: boolean;
   deployOptionsError: string | null;
-  deployOptionsFetchedAt: number | null;
 
   // Resources cache - not persisted (dynamic data)
   resources: ResourcesResponse | null;
@@ -75,7 +79,11 @@ interface DeployState {
   clearArchitectureDetails: () => void;
 
   // Deploy options actions
-  setDeployOptions: (data: DeployOptionsResponse) => void;
+  setDeployOptions: (
+    architectureId: string,
+    data: DeployOptionsResponse,
+  ) => void;
+  getDeployOptions: (architectureId: string) => DeployOptionsResponse | null;
   setDeployOptionsLoading: (loading: boolean) => void;
   setDeployOptionsError: (error: string | null) => void;
   clearDeployOptions: () => void;
@@ -107,7 +115,7 @@ interface DeployState {
   isArchitecturesStale: () => boolean;
   isServiceSummariesStale: () => boolean;
   isArchitectureDetailsStale: () => boolean;
-  isDeployOptionsStale: () => boolean;
+  isDeployOptionsStale: (architectureId: string) => boolean;
   isResourcesStale: () => boolean;
   isProviderParamsStale: (componentType: string, providerId: string) => boolean;
   isServiceParamsStale: (serviceId: string) => boolean;
@@ -154,10 +162,9 @@ export const useDeployStore = create<DeployState>()(
       architectureDetailsFetchedAt: null,
 
       // Deploy options state
-      deployOptions: null,
+      deployOptions: {},
       deployOptionsLoading: false,
       deployOptionsError: null,
-      deployOptionsFetchedAt: null,
 
       // Resources state
       resources: null,
@@ -249,13 +256,23 @@ export const useDeployStore = create<DeployState>()(
         }),
 
       // Deploy options actions
-      setDeployOptions: (data) =>
-        set({
-          deployOptions: data,
+      setDeployOptions: (architectureId, data) =>
+        set((state) => ({
+          deployOptions: {
+            ...state.deployOptions,
+            [architectureId]: {
+              data,
+              fetchedAt: Date.now(),
+            },
+          },
           deployOptionsError: null,
-          deployOptionsFetchedAt: Date.now(),
           deployOptionsLoading: false,
-        }),
+        })),
+
+      getDeployOptions: (architectureId) => {
+        const cached = get().deployOptions[architectureId];
+        return cached ? cached.data : null;
+      },
 
       setDeployOptionsLoading: (loading) =>
         set({ deployOptionsLoading: loading }),
@@ -265,9 +282,8 @@ export const useDeployStore = create<DeployState>()(
 
       clearDeployOptions: () =>
         set({
-          deployOptions: null,
+          deployOptions: {},
           deployOptionsError: null,
-          deployOptionsFetchedAt: null,
         }),
 
       // Resources actions
@@ -355,12 +371,10 @@ export const useDeployStore = create<DeployState>()(
         );
       },
 
-      isDeployOptionsStale: () => {
-        const { deployOptionsFetchedAt } = get();
-        if (!deployOptionsFetchedAt) return true;
-        return (
-          Date.now() - deployOptionsFetchedAt > DEPLOY_OPTIONS_CACHE_DURATION
-        );
+      isDeployOptionsStale: (architectureId) => {
+        const cached = get().deployOptions[architectureId];
+        if (!cached || !cached.fetchedAt) return true;
+        return Date.now() - cached.fetchedAt > DEPLOY_OPTIONS_CACHE_DURATION;
       },
 
       isResourcesStale: () => {
@@ -396,9 +410,8 @@ export const useDeployStore = create<DeployState>()(
           architectureDetails: null,
           architectureDetailsError: null,
           architectureDetailsFetchedAt: null,
-          deployOptions: null,
+          deployOptions: {},
           deployOptionsError: null,
-          deployOptionsFetchedAt: null,
           resources: null,
           resourcesError: null,
           resourcesFetchedAt: null,
@@ -434,7 +447,6 @@ export const useDeployStore = create<DeployState>()(
         architectureDetails: state.architectureDetails,
         architectureDetailsFetchedAt: state.architectureDetailsFetchedAt,
         deployOptions: state.deployOptions,
-        deployOptionsFetchedAt: state.deployOptionsFetchedAt,
         providerParams: state.providerParams,
         serviceParams: state.serviceParams,
       }),
@@ -453,8 +465,7 @@ export const useDeployStore = create<DeployState>()(
             serviceSummariesFetchedAt: null,
             architectureDetails: null,
             architectureDetailsFetchedAt: null,
-            deployOptions: null,
-            deployOptionsFetchedAt: null,
+            deployOptions: {},
             providerParams: {},
             serviceParams: {},
           };

--- a/ui/catalog/src/store/deploy.store.ts
+++ b/ui/catalog/src/store/deploy.store.ts
@@ -10,28 +10,24 @@ import type {
 
 interface ProviderParamsCache {
   data: Record<string, unknown>;
-  fetchedAt: number;
 }
 
 interface DeployState {
-  // Architectures - persisted with 15-minute cache
+  // Architectures - persisted (no cache expiration)
   architectures: ArchitectureSummary[];
   selectedArchitectureId: string | null;
   architecturesLoading: boolean;
   architecturesError: string | null;
-  architecturesFetchedAt: number | null;
 
-  // Services - persisted with 15-minute cache
+  // Services - persisted (no cache expiration)
   serviceSummaries: ServiceSummary[];
   serviceSummariesLoading: boolean;
   serviceSummariesError: string | null;
-  serviceSummariesFetchedAt: number | null;
 
-  // Architecture details - persisted with 15-minute cache
+  // Architecture details - persisted (no cache expiration)
   architectureDetails: ArchitectureDetailsResponse | null;
   architectureDetailsLoading: boolean;
   architectureDetailsError: string | null;
-  architectureDetailsFetchedAt: number | null;
 
   // Deploy options - persisted with 15-minute cache
   deployOptions: DeployOptionsResponse | null;
@@ -45,10 +41,10 @@ interface DeployState {
   resourcesError: string | null;
   resourcesFetchedAt: number | null;
 
-  // Provider params cache - persisted (configuration data)
+  // Provider params cache - persisted (no cache expiration)
   providerParams: Record<string, ProviderParamsCache>;
 
-  // Service params cache - persisted (configuration data)
+  // Service params cache - persisted (no cache expiration)
   serviceParams: Record<string, ProviderParamsCache>;
 
   // Architecture actions
@@ -100,13 +96,8 @@ interface DeployState {
   getServiceParams: (serviceId: string) => Record<string, unknown> | null;
   clearServiceParams: () => void;
 
-  // Check if cache is stale (older than 15 minutes)
-  isArchitecturesStale: () => boolean;
-  isServiceSummariesStale: () => boolean;
-  isArchitectureDetailsStale: () => boolean;
+  // Check if cache is stale (only for deployOptions and resources)
   isDeployOptionsStale: () => boolean;
-  isProviderParamsStale: (componentType: string, providerId: string) => boolean;
-  isServiceParamsStale: (serviceId: string) => boolean;
   isResourcesStale: () => boolean;
 
   // Clear all deploy store data
@@ -124,19 +115,16 @@ export const useDeployStore = create<DeployState>()(
       selectedArchitectureId: null,
       architecturesLoading: false,
       architecturesError: null,
-      architecturesFetchedAt: null,
 
       // Service summaries state
       serviceSummaries: [],
       serviceSummariesLoading: false,
       serviceSummariesError: null,
-      serviceSummariesFetchedAt: null,
 
       // Architecture details state
       architectureDetails: null,
       architectureDetailsLoading: false,
       architectureDetailsError: null,
-      architectureDetailsFetchedAt: null,
 
       // Deploy options state
       deployOptions: null,
@@ -162,7 +150,6 @@ export const useDeployStore = create<DeployState>()(
           architectures: data,
           selectedArchitectureId: data.length > 0 ? data[0].id : null,
           architecturesError: null,
-          architecturesFetchedAt: Date.now(),
           architecturesLoading: false,
         }),
 
@@ -179,7 +166,6 @@ export const useDeployStore = create<DeployState>()(
           architectures: [],
           selectedArchitectureId: null,
           architecturesError: null,
-          architecturesFetchedAt: null,
         }),
 
       // Service summaries actions
@@ -187,7 +173,6 @@ export const useDeployStore = create<DeployState>()(
         set({
           serviceSummaries: data,
           serviceSummariesError: null,
-          serviceSummariesFetchedAt: Date.now(),
           serviceSummariesLoading: false,
         }),
 
@@ -206,7 +191,6 @@ export const useDeployStore = create<DeployState>()(
         set({
           serviceSummaries: [],
           serviceSummariesError: null,
-          serviceSummariesFetchedAt: null,
         }),
 
       // Architecture details actions
@@ -214,7 +198,6 @@ export const useDeployStore = create<DeployState>()(
         set({
           architectureDetails: data,
           architectureDetailsError: null,
-          architectureDetailsFetchedAt: Date.now(),
           architectureDetailsLoading: false,
         }),
 
@@ -231,7 +214,6 @@ export const useDeployStore = create<DeployState>()(
         set({
           architectureDetails: null,
           architectureDetailsError: null,
-          architectureDetailsFetchedAt: null,
         }),
 
       // Deploy options actions
@@ -285,7 +267,6 @@ export const useDeployStore = create<DeployState>()(
             ...state.providerParams,
             [key]: {
               data,
-              fetchedAt: Date.now(),
             },
           },
         }));
@@ -294,21 +275,7 @@ export const useDeployStore = create<DeployState>()(
       getProviderParams: (componentType, providerId) => {
         const key = `${componentType}:${providerId}`;
         const cached = get().providerParams[key];
-        if (!cached) return null;
-
-        // Check if stale (older than 15 minutes)
-        if (Date.now() - cached.fetchedAt > CACHE_DURATION) {
-          return null;
-        }
-
-        return cached.data;
-      },
-
-      isProviderParamsStale: (componentType, providerId) => {
-        const key = `${componentType}:${providerId}`;
-        const cached = get().providerParams[key];
-        if (!cached) return true;
-        return Date.now() - cached.fetchedAt > CACHE_DURATION;
+        return cached ? cached.data : null;
       },
 
       clearProviderParams: () => set({ providerParams: {} }),
@@ -320,7 +287,6 @@ export const useDeployStore = create<DeployState>()(
             ...state.serviceParams,
             [serviceId]: {
               data,
-              fetchedAt: Date.now(),
             },
           },
         }));
@@ -328,42 +294,12 @@ export const useDeployStore = create<DeployState>()(
 
       getServiceParams: (serviceId) => {
         const cached = get().serviceParams[serviceId];
-        if (!cached) return null;
-
-        // Check if stale (older than 15 minutes)
-        if (Date.now() - cached.fetchedAt > CACHE_DURATION) {
-          return null;
-        }
-
-        return cached.data;
-      },
-
-      isServiceParamsStale: (serviceId) => {
-        const cached = get().serviceParams[serviceId];
-        if (!cached) return true;
-        return Date.now() - cached.fetchedAt > CACHE_DURATION;
+        return cached ? cached.data : null;
       },
 
       clearServiceParams: () => set({ serviceParams: {} }),
 
-      // Cache staleness checks (15 minutes for config data, 5 minutes for resources)
-      isArchitecturesStale: () => {
-        const { architecturesFetchedAt } = get();
-        if (!architecturesFetchedAt) return true;
-        return Date.now() - architecturesFetchedAt > CACHE_DURATION;
-      },
-
-      isServiceSummariesStale: () => {
-        const { serviceSummariesFetchedAt } = get();
-        if (!serviceSummariesFetchedAt) return true;
-        return Date.now() - serviceSummariesFetchedAt > CACHE_DURATION;
-      },
-
-      isArchitectureDetailsStale: () => {
-        const { architectureDetailsFetchedAt } = get();
-        if (!architectureDetailsFetchedAt) return true;
-        return Date.now() - architectureDetailsFetchedAt > CACHE_DURATION;
-      },
+      // Cache staleness checks (only for deployOptions and resources)
 
       isDeployOptionsStale: () => {
         const { deployOptionsFetchedAt } = get();
@@ -383,13 +319,10 @@ export const useDeployStore = create<DeployState>()(
           architectures: [],
           selectedArchitectureId: null,
           architecturesError: null,
-          architecturesFetchedAt: null,
           serviceSummaries: [],
           serviceSummariesError: null,
-          serviceSummariesFetchedAt: null,
           architectureDetails: null,
           architectureDetailsError: null,
-          architectureDetailsFetchedAt: null,
           deployOptions: null,
           deployOptionsError: null,
           deployOptionsFetchedAt: null,
@@ -405,14 +338,11 @@ export const useDeployStore = create<DeployState>()(
       name: "deploy-storage",
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
-        // Persist configuration data with timestamps for 15-minute cache
+        // Persist configuration data (only deployOptions has cache expiration)
         architectures: state.architectures,
         selectedArchitectureId: state.selectedArchitectureId,
-        architecturesFetchedAt: state.architecturesFetchedAt,
         serviceSummaries: state.serviceSummaries,
-        serviceSummariesFetchedAt: state.serviceSummariesFetchedAt,
         architectureDetails: state.architectureDetails,
-        architectureDetailsFetchedAt: state.architectureDetailsFetchedAt,
         deployOptions: state.deployOptions,
         deployOptionsFetchedAt: state.deployOptionsFetchedAt,
         providerParams: state.providerParams,

--- a/ui/catalog/src/utils/deploymentTransform.ts
+++ b/ui/catalog/src/utils/deploymentTransform.ts
@@ -1,6 +1,7 @@
 import type {
   DeployFormData,
   ComponentConfig,
+  ServiceConfig,
 } from "@/components/DeployFlow/types";
 import type {
   DeployOptionsResponse,
@@ -9,6 +10,31 @@ import type {
   Provider,
 } from "@/types/digitalAssistants";
 import { isInferenceComponent } from "./inferenceComponentHelper";
+import { shouldIncludeParam } from "./paramFilter";
+
+/**
+ * Determines the component type (llm or reranker) that uses the inference backend
+ * for a given service configuration
+ */
+function getInferenceComponentType(
+  serviceDefinition: Service,
+  serviceConfig: ServiceConfig,
+): string {
+  // Default to llm
+  let componentType = "llm";
+
+  // Check if service has reranker component
+  const hasReranker = serviceDefinition.components.some(
+    (c) => c.type === "reranker",
+  );
+
+  // Use reranker if available and enabled in config
+  if (hasReranker && serviceConfig.components?.reranker?.providerId) {
+    componentType = "reranker";
+  }
+
+  return componentType;
+}
 
 interface DeploymentComponent {
   component_type: string;
@@ -150,7 +176,8 @@ function buildDeploymentComponent(
     ),
   };
 
-  // Only include params if there are any non-empty values
+  // Only include params if there are any values
+  // Params are already filtered in separateParams based on schema defaults
   if (Object.keys(params).length > 0) {
     component.params = params;
   }
@@ -176,37 +203,44 @@ function separateParams(
     return { inferenceBackendParams: {}, serviceParams: allParams || {} };
   }
 
-  // Extract provider param names from cached schema
-  const providerParamNames = new Set<string>();
-  if (providerSchemaData?.properties) {
-    Object.keys(
-      providerSchemaData.properties as Record<string, unknown>,
-    ).forEach((key) => providerParamNames.add(key));
-  }
+  // Get provider schema properties with defaults
+  const providerProperties =
+    (providerSchemaData?.properties as Record<string, { default?: unknown }>) ||
+    {};
 
-  // Extract service param names from cached schema (under backend.properties)
-  const serviceParamNames = new Set<string>();
+  // Get service schema properties with defaults (under backend.properties)
+  const serviceProperties: Record<string, { default?: unknown }> = {};
   if (serviceSchemaData?.properties) {
     const properties = serviceSchemaData.properties as Record<string, unknown>;
     if (properties.backend) {
       const backend = properties.backend as Record<string, unknown>;
       if (backend.properties) {
-        Object.keys(backend.properties as Record<string, unknown>).forEach(
-          (key) => serviceParamNames.add(key),
+        Object.assign(
+          serviceProperties,
+          backend.properties as Record<string, { default?: unknown }>,
         );
       }
     }
   }
 
-  // Classify parameters based on schema definitions
+  // Classify and filter parameters based on schema definitions
   const inferenceBackendParams: Record<string, unknown> = {};
   const serviceParams: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(allParams)) {
-    if (providerParamNames.has(key)) {
-      inferenceBackendParams[key] = value;
-    } else {
-      serviceParams[key] = value;
+    // Check if this is a provider param or service param
+    const isProviderParam = key in providerProperties;
+    const schemaProperty = isProviderParam
+      ? providerProperties[key]
+      : serviceProperties[key];
+
+    // Use shouldIncludeParam to filter based on schema defaults
+    if (shouldIncludeParam(value, schemaProperty)) {
+      if (isProviderParam) {
+        inferenceBackendParams[key] = value;
+      } else {
+        serviceParams[key] = value;
+      }
     }
   }
 
@@ -229,40 +263,35 @@ export function transformToDeploymentPayload(
 ): DeploymentPayload {
   const services: DeploymentService[] = [];
 
-  // Process each enabled service dynamically
+  // Process each enabled service
   for (const [serviceId, serviceConfig] of Object.entries(formData.services)) {
-    if (!serviceConfig.enabled) continue;
+    if (!serviceConfig.enabled) {
+      continue;
+    }
 
     // Find the service definition in deploy options
     const serviceDefinition = deployOptions.services.find(
       (s) => s.id === serviceId,
     );
     if (!serviceDefinition) {
-      console.warn(`Service definition not found for: ${serviceId}`);
       continue;
     }
 
-    // Find the component type that uses the inference backend (llm or reranker)
+    // Determine component type (llm or reranker)
     // TODO: [Next Release] Replace hardcoded "llm"/"reranker" with constants from a shared file
-    let componentType = "llm";
-    const hasReranker = serviceDefinition.components.some(
-      (c) => c.type === "reranker",
+    const componentType = getInferenceComponentType(
+      serviceDefinition,
+      serviceConfig,
     );
-    if (hasReranker && serviceConfig.components?.reranker) {
-      componentType = "reranker";
-    }
 
-    // Get cached schemas - extract .data from cache objects
+    // Get cached schemas from store
     const providerKey = `${componentType}:${serviceConfig.inferenceBackend}`;
     const providerSchemaData =
-      (providerParamsCache[providerKey]?.data as Record<string, unknown>) ||
-      null;
+      (providerParamsCache[providerKey] as Record<string, unknown>) || null;
     const serviceSchemaData =
-      (serviceParamsCache[serviceId]?.data as Record<string, unknown>) || null;
+      (serviceParamsCache[serviceId] as Record<string, unknown>) || null;
 
     // Separate inference backend params from service-level params for this service
-    // Each service keeps its own parameters - no merging/sharing
-    // Backend will validate consistency for services using same provider+model
     const { inferenceBackendParams, serviceParams } = separateParams(
       serviceConfig.params || {},
       providerSchemaData,
@@ -285,7 +314,7 @@ export function transformToDeploymentPayload(
             deployOptions,
             formData.globalComponents,
             serviceConfig.inferenceBackend, // Pass inference backend for LLM/reranker components
-            inferenceBackendParams, // Pass shared inference backend params (e.g., API keys)
+            inferenceBackendParams, // Pass inference backend params (e.g., API keys)
           ),
         );
       }

--- a/ui/catalog/src/utils/paramFilter.ts
+++ b/ui/catalog/src/utils/paramFilter.ts
@@ -1,0 +1,44 @@
+/**
+ * Filters out empty values and values matching schema defaults
+ * Handles boolean false and number 0 as valid values
+ */
+export function shouldIncludeParam(
+  value: unknown,
+  schemaProperty: { default?: unknown } | undefined,
+): boolean {
+  const hasValue =
+    value !== undefined &&
+    value !== null &&
+    (typeof value === "boolean" || typeof value === "number" || value !== "");
+
+  if (!hasValue) {
+    return false;
+  }
+
+  if (schemaProperty?.default !== undefined) {
+    return value !== schemaProperty.default;
+  }
+
+  return true;
+}
+
+/**
+ * Checks if a parameter should be displayed in UI
+ * Excludes specific keys and applies shouldIncludeParam logic
+ */
+export function shouldShowParam(
+  key: string,
+  value: unknown,
+  schema: { properties?: Record<string, { default?: unknown }> },
+  excludeKeys: Set<string> = new Set(["model"]),
+): boolean {
+  if (excludeKeys.has(key)) {
+    return false;
+  }
+
+  const property = (
+    schema.properties as Record<string, { default?: unknown }>
+  )?.[key];
+
+  return shouldIncludeParam(value, property);
+}

--- a/ui/catalog/src/utils/requestManager.ts
+++ b/ui/catalog/src/utils/requestManager.ts
@@ -1,0 +1,18 @@
+// De-duplicates in-flight requests to prevent race conditions
+const inFlightRequests = new Map<string, Promise<unknown>>();
+
+export async function dedupe<T>(
+  key: string,
+  fetcher: () => Promise<T>,
+): Promise<T> {
+  if (inFlightRequests.has(key)) {
+    return inFlightRequests.get(key) as Promise<T>;
+  }
+
+  const promise = fetcher().finally(() => {
+    inFlightRequests.delete(key);
+  });
+
+  inFlightRequests.set(key, promise);
+  return promise;
+}


### PR DESCRIPTION
- Preserved the cache only for deploy-options API and removed them for others as it was resulting in race condition and the dropdown values were getting messed up. 
- Fixed the old values get preserved on the view mode of deploy options even after removal by the user.