### PR TITLE
Invalid args

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.124
+TAG?=v0.0.125
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.124
+  image: icr.io/ai-services-cicd/ai-services:v0.0.125
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -60,6 +60,7 @@ Examples:
 
 	 # Configure with custom HTTPS port
 	 ai-services catalog configure --runtime podman --https-port 8443`,
+		Args: cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 


### PR DESCRIPTION
Added `Args: cobra.NoArgs` validation to the catalog configure command to reject unexpected positional arguments. This prevents silent failures when users accidentally use em-dashes (`—`) instead of double hyphens (`--`) for flags, which are often auto-inserted by word processors and cause flags to be ignored without error messages.