### PR TITLE
Increase llm-cpu memory limits to 150G

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.141
+TAG?=v0.0.142
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.141
+  image: icr.io/ai-services-cicd/ai-services:v0.0.142
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/components/llm/vllm-cpu/podman/metadata.yaml
+++ b/ai-services/assets/components/llm/vllm-cpu/podman/metadata.yaml
@@ -8,5 +8,5 @@ podTemplateExecutions:
 # Resource requirements
 resources:
   cpu: 12
-  memory: 161061273600 # 150GB in bytes
+  memory: 161061273600 # 150Gi in bytes
   storage: 53687091200 # 50Gi for model storage in bytes

--- a/ai-services/assets/components/llm/vllm-cpu/podman/metadata.yaml
+++ b/ai-services/assets/components/llm/vllm-cpu/podman/metadata.yaml
@@ -8,5 +8,5 @@ podTemplateExecutions:
 # Resource requirements
 resources:
   cpu: 12
-  memory: 107374182400 # 100Gi in bytes
+  memory: 161061273600 # 150GB in bytes
   storage: 53687091200 # 50Gi for model storage in bytes

--- a/ai-services/assets/components/llm/vllm-cpu/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/vllm-cpu/podman/templates/vllm-server.yaml.tmpl
@@ -49,9 +49,9 @@ spec:
       {{- end }}
       resources:
         requests:
-          memory: "100Gi"
+          memory: "150Gi"
         limits:
-          memory: "100Gi"
+          memory: "150Gi"
       ports:
         - containerPort: 8000
       volumeMounts:


### PR DESCRIPTION
- The vllm cpu pod for llm crashes intermittently due to OOM.
- Based on the suggestion received from the folks, with the configurations we have it requires around 120G, but stable would be 150G.
- Tried with 120G, but still intermittently saw the issue. After moving to 150G didnt see the issue (ran 4-5 times)