### PR TITLE
fix: add actions to udev rules

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.141
+TAG?=v0.0.142
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.141
+  image: icr.io/ai-services-cicd/ai-services:v0.0.142
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
@@ -148,9 +148,8 @@ func fixUdevRule(checkMap map[string]check.CheckResult) RepairResult {
 
 	const expectedRuleCount = 2
 	expectedRules := make([]string, 0, expectedRuleCount)
-	expectedRules = append(expectedRules, `SUBSYSTEM=="vfio", GROUP:="sentient", MODE:="0660", SECLABEL{selinux}="system_u:object_r:vfio_device_t:s0"`)
-	expectedRules = append(expectedRules, `KERNEL=="vfio", GROUP:="sentient", MODE:="0660", SECLABEL{selinux}="system_u:object_r:vfio_device_t:s0"`)
-
+	expectedRules = append(expectedRules, `SUBSYSTEM=="vfio", ACTION=="add|change", GROUP="sentient", MODE="0660", SECLABEL{selinux}="system_u:object_r:vfio_device_t:s0"`)
+	expectedRules = append(expectedRules, `KERNEL=="vfio", SUBSYSTEM=="misc", ACTION=="add|change", GROUP="sentient", MODE="0660", SECLABEL{selinux}="system_u:object_r:vfio_device_t:s0"`)
 	// Read existing file if it exists.
 	var updatedLines []string
 	if utils.FileExists(confCheck.FilePath) {
@@ -182,7 +181,13 @@ func fixUdevRule(checkMap map[string]check.CheckResult) RepairResult {
 
 // isVFIORuleRedundant checks if a udev rule is redundant.
 func isVFIORuleRedundant(rule string) bool {
-	if rule == "" || !strings.Contains(rule, `SUBSYSTEM=="vfio"`) {
+	if rule == "" {
+		return false
+	}
+
+	isVFIOSubsystem := strings.Contains(rule, `SUBSYSTEM=="vfio"`)
+	isVFIOKernel := strings.Contains(rule, `KERNEL=="vfio"`)
+	if !isVFIOSubsystem && !isVFIOKernel {
 		return false
 	}
 
@@ -199,7 +204,7 @@ func isVFIORuleRedundant(rule string) bool {
 		hasMode = hasMode || strings.Contains(part, "MODE")
 	}
 
-	return len(parts) <= 3 && (len(parts) == 1 || hasGroup || hasMode)
+	return len(parts) == 1 || hasGroup || hasMode
 }
 
 // fixVFIOPCIConf repairs VFIO PCI module configuration.

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
@@ -185,8 +185,8 @@ func checkDriverConfig() *check.ConfigurationFileCheck {
 func checkUdevRule() *check.ConfigurationFileCheck {
 	configFile := "/etc/udev/rules.d/95-vfio-3.rules"
 	expectedRules := []string{
-		`SUBSYSTEM=="vfio", GROUP:="sentient", MODE:="0660", SECLABEL{selinux}="system_u:object_r:vfio_device_t:s0"`,
-		`KERNEL=="vfio", GROUP:="sentient", MODE:="0660", SECLABEL{selinux}="system_u:object_r:vfio_device_t:s0"`,
+		`SUBSYSTEM=="vfio", ACTION=="add|change", GROUP="sentient", MODE="0660", SECLABEL{selinux}="system_u:object_r:vfio_device_t:s0"`,
+		`KERNEL=="vfio", SUBSYSTEM=="misc", ACTION=="add|change", GROUP="sentient", MODE="0660", SECLABEL{selinux}="system_u:object_r:vfio_device_t:s0"`,
 	}
 	confCheck := check.NewConfigurationFileCheck("VFIO udev rules configuration", configFile)
 


### PR DESCRIPTION
certain actions are required to take rules into effect.
udevadm trigger with the default change action does not re-apply group ownership to virtual VFIO device nodes that already exist on disk. So changed udevadm trigger to use --action=add|change to force re-evaluation of GROUP assignment on existing virtual device nodes.

