### PR TITLE
[Jenkins-Pipeline] Minor fixes in code signature pipeline

### DIFF
--- a/hack/cicd/code-signing-service
+++ b/hack/cicd/code-signing-service
@@ -264,12 +264,16 @@ def signAndVerifyBinaries() {
                 --outputDirectory "$DOCKER_AGENT_PUBLIC_ARTIFACTS_DIR" \
                 --overwrite
             
+            # Rename signature file to <binary>.sig
+            mv "$DOCKER_AGENT_PUBLIC_ARTIFACTS_DIR/${BINARY_NAME}.cosign.sig" \
+               "$DOCKER_AGENT_PUBLIC_ARTIFACTS_DIR/${BINARY_NAME}.sig"
+            
             # Verify the signature
             echo "Verifying signature for $BINARY_NAME..."
             cosign verify-blob \
                 --key "$DOCKER_AGENT_PUBLIC_ARTIFACTS_DIR/cosign.pub" \
                 --insecure-ignore-tlog \
-                --signature "$DOCKER_AGENT_PUBLIC_ARTIFACTS_DIR/${BINARY_NAME}.cosign.sig" \
+                --signature "$DOCKER_AGENT_PUBLIC_ARTIFACTS_DIR/${BINARY_NAME}.sig" \
                 "$BINARY_PATH"
             
             echo "✓ $BINARY_NAME signed and verified successfully"

--- a/hack/cicd/image-signing-service
+++ b/hack/cicd/image-signing-service
@@ -475,7 +475,7 @@ def generateImageList() {
         env.ICR_AI_SERVICES_IMAGE     
     ]
 
-    def imageList = images.join('\n')
+    def imageList = images.join('\n') + '\n'
 
 
     dir("${CERT_DIR}") {


### PR DESCRIPTION
Minor fixes for code signature pipelines:

- **Binary signature naming:** Go binary signatures are now stored as `<binary-name>.sig` instead of the previous `<binary-name>-cosign.sig` format, aligning with the expected convention.
- **Image signature generation pipeline fix:** Resolved an issue where the pipeline failed to generate a signature for the last image in the list.