### PR TITLE
fix: resolve relative --basedir to absolute path before embedding in pod YAML

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.159
+TAG?=v0.0.160
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.159
+  image: icr.io/ai-services-cicd/ai-services:v0.0.160
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -266,7 +266,7 @@ func configureConfigureFlags(cmd *cobra.Command) {
 		&baseDir,
 		"basedir",
 		"",
-		"Base directory for AI services data (applications, models, cache).\n"+
+		"Base directory for AI services data (models, caddy).\n"+
 			"Example: --basedir /custom/path\n",
 	)
 

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -524,8 +524,15 @@ func GetModelsPath() string {
 // ValidateBaseDir validates that the base directory exists or can be created.
 // It always appends 'ai-services' subdirectory to the provided base directory for all AI services content.
 func ValidateBaseDir(baseDir string) (string, error) {
-	// Clean the path and append ai-services subdirectory
-	baseDir = filepath.Join(filepath.Clean(baseDir), "ai-services")
+	// Resolve relative paths to absolute paths to prevent Podman from mounting
+	//the wrong (or empty) host directory.
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve absolute path: %w", err)
+	}
+
+	// Clean the absolute path and append ai-services subdirectory
+	baseDir = filepath.Join(filepath.Clean(absBase), "ai-services")
 
 	// Check if directory exists or can be created
 	if err := os.MkdirAll(baseDir, constants.DirPerm); err != nil {


### PR DESCRIPTION
### Problem
ai-services catalog configure --basedir ./my-ais fails with the caddy container crashing on startup:

`Error: reading config from file: open /data/caddy/Caddyfile: no such file or directory`

The Caddyfile is correctly written to the host at <CWD>/my-ais/ai-services/common/caddy/Caddyfile, but the rendered pod YAML contains a relative hostPath: my-ais/ai-services/common/caddy. The podman daemon resolves that relative path from its own working directory (not the user's shell CWD), so the container mounts an empty directory and never sees the Caddyfile. Using an absolute path (--basedir /root/.../my-ais) works because the hostPath is unambiguous.

### Fix
Call filepath.Abs inside ValidateBaseDir before cleaning and appending the ai-services subdirectory.