### PR TITLE
fix: AISERVICES-1333: deployment failing if auth.json is empty

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.157
+TAG?=v0.0.158
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services/ai-services:v0.0.157
+  image: icr.io/ai-services/ai-services:v0.0.158
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -179,7 +179,7 @@ func generateArgParams(passwordHash string, httpsPort int) (map[string]string, e
 			// Auth file doesn't exist - user hasn't logged into podman
 			logger.Warningln("Podman auth file not found. Deployment may fail since deployment may require pulling images.")
 			logger.Warningln("If you need to update registry credentials later, you can use the '--reset-podman-auth' flag after running 'podman login'.")
-			authFileContent = []byte{}
+			authFileContent = []byte("{}")
 		} else {
 			return nil, fmt.Errorf("failed to read auth file from %s: %w", authFilePath, err)
 		}


### PR DESCRIPTION
Unable to deploy an application on CPU without podman login is failing with the error:
```
failed to execute deployment: failed to pull images: failed to pull images: failed to download image: retry failed after 3 attempts with err: failed to pull image icr.io/ai-services/chatbot-service:v0.0.21: reading JSON file "/run/containers/auth.json": unmarshaling JSON at "/run/containers/auth.json": unexpected end of JSON input
```

This is happening because the Podman auth file is empty on a newly created machine. The auth file on the catalog pod is empty as well. While pulling the image, Podman complains that the auth file is not valid JSON.

Workaround: 
1. Podman login to any registry and then logout
2. Create an empty json file `/run/user/0/containers/auth.json`  with content as "{}"
3. Edit the secret `podman-auth-secret` with: `data: auth.json: e30K`
