### PR TITLE
Set empty System prompt in values.yaml

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.140
+TAG?=v0.0.141
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.139
+TAG?=v0.0.140
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.141
+TAG?=v0.0.140
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.140
+  image: icr.io/ai-services-cicd/ai-services:v0.0.141
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.141
+  image: icr.io/ai-services-cicd/ai-services:v0.0.140
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.139
+  image: icr.io/ai-services-cicd/ai-services:v0.0.140
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/chat/podman/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/services/chat/podman/templates/chat-bot.yaml.tmpl
@@ -104,7 +104,11 @@ spec:
         - name: CHATBOT_SIMILARITY_SERVICE_URL
           value: "http://similarity-api-{{ .InstanceSlug }}:7000"
         - name: CHATBOT_SYSTEM_PROMPT
+          {{- if .Values.backend.systemPrompt }}
           value: "{{ .Values.backend.systemPrompt }}"
+          {{- else }}
+          value: ""
+          {{ end }}
       ports:
         - containerPort: 5000
           protocol: TCP

--- a/ai-services/assets/services/chat/podman/values.yaml
+++ b/ai-services/assets/services/chat/podman/values.yaml
@@ -10,3 +10,4 @@ backend:
     searchMode: "hybrid"
     numChunksPostReranker: 3
     rerank: true
+    systemPrompt: ""


### PR DESCRIPTION
- This is required to ensure that if no prompt is set within the params from client (UI/CLI) then need to use "" (empty) by default.
- If not used currently `"CHATBOT_SYSTEM_PROMPT=\u003cno value\u003e",` will be set