### PR TITLE
build: add multi-arch support and release targets

### DIFF
--- a/ai-services/Containerfile
+++ b/ai-services/Containerfile
@@ -6,11 +6,15 @@ ARG BUILDDATE
 ARG BUILDTAGS
 ARG GO_VERSION=1.26.4
 
+# TARGETOS / TARGETARCH are set automatically by --platform; default to linux/ppc64le.
+ARG TARGETOS=linux
+ARG TARGETARCH=ppc64le
+
 WORKDIR /go/src/github.com/project-ai-services/ai-services
 
 USER root
 
-RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.linux-ppc64le.tar.gz -o go.tar.gz && \
+RUN curl -fsSL https://go.dev/dl/go${GO_VERSION}.${TARGETOS}-${TARGETARCH}.tar.gz -o go.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz
 
@@ -33,8 +37,10 @@ RUN CGO_ENABLED=0 go build \
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8
 
+ARG DNF_FLAGS="--disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms"
+
 # Install pciutils for lspci command (required for Spyre card detection)
-RUN microdnf install -y pciutils && \
+RUN microdnf install ${DNF_FLAGS} -y pciutils && \
     microdnf clean all
 
 COPY --from=builder /go/src/github.com/project-ai-services/ai-services/bin/ai-services /usr/bin/ai-services

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,4 +1,5 @@
 REGISTRY?=icr.io/ai-services-private
+RELEASE_REGISTRY?=icr.io/ai-services
 IMAGE=ai-services
 TAG?=v0.0.152
 CONTAINER_BUILDER?=podman
@@ -27,14 +28,25 @@ PLATFORMS := \
 	linux/amd64 \
 	linux/ppc64le
 
+# Tools image baked into the binary as the default at build time.
+# The default points at the cicd registry. Release targets pass RELEASE_REGISTRY
+# so that both the container image and all binaries embed the prod/public ref.
+# Override the full ref directly if needed:
+#   make release TOOLS_IMAGE=icr.io/my-org/tools:0.12
+TOOLS_IMAGE_NAME ?= tools
+TOOLS_IMAGE_TAG  ?= 0.11
+TOOLS_IMAGE      ?= icr.io/ai-services-cicd/$(TOOLS_IMAGE_NAME):$(TOOLS_IMAGE_TAG)
+
+LDFLAGS = \
+	-X 'github.com/project-ai-services/ai-services/cmd/ai-services/cmd/version.Version=$(VERSION)' \
+	-X 'github.com/project-ai-services/ai-services/cmd/ai-services/cmd/version.GitCommit=$(GITCOMMIT)' \
+	-X 'github.com/project-ai-services/ai-services/cmd/ai-services/cmd/version.BuildDate=$(BUILDDATE)' \
+	-X 'github.com/project-ai-services/ai-services/internal/pkg/vars.ToolImage=$(TOOLS_IMAGE)'
+
 BUILD_CMD = CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -trimpath $(BUILDFLAGS) \
      -o $(BIN)/ai-services-$(GOOS)-$(GOARCH) \
      -tags "$(BUILDTAGS)" \
-     -ldflags " \
-    -X 'github.com/project-ai-services/ai-services/cmd/ai-services/cmd/version.Version=$(VERSION)' \
-    -X 'github.com/project-ai-services/ai-services/cmd/ai-services/cmd/version.GitCommit=$(GITCOMMIT)' \
-    -X 'github.com/project-ai-services/ai-services/cmd/ai-services/cmd/version.BuildDate=$(BUILDDATE)' \
-     " \
+     -ldflags "$(LDFLAGS)" \
      ./cmd/ai-services
 
 REPORT_DIR := tests/e2e/reports
@@ -75,11 +87,7 @@ binaries:
 		CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) $(GO) build $(BUILDFLAGS) \
 			-o $(BIN)/ai-services-$(OS)-$(ARCH) \
 			-tags "$(BUILDTAGS)" \
-			-ldflags " \
-				-X 'github.com/project-ai-services/ai-services/cmd/ai-services/cmd/version.Version=$(VERSION)' \
-				-X 'github.com/project-ai-services/ai-services/cmd/ai-services/cmd/version.GitCommit=$(GITCOMMIT)' \
-				-X 'github.com/project-ai-services/ai-services/cmd/ai-services/cmd/version.BuildDate=$(BUILDDATE)' \
-			" \
+			-ldflags "$(LDFLAGS)" \
 			./cmd/ai-services || exit 1; \
 	)
 	@echo "All binaries built successfully in $(BIN)/"
@@ -105,6 +113,29 @@ build:
 push:
 	$(CONTAINER_BUILDER) push $(CREDS_ARG) $(REGISTRY)/$(IMAGE):$(TAG)
 .PHONY: push
+
+# Release targets — all artifacts (binaries + container image) embed a
+# TOOLS_IMAGE pointing at RELEASE_REGISTRY, and the container is pushed there.
+# RELEASE_TOOLS_IMAGE is always derived from RELEASE_REGISTRY so the two stay
+# in sync; override the full ref only if you need a different image entirely:
+#   make release RELEASE_REGISTRY=icr.io/my-org
+#   make release RELEASE_REGISTRY=icr.io/my-org TOOLS_IMAGE_TAG=0.12
+RELEASE_TOOLS_IMAGE = $(RELEASE_REGISTRY)/$(TOOLS_IMAGE_NAME):$(TOOLS_IMAGE_TAG)
+
+release: release-binaries release-build release-push
+.PHONY: release
+
+release-binaries:
+	$(MAKE) binaries TOOLS_IMAGE=$(RELEASE_TOOLS_IMAGE)
+.PHONY: release-binaries
+
+release-build:
+	$(MAKE) build REGISTRY=$(RELEASE_REGISTRY) TOOLS_IMAGE=$(RELEASE_TOOLS_IMAGE)
+.PHONY: release-build
+
+release-push:
+	$(MAKE) push REGISTRY=$(RELEASE_REGISTRY)
+.PHONY: release-push
 
 test:
 	$(TEST_CMD)


### PR DESCRIPTION
## Summary

Two build-system improvements to `ai-services/Containerfile` and `ai-services/Makefile`.

Main purpose of this PR is for controlling tools reference via makefile during the release after the promotion

---

### Containerfile

**Multi-arch builder stage**
- Added `TARGETOS` / `TARGETARCH` ARGs (defaulting to `linux/ppc64le`) so the Go download URL is constructed from the platform args rather than being hard-coded.
- Enables `--platform`-based cross-builds (e.g. `podman build --platform linux/amd64`) without editing the file.

**Locked DNF repos in the runtime stage**
- Added a `DNF_FLAGS` ARG that restricts `microdnf install` to `ubi-9-baseos-rpms` and `ubi-9-appstream-rpms`.
- Prevents accidental package resolution from unintended repos that may be registered on the build host.

---

### Makefile

**`RELEASE_REGISTRY` variable**
- Introduces a separate `RELEASE_REGISTRY` (`icr.io/ai-services`) distinct from the default CICD registry (`icr.io/ai-services-private`).

**Configurable `TOOLS_IMAGE`**
- Adds `TOOLS_IMAGE_NAME`, `TOOLS_IMAGE_TAG`, and `TOOLS_IMAGE` variables so the tools image reference is overridable at call time without editing the file.

**`LDFLAGS` extracted as a top-level variable**
- Removes the duplicated inline `-ldflags` blocks in `BUILD_CMD` and the `binaries` target (DRY).
- Adds `-X vars.ToolImage=$(TOOLS_IMAGE)` to embed the tools image ref directly into built binaries.

**`release` targets**
- Adds `release`, `release-binaries`, `release-build`, and `release-push` targets.
- All release artifacts (binaries + container image) are built with `RELEASE_TOOLS_IMAGE` derived from `RELEASE_REGISTRY`, keeping the embedded ref and the pushed image in sync.
- The full ref can still be overridden independently if needed:
  ```
  make release RELEASE_REGISTRY=icr.io/my-org
  make release RELEASE_REGISTRY=icr.io/my-org TOOLS_IMAGE_TAG=0.12
  ```