### PR TITLE
[CVE-FIX] Bump up pip in service base image

### DIFF
--- a/images/service-base/Containerfile
+++ b/images/service-base/Containerfile
@@ -10,7 +10,8 @@ RUN microdnf install -y python3.12-devel python3.12-pip \
     rm -rf /usr/bin/python && rm -rf /usr/bin/python3 && \
     ln -s /usr/bin/pip3.12 /usr/bin/pip && ln -s /usr/bin/pip3.12 /usr/bin/pip3 && \
     ln -s /usr/bin/python3.12 /usr/bin/python && ln -s /usr/bin/python3.12 /usr/bin/python3 && \
-    python3.12 -m pip install --upgrade pip
+    python3.12 -m pip install --upgrade pip && \
+    rm -rf /usr/lib/python3.12/site-packages/pip-23.2.1.dist-info
 
 ENV DOCLING_MODELS_PATH=/var/docling-models
 

--- a/images/service-base/Containerfile
+++ b/images/service-base/Containerfile
@@ -9,7 +9,8 @@ RUN microdnf install -y python3.12-devel python3.12-pip \
     microdnf clean all && \
     rm -rf /usr/bin/python && rm -rf /usr/bin/python3 && \
     ln -s /usr/bin/pip3.12 /usr/bin/pip && ln -s /usr/bin/pip3.12 /usr/bin/pip3 && \
-    ln -s /usr/bin/python3.12 /usr/bin/python && ln -s /usr/bin/python3.12 /usr/bin/python3
+    ln -s /usr/bin/python3.12 /usr/bin/python && ln -s /usr/bin/python3.12 /usr/bin/python3 && \
+    python3.12 -m pip install --upgrade pip
 
 ENV DOCLING_MODELS_PATH=/var/docling-models
 

--- a/images/service-base/Makefile
+++ b/images/service-base/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=service-base
-TAG?=v0.0.33
+TAG?=v0.0.34
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman


### PR DESCRIPTION
In our we have installed pip 23.2.1 which is affected by [CVE](https://access.redhat.com/security/cve/cve-2026-8643), therefore adding line to upgrade pip version 