### PR TITLE
Fix caching during sync

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.132
+TAG?=v0.0.133
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.132
+  image: icr.io/ai-services-cicd/ai-services:v0.0.133
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -530,18 +530,18 @@ func (s *SyncService) updateApplicationStatus(ctx context.Context, app *models.A
 }
 
 // getExpectedResourceCounts retrieves expected resource counts from cache.
-func (s *SyncService) getExpectedResourceCounts(catalogID string) *ResourceCounts {
+func (s *SyncService) getExpectedResourceCounts(instanceID string) *ResourceCounts {
 	s.cacheMutex.RLock()
 	defer s.cacheMutex.RUnlock()
 
-	return s.resourceCache[catalogID]
+	return s.resourceCache[instanceID]
 }
 
 // setExpectedResourceCounts stores expected resource counts in cache.
-func (s *SyncService) setExpectedResourceCounts(catalogID string, counts *ResourceCounts) {
+func (s *SyncService) setExpectedResourceCounts(instanceID string, counts *ResourceCounts) {
 	s.cacheMutex.Lock()
 	defer s.cacheMutex.Unlock()
-	s.resourceCache[catalogID] = counts
+	s.resourceCache[instanceID] = counts
 }
 
 // countResourcesFromTemplates counts expected Pods and Secrets from service/component templates.
@@ -674,8 +674,10 @@ func (s *SyncService) extractResourceLabelsFromPodSpec(podSpec *modelpkg.PodSpec
 // validateResourceCounts validates that actual resources match expected counts from templates.
 // Returns error message if validation fails, empty string if all resources are present.
 func (s *SyncService) validateResourceCounts(ctx context.Context, catalogID, instanceID, itemType string, actualPodCount int, rt runtime.Runtime) string {
-	// Get expected counts from cache
-	expectedCounts := s.getExpectedResourceCounts(catalogID)
+	// Get expected counts from cache.
+	// Cache key is instanceID (not catalogID) because SecretNames/VolumeNames contain
+	// instance-specific slugs derived from instanceID, so each instance needs its own entry.
+	expectedCounts := s.getExpectedResourceCounts(instanceID)
 
 	// If not in cache, count from templates and cache it
 	if expectedCounts == nil {
@@ -686,7 +688,7 @@ func (s *SyncService) validateResourceCounts(ctx context.Context, catalogID, ins
 			return ""
 		}
 		expectedCounts = counts
-		s.setExpectedResourceCounts(catalogID, counts)
+		s.setExpectedResourceCounts(instanceID, counts)
 	}
 
 	var errorMessages []string

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -674,10 +674,9 @@ func (s *SyncService) extractResourceLabelsFromPodSpec(podSpec *modelpkg.PodSpec
 // validateResourceCounts validates that actual resources match expected counts from templates.
 // Returns error message if validation fails, empty string if all resources are present.
 func (s *SyncService) validateResourceCounts(ctx context.Context, catalogID, instanceID, itemType string, actualPodCount int, rt runtime.Runtime) string {
-	// Get expected counts from cache.
-	// Cache key is instanceID (not catalogID) because SecretNames/VolumeNames contain
-	// instance-specific slugs derived from instanceID, so each instance needs its own entry.
-	expectedCounts := s.getExpectedResourceCounts(instanceID)
+	// Cache key combines catalogID and instanceID:
+	cacheKey := catalogID + ":" + instanceID
+	expectedCounts := s.getExpectedResourceCounts(cacheKey)
 
 	// If not in cache, count from templates and cache it
 	if expectedCounts == nil {
@@ -688,7 +687,7 @@ func (s *SyncService) validateResourceCounts(ctx context.Context, catalogID, ins
 			return ""
 		}
 		expectedCounts = counts
-		s.setExpectedResourceCounts(instanceID, counts)
+		s.setExpectedResourceCounts(cacheKey, counts)
 	}
 
 	var errorMessages []string


### PR DESCRIPTION
- Since the local cache was using catalogID, if there were multiple entries in cache with different instances, then it used to get override causing issues with slug for secret and volumes.
- The above was causing DB sync to update to error as it was saying secret and volumes are missing.