### PR TITLE
[CATALOG-CMD] AISERVICES-1243: Fixing long and short help message of catalog configure.

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.123
+TAG?=v0.0.124
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.123
+  image: icr.io/ai-services-cicd/ai-services:v0.0.124
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -44,8 +44,8 @@ const (
 func NewConfigureCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "configure",
-		Short: "Configure the catalog service with initial configuration",
-		Long: `Deploys the catalog service with the provided configuration.
+		Short: "Configure the catalog service",
+		Long: `Configures the catalog service with the provided configuration.
 
 Examples:
 	 # Configure catalog service for podman

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -45,15 +45,14 @@ func NewConfigureCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "configure",
 		Short: "Configure the catalog service",
-		Long: `Configures the catalog service and includes reset flags to update admin credentials, podman authentication, and SSL certificates.
+		Long: `Configure and deploy the AI Services catalog service with the specified runtime and configuration.
 
-The configure process will:
-		- Create a new admin user if one does not exist.
-		- Create a new podman authentication secret if one does not exist.
-		- Create a new SSL certificate if one does not exist.
-		- Deploys the catalog services.
+The configure and deploy process will:
+	- Deploys the catalog services.
+	- Create a new admin user if one does not exist.
+	- Sets up base directory structure for applications and models
 
-Command also support additional parameters to configure base directories, SSL/TLS certificates, and HTTPS port. 
+The command also supports additional parameters to configure base directories, SSL/TLS certificates, HTTPS port, and reset flags to update passwords and certificates.
 
 Examples:
 	 # Configure catalog service for podman

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -45,7 +45,12 @@ func NewConfigureCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "configure",
 		Short: "Configure the catalog service",
-		Long: `Configures the catalog service with the provided configuration.
+		Long: `Configures the catalog service for the specified runtime type.
+
+The catalog service manages AI services through two main components:
+	- Catalog UI: Web-based interface for managing AI services
+	- Catalog API: REST API for programmatic management of AI services
+
 
 Examples:
 	 # Configure catalog service for podman

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -45,12 +45,15 @@ func NewConfigureCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "configure",
 		Short: "Configure the catalog service",
-		Long: `Configures the catalog service for the specified runtime type.
+		Long: `Configures the catalog service it includes reset flags to update admin credentials, podman authentication, and SSL certificates.
 
-The catalog service manages AI services through two main components:
-	- Catalog UI: Web-based interface for managing AI services
-	- Catalog API: REST API for programmatic management of AI services
+The configure process will:
+		- Create a new admin user if one does not exist.
+		- Create a new podman authentication secret if one does not exist.
+		- Create a new SSL certificate if one does not exist.
+		- Deploys the catalog services.
 
+Command also support additional parameters to configure base directories, SSL/TLS certificates, and HTTPS port. 
 
 Examples:
 	 # Configure catalog service for podman

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -45,7 +45,7 @@ func NewConfigureCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "configure",
 		Short: "Configure the catalog service",
-		Long: `Configures the catalog service it includes reset flags to update admin credentials, podman authentication, and SSL certificates.
+		Long: `Configures the catalog service and includes reset flags to update admin credentials, podman authentication, and SSL certificates.
 
 The configure process will:
 		- Create a new admin user if one does not exist.

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -52,7 +52,7 @@ The configure and deploy process will:
 	- Create a new admin user if one does not exist.
 	- Sets up base directory structure for applications and models
 
-The command also supports additional parameters to configure base directories, SSL/TLS certificates, HTTPS port, and reset flags to update passwords and certificates.
+The command also supports additional parameters to configure base directories, domain name, SSL/TLS certificates, HTTPS port, and reset flags to update passwords and certificates.
 
 Examples:
 	 # Configure catalog service for podman


### PR DESCRIPTION
Fixed catalog configure command descriptions for long and short format.