### PR TITLE
AISERVICES-1311: remove experimental from image, model, templates commands

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.135
+TAG?=v0.0.136
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.135
+  image: icr.io/ai-services-cicd/ai-services:v0.0.136
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/components/llm/watsonx/podman/values.schema.json
+++ b/ai-services/assets/components/llm/watsonx/podman/values.schema.json
@@ -29,7 +29,7 @@
     "watsonxProjectId": {
       "type": "string",
       "title": "Project ID",
-      "description": "Find your ID on the watsonx cloud site when you create a project\n\n[Open project](https://dataplatform.cloud.ibm.com/projects/?context=wx)",
+      "description": "Find your ID on the watsonx cloud site when you create a project.\n\n[Open project](https://dataplatform.cloud.ibm.com/projects/?context=wx)",
       "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
     },
     "watsonxUrl": {

--- a/ai-services/cmd/ai-services/cmd/application/image/image.go
+++ b/ai-services/cmd/ai-services/cmd/application/image/image.go
@@ -10,8 +10,8 @@ import (
 )
 
 var (
-	templateName       string
-	experimentalImages bool
+	templateName string
+	legacyImage  bool
 )
 
 var ImageCmd = &cobra.Command{
@@ -44,5 +44,5 @@ func init() {
 	ImageCmd.AddCommand(pullCmd)
 	ImageCmd.PersistentFlags().StringVarP(&templateName, "template", "t", "", "Application template name (Required)")
 	_ = ImageCmd.MarkPersistentFlagRequired("template")
-	ImageCmd.PersistentFlags().BoolVar(&experimentalImages, "experimental", false, "Use experimental catalog-based image listing")
+	ImageCmd.PersistentFlags().BoolVar(&legacyImage, "legacy", false, "Use legacy application image implementation")
 }

--- a/ai-services/cmd/ai-services/cmd/application/image/list.go
+++ b/ai-services/cmd/ai-services/cmd/application/image/list.go
@@ -15,11 +15,14 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List container images for a given application template",
 	Long:  ``,
-	Example: `  # List images for a specific template
-  ai-services application image list --template chatbot --runtime podman
+	Example: `  # List images for Digital Assistant
+  ai-services application image list --template rag --runtime podman
+
+  # List images for a specific service
+  ai-services application image list --template chat --runtime podman
 
   # List images using legacy implementation
-  ai-services application image list --template chatbot --legacy --runtime podman`,
+  ai-services application image list --template rag --legacy --runtime podman`,
 	Args: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Once precheck passes, silence usage for any *later* internal errors.

--- a/ai-services/cmd/ai-services/cmd/application/image/list.go
+++ b/ai-services/cmd/ai-services/cmd/application/image/list.go
@@ -15,7 +15,12 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List container images for a given application template",
 	Long:  ``,
-	Args:  cobra.MaximumNArgs(0),
+	Example: `  # List images for a specific template
+  ai-services application image list --template chatbot --runtime podman
+
+  # List images using legacy implementation
+  ai-services application image list --template chatbot --legacy --runtime podman`,
+	Args: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true
@@ -25,7 +30,7 @@ var listCmd = &cobra.Command{
 }
 
 func list(templateName string) error {
-	if experimentalImages && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+	if !legacyImage && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
 		return listCatalogImages(templateName)
 	}
 

--- a/ai-services/cmd/ai-services/cmd/application/image/pull.go
+++ b/ai-services/cmd/ai-services/cmd/application/image/pull.go
@@ -17,11 +17,14 @@ var pullCmd = &cobra.Command{
 	Use:   "pull",
 	Short: "Pulls all container images for a given application template",
 	Long:  ``,
-	Example: `  # Pull images for a specific template
-  ai-services application image pull --template chatbot --runtime podman
+	Example: `  # List images for Digital Assistant
+  ai-services application image list --template rag --runtime podman
+
+  # Pull images for a specific service
+  ai-services application image pull --template chat --runtime podman
 
   # Pull images using legacy implementation
-  ai-services application image pull --template chatbot --legacy --runtime podman`,
+  ai-services application image pull --template rag --legacy --runtime podman`,
 	Args: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Once precheck passes, silence usage for any *later* internal errors.

--- a/ai-services/cmd/ai-services/cmd/application/image/pull.go
+++ b/ai-services/cmd/ai-services/cmd/application/image/pull.go
@@ -17,7 +17,12 @@ var pullCmd = &cobra.Command{
 	Use:   "pull",
 	Short: "Pulls all container images for a given application template",
 	Long:  ``,
-	Args:  cobra.MaximumNArgs(0),
+	Example: `  # Pull images for a specific template
+  ai-services application image pull --template chatbot --runtime podman
+
+  # Pull images using legacy implementation
+  ai-services application image pull --template chatbot --legacy --runtime podman`,
+	Args: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true
@@ -27,7 +32,7 @@ var pullCmd = &cobra.Command{
 }
 
 func pull(template string) error {
-	if experimentalImages && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+	if !legacyImage && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
 		return pullCatalogImages(templateName)
 	}
 

--- a/ai-services/cmd/ai-services/cmd/application/model/download.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/download.go
@@ -23,14 +23,17 @@ Note:
   - Supports only podman runtime
   - Models are downloaded to the default models directory unless --dir is specified
   - Use 'ai-services application model list' to see available models for a template`,
-	Example: `  # Download models for a specific template
-	 ai-services application model download --template chatbot --runtime podman
+	Example: `  # Download models for Digital Assistant
+	 ai-services application model download --template rag --runtime podman
+
+	 # Download models for a specific service
+	 ai-services application model download --template chat --runtime podman
 
 	 # Download models to a custom directory
-	 ai-services application model download --template chatbot --dir /path/to/models --runtime podman
+	 ai-services application model download --template chat --dir /path/to/models --runtime podman
 
 	 # Download models using legacy implementation
-	 ai-services application model download --template chatbot --legacy --runtime podman`,
+	 ai-services application model download --template rag --legacy --runtime podman`,
 	Args: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Once precheck passes, silence usage for any *later* internal errors.

--- a/ai-services/cmd/ai-services/cmd/application/model/download.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/download.go
@@ -24,10 +24,13 @@ Note:
   - Models are downloaded to the default models directory unless --dir is specified
   - Use 'ai-services application model list' to see available models for a template`,
 	Example: `  # Download models for a specific template
-  ai-services application model download --template chatbot --runtime podman
+	 ai-services application model download --template chatbot --runtime podman
 
-  # Download models to a custom directory
-  ai-services application model download --template chatbot --dir /path/to/models --runtime podman`,
+	 # Download models to a custom directory
+	 ai-services application model download --template chatbot --dir /path/to/models --runtime podman
+
+	 # Download models using legacy implementation
+	 ai-services application model download --template chatbot --legacy --runtime podman`,
 	Args: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Once precheck passes, silence usage for any *later* internal errors.
@@ -47,7 +50,7 @@ func init() {
 }
 
 func download(cmd *cobra.Command) error {
-	if experimentalModels && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+	if !legacyModel && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
 		return downloadCatalogModels(templateName)
 	}
 

--- a/ai-services/cmd/ai-services/cmd/application/model/list.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/list.go
@@ -18,8 +18,11 @@ var listCmd = &cobra.Command{
 Note:
   - Supports only podman runtime.
   - Use 'ai-services application templates' to see available template names`,
-	Example: `  # List models for a specific template for podman runtime
-  ai-services application model list --template chatbot --runtime podman`,
+	Example: `  # List models for a specific template
+	 ai-services application model list --template chatbot --runtime podman
+
+	 # List models using legacy implementation
+	 ai-services application model list --template chatbot --legacy --runtime podman`,
 	Args: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Once precheck passes, silence usage for any *later* internal errors.
@@ -36,7 +39,7 @@ func init() {
 }
 
 func list(cmd *cobra.Command) error {
-	if experimentalModels && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+	if !legacyModel && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
 		return listCatalogModels(templateName)
 	}
 

--- a/ai-services/cmd/ai-services/cmd/application/model/list.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/list.go
@@ -18,11 +18,14 @@ var listCmd = &cobra.Command{
 Note:
   - Supports only podman runtime.
   - Use 'ai-services application templates' to see available template names`,
-	Example: `  # List models for a specific template
-	 ai-services application model list --template chatbot --runtime podman
+	Example: `  # List models for Digital Assistant
+     ai-services application model list --template rag --runtime podman
+
+     # List models for a specific template
+	 ai-services application model list --template chat --runtime podman
 
 	 # List models using legacy implementation
-	 ai-services application model list --template chatbot --legacy --runtime podman`,
+	 ai-services application model list --template rag --legacy --runtime podman`,
 	Args: cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Once precheck passes, silence usage for any *later* internal errors.

--- a/ai-services/cmd/ai-services/cmd/application/model/model.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/model.go
@@ -29,14 +29,14 @@ This command provides subcommands to list and download models required by applic
 		},
 	}
 
-	hiddenTemplates    bool
-	experimentalModels bool
+	hiddenTemplates bool
+	legacyModel     bool
 )
 
 func init() {
 	ModelCmd.AddCommand(listCmd)
 	ModelCmd.AddCommand(downloadCmd)
-	ModelCmd.PersistentFlags().BoolVar(&experimentalModels, "experimental", false, "Use experimental catalog-based model listing")
+	ModelCmd.PersistentFlags().BoolVar(&legacyModel, "legacy", false, "Use legacy application model implementation")
 }
 
 func models(template string) ([]string, error) {

--- a/ai-services/cmd/ai-services/cmd/application/model/model.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/model.go
@@ -18,11 +18,6 @@ var (
 		Short: "Manage application models",
 		Long: `Manage AI models for application templates.
 This command provides subcommands to list and download models required by application templates.`,
-		Example: `  # List available models for a template
-	 ai-services application model list --template chatbot --runtime podman
-
-	 # Download models for a template
-	 ai-services application model download --template chatbot --runtime podman`,
 		Args: cobra.MaximumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()

--- a/ai-services/cmd/ai-services/cmd/application/templates.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	experimentalTemplates bool
+	legacyTemplates bool
 )
 
 var templatesCmd = &cobra.Command{
@@ -27,26 +27,29 @@ var templatesCmd = &cobra.Command{
 	Short: "Lists the offered application templates and their supported parameters",
 	Long:  `Retrieves information about the offered application templates and their supported parameters`,
 	Example: `  For Podman:
-  # List all available application templates (Podman)
-  ai-services application templates --runtime podman
+	 # List all available application templates (Podman)
+	 ai-services application templates --runtime podman
 
-  # List parameters for a specific template (see subcommand)
-  ai-services application templates parameters --template digitize --runtime podman
-  
-  For OpenShift:
-  # List all available application templates (OpenShift)
-  ai-services application templates --runtime openshift
+	 # List parameters for a specific template (see subcommand)
+	 ai-services application templates parameters --template digitize --runtime podman
 
-  # List parameters for a specific template (see subcommand)
-  ai-services application templates parameters --template digitize --runtime openshift `,
+	 # List templates using legacy implementation
+	 ai-services application templates --legacy --runtime podman
+
+	 For OpenShift:
+	 # List all available application templates (OpenShift)
+	 ai-services application templates --runtime openshift
+
+	 # List parameters for a specific template (see subcommand)
+	 ai-services application templates parameters --template digitize --runtime openshift `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true
 
-		// When experimentalTemplates is true and runtime is podman, use experimental catalog templates
-		// For openshift runtime, always use the older/stable code path regardless of experimental flag
-		if experimentalTemplates && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
-			// Use experimental catalog templates listing (architectures and services)
+		// When legacyTemplates is true and runtime is podman, use the older/stable code path
+		// For openshift runtime, always use the older/stable code path regardless of legacy flag
+		if !legacyTemplates && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
+			// Use catalog templates listing (architectures and services)
 			return listCatalogTemplates(cmd)
 		}
 
@@ -106,7 +109,7 @@ var templatesCmd = &cobra.Command{
 }
 
 func init() {
-	templatesCmd.Flags().BoolVar(&experimentalTemplates, "experimental", false, "Include experimental application templates")
+	templatesCmd.Flags().BoolVar(&legacyTemplates, "legacy", false, "Use legacy application templates implementation")
 
 	// Add parameters subcommand
 	templatesCmd.AddCommand(appTemplates.NewParametersCmd())

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -3,6 +3,7 @@ package templates
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -181,7 +182,7 @@ func displayPropertiesRecursive(properties map[string]any, prefix string) {
 		}
 
 		propType, _ := prop["type"].(string)
-		description, _ := prop["description"].(string)
+		description := cleanDescription(prop["description"])
 
 		// If this is an object type with nested properties, recurse into it
 		if propType == "object" {
@@ -199,4 +200,21 @@ func displayPropertiesRecursive(properties map[string]any, prefix string) {
 			logger.Infof("  %s.%s: %s", prefix, paramName, description)
 		}
 	}
+}
+
+// cleanDescription normalises a JSON schema description for CLI display:
+// it collapses newlines to spaces and strips markdown bold markers.
+func cleanDescription(raw any) string {
+	s, _ := raw.(string)
+	if s == "" {
+		return ""
+	}
+
+	// Collapse newlines (and surrounding whitespace) to a single space
+	s = strings.Join(strings.Fields(s), " ")
+
+	// Strip markdown bold: **text** → text
+	s = strings.ReplaceAll(s, "**", "")
+
+	return s
 }

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters_test.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters_test.go
@@ -1,0 +1,73 @@
+package templates
+
+import (
+	"testing"
+)
+
+func TestCleanDescription(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+		want  string
+	}{
+		{
+			name:  "nil input",
+			input: nil,
+			want:  "",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "plain description unchanged",
+			input: "API key for accessing watsonx",
+			want:  "API key for accessing watsonx",
+		},
+		{
+			name:  "newlines collapsed to spaces",
+			input: "First line\n\nSecond line",
+			want:  "First line Second line",
+		},
+		{
+			name:  "markdown bold stripped",
+			input: "**Model strengths**: Improved instruction following",
+			want:  "Model strengths: Improved instruction following",
+		},
+		{
+			name:  "markdown inline link kept as-is",
+			input: "Find your ID on the site\n\n[Open project](https://dataplatform.cloud.ibm.com/projects/?context=wx)",
+			want:  "Find your ID on the site [Open project](https://dataplatform.cloud.ibm.com/projects/?context=wx)",
+		},
+		{
+			name: "real watsonxProjectId description",
+			input: "Find your ID on the watsonx cloud site when you create a project.\n\n" +
+				"[Open project](https://dataplatform.cloud.ibm.com/projects/?context=wx)",
+			want: "Find your ID on the watsonx cloud site when you create a project. [Open project](https://dataplatform.cloud.ibm.com/projects/?context=wx)",
+		},
+		{
+			name: "real vllm model description",
+			input: "An 8b-parameter instruction-tuned LLM used for natural language understanding and generation tasks.\n\n" +
+				"**Model strengths**: Reliable instruction-following, natural conversation, strong reasoning.\n\n" +
+				"**Supported Languages**: English (primary), Spanish, French.",
+			want: "An 8b-parameter instruction-tuned LLM used for natural language understanding and generation tasks. " +
+				"Model strengths: Reliable instruction-following, natural conversation, strong reasoning. " +
+				"Supported Languages: English (primary), Spanish, French.",
+		},
+		{
+			name:  "non-string input returns empty",
+			input: 42,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cleanDescription(tt.input)
+			if got != tt.want {
+				t.Errorf("cleanDescription(%q)\n got:  %q\n want: %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
1. Remove experimental flags from application subcommand that were missed before. (https://github.com/IBM/project-ai-services/commit/1ab360b5fe832df1d953a8df9c9c30f388b0e920)
2. Fix the format on parameter description that was observed for watsonx project id. (https://github.com/IBM/project-ai-services/commit/8002df26571dd82ad32aad22a28279bfea27ebe3)
3. Correct all examples in these subcommands. (https://github.com/IBM/project-ai-services/pull/1057/changes/7376f56784cbcd65978cdef04020718e8374d27f)