### PR TITLE
Update name field validation

### DIFF
--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,6 +1,6 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.40
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.41
 
 backend:
   port: ""

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,6 +1,6 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.39
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.40
 
 backend:
   port: ""

--- a/ui/catalog/Makefile
+++ b/ui/catalog/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= catalog-ui
-TAG ?= v0.0.40
+TAG ?= v0.0.41
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/catalog/Makefile
+++ b/ui/catalog/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= catalog-ui
-TAG ?= v0.0.39
+TAG ?= v0.0.40
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/catalog/src/components/DeployedServicesTable/DeployedServices.module.scss
+++ b/ui/catalog/src/components/DeployedServicesTable/DeployedServices.module.scss
@@ -153,7 +153,3 @@
     fill: theme.$text-secondary;
   }
 }
-
-.nameText {
-  color: theme.$link-primary;
-}

--- a/ui/catalog/src/components/DeploymentDetails/DeploymentDetails.module.scss
+++ b/ui/catalog/src/components/DeploymentDetails/DeploymentDetails.module.scss
@@ -252,9 +252,11 @@
   justify-content: flex-start;
 }
 
-.saveError {
-  margin-bottom: $spacing-05;
-  color: $support-error;
+.toastNotification {
+  position: fixed;
+  top: $spacing-10;
+  right: $spacing-05;
+  z-index: 9999;
 }
 
 .placeholderContent {

--- a/ui/catalog/src/components/DeploymentDetails/DeploymentDetails.tsx
+++ b/ui/catalog/src/components/DeploymentDetails/DeploymentDetails.tsx
@@ -12,6 +12,7 @@ import {
   TextInputSkeleton,
   SkeletonText,
   SkeletonPlaceholder,
+  ToastNotification,
 } from "@carbon/react";
 import { PageHeader, ProductiveCard } from "@carbon/ibm-products";
 import {
@@ -32,6 +33,7 @@ import type {
 } from "@/types/digitalAssistants";
 import styles from "./DeploymentDetails.module.scss";
 import { api } from "@/api/axios";
+import axios from "axios";
 import { APPLICATION_ENDPOINTS, SERVICE_ENDPOINTS } from "@/constants";
 
 interface DeploymentDetailsProps {
@@ -62,6 +64,7 @@ const DeploymentDetails = ({
   const [editedName, setEditedName] = useState(deployment.name);
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState("");
+  const [saveSuccess, setSaveSuccess] = useState(false);
   const [certifiedBy, setCertifiedBy] = useState<string | null>(null);
 
   useEffect(() => {
@@ -338,17 +341,6 @@ const DeploymentDetails = ({
   };
 
   const handleSave = async () => {
-    // Validate name
-    if (editedName.length < 3 || editedName.length > 100) {
-      setSaveError("Name must be between 3 and 100 characters");
-      return;
-    }
-
-    // Check if name actually changed
-    if (editedName === deployment.name) {
-      return;
-    }
-
     setIsSaving(true);
     setSaveError("");
 
@@ -357,11 +349,17 @@ const DeploymentDetails = ({
         name: editedName,
       });
       onNameUpdate?.(editedName);
+      setSaveSuccess(true);
     } catch (error) {
-      const errorMessage =
-        error instanceof Error
-          ? error.message
+      const rawError: string =
+        axios.isAxiosError(error) && error.response?.data?.error
+          ? error.response.data.error
           : "Failed to update deployment name";
+      const errorIndex = rawError.indexOf("Error:");
+      const errorMessage =
+        errorIndex !== -1
+          ? rawError.slice(errorIndex + "Error:".length).trim()
+          : rawError;
       setSaveError(errorMessage);
     } finally {
       setIsSaving(false);
@@ -375,6 +373,24 @@ const DeploymentDetails = ({
 
   return (
     <>
+      {saveSuccess && (
+        <ToastNotification
+          kind="success"
+          title="Name updated successfully"
+          timeout={5000}
+          onClose={() => setSaveSuccess(false)}
+          className={styles.toastNotification}
+        />
+      )}
+      {saveError && (
+        <ToastNotification
+          kind="error"
+          title="Failed to update name"
+          subtitle={saveError}
+          onClose={() => setSaveError("")}
+          className={styles.toastNotification}
+        />
+      )}
       <div>
         <PageHeader
           breadcrumbs={[
@@ -476,14 +492,6 @@ const DeploymentDetails = ({
                               setEditedName(e.target.value);
                               setSaveError("");
                             }}
-                            invalid={
-                              editedName.length < 3 || editedName.length > 100
-                            }
-                            invalidText={
-                              editedName.length < 3
-                                ? "Name must be at least 3 characters"
-                                : "Name must be at most 100 characters"
-                            }
                             disabled={isSaving}
                           />
                         )}
@@ -635,9 +643,6 @@ const DeploymentDetails = ({
 
               <Grid className={styles.actionsGrid}>
                 <Column sm={4} md={8} lg={16}>
-                  {saveError && (
-                    <div className={styles.saveError}>{saveError}</div>
-                  )}
                   <div className={styles.actionButtons}>
                     <Button
                       kind="secondary"
@@ -649,12 +654,7 @@ const DeploymentDetails = ({
                     <Button
                       kind="primary"
                       onClick={handleSave}
-                      disabled={
-                        isSaving ||
-                        editedName === deployment.name ||
-                        editedName.length < 3 ||
-                        editedName.length > 100
-                      }
+                      disabled={isSaving}
                     >
                       {isSaving ? "Saving..." : "Save"}
                     </Button>

--- a/ui/catalog/src/pages/DigitalAssistants/DigitalAssistants.module.scss
+++ b/ui/catalog/src/pages/DigitalAssistants/DigitalAssistants.module.scss
@@ -333,7 +333,3 @@
 .codeButton {
   margin-top: spacing.$spacing-07;
 }
-
-.nameText {
-  color: theme.$link-primary;
-}


### PR DESCRIPTION
- Removed the name field error handling on the client side while updating the application name in the deployment details and kept everything as backend check as in deploy flows as well so that there is consistency throughout.
- Added toast notification to indicate respective messages
- Removed the blue font color that was present for the deployment names which are not clickable when the application is in deploying or error state

<img width="1918" height="945" alt="image" src="https://github.com/user-attachments/assets/63f79b03-e27a-461a-82c0-de36c85d2d18" />
<img width="1918" height="945" alt="image (1)" src="https://github.com/user-attachments/assets/87756ad1-17cf-49c0-a816-3500a0ba0206" />
<img width="1918" height="945" alt="image (2)" src="https://github.com/user-attachments/assets/718b5a82-36bc-4b87-b3dc-f2bb4b930379" />
<img width="1918" height="945" alt="image (3)" src="https://github.com/user-attachments/assets/f92a8132-520a-4d20-aae2-221e22ea8d6a" />




