### PR TITLE
[GHA] fix: trigger CI checks on ready-for-review PR events

### DIFF
--- a/.github/workflows/bump-makefile-version.yml
+++ b/.github/workflows/bump-makefile-version.yml
@@ -2,6 +2,7 @@ name: Check Makefile Version Bump
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'services/chatbot/**'
       - 'services/digitize/**'

--- a/.github/workflows/check-image-names.yml
+++ b/.github/workflows/check-image-names.yml
@@ -2,6 +2,7 @@ name: Check Image Names
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'services/*'
       - 'ui/*'

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.133
+TAG?=v0.0.134
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.134
+TAG?=v0.0.133
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 


### PR DESCRIPTION
## Problem
The "**Check Image Name**" and "**Check Make Version Bump**" GitHub Actions workflows were skipped when a PR was converted from draft to ready for review. This left PRs without required checks until a subsequent commit was pushed.

## Solution
Updated the workflow trigger to include the `ready_for_review` activity type on the `pull_request` event, ensuring both checks are triggered as soon as a PR is marked ready for review.