### PR TITLE
Pagination related fixes

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.156
+TAG?=v0.0.157
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.155
+TAG?=v0.0.156
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.157
+TAG?=v0.0.156
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,10 +1,10 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.41
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.42
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.156
+  image: icr.io/ai-services-cicd/ai-services:v0.0.157
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,10 +1,10 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.40
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.41
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.155
+  image: icr.io/ai-services-cicd/ai-services:v0.0.156
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.157
+  image: icr.io/ai-services-cicd/ai-services:v0.0.156
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,6 +1,6 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.39
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.40
 
 backend:
   port: ""

--- a/ui/catalog/Makefile
+++ b/ui/catalog/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= catalog-ui
-TAG ?= v0.0.40
+TAG ?= v0.0.41
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/catalog/Makefile
+++ b/ui/catalog/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= catalog-ui
-TAG ?= v0.0.39
+TAG ?= v0.0.40
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/catalog/Makefile
+++ b/ui/catalog/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= catalog-ui
-TAG ?= v0.0.41
+TAG ?= v0.0.42
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/catalog/src/components/DeployedServicesTable/DeployedServicesTable.tsx
+++ b/ui/catalog/src/components/DeployedServicesTable/DeployedServicesTable.tsx
@@ -106,15 +106,9 @@ const DeployedServicesTable = ({
 }: DeployedServicesTableProps) => {
   const [state, dispatch] = useReducer(appReducer, INITIAL_STATE);
 
-  // Zustand store for deployed services caching and services data
-  const {
-    deployedServices,
-    setDeployedServices,
-    setDeployedServicesLoading,
-    setDeployedServicesError,
-    isDeployedServicesStale,
-    services,
-  } = useServiceDeployStore();
+  // Zustand store for services data
+  const { setDeployedServicesLoading, setDeployedServicesError, services } =
+    useServiceDeployStore();
 
   // Generate dynamic service filter options from backend services
   // Only show services where standalone === true
@@ -150,41 +144,10 @@ const DeployedServicesTable = ({
   // Fetch deployed services data
   const fetchDeployedServices = useCallback(
     async (
-      force = false,
       page = state.page,
       pageSize = state.pageSize,
       selectedServices = state.selectedServices,
     ) => {
-      // Skip if cache is fresh and not forcing refresh (only for page 1, no filter active)
-      if (
-        !force &&
-        page === 1 &&
-        selectedServices.length === 0 &&
-        !isDeployedServicesStale()
-      ) {
-        const cachedServices = deployedServices;
-        if (cachedServices.length > 0) {
-          // Use cached data
-          dispatch({
-            type: ACTION_TYPES.DEPLOYED_SERVICES_SET_ROWS_DATA,
-            payload: transformDeployedServices(
-              cachedServices as ApplicationApiResponse[],
-            ),
-          });
-          dispatch({
-            type: ACTION_TYPES.DEPLOYED_SERVICES_SET_TOTAL_ITEMS,
-            payload: cachedServices.length,
-          });
-          // Reset loading state when using cached data
-          dispatch({
-            type: ACTION_TYPES.DEPLOYED_SERVICES_SET_LOADING,
-            payload: false,
-          });
-          setDeployedServicesLoading(false);
-          return;
-        }
-      }
-
       setDeployedServicesLoading(true);
       dispatch({
         type: ACTION_TYPES.DEPLOYED_SERVICES_SET_LOADING,
@@ -200,9 +163,7 @@ const DeployedServicesTable = ({
           `${APPLICATION_ENDPOINTS.GET_DEPLOYED_SERVICES}&page=${page}&page_size=${pageSize}${catalogIdParam}`,
         );
 
-        // Store raw data in Zustand
         const rawData = response.data?.data || [];
-        setDeployedServices(rawData);
 
         // Capture server-side total so Pagination knows the real count
         const totalItems =
@@ -220,7 +181,7 @@ const DeployedServicesTable = ({
             type: ACTION_TYPES.DEPLOYED_SERVICES_SET_LOADING,
             payload: false,
           });
-          fetchDeployedServices(true, totalPages, pageSize);
+          fetchDeployedServices(totalPages, pageSize);
           return;
         }
 
@@ -257,9 +218,6 @@ const DeployedServicesTable = ({
       state.page,
       state.pageSize,
       state.selectedServices,
-      deployedServices,
-      isDeployedServicesStale,
-      setDeployedServices,
       setDeployedServicesError,
       setDeployedServicesLoading,
     ],
@@ -274,14 +232,14 @@ const DeployedServicesTable = ({
     // On mount: use cache if fresh (force = false)
     if (!hasFetchedRef.current) {
       hasFetchedRef.current = true;
-      fetchDeployedServices(false);
+      fetchDeployedServices();
       return;
     }
 
     // On refreshTrigger change: force refresh to get latest data
     if (refreshTrigger !== prevRefreshTriggerRef.current) {
       prevRefreshTriggerRef.current = refreshTrigger;
-      fetchDeployedServices(true);
+      fetchDeployedServices();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refreshTrigger]);
@@ -290,7 +248,7 @@ const DeployedServicesTable = ({
   useEffect(() => {
     if (state.rowsData.length > 0) {
       const intervalId = setInterval(() => {
-        fetchDeployedServices(true);
+        fetchDeployedServices();
       }, 120000);
       return () => clearInterval(intervalId);
     }
@@ -404,7 +362,6 @@ const DeployedServicesTable = ({
   const downloadCSV = async () => {
     const name = state.csvFileName.trim();
 
-    // Validate filename before closing modal
     if (!name) {
       dispatch({
         type: ACTION_TYPES.DEPLOYED_SERVICES_SET_EXPORT_ERROR,
@@ -421,21 +378,34 @@ const DeployedServicesTable = ({
       return;
     }
 
-    // Close modal immediately
-    dispatch({ type: ACTION_TYPES.DEPLOYED_SERVICES_CLOSE_EXPORT_DIALOG });
+    // Show exporting state on modal button
+    dispatch({
+      type: ACTION_TYPES.DEPLOYED_SERVICES_SET_EXPORTING,
+      payload: true,
+    });
 
     try {
-      // Fetch up to 100 rows (API max), respecting active service filter
       const catalogIdParam =
         state.selectedServices.length > 0
           ? `&catalog_id=${state.selectedServices[0]}`
           : "";
-      const response = await api.get(
-        `${APPLICATION_ENDPOINTS.GET_DEPLOYED_SERVICES}&page=1&page_size=100${catalogIdParam}`,
-      );
-      const allRows = transformDeployedServices(
-        response.data?.data || [],
-      ).filter((row) => {
+
+      // Fetch all pages sequentially until has_next is false
+      let currentPage = 1;
+      let hasNext = true;
+      const allData: ApplicationApiResponse[] = [];
+
+      while (hasNext) {
+        const response = await api.get(
+          `${APPLICATION_ENDPOINTS.GET_DEPLOYED_SERVICES}&page=${currentPage}&page_size=100${catalogIdParam}`,
+        );
+        const pageData = response.data?.data || [];
+        allData.push(...pageData);
+        hasNext = response.data?.pagination?.has_next ?? false;
+        currentPage++;
+      }
+
+      const allRows = transformDeployedServices(allData).filter((row) => {
         if (!state.search) return true;
         return [row.name, row.status, row.uptime, row.messages, row.service]
           .join(" ")
@@ -443,7 +413,6 @@ const DeployedServicesTable = ({
           .includes(state.search.toLowerCase());
       });
 
-      // Only export visible columns
       const visibleHeaders = HEADERS.filter(
         (h) =>
           h.key !== "actions" &&
@@ -456,6 +425,7 @@ const DeployedServicesTable = ({
         name,
       );
 
+      dispatch({ type: ACTION_TYPES.DEPLOYED_SERVICES_CLOSE_EXPORT_DIALOG });
       dispatch({
         type: ACTION_TYPES.DEPLOYED_SERVICES_SHOW_EXPORT_TOAST,
         payload: {
@@ -470,6 +440,11 @@ const DeployedServicesTable = ({
           message: "Failed to fetch data for export",
           kind: "error",
         },
+      });
+    } finally {
+      dispatch({
+        type: ACTION_TYPES.DEPLOYED_SERVICES_SET_EXPORTING,
+        payload: false,
       });
     }
   };
@@ -583,7 +558,7 @@ const DeployedServicesTable = ({
                             renderIcon={Renew}
                             iconDescription="Refresh"
                             size="lg"
-                            onClick={() => fetchDeployedServices(true)}
+                            onClick={() => fetchDeployedServices()}
                           />
                           <OverflowMenu
                             renderIcon={Filter}
@@ -617,7 +592,6 @@ const DeployedServicesTable = ({
                                     payload: value,
                                   });
                                   fetchDeployedServices(
-                                    true,
                                     1,
                                     state.pageSize,
                                     newSelected,
@@ -642,7 +616,6 @@ const DeployedServicesTable = ({
                                       type: ACTION_TYPES.DEPLOYED_SERVICES_RESET_SERVICE_FILTER,
                                     });
                                     fetchDeployedServices(
-                                      true,
                                       1,
                                       state.pageSize,
                                       [],
@@ -836,7 +809,7 @@ const DeployedServicesTable = ({
                             type: ACTION_TYPES.DEPLOYED_SERVICES_SET_PAGE_SIZE,
                             payload: pageSize,
                           });
-                          fetchDeployedServices(true, page, pageSize);
+                          fetchDeployedServices(page, pageSize);
                         }}
                       />
                     )}
@@ -900,14 +873,16 @@ const DeployedServicesTable = ({
               open={state.isExportDialogOpen}
               size="sm"
               modalHeading="Export as CSV"
-              primaryButtonText="Export"
+              primaryButtonText={state.isExporting ? "Exporting..." : "Export"}
+              primaryButtonDisabled={state.isExporting}
               secondaryButtonText="Cancel"
               onRequestSubmit={downloadCSV}
-              onRequestClose={() =>
-                dispatch({
-                  type: ACTION_TYPES.DEPLOYED_SERVICES_CLOSE_EXPORT_DIALOG,
-                })
-              }
+              onRequestClose={() => {
+                if (!state.isExporting)
+                  dispatch({
+                    type: ACTION_TYPES.DEPLOYED_SERVICES_CLOSE_EXPORT_DIALOG,
+                  });
+              }}
             >
               <TextInput
                 id="csv-file-name"

--- a/ui/catalog/src/components/DeployedServicesTable/DeployedServicesTable.tsx
+++ b/ui/catalog/src/components/DeployedServicesTable/DeployedServicesTable.tsx
@@ -29,6 +29,8 @@ import {
   Column,
   Checkbox,
   CheckboxGroup,
+  RadioButton,
+  RadioButtonGroup,
   ActionableNotification,
   Modal,
   TextInput,
@@ -147,9 +149,19 @@ const DeployedServicesTable = ({
 
   // Fetch deployed services data
   const fetchDeployedServices = useCallback(
-    async (force = false) => {
-      // Skip if cache is fresh and not forcing refresh
-      if (!force && !isDeployedServicesStale()) {
+    async (
+      force = false,
+      page = state.page,
+      pageSize = state.pageSize,
+      selectedServices = state.selectedServices,
+    ) => {
+      // Skip if cache is fresh and not forcing refresh (only for page 1, no filter active)
+      if (
+        !force &&
+        page === 1 &&
+        selectedServices.length === 0 &&
+        !isDeployedServicesStale()
+      ) {
         const cachedServices = deployedServices;
         if (cachedServices.length > 0) {
           // Use cached data
@@ -158,6 +170,10 @@ const DeployedServicesTable = ({
             payload: transformDeployedServices(
               cachedServices as ApplicationApiResponse[],
             ),
+          });
+          dispatch({
+            type: ACTION_TYPES.DEPLOYED_SERVICES_SET_TOTAL_ITEMS,
+            payload: cachedServices.length,
           });
           // Reset loading state when using cached data
           dispatch({
@@ -176,13 +192,42 @@ const DeployedServicesTable = ({
       });
 
       try {
+        const catalogIdParam =
+          selectedServices.length > 0
+            ? `&catalog_id=${selectedServices[0]}`
+            : "";
         const response = await api.get(
-          APPLICATION_ENDPOINTS.GET_DEPLOYED_SERVICES,
+          `${APPLICATION_ENDPOINTS.GET_DEPLOYED_SERVICES}&page=${page}&page_size=${pageSize}${catalogIdParam}`,
         );
 
         // Store raw data in Zustand
         const rawData = response.data?.data || [];
         setDeployedServices(rawData);
+
+        // Capture server-side total so Pagination knows the real count
+        const totalItems =
+          response.data?.pagination?.total_items ?? rawData.length;
+        const totalPages = response.data?.pagination?.total_pages ?? 1;
+
+        // If the current page is beyond total_pages (e.g. last item on page N was deleted),
+        // jump back to the last valid page and re-fetch.
+        if (page > totalPages && totalPages >= 1) {
+          dispatch({
+            type: ACTION_TYPES.DEPLOYED_SERVICES_SET_PAGE,
+            payload: totalPages,
+          });
+          dispatch({
+            type: ACTION_TYPES.DEPLOYED_SERVICES_SET_LOADING,
+            payload: false,
+          });
+          fetchDeployedServices(true, totalPages, pageSize);
+          return;
+        }
+
+        dispatch({
+          type: ACTION_TYPES.DEPLOYED_SERVICES_SET_TOTAL_ITEMS,
+          payload: totalItems,
+        });
 
         // Transform and set in local state for table
         const transformedRows = transformDeployedServices(rawData);
@@ -209,6 +254,9 @@ const DeployedServicesTable = ({
       }
     },
     [
+      state.page,
+      state.pageSize,
+      state.selectedServices,
       deployedServices,
       isDeployedServicesStale,
       setDeployedServices,
@@ -365,8 +413,7 @@ const DeployedServicesTable = ({
       return;
     }
 
-    // Validate data before closing modal
-    if (filteredRows.length === 0) {
+    if (state.totalItems === 0) {
       dispatch({
         type: ACTION_TYPES.DEPLOYED_SERVICES_SET_EXPORT_ERROR,
         payload: "No data available to export",
@@ -377,49 +424,66 @@ const DeployedServicesTable = ({
     // Close modal immediately
     dispatch({ type: ACTION_TYPES.DEPLOYED_SERVICES_CLOSE_EXPORT_DIALOG });
 
-    // Filter headers to only include visible columns (excluding actions)
-    const visibleHeaders = HEADERS.filter(
-      (h) =>
-        h.key !== "actions" &&
-        state.visibleColumns[h.key as keyof typeof state.visibleColumns],
-    );
+    try {
+      // Fetch up to 100 rows (API max), respecting active service filter
+      const catalogIdParam =
+        state.selectedServices.length > 0
+          ? `&catalog_id=${state.selectedServices[0]}`
+          : "";
+      const response = await api.get(
+        `${APPLICATION_ENDPOINTS.GET_DEPLOYED_SERVICES}&page=1&page_size=100${catalogIdParam}`,
+      );
+      const allRows = transformDeployedServices(
+        response.data?.data || [],
+      ).filter((row) => {
+        if (!state.search) return true;
+        return [row.name, row.status, row.uptime, row.messages, row.service]
+          .join(" ")
+          .toLowerCase()
+          .includes(state.search.toLowerCase());
+      });
 
-    // Use utility function to handle export
-    const result = downloadCSVWithChildren(filteredRows, visibleHeaders, name);
+      // Only export visible columns
+      const visibleHeaders = HEADERS.filter(
+        (h) =>
+          h.key !== "actions" &&
+          state.visibleColumns[h.key as keyof typeof state.visibleColumns],
+      );
 
-    // Show toast based on result
-    dispatch({
-      type: ACTION_TYPES.DEPLOYED_SERVICES_SHOW_EXPORT_TOAST,
-      payload: {
-        message: result.message,
-        kind: result.success ? "success" : "error",
-      },
-    });
+      const result = downloadCSVWithChildren(
+        allRows as DeployedServicesRow[],
+        visibleHeaders,
+        name,
+      );
+
+      dispatch({
+        type: ACTION_TYPES.DEPLOYED_SERVICES_SHOW_EXPORT_TOAST,
+        payload: {
+          message: result.message,
+          kind: result.success ? "success" : "error",
+        },
+      });
+    } catch {
+      dispatch({
+        type: ACTION_TYPES.DEPLOYED_SERVICES_SHOW_EXPORT_TOAST,
+        payload: {
+          message: "Failed to fetch data for export",
+          kind: "error",
+        },
+      });
+    }
   };
 
+  // Service filter is server-side (catalog_id param) — only search filters client-side
   const filteredRows = state.rowsData.filter((row) => {
-    const matchesSearch = [
-      row.name,
-      row.status,
-      row.uptime,
-      row.messages,
-      row.service,
-    ]
+    return [row.name, row.status, row.uptime, row.messages, row.service]
       .join(" ")
       .toLowerCase()
       .includes(state.search.toLowerCase());
-
-    const matchesServiceFilter =
-      state.selectedServices.length === 0 ||
-      state.selectedServices.includes(row.service);
-
-    return matchesSearch && matchesServiceFilter;
   });
 
-  const paginatedRows = filteredRows.slice(
-    (state.page - 1) * state.pageSize,
-    state.page * state.pageSize,
-  );
+  // Server already returns the correct page — no client-side slice needed
+  const paginatedRows = filteredRows;
 
   const noApplications =
     !state.isLoading && state.rowsData.length === 0 && !state.fetchError;
@@ -535,33 +599,55 @@ const DeployedServicesTable = ({
                               <h6 className={styles.overflowMenuHeading}>
                                 Filter by service
                               </h6>
-                              <CheckboxGroup legendText="">
+                              <RadioButtonGroup
+                                legendText=""
+                                name="service-filter"
+                                orientation="vertical"
+                                valueSelected={state.selectedServices[0] ?? ""}
+                                onChange={(selection) => {
+                                  const value = String(selection ?? "");
+                                  if (!value) return;
+                                  // Clicking the already-selected option deselects it
+                                  const newSelected =
+                                    state.selectedServices.includes(value)
+                                      ? []
+                                      : [value];
+                                  dispatch({
+                                    type: ACTION_TYPES.DEPLOYED_SERVICES_TOGGLE_SERVICE_FILTER,
+                                    payload: value,
+                                  });
+                                  fetchDeployedServices(
+                                    true,
+                                    1,
+                                    state.pageSize,
+                                    newSelected,
+                                  );
+                                }}
+                              >
                                 {availableServiceFilters.map((service) => (
-                                  <Checkbox
+                                  <RadioButton
                                     key={service.id}
                                     labelText={service.name}
+                                    value={service.id}
                                     id={`filter-${service.id}`}
-                                    checked={state.selectedServices.includes(
-                                      service.name,
-                                    )}
-                                    onChange={() =>
-                                      dispatch({
-                                        type: ACTION_TYPES.DEPLOYED_SERVICES_TOGGLE_SERVICE_FILTER,
-                                        payload: service.name,
-                                      })
-                                    }
                                   />
                                 ))}
-                              </CheckboxGroup>
+                              </RadioButtonGroup>
                               <div className={styles.overflowMenuActions}>
                                 <Button
                                   kind="secondary"
                                   size="sm"
-                                  onClick={() =>
+                                  onClick={() => {
                                     dispatch({
                                       type: ACTION_TYPES.DEPLOYED_SERVICES_RESET_SERVICE_FILTER,
-                                    })
-                                  }
+                                    });
+                                    fetchDeployedServices(
+                                      true,
+                                      1,
+                                      state.pageSize,
+                                      [],
+                                    );
+                                  }}
                                 >
                                   Reset filter
                                 </Button>
@@ -733,24 +819,27 @@ const DeployedServicesTable = ({
                     )}
                   </TableContainer>
 
-                  {filteredRows.length > 20 && (
-                    <Pagination
-                      page={state.page}
-                      pageSize={state.pageSize}
-                      pageSizes={[5, 10, 20, 30]}
-                      totalItems={filteredRows.length}
-                      onChange={({ page, pageSize }) => {
-                        dispatch({
-                          type: ACTION_TYPES.DEPLOYED_SERVICES_SET_PAGE,
-                          payload: page,
-                        });
-                        dispatch({
-                          type: ACTION_TYPES.DEPLOYED_SERVICES_SET_PAGE_SIZE,
-                          payload: pageSize,
-                        });
-                      }}
-                    />
-                  )}
+                  {!state.isLoading &&
+                    state.totalItems > 20 &&
+                    filteredRows.length > 0 && (
+                      <Pagination
+                        page={state.page}
+                        pageSize={state.pageSize}
+                        pageSizes={[20, 30, 50]}
+                        totalItems={state.totalItems}
+                        onChange={({ page, pageSize }) => {
+                          dispatch({
+                            type: ACTION_TYPES.DEPLOYED_SERVICES_SET_PAGE,
+                            payload: page,
+                          });
+                          dispatch({
+                            type: ACTION_TYPES.DEPLOYED_SERVICES_SET_PAGE_SIZE,
+                            payload: pageSize,
+                          });
+                          fetchDeployedServices(true, page, pageSize);
+                        }}
+                      />
+                    )}
                 </>
               )}
             </DataTable>

--- a/ui/catalog/src/components/DeployedServicesTable/types.ts
+++ b/ui/catalog/src/components/DeployedServicesTable/types.ts
@@ -34,6 +34,7 @@ export interface AppState {
   search: string;
   page: number;
   pageSize: number;
+  totalItems: number;
   isDeleteDialogOpen: boolean;
   isConfirmed: boolean;
   rowsData: DeployedServicesRow[];
@@ -56,6 +57,7 @@ export interface AppState {
 }
 
 export const ACTION_TYPES = {
+  DEPLOYED_SERVICES_SET_TOTAL_ITEMS: "DEPLOYED_SERVICES_SET_TOTAL_ITEMS",
   DEPLOYED_SERVICES_SET_SEARCH: "DEPLOYED_SERVICES_SET_SEARCH",
   DEPLOYED_SERVICES_SET_PAGE: "DEPLOYED_SERVICES_SET_PAGE",
   DEPLOYED_SERVICES_SET_PAGE_SIZE: "DEPLOYED_SERVICES_SET_PAGE_SIZE",
@@ -93,6 +95,10 @@ export const ACTION_TYPES = {
 } as const;
 
 export type AppAction =
+  | {
+      type: typeof ACTION_TYPES.DEPLOYED_SERVICES_SET_TOTAL_ITEMS;
+      payload: number;
+    }
   | { type: typeof ACTION_TYPES.DEPLOYED_SERVICES_SET_SEARCH; payload: string }
   | { type: typeof ACTION_TYPES.DEPLOYED_SERVICES_SET_PAGE; payload: number }
   | {
@@ -190,7 +196,8 @@ export const STATUS_SORT_ORDER: Record<string, number> = {
 export const INITIAL_STATE: AppState = {
   search: "",
   page: 1,
-  pageSize: 10,
+  pageSize: 20,
+  totalItems: 0,
   isDeleteDialogOpen: false,
   isConfirmed: false,
   // rowsData: [...MOCK_ROWS].sort(
@@ -224,6 +231,8 @@ export const INITIAL_STATE: AppState = {
 // Reducer
 export const appReducer = (state: AppState, action: AppAction): AppState => {
   switch (action.type) {
+    case ACTION_TYPES.DEPLOYED_SERVICES_SET_TOTAL_ITEMS:
+      return { ...state, totalItems: action.payload };
     case ACTION_TYPES.DEPLOYED_SERVICES_SET_SEARCH:
       return { ...state, search: action.payload };
     case ACTION_TYPES.DEPLOYED_SERVICES_SET_PAGE:
@@ -332,11 +341,12 @@ export const appReducer = (state: AppState, action: AppAction): AppState => {
         exportToastOpen: false,
       };
     case ACTION_TYPES.DEPLOYED_SERVICES_TOGGLE_SERVICE_FILTER:
+      // Single-select: selecting same deselects, selecting new replaces previous
       return {
         ...state,
         selectedServices: state.selectedServices.includes(action.payload)
-          ? state.selectedServices.filter((s) => s !== action.payload)
-          : [...state.selectedServices, action.payload],
+          ? []
+          : [action.payload],
         page: 1,
       };
     case ACTION_TYPES.DEPLOYED_SERVICES_RESET_SERVICE_FILTER:

--- a/ui/catalog/src/components/DeployedServicesTable/types.ts
+++ b/ui/catalog/src/components/DeployedServicesTable/types.ts
@@ -44,6 +44,7 @@ export interface AppState {
   deleteErrorRowName: string;
   isDeleting: boolean;
   isExportDialogOpen: boolean;
+  isExporting: boolean;
   csvFileName: string;
   exportErrorMessage: string;
   hasError: boolean;
@@ -57,6 +58,7 @@ export interface AppState {
 }
 
 export const ACTION_TYPES = {
+  DEPLOYED_SERVICES_SET_EXPORTING: "DEPLOYED_SERVICES_SET_EXPORTING",
   DEPLOYED_SERVICES_SET_TOTAL_ITEMS: "DEPLOYED_SERVICES_SET_TOTAL_ITEMS",
   DEPLOYED_SERVICES_SET_SEARCH: "DEPLOYED_SERVICES_SET_SEARCH",
   DEPLOYED_SERVICES_SET_PAGE: "DEPLOYED_SERVICES_SET_PAGE",
@@ -95,6 +97,10 @@ export const ACTION_TYPES = {
 } as const;
 
 export type AppAction =
+  | {
+      type: typeof ACTION_TYPES.DEPLOYED_SERVICES_SET_EXPORTING;
+      payload: boolean;
+    }
   | {
       type: typeof ACTION_TYPES.DEPLOYED_SERVICES_SET_TOTAL_ITEMS;
       payload: number;
@@ -200,6 +206,7 @@ export const INITIAL_STATE: AppState = {
   totalItems: 0,
   isDeleteDialogOpen: false,
   isConfirmed: false,
+  isExporting: false,
   // rowsData: [...MOCK_ROWS].sort(
   //   (a, b) => STATUS_SORT_ORDER[a.status] - STATUS_SORT_ORDER[b.status],
   // ),
@@ -231,6 +238,8 @@ export const INITIAL_STATE: AppState = {
 // Reducer
 export const appReducer = (state: AppState, action: AppAction): AppState => {
   switch (action.type) {
+    case ACTION_TYPES.DEPLOYED_SERVICES_SET_EXPORTING:
+      return { ...state, isExporting: action.payload };
     case ACTION_TYPES.DEPLOYED_SERVICES_SET_TOTAL_ITEMS:
       return { ...state, totalItems: action.payload };
     case ACTION_TYPES.DEPLOYED_SERVICES_SET_SEARCH:

--- a/ui/catalog/src/pages/DigitalAssistants/DigitalAssistants.tsx
+++ b/ui/catalog/src/pages/DigitalAssistants/DigitalAssistants.tsx
@@ -137,6 +137,14 @@ const DigitalAssistantsPage = () => {
 
       const rows = response.data.map(transformApplicationToRow);
 
+      // If the current page is beyond total_pages (e.g. last item on page N was deleted),
+      // jump back to the last valid page — the useEffect will re-fetch automatically.
+      const totalPages = response.pagination?.total_pages ?? 1;
+      if (state.page > totalPages && totalPages >= 1) {
+        dispatch({ type: ACTION_TYPES.SET_PAGE, payload: totalPages });
+        return;
+      }
+
       dispatch({
         type: ACTION_TYPES.FETCH_APPLICATIONS_SUCCESS,
         payload: {
@@ -231,8 +239,7 @@ const DigitalAssistantsPage = () => {
       return;
     }
 
-    // Validate data before closing modal
-    if (filteredRows.length === 0) {
+    if (state.totalItems === 0) {
       dispatch({
         type: ACTION_TYPES.SET_EXPORT_ERROR,
         payload: "No data available to export",
@@ -243,24 +250,48 @@ const DigitalAssistantsPage = () => {
     // Close modal immediately
     dispatch({ type: ACTION_TYPES.CLOSE_EXPORT_DIALOG });
 
-    // Filter headers to only include visible columns (excluding actions)
-    const visibleHeaders = HEADERS.filter(
-      (h) =>
-        h.key !== "actions" &&
-        state.visibleColumns[h.key as keyof typeof state.visibleColumns],
-    );
+    try {
+      // Fetch up to 100 rows (API max) to export all data
+      const response = await fetchApplications({
+        page: 1,
+        page_size: 100,
+        catalog_id: catalogId,
+      });
+      const allRows = response.data
+        .map(transformApplicationToRow)
+        .filter((row) => {
+          if (!state.search) return true;
+          return [row.name, row.status, row.uptime, row.messages]
+            .join(" ")
+            .toLowerCase()
+            .includes(state.search.toLowerCase());
+        });
 
-    // Use utility function to handle export
-    const result = downloadCSVWithChildren(filteredRows, visibleHeaders, name);
+      // Only export visible columns
+      const visibleHeaders = HEADERS.filter(
+        (h) =>
+          h.key !== "actions" &&
+          state.visibleColumns[h.key as keyof typeof state.visibleColumns],
+      );
 
-    // Show toast based on result
-    dispatch({
-      type: ACTION_TYPES.SHOW_EXPORT_TOAST,
-      payload: {
-        message: result.message,
-        kind: result.success ? "success" : "error",
-      },
-    });
+      const result = downloadCSVWithChildren(allRows, visibleHeaders, name);
+
+      dispatch({
+        type: ACTION_TYPES.SHOW_EXPORT_TOAST,
+        payload: {
+          message: result.message,
+          kind: result.success ? "success" : "error",
+        },
+      });
+    } catch {
+      dispatch({
+        type: ACTION_TYPES.SHOW_EXPORT_TOAST,
+        payload: {
+          message: "Failed to fetch data for export",
+          kind: "error",
+        },
+      });
+    }
   };
 
   const filteredRows = state.rowsData.filter((row) => {
@@ -596,24 +627,26 @@ const DigitalAssistantsPage = () => {
                             )}
                           </TableContainer>
 
-                          {state.totalItems > 20 && (
-                            <Pagination
-                              page={state.page}
-                              pageSize={state.pageSize}
-                              pageSizes={[10, 20, 30, 50]}
-                              totalItems={state.totalItems}
-                              onChange={({ page, pageSize }) => {
-                                dispatch({
-                                  type: ACTION_TYPES.SET_PAGE,
-                                  payload: page,
-                                });
-                                dispatch({
-                                  type: ACTION_TYPES.SET_PAGE_SIZE,
-                                  payload: pageSize,
-                                });
-                              }}
-                            />
-                          )}
+                          {!state.isLoadingApplications &&
+                            state.totalItems > 20 &&
+                            filteredRows.length > 0 && (
+                              <Pagination
+                                page={state.page}
+                                pageSize={state.pageSize}
+                                pageSizes={[20, 30, 50]}
+                                totalItems={state.totalItems}
+                                onChange={({ page, pageSize }) => {
+                                  dispatch({
+                                    type: ACTION_TYPES.SET_PAGE,
+                                    payload: page,
+                                  });
+                                  dispatch({
+                                    type: ACTION_TYPES.SET_PAGE_SIZE,
+                                    payload: pageSize,
+                                  });
+                                }}
+                              />
+                            )}
                         </>
                       )}
                     </DataTable>

--- a/ui/catalog/src/pages/DigitalAssistants/DigitalAssistants.tsx
+++ b/ui/catalog/src/pages/DigitalAssistants/DigitalAssistants.tsx
@@ -230,7 +230,6 @@ const DigitalAssistantsPage = () => {
   const downloadCSV = async () => {
     const name = state.csvFileName.trim();
 
-    // Validate filename before closing modal
     if (!name) {
       dispatch({
         type: ACTION_TYPES.SET_EXPORT_ERROR,
@@ -247,27 +246,34 @@ const DigitalAssistantsPage = () => {
       return;
     }
 
-    // Close modal immediately
-    dispatch({ type: ACTION_TYPES.CLOSE_EXPORT_DIALOG });
+    // Show exporting state on modal button
+    dispatch({ type: ACTION_TYPES.SET_EXPORTING, payload: true });
 
     try {
-      // Fetch up to 100 rows (API max) to export all data
-      const response = await fetchApplications({
-        page: 1,
-        page_size: 100,
-        catalog_id: catalogId,
-      });
-      const allRows = response.data
-        .map(transformApplicationToRow)
-        .filter((row) => {
-          if (!state.search) return true;
-          return [row.name, row.status, row.uptime, row.messages]
-            .join(" ")
-            .toLowerCase()
-            .includes(state.search.toLowerCase());
-        });
+      // Fetch all pages sequentially until has_next is false
+      let currentPage = 1;
+      let hasNext = true;
+      const allData: import("@/types/digitalAssistants").Application[] = [];
 
-      // Only export visible columns
+      while (hasNext) {
+        const response = await fetchApplications({
+          page: currentPage,
+          page_size: 100,
+          catalog_id: catalogId,
+        });
+        allData.push(...response.data);
+        hasNext = response.pagination?.has_next ?? false;
+        currentPage++;
+      }
+
+      const allRows = allData.map(transformApplicationToRow).filter((row) => {
+        if (!state.search) return true;
+        return [row.name, row.status, row.uptime, row.messages]
+          .join(" ")
+          .toLowerCase()
+          .includes(state.search.toLowerCase());
+      });
+
       const visibleHeaders = HEADERS.filter(
         (h) =>
           h.key !== "actions" &&
@@ -276,6 +282,7 @@ const DigitalAssistantsPage = () => {
 
       const result = downloadCSVWithChildren(allRows, visibleHeaders, name);
 
+      dispatch({ type: ACTION_TYPES.CLOSE_EXPORT_DIALOG });
       dispatch({
         type: ACTION_TYPES.SHOW_EXPORT_TOAST,
         payload: {
@@ -291,6 +298,8 @@ const DigitalAssistantsPage = () => {
           kind: "error",
         },
       });
+    } finally {
+      dispatch({ type: ACTION_TYPES.SET_EXPORTING, payload: false });
     }
   };
 
@@ -710,12 +719,16 @@ const DigitalAssistantsPage = () => {
                     open={state.isExportDialogOpen}
                     size="sm"
                     modalHeading="Export as CSV"
-                    primaryButtonText="Export"
+                    primaryButtonText={
+                      state.isExporting ? "Exporting..." : "Export"
+                    }
+                    primaryButtonDisabled={state.isExporting}
                     secondaryButtonText="Cancel"
                     onRequestSubmit={downloadCSV}
-                    onRequestClose={() =>
-                      dispatch({ type: ACTION_TYPES.CLOSE_EXPORT_DIALOG })
-                    }
+                    onRequestClose={() => {
+                      if (!state.isExporting)
+                        dispatch({ type: ACTION_TYPES.CLOSE_EXPORT_DIALOG });
+                    }}
                   >
                     <TextInput
                       id="csv-file-name"

--- a/ui/catalog/src/pages/DigitalAssistants/types.ts
+++ b/ui/catalog/src/pages/DigitalAssistants/types.ts
@@ -28,6 +28,7 @@ export interface AppState {
   deleteErrorRowName: string;
   isDeleting: boolean;
   isExportDialogOpen: boolean;
+  isExporting: boolean;
   csvFileName: string;
   exportErrorMessage: string;
   visibleColumns: Record<string, boolean>;
@@ -46,6 +47,7 @@ export interface AppState {
 }
 
 export const ACTION_TYPES = {
+  SET_EXPORTING: "SET_EXPORTING",
   SET_SEARCH: "SET_SEARCH",
   SET_PAGE: "SET_PAGE",
   SET_PAGE_SIZE: "SET_PAGE_SIZE",
@@ -78,6 +80,7 @@ export const ACTION_TYPES = {
 } as const;
 
 export type AppAction =
+  | { type: typeof ACTION_TYPES.SET_EXPORTING; payload: boolean }
   | { type: typeof ACTION_TYPES.SET_SEARCH; payload: string }
   | { type: typeof ACTION_TYPES.SET_PAGE; payload: number }
   | { type: typeof ACTION_TYPES.SET_PAGE_SIZE; payload: number }
@@ -144,6 +147,7 @@ export const INITIAL_STATE: AppState = {
   deleteErrorRowName: "",
   isDeleting: false,
   isExportDialogOpen: false,
+  isExporting: false,
   csvFileName: "",
   exportErrorMessage: "",
   visibleColumns: {
@@ -167,6 +171,8 @@ export const INITIAL_STATE: AppState = {
 // Reducer
 export const appReducer = (state: AppState, action: AppAction): AppState => {
   switch (action.type) {
+    case ACTION_TYPES.SET_EXPORTING:
+      return { ...state, isExporting: action.payload };
     case ACTION_TYPES.SET_SEARCH:
       return { ...state, search: action.payload };
     case ACTION_TYPES.SET_PAGE:

--- a/ui/catalog/src/pages/DigitalAssistants/types.ts
+++ b/ui/catalog/src/pages/DigitalAssistants/types.ts
@@ -134,7 +134,7 @@ export const HEADERS: DataTableHeader[] = [
 export const INITIAL_STATE: AppState = {
   search: "",
   page: 1,
-  pageSize: 10,
+  pageSize: 20,
   isDeleteDialogOpen: false,
   isConfirmed: false,
   rowsData: [],


### PR DESCRIPTION
Before

- Tables only ever showed 10 rows, even when there were more
- No way to see rows beyond the first 10 — pagination bar never appeared
- Deleting the last item on a page showed a blank table
- The "Filter by service" filter only searched through rows visible on screen, not all data
- Exporting downloaded only what was on the current page (max 20 rows)

After

- Tables now show up to 20 rows by default and fetch the correct page from the server
- Pagination bar appears when there are more than 20 total items, allowing navigation through all data
- Deleting the last item on a page automatically takes you back to the previous page
- "Filter by service" now filters on the server — works across all data, not just what's on screen. Changed the filter menu option from checkbox to radio button as backend supports only one filter type at a time (Type string as seen [here](https://github.com/IBM/project-ai-services/blob/efa0ac6359d51e6d631aa7cf07c28dce5287ad51/ai-services/docs/swagger.yaml#L556))
- Export now fetches all data (up to 100 rows as limit fixed by the GET API call), applies any active search or filter, and respects hidden columns

Known Limitation:
Search and sort by status column value works only for the current page data