### PR TITLE
[Podman] Do secret mounting instead of using secretRef

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.152
+TAG?=v0.0.153
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/templates/catalog-db.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog-db.yaml.tmpl
@@ -17,17 +17,19 @@ spec:
   containers:
   - name: postgresql
     image: "{{ .Values.db.image }}"
+    command:
+      - "/bin/sh"
+      - "-c"
+    args:
+      - |
+        export POSTGRES_PASSWORD=$(cat /etc/secret/catalog-db-secret/db-password)
+        exec docker-entrypoint.sh postgres
     ports:
     - containerPort: 5432
       hostPort: {{ .Values.db.port }}
     env:
     - name: POSTGRES_USER
       value: "{{ .Values.db.user }}"
-    - name: POSTGRES_PASSWORD
-      valueFrom:
-        secretKeyRef:
-          name: catalog-db-secret
-          key: db-password
     - name: POSTGRES_DB
       value: "{{ .Values.db.database }}"
     - name: PGDATA
@@ -38,6 +40,9 @@ spec:
     volumeMounts:
     - name: postgres-data
       mountPath: /var/lib/pgsql:z
+    - name: catalog-db-secret
+      mountPath: /etc/secret/catalog-db-secret
+      readOnly: true
     livenessProbe:
       exec:
         command:
@@ -67,3 +72,6 @@ spec:
   - name: postgres-data
     persistentVolumeClaim:
       claimName: "postgres-catalog"
+  - name: catalog-db-secret
+    secret:
+      secretName: catalog-db-secret

--- a/ai-services/assets/catalog/podman/templates/catalog-db.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog-db.yaml.tmpl
@@ -8,7 +8,7 @@ metadata:
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/secret: "catalog-db-secret"
     ai-services.io/secret-skip-cleanup: "true"
-    ai-services.io/volume: "postgres-catalog"
+    ai-services.io/volume: "postgres-catalog,catalog-db-secret"
     ai-services.io/volume-skip-cleanup: "true"
   annotations:
     io.podman.annotations.pids-limit/postgresql: "4096"

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -7,7 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/secret: "catalog-secret"
-    ai-services.io/volume: "podman-auth-secret"
+    ai-services.io/volume: "podman-auth-secret,catalog-secret"
   annotations:
     run.oci.keep_original_groups: "1"
     ai-services.io/routes: "8081:catalog-ui:ui, 8080:catalog-api:api"

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -20,9 +20,8 @@ spec:
       command: ["/bin/sh", "-c"]
       args:
         - |
+          set -e
           export DB_PASSWORD=$(cat /etc/secret/catalog-db-secret/db-password)
-
-          set -e  # Exit immediately if any command fails
 
           max_retries=5
           retry_delay=5

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -20,6 +20,8 @@ spec:
       command: ["/bin/sh", "-c"]
       args:
         - |
+          export DB_PASSWORD=$(cat /etc/secret/catalog-db-secret/db-password)
+
           set -e  # Exit immediately if any command fails
 
           max_retries=5
@@ -49,17 +51,15 @@ spec:
               exit 1
             fi
           done
-      env:
-        - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: catalog-db-secret
-              key: db-password
       resources:
         requests:
           memory: "512Mi"
         limits:
           memory: "512Mi"
+      volumeMounts:
+        - name: catalog-db-secret
+          mountPath: /etc/secret/catalog-db-secret
+          readOnly: true
   containers:
     - name: ui
       image: "{{ .Values.ui.image }}"
@@ -95,7 +95,10 @@ spec:
           {{- end }}
       command: ["/bin/sh", "-c"]
       args:
-        - "/usr/bin/ai-services catalog apiserver --port=8080 --admin-username=admin --admin-password-hash=${ADMIN_PASSWORD} --runtime={{ .Values.backend.runtime }}"
+        - |
+          export ADMIN_PASSWORD=$(cat /etc/secret/catalog-secret/admin-password)
+          export DB_PASSWORD=$(cat /etc/secret/catalog-db-secret/db-password)
+          exec /usr/bin/ai-services catalog apiserver --port=8080 --admin-username=admin --admin-password-hash=${ADMIN_PASSWORD} --runtime={{ .Values.backend.runtime }}
       env:
         - name: GIN_MODE
           value: "release"
@@ -107,22 +110,12 @@ spec:
           value: "unix://{{ .Values.backend.podman.uri }}"
         - name: REGISTRY_AUTH_FILE
           value: "/run/containers/auth.json"
-        - name: ADMIN_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: catalog-secret
-              key: admin-password
         - name: DB_HOST
           value: {{ .AppName }}--db
         - name: DB_PORT
           value: "5432"
         - name: DB_USER
           value: "{{ .Values.db.user }}"
-        - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: catalog-db-secret
-              key: db-password
         - name: AI_SERVICES_BASE_DIR
           value: "{{ .BaseDir }}"
         - name: CADDY_ADMIN_URL
@@ -154,6 +147,12 @@ spec:
           readOnly: true
         - name: ai-services-data
           mountPath: {{ .BaseDir }}
+        - name: catalog-secret
+          mountPath: /etc/secret/catalog-secret
+          readOnly: true
+        - name: catalog-db-secret
+          mountPath: /etc/secret/catalog-db-secret
+          readOnly: true
       resources:
         requests:
           podman.io/device=/dev/vfio: 4
@@ -178,3 +177,9 @@ spec:
       hostPath:
         path: {{ .BaseDir }}
         type: DirectoryOrCreate
+    - name: catalog-secret
+      secret:
+        secretName: catalog-secret
+    - name: catalog-db-secret
+      secret:
+        secretName: catalog-db-secret

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.152
+  image: icr.io/ai-services-cicd/ai-services:v0.0.153
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/components/llm/vllm-cpu/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/vllm-cpu/podman/templates/vllm-server.yaml.tmpl
@@ -32,8 +32,7 @@ spec:
           {{- if .Values.apiKey }}
           export VLLM_API_KEY=$(cat /etc/secret/vllm-secret/apiKey)
           {{- end }}
-          exec /usr/local/bin/python -m vllm.entrypoints.openai.api_server \
-            --model /models/{{ .Values.model }} \
+          exec vllm serve /models/{{ .Values.model }} \
             --served-model-name {{ .Values.model }} \
             --max-num-batched-tokens={{ .Values.maxNumBatchedTokens }} \
             --max-model-len={{ .Values.maxModelLen }} \

--- a/ai-services/assets/components/llm/vllm-cpu/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/vllm-cpu/podman/templates/vllm-server.yaml.tmpl
@@ -6,6 +6,7 @@ metadata:
     ai-services.io/template: "{{ .TemplateID }}"
     {{- if .Values.apiKey }}
     ai-services.io/secret: "vllm-secret-{{ .InstanceSlug }}"
+    ai-services.io/volume: "vllm-secret-{{ .InstanceSlug }}"
     {{- end }}
   annotations:
     io.podman.annotations.ulimit: "nofile=134217728:134217728,memlock=-1:-1"

--- a/ai-services/assets/components/llm/vllm-cpu/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/vllm-cpu/podman/templates/vllm-server.yaml.tmpl
@@ -16,17 +16,27 @@ spec:
       hostPath:
         path: "{{ .BaseDir }}/models"
         type: Directory
+    {{- if .Values.apiKey }}
+    - name: vllm-secret
+      secret:
+        secretName: "vllm-secret-{{ .InstanceSlug }}"
+    {{- end }}
   containers:
     - name: llm
       image: "{{ .Values.image }}"
+      command: ["/bin/sh"]
       args:
-      - --model
-      - /models/{{ .Values.model }}
-      - --served-model-name
-      - {{ .Values.model }}
-      - --max-num-batched-tokens={{ .Values.maxNumBatchedTokens }}
-      - --max-model-len={{ .Values.maxModelLen }}
-      - --port=8000
+        - "-c"
+        - |
+          {{- if .Values.apiKey }}
+          export VLLM_API_KEY=$(cat /etc/secret/vllm-secret/apiKey)
+          {{- end }}
+          exec /usr/local/bin/python -m vllm.entrypoints.openai.api_server \
+            --model /models/{{ .Values.model }} \
+            --served-model-name {{ .Values.model }} \
+            --max-num-batched-tokens={{ .Values.maxNumBatchedTokens }} \
+            --max-model-len={{ .Values.maxModelLen }} \
+            --port=8000
       livenessProbe:
         httpGet:
           path: /health
@@ -40,13 +50,6 @@ spec:
         value: auto
       - name: VLLM_CPU_KVCACHE_SPACE
         value: "32"
-      {{- if .Values.apiKey }}
-      - name: VLLM_API_KEY
-        valueFrom:
-          secretKeyRef:
-            name: "vllm-secret-{{ .InstanceSlug }}"
-            key: apiKey
-      {{- end }}
       resources:
         requests:
           memory: "150Gi"
@@ -58,3 +61,8 @@ spec:
         - mountPath: /models:z
           name: models
           readOnly: true
+        {{- if .Values.apiKey }}
+        - mountPath: /etc/secret/vllm-secret
+          name: vllm-secret
+          readOnly: true
+        {{- end }}

--- a/ai-services/assets/components/llm/vllm-spyre/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/vllm-spyre/podman/templates/vllm-server.yaml.tmpl
@@ -23,6 +23,11 @@ spec:
       hostPath:
         path: "{{ .BaseDir }}/models"
         type: Directory
+    {{- if .Values.apiKey }}
+    - name: vllm-secret
+      secret:
+        secretName: "vllm-secret-{{ .InstanceSlug }}"
+    {{- end }}
   containers:
     - name: llm
       image: "{{ .Values.image }}"
@@ -30,6 +35,9 @@ spec:
       args:
         - "-c"
         - |
+          {{- if .Values.apiKey }}
+          export VLLM_API_KEY=$(cat /etc/secret/vllm-secret/apiKey)
+          {{- end }}
           /opt/app-root/spyre_entrypoint.sh \
           --model ${VLLM_MODEL_PATH} \
           -tp ${AIU_WORLD_SIZE} \
@@ -57,13 +65,6 @@ spec:
           value: "{{ .Values.maxBatchSize }}"
         - name: MASTER_PORT
           value: "12355"
-        {{- if .Values.apiKey }}
-        - name: VLLM_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: "vllm-secret-{{ .InstanceSlug }}"
-              key: apiKey
-        {{- end }}
         {{- /* Check if .env.llm exists and is a non-empty map */}}
         {{- with .env.llm }}
           {{- /* If it does, '.' (dot) is now scoped to .env.llm */}}
@@ -86,3 +87,8 @@ spec:
           readOnly: true
         - mountPath: /dev/shm
           name: dshm
+        {{- if .Values.apiKey }}
+        - mountPath: /etc/secret/vllm-secret
+          name: vllm-secret
+          readOnly: true
+        {{- end }}

--- a/ai-services/assets/components/llm/vllm-spyre/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/vllm-spyre/podman/templates/vllm-server.yaml.tmpl
@@ -39,7 +39,7 @@ spec:
           {{- if .Values.apiKey }}
           export VLLM_API_KEY=$(cat /etc/secret/vllm-secret/apiKey)
           {{- end }}
-          /opt/app-root/spyre_entrypoint.sh \
+          exec /opt/app-root/spyre_entrypoint.sh \
           --model ${VLLM_MODEL_PATH} \
           -tp ${AIU_WORLD_SIZE} \
           --max-model-len ${MAX_MODEL_LEN} \

--- a/ai-services/assets/components/llm/vllm-spyre/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/vllm-spyre/podman/templates/vllm-server.yaml.tmpl
@@ -6,6 +6,7 @@ metadata:
     ai-services.io/template: "{{ .TemplateID }}"
     {{- if .Values.apiKey }}
     ai-services.io/secret: "vllm-secret-{{ .InstanceSlug }}"
+    ai-services.io/volume: "vllm-secret-{{ .InstanceSlug }}"
     {{- end }}
   annotations:
     io.podman.annotations.ulimit: "nofile=134217728:134217728,memlock=-1:-1"

--- a/ai-services/assets/components/llm/watsonx/podman/templates/watsonx-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/watsonx/podman/templates/watsonx-server.yaml.tmpl
@@ -7,22 +7,23 @@ metadata:
     ai-services.io/secret: "watsonx-secret-{{ .InstanceSlug }}"
 spec:
   restartPolicy: always
+  volumes:
+    - name: watsonx-secret
+      secret:
+        secretName: "watsonx-secret-{{ .InstanceSlug }}"
   containers:
     - name: litellm
       image: "{{ .Values.image }}"
-      command: ["litellm"]
+      command: ["/bin/sh"]
       args:
-        - --config
-        - /app/config.yaml
-        - --port
-        - "8000"
-        - --debug
+        - "-c"
+        - |
+          export WATSONX_APIKEY=$(cat /etc/secret/watsonx-secret/apiKey)
+          exec litellm \
+            --config /app/config.yaml \
+            --port 8000 \
+            --debug
       env:
-        - name: WATSONX_APIKEY
-          valueFrom:
-            secretKeyRef:
-              name: "watsonx-secret-{{ .InstanceSlug }}"
-              key: apiKey
         - name: WATSONX_PROJECT_ID
           value: "{{ .Values.watsonxProjectId }}"
         - name: WATSONX_URL
@@ -55,3 +56,7 @@ spec:
       ports:
         - containerPort: 8000
           protocol: TCP
+      volumeMounts:
+        - mountPath: /etc/secret/watsonx-secret
+          name: watsonx-secret
+          readOnly: true

--- a/ai-services/assets/components/llm/watsonx/podman/templates/watsonx-server.yaml.tmpl
+++ b/ai-services/assets/components/llm/watsonx/podman/templates/watsonx-server.yaml.tmpl
@@ -5,6 +5,7 @@ metadata:
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
     ai-services.io/secret: "watsonx-secret-{{ .InstanceSlug }}"
+    ai-services.io/volume: "watsonx-secret-{{ .InstanceSlug }}"
 spec:
   restartPolicy: always
   volumes:

--- a/ai-services/assets/components/vector_db/opensearch/podman/templates/opensearch.yaml.tmpl
+++ b/ai-services/assets/components/vector_db/opensearch/podman/templates/opensearch.yaml.tmpl
@@ -11,22 +11,27 @@ metadata:
     io.podman.annotations.pids-limit/opensearch: "4096"
 spec:
   restartPolicy: always
+  volumes:
+    - name: opensearch-data
+      persistentVolumeClaim:
+        claimName: "opensearch-{{ .InstanceSlug }}"
+    - name: opensearch-secret
+      secret:
+        secretName: "opensearch-secret-{{ .InstanceSlug }}"
   containers:
     - name: opensearch
       image: "{{ .Values.image }}"
+      command:
+        - "/bin/sh"
+        - "-c"
+      args:
+        - |
+          export OPENSEARCH_USERNAME=$(cat /etc/secret/opensearch-secret/username)
+          export OPENSEARCH_INITIAL_ADMIN_PASSWORD=$(cat /etc/secret/opensearch-secret/password)
+          exec /usr/share/opensearch/bin/opensearch
       env:
         - name: "discovery.type"
           value: "single-node"
-        - name: OPENSEARCH_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: "opensearch-secret-{{ .InstanceSlug }}"
-              key: username
-        - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: "opensearch-secret-{{ .InstanceSlug }}"
-              key: password
         - name: OPENSEARCH_JAVA_OPTS
           value: "-Xms4g -Xmx4g -XX:MaxDirectMemorySize=2g -XX:-UseSuperWord -XX:TieredStopAtLevel=1"
       ports:
@@ -45,6 +50,9 @@ spec:
       volumeMounts:
         - mountPath: /usr/share/opensearch/data:z
           name: opensearch-data
+        - mountPath: /etc/secret/opensearch-secret
+          name: opensearch-secret
+          readOnly: true
       livenessProbe:
         exec:
           command:
@@ -55,7 +63,3 @@ spec:
         periodSeconds: 30
         timeoutSeconds: 20
         failureThreshold: 5
-  volumes:
-    - name: opensearch-data
-      persistentVolumeClaim:
-        claimName: "opensearch-{{ .InstanceSlug }}"

--- a/ai-services/assets/components/vector_db/opensearch/podman/templates/opensearch.yaml.tmpl
+++ b/ai-services/assets/components/vector_db/opensearch/podman/templates/opensearch.yaml.tmpl
@@ -6,7 +6,7 @@ metadata:
     ai-services.io/template: "{{ .TemplateID }}"
     ai-services.io/secret: "opensearch-secret-{{ .InstanceSlug }}"
     ai-services.io/secret-skip-cleanup: "true"
-    ai-services.io/volume: "opensearch-{{ .InstanceSlug }}"
+    ai-services.io/volume: "opensearch-{{ .InstanceSlug }},opensearch-secret-{{ .InstanceSlug }}"
   annotations:
     io.podman.annotations.pids-limit/opensearch: "4096"
 spec:

--- a/ai-services/assets/components/vector_db/opensearch/podman/templates/opensearch.yaml.tmpl
+++ b/ai-services/assets/components/vector_db/opensearch/podman/templates/opensearch.yaml.tmpl
@@ -28,7 +28,7 @@ spec:
         - |
           export OPENSEARCH_USERNAME=$(cat /etc/secret/opensearch-secret/username)
           export OPENSEARCH_INITIAL_ADMIN_PASSWORD=$(cat /etc/secret/opensearch-secret/password)
-          exec /usr/share/opensearch/bin/opensearch
+          exec /usr/share/opensearch/opensearch-docker-entrypoint.sh opensearch
       env:
         - name: "discovery.type"
           value: "single-node"
@@ -58,7 +58,7 @@ spec:
           command:
           - sh
           - -c
-          - curl -fk -u "$OPENSEARCH_USERNAME:$OPENSEARCH_INITIAL_ADMIN_PASSWORD" https://localhost:9200/_cluster/health
+          - curl -fk -u "$(cat /etc/secret/opensearch-secret/username):$(cat /etc/secret/opensearch-secret/password)" https://localhost:9200/_cluster/health
         initialDelaySeconds: 90
         periodSeconds: 30
         timeoutSeconds: 20

--- a/ai-services/assets/services/chat/podman/templates/chat-bot.yaml.tmpl
+++ b/ai-services/assets/services/chat/podman/templates/chat-bot.yaml.tmpl
@@ -9,6 +9,10 @@ metadata:
     # ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
   restartPolicy: always
+  volumes:
+    - name: opensearch-secret
+      secret:
+        secretName: "opensearch-secret-{{ .Values.vector_store.instanceSlug }}"
   containers:
     - name: ui
       image: "{{ .Values.ui.image }}"
@@ -46,18 +50,17 @@ spec:
     - name: backend-server
       image: "{{ .Values.backend.image }}"
       command:
-        - "/var/venv/bin/python"
-        - "-m"
-        - "uvicorn"
-        - "app:app"
-        - "--host"
-        - "0.0.0.0"
-        - "--port"
-        - "5000"
-        - "--loop"
-        - "uvloop"
-        - "--http"
-        - "httptools"
+        - "/bin/sh"
+        - "-c"
+      args:
+        - |
+          export OPENSEARCH_USERNAME=$(cat /etc/secret/opensearch-secret/username)
+          export OPENSEARCH_PASSWORD=$(cat /etc/secret/opensearch-secret/password)
+          exec /var/venv/bin/python -m uvicorn app:app \
+            --host 0.0.0.0 \
+            --port 5000 \
+            --loop uvloop \
+            --http httptools
       env:
         - name: EMB_ENDPOINT
           value: "http://{{ .Values.embedding.host }}:{{ .Values.embedding.port }}"
@@ -81,16 +84,6 @@ spec:
           value: "RAG_DB"
         - name: OPENSEARCH_INDEX_NAME
           value: "RAG_INDEX"
-        - name: OPENSEARCH_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: "opensearch-secret-{{ .Values.vector_store.instanceSlug }}"
-              key: username
-        - name: OPENSEARCH_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: "opensearch-secret-{{ .Values.vector_store.instanceSlug }}"
-              key: password
         - name: OPENSEARCH_NUM_SHARDS
           value: "1"
         - name: LOG_LEVEL
@@ -125,3 +118,7 @@ spec:
           memory: "1Gi"
         limits:
           memory: "1Gi"
+      volumeMounts:
+        - mountPath: /etc/secret/opensearch-secret
+          name: opensearch-secret
+          readOnly: true

--- a/ai-services/assets/services/digitize/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/services/digitize/podman/templates/digitize.yaml.tmpl
@@ -6,6 +6,9 @@ metadata:
     ai-services.io/template: "{{ .TemplateID }}"
     ai-services.io/secret: "digitize-db-secret-{{ .InstanceSlug }}"
     ai-services.io/secret-skip-cleanup: "true"
+    {{- if .Values.llm.apiKey }}
+    ai-services.io/secret: "vllm-secret-{{ .Values.llm.instanceSlug }}"
+    {{- end }}
     ai-services.io/volume: "digitize-cache-{{ .InstanceSlug }}"
   annotations:
     ai-services.io/routes: "4001:digitize-ui-{{ .InstanceSlug }}:ui,4000:digitize-backend-{{ .InstanceSlug }}:api"
@@ -16,8 +19,13 @@ spec:
     - name: digitize-db-init
       image: "{{ .Values.digitize.image }}"
       command:
-        - "/var/venv/bin/python"
-        - "db/scripts/init_db.py"
+        - "/bin/sh"
+        - "-c"
+      args:
+        - |
+          export POSTGRES_USER=$(cat /etc/secret/digitize-db-secret/username)
+          export POSTGRES_PASSWORD=$(cat /etc/secret/digitize-db-secret/password)
+          exec /var/venv/bin/python db/scripts/init_db.py
       env:
         - name: POSTGRES_HOST
           value: "digitize-db-{{ .InstanceSlug }}"
@@ -25,16 +33,10 @@ spec:
           value: "5432"
         - name: POSTGRES_DB
           value: "{{ .Values.digitize.database }}"
-        - name: POSTGRES_USER
-          valueFrom:
-            secretKeyRef:
-              name: "digitize-db-secret-{{ .InstanceSlug }}"
-              key: username
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: "digitize-db-secret-{{ .InstanceSlug }}"
-              key: password
+      volumeMounts:
+        - mountPath: /etc/secret/digitize-db-secret
+          name: digitize-db-secret
+          readOnly: true
   containers:
     - name: ui
       image: "{{ .Values.digitizeUi.image }}"
@@ -62,18 +64,22 @@ spec:
     - name: backend-server
       image: "{{ .Values.digitize.image }}"
       command:
-        - "/var/venv/bin/python"
-        - "-m"
-        - "uvicorn"
-        - "app:app"
-        - "--host"
-        - "0.0.0.0"
-        - "--port"
-        - "4000"
-        - "--loop"
-        - "uvloop"
-        - "--http"
-        - "httptools"
+        - "/bin/sh"
+        - "-c"
+      args:
+        - |
+          export POSTGRES_USER=$(cat /etc/secret/digitize-db-secret/username)
+          export POSTGRES_PASSWORD=$(cat /etc/secret/digitize-db-secret/password)
+          export OPENSEARCH_USERNAME=$(cat /etc/secret/opensearch-secret/username)
+          export OPENSEARCH_PASSWORD=$(cat /etc/secret/opensearch-secret/password)
+          {{- if .Values.llm.apiKey }}
+          export LLM_API_KEY=$(cat /etc/secret/vllm-secret/apiKey)
+          {{- end }}
+          exec /var/venv/bin/python -m uvicorn app:app \
+            --host 0.0.0.0 \
+            --port 4000 \
+            --loop uvloop \
+            --http httptools
       ports:
         - containerPort: 4000
           name: http
@@ -97,16 +103,6 @@ spec:
           value: "5432"
         - name: POSTGRES_DB
           value: "{{ .Values.digitize.database }}"
-        - name: POSTGRES_USER
-          valueFrom:
-            secretKeyRef:
-              name: "digitize-db-secret-{{ .InstanceSlug }}"
-              key: username
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: "digitize-db-secret-{{ .InstanceSlug }}"
-              key: password
         - name: DB_POOL_SIZE
           value: "5"
         - name: DB_MAX_OVERFLOW
@@ -133,29 +129,37 @@ spec:
           value: "RAG_DB"
         - name: OPENSEARCH_INDEX_NAME
           value: "RAG_INDEX"
-        - name: OPENSEARCH_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: "opensearch-secret-{{ .Values.vector_store.instanceSlug }}"
-              key: username
-        - name: OPENSEARCH_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: "opensearch-secret-{{ .Values.vector_store.instanceSlug }}"
-              key: password
         - name: OPENSEARCH_NUM_SHARDS
           value: "1"
         - name: LOG_LEVEL
           value: "{{ .Values.digitize.log_level }}"
-        {{- if .Values.llm.apiKey }}
-        - name: LLM_API_KEY
-          value: "{{ .Values.llm.apiKey }}"
-        {{- end }}
       volumeMounts:
         - mountPath: /var/cache:z
           name: cache
+        - mountPath: /etc/secret/digitize-db-secret
+          name: digitize-db-secret
+          readOnly: true
+        - mountPath: /etc/secret/opensearch-secret
+          name: opensearch-secret
+          readOnly: true
+        {{- if .Values.llm.apiKey }}
+        - mountPath: /etc/secret/vllm-secret
+          name: vllm-secret
+          readOnly: true
+        {{- end }}
   restartPolicy: Always
   volumes:
     - name: cache
       persistentVolumeClaim:
         claimName: "digitize-cache-{{ .InstanceSlug }}"
+    - name: digitize-db-secret
+      secret:
+        secretName: "digitize-db-secret-{{ .InstanceSlug }}"
+    - name: opensearch-secret
+      secret:
+        secretName: "opensearch-secret-{{ .Values.vector_store.instanceSlug }}"
+    {{- if .Values.llm.apiKey }}
+    - name: vllm-secret
+      secret:
+        secretName: "vllm-secret-{{ .Values.llm.instanceSlug }}"
+    {{- end }}

--- a/ai-services/assets/services/digitize/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/services/digitize/podman/templates/digitize.yaml.tmpl
@@ -4,11 +4,6 @@ metadata:
   name: "digitize-{{ .InstanceSlug }}"
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
-    ai-services.io/secret: "digitize-db-secret-{{ .InstanceSlug }}"
-    ai-services.io/secret-skip-cleanup: "true"
-    {{- if .Values.llm.apiKey }}
-    ai-services.io/secret: "vllm-secret-{{ .Values.llm.instanceSlug }}"
-    {{- end }}
     ai-services.io/volume: "digitize-cache-{{ .InstanceSlug }}"
   annotations:
     ai-services.io/routes: "4001:digitize-ui-{{ .InstanceSlug }}:ui,4000:digitize-backend-{{ .InstanceSlug }}:api"

--- a/ai-services/assets/services/digitize/podman/templates/postgres.yaml.tmpl
+++ b/ai-services/assets/services/digitize/podman/templates/postgres.yaml.tmpl
@@ -4,7 +4,9 @@ metadata:
   name: "digitize-db-{{ .InstanceSlug }}"
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
-    ai-services.io/volume: "postgres-digitize-{{ .InstanceSlug }}"
+    ai-services.io/secret: "digitize-db-secret-{{ .InstanceSlug }}"
+    ai-services.io/secret-skip-cleanup: "true"
+    ai-services.io/volume: "postgres-digitize-{{ .InstanceSlug }},digitize-db-secret-{{ .InstanceSlug }}"
   annotations:
     io.podman.annotations.pids-limit/postgres: "4096"
 spec:

--- a/ai-services/assets/services/digitize/podman/templates/postgres.yaml.tmpl
+++ b/ai-services/assets/services/digitize/podman/templates/postgres.yaml.tmpl
@@ -9,20 +9,25 @@ metadata:
     io.podman.annotations.pids-limit/postgres: "4096"
 spec:
   restartPolicy: always
+  volumes:
+    - name: postgres-data
+      persistentVolumeClaim:
+        claimName: "postgres-digitize-{{ .InstanceSlug }}"
+    - name: digitize-db-secret
+      secret:
+        secretName: "digitize-db-secret-{{ .InstanceSlug }}"
   containers:
     - name: postgres
       image: "{{ .Values.postgres.image }}"
+      command:
+        - "/bin/sh"
+        - "-c"
+      args:
+        - |
+          export POSTGRES_USER=$(cat /etc/secret/digitize-db-secret/username)
+          export POSTGRES_PASSWORD=$(cat /etc/secret/digitize-db-secret/password)
+          exec docker-entrypoint.sh postgres
       env:
-        - name: POSTGRES_USER
-          valueFrom:
-            secretKeyRef:
-              name: "digitize-db-secret-{{ .InstanceSlug }}"
-              key: username
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: "digitize-db-secret-{{ .InstanceSlug }}"
-              key: password
         - name: POSTGRES_DB
           value: "postgres"
         - name: PGDATA
@@ -36,6 +41,9 @@ spec:
       volumeMounts:
         - mountPath: /var/lib/pgsql:z
           name: postgres-data
+        - mountPath: /etc/secret/digitize-db-secret
+          name: digitize-db-secret
+          readOnly: true
       livenessProbe:
         exec:
           command:
@@ -56,8 +64,3 @@ spec:
         periodSeconds: 5
         timeoutSeconds: 3
         failureThreshold: 3
-
-  volumes:
-    - name: postgres-data
-      persistentVolumeClaim:
-        claimName: "postgres-digitize-{{ .InstanceSlug }}"

--- a/ai-services/assets/services/similarity/podman/templates/similarity-api.yaml.tmpl
+++ b/ai-services/assets/services/similarity/podman/templates/similarity-api.yaml.tmpl
@@ -9,22 +9,25 @@ metadata:
     # ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
   restartPolicy: always
+  volumes:
+    - name: opensearch-secret
+      secret:
+        secretName: "opensearch-secret-{{ .Values.vector_store.instanceSlug }}"
   containers:
     - name: similarity-api
       image: "{{ .Values.similarity.image }}"
       command:
-        - "/var/venv/bin/python"
-        - "-m"
-        - "uvicorn"
-        - "app:app"
-        - "--host"
-        - "0.0.0.0"
-        - "--port"
-        - "7000"
-        - "--loop"
-        - "uvloop"
-        - "--http"
-        - "httptools"
+        - "/bin/sh"
+        - "-c"
+      args:
+        - |
+          export OPENSEARCH_USERNAME=$(cat /etc/secret/opensearch-secret/username)
+          export OPENSEARCH_PASSWORD=$(cat /etc/secret/opensearch-secret/password)
+          exec /var/venv/bin/python -m uvicorn app:app \
+            --host 0.0.0.0 \
+            --port 7000 \
+            --loop uvloop \
+            --http httptools
       env:
         - name: PORT
           value: "7000"
@@ -46,16 +49,6 @@ spec:
           value: "RAG_DB"
         - name: OPENSEARCH_INDEX_NAME
           value: "RAG_INDEX"
-        - name: OPENSEARCH_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: "opensearch-secret-{{ .Values.vector_store.instanceSlug }}"
-              key: username
-        - name: OPENSEARCH_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: "opensearch-secret-{{ .Values.vector_store.instanceSlug }}"
-              key: password
         - name: LOG_LEVEL
           value: "{{ .Values.similarity.log_level }}"
       resources:
@@ -74,3 +67,7 @@ spec:
         periodSeconds: 30
         timeoutSeconds: 5
         failureThreshold: 3
+      volumeMounts:
+        - mountPath: /etc/secret/opensearch-secret
+          name: opensearch-secret
+          readOnly: true

--- a/ai-services/assets/services/summarize/podman/templates/postgres.yaml.tmpl
+++ b/ai-services/assets/services/summarize/podman/templates/postgres.yaml.tmpl
@@ -9,20 +9,25 @@ metadata:
     io.podman.annotations.pids-limit/postgres: "4096"
 spec:
   restartPolicy: always
+  volumes:
+    - name: postgres-data
+      persistentVolumeClaim:
+        claimName: "postgres-summarize-{{ .InstanceSlug }}"
+    - name: summarize-db-secret
+      secret:
+        secretName: "summarize-db-secret-{{ .InstanceSlug }}"
   containers:
     - name: postgres
       image: "{{ .Values.postgres.image }}"
+      command:
+        - "/bin/sh"
+        - "-c"
+      args:
+        - |
+          export POSTGRES_USER=$(cat /etc/secret/summarize-db-secret/username)
+          export POSTGRES_PASSWORD=$(cat /etc/secret/summarize-db-secret/password)
+          exec docker-entrypoint.sh postgres
       env:
-        - name: POSTGRES_USER
-          valueFrom:
-            secretKeyRef:
-              name: "summarize-db-secret-{{ .InstanceSlug }}"
-              key: username
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: "summarize-db-secret-{{ .InstanceSlug }}"
-              key: password
         - name: POSTGRES_DB
           value: "postgres"
         - name: PGDATA
@@ -36,6 +41,9 @@ spec:
       volumeMounts:
         - mountPath: /var/lib/pgsql:z
           name: postgres-data
+        - mountPath: /etc/secret/summarize-db-secret
+          name: summarize-db-secret
+          readOnly: true
       livenessProbe:
         exec:
           command:
@@ -56,8 +64,3 @@ spec:
         periodSeconds: 5
         timeoutSeconds: 3
         failureThreshold: 3
-
-  volumes:
-    - name: postgres-data
-      persistentVolumeClaim:
-        claimName: "postgres-summarize-{{ .InstanceSlug }}"

--- a/ai-services/assets/services/summarize/podman/templates/postgres.yaml.tmpl
+++ b/ai-services/assets/services/summarize/podman/templates/postgres.yaml.tmpl
@@ -4,7 +4,9 @@ metadata:
   name: "summarize-db-{{ .InstanceSlug }}"
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
-    ai-services.io/volume: "postgres-summarize-{{ .InstanceSlug }}"
+    ai-services.io/secret: "summarize-db-secret-{{ .InstanceSlug }}"
+    ai-services.io/secret-skip-cleanup: "true"
+    ai-services.io/volume: "postgres-summarize-{{ .InstanceSlug }},summarize-db-secret-{{ .InstanceSlug }}"
   annotations:
     io.podman.annotations.pids-limit/postgres: "4096"
 spec:

--- a/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
+++ b/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
@@ -4,11 +4,6 @@ metadata:
   name: "summarize-api-{{ .InstanceSlug }}"
   labels:
     ai-services.io/template: "{{ .TemplateID }}"
-    ai-services.io/secret: "summarize-db-secret-{{ .InstanceSlug }}"
-    ai-services.io/secret-skip-cleanup: "true"
-    {{- if .Values.llm.apiKey }}
-    ai-services.io/secret: "vllm-secret-{{ .Values.llm.instanceSlug }}"
-    {{- end }}
   annotations:
     ai-services.io/routes: "6000:summarize-api-{{ .InstanceSlug }}:api"
     # ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"  # Uncomment to expose ports directly (bypasses Caddy)

--- a/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
+++ b/ai-services/assets/services/summarize/podman/templates/summarize-api.yaml.tmpl
@@ -6,17 +6,34 @@ metadata:
     ai-services.io/template: "{{ .TemplateID }}"
     ai-services.io/secret: "summarize-db-secret-{{ .InstanceSlug }}"
     ai-services.io/secret-skip-cleanup: "true"
+    {{- if .Values.llm.apiKey }}
+    ai-services.io/secret: "vllm-secret-{{ .Values.llm.instanceSlug }}"
+    {{- end }}
   annotations:
     ai-services.io/routes: "6000:summarize-api-{{ .InstanceSlug }}:api"
     # ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"  # Uncomment to expose ports directly (bypasses Caddy)
 spec:
   restartPolicy: always
+  volumes:
+    - name: summarize-db-secret
+      secret:
+        secretName: "summarize-db-secret-{{ .InstanceSlug }}"
+    {{- if .Values.llm.apiKey }}
+    - name: vllm-secret
+      secret:
+        secretName: "vllm-secret-{{ .Values.llm.instanceSlug }}"
+    {{- end }}
   initContainers:
     - name: summarize-db-init
       image: "{{ .Values.summarize.image }}"
       command:
-        - "/var/venv/bin/python"
-        - "db/scripts/init_db.py"
+        - "/bin/sh"
+        - "-c"
+      args:
+        - |
+          export POSTGRES_USER=$(cat /etc/secret/summarize-db-secret/username)
+          export POSTGRES_PASSWORD=$(cat /etc/secret/summarize-db-secret/password)
+          exec /var/venv/bin/python db/scripts/init_db.py
       env:
         - name: POSTGRES_HOST
           value: "summarize-db-{{ .InstanceSlug }}"
@@ -24,32 +41,28 @@ spec:
           value: "5432"
         - name: POSTGRES_DB
           value: "{{ .Values.summarize.database }}"
-        - name: POSTGRES_USER
-          valueFrom:
-            secretKeyRef:
-              name: "summarize-db-secret-{{ .InstanceSlug }}"
-              key: username
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: "summarize-db-secret-{{ .InstanceSlug }}"
-              key: password
+      volumeMounts:
+        - mountPath: /etc/secret/summarize-db-secret
+          name: summarize-db-secret
+          readOnly: true
   containers:
     - name: summarize-api
       image: "{{ .Values.summarize.image }}"
       command:
-        - "/var/venv/bin/python"
-        - "-m"
-        - "uvicorn"
-        - "summarize.app:app"
-        - "--host"
-        - "0.0.0.0"
-        - "--port"
-        - "6000"
-        - "--loop"
-        - "uvloop"
-        - "--http"
-        - "httptools"
+        - "/bin/sh"
+        - "-c"
+      args:
+        - |
+          export POSTGRES_USER=$(cat /etc/secret/summarize-db-secret/username)
+          export POSTGRES_PASSWORD=$(cat /etc/secret/summarize-db-secret/password)
+          {{- if .Values.llm.apiKey }}
+          export LLM_API_KEY=$(cat /etc/secret/vllm-secret/apiKey)
+          {{- end }}
+          exec /var/venv/bin/python -m uvicorn summarize.app:app \
+            --host 0.0.0.0 \
+            --port 6000 \
+            --loop uvloop \
+            --http httptools
       env:
         - name: POSTGRES_HOST
           value: "summarize-db-{{ .InstanceSlug }}"
@@ -57,16 +70,6 @@ spec:
           value: "5432"
         - name: POSTGRES_DB
           value: "{{ .Values.summarize.database }}"
-        - name: POSTGRES_USER
-          valueFrom:
-            secretKeyRef:
-              name: "summarize-db-secret-{{ .InstanceSlug }}"
-              key: username
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: "summarize-db-secret-{{ .InstanceSlug }}"
-              key: password
         - name: DB_POOL_SIZE
           value: "5"
         - name: DB_MAX_OVERFLOW
@@ -83,10 +86,6 @@ spec:
           value: "{{ .Values.llm.maxBatchSize }}"
         - name: LOG_LEVEL
           value: "{{ .Values.summarize.log_level }}"
-        {{- if .Values.llm.apiKey }}
-        - name: LLM_API_KEY
-          value: "{{ .Values.llm.apiKey }}"
-        {{- end }}
       resources:
         requests:
           memory: "512Mi"
@@ -103,3 +102,12 @@ spec:
         periodSeconds: 30
         timeoutSeconds: 5
         failureThreshold: 3
+      volumeMounts:
+        - mountPath: /etc/secret/summarize-db-secret
+          name: summarize-db-secret
+          readOnly: true
+        {{- if .Values.llm.apiKey }}
+        - mountPath: /etc/secret/vllm-secret
+          name: vllm-secret
+          readOnly: true
+        {{- end }}

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -696,11 +696,19 @@ func (s *SyncService) extractResourceLabelsFromPodSpec(podSpec *modelpkg.PodSpec
 	}
 
 	if secretLabel, ok := podSpec.Labels["ai-services.io/secret"]; ok && secretLabel != "" {
-		counts.SecretNames = append(counts.SecretNames, secretLabel)
+		for name := range strings.SplitSeq(secretLabel, ",") {
+			if name = strings.TrimSpace(name); name != "" {
+				counts.SecretNames = append(counts.SecretNames, name)
+			}
+		}
 	}
 
 	if volumeLabel, ok := podSpec.Labels["ai-services.io/volume"]; ok && volumeLabel != "" {
-		counts.VolumeNames = append(counts.VolumeNames, volumeLabel)
+		for name := range strings.SplitSeq(volumeLabel, ",") {
+			if name = strings.TrimSpace(name); name != "" {
+				counts.VolumeNames = append(counts.VolumeNames, name)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
- Jira ID: [AISERVICES-1323](https://jsw.ibm.com/browse/AISERVICES-1323)
- Currently with secretRef, when we do podman inspect -> it displays the apiKey/password referenced from the secrets which can be a security concern.
- So migrating to use mounting as it just displays the mountPath without exposing secrets.