### PR TITLE
fix: refresh token if expired while polling application

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.137
+TAG?=v0.0.138
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.137
+  image: icr.io/ai-services-cicd/ai-services:v0.0.138
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -521,7 +521,7 @@ func pollApplicationStatus(appClient *catalogClient.ApplicationClient, appName, 
 			return fmt.Errorf("timeout waiting for application '%s' to be ready", appName)
 
 		case <-ticker.C:
-			app, err := cliutils.GetAppByID(appClient, id)
+			app, err := appClient.GetApplication(id)
 			if err != nil {
 				return fmt.Errorf("failed to get application status: %w", err)
 			}

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -539,7 +539,6 @@ func pollApplicationStatus(appClient *catalogClient.ApplicationClient, appName s
 
 // handleApplicationStatus handles the application status and returns (done, error).
 func handleApplicationStatus(app *catalogTypes.Application, appName string) (bool, error) {
-	// Status values from ai-services/internal/pkg/catalog/db/models/application.go.
 	switch app.Status {
 	case "Running":
 		logger.Infof("Application '%s' is ready!\n", appName)

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -465,7 +465,7 @@ func createApp(appName string) error {
 	logger.Infof("Application creation initiated (ID: %s)\n", resp.ID)
 
 	// 5. Poll for application status
-	return pollApplicationStatus(appClient, appName)
+	return pollApplicationStatus(appClient, appName, resp.ID)
 }
 
 // checkApplicationExists checks if an application with the given name already exists.
@@ -507,7 +507,7 @@ func buildCatalogPayload(appName string) (*apiModels.CreateApplicationRequest, e
 }
 
 // pollApplicationStatus polls the application status until it's ready or fails.
-func pollApplicationStatus(appClient *catalogClient.ApplicationClient, appName string) error {
+func pollApplicationStatus(appClient *catalogClient.ApplicationClient, appName, id string) error {
 	logger.Infof("Waiting for application '%s' to be ready...\n", appName)
 
 	ticker := time.NewTicker(pollInterval)
@@ -521,7 +521,7 @@ func pollApplicationStatus(appClient *catalogClient.ApplicationClient, appName s
 			return fmt.Errorf("timeout waiting for application '%s' to be ready", appName)
 
 		case <-ticker.C:
-			app, err := cliutils.GetAppByName(appClient, appName)
+			app, err := cliutils.GetAppByID(appClient, id)
 			if err != nil {
 				return fmt.Errorf("failed to get application status: %w", err)
 			}

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -521,7 +521,7 @@ func pollApplicationStatus(appClient *catalogClient.ApplicationClient, appName, 
 			return fmt.Errorf("timeout waiting for application '%s' to be ready", appName)
 
 		case <-ticker.C:
-			app, err := appClient.GetApplication(id)
+			app, err := appClient.GetApplicationWithRefresh(id)
 			if err != nil {
 				return fmt.Errorf("failed to get application status: %w", err)
 			}

--- a/ai-services/internal/pkg/catalog/client/application.go
+++ b/ai-services/internal/pkg/catalog/client/application.go
@@ -242,4 +242,10 @@ func (c *ApplicationClient) GetComponentProviderParams(componentType, providerID
 	return result, nil
 }
 
+// Client returns the underlying authenticated HTTP client.
+// This allows access to client-level operations like token refresh.
+func (c *ApplicationClient) Client() *Client {
+	return c.client
+}
+
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/client/application.go
+++ b/ai-services/internal/pkg/catalog/client/application.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -150,7 +151,6 @@ func (c *ApplicationClient) DeleteApplication(id string, params *DeleteApplicati
 }
 
 // GetApplication retrieves full details for a specific application by ID.
-// If the server returns 401 Unauthorized, it refreshes the access token once and retries.
 func (c *ApplicationClient) GetApplication(id string) (*types.Application, error) {
 	var result types.Application
 	resp, err := c.client.HTTPClient().R().
@@ -161,22 +161,30 @@ func (c *ApplicationClient) GetApplication(id string) (*types.Application, error
 	}
 
 	if resp.IsError() {
-		httpErr := &HTTPError{
+		return nil, &HTTPError{
 			StatusCode: resp.StatusCode(),
 			Message:    utils.ParseErrorResponse(resp),
 		}
-		if httpErr.StatusCode == http.StatusUnauthorized {
-			if refreshErr := c.client.RefreshToken(); refreshErr != nil {
-				return nil, httpErr
-			}
-
-			return c.GetApplication(id)
-		}
-
-		return nil, httpErr
 	}
 
 	return &result, nil
+}
+
+// GetApplicationWithRefresh retrieves full details for a specific application by ID.
+// If the server returns 401 Unauthorized, it refreshes the access token once and retries.
+func (c *ApplicationClient) GetApplicationWithRefresh(id string) (*types.Application, error) {
+	result, err := c.GetApplication(id)
+	if err != nil {
+		var httpErr *HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnauthorized {
+			if refreshErr := c.client.RefreshToken(); refreshErr != nil {
+				return nil, err
+			}
+			return c.GetApplication(id)
+		}
+		return nil, err
+	}
+	return result, nil
 }
 
 // CreateApplication creates a new application deployment via catalog API.

--- a/ai-services/internal/pkg/catalog/client/application.go
+++ b/ai-services/internal/pkg/catalog/client/application.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
@@ -149,6 +150,7 @@ func (c *ApplicationClient) DeleteApplication(id string, params *DeleteApplicati
 }
 
 // GetApplication retrieves full details for a specific application by ID.
+// If the server returns 401 Unauthorized, it refreshes the access token once and retries.
 func (c *ApplicationClient) GetApplication(id string) (*types.Application, error) {
 	var result types.Application
 	resp, err := c.client.HTTPClient().R().
@@ -159,10 +161,19 @@ func (c *ApplicationClient) GetApplication(id string) (*types.Application, error
 	}
 
 	if resp.IsError() {
-		return nil, &HTTPError{
+		httpErr := &HTTPError{
 			StatusCode: resp.StatusCode(),
 			Message:    utils.ParseErrorResponse(resp),
 		}
+		if httpErr.StatusCode == http.StatusUnauthorized {
+			if refreshErr := c.client.RefreshToken(); refreshErr != nil {
+				return nil, httpErr
+			}
+
+			return c.GetApplication(id)
+		}
+
+		return nil, httpErr
 	}
 
 	return &result, nil
@@ -240,12 +251,6 @@ func (c *ApplicationClient) GetComponentProviderParams(componentType, providerID
 	}
 
 	return result, nil
-}
-
-// Client returns the underlying authenticated HTTP client.
-// This allows access to client-level operations like token refresh.
-func (c *ApplicationClient) Client() *Client {
-	return c.client
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/client/application.go
+++ b/ai-services/internal/pkg/catalog/client/application.go
@@ -180,10 +180,13 @@ func (c *ApplicationClient) GetApplicationWithRefresh(id string) (*types.Applica
 			if refreshErr := c.client.RefreshToken(); refreshErr != nil {
 				return nil, err
 			}
+
 			return c.GetApplication(id)
 		}
+
 		return nil, err
 	}
+
 	return result, nil
 }
 

--- a/ai-services/internal/pkg/cli/utils/application_utils.go
+++ b/ai-services/internal/pkg/cli/utils/application_utils.go
@@ -1,7 +1,9 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
@@ -20,8 +22,23 @@ func GetAllApps(appClient *catalogClient.ApplicationClient) ([]types.Application
 func GetAppByName(appClient *catalogClient.ApplicationClient, appName string) (*types.Application, error) {
 	listResponse, err := appClient.ListApplications(nil)
 	if err != nil {
-		return nil, err
+		// Check if error is HTTP 401 (invalid token) and retry with token refresh
+		if !isUnauthorizedError(err) {
+			return nil, err
+		}
+
+		// Refresh token and retry once
+		if refreshErr := appClient.Client().RefreshToken(); refreshErr != nil {
+			return nil, fmt.Errorf("failed to refresh token: %w", refreshErr)
+		}
+
+		// Retry the request with refreshed token
+		listResponse, err = appClient.ListApplications(nil)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	for _, app := range listResponse.Data {
 		if app.Name == appName {
 			return &app, nil
@@ -29,6 +46,13 @@ func GetAppByName(appClient *catalogClient.ApplicationClient, appName string) (*
 	}
 
 	return nil, fmt.Errorf("application with name '%s' not found", appName)
+}
+
+// isUnauthorizedError checks if the error is an HTTP 401 Unauthorized error.
+func isUnauthorizedError(err error) bool {
+	var httpErr *catalogClient.HTTPError
+
+	return errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnauthorized
 }
 
 // GetAppDetailsWithComponents retrieves full application details including services and components.

--- a/ai-services/internal/pkg/cli/utils/application_utils.go
+++ b/ai-services/internal/pkg/cli/utils/application_utils.go
@@ -32,15 +32,6 @@ func GetAppByName(appClient *catalogClient.ApplicationClient, appName string) (*
 	return nil, fmt.Errorf("application with name '%s' not found", appName)
 }
 
-func GetAppByID(appClient *catalogClient.ApplicationClient, id string) (*types.Application, error) {
-	resp, err := appClient.GetApplication(id)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, fmt.Errorf("application with name '%s' not found", id)
-}
-
 // GetAppDetailsWithComponents retrieves full application details including services and components.
 // It first finds the app by name, then fetches full details by ID.
 func GetAppDetailsWithComponents(appName string) (*types.Application, error) {

--- a/ai-services/internal/pkg/cli/utils/application_utils.go
+++ b/ai-services/internal/pkg/cli/utils/application_utils.go
@@ -22,7 +22,6 @@ func GetAppByName(appClient *catalogClient.ApplicationClient, appName string) (*
 	if err != nil {
 		return nil, err
 	}
-
 	for _, app := range listResponse.Data {
 		if app.Name == appName {
 			return &app, nil

--- a/ai-services/internal/pkg/cli/utils/application_utils.go
+++ b/ai-services/internal/pkg/cli/utils/application_utils.go
@@ -1,9 +1,7 @@
 package utils
 
 import (
-	"errors"
 	"fmt"
-	"net/http"
 
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
@@ -22,21 +20,7 @@ func GetAllApps(appClient *catalogClient.ApplicationClient) ([]types.Application
 func GetAppByName(appClient *catalogClient.ApplicationClient, appName string) (*types.Application, error) {
 	listResponse, err := appClient.ListApplications(nil)
 	if err != nil {
-		// Check if error is HTTP 401 (invalid token) and retry with token refresh
-		if !isUnauthorizedError(err) {
-			return nil, err
-		}
-
-		// Refresh token and retry once
-		if refreshErr := appClient.Client().RefreshToken(); refreshErr != nil {
-			return nil, fmt.Errorf("failed to refresh token: %w", refreshErr)
-		}
-
-		// Retry the request with refreshed token
-		listResponse, err = appClient.ListApplications(nil)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	for _, app := range listResponse.Data {
@@ -48,11 +32,13 @@ func GetAppByName(appClient *catalogClient.ApplicationClient, appName string) (*
 	return nil, fmt.Errorf("application with name '%s' not found", appName)
 }
 
-// isUnauthorizedError checks if the error is an HTTP 401 Unauthorized error.
-func isUnauthorizedError(err error) bool {
-	var httpErr *catalogClient.HTTPError
+func GetAppByID(appClient *catalogClient.ApplicationClient, id string) (*types.Application, error) {
+	resp, err := appClient.GetApplication(id)
+	if err != nil {
+		return nil, err
+	}
 
-	return errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnauthorized
+	return resp, fmt.Errorf("application with name '%s' not found", id)
 }
 
 // GetAppDetailsWithComponents retrieves full application details including services and components.


### PR DESCRIPTION
- Problem: 
Create cmd was throwing below error while deploying application.
```
Deploying, Message: Deploying application
Error: failed to get application status: HTTP 401: invalid token 
```

- Solution: refresh token if it expires