### PR TITLE
[Catalog-API] Populate catalog_id and version in List Applications

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.162
+TAG?=v0.0.163
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.162
+  image: icr.io/ai-services-cicd/ai-services:v0.0.163
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -137,10 +137,12 @@ func (s *ApplicationService) buildApplication(app models.Application) (types.App
 	appData := types.Application{
 		ID:             app.ID.String(),
 		Name:           app.Name,
+		CatalogID:      app.CatalogID,
 		DeploymentType: string(app.DeploymentType),
 		Type:           typeName,
 		Status:         string(app.Status),
 		Message:        app.Message,
+		Version:        app.Version,
 		CreatedAt:      app.CreatedAt.Format(constants.RFC3339WithTimezone),
 		UpdatedAt:      app.UpdatedAt.Format(constants.RFC3339WithTimezone),
 	}


### PR DESCRIPTION
- Currently the catalog_id and version key is present in List Applications but is empty (Since we are using the same underlying struct for both List Applications and GetAppByID).
- Instead of it being empty, let the values be populated.