### PR TITLE
[Catalog] Implement Log Sanitizer

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.149
+TAG?=v0.0.150
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.149
+  image: icr.io/ai-services-cicd/ai-services:v0.0.150
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -1096,7 +1096,7 @@ func (d *PodmanDeployer) getEnvParamsForComponent(ctx context.Context, podSpec *
 
 			env[containerName][string(constants.PCIAddressKey)] = pciAddressStr
 
-			logger.InfofCtx(ctx, "Allocated %d Spyre cards to container '%s' in pod '%s': %s\n",
+			logger.DebugfCtx(ctx, "Allocated %d Spyre cards to container '%s' in pod '%s': %s\n",
 				spyreCount, containerName, podSpec.Name, pciAddressStr)
 		}
 	}

--- a/ai-services/internal/pkg/logger/logger.go
+++ b/ai-services/internal/pkg/logger/logger.go
@@ -167,7 +167,7 @@ func WarningfCtx(ctx context.Context, format string, args ...any) {
 	if activeMinLevel > LevelRankWarn {
 		return
 	}
-	formattedMsg := fmt.Sprintf(format, args...)
+	formattedMsg := sanitizedSprintf(format, args...)
 	if isServiceEnv {
 		klog.InfoSDepth(1, formattedMsg, buildKV(ctx, LogLevelWarn, 1)...)
 	} else {
@@ -184,7 +184,7 @@ func ErrorlnCtx(ctx context.Context, msg string) {
 }
 
 func ErrorfCtx(ctx context.Context, format string, args ...any) {
-	formattedMsg := fmt.Sprintf(format, args...)
+	formattedMsg := sanitizedSprintf(format, args...)
 	if isServiceEnv {
 		klog.InfoSDepth(1, formattedMsg, buildKV(ctx, LogLevelError, 1)...)
 	} else {
@@ -209,7 +209,7 @@ func InfofCtx(ctx context.Context, format string, args ...any) {
 		return
 	}
 
-	formattedMsg := fmt.Sprintf(format, args...)
+	formattedMsg := sanitizedSprintf(format, args...)
 	if isServiceEnv {
 		klog.InfoSDepth(1, formattedMsg, buildKV(ctx, LogLevelInfo, 1)...)
 	} else {
@@ -236,7 +236,7 @@ func DebugfCtx(ctx context.Context, format string, args ...any) {
 		return
 	}
 
-	formattedMsg := fmt.Sprintf(format, args...)
+	formattedMsg := sanitizedSprintf(format, args...)
 	if isServiceEnv {
 		klog.V(klog.Level(verbosityLevelDebug)).InfoSDepth(1, formattedMsg, buildKV(ctx, LogLevelDebug, 1)...)
 	} else {

--- a/ai-services/internal/pkg/logger/sanitize.go
+++ b/ai-services/internal/pkg/logger/sanitize.go
@@ -1,0 +1,18 @@
+package logger
+
+import (
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/utils/sanitize"
+)
+
+// defaultSanitizer is the package-level SecretSanitizer used by all logger
+// functions. It is initialised once at startup via NewSecretSanitizer.
+var defaultSanitizer = sanitize.NewSecretSanitizer()
+
+// sanitizedSprintf is a drop-in replacement for fmt.Sprintf that sanitises
+// all map arguments through the SecretSanitizer before formatting.
+// All *fCtx logger functions route through this call.
+func sanitizedSprintf(format string, args ...any) string {
+	return fmt.Sprintf(format, defaultSanitizer.SanitizeArgs(args)...)
+}

--- a/ai-services/internal/pkg/utils/sanitize/sanitize.go
+++ b/ai-services/internal/pkg/utils/sanitize/sanitize.go
@@ -1,0 +1,146 @@
+package sanitize
+
+import "regexp"
+
+// Redacted is the placeholder written in place of a sensitive value.
+const Redacted = "[REDACTED]"
+
+// SecretSanitizer redacts sensitive values from map arguments before they are
+// serialised (e.g. into log messages or error strings).
+//
+// A map key is considered sensitive when it matches any of the compiled
+// patterns.  Each pattern uses (?i) for case-insensitive matching and .*
+// anchors so partial key names are caught (e.g. "dbPassword", "tls_cert").
+//
+// False-positive mitigation:
+//   - bare "key"     → catches "componentKey", "cacheKey" — replaced by the
+//     more specific api.*key / private.*key / access.*key.
+//   - "token"        → catches "tokenizer" — scoped with \btoken\b.
+//   - "auth"         → catches "author"    — scoped with \bauth\b.
+//   - bare "private" → catches "isPrivate" — scoped to private.*key.
+type SecretSanitizer struct {
+	sensitiveKeyPatterns []*regexp.Regexp
+}
+
+// NewSecretSanitizer creates a SecretSanitizer with the default sensitive-key
+// pattern set.
+func NewSecretSanitizer() *SecretSanitizer {
+	patterns := []*regexp.Regexp{
+		// password / passwd
+		regexp.MustCompile(`(?i).*passw(or)?d.*`),
+		// secret
+		regexp.MustCompile(`(?i).*secret.*`),
+		// token — matches oauth_token, accessToken, refresh_token, X-Auth-Token.
+		// "tokenizer" is intentionally also caught: map keys named "tokenizer"
+		// do not appear in this codebase and erring on the side of redaction is safer.
+		regexp.MustCompile(`(?i).*token.*`),
+		// api key variants: apikey, api_key, api-key, ApiKey
+		regexp.MustCompile(`(?i).*api.?key.*`),
+		// access key variants: accesskey, access_key, accessKey
+		regexp.MustCompile(`(?i).*access.?key.*`),
+		// private key variants: privatekey, private_key, privateKey
+		regexp.MustCompile(`(?i).*private.?key.*`),
+		// credential / credentials
+		regexp.MustCompile(`(?i).*credential.*`),
+		// auth — matches auth, Authorization, x-auth, authToken, oauth_auth.
+		// "author" / "authorName" are intentionally also caught: map keys named
+		// "author" do not appear in this codebase and erring on redaction is safer.
+		regexp.MustCompile(`(?i).*auth.*`),
+		// certificate / cert / tls_cert
+		regexp.MustCompile(`(?i).*cert.*`),
+	}
+
+	return &SecretSanitizer{sensitiveKeyPatterns: patterns}
+}
+
+// SanitizeArgs is the single public entry point used by the logger package.
+// It returns a new slice with every sensitive map argument sanitised.
+// Returns the original slice unchanged when no map argument is present,
+// avoiding any allocation on the hot path.
+func (s *SecretSanitizer) SanitizeArgs(args []any) []any {
+	hasMaps := false
+	for _, a := range args {
+		switch a.(type) {
+		case map[string]any, map[string]string:
+			hasMaps = true
+		}
+
+		if hasMaps {
+			break
+		}
+	}
+
+	if !hasMaps {
+		return args
+	}
+
+	out := make([]any, len(args))
+	for i, a := range args {
+		out[i] = s.sanitizeArg(a)
+	}
+
+	return out
+}
+
+// isSensitiveKey reports whether the map key k should have its value redacted.
+func (s *SecretSanitizer) isSensitiveKey(k string) bool {
+	for _, re := range s.sensitiveKeyPatterns {
+		if re.MatchString(k) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// sanitizeMapAny returns a shallow copy of m with sensitive values redacted.
+// Values that are themselves maps are sanitised recursively.
+func (s *SecretSanitizer) sanitizeMapAny(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if s.isSensitiveKey(k) {
+			out[k] = Redacted
+			continue
+		}
+		switch nested := v.(type) {
+		case map[string]any:
+			out[k] = s.sanitizeMapAny(nested)
+		case map[string]string:
+			out[k] = s.sanitizeMapString(nested)
+		default:
+			out[k] = v
+		}
+	}
+
+	return out
+}
+
+// sanitizeMapString returns a shallow copy of m with sensitive values redacted.
+func (s *SecretSanitizer) sanitizeMapString(m map[string]string) map[string]string {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		if s.isSensitiveKey(k) {
+			out[k] = Redacted
+		} else {
+			out[k] = v
+		}
+	}
+
+	return out
+}
+
+// sanitizeArg returns a safe-to-log representation of a single argument.
+//
+//   - map[string]any    → copy with sensitive values replaced by Redacted
+//   - map[string]string → copy with sensitive values replaced by Redacted
+//   - anything else     → returned unchanged (no allocation, no reflection)
+func (s *SecretSanitizer) sanitizeArg(arg any) any {
+	switch v := arg.(type) {
+	case map[string]any:
+		return s.sanitizeMapAny(v)
+	case map[string]string:
+		return s.sanitizeMapString(v)
+	default:
+		return arg
+	}
+}

--- a/ai-services/internal/pkg/utils/sanitize/sanitize.go
+++ b/ai-services/internal/pkg/utils/sanitize/sanitize.go
@@ -5,19 +5,9 @@ import "regexp"
 // Redacted is the placeholder written in place of a sensitive value.
 const Redacted = "[REDACTED]"
 
-// SecretSanitizer redacts sensitive values from map arguments before they are
-// serialised (e.g. into log messages or error strings).
-//
-// A map key is considered sensitive when it matches any of the compiled
-// patterns.  Each pattern uses (?i) for case-insensitive matching and .*
-// anchors so partial key names are caught (e.g. "dbPassword", "tls_cert").
-//
-// False-positive mitigation:
-//   - bare "key"     → catches "componentKey", "cacheKey" — replaced by the
-//     more specific api.*key / private.*key / access.*key.
-//   - "token"        → catches "tokenizer" — scoped with \btoken\b.
-//   - "auth"         → catches "author"    — scoped with \bauth\b.
-//   - bare "private" → catches "isPrivate" — scoped to private.*key.
+// SecretSanitizer redacts values of sensitive map keys before they are
+// serialised into log messages or error strings.
+// Use NewSecretSanitizer to create an instance and SanitizeArgs as the entry point.
 type SecretSanitizer struct {
 	sensitiveKeyPatterns []*regexp.Regexp
 }
@@ -53,10 +43,9 @@ func NewSecretSanitizer() *SecretSanitizer {
 	return &SecretSanitizer{sensitiveKeyPatterns: patterns}
 }
 
-// SanitizeArgs is the single public entry point used by the logger package.
-// It returns a new slice with every sensitive map argument sanitised.
-// Returns the original slice unchanged when no map argument is present,
-// avoiding any allocation on the hot path.
+// SanitizeArgs redacts sensitive values from any map arguments in args.
+// Non-map arguments are passed through unchanged.
+// If no map arguments are present the original slice is returned as-is (no allocation).
 func (s *SecretSanitizer) SanitizeArgs(args []any) []any {
 	hasMaps := false
 	for _, a := range args {
@@ -100,6 +89,7 @@ func (s *SecretSanitizer) sanitizeMapAny(m map[string]any) map[string]any {
 	for k, v := range m {
 		if s.isSensitiveKey(k) {
 			out[k] = Redacted
+
 			continue
 		}
 		switch nested := v.(type) {

--- a/ai-services/internal/pkg/utils/sanitize/sanitize_test.go
+++ b/ai-services/internal/pkg/utils/sanitize/sanitize_test.go
@@ -1,0 +1,396 @@
+package sanitize
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// ── isSensitiveKey: keys that MUST be redacted ────────────────────────────────
+
+func TestIsSensitiveKey_Sensitive(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	cases := []string{
+		// password / passwd
+		"password", "Password", "db_password", "dbPassword",
+		"passwd", "PASSWD", "dbPasswd", "db_passwd",
+		// opensearch / component-style dotted keys
+		"opensearch.password", "opensearch.admin_password",
+		// secret
+		"secret", "client_secret", "clientSecret", "SECRET_KEY",
+		// token (word-boundary still catches these)
+		"token", "oauth_token", "accessToken", "X-Auth-Token", "refresh_token",
+		// api key variants
+		"apiKey", "apikey", "api_key", "api-key", "ApiKey", "APIKEY", "Api.Key",
+		// access key
+		"accessKey", "accesskey", "access_key", "ACCESS_KEY",
+		// private key
+		"privateKey", "privatekey", "private_key", "PRIVATE_KEY",
+		// credential(s)
+		"credential", "credentials", "db_credentials",
+		// auth (word-boundary catches Authorization, x-auth, authToken)
+		"auth", "Authorization", "x-auth", "authToken", "oauth_auth",
+		// cert
+		"cert", "tls_cert", "certificate", "ssl_certificate", "CERT", "ca_cert",
+	}
+
+	for _, k := range cases {
+		if !s.isSensitiveKey(k) {
+			t.Errorf("isSensitiveKey(%q) = false, want true", k)
+		}
+	}
+}
+
+// ── isSensitiveKey: keys that must NOT be redacted ────────────────────────────
+
+func TestIsSensitiveKey_Safe(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	// Note: Go's RE2 engine does not support \b word boundaries, so patterns
+	// use plain substrings. "tokenizer", "author" etc. that contain sensitive
+	// substrings are therefore intentionally caught — they do not appear as map
+	// keys in this codebase, so false-positive redaction is harmless.
+	cases := []string{
+		// generic infra / config — no sensitive substring
+		"model", "host", "port", "url", "name", "version",
+		"componentType", "providerID", "instanceSlug",
+		"templateID", "baseDir", "catalogID",
+	}
+
+	for _, k := range cases {
+		if s.isSensitiveKey(k) {
+			t.Errorf("isSensitiveKey(%q) = true, want false", k)
+		}
+	}
+}
+
+// ── sanitizeMapAny: flat map ──────────────────────────────────────────────────
+
+func TestSanitizeMapAny_FlatMap(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	in := map[string]any{
+		// sensitive
+		"apiKey":   "sk-abc123",
+		"password": "hunter2",
+		// safe
+		"model": "ibm-granite/granite-3.3-8b-instruct",
+		"host":  "opensearch-d41fed174e",
+		"port":  "9200",
+	}
+
+	out := s.sanitizeMapAny(in)
+
+	assertRedacted(t, out, "apiKey")
+	assertRedacted(t, out, "password")
+	assertValue(t, out, "model", "ibm-granite/granite-3.3-8b-instruct")
+	assertValue(t, out, "host", "opensearch-d41fed174e")
+	assertValue(t, out, "port", "9200")
+}
+
+// ── sanitizeMapAny: real-world component params (matches original bug report) ─
+
+func TestSanitizeMapAny_ComponentParams(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	// Reproduces: "First instance: map[apiKey:1234567 model:ibm-granite/...]"
+	params := map[string]any{
+		"apiKey": "1234567",
+		"model":  "ibm-granite/granite-3.3-8b-instruct",
+	}
+
+	out := s.sanitizeMapAny(params)
+	msg := fmt.Sprintf("%v", out)
+
+	if strings.Contains(msg, "1234567") {
+		t.Errorf("API key leaked into formatted output: %s", msg)
+	}
+	if !strings.Contains(msg, Redacted) {
+		t.Errorf("expected %s in output: %s", Redacted, msg)
+	}
+	if !strings.Contains(msg, "ibm-granite/granite-3.3-8b-instruct") {
+		t.Errorf("safe model value was removed: %s", msg)
+	}
+}
+
+// ── sanitizeMapAny: OpenSearch-style dotted keys ──────────────────────────────
+
+func TestSanitizeMapAny_OpenSearchDottedKeys(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	in := map[string]any{
+		"opensearch.password":       "admin-secret",
+		"opensearch.admin_password": "admin2",
+		"opensearch.host":           "opensearch-d41fed174e",
+		"opensearch.port":           "9200",
+	}
+
+	out := s.sanitizeMapAny(in)
+
+	assertRedacted(t, out, "opensearch.password")
+	assertRedacted(t, out, "opensearch.admin_password")
+	assertValue(t, out, "opensearch.host", "opensearch-d41fed174e")
+	assertValue(t, out, "opensearch.port", "9200")
+}
+
+// ── sanitizeMapAny: nested map[string]any (one level) ────────────────────────
+
+func TestSanitizeMapAny_NestedMapAny_OneLevelDeep(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	in := map[string]any{
+		"opensearch": map[string]any{
+			"host":     "opensearch-d41fed174e",
+			"port":     "9200",
+			"password": "admin-secret",
+			"apiKey":   "os-key-xyz",
+		},
+		"model": "granite",
+	}
+
+	out := s.sanitizeMapAny(in)
+
+	assertValue(t, out, "model", "granite")
+
+	nested, ok := out["opensearch"].(map[string]any)
+	if !ok {
+		t.Fatal("nested 'opensearch' map was not preserved as map[string]any")
+	}
+	assertValue(t, nested, "host", "opensearch-d41fed174e")
+	assertValue(t, nested, "port", "9200")
+	assertRedacted(t, nested, "password")
+	assertRedacted(t, nested, "apiKey")
+}
+
+// ── sanitizeMapAny: deeply nested map[string]any (two levels) ────────────────
+
+func TestSanitizeMapAny_NestedMapAny_TwoLevelsDeep(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	in := map[string]any{
+		"services": map[string]any{
+			"opensearch": map[string]any{
+				"admin_password": "deep-secret",
+				"host":           "opensearch-host",
+			},
+		},
+	}
+
+	out := s.sanitizeMapAny(in)
+
+	services, ok := out["services"].(map[string]any)
+	if !ok {
+		t.Fatal("'services' not preserved as map[string]any")
+	}
+	opensearch, ok := services["opensearch"].(map[string]any)
+	if !ok {
+		t.Fatal("'services.opensearch' not preserved as map[string]any")
+	}
+	assertRedacted(t, opensearch, "admin_password")
+	assertValue(t, opensearch, "host", "opensearch-host")
+}
+
+// ── sanitizeMapAny: nested map[string]string ──────────────────────────────────
+
+func TestSanitizeMapAny_NestedMapString(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	in := map[string]any{
+		"env": map[string]string{
+			"POSTGRES_PASSWORD": "hunter2",
+			"POSTGRES_HOST":     "db-host",
+			"API_KEY":           "sk-999",
+		},
+	}
+
+	out := s.sanitizeMapAny(in)
+
+	nested, ok := out["env"].(map[string]string)
+	if !ok {
+		t.Fatal("nested map[string]string was not preserved")
+	}
+	if nested["POSTGRES_PASSWORD"] != Redacted {
+		t.Errorf("POSTGRES_PASSWORD not redacted: got %v", nested["POSTGRES_PASSWORD"])
+	}
+	if nested["API_KEY"] != Redacted {
+		t.Errorf("API_KEY not redacted: got %v", nested["API_KEY"])
+	}
+	if nested["POSTGRES_HOST"] != "db-host" {
+		t.Errorf("POSTGRES_HOST was changed: got %v", nested["POSTGRES_HOST"])
+	}
+}
+
+// ── sanitizeMapAny: original map must not be mutated ─────────────────────────
+
+func TestSanitizeMapAny_DoesNotMutateOriginal(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	in := map[string]any{
+		"apiKey":   "sk-original",
+		"password": "pw-original",
+		"model":    "granite",
+	}
+
+	_ = s.sanitizeMapAny(in)
+
+	if in["apiKey"] != "sk-original" {
+		t.Error("sanitizeMapAny mutated apiKey in original map")
+	}
+	if in["password"] != "pw-original" {
+		t.Error("sanitizeMapAny mutated password in original map")
+	}
+}
+
+// ── sanitizeMapString ─────────────────────────────────────────────────────────
+
+func TestSanitizeMapString(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	in := map[string]string{
+		"api_key":  "sk-abc123",
+		"password": "hunter2",
+		"model":    "granite",
+		"host":     "localhost",
+	}
+
+	out := s.sanitizeMapString(in)
+
+	if out["api_key"] != Redacted {
+		t.Errorf("api_key not redacted: got %v", out["api_key"])
+	}
+	if out["password"] != Redacted {
+		t.Errorf("password not redacted: got %v", out["password"])
+	}
+	if out["model"] != "granite" {
+		t.Errorf("model was changed: got %v", out["model"])
+	}
+	if out["host"] != "localhost" {
+		t.Errorf("host was changed: got %v", out["host"])
+	}
+}
+
+// ── SanitizeArgs (public) ─────────────────────────────────────────────────────
+
+func TestSanitizeArgs_FastPath_NoMaps(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	args := []any{"hello", 42, true}
+	out := s.SanitizeArgs(args)
+
+	if len(out) != len(args) {
+		t.Fatalf("fast-path: wrong length: got %d, want %d", len(out), len(args))
+	}
+	// Same backing array — mutate args and verify out reflects the change.
+	args[0] = "mutated"
+	if out[0] != "mutated" {
+		t.Error("SanitizeArgs returned a new slice for non-map args (expected same backing array)")
+	}
+}
+
+func TestSanitizeArgs_SanitisesMapAnyArg(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	args := []any{
+		"component llm/vllm-cpu params",
+		map[string]any{
+			"apiKey":   "1234567",
+			"password": "hunter2",
+			"model":    "ibm-granite/granite-3.3-8b-instruct",
+		},
+	}
+
+	out := s.SanitizeArgs(args)
+
+	if out[0] != "component llm/vllm-cpu params" {
+		t.Errorf("string arg was changed: got %v", out[0])
+	}
+
+	m, ok := out[1].(map[string]any)
+	if !ok {
+		t.Fatal("second arg is not map[string]any after SanitizeArgs")
+	}
+	assertRedacted(t, m, "apiKey")
+	assertRedacted(t, m, "password")
+	assertValue(t, m, "model", "ibm-granite/granite-3.3-8b-instruct")
+}
+
+func TestSanitizeArgs_SanitisesMapStringArg(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	args := []any{
+		map[string]string{
+			"api_key": "sk-xyz",
+			"host":    "localhost",
+		},
+	}
+
+	out := s.SanitizeArgs(args)
+
+	m, ok := out[0].(map[string]string)
+	if !ok {
+		t.Fatal("arg is not map[string]string after SanitizeArgs")
+	}
+	if m["api_key"] != Redacted {
+		t.Errorf("api_key not redacted: got %v", m["api_key"])
+	}
+	if m["host"] != "localhost" {
+		t.Errorf("host was changed: got %v", m["host"])
+	}
+}
+
+func TestSanitizeArgs_NestedMapInsideArg(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	// Nested map[string]any passed as a single variadic arg — verifies that
+	// SanitizeArgs recurses into nested maps, not just the top level.
+	args := []any{
+		map[string]any{
+			"opensearch": map[string]any{
+				"password": "deep-secret",
+				"host":     "opensearch-host",
+			},
+		},
+	}
+
+	out := s.SanitizeArgs(args)
+
+	top, ok := out[0].(map[string]any)
+	if !ok {
+		t.Fatal("arg not map[string]any after SanitizeArgs")
+	}
+	nested, ok := top["opensearch"].(map[string]any)
+	if !ok {
+		t.Fatal("nested opensearch map not preserved")
+	}
+	assertRedacted(t, nested, "password")
+	assertValue(t, nested, "host", "opensearch-host")
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func assertRedacted(t *testing.T, m map[string]any, key string) {
+	t.Helper()
+
+	v, ok := m[key]
+	if !ok {
+		t.Errorf("key %q missing from sanitized map", key)
+		return
+	}
+	if v != Redacted {
+		t.Errorf("key %q: expected %s, got %v", key, Redacted, v)
+	}
+}
+
+func assertValue(t *testing.T, m map[string]any, key, want string) {
+	t.Helper()
+
+	v, ok := m[key]
+	if !ok {
+		t.Errorf("key %q missing from sanitized map", key)
+		return
+	}
+	if v != want {
+		t.Errorf("key %q: expected %q, got %v", key, want, v)
+	}
+}

--- a/ai-services/internal/pkg/utils/sanitize/sanitize_test.go
+++ b/ai-services/internal/pkg/utils/sanitize/sanitize_test.go
@@ -191,6 +191,49 @@ func TestSanitizeMapAny_NestedMapAny_TwoLevelsDeep(t *testing.T) {
 	assertValue(t, opensearch, "host", "opensearch-host")
 }
 
+// ── sanitizeMapAny: multiple sibling nested maps (real-world component params) ─
+
+func TestSanitizeMapAny_MultipleNestedComponents(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	// Mirrors the shape of a deployment request Values map:
+	// { llm: { apiKey: "...", model: "..." }, opensearch: { password: "...", host: "..." } }
+	in := map[string]any{
+		"llm": map[string]any{
+			"apiKey": "sk-llm-secret",
+			"model":  "ibm-granite/granite-3.3-8b-instruct",
+		},
+		"opensearch": map[string]any{
+			"password": "os-admin-pw",
+			"host":     "opensearch-d41fed174e",
+			"port":     "9200",
+		},
+		"name": "Test RAG",
+	}
+
+	out := s.sanitizeMapAny(in)
+
+	// Top-level safe key unchanged
+	assertValue(t, out, "name", "Test RAG")
+
+	// llm block: apiKey redacted, model preserved
+	llm, ok := out["llm"].(map[string]any)
+	if !ok {
+		t.Fatal("'llm' not preserved as map[string]any")
+	}
+	assertRedacted(t, llm, "apiKey")
+	assertValue(t, llm, "model", "ibm-granite/granite-3.3-8b-instruct")
+
+	// opensearch block: password redacted, host/port preserved
+	opensearch, ok := out["opensearch"].(map[string]any)
+	if !ok {
+		t.Fatal("'opensearch' not preserved as map[string]any")
+	}
+	assertRedacted(t, opensearch, "password")
+	assertValue(t, opensearch, "host", "opensearch-d41fed174e")
+	assertValue(t, opensearch, "port", "9200")
+}
+
 // ── sanitizeMapAny: nested map[string]string ──────────────────────────────────
 
 func TestSanitizeMapAny_NestedMapString(t *testing.T) {
@@ -365,6 +408,53 @@ func TestSanitizeArgs_NestedMapInsideArg(t *testing.T) {
 	}
 	assertRedacted(t, nested, "password")
 	assertValue(t, nested, "host", "opensearch-host")
+}
+
+func TestSanitizeArgs_MultipleNestedComponents(t *testing.T) {
+	s := NewSecretSanitizer()
+
+	// Same shape as above but exercised through SanitizeArgs — the path the
+	// logger takes when a Values map is passed as a %v format argument.
+	args := []any{
+		"deploying application",
+		map[string]any{
+			"llm": map[string]any{
+				"apiKey": "sk-llm-secret",
+				"model":  "ibm-granite/granite-3.3-8b-instruct",
+			},
+			"opensearch": map[string]any{
+				"password": "os-admin-pw",
+				"host":     "opensearch-d41fed174e",
+				"port":     "9200",
+			},
+		},
+	}
+
+	out := s.SanitizeArgs(args)
+
+	if out[0] != "deploying application" {
+		t.Errorf("string arg was changed: got %v", out[0])
+	}
+
+	top, ok := out[1].(map[string]any)
+	if !ok {
+		t.Fatal("second arg not map[string]any after SanitizeArgs")
+	}
+
+	llm, ok := top["llm"].(map[string]any)
+	if !ok {
+		t.Fatal("'llm' not preserved as map[string]any")
+	}
+	assertRedacted(t, llm, "apiKey")
+	assertValue(t, llm, "model", "ibm-granite/granite-3.3-8b-instruct")
+
+	opensearch, ok := top["opensearch"].(map[string]any)
+	if !ok {
+		t.Fatal("'opensearch' not preserved as map[string]any")
+	}
+	assertRedacted(t, opensearch, "password")
+	assertValue(t, opensearch, "host", "opensearch-d41fed174e")
+	assertValue(t, opensearch, "port", "9200")
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
- Implement a log sanitizer so that sensitive information are not logged (redacted)
- Sanitize at logger pkg so that its extensible and avoids printing/adding any sensitive info as part of args in logs.

Ref for sanitizing patterns: https://github.com/IBM/project-ai-services/pull/675