### PR TITLE
[CVE-FIX] AISERVICES-1294: Bump up go version in postgres image

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.119
+TAG?=v0.0.120
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -46,7 +46,7 @@ opensearch:
 
 postgres:
   # @hidden
-  image: icr.io/ai-services-cicd/postgres:18-2
+  image: icr.io/ai-services-cicd/postgres:18-3
   # @description Password for PostgreSQL default 'postgres' user authentication. Must be at least 8 characters. Use this to override the default password.
   password: "Aiservicesdb@1234"
 

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -95,7 +95,7 @@ opensearch:
 
 postgres:
   # @hidden
-  image: icr.io/ai-services-cicd/postgres:18-2
+  image: icr.io/ai-services-cicd/postgres:18-3
   # @description Sets the storage limit for the PostgreSQL service (Default: 5Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   storage: 5Gi
   # @description Password for PostgreSQL default 'postgres' user authentication. Must be at least 8 characters. Use this to override the default password.

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -46,7 +46,7 @@ opensearch:
 
 postgres:
   # @hidden
-  image: icr.io/ai-services-cicd/postgres:18-2
+  image: icr.io/ai-services-cicd/postgres:18-3
   # @description Password for PostgreSQL default 'postgres' user authentication. Must be at least 8 characters. Use this to override the default password.
   password: "Aiservicesdb@1234"
 

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -95,7 +95,7 @@ opensearch:
 
 postgres:
   # @hidden
-  image: icr.io/ai-services-cicd/postgres:18-2
+  image: icr.io/ai-services-cicd/postgres:18-3
   # @description Sets the storage limit for the PostgreSQL service (Default: 5Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   storage: 5Gi
   # @description Password for PostgreSQL default 'postgres' user authentication. Must be at least 8 characters. Use this to override the default password.

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -46,7 +46,7 @@ opensearch:
 
 postgres:
   # @hidden
-  image: icr.io/ai-services-cicd/postgres:18-2
+  image: icr.io/ai-services-cicd/postgres:18-3
   # @description Password for PostgreSQL default 'postgres' user authentication. Must be at least 8 characters. Use this to override the default password.
   password: "Aiservicesdb@1234"
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.119
+  image: icr.io/ai-services-cicd/ai-services:v0.0.120
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -13,7 +13,7 @@ backend:
 
 db:
   port: ""
-  image: icr.io/ai-services-cicd/postgres:18-2
+  image: icr.io/ai-services-cicd/postgres:18-3
   user: "admin"
   database: "ai_services"
   password: ""

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -9,7 +9,7 @@ digitizeUi:
   image: icr.io/ai-services-cicd/digitize-ui:v0.0.24
 
 postgres:
-  image: icr.io/ai-services-cicd/postgres:18-2
+  image: icr.io/ai-services-cicd/postgres:18-3
   username: "postgres"
   # @generate:password
   password: ""

--- a/ai-services/assets/services/summarize/podman/values.yaml
+++ b/ai-services/assets/services/summarize/podman/values.yaml
@@ -5,7 +5,7 @@ summarize:
   database: "summarize_metadata"
 
 postgres:
-  image: icr.io/ai-services-cicd/postgres:18-2
+  image: icr.io/ai-services-cicd/postgres:18-3
   username: "postgres"
   # @generate:password
   password: ""

--- a/docs/proposals/digitize_metadata_db_migration.md
+++ b/docs/proposals/digitize_metadata_db_migration.md
@@ -672,7 +672,7 @@ spec:
       # Init container to initialize database schema
       initContainers:
         - name: digitize-db-init
-          image: "icr.io/ai-services-cicd/postgres:18-2"  # ppc64le compatible UBI based Postgres image
+          image: "icr.io/ai-services-cicd/postgres:18-3"  # ppc64le compatible UBI based Postgres image
           command: ["/bin/sh", "/scripts/init_db.sh"]
           env:
             - name: POSTGRES_HOST

--- a/images/postgres/Dockerfile
+++ b/images/postgres/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM registry.access.redhat.com/ubi9/ubi:9.8 AS gosu-builder
 
-ARG GO_VERSION=1.25.10
+ARG GO_VERSION=1.26.4
 
 ENV GOSU_VERSION=1.19 \
 	CGO_ENABLED=0

--- a/images/postgres/Makefile
+++ b/images/postgres/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=postgres
-TAG?=18-2
+TAG?=18-3
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 # Image references


### PR DESCRIPTION
PR is for fixing cve which is coming from `gosu` pkg in postgres image