### PR TITLE
Make target to update the image tag in values.yaml files

### DIFF
--- a/.bob/skills/bump-service-version/SKILL.md
+++ b/.bob/skills/bump-service-version/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bump-service-version
-description: Use when the user wants to bump, update, or change the version/image tag of any service, UI component, or the catalog backend (ai-services) inside the ai-services project. Runs make release to auto-detect all modified components, bump their Makefile TAGs, and sync all values.yaml files in one shot.
+description: Use when the user wants to bump, update, or change the version/image tag of any service, UI component, or the catalog backend (ai-services) inside the ai-services project. Runs make bump-up-image-version to auto-detect all modified components, bump their Makefile TAGs, and sync all values.yaml files in one shot.
 metadata:
   argument-hint: "<optional: base-branch>"
 ---
@@ -8,27 +8,27 @@ metadata:
 # Bump Service Version
 
 Bumps the TAG in every modified component Makefile and syncs all corresponding `values.yaml`
-files using the repo-root `make release` target. No manual component selection required —
+files using the repo-root `make bump-up-image-version` target. No manual component selection required —
 changed components are auto-detected via git diff.
 
 ## Available make targets
 
 | Target | What it does |
 |---|---|
-| `make release` | Auto-detect changed components → bump TAGs → sync all `values.yaml` |
-| `make release REGISTRY=<url>` | Same, with a custom registry |
-| `make release BASE_BRANCH=<ref>` | Same, diffing against a different base branch |
+| `make bump-up-image-version` | Auto-detect changed components → bump TAGs → sync all `values.yaml` |
+| `make bump-up-image-version REGISTRY=<url>` | Same, with a custom registry |
+| `make bump-up-image-version BASE_BRANCH=<ref>` | Same, diffing against a different base branch |
 
 ---
 
 ## Step 1 — Run release
 
 ```
-execute_command: make release
+execute_command: make bump-up-image-version
 ```
 
-This runs `bump-tags` (auto-detects changed components from git diff, bumps each Makefile TAG
-from the base-branch value + 1) followed by `update-tags` (syncs every modified Makefile's
+This runs `bump-makefile-tags` (auto-detects changed components from git diff, bumps each Makefile TAG
+from the base-branch value + 1) followed by `bump-values-yaml` (syncs every modified Makefile's
 new TAG into the corresponding `values.yaml` files).
 
 ---

--- a/.bob/skills/bump-service-version/SKILL.md
+++ b/.bob/skills/bump-service-version/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: bump-service-version
+description: Use when the user wants to bump, update, or change the version/image tag of any service, UI component, or the catalog backend (ai-services) inside the ai-services project. Runs make release to auto-detect all modified components, bump their Makefile TAGs, and sync all values.yaml files in one shot.
+metadata:
+  argument-hint: "<optional: base-branch>"
+---
+
+# Bump Service Version
+
+Bumps the TAG in every modified component Makefile and syncs all corresponding `values.yaml`
+files using the repo-root `make release` target. No manual component selection required —
+changed components are auto-detected via git diff.
+
+## Available make targets
+
+| Target | What it does |
+|---|---|
+| `make release` | Auto-detect changed components → bump TAGs → sync all `values.yaml` |
+| `make release REGISTRY=<url>` | Same, with a custom registry |
+| `make release BASE_BRANCH=<ref>` | Same, diffing against a different base branch |
+
+---
+
+## Step 1 — Run release
+
+```
+execute_command: make release
+```
+
+This runs `bump-tags` (auto-detects changed components from git diff, bumps each Makefile TAG
+from the base-branch value + 1) followed by `update-tags` (syncs every modified Makefile's
+new TAG into the corresponding `values.yaml` files).
+
+---
+
+## Step 2 — Verify
+
+Grep to confirm no stale image tags remain:
+
+```
+grep pattern: TAG\?=
+path: ai-services/Makefile
+```
+
+If any unexpected stale references remain outside `ai-services/assets/applications/`,
+investigate and fix before reporting.
+
+---
+
+## Step 3 — Report
+
+Summarise what was changed: list each component whose Makefile TAG was bumped and each
+`values.yaml` that was updated, in a single table.
+
+| File | Change |
+|------|--------|
+| `<component>/Makefile` | `TAG=<old>` → `TAG=<new>` |
+| `<values.yaml path>` | `<image>:<old>` → `<image>:<new>` |
+
+Confirm no stale references were found.

--- a/.github/scripts/check_image_names.py
+++ b/.github/scripts/check_image_names.py
@@ -12,146 +12,41 @@ import sys
 from pathlib import Path
 from typing import Optional, Tuple
 
-# Registry used in values.yaml files
-EXPECTED_REGISTRY = "icr.io/ai-services-cicd"
-
-# Map of: makefile_path -> list of (values_yaml_path, values_key)
-# values_key is the top-level key in values.yaml that contains the image reference
-COMPONENTS = {
-    "services/chatbot/Makefile": [
-        ("ai-services/assets/applications/rag/podman/values.yaml", "backend"),
-        ("ai-services/assets/applications/rag/openshift/values.yaml", "backend"),
-        ("ai-services/assets/applications/rag-dev/podman/values.yaml", "backend"),
-        ("ai-services/assets/applications/rag-dev/openshift/values.yaml", "backend"),
-        ("ai-services/assets/applications/rag-cpu/podman/values.yaml", "backend"),
-        ("ai-services/assets/services/chat/podman/values.yaml", "backend"),
-    ],
-    "services/digitize/Makefile": [
-        ("ai-services/assets/applications/rag/podman/values.yaml", "digitize"),
-        ("ai-services/assets/applications/rag/openshift/values.yaml", "digitize"),
-        ("ai-services/assets/applications/rag-dev/podman/values.yaml", "digitize"),
-        ("ai-services/assets/applications/rag-dev/openshift/values.yaml", "digitize"),
-        ("ai-services/assets/applications/rag-cpu/podman/values.yaml", "digitize"),
-        ("ai-services/assets/services/digitize/podman/values.yaml", "digitize"),
-    ],
-    "services/summarize/Makefile": [
-        ("ai-services/assets/applications/rag/podman/values.yaml", "summarize"),
-        ("ai-services/assets/applications/rag/openshift/values.yaml", "summarize"),
-        ("ai-services/assets/applications/rag-dev/podman/values.yaml", "summarize"),
-        ("ai-services/assets/applications/rag-dev/openshift/values.yaml", "summarize"),
-        ("ai-services/assets/applications/rag-cpu/podman/values.yaml", "summarize"),
-        ("ai-services/assets/services/summarize/podman/values.yaml", "summarize"),
-    ],
-    "services/similarity/Makefile": [
-        ("ai-services/assets/applications/rag/podman/values.yaml", "similarity"),
-        ("ai-services/assets/applications/rag/openshift/values.yaml", "similarity"),
-        ("ai-services/assets/applications/rag-dev/podman/values.yaml", "similarity"),
-        ("ai-services/assets/applications/rag-dev/openshift/values.yaml", "similarity"),
-        ("ai-services/assets/applications/rag-cpu/podman/values.yaml", "similarity"),
-        ("ai-services/assets/services/similarity/podman/values.yaml", "similarity"),
-    ],
-    "ui/chatbot/Makefile": [
-        ("ai-services/assets/applications/rag/podman/values.yaml", "ui"),
-        ("ai-services/assets/applications/rag-dev/podman/values.yaml", "ui"),
-        ("ai-services/assets/applications/rag/openshift/values.yaml", "ui"),
-        ("ai-services/assets/applications/rag-dev/openshift/values.yaml", "ui"),
-        ("ai-services/assets/applications/rag-cpu/podman/values.yaml", "ui"),
-    ],
-    "ui/digitize/Makefile": [
-        ("ai-services/assets/applications/rag/openshift/values.yaml", "digitizeUi"),
-        ("ai-services/assets/applications/rag/podman/values.yaml", "digitizeUi"),
-        ("ai-services/assets/applications/rag-dev/openshift/values.yaml", "digitizeUi"),
-        ("ai-services/assets/applications/rag-dev/podman/values.yaml", "digitizeUi"),
-        ("ai-services/assets/applications/rag-cpu/podman/values.yaml", "digitizeUi"),
-    ],
-    "ui/catalog/Makefile": [
-        ("ai-services/assets/catalog/podman/values.yaml", "ui"),
-    ],
-    "ai-services/Makefile": [
-        ("ai-services/assets/catalog/podman/values.yaml", "backend"),
-    ],
-    "images/postgres/Makefile": [
-        ("ai-services/assets/catalog/podman/values.yaml", "db"),
-        ("ai-services/assets/applications/rag/podman/values.yaml", "postgres"),
-        ("ai-services/assets/applications/rag/openshift/values.yaml", "postgres"),
-        ("ai-services/assets/applications/rag-dev/podman/values.yaml", "postgres"),
-        ("ai-services/assets/applications/rag-dev/openshift/values.yaml", "postgres"),
-        ("ai-services/assets/applications/rag-cpu/podman/values.yaml", "postgres"),
-    ],
-    "images/litellm/Makefile": [
-        ("ai-services/assets/applications/rag-cpu/podman/values.yaml", "litellm"),
-    ],
-    "images/caddy/Makefile": [
-        ("ai-services/assets/catalog/podman/values.yaml", "caddy"),
-    ]
-}
-
-
-def get_makefile_info(makefile_path: Path) -> Tuple[str, str]:
-    """Extract IMAGE= and TAG= values from a Makefile, calculating TAG if it references other variables."""
-    content = makefile_path.read_text()
-
-    # Extract all variable definitions
-    variables = {}
-    for line in content.split('\n'):
-        # Match variable assignments: VAR?=value or VAR=value
-        var_match = re.match(r'^(\w+)\s*\??\s*=\s*(.+?)(?:\s*#.*)?$', line.strip())
-        if var_match:
-            var_name = var_match.group(1)
-            var_value = var_match.group(2).strip()
-            variables[var_name] = var_value
-
-    # Get IMAGE value
-    image = variables.get('IMAGE')
-    if not image:
-        raise ValueError(f"Could not find IMAGE= in {makefile_path}")
-
-    # Get TAG value
-    tag_value = variables.get('TAG')
-    if not tag_value:
-        raise ValueError(f"Could not find TAG= in {makefile_path}")
-
-    # If TAG references other variables, resolve them
-    # Handle patterns like: $(VAR1)-$(VAR2) or v$(VAR1)-$(VAR2)
-    def resolve_variables(value: str) -> str:
-        # Replace $(VAR) with actual values
-        pattern = r'\$\((\w+)\)'
-        while re.search(pattern, value):
-            match = re.search(pattern, value)
-            if match:
-                var_name = match.group(1)
-                var_replacement = variables.get(var_name, match.group(0))
-                value = value.replace(match.group(0), var_replacement)
-        return value
-
-    resolved_tag = resolve_variables(tag_value)
-    return image, resolved_tag
+from common import COMPONENTS, EXPECTED_REGISTRY, get_makefile_info
 
 
 def get_image_from_values_yaml(values_path: Path, key: str) -> Tuple[Optional[str], Optional[str]]:
     """
     Extract image name and tag from a values.yaml section.
 
+    If key is empty, reads the top-level 'image:' line directly (no section lookup).
     Example: key=backend, image line: icr.io/ai-services-cicd/rag:v0.0.32
     Returns: ("rag", "v0.0.32")
     """
     content = values_path.read_text()
 
-    # Find the section for the key and extract the image line within it
-    pattern = re.compile(
-        rf"^{key}:\s*\n(.*?)(?=^\w|\Z)",
-        re.MULTILINE | re.DOTALL,
-    )
-    section_match = pattern.search(content)
-    if not section_match:
-        raise ValueError(f"Could not find '{key}:' section in {values_path}")
+    if key == "":
+        # Top-level image field — no section wrapper, find the first bare `image:` line
+        image_match = re.search(r'^image:\s*["\']?(\S+?)["\']?\s*$', content, re.MULTILINE)
+        if not image_match:
+            raise ValueError(f"Could not find top-level 'image:' in {values_path}")
+        full_image = image_match.group(1).strip("\"'")
+    else:
+        # Find the section for the key and extract the image line within it
+        pattern = re.compile(
+            rf"^{key}:\s*\n(.*?)(?=^\w|\Z)",
+            re.MULTILINE | re.DOTALL,
+        )
+        section_match = pattern.search(content)
+        if not section_match:
+            raise ValueError(f"Could not find '{key}:' section in {values_path}")
 
-    section = section_match.group(1)
-    image_match = re.search(r"image:\s*(\S+)", section)
-    if not image_match:
-        raise ValueError(f"Could not find 'image:' in '{key}' section of {values_path}")
+        section = section_match.group(1)
+        image_match = re.search(r"image:\s*(\S+)", section)
+        if not image_match:
+            raise ValueError(f"Could not find 'image:' in '{key}' section of {values_path}")
 
-    full_image = image_match.group(1)
+        full_image = image_match.group(1)
 
     # Only validate images from our own registry
     if not full_image.startswith(EXPECTED_REGISTRY + "/"):

--- a/.github/scripts/check_makefile_version_bump.py
+++ b/.github/scripts/check_makefile_version_bump.py
@@ -12,33 +12,7 @@ import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-# Map of component paths to their configuration
-# Format: (component_path, name)
-COMPONENTS = [
-    # Services Images
-    ("services/chatbot", "chatbot-service"),
-    ("services/digitize", "digitize-service"),
-    ("services/similarity", "similarity-service"),
-    ("services/summarize", "summarize-service"),
-    # Images
-    ("images/service-base", "service-base"),
-    ("images/postgres", "postgres"),
-    ("images/caddy", "caddy"),
-    ("images/litellm", "litellm"),
-    ("images/tools", "tools"),
-    # UI Images
-    ("ui/chatbot", "chatbot-ui"),
-    ("ui/digitize", "digitize-ui"),
-    ("ui/catalog", "catalog-ui"),
-    # Ai Services
-    ("ai-services", "ai-services"),
-]
-
-# Paths that don't require version bumps when modified
-EXCLUDED_PATHS = [
-    "ai-services/assets/catalog",
-    "ai-services/assets/bootstrap",
-]
+from common import EXCLUDED_PATHS, SOURCE_COMPONENTS as COMPONENTS
 
 
 def get_changed_files(base_ref: str) -> List[str]:

--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -1,0 +1,162 @@
+import re
+from pathlib import Path
+from typing import Tuple
+
+# Registry used in values.yaml files
+EXPECTED_REGISTRY = "icr.io/ai-services-cicd"
+
+# ---------------------------------------------------------------------------
+# Path helpers for COMPONENTS
+# ---------------------------------------------------------------------------
+_rag_app_base_path = "ai-services/assets/applications/rag"
+_podman = "podman"
+_openshift = "openshift"
+_values_yaml = "values.yaml"
+
+
+def _p(variant: str, deploy: str) -> str:
+    """Build an application values.yaml path: rag[-variant]/deploy/values.yaml"""
+    suffix = f"-{variant}" if variant else ""
+    return f"{_rag_app_base_path}{suffix}/{deploy}/{_values_yaml}"
+
+
+# ---------------------------------------------------------------------------
+# Map of: makefile_path -> list of (values_yaml_path, values_key)
+# values_key is the top-level key in values.yaml that contains the image reference
+# ---------------------------------------------------------------------------
+COMPONENTS = {
+    "services/chatbot/Makefile": [
+        (_p("", _podman), "backend"),
+        (_p("", _openshift), "backend"),
+        (_p("dev", _podman), "backend"),
+        (_p("dev", _openshift), "backend"),
+        (_p("cpu", _podman), "backend"),
+        (f"ai-services/assets/services/chat/{_podman}/{_values_yaml}", "backend"),
+    ],
+    "services/digitize/Makefile": [
+        (_p("", _podman), "digitize"),
+        (_p("", _openshift), "digitize"),
+        (_p("dev", _podman), "digitize"),
+        (_p("dev", _openshift), "digitize"),
+        (_p("cpu", _podman), "digitize"),
+        (f"ai-services/assets/services/digitize/{_podman}/{_values_yaml}", "digitize"),
+    ],
+    "services/summarize/Makefile": [
+        (_p("", _podman), "summarize"),
+        (_p("", _openshift), "summarize"),
+        (_p("dev", _podman), "summarize"),
+        (_p("dev", _openshift), "summarize"),
+        (_p("cpu", _podman), "summarize"),
+        (f"ai-services/assets/services/summarize/{_podman}/{_values_yaml}", "summarize"),
+    ],
+    "services/similarity/Makefile": [
+        (_p("", _podman), "similarity"),
+        (_p("", _openshift), "similarity"),
+        (_p("dev", _podman), "similarity"),
+        (_p("dev", _openshift), "similarity"),
+        (_p("cpu", _podman), "similarity"),
+        (f"ai-services/assets/services/similarity/{_podman}/{_values_yaml}", "similarity"),
+    ],
+    "ui/chatbot/Makefile": [
+        (_p("", _podman), "ui"),
+        (_p("dev", _podman), "ui"),
+        (_p("", _openshift), "ui"),
+        (_p("dev", _openshift), "ui"),
+        (_p("cpu", _podman), "ui"),
+        (f"ai-services/assets/services/chat/{_podman}/{_values_yaml}", "ui"),
+    ],
+    "ui/digitize/Makefile": [
+        (_p("", _openshift), "digitizeUi"),
+        (_p("", _podman), "digitizeUi"),
+        (_p("dev", _openshift), "digitizeUi"),
+        (_p("dev", _podman), "digitizeUi"),
+        (_p("cpu", _podman), "digitizeUi"),
+        (f"ai-services/assets/services/digitize/{_podman}/{_values_yaml}", "digitizeUi"),
+    ],
+    "ui/catalog/Makefile": [
+        (f"ai-services/assets/catalog/{_podman}/{_values_yaml}", "ui"),
+    ],
+    "ai-services/Makefile": [
+        (f"ai-services/assets/catalog/{_podman}/{_values_yaml}", "backend"),
+    ],
+    "images/postgres/Makefile": [
+        (f"ai-services/assets/catalog/{_podman}/{_values_yaml}", "db"),
+        (_p("", _podman), "postgres"),
+        (_p("", _openshift), "postgres"),
+        (_p("dev", _podman), "postgres"),
+        (_p("dev", _openshift), "postgres"),
+        (_p("cpu", _podman), "postgres"),
+    ],
+    "images/litellm/Makefile": [
+        (_p("cpu", _podman), "litellm"),
+        (f"ai-services/assets/components/llm/watsonx/{_podman}/{_values_yaml}", ""),
+    ],
+    "images/caddy/Makefile": [
+        (f"ai-services/assets/catalog/{_podman}/{_values_yaml}", "caddy"),
+    ],
+    # images/tools/Makefile uses a different registry (icr.io/ai-services-private)
+    # and stores its reference in a Go file — validation is skipped for now.
+}
+
+# ---------------------------------------------------------------------------
+# Map of: component root path -> display name
+# Used by check_makefile_version_bump.py and bump_makefile_tag.py
+# ---------------------------------------------------------------------------
+SOURCE_COMPONENTS = [
+    # Services Images
+    ("services/chatbot", "chatbot-service"),
+    ("services/digitize", "digitize-service"),
+    ("services/similarity", "similarity-service"),
+    ("services/summarize", "summarize-service"),
+    # Images
+    ("images/service-base", "service-base"),
+    ("images/postgres", "postgres"),
+    ("images/caddy", "caddy"),
+    ("images/litellm", "litellm"),
+    ("images/tools", "tools"),
+    # UI Images
+    ("ui/chatbot", "chatbot-ui"),
+    ("ui/digitize", "digitize-ui"),
+    ("ui/catalog", "catalog-ui"),
+    # Ai Services
+    ("ai-services", "ai-services"),
+]
+
+# Paths that don't require version bumps when modified
+EXCLUDED_PATHS = [
+    "ai-services/assets/catalog",
+    "ai-services/assets/bootstrap",
+]
+
+
+# ---------------------------------------------------------------------------
+# Shared helper
+# ---------------------------------------------------------------------------
+def get_makefile_info(makefile_path: Path) -> Tuple[str, str]:
+    """Extract IMAGE= and TAG= values from a Makefile, resolving any variable references."""
+    content = makefile_path.read_text()
+
+    variables = {}
+    for line in content.split('\n'):
+        var_match = re.match(r'^(\w+)\s*\??\s*=\s*(.+?)(?:\s*#.*)?$', line.strip())
+        if var_match:
+            variables[var_match.group(1)] = var_match.group(2).strip()
+
+    image = variables.get('IMAGE')
+    if not image:
+        raise ValueError(f"Could not find IMAGE= in {makefile_path}")
+
+    tag_value = variables.get('TAG')
+    if not tag_value:
+        raise ValueError(f"Could not find TAG= in {makefile_path}")
+
+    def resolve_variables(value: str) -> str:
+        pattern = r'\$\((\w+)\)'
+        while re.search(pattern, value):
+            match = re.search(pattern, value)
+            if match:
+                var_replacement = variables.get(match.group(1), match.group(0))
+                value = value.replace(match.group(0), var_replacement)
+        return value
+
+    return image, resolve_variables(tag_value)

--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -14,7 +14,7 @@ _openshift = "openshift"
 _values_yaml = "values.yaml"
 
 
-def _p(variant: str, deploy: str) -> str:
+def _get_rag_values_path(variant: str, deploy: str) -> str:
     """Build an application values.yaml path: rag[-variant]/deploy/values.yaml"""
     suffix = f"-{variant}" if variant else ""
     return f"{_rag_app_base_path}{suffix}/{deploy}/{_values_yaml}"
@@ -26,51 +26,51 @@ def _p(variant: str, deploy: str) -> str:
 # ---------------------------------------------------------------------------
 COMPONENTS = {
     "services/chatbot/Makefile": [
-        (_p("", _podman), "backend"),
-        (_p("", _openshift), "backend"),
-        (_p("dev", _podman), "backend"),
-        (_p("dev", _openshift), "backend"),
-        (_p("cpu", _podman), "backend"),
+        (_get_rag_values_path("", _podman), "backend"),
+        (_get_rag_values_path("", _openshift), "backend"),
+        (_get_rag_values_path("dev", _podman), "backend"),
+        (_get_rag_values_path("dev", _openshift), "backend"),
+        (_get_rag_values_path("cpu", _podman), "backend"),
         (f"ai-services/assets/services/chat/{_podman}/{_values_yaml}", "backend"),
     ],
     "services/digitize/Makefile": [
-        (_p("", _podman), "digitize"),
-        (_p("", _openshift), "digitize"),
-        (_p("dev", _podman), "digitize"),
-        (_p("dev", _openshift), "digitize"),
-        (_p("cpu", _podman), "digitize"),
+        (_get_rag_values_path("", _podman), "digitize"),
+        (_get_rag_values_path("", _openshift), "digitize"),
+        (_get_rag_values_path("dev", _podman), "digitize"),
+        (_get_rag_values_path("dev", _openshift), "digitize"),
+        (_get_rag_values_path("cpu", _podman), "digitize"),
         (f"ai-services/assets/services/digitize/{_podman}/{_values_yaml}", "digitize"),
     ],
     "services/summarize/Makefile": [
-        (_p("", _podman), "summarize"),
-        (_p("", _openshift), "summarize"),
-        (_p("dev", _podman), "summarize"),
-        (_p("dev", _openshift), "summarize"),
-        (_p("cpu", _podman), "summarize"),
+        (_get_rag_values_path("", _podman), "summarize"),
+        (_get_rag_values_path("", _openshift), "summarize"),
+        (_get_rag_values_path("dev", _podman), "summarize"),
+        (_get_rag_values_path("dev", _openshift), "summarize"),
+        (_get_rag_values_path("cpu", _podman), "summarize"),
         (f"ai-services/assets/services/summarize/{_podman}/{_values_yaml}", "summarize"),
     ],
     "services/similarity/Makefile": [
-        (_p("", _podman), "similarity"),
-        (_p("", _openshift), "similarity"),
-        (_p("dev", _podman), "similarity"),
-        (_p("dev", _openshift), "similarity"),
-        (_p("cpu", _podman), "similarity"),
+        (_get_rag_values_path("", _podman), "similarity"),
+        (_get_rag_values_path("", _openshift), "similarity"),
+        (_get_rag_values_path("dev", _podman), "similarity"),
+        (_get_rag_values_path("dev", _openshift), "similarity"),
+        (_get_rag_values_path("cpu", _podman), "similarity"),
         (f"ai-services/assets/services/similarity/{_podman}/{_values_yaml}", "similarity"),
     ],
     "ui/chatbot/Makefile": [
-        (_p("", _podman), "ui"),
-        (_p("dev", _podman), "ui"),
-        (_p("", _openshift), "ui"),
-        (_p("dev", _openshift), "ui"),
-        (_p("cpu", _podman), "ui"),
+        (_get_rag_values_path("", _podman), "ui"),
+        (_get_rag_values_path("dev", _podman), "ui"),
+        (_get_rag_values_path("", _openshift), "ui"),
+        (_get_rag_values_path("dev", _openshift), "ui"),
+        (_get_rag_values_path("cpu", _podman), "ui"),
         (f"ai-services/assets/services/chat/{_podman}/{_values_yaml}", "ui"),
     ],
     "ui/digitize/Makefile": [
-        (_p("", _openshift), "digitizeUi"),
-        (_p("", _podman), "digitizeUi"),
-        (_p("dev", _openshift), "digitizeUi"),
-        (_p("dev", _podman), "digitizeUi"),
-        (_p("cpu", _podman), "digitizeUi"),
+        (_get_rag_values_path("", _openshift), "digitizeUi"),
+        (_get_rag_values_path("", _podman), "digitizeUi"),
+        (_get_rag_values_path("dev", _openshift), "digitizeUi"),
+        (_get_rag_values_path("dev", _podman), "digitizeUi"),
+        (_get_rag_values_path("cpu", _podman), "digitizeUi"),
         (f"ai-services/assets/services/digitize/{_podman}/{_values_yaml}", "digitizeUi"),
     ],
     "ui/catalog/Makefile": [
@@ -81,14 +81,14 @@ COMPONENTS = {
     ],
     "images/postgres/Makefile": [
         (f"ai-services/assets/catalog/{_podman}/{_values_yaml}", "db"),
-        (_p("", _podman), "postgres"),
-        (_p("", _openshift), "postgres"),
-        (_p("dev", _podman), "postgres"),
-        (_p("dev", _openshift), "postgres"),
-        (_p("cpu", _podman), "postgres"),
+        (_get_rag_values_path("", _podman), "postgres"),
+        (_get_rag_values_path("", _openshift), "postgres"),
+        (_get_rag_values_path("dev", _podman), "postgres"),
+        (_get_rag_values_path("dev", _openshift), "postgres"),
+        (_get_rag_values_path("cpu", _podman), "postgres"),
     ],
     "images/litellm/Makefile": [
-        (_p("cpu", _podman), "litellm"),
+        (_get_rag_values_path("cpu", _podman), "litellm"),
         (f"ai-services/assets/components/llm/watsonx/{_podman}/{_values_yaml}", ""),
     ],
     "images/caddy/Makefile": [

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ BASE_BRANCH?=origin/main
 
 # Bump TAG in Makefiles for components with changed source files
 # Usage:
-#   make bump-tags                         # Auto-detect changed components
-#   make bump-tags BASE_BRANCH=origin/dev  # Use custom base branch
-#   make bump-tags COMPONENT=services/chatbot  # Bump a specific component
-.PHONY: bump-tags
-bump-tags:
+#   make bump-makefile-tags                         # Auto-detect changed components
+#   make bump-makefile-tags BASE_BRANCH=origin/dev  # Use custom base branch
+#   make bump-makefile-tags COMPONENT=services/chatbot  # Bump a specific component
+.PHONY: bump-makefile-tags
+bump-makefile-tags:
 	@echo "Bumping Makefile TAGs..."
 	@if [ -n "$(COMPONENT)" ]; then \
 		python3 hack/bump_makefile_tag.py --component $(COMPONENT); \
@@ -19,11 +19,11 @@ bump-tags:
 
 # Update image tags in values.yaml files
 # Usage:
-#   make update-tags                    # Auto-detect modified Makefiles
-#   make update-tags SYNC=true          # Sync ALL Makefiles tags with values.yaml files
-#   make update-tags REGISTRY=custom    # Use custom registry
-.PHONY: update-tags
-update-tags:
+#   make bump-values-yaml                    # Auto-detect modified Makefiles
+#   make bump-values-yaml SYNC=true          # Sync ALL Makefiles tags with values.yaml files
+#   make bump-values-yaml REGISTRY=custom    # Use custom registry
+.PHONY: bump-values-yaml
+bump-values-yaml:
 	@echo "Updating image tags in values.yaml files..."
 	@if [ "$(SYNC)" = "true" ]; then \
 		python3 hack/update_image_tags.py --sync --registry $(REGISTRY); \
@@ -33,32 +33,32 @@ update-tags:
 
 # Bump TAGs and then sync image tags in values.yaml files
 # Usage:
-#   make release                        # Auto-detect changed components + sync values.yaml
-#   make release REGISTRY=custom        # Use custom registry
-.PHONY: release
-release: bump-tags update-tags
+#   make bump-up-image-version                        # Auto-detect changed components + sync values.yaml
+#   make bump-up-image-version REGISTRY=custom        # Use custom registry
+.PHONY: bump-up-image-version
+bump-up-image-version: bump-makefile-tags bump-values-yaml
 
 # Help target
 .PHONY: help
 help:
 	@echo "Available targets:"
-	@echo "  bump-tags             - Bump TAG in Makefiles for components with changed source files"
-	@echo "  update-tags           - Update image tags in values.yaml files"
-	@echo "  release               - Bump TAGs then update image tags in values.yaml (bump-tags + update-tags)"
+	@echo "  bump-makefile-tags             - Bump TAG in Makefiles for components with changed source files"
+	@echo "  bump-values-yaml               - Update image tags in values.yaml files"
+	@echo "  bump-up-image-version          - Bump TAGs then update image tags in values.yaml (bump-makefile-tags + bump-values-yaml)"
 	@echo ""
 	@echo "Variables:"
 	@echo "  REGISTRY=<url>        - Container registry URL (default: icr.io/ai-services-cicd)"
 	@echo "  BASE_BRANCH=<ref>     - Base branch for git diff (default: origin/main)"
-	@echo "  SYNC=true             - Sync ALL Makefiles instead of auto-detecting (update-tags only)"
-	@echo "  COMPONENT=<path>      - Bump a specific component only, e.g. services/chatbot (bump-tags only)"
+	@echo "  SYNC=true             - Sync ALL Makefiles instead of auto-detecting (bump-values-yaml only)"
+	@echo "  COMPONENT=<path>      - Bump a specific component only, e.g. services/chatbot (bump-makefile-tags only)"
 	@echo ""
 	@echo "Examples:"
-	@echo "  make bump-tags                              # Auto-detect and bump changed components"
-	@echo "  make bump-tags COMPONENT=services/chatbot   # Bump a specific component"
-	@echo "  make update-tags                            # Auto-detect modified Makefiles"
-	@echo "  make update-tags SYNC=true                  # Sync ALL Makefiles tags with values.yaml files"
-	@echo "  make update-tags REGISTRY=custom-registry   # Use custom registry"
-	@echo "  make release                                # Bump TAGs + update values.yaml (full flow)"
-	@echo "  make release REGISTRY=icr.io/custom         # Full flow with custom registry"
+	@echo "  make bump-makefile-tags                              # Auto-detect and bump changed components"
+	@echo "  make bump-makefile-tags COMPONENT=services/chatbot   # Bump a specific component"
+	@echo "  make bump-values-yaml                                # Auto-detect modified Makefiles"
+	@echo "  make bump-values-yaml SYNC=true                      # Sync ALL Makefiles tags with values.yaml files"
+	@echo "  make bump-values-yaml REGISTRY=custom-registry       # Use custom registry"
+	@echo "  make bump-up-image-version                           # Bump TAGs + update values.yaml (full flow)"
+	@echo "  make bump-up-image-version REGISTRY=icr.io/custom    # Full flow with custom registry"
 
 # Made with Bob

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+# Default registry for image updates
+REGISTRY?=icr.io/ai-services-cicd
+# Base branch used for git diff in auto-detection mode
+BASE_BRANCH?=origin/main
+
+# Bump TAG in Makefiles for components with changed source files
+# Usage:
+#   make bump-tags                         # Auto-detect changed components
+#   make bump-tags BASE_BRANCH=origin/dev  # Use custom base branch
+#   make bump-tags COMPONENT=services/chatbot  # Bump a specific component
+.PHONY: bump-tags
+bump-tags:
+	@echo "Bumping Makefile TAGs..."
+	@if [ -n "$(COMPONENT)" ]; then \
+		python3 hack/bump_makefile_tag.py --component $(COMPONENT); \
+	else \
+		python3 hack/bump_makefile_tag.py --base-branch $(BASE_BRANCH); \
+	fi
+
+# Update image tags in values.yaml files
+# Usage:
+#   make update-tags                    # Auto-detect modified Makefiles
+#   make update-tags SYNC=true          # Sync ALL Makefiles tags with values.yaml files
+#   make update-tags REGISTRY=custom    # Use custom registry
+.PHONY: update-tags
+update-tags:
+	@echo "Updating image tags in values.yaml files..."
+	@if [ "$(SYNC)" = "true" ]; then \
+		python3 hack/update_image_tags.py --sync --registry $(REGISTRY); \
+	else \
+		python3 hack/update_image_tags.py --registry $(REGISTRY); \
+	fi
+
+# Bump TAGs and then sync image tags in values.yaml files
+# Usage:
+#   make release                        # Auto-detect changed components + sync values.yaml
+#   make release REGISTRY=custom        # Use custom registry
+.PHONY: release
+release: bump-tags update-tags
+
+# Help target
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@echo "  bump-tags             - Bump TAG in Makefiles for components with changed source files"
+	@echo "  update-tags           - Update image tags in values.yaml files"
+	@echo "  release               - Bump TAGs then update image tags in values.yaml (bump-tags + update-tags)"
+	@echo ""
+	@echo "Variables:"
+	@echo "  REGISTRY=<url>        - Container registry URL (default: icr.io/ai-services-cicd)"
+	@echo "  BASE_BRANCH=<ref>     - Base branch for git diff (default: origin/main)"
+	@echo "  SYNC=true             - Sync ALL Makefiles instead of auto-detecting (update-tags only)"
+	@echo "  COMPONENT=<path>      - Bump a specific component only, e.g. services/chatbot (bump-tags only)"
+	@echo ""
+	@echo "Examples:"
+	@echo "  make bump-tags                              # Auto-detect and bump changed components"
+	@echo "  make bump-tags COMPONENT=services/chatbot   # Bump a specific component"
+	@echo "  make update-tags                            # Auto-detect modified Makefiles"
+	@echo "  make update-tags SYNC=true                  # Sync ALL Makefiles tags with values.yaml files"
+	@echo "  make update-tags REGISTRY=custom-registry   # Use custom registry"
+	@echo "  make release                                # Bump TAGs + update values.yaml (full flow)"
+	@echo "  make release REGISTRY=icr.io/custom         # Full flow with custom registry"
+
+# Made with Bob

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.158
+TAG?=v0.0.159
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.159
+TAG?=v0.0.158
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/hack/bump_makefile_tag.py
+++ b/hack/bump_makefile_tag.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+Bumps the TAG value in a Makefile when files under its component root path are modified.
+
+Detects which component root paths have changed files (via git diff), reads the current
+TAG from the Makefile, increments the patch version, and writes it back.
+
+Usage:
+    python hack/bump_makefile_tag.py
+    python hack/bump_makefile_tag.py --base-branch origin/main
+    python hack/bump_makefile_tag.py --component services/chatbot
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+# Import shared mappings from .github/scripts/common.py
+sys.path.insert(0, str(Path(__file__).parent.parent / ".github" / "scripts"))
+from common import EXCLUDED_PATHS, SOURCE_COMPONENTS  # noqa: E402
+
+
+def get_changed_files(base_branch: str) -> List[str]:
+    """Return list of files changed compared to base_branch."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", base_branch],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return [l.strip() for l in result.stdout.strip().splitlines() if l.strip()]
+    except subprocess.CalledProcessError as e:
+        print(f"❌ Error running git diff: {e}")
+        sys.exit(1)
+
+
+def get_tag_from_makefile(makefile_path: Path, ref: Optional[str] = None, component_path: Optional[str] = None) -> Optional[str]:
+    """
+    Extract and resolve the TAG value from a Makefile.
+
+    Args:
+        makefile_path:   Path to the Makefile on disk (used when ref is None).
+        ref:             Git ref to read from (e.g. 'origin/main'). When set,
+                         the file is read from git rather than the working tree.
+        component_path:  Component root path required for git show (e.g. 'services/chatbot').
+    """
+    try:
+        if ref and component_path:
+            result = subprocess.run(
+                ["git", "show", f"{ref}:./{component_path}/Makefile"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            content = result.stdout
+        else:
+            content = makefile_path.read_text()
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.strip() if e.stderr else "unknown error"
+        print(f"   ⚠️  Warning: Could not read {makefile_path} from {ref}: {stderr}")
+        return None
+
+    variables = {}
+    for line in content.splitlines():
+        m = re.match(r'^(\w+)\s*\??\s*=\s*(.+?)(?:\s*#.*)?$', line.strip())
+        if m:
+            variables[m.group(1)] = m.group(2).strip()
+
+    tag_value = variables.get('TAG')
+    if not tag_value:
+        return None
+
+    # Resolve variable references: $(VAR)
+    pattern = r'\$\((\w+)\)'
+    while re.search(pattern, tag_value):
+        m = re.search(pattern, tag_value)
+        if m:
+            tag_value = tag_value.replace(m.group(0), variables.get(m.group(1), m.group(0)))
+
+    return tag_value
+
+
+def bump_patch(tag: str) -> str:
+    """
+    Increment the last numeric segment of a version string.
+
+    Examples:
+        "v0.0.32"  -> "v0.0.33"
+        "0.11"     -> "0.12"
+        "1.2.3-4"  -> "1.2.3-5"
+    """
+    # Find the last sequence of digits in the tag and increment it
+    match = re.search(r'(\d+)(?=\D*$)', tag)
+    if not match:
+        raise ValueError(f"Cannot determine patch version to bump in tag: '{tag}'")
+    old_num = match.group(1)
+    new_num = str(int(old_num) + 1)
+    # Replace only the last occurrence
+    idx = tag.rfind(old_num)
+    return tag[:idx] + new_num + tag[idx + len(old_num):]
+
+
+def write_tag_to_makefile(makefile_path: Path, new_tag: str) -> None:
+    """Replace the TAG assignment in a Makefile with new_tag."""
+    content = makefile_path.read_text()
+    # Match TAG?=... or TAG=... (optional ?), preserve any inline comment
+    new_content = re.sub(
+        r'^(TAG\s*\??\s*=\s*)(\S+)',
+        lambda m: m.group(1) + new_tag,
+        content,
+        flags=re.MULTILINE,
+    )
+    if new_content == content:
+        raise ValueError(f"Could not find TAG= line to update in {makefile_path}")
+    makefile_path.write_text(new_content)
+
+
+def components_changed_for(component_path: str, changed_files: List[str]) -> bool:
+    """Return True if any changed file belongs to component_path (respecting EXCLUDED_PATHS)."""
+    return any(
+        f.startswith(f"{component_path}/")
+        and not any(f.startswith(ex) for ex in EXCLUDED_PATHS)
+        for f in changed_files
+    )
+
+
+def process_component(
+    component_path: str,
+    name: str,
+    repo_root: Path,
+    base_branch: str,
+) -> Tuple[bool, Optional[str]]:
+    """
+    Bump TAG in component_path/Makefile.
+
+    The new TAG is derived from the base branch version, not the working tree,
+    so re-running the script on the same branch never double-bumps.
+
+    Returns (bumped, error_message).
+    """
+    makefile_path = repo_root / component_path / "Makefile"
+
+    if not makefile_path.exists():
+        return False, f"❌ Makefile not found: {component_path}/Makefile"
+
+    # Read TAG from the base branch (origin) to avoid double-bumping
+    base_tag = get_tag_from_makefile(makefile_path, ref=base_branch, component_path=component_path)
+    if base_tag is None:
+        return False, f"❌ Could not read TAG from {base_branch} for {component_path}/Makefile"
+
+    try:
+        new_tag = bump_patch(base_tag)
+    except ValueError as e:
+        return False, f"❌ {e}"
+
+    # Check if the working tree already has the bumped tag (idempotent)
+    current_tag = get_tag_from_makefile(makefile_path)
+    if current_tag == new_tag:
+        print(f"  ⏭  {name}: TAG already bumped to {new_tag}  ({component_path}/Makefile)")
+        return True, None
+
+    write_tag_to_makefile(makefile_path, new_tag)
+    print(f"  ✅ {name}: TAG {base_tag} → {new_tag}  ({component_path}/Makefile)")
+    return True, None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Bump Makefile TAG when component source files are modified",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Auto-detect changed components via git diff against origin/main
+  %(prog)s
+
+  # Use a different base branch
+  %(prog)s --base-branch origin/develop
+
+  # Bump a specific component regardless of git diff
+  %(prog)s --component services/chatbot
+        """,
+    )
+    parser.add_argument(
+        "--base-branch",
+        default="origin/main",
+        help="Base branch for git diff (default: origin/main). Ignored when --component is set.",
+    )
+    parser.add_argument(
+        "--component",
+        default=None,
+        help="Component root path to bump (e.g. services/chatbot). Skips git diff detection.",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+
+    # --- Determine which components to bump ---
+    if args.component:
+        # Find matching entry in SOURCE_COMPONENTS
+        entry = next(
+            ((cp, name) for cp, name in SOURCE_COMPONENTS if cp == args.component),
+            None,
+        )
+        if entry is None:
+            print(f"❌ Component '{args.component}' not found in SOURCE_COMPONENTS.")
+            print("\nAvailable components:")
+            for cp, name in SOURCE_COMPONENTS:
+                print(f"  {cp}  ({name})")
+            return 1
+        components_to_bump = [entry]
+    else:
+        print(f"🔍 Detecting changed components via git diff against {args.base_branch}...")
+        changed_files = get_changed_files(args.base_branch)
+        if not changed_files:
+            print("ℹ️  No changed files detected.")
+            return 0
+        components_to_bump = [
+            (cp, name)
+            for cp, name in SOURCE_COMPONENTS
+            if components_changed_for(cp, changed_files)
+        ]
+        if not components_to_bump:
+            print("ℹ️  No tracked components have changed files.")
+            return 0
+
+    # --- Process ---
+    print("=" * 70)
+    print(f"Bumping TAG for {len(components_to_bump)} component(s)...")
+    print("=" * 70)
+    print()
+
+    errors = []
+    bumped = []
+
+    for component_path, name in components_to_bump:
+        ok, err = process_component(component_path, name, repo_root, args.base_branch)
+        if err:
+            errors.append(err)
+        elif ok:
+            bumped.append(name)
+
+    print()
+    print("=" * 70)
+    print("Summary:")
+    print("=" * 70)
+    print(f"Bumped:  {len(bumped)}")
+    print(f"Errors:  {len(errors)}")
+    print("=" * 70)
+
+    if errors:
+        print()
+        for err in errors:
+            print(err)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+# Made with Bob

--- a/hack/update_image_tags.py
+++ b/hack/update_image_tags.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+Updates image tags in values.yaml files when a Makefile is modified.
+
+This script reads the IMAGE and TAG values from a specified Makefile and updates
+all corresponding values.yaml files based on the COMPONENTS mapping from the
+check_image_names.py script.
+
+Usage:
+    python hack/update_image_tags.py --makefile services/chatbot/Makefile --registry icr.io/ai-services-cicd
+    python hack/update_image_tags.py -m services/digitize/Makefile -r icr.io/ai-services-cicd
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple, Optional
+
+# Import shared component mapping and helpers from .github/scripts/common.py
+sys.path.insert(0, str(Path(__file__).parent.parent / ".github" / "scripts"))
+from common import COMPONENTS, get_makefile_info  # noqa: E402
+
+
+def get_modified_makefiles(base_branch: str = "origin/main") -> List[str]:
+    """
+    Get list of modified Makefiles compared to base branch using git diff.
+    
+    Args:
+        base_branch: The base branch to compare against (default: origin/main)
+    
+    Returns:
+        List of modified Makefile paths that are in COMPONENTS mapping
+    """
+    try:
+        # Run git diff to get modified files
+        result = subprocess.run(
+            ["git", "diff", "--name-only", base_branch],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        
+        # Get all modified files
+        modified_files = result.stdout.strip().split('\n')
+        
+        # Filter for Makefiles that are in our COMPONENTS mapping
+        modified_makefiles = []
+        for file_path in modified_files:
+            if file_path in COMPONENTS:
+                modified_makefiles.append(file_path)
+        
+        return modified_makefiles
+    
+    except subprocess.CalledProcessError as e:
+        print(f"❌ Error running git diff: {e}")
+        return []
+    except Exception as e:
+        print(f"❌ Error getting modified Makefiles: {e}")
+        return []
+
+def update_image_in_values_yaml(values_path: Path, key: str, registry: str, image_name: str, tag: str) -> bool:
+    """
+    Update the image reference in a values.yaml file for a specific key.
+    
+    Returns True if the file was modified, False otherwise.
+    """
+    content = values_path.read_text()
+    new_image = f"{registry}/{image_name}:{tag}"
+    
+    # Find the section for the key and extract the image line within it
+    pattern = re.compile(
+        rf"^({key}:\s*\n(?:.*?\n)*?)(  image:\s*)(\S+)",
+        re.MULTILINE,
+    )
+    
+    match = pattern.search(content)
+    if not match:
+        print(f"  ⚠️  Could not find 'image:' in '{key}' section of {values_path}")
+        return False
+    
+    old_image = match.group(3)
+    
+    # Check if update is needed
+    if old_image == new_image:
+        print(f"  ✅ Already up-to-date: {values_path} [{key}]")
+        return False
+    
+    # Replace the image
+    new_content = pattern.sub(rf"\1\g<2>{new_image}", content)
+    
+    # Write back to file
+    values_path.write_text(new_content)
+    print(f"  ✅ Updated: {values_path} [{key}]")
+    print(f"     Old: {old_image}")
+    print(f"     New: {new_image}")
+    
+    return True
+
+
+def process_makefile(makefile_rel: str, registry: str, repo_root: Path) -> Tuple[int, int, int]:
+    """
+    Process a single Makefile and update its corresponding values.yaml files.
+    
+    Returns:
+        Tuple of (updated_count, skipped_count, error_count)
+    """
+    makefile_path = repo_root / makefile_rel
+    
+    if not makefile_path.exists():
+        print(f"  ❌ Makefile not found: {makefile_rel}")
+        return 0, 0, 1
+    
+    # Extract IMAGE and TAG from Makefile
+    try:
+        image_name, tag = get_makefile_info(makefile_path)
+    except ValueError as e:
+        print(f"  ❌ Error: {e}")
+        return 0, 0, 1
+    
+    print(f"\n📦 Processing: {makefile_rel}")
+    print(f"   Image: {image_name}")
+    print(f"   Tag:   {tag}")
+    print(f"   Full:  {registry}/{image_name}:{tag}")
+    print()
+    
+    # Get list of values.yaml files to update
+    values_entries = COMPONENTS[makefile_rel]
+    
+    updated_count = 0
+    skipped_count = 0
+    error_count = 0
+    
+    for values_rel, values_key in values_entries:
+        values_path = repo_root / values_rel
+        
+        if not values_path.exists():
+            print(f"  ❌ File not found: {values_rel}")
+            error_count += 1
+            continue
+        
+        try:
+            if update_image_in_values_yaml(values_path, values_key, registry, image_name, tag):
+                updated_count += 1
+            else:
+                skipped_count += 1
+        except Exception as e:
+            print(f"  ❌ Error updating {values_rel}: {e}")
+            error_count += 1
+    
+    return updated_count, skipped_count, error_count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Update image tags in values.yaml files based on Makefile changes",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Update all values.yaml files for a specific Makefile
+  %(prog)s --makefile services/chatbot/Makefile --registry icr.io/ai-services-cicd
+  
+  # Auto-detect modified Makefiles using git diff
+  %(prog)s --registry icr.io/ai-services-cicd
+  
+  # Sync ALL Makefiles (update all values.yaml to match current Makefile TAGs)
+  %(prog)s --sync --registry icr.io/ai-services-cicd
+  
+  # Auto-detect with custom base branch
+  %(prog)s --registry icr.io/ai-services-cicd --base-branch origin/develop
+        """
+    )
+    
+    parser.add_argument(
+        "-m", "--makefile",
+        required=False,
+        help="Path to the Makefile (relative to repository root). If not provided, auto-detects modified Makefiles using git diff (unless --sync is used)"
+    )
+    
+    parser.add_argument(
+        "--sync",
+        action="store_true",
+        help="Sync ALL Makefiles - iterate over all COMPONENTS and update values.yaml files to match current Makefile TAGs. Ignores --makefile and --base-branch flags"
+    )
+    
+    parser.add_argument(
+        "--base-branch",
+        default="origin/main",
+        help="Base branch for git diff comparison (default: origin/main). Only used when --makefile and --sync are not provided"
+    )
+    
+    parser.add_argument(
+        "-r", "--registry",
+        required=True,
+        help="Container registry URL (e.g., icr.io/ai-services-cicd)"
+    )
+    
+    args = parser.parse_args()
+    
+    # Determine repository root (script is in hack/ directory)
+    script_path = Path(__file__).resolve()
+    repo_root = script_path.parent.parent
+    
+    # Determine which Makefiles to process
+    makefiles_to_process = []
+    
+    if args.sync:
+        # Sync mode: process ALL Makefiles in COMPONENTS
+        print("🔄 SYNC MODE: Processing all Makefiles in COMPONENTS mapping...")
+        makefiles_to_process = sorted(COMPONENTS.keys())
+        mode = "sync"
+    elif args.makefile:
+        # Single Makefile specified
+        makefile_path = repo_root / args.makefile
+        
+        if not makefile_path.exists():
+            print(f"❌ Error: Makefile not found: {args.makefile}")
+            return 1
+        
+        # Check if this Makefile is in our COMPONENTS mapping
+        if args.makefile not in COMPONENTS:
+            print(f"❌ Error: Makefile not found in COMPONENTS mapping: {args.makefile}")
+            print(f"\nAvailable Makefiles:")
+            for makefile in sorted(COMPONENTS.keys()):
+                print(f"  - {makefile}")
+            return 1
+        
+        makefiles_to_process = [args.makefile]
+        mode = "single"
+    else:
+        # Auto-detect modified Makefiles
+        print(f"🔍 Auto-detecting modified Makefiles using git diff against {args.base_branch}...")
+        makefiles_to_process = get_modified_makefiles(args.base_branch)
+        
+        if not makefiles_to_process:
+            print(f"\n✅ No modified Makefiles found in COMPONENTS mapping.")
+            print(f"   Compared against: {args.base_branch}")
+            print(f"\n   Tracked Makefiles:")
+            for makefile in sorted(COMPONENTS.keys()):
+                print(f"     - {makefile}")
+            return 0
+        
+        mode = "auto"
+    
+    # Print header
+    print("=" * 70)
+    if mode == "sync":
+        print(f"SYNC MODE: Syncing all {len(makefiles_to_process)} Makefiles with values.yaml")
+        print("All values.yaml files will be synced to match current Makefile TAGs")
+    elif mode == "single":
+        print(f"Updating image tags for: {args.makefile}")
+    else:
+        print(f"Updating image tags for {len(makefiles_to_process)} modified Makefile(s)")
+        print(f"Base branch: {args.base_branch}")
+    print("=" * 70)
+    print(f"Registry: {args.registry}")
+    print("=" * 70)
+    
+    # Process each Makefile
+    total_updated = 0
+    total_skipped = 0
+    total_errors = 0
+    
+    for makefile_rel in makefiles_to_process:
+        updated, skipped, errors = process_makefile(
+            makefile_rel, args.registry, repo_root
+        )
+        total_updated += updated
+        total_skipped += skipped
+        total_errors += errors
+    
+    print()
+    print("=" * 70)
+    print("Summary:")
+    print("=" * 70)
+    if mode in ["auto", "sync"]:
+        print(f"Makefiles processed: {len(makefiles_to_process)}")
+    print(f"Updated:             {total_updated}")
+    print(f"Already current:     {total_skipped}")
+    print(f"Errors:              {total_errors}")
+    print("=" * 70)
+    
+    if total_errors > 0:
+        return 1
+    
+    if total_updated > 0:
+        if mode == "sync":
+            print("\n✅ All Makefiles synced successfully!")
+        else:
+            print("\n✅ Image tags updated successfully!")
+    else:
+        print("\n✅ All image tags are already up-to-date!")
+    
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+# Made with Bob


### PR DESCRIPTION
## Automate Image Tag Updates in values.yaml Files

### Summary
Automated solution for updating container image references in `values.yaml` files and updating Makefile TAGs, when files are modified for the services, which is eliminating manual updates across 12 components and 44+ files.