### PR TITLE
fix: fetch and delete dir from catalog pod env

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.122
+TAG?=v0.0.123
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.122
+  image: icr.io/ai-services-cicd/ai-services:v0.0.123
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/cli/configure/common.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/common.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	catalogPodman "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure/podman"
+	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 )
 
@@ -15,7 +16,7 @@ func Run(runtime types.RuntimeType, baseDir, domainName, sslCertPath, sslKeyPath
 	// Deploy catalog service based on runtime
 	switch runtime {
 	case types.RuntimeTypePodman:
-		opts := catalogPodman.PodmanConfigureOptions{
+		opts := catalogUtils.PodmanConfigureOptions{
 			BaseDir:     baseDir,
 			DomainName:  domainName,
 			SSLCertPath: sslCertPath,

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -10,6 +10,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
 	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/spinner"
@@ -20,17 +21,8 @@ const (
 	defaultPasswordIterations = 100000
 )
 
-// PodmanConfigureOptions contains the configuration for configuring the catalog service on Podman runtime.
-type PodmanConfigureOptions struct {
-	BaseDir     string
-	DomainName  string // Custom domain name for self-signed certificates
-	SSLCertPath string // Path to user-provided SSL certificate
-	SSLKeyPath  string // Path to user-provided SSL private key
-	HttpsPort   int
-}
-
 // DeployCatalog deploys the catalog service using the assets/catalog template for podman runtime.
-func DeployCatalog(ctx context.Context, opts PodmanConfigureOptions) error {
+func DeployCatalog(ctx context.Context, opts catalogUtils.PodmanConfigureOptions) error {
 	// Create deployment context without argParams for status check
 	deployCtx, err := deploy.NewDeployContext()
 	if err != nil {
@@ -57,7 +49,7 @@ func DeployCatalog(ctx context.Context, opts PodmanConfigureOptions) error {
 	return handlePostDeployment(caddyCtx, deployCtx)
 }
 
-func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployContext, opts PodmanConfigureOptions, passwordHash string) (*caddy.Context, error) {
+func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployContext, opts catalogUtils.PodmanConfigureOptions, passwordHash string) (*caddy.Context, error) {
 	logger.Debugln("started configuring catalog service...")
 
 	s := spinner.New("Configuring catalog service...")
@@ -223,7 +215,7 @@ func generateArgParams(passwordHash string, httpsPort int) (map[string]string, e
 // 2. Computes domain configuration (cert domain extraction + domain suffix resolution)
 // 3. Creates Caddy context with pod name and domain suffix
 // 4. Generates and writes Caddyfile.
-func setupCaddyContext(deployCtx *deploy.DeployContext, opts PodmanConfigureOptions, s *spinner.Spinner) (*caddy.Context, error) {
+func setupCaddyContext(deployCtx *deploy.DeployContext, opts catalogUtils.PodmanConfigureOptions, s *spinner.Spinner) (*caddy.Context, error) {
 	// Get Caddy pod name from deployment context (templates)
 	caddyPodName, err := deployCtx.GetCaddyPodName()
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
+	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 )
 
@@ -13,9 +14,15 @@ const certsDirName = "certs"
 // getExistingConfigFromCatalogBackend retrieves the existing configuration from the catalog pod.
 // These values are used to validate that configuration hasn't changed during reconfigure operations.
 func getExistingConfigFromCatalogBackend(rt runtime.Runtime) (*PodmanConfigureOptions, error) {
-	opts, _, err := getCatalogPodDetails(rt)
+	config, _, err := catalogUtils.GetCatalogPodConfig(rt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get catalog pod details: %w", err)
+	}
+
+	opts := &PodmanConfigureOptions{
+		BaseDir:    config.BaseDir,
+		DomainName: config.DomainName,
+		HttpsPort:  config.HttpsPort,
 	}
 
 	if err := validateRequiredFields(opts); err != nil {

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -13,16 +13,10 @@ const certsDirName = "certs"
 
 // getExistingConfigFromCatalogBackend retrieves the existing configuration from the catalog pod.
 // These values are used to validate that configuration hasn't changed during reconfigure operations.
-func getExistingConfigFromCatalogBackend(rt runtime.Runtime) (*PodmanConfigureOptions, error) {
-	config, _, err := catalogUtils.GetCatalogPodConfig(rt)
+func getExistingConfigFromCatalogBackend(rt runtime.Runtime) (*catalogUtils.PodmanConfigureOptions, error) {
+	opts, _, err := catalogUtils.GetCatalogPodConfig(rt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get catalog pod details: %w", err)
-	}
-
-	opts := &PodmanConfigureOptions{
-		BaseDir:    config.BaseDir,
-		DomainName: config.DomainName,
-		HttpsPort:  config.HttpsPort,
 	}
 
 	if err := validateRequiredFields(opts); err != nil {
@@ -33,7 +27,7 @@ func getExistingConfigFromCatalogBackend(rt runtime.Runtime) (*PodmanConfigureOp
 }
 
 // validateRequiredFields validates that all required configuration values are present.
-func validateRequiredFields(opts *PodmanConfigureOptions) error {
+func validateRequiredFields(opts *catalogUtils.PodmanConfigureOptions) error {
 	if opts.DomainName == "" {
 		return fmt.Errorf("DOMAIN_SUFFIX environment variable not found in catalog pod")
 	}
@@ -49,7 +43,7 @@ func validateRequiredFields(opts *PodmanConfigureOptions) error {
 
 // validateReconfigureParameters validates that domain, HTTPS port, base directory, and certificates haven't changed during reconfigure.
 // This function performs all validation checks including certificate validation.
-func validateReconfigureParameters(rt runtime.Runtime, newOpts *PodmanConfigureOptions, domainSuffix string) error {
+func validateReconfigureParameters(rt runtime.Runtime, newOpts *catalogUtils.PodmanConfigureOptions, domainSuffix string) error {
 	// Get existing configuration from catalog-backend pod
 	existingOpts, err := getExistingConfigFromCatalogBackend(rt)
 	if err != nil {
@@ -67,7 +61,7 @@ func validateReconfigureParameters(rt runtime.Runtime, newOpts *PodmanConfigureO
 }
 
 // validateConfigParameters validates domain, HTTPS port, and base directory haven't changed.
-func validateConfigParameters(existingOpts *PodmanConfigureOptions, newOpts *PodmanConfigureOptions, domainSuffix string) error {
+func validateConfigParameters(existingOpts *catalogUtils.PodmanConfigureOptions, newOpts *catalogUtils.PodmanConfigureOptions, domainSuffix string) error {
 	if existingOpts.DomainName != domainSuffix {
 		return fmt.Errorf("domain change not allowed during reconfigure: existing=%s, new=%s. Please uninstall the catalog deployment and re-run configure to change domain", existingOpts.DomainName, domainSuffix)
 	}
@@ -86,7 +80,7 @@ func validateConfigParameters(existingOpts *PodmanConfigureOptions, newOpts *Pod
 // validateCertificateChanges prevents switching from custom certificates back to Caddy self-signed certificates.
 // Allows updating custom certificate content (e.g., for expiry or renewal).
 // Uses glob patterns to detect timestamped certificate files.
-func validateCertificateChanges(opts *PodmanConfigureOptions) error {
+func validateCertificateChanges(opts *catalogUtils.PodmanConfigureOptions) error {
 	// Define staged certificate directory
 	certDir := filepath.Join(opts.BaseDir, "common", "caddy", certsDirName)
 
@@ -112,7 +106,7 @@ func validateCertificateChanges(opts *PodmanConfigureOptions) error {
 }
 
 // validateDomainUnchanged validates that the domain hasn't changed from the existing configuration.
-func validateDomainUnchanged(existingOpts *PodmanConfigureOptions, sslCertPath, sslKeyPath string) error {
+func validateDomainUnchanged(existingOpts *catalogUtils.PodmanConfigureOptions, sslCertPath, sslKeyPath string) error {
 	// Compute the current domain configuration based on the provided SSL certificates
 	// This uses the same logic as initial configuration
 	currentDomainSuffix, err := caddy.ComputeDomainConfig(sslCertPath, sslKeyPath, "")

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
+	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 )
 
@@ -21,12 +22,12 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 	}
 
 	// Get existing catalog pod details
-	opts, _, err := getCatalogPodDetails(deployCtx.Runtime)
+	config, _, err := catalogUtils.GetCatalogPodConfig(deployCtx.Runtime)
 	if err != nil {
 		return fmt.Errorf("failed to get catalog pod details: %w", err)
 	}
 
-	if opts.BaseDir == "" {
+	if config.BaseDir == "" {
 		return fmt.Errorf("AI_SERVICES_BASE_DIR not found in catalog configuration")
 	}
 
@@ -55,7 +56,7 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 	}
 
 	// Load new SSL certificates to Caddy
-	if err := caddyCtx.LoadSSLCertificates(opts.BaseDir, sslCertPath, sslKeyPath); err != nil {
+	if err := caddyCtx.LoadSSLCertificates(config.BaseDir, sslCertPath, sslKeyPath); err != nil {
 		return fmt.Errorf("failed to load certificates: %w", err)
 	}
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -22,12 +22,12 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 	}
 
 	// Get existing catalog pod details
-	config, _, err := catalogUtils.GetCatalogPodConfig(deployCtx.Runtime)
+	opts, _, err := catalogUtils.GetCatalogPodConfig(deployCtx.Runtime)
 	if err != nil {
 		return fmt.Errorf("failed to get catalog pod details: %w", err)
 	}
 
-	if config.BaseDir == "" {
+	if opts.BaseDir == "" {
 		return fmt.Errorf("AI_SERVICES_BASE_DIR not found in catalog configuration")
 	}
 
@@ -56,7 +56,7 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 	}
 
 	// Load new SSL certificates to Caddy
-	if err := caddyCtx.LoadSSLCertificates(config.BaseDir, sslCertPath, sslKeyPath); err != nil {
+	if err := caddyCtx.LoadSSLCertificates(opts.BaseDir, sslCertPath, sslKeyPath); err != nil {
 		return fmt.Errorf("failed to load certificates: %w", err)
 	}
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
@@ -46,7 +46,7 @@ func ResetCatalogPassword() error {
 	return nil
 }
 
-func getAndDeleteCatalogPod(rt runtime.Runtime) (*PodmanConfigureOptions, error) {
+func getAndDeleteCatalogPod(rt runtime.Runtime) (*catalogUtils.PodmanConfigureOptions, error) {
 	opts, podID, err := getCatalogPodDetails(rt)
 	if err != nil {
 		return nil, err
@@ -62,17 +62,11 @@ func getAndDeleteCatalogPod(rt runtime.Runtime) (*PodmanConfigureOptions, error)
 }
 
 // getCatalogPodDetails retrieves catalog pod configuration by inspecting the running pod and its containers.
-func getCatalogPodDetails(rt runtime.Runtime) (*PodmanConfigureOptions, string, error) {
+func getCatalogPodDetails(rt runtime.Runtime) (*catalogUtils.PodmanConfigureOptions, string, error) {
 	config, podID, err := catalogUtils.GetCatalogPodConfig(rt)
 	if err != nil {
 		return nil, "", err
 	}
 
-	opts := &PodmanConfigureOptions{
-		BaseDir:    config.BaseDir,
-		DomainName: config.DomainName,
-		HttpsPort:  config.HttpsPort,
-	}
-
-	return opts, podID, nil
+	return config, podID, nil
 }

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
@@ -3,10 +3,10 @@ package podman
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
 	catalogConstant "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
@@ -63,55 +63,16 @@ func getAndDeleteCatalogPod(rt runtime.Runtime) (*PodmanConfigureOptions, error)
 
 // getCatalogPodDetails retrieves catalog pod configuration by inspecting the running pod and its containers.
 func getCatalogPodDetails(rt runtime.Runtime) (*PodmanConfigureOptions, string, error) {
-	// Build filter to find all pods using the catalog secret via label
-	logger.Infof("Getting catalog pod details")
-	filter := map[string][]string{
-		"label": {fmt.Sprintf(
-			"%s=%s",
-			catalogConstant.CatalogSecretLabel,
-			catalogConstant.CatalogSecretName,
-		)},
-	}
-
-	// List all pods that reference the catalog secret
-	pods, err := rt.ListPods(filter)
+	config, podID, err := catalogUtils.GetCatalogPodConfig(rt)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to list pods: %w", err)
-	}
-	if len(pods) == 0 {
-		return nil, "", fmt.Errorf("no catalog pod found")
+		return nil, "", err
 	}
 
-	// Inspect catalog pod
-	pod := pods[0]
-	pInfo, err := rt.InspectPod(pod.ID)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to inspect pod %s: %w", pod.Name, err)
+	opts := &PodmanConfigureOptions{
+		BaseDir:    config.BaseDir,
+		DomainName: config.DomainName,
+		HttpsPort:  config.HttpsPort,
 	}
 
-	opts := &PodmanConfigureOptions{}
-
-	for _, container := range pInfo.Containers {
-		// Inspect container for get hold of envs
-		cInfo, err := rt.InspectContainer(container.ID)
-		if err != nil {
-			return nil, "", fmt.Errorf("failed to inspect container %s: %w", container.Name, err)
-		}
-		setConfigureOptions(cInfo.Env, opts)
-	}
-
-	return opts, pod.ID, nil
-}
-
-func setConfigureOptions(podEnv map[string]string, opts *PodmanConfigureOptions) {
-	// Setting required 3 envs
-	if value, ok := podEnv["AI_SERVICES_BASE_DIR"]; ok {
-		opts.BaseDir = value
-	}
-	if value, ok := podEnv["DOMAIN_SUFFIX"]; ok {
-		opts.DomainName = value
-	}
-	if value, ok := podEnv["CADDY_HTTPS_PORT"]; ok {
-		opts.HttpsPort, _ = strconv.Atoi(value)
-	}
+	return opts, podID, nil
 }

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -126,6 +126,12 @@ func performCleanup(rt *podman.PodmanClient, pods []types.Pod, skipCleanup bool)
 		return err
 	}
 
+	// Delete models data
+	modelsDataPath := filepath.Join(baseDir, "models")
+	if err := dataDeletion(modelsDataPath); err != nil {
+		return err
+	}
+
 	// Delete database data and secrets
 	if err := cleanupDatabaseResources(rt, secretsToSkip, volumesToSkip, skipCleanup); err != nil {
 		return err

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -9,7 +9,6 @@ import (
 
 	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
-	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
@@ -122,7 +121,7 @@ func performCleanup(rt *podman.PodmanClient, pods []types.Pod, skipCleanup bool)
 	}
 
 	// Delete caddy data
-	caddyDataPath := getDataPath(baseDir, "common")
+	caddyDataPath := filepath.Join(baseDir, "common")
 	if err := dataDeletion(caddyDataPath); err != nil {
 		return err
 	}
@@ -146,16 +145,6 @@ func deleteSecrets(rt *podman.PodmanClient, secrets []string) error {
 	}
 
 	return nil
-}
-
-// getDataPath constructs the data path based on the base directory and subdirectory.
-func getDataPath(baseDir, subDir string) string {
-	// this is because we prepend "ai-services" to custom directory and not to default directory
-	if baseDir == constants.DefaultBaseDir {
-		return filepath.Join(baseDir, subDir)
-	}
-
-	return filepath.Join(baseDir, "ai-services", subDir)
 }
 
 // cleanupDatabaseResources handles database volume and secret cleanup.

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -89,7 +89,17 @@ func confirmDeletion(pods []types.Pod) (bool, error) {
 // performCleanup executes all cleanup operations.
 func performCleanup(rt *podman.PodmanClient, pods []types.Pod, skipCleanup bool) error {
 	logger.Infoln("Proceeding with deletion...")
-	baseDir := utils.GetBaseDir()
+
+	// Retrieve the BaseDir from the catalog pod configuration
+	var baseDir string
+	config, _, err := catalogUtils.GetCatalogPodConfig(rt)
+	if err != nil {
+		logger.Warningf("Failed to retrieve BaseDir from catalog pod: %v. Using default BaseDir.\n", err)
+		baseDir = utils.GetBaseDir()
+	} else {
+		baseDir = config.BaseDir
+	}
+	logger.Infof("Using base directory for cleanup: %s\n", baseDir)
 
 	secretsToDelete, secretsToSkip := fetchSecretsToDelete(pods)
 	secretsToDelete = append(secretsToDelete, catalogConstants.PodmanAuthSecret)

--- a/ai-services/internal/pkg/catalog/utils/common.go
+++ b/ai-services/internal/pkg/catalog/utils/common.go
@@ -1,0 +1,75 @@
+package utils
+
+import (
+	"fmt"
+	"strconv"
+
+	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+)
+
+// CatalogPodConfig holds configuration retrieved from a catalog pod.
+type CatalogPodConfig struct {
+	BaseDir    string
+	DomainName string
+	HttpsPort  int
+}
+
+// GetCatalogPodConfig retrieves catalog pod configuration by inspecting the running pod and its containers.
+// It extracts environment variables like AI_SERVICES_BASE_DIR, DOMAIN_SUFFIX, and CADDY_HTTPS_PORT.
+func GetCatalogPodConfig(rt runtime.Runtime) (*CatalogPodConfig, string, error) {
+	// Build filter to find all pods using the catalog secret via label
+	logger.Debugf("Getting catalog pod configuration")
+	filter := map[string][]string{
+		"label": {fmt.Sprintf(
+			"%s=%s",
+			catalogConstants.CatalogSecretLabel,
+			catalogConstants.CatalogSecretName,
+		)},
+	}
+
+	// List all pods that reference the catalog secret
+	pods, err := rt.ListPods(filter)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to list pods: %w", err)
+	}
+	if len(pods) == 0 {
+		return nil, "", fmt.Errorf("no catalog pod found")
+	}
+
+	// Inspect catalog pod
+	pod := pods[0]
+	pInfo, err := rt.InspectPod(pod.ID)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to inspect pod %s: %w", pod.Name, err)
+	}
+
+	config := &CatalogPodConfig{}
+
+	for _, container := range pInfo.Containers {
+		// Inspect container to get environment variables
+		cInfo, err := rt.InspectContainer(container.ID)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to inspect container %s: %w", container.Name, err)
+		}
+		extractConfigFromEnv(cInfo.Env, config)
+	}
+
+	return config, pod.ID, nil
+}
+
+// extractConfigFromEnv extracts configuration values from container environment variables.
+func extractConfigFromEnv(podEnv map[string]string, config *CatalogPodConfig) {
+	if value, ok := podEnv["AI_SERVICES_BASE_DIR"]; ok {
+		config.BaseDir = value
+	}
+	if value, ok := podEnv["DOMAIN_SUFFIX"]; ok {
+		config.DomainName = value
+	}
+	if value, ok := podEnv["CADDY_HTTPS_PORT"]; ok {
+		config.HttpsPort, _ = strconv.Atoi(value)
+	}
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/utils/common.go
+++ b/ai-services/internal/pkg/catalog/utils/common.go
@@ -9,16 +9,18 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 )
 
-// CatalogPodConfig holds configuration retrieved from a catalog pod.
-type CatalogPodConfig struct {
-	BaseDir    string
-	DomainName string
-	HttpsPort  int
+// PodmanConfigureOptions contains the configuration for configuring the catalog service on Podman runtime.
+type PodmanConfigureOptions struct {
+	BaseDir     string
+	DomainName  string // Custom domain name for self-signed certificates
+	SSLCertPath string // Path to user-provided SSL certificate
+	SSLKeyPath  string // Path to user-provided SSL private key
+	HttpsPort   int
 }
 
 // GetCatalogPodConfig retrieves catalog pod configuration by inspecting the running pod and its containers.
 // It extracts environment variables like AI_SERVICES_BASE_DIR, DOMAIN_SUFFIX, and CADDY_HTTPS_PORT.
-func GetCatalogPodConfig(rt runtime.Runtime) (*CatalogPodConfig, string, error) {
+func GetCatalogPodConfig(rt runtime.Runtime) (*PodmanConfigureOptions, string, error) {
 	// Build filter to find all pods using the catalog secret via label
 	logger.Debugf("Getting catalog pod configuration")
 	filter := map[string][]string{
@@ -45,7 +47,7 @@ func GetCatalogPodConfig(rt runtime.Runtime) (*CatalogPodConfig, string, error) 
 		return nil, "", fmt.Errorf("failed to inspect pod %s: %w", pod.Name, err)
 	}
 
-	config := &CatalogPodConfig{}
+	config := &PodmanConfigureOptions{}
 
 	for _, container := range pInfo.Containers {
 		// Inspect container to get environment variables
@@ -60,7 +62,7 @@ func GetCatalogPodConfig(rt runtime.Runtime) (*CatalogPodConfig, string, error) 
 }
 
 // extractConfigFromEnv extracts configuration values from container environment variables.
-func extractConfigFromEnv(podEnv map[string]string, config *CatalogPodConfig) {
+func extractConfigFromEnv(podEnv map[string]string, config *PodmanConfigureOptions) {
 	if value, ok := podEnv["AI_SERVICES_BASE_DIR"]; ok {
 		config.BaseDir = value
 	}


### PR DESCRIPTION
Problem: As part of catalog uninstall, if a custom dir path is specified, it fails to cleanup as it is always removing from the default path

Solution: We should inspect the catalog pod, read the custom dir set and use that path to remove all the time.