### PR TITLE
Ensure service/components assets are accurate

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.144
+TAG?=v0.0.145
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.144
+  image: icr.io/ai-services-cicd/ai-services:v0.0.145
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/components/embedding/vllm-cpu/podman/values.yaml
+++ b/ai-services/assets/components/embedding/vllm-cpu/podman/values.yaml
@@ -1,2 +1,3 @@
 image: icr.io/ppc64le-oss/vllm-ppc64le:0.19.1
 model: ""
+maxModelLen: 512

--- a/ai-services/assets/components/embedding/vllm-cpu/podman/values.yaml
+++ b/ai-services/assets/components/embedding/vllm-cpu/podman/values.yaml
@@ -1,3 +1,2 @@
 image: icr.io/ppc64le-oss/vllm-ppc64le:0.19.1
 model: ""
-maxModelLen: 512

--- a/ai-services/assets/components/llm/vllm-cpu/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/vllm-cpu/podman/templates/vllm-server.yaml.tmpl
@@ -24,8 +24,8 @@ spec:
       - /models/{{ .Values.model }}
       - --served-model-name
       - {{ .Values.model }}
-      - --max-num-batched-tokens=26208
-      - --max-model-len=26208
+      - --max-num-batched-tokens={{ .Values.maxNumBatchedTokens }}
+      - --max-model-len={{ .Values.maxModelLen }}
       - --port=8000
       livenessProbe:
         httpGet:

--- a/ai-services/assets/components/llm/vllm-spyre/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/vllm-spyre/podman/templates/vllm-server.yaml.tmpl
@@ -52,9 +52,9 @@ spec:
         - name: VLLM_SPYRE_USE_CB
           value: "1"
         - name: MAX_MODEL_LEN
-          value: "32768"
+          value: "{{ .Values.maxModelLen }}"
         - name: MAX_BATCH_SIZE
-          value: "32"
+          value: "{{ .Values.maxBatchSize }}"
         - name: MASTER_PORT
           value: "12355"
         {{- if .Values.apiKey }}

--- a/ai-services/assets/components/llm/vllm-spyre/podman/values.yaml
+++ b/ai-services/assets/components/llm/vllm-spyre/podman/values.yaml
@@ -1,6 +1,5 @@
 image: registry.redhat.io/rhaii/vllm-spyre-rhel9:3.4.0
 model: ""
 apiKey: ""
-maxNumBatchedTokens: 26208
-maxModelLen: 26208
+maxModelLen: 32768
 maxBatchSize: 32

--- a/ai-services/assets/components/llm/watsonx/podman/templates/watsonx-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/watsonx/podman/templates/watsonx-server.yaml.tmpl
@@ -6,6 +6,7 @@ metadata:
     ai-services.io/template: "{{ .TemplateID }}"
     ai-services.io/secret: "watsonx-secret-{{ .InstanceSlug }}"
 spec:
+  restartPolicy: always
   containers:
     - name: litellm
       image: "{{ .Values.image }}"

--- a/ai-services/assets/components/llm/watsonx/podman/values.yaml
+++ b/ai-services/assets/components/llm/watsonx/podman/values.yaml
@@ -3,6 +3,5 @@ model: "ibm/granite-4-h-small"
 watsonxApiKey: ""
 watsonxProjectId: ""
 watsonxUrl: ""
-maxNumBatchedTokens: 26208
 maxModelLen: 26208
 maxBatchSize: 32

--- a/ai-services/assets/services/chat/podman/values.yaml
+++ b/ai-services/assets/services/chat/podman/values.yaml
@@ -1,9 +1,7 @@
 ui:
-  port: ""
   image: icr.io/ai-services-cicd/chatbot-ui:v0.0.44
 
 backend:
-  port: ""
   image: icr.io/ai-services-cicd/chatbot-service:v0.0.20
   log_level: "INFO"
   chatbot:

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,11 +1,9 @@
 digitize:
-  port: ""
   image: icr.io/ai-services-cicd/digitize-service:v0.0.28
   log_level: "INFO"
   database: "digitize_metadata"
 
 digitizeUi:
-  port: ""
   image: icr.io/ai-services-cicd/digitize-ui:v0.0.25
 
 postgres:

--- a/ai-services/assets/services/similarity/podman/values.yaml
+++ b/ai-services/assets/services/similarity/podman/values.yaml
@@ -1,6 +1,3 @@
 similarity:
-  port: ""
   image: icr.io/ai-services-cicd/similarity-service:v0.0.13
   log_level: "INFO"
-
-# Made with Bob

--- a/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
+++ b/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
@@ -77,6 +77,10 @@ spec:
           value: "http://{{ .Values.llm.host }}:{{ .Values.llm.port }}"
         - name: LLM_MODEL
           value: "{{ .Values.llm.model }}"
+        - name: LLM_MAX_MODEL_LEN
+          value: "{{ .Values.llm.maxModelLen }}"
+        - name: LLM_MAX_BATCH_SIZE
+          value: "{{ .Values.llm.maxBatchSize }}"
         - name: LOG_LEVEL
           value: "{{ .Values.summarize.log_level }}"
       resources:

--- a/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
+++ b/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
@@ -83,6 +83,10 @@ spec:
           value: "{{ .Values.llm.maxBatchSize }}"
         - name: LOG_LEVEL
           value: "{{ .Values.summarize.log_level }}"
+        {{- if .Values.llm.apiKey }}
+        - name: LLM_API_KEY
+          value: "{{ .Values.llm.apiKey }}"
+        {{- end }}
       resources:
         requests:
           memory: "512Mi"

--- a/ai-services/assets/services/summarize/podman/values.yaml
+++ b/ai-services/assets/services/summarize/podman/values.yaml
@@ -1,5 +1,4 @@
 summarize:
-  port: ""
   image: icr.io/ai-services-cicd/summarize-service:v0.0.14
   log_level: "INFO"
   database: "summarize_metadata"


### PR DESCRIPTION
- Jira issue: [AISERVICES-1320](https://jsw.ibm.com/browse/AISERVICES-1320)
- Compared services/components assets with application assets to ensure we are not missing anything.
- Remove unnecesary fields from values.yaml and use references of it in templates wherever applicable.

- The only major discrepancy found was for summarize, below envs were not set under services assets which is been added
```
        - name: LLM_MAX_MODEL_LEN
          value: "{{ .Values.llm.maxModelLen }}"
        - name: LLM_MAX_BATCH_SIZE
          value: "{{ .Values.llm.maxBatchSize }}"
        - name: LLM_API_KEY
          value: "{{ .Values.llm.apiKey }}"
```
- Also watsonx provider for llm had `restartPolicy` missing which needs to be set to `always`