### PR TITLE
fix(ci): bump Go version to 1.26 to match go.mod requirement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - run: go version
 


### PR DESCRIPTION
## Problem

The release workflow was pinned to `go-version: '1.25'`, but [`ai-services/go.mod`](https://github.com/IBM/project-ai-services/blob/main/ai-services/go.mod) requires `go 1.26.4`. This caused the `Build Go binaries for all platforms` step to fail immediately:

```
go: go.mod requires go >= 1.26.4 (running go 1.25.11; GOTOOLCHAIN=local)
make: *** [Makefile:71: binaries] Error 1
```

Failing run: https://github.com/IBM/project-ai-services/actions/runs/28345458786

## Fix

Bump `go-version` from `'1.25'` to `'1.26'` in `.github/workflows/release.yml` so the toolchain satisfies the minimum version declared in `go.mod`.