### PR TITLE
[DB-Sync] Fix missing multi pods and add syncing other resources like secrets, volumes, pods missing

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.121
+TAG?=v0.0.122
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.121
+  image: icr.io/ai-services-cicd/ai-services:v0.0.122
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -95,13 +95,16 @@ func runAPIServer(port int, accessTTL, refreshTTL time.Duration, adminUser, admi
 	serviceDependencyRepo := repository.NewServiceDependencyRepository(pool)
 
 	// Initialize sync service for background DB-Pod synchronization
-	syncService := sync.NewSyncService(
+	syncService, err := sync.NewSyncService(
 		applicationRepo,
 		serviceRepo,
 		componentRepo,
 		serviceDependencyRepo,
 		sync.DefaultSyncInterval,
 	)
+	if err != nil {
+		return fmt.Errorf("failed to initialize sync service: %w", err)
+	}
 	syncService.Start(ctx)
 	defer syncService.Stop(ctx)
 

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -5,14 +5,17 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	texttemplate "text/template"
 	"time"
 
 	"github.com/google/uuid"
+	catalogpkg "github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
 	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	modelpkg "github.com/project-ai-services/ai-services/internal/pkg/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/common"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
@@ -21,7 +24,21 @@ import (
 const (
 	// DefaultSyncInterval is the default interval for syncing DB with pod status.
 	DefaultSyncInterval = 30 * time.Second
+
+	// Resource item types.
+	resourceItemTypeService   = "service"
+	resourceItemTypeComponent = "component"
+
+	// Component catalogID format: "type/provider" has 2 parts.
+	componentCatalogIDParts = 2
 )
+
+// ResourceCounts tracks expected resource counts and names from templates.
+type ResourceCounts struct {
+	Pods        int
+	SecretNames []string // Names of secrets referenced in pod labels
+	VolumeNames []string // Names of volumes referenced in pod labels
+}
 
 // SyncService handles periodic synchronization of DB records with actual pod status.
 type SyncService struct {
@@ -31,8 +48,11 @@ type SyncService struct {
 	serviceDepsRepo dbrepo.ServiceDependencyRepository
 	syncInterval    time.Duration
 	stopChan        chan struct{}
-	syncMutex       sync.Mutex // Prevents overlapping sync cycles
-	isSyncing       bool       // Tracks if a sync is currently running
+	syncMutex       sync.Mutex                 // Prevents overlapping sync cycles
+	isSyncing       bool                       // Tracks if a sync is currently running
+	resourceCache   map[string]*ResourceCounts // Tracks expected resource counts per catalogID
+	cacheMutex      sync.RWMutex               // Protects resourceCache
+	catalogProvider *catalogpkg.CatalogProvider
 }
 
 // NewSyncService creates a new sync service instance.
@@ -47,6 +67,11 @@ func NewSyncService(
 		syncInterval = DefaultSyncInterval
 	}
 
+	catalogProvider, err := catalogpkg.NewCatalogProvider()
+	if err != nil {
+		logger.Errorf("Failed to create catalog provider for sync service: %v", err)
+	}
+
 	return &SyncService{
 		appRepo:         appRepo,
 		serviceRepo:     serviceRepo,
@@ -54,6 +79,8 @@ func NewSyncService(
 		serviceDepsRepo: serviceDepsRepo,
 		syncInterval:    syncInterval,
 		stopChan:        make(chan struct{}),
+		resourceCache:   make(map[string]*ResourceCounts),
+		catalogProvider: catalogProvider,
 	}
 }
 
@@ -246,23 +273,54 @@ func (s *SyncService) syncServicePod(ctx context.Context, rt runtime.Runtime, se
 	// Fetch all pods using service ID as template label
 	pods, err := s.fetchPodsByTemplateID(rt, service.ID.String())
 	if err != nil {
-		// Pod not found or error - mark service as Error
-		newStatus := models.ServiceStatusError
-		message := fmt.Sprintf("Pod not found or error: %v", err)
+		return s.handleServicePodFetchError(ctx, service, err)
+	}
 
-		if service.Status != newStatus {
-			if err := catalogutils.UpdateServiceStatus(ctx, s.serviceRepo, service.ID, newStatus, message); err != nil {
-				return "", fmt.Errorf("failed to update service status: %w", err)
-			}
-			logger.InfofCtx(ctx, "Updated service %s status to %s", service.ID, newStatus)
-		}
+	// Determine service status based on pods and resources
+	newStatus, message := s.determineServiceStatusFromPods(ctx, service.CatalogID, pods, rt)
 
+	// Update service status if changed
+	if err := s.updateServiceStatusIfChanged(ctx, service, newStatus, message); err != nil {
+		return "", err
+	}
+
+	// Return error message if service is in error state
+	if newStatus == models.ServiceStatusError {
 		return message, nil
 	}
+
+	return "", nil
+}
+
+// handleServicePodFetchError handles the case when pods cannot be fetched for a service.
+func (s *SyncService) handleServicePodFetchError(ctx context.Context, service models.Service, fetchErr error) (string, error) {
+	newStatus := models.ServiceStatusError
+	message := fmt.Sprintf("Pod not found or error: %v", fetchErr)
+
+	if service.Status != newStatus {
+		if err := catalogutils.UpdateServiceStatus(ctx, s.serviceRepo, service.ID, newStatus, message); err != nil {
+			return "", fmt.Errorf("failed to update service status: %w", err)
+		}
+		logger.InfofCtx(ctx, "Updated service %s status to %s", service.ID, newStatus)
+	}
+
+	return message, nil
+}
+
+// determineServiceStatusFromPods determines service status based on pods and resource validation.
+func (s *SyncService) determineServiceStatusFromPods(ctx context.Context, catalogID string, pods []*podStatus, rt runtime.Runtime) (models.ServiceStatus, string) {
+	// Validate resource counts against templates
+	resourceValidationMsg := s.validateResourceCounts(ctx, catalogID, resourceItemTypeService, len(pods), rt)
 
 	// Check all pods - if any pod is unhealthy, service is in error
 	newStatus := models.ServiceStatusRunning
 	var errorMessages []string
+
+	// Add resource validation error if present
+	if resourceValidationMsg != "" {
+		newStatus = models.ServiceStatusError
+		errorMessages = append(errorMessages, resourceValidationMsg)
+	}
 
 	for _, pod := range pods {
 		isHealthy, message := s.determinePodStatus(pod)
@@ -272,25 +330,19 @@ func (s *SyncService) syncServicePod(ctx context.Context, rt runtime.Runtime, se
 		}
 	}
 
-	message := ""
-	if len(errorMessages) > 0 {
-		message = strings.Join(errorMessages, "; ")
-	}
+	return newStatus, strings.Join(errorMessages, "; ")
+}
 
-	// Update only if status changed
+// updateServiceStatusIfChanged updates service status only if it has changed.
+func (s *SyncService) updateServiceStatusIfChanged(ctx context.Context, service models.Service, newStatus models.ServiceStatus, message string) error {
 	if service.Status != newStatus {
 		if err := catalogutils.UpdateServiceStatus(ctx, s.serviceRepo, service.ID, newStatus, message); err != nil {
-			return "", fmt.Errorf("failed to update service status: %w", err)
+			return fmt.Errorf("failed to update service status: %w", err)
 		}
 		logger.InfofCtx(ctx, "Updated service %s status to %s", service.ID, newStatus)
 	}
 
-	// Return error message if service is in error state
-	if newStatus == models.ServiceStatusError {
-		return message, nil
-	}
-
-	return "", nil
+	return nil
 }
 
 // syncComponentPod syncs a single component's pod status
@@ -311,8 +363,24 @@ func (s *SyncService) syncComponentPod(ctx context.Context, rt runtime.Runtime, 
 		return s.handleComponentPodFetchError(ctx, component, componentID, err)
 	}
 
+	// Build component catalogID in format "type/provider"
+	componentCatalogID := fmt.Sprintf("%s/%s", component.Type, component.Provider)
+
+	// Validate resource counts against templates
+	resourceValidationMsg := s.validateResourceCounts(ctx, componentCatalogID, resourceItemTypeComponent, len(pods), rt)
+
 	// Check all pods health
 	newStatus, message := s.checkPodsHealth(pods)
+
+	// Add resource validation error if present
+	if resourceValidationMsg != "" {
+		newStatus = models.ComponentStatusError
+		if message != "" {
+			message = fmt.Sprintf("%s; %s", resourceValidationMsg, message)
+		} else {
+			message = resourceValidationMsg
+		}
+	}
 
 	// Update component status if changed
 	if err := s.updateComponentStatusIfChanged(ctx, component, componentID, newStatus, message); err != nil {
@@ -355,12 +423,7 @@ func (s *SyncService) checkPodsHealth(pods []*podStatus) (models.ComponentStatus
 		}
 	}
 
-	message := ""
-	if len(errorMessages) > 0 {
-		message = strings.Join(errorMessages, "; ")
-	}
-
-	return newStatus, message
+	return newStatus, strings.Join(errorMessages, "; ")
 }
 
 // updateComponentStatusIfChanged updates component status only if it has changed.
@@ -460,6 +523,228 @@ func (s *SyncService) updateApplicationStatus(ctx context.Context, app *models.A
 	}
 
 	return nil
+}
+
+// getExpectedResourceCounts retrieves expected resource counts from cache.
+func (s *SyncService) getExpectedResourceCounts(catalogID string) *ResourceCounts {
+	s.cacheMutex.RLock()
+	defer s.cacheMutex.RUnlock()
+
+	return s.resourceCache[catalogID]
+}
+
+// setExpectedResourceCounts stores expected resource counts in cache.
+func (s *SyncService) setExpectedResourceCounts(catalogID string, counts *ResourceCounts) {
+	s.cacheMutex.Lock()
+	defer s.cacheMutex.Unlock()
+	s.resourceCache[catalogID] = counts
+}
+
+// countResourcesFromTemplates counts expected Pods and Secrets from service/component templates.
+func (s *SyncService) countResourcesFromTemplates(ctx context.Context, catalogID, itemType string) (*ResourceCounts, error) {
+	if s.catalogProvider == nil {
+		return nil, fmt.Errorf("catalog provider not initialized")
+	}
+
+	templates, values, err := s.loadTemplatesAndValues(catalogID, itemType)
+	if err != nil {
+		return nil, err
+	}
+
+	counts := s.processTemplatesForResourceCounts(ctx, templates, values)
+	if counts == nil {
+		return nil, fmt.Errorf("failed to process templates")
+	}
+
+	logger.InfofCtx(ctx, "Counted resources for %s %s: %d pods, %d secret refs, %d volume refs",
+		itemType, catalogID, counts.Pods, len(counts.SecretNames), len(counts.VolumeNames))
+
+	return counts, nil
+}
+
+// loadTemplatesAndValues loads templates and values based on item type.
+func (s *SyncService) loadTemplatesAndValues(catalogID, itemType string) (map[string]*texttemplate.Template, map[string]any, error) {
+	switch itemType {
+	case resourceItemTypeService:
+		return s.loadServiceTemplatesAndValues(catalogID)
+	case resourceItemTypeComponent:
+		return s.loadComponentTemplatesAndValues(catalogID)
+	default:
+		return nil, nil, fmt.Errorf("unknown item type: %s", itemType)
+	}
+}
+
+// loadServiceTemplatesAndValues loads service templates and values.
+func (s *SyncService) loadServiceTemplatesAndValues(catalogID string) (map[string]*texttemplate.Template, map[string]any, error) {
+	templates, err := s.catalogProvider.LoadServiceTemplates(catalogID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load service templates: %w", err)
+	}
+	values, err := s.catalogProvider.LoadServiceValues(catalogID, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load service values: %w", err)
+	}
+
+	return templates, values, nil
+}
+
+// loadComponentTemplatesAndValues loads component templates and values.
+func (s *SyncService) loadComponentTemplatesAndValues(catalogID string) (map[string]*texttemplate.Template, map[string]any, error) {
+	parts := strings.Split(catalogID, "/")
+	if len(parts) != componentCatalogIDParts {
+		return nil, nil, fmt.Errorf("invalid component catalogID format: %s (expected format: type/provider)", catalogID)
+	}
+	componentType, providerID := parts[0], parts[1]
+
+	templates, err := s.catalogProvider.LoadComponentTemplates(componentType, providerID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load component templates: %w", err)
+	}
+
+	values, err := s.catalogProvider.LoadComponentValues(componentType, providerID, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load component values: %w", err)
+	}
+
+	return templates, values, nil
+}
+
+// processTemplatesForResourceCounts processes templates and counts resources.
+func (s *SyncService) processTemplatesForResourceCounts(ctx context.Context, templates map[string]*texttemplate.Template, values map[string]any) *ResourceCounts {
+	counts := &ResourceCounts{}
+
+	processor := func(templateName string, podSpec *modelpkg.PodSpec) error {
+		if podSpec.Kind != "Pod" {
+			return nil
+		}
+
+		counts.Pods++
+		s.extractResourceLabelsFromPodSpec(podSpec, counts)
+
+		return nil
+	}
+
+	if err := s.catalogProvider.ProcessTemplates(ctx, templates, values, "resource-counting", processor); err != nil {
+		logger.ErrorfCtx(ctx, "Failed to process templates: %v", err)
+
+		return nil
+	}
+
+	return counts
+}
+
+// extractResourceLabelsFromPodSpec extracts secret and volume labels from pod spec.
+func (s *SyncService) extractResourceLabelsFromPodSpec(podSpec *modelpkg.PodSpec, counts *ResourceCounts) {
+	if podSpec.Labels == nil {
+		return
+	}
+
+	if secretLabel, ok := podSpec.Labels["ai-services.io/secret"]; ok && secretLabel != "" {
+		counts.SecretNames = append(counts.SecretNames, secretLabel)
+	}
+
+	if volumeLabel, ok := podSpec.Labels["ai-services.io/volume"]; ok && volumeLabel != "" {
+		counts.VolumeNames = append(counts.VolumeNames, volumeLabel)
+	}
+}
+
+// validateResourceCounts validates that actual resources match expected counts from templates.
+// Returns error message if validation fails, empty string if all resources are present.
+func (s *SyncService) validateResourceCounts(ctx context.Context, catalogID, itemType string, actualPodCount int, rt runtime.Runtime) string {
+	// Get expected counts from cache
+	expectedCounts := s.getExpectedResourceCounts(catalogID)
+
+	// If not in cache, count from templates and cache it
+	if expectedCounts == nil {
+		counts, err := s.countResourcesFromTemplates(ctx, catalogID, itemType)
+		if err != nil {
+			logger.ErrorfCtx(ctx, "Failed to count resources from templates for %s %s: %v", itemType, catalogID, err)
+			// Don't fail sync if we can't count templates - just skip validation
+			return ""
+		}
+		expectedCounts = counts
+		s.setExpectedResourceCounts(catalogID, counts)
+	}
+
+	var errorMessages []string
+
+	// Validate pod count
+	if actualPodCount < expectedCounts.Pods {
+		errorMessages = append(errorMessages,
+			fmt.Sprintf("Pod count mismatch: expected %d, found %d", expectedCounts.Pods, actualPodCount))
+	}
+
+	// Validate secrets and volumes exist by checking pod labels
+	// If pods are running with these labels, the secrets/volumes must exist
+	if len(expectedCounts.SecretNames) > 0 || len(expectedCounts.VolumeNames) > 0 {
+		resourceValidationMsg := s.validateResourcesFromPodLabels(ctx, expectedCounts.SecretNames, expectedCounts.VolumeNames, rt)
+		if resourceValidationMsg != "" {
+			errorMessages = append(errorMessages, resourceValidationMsg)
+		}
+	}
+
+	if len(errorMessages) > 0 {
+		return strings.Join(errorMessages, "; ")
+	}
+
+	return ""
+}
+
+// validateResourcesFromPodLabels validates that secrets and volumes referenced in templates exist
+// by checking the runtime for their existence.
+func (s *SyncService) validateResourcesFromPodLabels(ctx context.Context, expectedSecretNames, expectedVolumeNames []string, rt runtime.Runtime) string {
+	if len(expectedSecretNames) == 0 && len(expectedVolumeNames) == 0 {
+		return ""
+	}
+
+	var errorMessages []string
+
+	// Validate secrets
+	if secretMsg := s.validateSecrets(ctx, expectedSecretNames, rt); secretMsg != "" {
+		errorMessages = append(errorMessages, secretMsg)
+	}
+
+	// Validate volumes
+	if volumeMsg := s.validateVolumes(ctx, expectedVolumeNames, rt); volumeMsg != "" {
+		errorMessages = append(errorMessages, volumeMsg)
+	}
+
+	if len(errorMessages) > 0 {
+		return strings.Join(errorMessages, "; ")
+	}
+
+	return ""
+}
+
+// validateSecrets validates that expected secrets exist in runtime.
+func (s *SyncService) validateSecrets(ctx context.Context, expectedSecretNames []string, rt runtime.Runtime) string {
+	return s.validateResourceExistence(ctx, expectedSecretNames, "secret", rt.SecretExists)
+}
+
+// validateVolumes validates that expected volumes exist in runtime.
+func (s *SyncService) validateVolumes(ctx context.Context, expectedVolumeNames []string, rt runtime.Runtime) string {
+	return s.validateResourceExistence(ctx, expectedVolumeNames, "volume", rt.VolumeExists)
+}
+
+// validateResourceExistence is a generic helper to validate resource existence.
+func (s *SyncService) validateResourceExistence(ctx context.Context, resourceNames []string, resourceType string, existsFunc func(string) (bool, error)) string {
+	var missingResources []string
+	for _, resourceName := range resourceNames {
+		exists, err := existsFunc(resourceName)
+		if err != nil {
+			logger.ErrorfCtx(ctx, "Failed to check %s existence for %s: %v", resourceType, resourceName, err)
+
+			continue
+		}
+		if !exists {
+			missingResources = append(missingResources, resourceName)
+		}
+	}
+	if len(missingResources) > 0 {
+		return fmt.Sprintf("Missing %ss: %s", resourceType, strings.Join(missingResources, ", "))
+	}
+
+	return ""
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -277,7 +277,8 @@ func (s *SyncService) syncServicePod(ctx context.Context, rt runtime.Runtime, se
 	}
 
 	// Determine service status based on pods and resources
-	newStatus, message := s.determineServiceStatusFromPods(ctx, service.CatalogID, pods, rt)
+	// For services, use AppID to generate instance slug
+	newStatus, message := s.determineServiceStatusFromPods(ctx, service.CatalogID, service.AppID.String(), pods, rt)
 
 	// Update service status if changed
 	if err := s.updateServiceStatusIfChanged(ctx, service, newStatus, message); err != nil {
@@ -308,9 +309,9 @@ func (s *SyncService) handleServicePodFetchError(ctx context.Context, service mo
 }
 
 // determineServiceStatusFromPods determines service status based on pods and resource validation.
-func (s *SyncService) determineServiceStatusFromPods(ctx context.Context, catalogID string, pods []*podStatus, rt runtime.Runtime) (models.ServiceStatus, string) {
+func (s *SyncService) determineServiceStatusFromPods(ctx context.Context, catalogID, instanceID string, pods []*podStatus, rt runtime.Runtime) (models.ServiceStatus, string) {
 	// Validate resource counts against templates
-	resourceValidationMsg := s.validateResourceCounts(ctx, catalogID, resourceItemTypeService, len(pods), rt)
+	resourceValidationMsg := s.validateResourceCounts(ctx, catalogID, instanceID, resourceItemTypeService, len(pods), rt)
 
 	// Check all pods - if any pod is unhealthy, service is in error
 	newStatus := models.ServiceStatusRunning
@@ -367,7 +368,7 @@ func (s *SyncService) syncComponentPod(ctx context.Context, rt runtime.Runtime, 
 	componentCatalogID := fmt.Sprintf("%s/%s", component.Type, component.Provider)
 
 	// Validate resource counts against templates
-	resourceValidationMsg := s.validateResourceCounts(ctx, componentCatalogID, resourceItemTypeComponent, len(pods), rt)
+	resourceValidationMsg := s.validateResourceCounts(ctx, componentCatalogID, componentID.String(), resourceItemTypeComponent, len(pods), rt)
 
 	// Check all pods health
 	newStatus, message := s.checkPodsHealth(pods)
@@ -541,12 +542,12 @@ func (s *SyncService) setExpectedResourceCounts(catalogID string, counts *Resour
 }
 
 // countResourcesFromTemplates counts expected Pods and Secrets from service/component templates.
-func (s *SyncService) countResourcesFromTemplates(ctx context.Context, catalogID, itemType string) (*ResourceCounts, error) {
+func (s *SyncService) countResourcesFromTemplates(ctx context.Context, catalogID, instanceID, itemType string) (*ResourceCounts, error) {
 	if s.catalogProvider == nil {
 		return nil, fmt.Errorf("catalog provider not initialized")
 	}
 
-	templates, values, err := s.loadTemplatesAndValues(catalogID, itemType)
+	templates, values, err := s.loadTemplatesAndValues(catalogID, instanceID, itemType)
 	if err != nil {
 		return nil, err
 	}
@@ -563,24 +564,33 @@ func (s *SyncService) countResourcesFromTemplates(ctx context.Context, catalogID
 }
 
 // loadTemplatesAndValues loads templates and values based on item type.
-func (s *SyncService) loadTemplatesAndValues(catalogID, itemType string) (map[string]*texttemplate.Template, map[string]any, error) {
+func (s *SyncService) loadTemplatesAndValues(catalogID, instanceID, itemType string) (map[string]*texttemplate.Template, map[string]any, error) {
 	switch itemType {
 	case resourceItemTypeService:
-		return s.loadServiceTemplatesAndValues(catalogID)
+		return s.loadServiceTemplatesAndValues(catalogID, instanceID)
 	case resourceItemTypeComponent:
-		return s.loadComponentTemplatesAndValues(catalogID)
+		return s.loadComponentTemplatesAndValues(catalogID, instanceID)
 	default:
 		return nil, nil, fmt.Errorf("unknown item type: %s", itemType)
 	}
 }
 
 // loadServiceTemplatesAndValues loads service templates and values.
-func (s *SyncService) loadServiceTemplatesAndValues(catalogID string) (map[string]*texttemplate.Template, map[string]any, error) {
+// For services, instanceID should be the Application ID.
+func (s *SyncService) loadServiceTemplatesAndValues(catalogID, instanceID string) (map[string]*texttemplate.Template, map[string]any, error) {
 	templates, err := s.catalogProvider.LoadServiceTemplates(catalogID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load service templates: %w", err)
 	}
-	values, err := s.catalogProvider.LoadServiceValues(catalogID, nil)
+
+	// Generate instance slug from Application ID
+	instanceSlug := catalogutils.GenerateInstanceSlug(instanceID)
+	overrides := map[string]string{
+		"InstanceSlug": instanceSlug,
+		"TemplateID":   instanceID,
+	}
+
+	values, err := s.catalogProvider.LoadServiceValues(catalogID, overrides)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load service values: %w", err)
 	}
@@ -589,7 +599,8 @@ func (s *SyncService) loadServiceTemplatesAndValues(catalogID string) (map[strin
 }
 
 // loadComponentTemplatesAndValues loads component templates and values.
-func (s *SyncService) loadComponentTemplatesAndValues(catalogID string) (map[string]*texttemplate.Template, map[string]any, error) {
+// For components, instanceID should be the Component ID.
+func (s *SyncService) loadComponentTemplatesAndValues(catalogID, instanceID string) (map[string]*texttemplate.Template, map[string]any, error) {
 	parts := strings.Split(catalogID, "/")
 	if len(parts) != componentCatalogIDParts {
 		return nil, nil, fmt.Errorf("invalid component catalogID format: %s (expected format: type/provider)", catalogID)
@@ -601,7 +612,14 @@ func (s *SyncService) loadComponentTemplatesAndValues(catalogID string) (map[str
 		return nil, nil, fmt.Errorf("failed to load component templates: %w", err)
 	}
 
-	values, err := s.catalogProvider.LoadComponentValues(componentType, providerID, nil)
+	// Generate instance slug from Component ID
+	instanceSlug := catalogutils.GenerateInstanceSlug(instanceID)
+	overrides := map[string]string{
+		"InstanceSlug": instanceSlug,
+		"TemplateID":   instanceID,
+	}
+
+	values, err := s.catalogProvider.LoadComponentValues(componentType, providerID, overrides)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load component values: %w", err)
 	}
@@ -650,13 +668,13 @@ func (s *SyncService) extractResourceLabelsFromPodSpec(podSpec *modelpkg.PodSpec
 
 // validateResourceCounts validates that actual resources match expected counts from templates.
 // Returns error message if validation fails, empty string if all resources are present.
-func (s *SyncService) validateResourceCounts(ctx context.Context, catalogID, itemType string, actualPodCount int, rt runtime.Runtime) string {
+func (s *SyncService) validateResourceCounts(ctx context.Context, catalogID, instanceID, itemType string, actualPodCount int, rt runtime.Runtime) string {
 	// Get expected counts from cache
 	expectedCounts := s.getExpectedResourceCounts(catalogID)
 
 	// If not in cache, count from templates and cache it
 	if expectedCounts == nil {
-		counts, err := s.countResourcesFromTemplates(ctx, catalogID, itemType)
+		counts, err := s.countResourcesFromTemplates(ctx, catalogID, instanceID, itemType)
 		if err != nil {
 			logger.ErrorfCtx(ctx, "Failed to count resources from templates for %s %s: %v", itemType, catalogID, err)
 			// Don't fail sync if we can't count templates - just skip validation

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -552,7 +552,9 @@ func (s *SyncService) countResourcesFromTemplates(ctx context.Context, catalogID
 		return nil, err
 	}
 
-	counts := s.processTemplatesForResourceCounts(ctx, templates, values)
+	// Generate instance slug for ProcessTemplates
+	instanceSlug := catalogutils.GenerateInstanceSlug(instanceID)
+	counts := s.processTemplatesForResourceCounts(ctx, templates, values, instanceSlug)
 	if counts == nil {
 		return nil, fmt.Errorf("failed to process templates")
 	}
@@ -628,7 +630,7 @@ func (s *SyncService) loadComponentTemplatesAndValues(catalogID, instanceID stri
 }
 
 // processTemplatesForResourceCounts processes templates and counts resources.
-func (s *SyncService) processTemplatesForResourceCounts(ctx context.Context, templates map[string]*texttemplate.Template, values map[string]any) *ResourceCounts {
+func (s *SyncService) processTemplatesForResourceCounts(ctx context.Context, templates map[string]*texttemplate.Template, values map[string]any, instanceSlug string) *ResourceCounts {
 	counts := &ResourceCounts{}
 
 	processor := func(templateName string, podSpec *modelpkg.PodSpec) error {
@@ -642,7 +644,7 @@ func (s *SyncService) processTemplatesForResourceCounts(ctx context.Context, tem
 		return nil
 	}
 
-	if err := s.catalogProvider.ProcessTemplates(ctx, templates, values, "resource-counting", processor); err != nil {
+	if err := s.catalogProvider.ProcessTemplates(ctx, templates, values, instanceSlug, processor); err != nil {
 		logger.ErrorfCtx(ctx, "Failed to process templates: %v", err)
 
 		return nil

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -243,8 +243,8 @@ func (s *SyncService) syncAllServices(ctx context.Context, rt runtime.Runtime, a
 // syncServicePod syncs a single service's pod status
 // Returns: error message (if any) and error.
 func (s *SyncService) syncServicePod(ctx context.Context, rt runtime.Runtime, service models.Service) (string, error) {
-	// Fetch pod using service ID as template label
-	pod, err := s.fetchPodByTemplateID(rt, service.ID.String())
+	// Fetch all pods using service ID as template label
+	pods, err := s.fetchPodsByTemplateID(rt, service.ID.String())
 	if err != nil {
 		// Pod not found or error - mark service as Error
 		newStatus := models.ServiceStatusError
@@ -260,8 +260,22 @@ func (s *SyncService) syncServicePod(ctx context.Context, rt runtime.Runtime, se
 		return message, nil
 	}
 
-	// Determine service status based on pod health
-	newStatus, message := s.determineServiceStatus(pod)
+	// Check all pods - if any pod is unhealthy, service is in error
+	newStatus := models.ServiceStatusRunning
+	var errorMessages []string
+
+	for _, pod := range pods {
+		isHealthy, message := s.determinePodStatus(pod)
+		if !isHealthy {
+			newStatus = models.ServiceStatusError
+			errorMessages = append(errorMessages, message)
+		}
+	}
+
+	message := ""
+	if len(errorMessages) > 0 {
+		message = strings.Join(errorMessages, "; ")
+	}
 
 	// Update only if status changed
 	if service.Status != newStatus {
@@ -291,32 +305,18 @@ func (s *SyncService) syncComponentPod(ctx context.Context, rt runtime.Runtime, 
 		return models.ComponentStatusError, "", fmt.Errorf("component not found: %s", componentID)
 	}
 
-	// Fetch pod using component ID as template label
-	pod, err := s.fetchPodByTemplateID(rt, componentID.String())
+	// Fetch all pods using component ID as template label
+	pods, err := s.fetchPodsByTemplateID(rt, componentID.String())
 	if err != nil {
-		// Pod not found or error - mark component as Error
-		newStatus := models.ComponentStatusError
-		message := fmt.Sprintf("Pod not found or error: %v", err)
-
-		if component.Status != newStatus {
-			if err := catalogutils.UpdateComponentStatus(ctx, s.componentRepo, componentID, newStatus, message); err != nil {
-				return newStatus, "", fmt.Errorf("failed to update component status: %w", err)
-			}
-			logger.InfofCtx(ctx, "Updated component %s status to %s", componentID, newStatus)
-		}
-		// Return formatted message for application status
-		return newStatus, fmt.Sprintf("Component %s/%s: %s", component.Type, component.Provider, message), nil
+		return s.handleComponentPodFetchError(ctx, component, componentID, err)
 	}
 
-	// Determine component status based on pod health
-	newStatus, message := s.determineComponentStatus(pod)
+	// Check all pods health
+	newStatus, message := s.checkPodsHealth(pods)
 
-	// Update only if status changed
-	if component.Status != newStatus {
-		if err := catalogutils.UpdateComponentStatus(ctx, s.componentRepo, componentID, newStatus, message); err != nil {
-			return newStatus, "", fmt.Errorf("failed to update component status: %w", err)
-		}
-		logger.InfofCtx(ctx, "Updated component %s status to %s", componentID, newStatus)
+	// Update component status if changed
+	if err := s.updateComponentStatusIfChanged(ctx, component, componentID, newStatus, message); err != nil {
+		return newStatus, "", err
 	}
 
 	// Return formatted message for application status if component is in error
@@ -327,8 +327,57 @@ func (s *SyncService) syncComponentPod(ctx context.Context, rt runtime.Runtime, 
 	return newStatus, "", nil
 }
 
-// fetchPodByTemplateID fetches a pod using the template ID label.
-func (s *SyncService) fetchPodByTemplateID(rt runtime.Runtime, templateID string) (*podStatus, error) {
+// handleComponentPodFetchError handles the case when pods cannot be fetched for a component.
+func (s *SyncService) handleComponentPodFetchError(ctx context.Context, component *models.Component, componentID uuid.UUID, fetchErr error) (models.ComponentStatus, string, error) {
+	newStatus := models.ComponentStatusError
+	message := fmt.Sprintf("Pod not found or error: %v", fetchErr)
+
+	if component.Status != newStatus {
+		if err := catalogutils.UpdateComponentStatus(ctx, s.componentRepo, componentID, newStatus, message); err != nil {
+			return newStatus, "", fmt.Errorf("failed to update component status: %w", err)
+		}
+		logger.InfofCtx(ctx, "Updated component %s status to %s", componentID, newStatus)
+	}
+
+	return newStatus, fmt.Sprintf("Component %s/%s: %s", component.Type, component.Provider, message), nil
+}
+
+// checkPodsHealth checks the health of all pods and returns the overall status.
+func (s *SyncService) checkPodsHealth(pods []*podStatus) (models.ComponentStatus, string) {
+	newStatus := models.ComponentStatusRunning
+	var errorMessages []string
+
+	for _, pod := range pods {
+		isHealthy, message := s.determinePodStatus(pod)
+		if !isHealthy {
+			newStatus = models.ComponentStatusError
+			errorMessages = append(errorMessages, message)
+		}
+	}
+
+	message := ""
+	if len(errorMessages) > 0 {
+		message = strings.Join(errorMessages, "; ")
+	}
+
+	return newStatus, message
+}
+
+// updateComponentStatusIfChanged updates component status only if it has changed.
+func (s *SyncService) updateComponentStatusIfChanged(ctx context.Context, component *models.Component, componentID uuid.UUID, newStatus models.ComponentStatus, message string) error {
+	if component.Status != newStatus {
+		if err := catalogutils.UpdateComponentStatus(ctx, s.componentRepo, componentID, newStatus, message); err != nil {
+			return fmt.Errorf("failed to update component status: %w", err)
+		}
+		logger.InfofCtx(ctx, "Updated component %s status to %s", componentID, newStatus)
+	}
+
+	return nil
+}
+
+// fetchPodsByTemplateID fetches all pods using the template ID label.
+// Returns a slice of pod statuses.
+func (s *SyncService) fetchPodsByTemplateID(rt runtime.Runtime, templateID string) ([]*podStatus, error) {
 	// Use the same logic as in ApplicationsPs - fetch pods with template label
 	filteredPods, err := common.FetchFilteredPods(rt, templateID)
 	if err != nil {
@@ -339,24 +388,26 @@ func (s *SyncService) fetchPodByTemplateID(rt runtime.Runtime, templateID string
 		return nil, fmt.Errorf("no pod found with template ID: %s", templateID)
 	}
 
-	// Take the first pod (should only be one per template ID)
-	pod := filteredPods[0]
+	// Process all pods
+	var podStatuses []*podStatus
+	for _, pod := range filteredPods {
+		processedPod, err := common.ProcessPod(rt, pod)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process pod: %w", err)
+		}
 
-	// Process pod to get status and health
-	processedPod, err := common.ProcessPod(rt, pod)
-	if err != nil {
-		return nil, fmt.Errorf("failed to process pod: %w", err)
+		if processedPod == nil {
+			return nil, fmt.Errorf("pod processing returned nil")
+		}
+
+		podStatuses = append(podStatuses, &podStatus{
+			state:   processedPod.State,
+			health:  processedPod.Health,
+			podName: processedPod.Name,
+		})
 	}
 
-	if processedPod == nil {
-		return nil, fmt.Errorf("pod processing returned nil")
-	}
-
-	return &podStatus{
-		state:   processedPod.State,
-		health:  processedPod.Health,
-		podName: processedPod.Name,
-	}, nil
+	return podStatuses, nil
 }
 
 // podStatus holds the relevant pod status information.
@@ -367,7 +418,7 @@ type podStatus struct {
 }
 
 // determinePodStatus determines status based on pod state and health
-// Returns: isRunning (bool), errorMessage (string).
+// Returns: isHealthy (bool), errorMessage (string).
 func (s *SyncService) determinePodStatus(pod *podStatus) (bool, string) {
 	if pod.state == "Running" && pod.health == string(constants.Ready) {
 		return true, ""
@@ -378,26 +429,6 @@ func (s *SyncService) determinePodStatus(pod *podStatus) (bool, string) {
 	}
 
 	return false, fmt.Sprintf("Pod %s is in state: %s", pod.podName, pod.state)
-}
-
-// determineServiceStatus determines service status based on pod state and health.
-func (s *SyncService) determineServiceStatus(pod *podStatus) (models.ServiceStatus, string) {
-	isRunning, message := s.determinePodStatus(pod)
-	if isRunning {
-		return models.ServiceStatusRunning, message
-	}
-
-	return models.ServiceStatusError, message
-}
-
-// determineComponentStatus determines component status based on pod state and health.
-func (s *SyncService) determineComponentStatus(pod *podStatus) (models.ComponentStatus, string) {
-	isRunning, message := s.determinePodStatus(pod)
-	if isRunning {
-		return models.ComponentStatusRunning, message
-	}
-
-	return models.ComponentStatusError, message
 }
 
 // updateApplicationStatus updates application status based on collected errors during sync

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -31,6 +31,9 @@ const (
 
 	// Component catalogID format: "type/provider" has 2 parts.
 	componentCatalogIDParts = 2
+
+	// Error message templates.
+	errMsgPodNotFound = "Pod not found or error: %v"
 )
 
 // ResourceCounts tracks expected resource counts and names from templates.
@@ -62,14 +65,14 @@ func NewSyncService(
 	componentRepo dbrepo.ComponentRepository,
 	serviceDepsRepo dbrepo.ServiceDependencyRepository,
 	syncInterval time.Duration,
-) *SyncService {
+) (*SyncService, error) {
 	if syncInterval == 0 {
 		syncInterval = DefaultSyncInterval
 	}
 
 	catalogProvider, err := catalogpkg.NewCatalogProvider()
 	if err != nil {
-		logger.Errorf("Failed to create catalog provider for sync service: %v", err)
+		return nil, fmt.Errorf("failed to create catalog provider for sync service: %w", err)
 	}
 
 	return &SyncService{
@@ -81,7 +84,7 @@ func NewSyncService(
 		stopChan:        make(chan struct{}),
 		resourceCache:   make(map[string]*ResourceCounts),
 		catalogProvider: catalogProvider,
-	}
+	}, nil
 }
 
 // Start begins the sync goroutine.
@@ -296,7 +299,7 @@ func (s *SyncService) syncServicePod(ctx context.Context, rt runtime.Runtime, se
 // handleServicePodFetchError handles the case when pods cannot be fetched for a service.
 func (s *SyncService) handleServicePodFetchError(ctx context.Context, service models.Service, fetchErr error) (string, error) {
 	newStatus := models.ServiceStatusError
-	message := fmt.Sprintf("Pod not found or error: %v", fetchErr)
+	message := fmt.Sprintf(errMsgPodNotFound, fetchErr)
 
 	if service.Status != newStatus {
 		if err := catalogutils.UpdateServiceStatus(ctx, s.serviceRepo, service.ID, newStatus, message); err != nil {
@@ -399,7 +402,7 @@ func (s *SyncService) syncComponentPod(ctx context.Context, rt runtime.Runtime, 
 // handleComponentPodFetchError handles the case when pods cannot be fetched for a component.
 func (s *SyncService) handleComponentPodFetchError(ctx context.Context, component *models.Component, componentID uuid.UUID, fetchErr error) (models.ComponentStatus, string, error) {
 	newStatus := models.ComponentStatusError
-	message := fmt.Sprintf("Pod not found or error: %v", fetchErr)
+	message := fmt.Sprintf(errMsgPodNotFound, fetchErr)
 
 	if component.Status != newStatus {
 		if err := catalogutils.UpdateComponentStatus(ctx, s.componentRepo, componentID, newStatus, message); err != nil {

--- a/ai-services/internal/pkg/runtime/interface.go
+++ b/ai-services/internal/pkg/runtime/interface.go
@@ -30,6 +30,7 @@ type Runtime interface {
 
 	// Volume operations
 	DeleteVolume(name string) error
+	VolumeExists(nameOrID string) (bool, error)
 
 	// Container operations
 	// ListContainers(filters map[string][]string) ([]types.Container, error)

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -448,6 +448,12 @@ func (kc *OpenshiftClient) DeleteVolume(name string) error {
 	return nil
 }
 
+func (kc *OpenshiftClient) VolumeExists(nameOrID string) (bool, error) {
+	logger.Warningln("Not implemented")
+
+	return false, nil
+}
+
 // GetSystemInfo returns empty system information for OpenShift runtime.
 // Resource information is managed by Kubernetes/OpenShift and not directly accessible.
 func (kc *OpenshiftClient) GetSystemInfo() (*models.SystemInfo, error) {

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -402,6 +402,10 @@ func (pc *PodmanClient) DeleteVolume(name string) error {
 	return nil
 }
 
+func (pc *PodmanClient) VolumeExists(nameOrID string) (bool, error) {
+	return volumes.Exists(pc.Context, nameOrID, nil)
+}
+
 func (pc *PodmanClient) ListSecrets(filters map[string][]string) ([]string, error) {
 	var listOpts secrets.ListOptions
 	if len(filters) >= 1 {


### PR DESCRIPTION
Fixes: https://jsw.ibm.com/browse/AISERVICES-1270 and also fixes: https://jsw.ibm.com/browse/AISERVICES-1289

- For a given service/component, if there are multiple pods, earlier syncing was done to only 1 pod. Now all the pods are synced and even if any pod is in error, then overall service/component/application status will be error.
- Also added syncing for missing pods, secrets and volumes and update the status appropriately.