### PR TITLE
fix: AISERVICES-1355: handle create parameters for components correctly

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.165
+TAG?=v0.0.166
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.165
+  image: icr.io/ai-services-cicd/ai-services:v0.0.166
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -737,7 +737,11 @@ func buildServiceEntryWithDeployOptions(appClient *catalogClient.ApplicationClie
 		providerParams := extractComponentParamsForService(serviceID, compDeployOpt.Type, argParams)
 
 		// Determine provider ID and get its params
-		providerID, userParams := selectProviderFromDeployOptions(compDeployOpt, providerParams)
+		providerID, userParams, err := selectProviderFromDeployOptions(compDeployOpt, providerParams)
+		if err != nil {
+			return apiModels.Service{}, err
+		}
+
 		if providerID == "" {
 			return apiModels.Service{}, fmt.Errorf("no provider found for component type '%s'", compDeployOpt.Type)
 		}
@@ -870,6 +874,10 @@ func extractComponentParamsForService(serviceID string, componentType string, al
 }
 
 // extractProviderParams extracts provider parameters from allParams with the given prefix.
+// For bare provider keys (e.g., llm.vllm-cpu=true/false):
+//   - "true" selects the provider.
+//   - "false" opts out of the provider (skipped).
+//   - Any other value logs a warning and is treated as "false".
 func extractProviderParams(prefix string, allParams map[string]string, providerParams map[string]map[string]string) {
 	for key, value := range allParams {
 		after, ok := strings.CutPrefix(key, prefix)
@@ -884,14 +892,25 @@ func extractProviderParams(prefix string, allParams map[string]string, providerP
 		}
 
 		providerID := parts[0]
+
+		// Bare provider key (e.g., llm.vllm-cpu=true/false).
+		if len(parts) != expectedParamParts && !strings.EqualFold(value, "true") {
+			// Any value other than "true" opts out of this provider.
+			if !strings.EqualFold(value, "false") {
+				logger.Warningf("Invalid value '%s' for provider parameter '%s': expected 'true' or 'false', treating as 'false'\n", value, key)
+			}
+
+			continue
+		}
+
+		// Ensure provider entry exists.
 		if providerParams[providerID] == nil {
 			providerParams[providerID] = make(map[string]string)
 		}
 
-		// If there's a param name, add it; otherwise just mark provider as selected.
+		// Store nested param (e.g., llm.vllm-cpu.model=granite).
 		if len(parts) == expectedParamParts {
-			paramName := parts[1]
-			providerParams[providerID][paramName] = value
+			providerParams[providerID][parts[1]] = value
 		}
 	}
 }
@@ -902,42 +921,62 @@ func extractProviderParams(prefix string, allParams map[string]string, providerP
 // 2. For LLM and reranker components: Use vllm-spyre by default.
 // 3. Default provider marked in deploy options.
 // 4. First available provider.
-func selectProviderFromDeployOptions(compDeployOpt catalogTypes.DeployOptionsComponent, providerParams map[string]map[string]string) (string, map[string]string) {
+// Returns an error if multiple providers are specified for the same component type.
+func selectProviderFromDeployOptions(compDeployOpt catalogTypes.DeployOptionsComponent, providerParams map[string]map[string]string) (string, map[string]string, error) {
 	// Check if user specified params for a specific provider.
-	if providerID, params := findUserSpecifiedProvider(compDeployOpt, providerParams); providerID != "" {
-		return providerID, params
+	providerID, params, err := findUserSpecifiedProvider(compDeployOpt, providerParams)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if providerID != "" {
+		return providerID, params, nil
 	}
 
 	// Special logic for LLM and reranker component types - prefer Spyre acceleration.
-	if providerID := findSpyreProvider(compDeployOpt); providerID != "" {
-		return providerID, make(map[string]string)
+	if spyreID := findSpyreProvider(compDeployOpt); spyreID != "" {
+		return spyreID, make(map[string]string), nil
 	}
 
 	// Use default provider if marked.
-	if providerID := findDefaultProvider(compDeployOpt); providerID != "" {
-		return providerID, make(map[string]string)
+	if defaultID := findDefaultProvider(compDeployOpt); defaultID != "" {
+		return defaultID, make(map[string]string), nil
 	}
 
 	// Fall back to first available provider.
 	if len(compDeployOpt.Providers) > 0 {
-		return compDeployOpt.Providers[0].ID, make(map[string]string)
+		return compDeployOpt.Providers[0].ID, make(map[string]string), nil
 	}
 
-	return "", make(map[string]string)
+	return "", make(map[string]string), nil
 }
 
 // findUserSpecifiedProvider checks if user specified params for a specific provider.
-func findUserSpecifiedProvider(compDeployOpt catalogTypes.DeployOptionsComponent, providerParams map[string]map[string]string) (string, map[string]string) {
+// Returns an error if multiple valid providers are specified for the same component type.
+func findUserSpecifiedProvider(compDeployOpt catalogTypes.DeployOptionsComponent, providerParams map[string]map[string]string) (string, map[string]string, error) {
+	var matchedProvider string
+	var matchedParams map[string]string
+
 	for providerID := range providerParams {
 		// Verify this provider exists in deploy options.
 		for _, p := range compDeployOpt.Providers {
 			if p.ID == providerID {
-				return providerID, providerParams[providerID]
+				if matchedProvider != "" {
+					return "", nil, fmt.Errorf(
+						"multiple providers specified for component type '%s': '%s' and '%s'. "+
+							"Only one provider can be selected per component type",
+						compDeployOpt.Type, matchedProvider, providerID)
+				}
+
+				matchedProvider = providerID
+				matchedParams = providerParams[providerID]
+
+				break
 			}
 		}
 	}
 
-	return "", nil
+	return matchedProvider, matchedParams, nil
 }
 
 // findSpyreProvider finds vllm-spyre provider if available for the component.

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -861,14 +861,23 @@ func isComponentParameter(param string, componentTypes map[string]bool) bool {
 // - Provider with params: {componentType}.{providerID}.{param} (e.g., llm.vllm-cpu.model).
 // - Service-specific: {serviceID}.{componentType}.{providerID}[.{param}] (e.g., chat.llm.vllm-cpu or chat.llm.vllm-cpu.model).
 // Returns a map with provider as key and params as value.
+// Warns if a provider is explicitly set to false with no other provider selected.
 func extractComponentParamsForService(serviceID string, componentType string, allParams map[string]string) map[string]map[string]string {
 	providerParams := make(map[string]map[string]string)
+	falseProviders := make(map[string]bool)
 
 	// Extract global component params: {componentType}.{providerID}[.{param}].
-	extractProviderParams(componentType+".", allParams, providerParams)
+	extractProviderParams(componentType+".", allParams, providerParams, falseProviders)
 
 	// Extract service-specific component params (these override global).
-	extractProviderParams(serviceID+"."+componentType+".", allParams, providerParams)
+	extractProviderParams(serviceID+"."+componentType+".", allParams, providerParams, falseProviders)
+
+	// Warn if any provider was explicitly set to false but no other provider was selected.
+	if len(falseProviders) > 0 && len(providerParams) == 0 {
+		for providerID := range falseProviders {
+			logger.Warningf("Provider '%s' for component type '%s' is set to 'false' but no other provider was specified; the default provider will be used\n", providerID, componentType)
+		}
+	}
 
 	return providerParams
 }
@@ -876,9 +885,9 @@ func extractComponentParamsForService(serviceID string, componentType string, al
 // extractProviderParams extracts provider parameters from allParams with the given prefix.
 // For bare provider keys (e.g., llm.vllm-cpu=true/false):
 //   - "true" selects the provider.
-//   - "false" opts out of the provider (skipped).
+//   - "false" records the provider in falseProviders and skips it.
 //   - Any other value logs a warning and is treated as "false".
-func extractProviderParams(prefix string, allParams map[string]string, providerParams map[string]map[string]string) {
+func extractProviderParams(prefix string, allParams map[string]string, providerParams map[string]map[string]string, falseProviders map[string]bool) {
 	for key, value := range allParams {
 		after, ok := strings.CutPrefix(key, prefix)
 		if !ok {
@@ -899,6 +908,8 @@ func extractProviderParams(prefix string, allParams map[string]string, providerP
 			if !strings.EqualFold(value, "false") {
 				logger.Warningf("Invalid value '%s' for provider parameter '%s': expected 'true' or 'false', treating as 'false'\n", value, key)
 			}
+
+			falseProviders[providerID] = true
 
 			continue
 		}

--- a/ai-services/cmd/ai-services/cmd/application/create_provider_test.go
+++ b/ai-services/cmd/ai-services/cmd/application/create_provider_test.go
@@ -12,7 +12,7 @@ func TestExtractProviderParams_FalseSkipsProvider(t *testing.T) {
 	}
 	providerParams := make(map[string]map[string]string)
 
-	extractProviderParams("llm.", allParams, providerParams)
+	extractProviderParams("llm.", allParams, providerParams, make(map[string]bool))
 
 	if _, exists := providerParams["vllm-cpu"]; exists {
 		t.Error("expected vllm-cpu to be skipped when value is 'false'")
@@ -25,7 +25,7 @@ func TestExtractProviderParams_TrueSelectsProvider(t *testing.T) {
 	}
 	providerParams := make(map[string]map[string]string)
 
-	extractProviderParams("llm.", allParams, providerParams)
+	extractProviderParams("llm.", allParams, providerParams, make(map[string]bool))
 
 	if _, exists := providerParams["vllm-cpu"]; !exists {
 		t.Error("expected vllm-cpu to be selected when value is 'true'")
@@ -38,7 +38,7 @@ func TestExtractProviderParams_FalseCaseInsensitive(t *testing.T) {
 	}
 	providerParams := make(map[string]map[string]string)
 
-	extractProviderParams("llm.", allParams, providerParams)
+	extractProviderParams("llm.", allParams, providerParams, make(map[string]bool))
 
 	if _, exists := providerParams["vllm-cpu"]; exists {
 		t.Error("expected vllm-cpu to be skipped when value is 'False' (case insensitive)")
@@ -51,7 +51,7 @@ func TestExtractProviderParams_TrueCaseInsensitive(t *testing.T) {
 	}
 	providerParams := make(map[string]map[string]string)
 
-	extractProviderParams("llm.", allParams, providerParams)
+	extractProviderParams("llm.", allParams, providerParams, make(map[string]bool))
 
 	if _, exists := providerParams["vllm-cpu"]; !exists {
 		t.Error("expected vllm-cpu to be selected when value is 'True' (case insensitive)")
@@ -76,7 +76,7 @@ func TestExtractProviderParams_InvalidValueTreatedAsFalse(t *testing.T) {
 			}
 			providerParams := make(map[string]map[string]string)
 
-			extractProviderParams("llm.", allParams, providerParams)
+			extractProviderParams("llm.", allParams, providerParams, make(map[string]bool))
 
 			if _, exists := providerParams["vllm-cpu"]; exists {
 				t.Errorf("expected vllm-cpu to be skipped for invalid value '%s' (treated as false)", tc.value)
@@ -92,7 +92,7 @@ func TestExtractProviderParams_NestedParamNotAffectedByFalse(t *testing.T) {
 	}
 	providerParams := make(map[string]map[string]string)
 
-	extractProviderParams("llm.", allParams, providerParams)
+	extractProviderParams("llm.", allParams, providerParams, make(map[string]bool))
 
 	if _, exists := providerParams["vllm-cpu"]; !exists {
 		t.Fatal("expected vllm-cpu to exist with nested param")
@@ -110,7 +110,7 @@ func TestExtractProviderParams_AllFalseResultsInEmpty(t *testing.T) {
 	}
 	providerParams := make(map[string]map[string]string)
 
-	extractProviderParams("llm.", allParams, providerParams)
+	extractProviderParams("llm.", allParams, providerParams, make(map[string]bool))
 
 	if len(providerParams) != 0 {
 		t.Errorf("expected empty providerParams when all providers are false, got %v", providerParams)
@@ -118,6 +118,7 @@ func TestExtractProviderParams_AllFalseResultsInEmpty(t *testing.T) {
 }
 
 func TestExtractComponentParamsForService_OneTrueOneFalse(t *testing.T) {
+	// vllm-spyre=false alongside vllm-cpu=true — no warning, vllm-cpu selected.
 	allParams := map[string]string{
 		"llm.vllm-spyre": "false",
 		"llm.vllm-cpu":   "true",
@@ -131,6 +132,19 @@ func TestExtractComponentParamsForService_OneTrueOneFalse(t *testing.T) {
 
 	if _, exists := providerParams["vllm-cpu"]; !exists {
 		t.Error("expected vllm-cpu to be selected")
+	}
+}
+
+func TestExtractComponentParamsForService_OnlyFalse_DefaultApplies(t *testing.T) {
+	// vllm-spyre=false with no other provider selected — warning logged, providerParams empty so default kicks in.
+	allParams := map[string]string{
+		"llm.vllm-spyre": "false",
+	}
+
+	providerParams := extractComponentParamsForService("chat", "llm", allParams)
+
+	if len(providerParams) != 0 {
+		t.Errorf("expected empty providerParams so default is used, got %v", providerParams)
 	}
 }
 

--- a/ai-services/cmd/ai-services/cmd/application/create_provider_test.go
+++ b/ai-services/cmd/ai-services/cmd/application/create_provider_test.go
@@ -1,0 +1,243 @@
+package application
+
+import (
+	"testing"
+
+	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+)
+
+func TestExtractProviderParams_FalseSkipsProvider(t *testing.T) {
+	allParams := map[string]string{
+		"llm.vllm-cpu": "false",
+	}
+	providerParams := make(map[string]map[string]string)
+
+	extractProviderParams("llm.", allParams, providerParams)
+
+	if _, exists := providerParams["vllm-cpu"]; exists {
+		t.Error("expected vllm-cpu to be skipped when value is 'false'")
+	}
+}
+
+func TestExtractProviderParams_TrueSelectsProvider(t *testing.T) {
+	allParams := map[string]string{
+		"llm.vllm-cpu": "true",
+	}
+	providerParams := make(map[string]map[string]string)
+
+	extractProviderParams("llm.", allParams, providerParams)
+
+	if _, exists := providerParams["vllm-cpu"]; !exists {
+		t.Error("expected vllm-cpu to be selected when value is 'true'")
+	}
+}
+
+func TestExtractProviderParams_FalseCaseInsensitive(t *testing.T) {
+	allParams := map[string]string{
+		"llm.vllm-cpu": "False",
+	}
+	providerParams := make(map[string]map[string]string)
+
+	extractProviderParams("llm.", allParams, providerParams)
+
+	if _, exists := providerParams["vllm-cpu"]; exists {
+		t.Error("expected vllm-cpu to be skipped when value is 'False' (case insensitive)")
+	}
+}
+
+func TestExtractProviderParams_TrueCaseInsensitive(t *testing.T) {
+	allParams := map[string]string{
+		"llm.vllm-cpu": "True",
+	}
+	providerParams := make(map[string]map[string]string)
+
+	extractProviderParams("llm.", allParams, providerParams)
+
+	if _, exists := providerParams["vllm-cpu"]; !exists {
+		t.Error("expected vllm-cpu to be selected when value is 'True' (case insensitive)")
+	}
+}
+
+func TestExtractProviderParams_InvalidValueTreatedAsFalse(t *testing.T) {
+	testCases := []struct {
+		name  string
+		value string
+	}{
+		{"empty string", ""},
+		{"arbitrary string", "yes"},
+		{"numeric", "1"},
+		{"typo", "tru"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			allParams := map[string]string{
+				"llm.vllm-cpu": tc.value,
+			}
+			providerParams := make(map[string]map[string]string)
+
+			extractProviderParams("llm.", allParams, providerParams)
+
+			if _, exists := providerParams["vllm-cpu"]; exists {
+				t.Errorf("expected vllm-cpu to be skipped for invalid value '%s' (treated as false)", tc.value)
+			}
+		})
+	}
+}
+
+func TestExtractProviderParams_NestedParamNotAffectedByFalse(t *testing.T) {
+	// A nested param like llm.vllm-cpu.model=false should still be treated as a param value.
+	allParams := map[string]string{
+		"llm.vllm-cpu.model": "false",
+	}
+	providerParams := make(map[string]map[string]string)
+
+	extractProviderParams("llm.", allParams, providerParams)
+
+	if _, exists := providerParams["vllm-cpu"]; !exists {
+		t.Fatal("expected vllm-cpu to exist with nested param")
+	}
+
+	if providerParams["vllm-cpu"]["model"] != "false" {
+		t.Errorf("expected model param to be 'false', got '%s'", providerParams["vllm-cpu"]["model"])
+	}
+}
+
+func TestExtractProviderParams_AllFalseResultsInEmpty(t *testing.T) {
+	allParams := map[string]string{
+		"llm.vllm-cpu":   "false",
+		"llm.vllm-spyre": "false",
+	}
+	providerParams := make(map[string]map[string]string)
+
+	extractProviderParams("llm.", allParams, providerParams)
+
+	if len(providerParams) != 0 {
+		t.Errorf("expected empty providerParams when all providers are false, got %v", providerParams)
+	}
+}
+
+func TestExtractComponentParamsForService_OneTrueOneFalse(t *testing.T) {
+	allParams := map[string]string{
+		"llm.vllm-spyre": "false",
+		"llm.vllm-cpu":   "true",
+	}
+
+	providerParams := extractComponentParamsForService("chat", "llm", allParams)
+
+	if _, exists := providerParams["vllm-spyre"]; exists {
+		t.Error("expected vllm-spyre to be skipped")
+	}
+
+	if _, exists := providerParams["vllm-cpu"]; !exists {
+		t.Error("expected vllm-cpu to be selected")
+	}
+}
+
+func TestFindUserSpecifiedProvider_SingleProvider(t *testing.T) {
+	compDeployOpt := catalogTypes.DeployOptionsComponent{
+		Type: "llm",
+		Providers: []catalogTypes.DeployOptionsProvider{
+			{ID: "vllm-cpu"},
+			{ID: "vllm-spyre"},
+		},
+	}
+	providerParams := map[string]map[string]string{
+		"vllm-cpu": {},
+	}
+
+	providerID, params, err := findUserSpecifiedProvider(compDeployOpt, providerParams)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if providerID != "vllm-cpu" {
+		t.Errorf("expected 'vllm-cpu', got '%s'", providerID)
+	}
+
+	if params == nil {
+		t.Error("expected non-nil params")
+	}
+}
+
+func TestFindUserSpecifiedProvider_MultipleProviders_ReturnsError(t *testing.T) {
+	compDeployOpt := catalogTypes.DeployOptionsComponent{
+		Type: "llm",
+		Providers: []catalogTypes.DeployOptionsProvider{
+			{ID: "vllm-cpu"},
+			{ID: "vllm-spyre"},
+		},
+	}
+	providerParams := map[string]map[string]string{
+		"vllm-cpu":   {},
+		"vllm-spyre": {},
+	}
+
+	_, _, err := findUserSpecifiedProvider(compDeployOpt, providerParams)
+	if err == nil {
+		t.Fatal("expected error when multiple providers specified, got nil")
+	}
+}
+
+func TestFindUserSpecifiedProvider_NoMatchingProvider(t *testing.T) {
+	compDeployOpt := catalogTypes.DeployOptionsComponent{
+		Type: "llm",
+		Providers: []catalogTypes.DeployOptionsProvider{
+			{ID: "vllm-cpu"},
+			{ID: "vllm-spyre"},
+		},
+	}
+	providerParams := map[string]map[string]string{
+		"watsonx": {"model": "ibm/granite"},
+	}
+
+	providerID, _, err := findUserSpecifiedProvider(compDeployOpt, providerParams)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if providerID != "" {
+		t.Errorf("expected empty provider ID for non-matching provider, got '%s'", providerID)
+	}
+}
+
+func TestSelectProviderFromDeployOptions_FallsBackToSpyre(t *testing.T) {
+	compDeployOpt := catalogTypes.DeployOptionsComponent{
+		Type: "llm",
+		Providers: []catalogTypes.DeployOptionsProvider{
+			{ID: "vllm-cpu"},
+			{ID: "vllm-spyre"},
+		},
+	}
+	// Empty providerParams — no user selection.
+	providerParams := map[string]map[string]string{}
+
+	providerID, _, err := selectProviderFromDeployOptions(compDeployOpt, providerParams)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if providerID != "vllm-spyre" {
+		t.Errorf("expected 'vllm-spyre' as default, got '%s'", providerID)
+	}
+}
+
+func TestSelectProviderFromDeployOptions_FallsBackToDefault(t *testing.T) {
+	compDeployOpt := catalogTypes.DeployOptionsComponent{
+		Type: "embedding",
+		Providers: []catalogTypes.DeployOptionsProvider{
+			{ID: "vllm-cpu"},
+			{ID: "tei", Default: true},
+		},
+	}
+	providerParams := map[string]map[string]string{}
+
+	providerID, _, err := selectProviderFromDeployOptions(compDeployOpt, providerParams)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if providerID != "tei" {
+		t.Errorf("expected 'tei' as default provider, got '%s'", providerID)
+	}
+}


### PR DESCRIPTION
- Provider selection with =false now opts out: previously llm.vllm-cpu=false would still select vllm-cpu. Now =false is treated as "don't use this provider."
- Two providers active at once now errors: previously if two providers were both active for the same component type, one was silently picked at random due to Go map iteration. Now it fails with a clear message.
- Any value other than true/false on a bare provider key logs a warning and defaults to opt-out: previously it would silently select the provider.