### PR TITLE
fix: Placed systemPrompt correctly in payload

### DIFF
--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,6 +1,6 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.33
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.34
 
 backend:
   port: ""

--- a/ui/catalog/Makefile
+++ b/ui/catalog/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= catalog-ui
-TAG ?= v0.0.33
+TAG ?= v0.0.34
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/catalog/src/utils/deploymentTransform.ts
+++ b/ui/catalog/src/utils/deploymentTransform.ts
@@ -47,7 +47,9 @@ interface DeploymentService {
   catalog_id: string;
   version: string;
   components: DeploymentComponent[];
-  backend?: Record<string, unknown>;
+  params?: {
+    backend?: Record<string, unknown>;
+  };
 }
 
 export interface DeploymentPayload {
@@ -328,7 +330,9 @@ export function transformToDeploymentPayload(
 
     // Add backend configuration if service has service-level params
     if (serviceParams && Object.keys(serviceParams).length > 0) {
-      deploymentService.backend = serviceParams;
+      deploymentService.params = {
+        backend: serviceParams,
+      };
     }
 
     services.push(deploymentService);


### PR DESCRIPTION
JIRA: https://jsw.ibm.com/browse/AISERVICES-1316

Fixed placing the systemprompt correctly inside params in the payload if the user enters a custom prompt

Current fixed payload
```
{
  "name": "ptest",
  "catalog_id": "rag",
  "version": "1.0.0",
  "services": [
    {
      "catalog_id": "chat",
      "version": "1.0.0",
      "components": [
        {
          "component_type": "vector_store",
          "provider_id": "opensearch",
          "version": "1.0.0"
        },
        {
          "component_type": "embedding",
          "provider_id": "vllm-cpu",
          "version": "1.0.0",
          "params": {
            "model": "ibm-granite/granite-embedding-278m-multilingual"
          }
        },
        {
          "component_type": "llm",
          "provider_id": "vllm-cpu",
          "version": "1.0.0",
          "params": {
            "model": "ibm-granite/granite-3.3-8b-instruct",
            "apiKey": "gg"
          }
        }
      ],
      "params": {
        "backend": {
          "systemPrompt": "You are a compliance-aware assistant for healthcare professionals. Critical rules: 1. Never provide medical diagnoses 2. Consult licensed professionals 3. Protect patient privacy 4. Cite HIPAA guidelines 5. Flag PHI queries"
        }
      }
    },
    {
      "catalog_id": "digitize",
      "version": "1.0.0",
      "components": [
        {
          "component_type": "vector_store",
          "provider_id": "opensearch",
          "version": "1.0.0"
        },
        {
          "component_type": "embedding",
          "provider_id": "vllm-cpu",
          "version": "1.0.0",
          "params": {
            "model": "ibm-granite/granite-embedding-278m-multilingual"
          }
        },
        {
          "component_type": "llm",
          "provider_id": "vllm-cpu",
          "version": "1.0.0",
          "params": {
            "model": "ibm-granite/granite-3.3-8b-instruct",
            "apiKey": "gg"
          }
        }
      ]
    },
    {
      "catalog_id": "similarity",
      "version": "1.0.0",
      "components": [
        {
          "component_type": "vector_store",
          "provider_id": "opensearch",
          "version": "1.0.0"
        },
        {
          "component_type": "embedding",
          "provider_id": "vllm-cpu",
          "version": "1.0.0",
          "params": {
            "model": "ibm-granite/granite-embedding-278m-multilingual"
          }
        },
        {
          "component_type": "reranker",
          "provider_id": "vllm-cpu",
          "version": "1.0.0",
          "params": {
            "model": "BAAI/bge-reranker-v2-m3"
          }
        }
      ]
    },
    {
      "catalog_id": "summarize",
      "version": "1.0.0",
      "components": [
        {
          "component_type": "llm",
          "provider_id": "watsonx",
          "version": "1.0.0",
          "params": {
            "model": "ibm/granite-4-h-small",
            "watsonxApiKey": "******",
            "watsonxUrl": "https://us-south.ml.cloud.ibm.com",
            "watsonxProjectId": "******"
          }
        }
      ]
    }
  ]
}
```

Tested with this custom prompt and checked on the chatbot UI as well after ingesting the doc I had got from Sathvik
`You are a compliance-aware assistant for healthcare professionals. Critical rules: 1. Never provide medical diagnoses 2. Consult licensed professionals 3. Protect patient privacy 4. Cite HIPAA guidelines 5. Flag PHI queries`

<img width="1918" height="947" alt="image" src="https://github.com/user-attachments/assets/d7edad81-e123-47fa-b78f-ba37624b81e3" />

<img width="1918" height="748" alt="image" src="https://github.com/user-attachments/assets/3ec17e51-c288-48f1-b4ce-5f32552c49aa" />
<img width="1918" height="947" alt="image" src="https://github.com/user-attachments/assets/ca4358b8-5a03-4eb1-8e9a-a34831501335" />

And the results are also as expected
<img width="1345" height="121" alt="image" src="https://github.com/user-attachments/assets/1981af37-1aff-404b-8cbd-0f5c58fb8afa" />
