### PR TITLE
Changes in UI code as per backend changes for vCPUs

### DIFF
--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,6 +1,6 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.34
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.35
 
 backend:
   port: ""

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,6 +1,6 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.33
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.34
 
 backend:
   port: ""

--- a/ui/catalog/Makefile
+++ b/ui/catalog/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= catalog-ui
-TAG ?= v0.0.34
+TAG ?= v0.0.35
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/catalog/Makefile
+++ b/ui/catalog/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= catalog-ui
-TAG ?= v0.0.33
+TAG ?= v0.0.34
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/catalog/src/components/DeployFlow/steps/StepTwo.tsx
+++ b/ui/catalog/src/components/DeployFlow/steps/StepTwo.tsx
@@ -252,7 +252,7 @@ export const StepTwo: React.FC<StepProps> = ({
     resourceItems.push({
       label: "Processors",
       required: calculateRequiredResources.cpu.toString(),
-      available: Math.floor(resources.cpu.available_cores).toString(),
+      available: Math.floor(resources.cpu.available_cpu).toString(),
       unit: "vCPUs",
       type: "cpu",
     });

--- a/ui/catalog/src/components/DeploymentDetails/DeploymentDetails.tsx
+++ b/ui/catalog/src/components/DeploymentDetails/DeploymentDetails.tsx
@@ -82,8 +82,8 @@ const DeploymentDetails = ({
         const transformedResources = [
           {
             name: "Processors",
-            used: response.data.cpu.used_cores,
-            allocated: response.data.cpu.total_cores,
+            used: response.data.cpu.used_cpu,
+            allocated: response.data.cpu.total_cpu,
             unit: "vCPUs",
           },
           {

--- a/ui/catalog/src/components/ServicesDeployFlow/components/ResourceRequirements.tsx
+++ b/ui/catalog/src/components/ServicesDeployFlow/components/ResourceRequirements.tsx
@@ -185,7 +185,7 @@ export const ResourceRequirements: React.FC<ResourceRequirementsProps> = ({
     resources.push({
       label: "Processors",
       required: calculateRequiredResources.cpu.toString(),
-      available: Math.floor(resourceData.cpu.available_cores).toString(),
+      available: Math.floor(resourceData.cpu.available_cpu).toString(),
       unit: "vCPUs",
       type: "cpu",
     });

--- a/ui/catalog/src/services/deployment.api.ts
+++ b/ui/catalog/src/services/deployment.api.ts
@@ -3,8 +3,8 @@ import { SERVICE_ENDPOINTS } from "@/constants/api-endpoints.constants";
 
 export interface ResourcesResponse {
   cpu: {
-    total_cores: number;
-    available_cores: number;
+    total_cpu: number;
+    available_cpu: number;
   };
   memory: {
     total_bytes: number;

--- a/ui/catalog/src/types/digitalAssistants.ts
+++ b/ui/catalog/src/types/digitalAssistants.ts
@@ -168,8 +168,8 @@ export interface DeployApplicationResponse {
 // Resources API Types - Used for fetching system resource availability
 export interface ResourcesResponse {
   cpu: {
-    total_cores: number;
-    available_cores: number;
+    total_cpu: number;
+    available_cpu: number;
   };
   memory: {
     total_bytes: number;
@@ -228,8 +228,8 @@ export interface DeployIntegrationEndpoints {
 
 export interface ResourcesApiResponse {
   cpu: {
-    used_cores: number;
-    total_cores: number;
+    used_cpu: number;
+    total_cpu: number;
   };
   memory: {
     used_bytes: number;


### PR DESCRIPTION
As discussed we had to change from "Cores" to "vCPUs"
UI labels were already changed in this PR: https://github.com/IBM/project-ai-services/pull/1031

Key changes as per backend is done in this PR
Verified numbers show up in the resources section of both digital assistants and services deploy flow as well as in the deployment details page

JIRA: https://jsw.ibm.com/browse/AISERVICES-1315