### PR TITLE
AISERVICES-1288: Check catalog status before resetting password and auth

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.124
+TAG?=v0.0.125
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.124
+  image: icr.io/ai-services-cicd/ai-services:v0.0.125
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -340,36 +340,10 @@ func configureResetFlags(cmd *cobra.Command) {
 }
 
 func runResetPassword() error {
-	logger.Warningf("Resetting password will reload the catalog pod, catalog service will be temporarily unavailable during this time!")
-	// Confirm deletion
-	confirmed, err := utils.ConfirmAction("\nDo you want to continue, with password reset?")
-	if err != nil {
-		return fmt.Errorf("failed to get confirmation: %w", err)
-	}
-
-	if !confirmed {
-		logger.Infoln("Catalog password reset cancelled")
-
-		return nil
-	}
-
 	return catalogPodman.ResetCatalogPassword()
 }
 
 func runResetPodmanAuth() error {
-	logger.Warningf("Resetting Podman auth will reload the catalog pod, catalog service will be temporarily unavailable during this time!")
-	// Confirm deletion
-	confirmed, err := utils.ConfirmAction("\nDo you want to continue, with podman auth reset?")
-	if err != nil {
-		return fmt.Errorf("failed to get confirmation: %w", err)
-	}
-
-	if !confirmed {
-		logger.Infoln("Catalog podman auth reset cancelled")
-
-		return nil
-	}
-
 	return catalogPodman.ResetPodmanAuth()
 }
 

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -249,8 +249,6 @@ func validateResetCertificateFlags(cmd *cobra.Command, flagName string) error {
 }
 
 func runResetCertificate() error {
-	logger.Infof("Resetting certificates and reloading catalog pod...")
-
 	// Sanitize SSL certificate paths to prevent path traversal attacks
 	cleanCertPath, cleanKeyPath := sanitizeSSLPaths(sslCertPath, sslKeyPath)
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -1,12 +1,16 @@
 package podman
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 const certsDirName = "certs"
@@ -120,6 +124,44 @@ func validateDomainUnchanged(existingOpts *catalogUtils.PodmanConfigureOptions, 
 	}
 
 	return nil
+}
+
+// IsCatalogServiceRunning checks if the catalog service is configured and running.
+func IsCatalogServiceRunning(rt runtime.Runtime) (bool, error) {
+	_, _, err := getCatalogPodDetails(rt)
+	if err != nil {
+		if errors.Is(err, ErrCatalogPodNotFound) {
+			logger.InfolnCtx(context.Background(), "Catalog service is not configured or running.")
+			logger.InfolnCtx(context.Background(), "Run 'ai-services catalog configure --runtime podman' to set up the catalog service.")
+
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
+// ConfirmCatalogReset displays a warning about catalog service unavailability and prompts for user confirmation.
+// The flagName parameter is used to customize the warning and confirmation messages.
+// Returns true if user confirms, false if cancelled, or an error if confirmation fails.
+func ConfirmCatalogReset(flagName string) (bool, error) {
+	logger.WarningfCtx(context.Background(), "Resetting %s will reload the catalog pod, catalog service will be temporarily unavailable during this time!", flagName)
+
+	// Confirm action
+	confirmed, err := utils.ConfirmAction(fmt.Sprintf("\nDo you want to continue, with %s reset?", flagName))
+	if err != nil {
+		return false, fmt.Errorf("failed to get confirmation: %w", err)
+	}
+
+	if !confirmed {
+		logger.InfofCtx(context.Background(), "Catalog %s reset cancelled", flagName)
+
+		return false, nil
+	}
+
+	return true, nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -128,9 +128,9 @@ func validateDomainUnchanged(existingOpts *catalogUtils.PodmanConfigureOptions, 
 
 // IsCatalogServiceRunning checks if the catalog service is configured and running.
 func IsCatalogServiceRunning(rt runtime.Runtime) (bool, error) {
-	_, _, err := getCatalogPodDetails(rt)
+	_, _, err := catalogUtils.GetCatalogPodConfig(rt)
 	if err != nil {
-		if errors.Is(err, ErrCatalogPodNotFound) {
+		if errors.Is(err, catalogUtils.ErrCatalogPodNotFound) {
 			logger.InfolnCtx(context.Background(), "Catalog service is not configured or running.")
 			logger.InfolnCtx(context.Background(), "Run 'ai-services catalog configure --runtime podman' to set up the catalog service.")
 
@@ -158,6 +158,32 @@ func ConfirmCatalogReset(flagName string) (bool, error) {
 	if !confirmed {
 		logger.InfofCtx(context.Background(), "Catalog %s reset cancelled", flagName)
 
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// validateCatalogServiceAndConfirmReset validates that the catalog service is running
+// and confirms the reset action with the user. Returns true if the operation should proceed.
+func validateCatalogServiceAndConfirmReset(rt runtime.Runtime, resetType string) (bool, error) {
+	// Validate catalog service is running
+	isCatalogRunning, err := IsCatalogServiceRunning(rt)
+	if err != nil {
+		return false, err
+	}
+
+	if !isCatalogRunning {
+		return false, nil
+	}
+
+	// Confirm reset action
+	confirmed, err := ConfirmCatalogReset(resetType)
+	if err != nil {
+		return false, err
+	}
+
+	if !confirmed {
 		return false, nil
 	}
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -1,6 +1,7 @@
 package podman
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
@@ -19,6 +20,16 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 	deployCtx, err := deploy.NewDeployContext()
 	if err != nil {
 		return fmt.Errorf("failed to create deployment context: %w", err)
+	}
+
+	// Validate catalog service is running
+	isCatalogRunning, err := IsCatalogServiceRunning(deployCtx.Runtime)
+	if err != nil {
+		return err
+	}
+
+	if !isCatalogRunning {
+		return nil
 	}
 
 	// Get existing catalog pod details
@@ -45,6 +56,18 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 	// Create Caddy context for certificate operations
 	caddyCtx := caddy.NewContext(caddyPodName, "")
 
+	// Load certificates with health check
+	if err := loadCertificatesToCaddy(caddyCtx, opts.BaseDir, sslCertPath, sslKeyPath); err != nil {
+		return err
+	}
+
+	logger.InfolnCtx(context.Background(), "SSL certificates reset successfully")
+
+	return nil
+}
+
+// loadCertificatesToCaddy checks Caddy health and loads SSL certificates.
+func loadCertificatesToCaddy(caddyCtx *caddy.Context, baseDir, sslCertPath, sslKeyPath string) error {
 	// Check Caddy health before attempting to load certificates
 	proxyManager, err := caddyCtx.CreateProxyManager()
 	if err != nil {
@@ -56,11 +79,9 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 	}
 
 	// Load new SSL certificates to Caddy
-	if err := caddyCtx.LoadSSLCertificates(opts.BaseDir, sslCertPath, sslKeyPath); err != nil {
+	if err := caddyCtx.LoadSSLCertificates(baseDir, sslCertPath, sslKeyPath); err != nil {
 		return fmt.Errorf("failed to load certificates: %w", err)
 	}
-
-	logger.Infof("SSL certificates reset successfully")
 
 	return nil
 }

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -14,7 +14,7 @@ import (
 // It stages new certificates and loads them into Caddy via the Admin API without pod restart.
 // Caddy health is verified internally when connecting to the Admin API.
 func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
-	logger.Debugln("resetting catalog SSL certificates...")
+	logger.DebuglnCtx(context.Background(), "Resetting catalog SSL certificates...")
 
 	// Create deployment context to get runtime
 	deployCtx, err := deploy.NewDeployContext()

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
@@ -8,12 +8,7 @@ import (
 	catalogConstant "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
-)
-
-var (
-	ErrCatalogPodNotFound = fmt.Errorf("catalog pod not found")
 )
 
 func ResetCatalogPassword() error {
@@ -41,15 +36,21 @@ func ResetCatalogPassword() error {
 		return err
 	}
 
-	logger.Infof("Deleting catalog secret %s", catalogConstant.CatalogSecretName)
+	logger.InfofCtx(context.Background(), "Deleting catalog secret %s", catalogConstant.CatalogSecretName)
 	err = deployCtx.Runtime.DeleteSecret(catalogConstant.CatalogSecretName)
 	if err != nil {
 		return fmt.Errorf("failed to delete existing catalog secret: %w", err)
 	}
 
-	opts, err := getAndDeleteCatalogPod(deployCtx.Runtime)
+	opts, podID, err := catalogUtils.GetCatalogPodConfig(deployCtx.Runtime)
 	if err != nil {
 		return fmt.Errorf("failed to get existing catalog pod details: %w", err)
+	}
+
+	logger.InfofCtx(context.Background(), "Deleting existing catalog pod %s", podID)
+	err = deployCtx.Runtime.DeletePod(podID, utils.BoolPtr(true))
+	if err != nil {
+		return fmt.Errorf("failed to delete existing catalog pod: %w", err)
 	}
 
 	_, err = executeCatalogDeployment(context.Background(), deployCtx, *opts, passwordHash)
@@ -58,55 +59,4 @@ func ResetCatalogPassword() error {
 	}
 
 	return nil
-}
-
-func getAndDeleteCatalogPod(rt runtime.Runtime) (*catalogUtils.PodmanConfigureOptions, error) {
-	opts, podID, err := getCatalogPodDetails(rt)
-	if err != nil {
-		return nil, err
-	}
-
-	logger.Infof("Deleting existing catalog pod %s", podID)
-	err = rt.DeletePod(podID, utils.BoolPtr(true))
-	if err != nil {
-		return nil, fmt.Errorf("failed to delete existing catalog pod: %w", err)
-	}
-
-	return opts, nil
-}
-
-// getCatalogPodDetails retrieves catalog pod configuration by inspecting the running pod and its containers.
-func getCatalogPodDetails(rt runtime.Runtime) (*catalogUtils.PodmanConfigureOptions, string, error) {
-	config, podID, err := catalogUtils.GetCatalogPodConfig(rt)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return config, podID, nil
-}
-
-// validateCatalogServiceAndConfirmReset validates that the catalog service is running
-// and confirms the reset action with the user. Returns true if the operation should proceed.
-func validateCatalogServiceAndConfirmReset(rt runtime.Runtime, resetType string) (bool, error) {
-	// Validate catalog service is running
-	isCatalogRunning, err := IsCatalogServiceRunning(rt)
-	if err != nil {
-		return false, err
-	}
-
-	if !isCatalogRunning {
-		return false, nil
-	}
-
-	// Confirm reset action
-	confirmed, err := ConfirmCatalogReset(resetType)
-	if err != nil {
-		return false, err
-	}
-
-	if !confirmed {
-		return false, nil
-	}
-
-	return true, nil
 }

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
@@ -12,11 +12,25 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
+var (
+	ErrCatalogPodNotFound = fmt.Errorf("catalog pod not found")
+)
+
 func ResetCatalogPassword() error {
 	// Create deployment context without argParams for status check
 	deployCtx, err := deploy.NewDeployContext()
 	if err != nil {
 		return err
+	}
+
+	// Validate catalog service and confirm reset action
+	shouldProceed, err := validateCatalogServiceAndConfirmReset(deployCtx.Runtime, "password")
+	if err != nil {
+		return err
+	}
+
+	if !shouldProceed {
+		return nil
 	}
 
 	// Collect new catalog password
@@ -69,4 +83,30 @@ func getCatalogPodDetails(rt runtime.Runtime) (*catalogUtils.PodmanConfigureOpti
 	}
 
 	return config, podID, nil
+}
+
+// validateCatalogServiceAndConfirmReset validates that the catalog service is running
+// and confirms the reset action with the user. Returns true if the operation should proceed.
+func validateCatalogServiceAndConfirmReset(rt runtime.Runtime, resetType string) (bool, error) {
+	// Validate catalog service is running
+	isCatalogRunning, err := IsCatalogServiceRunning(rt)
+	if err != nil {
+		return false, err
+	}
+
+	if !isCatalogRunning {
+		return false, nil
+	}
+
+	// Confirm reset action
+	confirmed, err := ConfirmCatalogReset(resetType)
+	if err != nil {
+		return false, err
+	}
+
+	if !confirmed {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
 	catalogConstant "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 func ResetPodmanAuth() error {
@@ -27,15 +29,21 @@ func ResetPodmanAuth() error {
 	}
 
 	// Delete podman auth secret.
-	logger.Infof("Deleting catalog podman auth secret %s", catalogConstant.CatalogPodmanAuthSecretName)
+	logger.InfofCtx(context.Background(), "Deleting catalog podman auth secret %s", catalogConstant.CatalogPodmanAuthSecretName)
 	err = deployCtx.Runtime.DeleteSecret(catalogConstant.CatalogPodmanAuthSecretName)
 	if err != nil {
 		return fmt.Errorf("failed to delete existing catalog podman auth secret: %w", err)
 	}
 
-	opts, err := getAndDeleteCatalogPod(deployCtx.Runtime)
+	opts, podID, err := catalogUtils.GetCatalogPodConfig(deployCtx.Runtime)
 	if err != nil {
 		return fmt.Errorf("failed to get existing catalog pod details: %w", err)
+	}
+
+	logger.InfofCtx(context.Background(), "Deleting existing catalog pod %s", podID)
+	err = deployCtx.Runtime.DeletePod(podID, utils.BoolPtr(true))
+	if err != nil {
+		return fmt.Errorf("failed to delete existing catalog pod: %w", err)
 	}
 
 	_, err = executeCatalogDeployment(context.Background(), deployCtx, *opts, "")

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
@@ -16,6 +16,16 @@ func ResetPodmanAuth() error {
 		return err
 	}
 
+	// Validate catalog service and confirm reset action
+	shouldProceed, err := validateCatalogServiceAndConfirmReset(deployCtx.Runtime, "podman auth")
+	if err != nil {
+		return err
+	}
+
+	if !shouldProceed {
+		return nil
+	}
+
 	// Delete podman auth secret.
 	logger.Infof("Deleting catalog podman auth secret %s", catalogConstant.CatalogPodmanAuthSecretName)
 	err = deployCtx.Runtime.DeleteSecret(catalogConstant.CatalogPodmanAuthSecretName)

--- a/ai-services/internal/pkg/catalog/utils/common.go
+++ b/ai-services/internal/pkg/catalog/utils/common.go
@@ -9,6 +9,10 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 )
 
+var (
+	ErrCatalogPodNotFound = fmt.Errorf("no catalog pod found")
+)
+
 // PodmanConfigureOptions contains the configuration for configuring the catalog service on Podman runtime.
 type PodmanConfigureOptions struct {
 	BaseDir     string
@@ -37,7 +41,7 @@ func GetCatalogPodConfig(rt runtime.Runtime) (*PodmanConfigureOptions, string, e
 		return nil, "", fmt.Errorf("failed to list pods: %w", err)
 	}
 	if len(pods) == 0 {
-		return nil, "", fmt.Errorf("no catalog pod found")
+		return nil, "", ErrCatalogPodNotFound
 	}
 
 	// Inspect catalog pod


### PR DESCRIPTION
Updating reset password and auth flow, to terminate fast, when catalog service is not deployed in system. 