### PR TITLE
fix: do not allow domain change during --reset-certificate

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.119
+TAG?=v0.0.120
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.119
+  image: icr.io/ai-services-cicd/ai-services:v0.0.120
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 )
 
@@ -100,6 +101,23 @@ func validateCertificateChanges(opts *PodmanConfigureOptions) error {
 	// - Reconfigure with same custom certs (content matches)
 	// - Reconfigure with updated custom certs (content differs - allow for cert renewal/expiry)
 	// - Caddy self-signed to custom certs transition
+	return nil
+}
+
+// validateDomainUnchanged validates that the domain hasn't changed from the existing configuration.
+func validateDomainUnchanged(existingOpts *PodmanConfigureOptions, sslCertPath, sslKeyPath string) error {
+	// Compute the current domain configuration based on the provided SSL certificates
+	// This uses the same logic as initial configuration
+	currentDomainSuffix, err := caddy.ComputeDomainConfig(sslCertPath, sslKeyPath, "")
+	if err != nil {
+		return fmt.Errorf("failed to compute current domain: %w", err)
+	}
+
+	// Compare existing domain with current domain
+	if existingOpts.DomainName != currentDomainSuffix {
+		return fmt.Errorf("domain change detected: existing=%s, current=%s. Domain changes are not allowed during reset-certificate. Please uninstall the catalog deployment and re-run configure with the new domain", existingOpts.DomainName, currentDomainSuffix)
+	}
+
 	return nil
 }
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -30,6 +30,11 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 		return fmt.Errorf("AI_SERVICES_BASE_DIR not found in catalog configuration")
 	}
 
+	// Validate that domain hasn't changed
+	if err := validateDomainUnchanged(opts, sslCertPath, sslKeyPath); err != nil {
+		return err
+	}
+
 	// Get Caddy pod name from templates
 	caddyPodName, err := deployCtx.GetCaddyPodName()
 	if err != nil {


### PR DESCRIPTION
Added domain validation to `--reset-certificate` to prevent certificate resets when the domain has changed. The operation now fails with a clear error if the domain extracted from new SSL certificates doesn't match the deployed configuration, preventing certificate-domain mismatches.