### PR TITLE
[Podman] Add SupplementGroup during reboot

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.154
+TAG?=v0.0.155
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.154
+  image: icr.io/ai-services-cicd/ai-services:v0.0.155
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/repair.go
@@ -478,17 +478,20 @@ func fixPodmanServiceSupplementaryGroups(checkMap map[string]check.CheckResult) 
 }
 
 func createPodmanServiceDropIn() error {
-	dropInDir := "/etc/systemd/system/podman.service.d"
-	if err := os.MkdirAll(dropInDir, dirPermissions); err != nil {
-		return err
+	dropInContent := "[Service]\nSupplementaryGroups=sentient\n"
+
+	for _, svc := range []string{"podman.service", "podman-restart.service"} {
+		dropInDir := "/etc/systemd/system/" + svc + ".d"
+		if err := os.MkdirAll(dropInDir, dirPermissions); err != nil {
+			return err
+		}
+
+		if err := utils.WriteToFile(dropInDir+"/override.conf", dropInContent); err != nil {
+			return err
+		}
 	}
 
-	dropInFile := dropInDir + "/override.conf"
-	dropInContent := `[Service]
-SupplementaryGroups=sentient
-`
-
-	return utils.WriteToFile(dropInFile, dropInContent)
+	return nil
 }
 
 func reloadAndRestartPodmanServices() error {
@@ -502,24 +505,15 @@ func reloadAndRestartPodmanServices() error {
 		return err
 	}
 
-	// Restart podman service
-	exitCode, _, _, err = utils.ExecuteCommand("systemctl", "restart", "podman.service")
-	if err != nil || exitCode != 0 {
-		if err == nil {
-			err = os.ErrInvalid
+	for _, svc := range []string{"podman.service", "podman.socket", "podman-restart.service"} {
+		exitCode, _, _, err = utils.ExecuteCommand("systemctl", "restart", svc)
+		if err != nil || exitCode != 0 {
+			if err == nil {
+				err = os.ErrInvalid
+			}
+
+			return err
 		}
-
-		return err
-	}
-
-	// Restart podman socket
-	exitCode, _, _, err = utils.ExecuteCommand("systemctl", "restart", "podman.socket")
-	if err != nil || exitCode != 0 {
-		if err == nil {
-			err = os.ErrInvalid
-		}
-
-		return err
 	}
 
 	return nil

--- a/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
+++ b/ai-services/internal/pkg/bootstrap/spyreconfig/spyre/spyre.go
@@ -340,36 +340,45 @@ func checkVfioDevicePermission(path string, expectedGid int) (bool, error) {
 	return fileGid == expectedGid && utils.IsReadWriteToOwnerGroupUsers(path), nil
 }
 
-// checkPodmanServiceSupplementaryGroups validates that the podman.service has SupplementaryGroups=sentient configured.
+// checkPodmanServiceSupplementaryGroups validates that both podman.service and podman-restart.service
+// have SupplementaryGroups=sentient configured.
 //
 // Background:
 // When Podman commands are executed directly from the shell, they inherit the user's supplementary groups,
 // including the 'sentient' group which provides access to VFIO devices for Spyre cards. However, when Podman
-// is invoked via the Podman socket (e.g., through systemd or remote API calls), the service runs with its own
-// process context and does not automatically inherit the user's supplementary groups.
+// is invoked via the Podman socket or podman-restart.service (e.g., at system boot), the services run with
+// their own process context and do not automatically inherit the user's supplementary groups.
 //
-// Without the 'sentient' group in SupplementaryGroups, containers started via the socket will not have the
-// necessary permissions to access VFIO devices (/dev/vfio/*), causing failures when trying to use Spyre cards.
+// Without the 'sentient' group in SupplementaryGroups, containers started at boot via podman-restart.service
+// will not have the necessary permissions to access VFIO devices (/dev/vfio/*), causing failures when trying
+// to use Spyre cards after a system reboot.
 //
-// This check ensures that the podman.service systemd unit is configured with:
+// This check ensures that both podman.service and podman-restart.service systemd units are configured with:
 //
 //	SupplementaryGroups=sentient
 //
-// in the [Service] section, allowing socket-based Podman operations to access VFIO devices properly.
+// in the [Service] section.
 func checkPodmanServiceSupplementaryGroups() *check.ConfigurationFileCheck {
-	serviceName := "podman.service"
-	confCheck := check.NewConfigurationFileCheck("Podman service SupplementaryGroups configuration", serviceName)
+	// Check both services; fail fast if either is missing the configuration.
+	var confCheck *check.ConfigurationFileCheck
+	for _, serviceName := range []string{"podman.service", "podman-restart.service"} {
+		confCheck = check.NewConfigurationFileCheck("Podman service SupplementaryGroups configuration", serviceName)
 
-	stdout, err := getServiceConfiguration(serviceName)
-	if err != nil {
-		confCheck.AddAttribute("SupplementaryGroups=sentient", false, "", "SupplementaryGroups=sentient")
-		confCheck.SetStatus(false)
+		stdout, err := getServiceConfiguration(serviceName)
+		if err != nil {
+			confCheck.AddAttribute("SupplementaryGroups=sentient", false, "", "SupplementaryGroups=sentient")
+			confCheck.SetStatus(false)
 
-		return confCheck
+			return confCheck
+		}
+
+		found, correctValue := checkSupplementaryGroupsInConfig(stdout)
+		setCheckResult(confCheck, found, correctValue)
+
+		if !confCheck.GetStatus() {
+			return confCheck
+		}
 	}
-
-	found, correctValue := checkSupplementaryGroupsInConfig(stdout)
-	setCheckResult(confCheck, found, correctValue)
 
 	return confCheck
 }


### PR DESCRIPTION
- During system reboot, the podman-restart systemd takes care of restarting all the pods. There is an issue where the pods requiring `vfio` devices fails with permission denied as sentient group is not supplied by podman restart systemd due to which the `catalog, llm, reranker (requiring spyre)` fails with permission denied.

Fix: The fix is to ensure that we add the override.conf with `SupplementaryGroups: sentient` while configuring podman-restart systemd during `ai-services bootstrap` so that necessary groups are supplied when it restarts.