### PR TITLE
Fetch max length from litellm & lang multipliers for token budget

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.172
+TAG?=v0.0.173
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.24
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.25
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.24
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.25
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.24
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.25
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.24
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.25
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.24
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.25
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.172
+  image: icr.io/ai-services-cicd/ai-services:v0.0.173
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/chat/podman/values.yaml
+++ b/ai-services/assets/services/chat/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.24
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.25
   log_level: "INFO"
   chatbot:
     searchMode: "hybrid"

--- a/services/chatbot/Makefile
+++ b/services/chatbot/Makefile
@@ -1,5 +1,5 @@
 IMAGE=chatbot-service
-TAG?=v0.0.24
+TAG?=v0.0.25
 
 run:
 	PORT=$${PORT:-5000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/chatbot/app.py
+++ b/services/chatbot/app.py
@@ -19,7 +19,7 @@ from lingua import Language
 from common.misc_utils import set_log_level, get_logger
 from common.lang_utils import detect_language, LanguageCodes, get_max_tokens_map
 
-from chatbot.settings import settings
+from chatbot.settings import settings, get_history_token_budget
 from chatbot.conversation_utils import get_conversation_context, truncate_history_by_tokens
 from chatbot.query_rephrasing import rephrase_query_with_context
 
@@ -523,7 +523,7 @@ async def chat_completion(req: ChatCompletionRequest, credentials: Optional[HTTP
             truncated_history_for_rephrasing = await asyncio.to_thread(
                 truncate_history_by_tokens,
                 previous_messages,
-                settings.query_rephrasing.history_token_budget,
+                get_history_token_budget(query_lang, settings.query_rephrasing.history_token_budget),
                 lambda text: tokenize_with_llm(text, llm_endpoint)
             )
 

--- a/services/chatbot/settings.py
+++ b/services/chatbot/settings.py
@@ -727,6 +727,30 @@ _RAG_CONFIG_MAP: dict = {
     LanguageCodes.FRENCH: settings.chatbot.french,
 }
 
+_HISTORY_TOKEN_RATIOS: dict[str, float] = {
+    LanguageCodes.ENGLISH:  1.0,
+    LanguageCodes.FRENCH:   1.2305,
+    LanguageCodes.ITALIAN:  1.3066,
+    LanguageCodes.GERMAN:   1.5,
+}
+
+def get_history_token_budget(lang: str, base: int) -> int:
+    """Return a history token budget scaled for the given language.
+
+    Uses the English base value and multiplies by the language-specific ratio,
+    so that non-English languages receive a proportionally larger budget to
+    account for their higher token density.
+
+    Args:
+        lang: Detected language code (e.g. LanguageCodes.FRENCH).
+        base: The English baseline token budget to scale from.
+
+    Returns:
+        Scaled integer token budget for the given language.
+    """
+    ratio = _HISTORY_TOKEN_RATIOS.get(lang, 1.0)
+    return round(base * ratio)
+
 def get_query_rephrasing_language_config(lang: str):
     """Get query rephrasing config for a language, falling back to English."""
     return _QUERY_REPHRASING_CONFIG_MAP.get(lang, _QUERY_REPHRASING_CONFIG_MAP[LanguageCodes.ENGLISH])

--- a/services/common/llm_utils.py
+++ b/services/common/llm_utils.py
@@ -19,7 +19,7 @@ def apply_token_buffer(max_tokens: int, token_buffer_ratio: float | None = None,
     """
     Apply token buffer to give LLM breathing room to respect prompt word limits.
     
-    The prompt instructs the LLM to limit to max_tokens, but we reduce the API limit
+    The API instructs the LLM to limit to max_tokens, but we reduce the prompt limit
     by token_buffer_ratio to ensure the LLM can naturally complete before hitting the hard limit.
     
     Args:

--- a/services/common/llm_utils.py
+++ b/services/common/llm_utils.py
@@ -191,6 +191,27 @@ def query_vllm_models(llm_endpoint, api_key: str | None = None):
     return resp_json
 
 
+def query_litellm_model_info(endpoint: str, api_key: str | None = None) -> dict:
+    """Query the LiteLLM /model/info endpoint and return the raw response JSON.
+
+    Args:
+        endpoint: Base URL of the LiteLLM proxy (e.g. ``http://localhost:4000``).
+        api_key: Optional bearer token for the proxy.
+
+    Returns:
+        Parsed JSON response dict from /model/info.
+    """
+    if misc_utils.SESSION is None:
+        raise RuntimeError("LLM session not initialized. Call create_llm_session() first.")
+
+    logger.debug("Querying LiteLLM /model/info")
+    response = misc_utils.SESSION.get(
+        f"{endpoint}/model/info"
+    )
+    response.raise_for_status()
+    return response.json()
+
+
 def query_vllm_payload(
     question,
     documents,

--- a/services/common/llm_utils.py
+++ b/services/common/llm_utils.py
@@ -228,7 +228,7 @@ def query_vllm_payload(
     token_buffer_ratio: float | None = None,
 ):
     # Lazy import to avoid circular dependencies
-    from chatbot.settings import get_rag_language_config, settings as chatbot_settings
+    from chatbot.settings import get_rag_language_config, get_history_token_budget, settings as chatbot_settings
     from chatbot.conversation_utils import truncate_history_by_tokens
     
     context = "\n\n".join([doc.get("page_content") for doc in documents])
@@ -271,7 +271,10 @@ def query_vllm_payload(
         # Context fits completely, use remaining budget for history
         remaining_budget_for_history = budget_for_context - context_token_count
         # Cap history budget at configured limit or remaining budget, whichever is smaller
-        history_budget = min(chatbot_settings.chatbot.history_token_budget, remaining_budget_for_history)
+        history_budget = min(
+            get_history_token_budget(lang, chatbot_settings.chatbot.history_token_budget),
+            remaining_budget_for_history
+        )
         logger.debug(
             f"Context fits completely ({context_token_count} tokens). "
             f"History budget: {history_budget} tokens"

--- a/services/common/misc_utils.py
+++ b/services/common/misc_utils.py
@@ -187,13 +187,37 @@ _model_max_len_cache: dict[tuple[str, str], int] = {}
 
 
 def resolve_model_max_len(endpoint: str, model_name: str, fallback_max_model_len: int, api_key: str | None = None) -> int:
-    """Resolve model max length from /v1/models using exact model-name matching."""
-    from common.llm_utils import query_vllm_models
-    
+    """Resolve model max length, trying three sources in priority order:
+
+    1. ``/model/info`` (LiteLLM proxy) — reads ``model_info.max_tokens`` for the
+       entry whose ``model_name`` matches *model_name*.
+    2. ``/v1/models`` (vLLM / OpenAI-compatible) — reads ``max_model_len`` for the
+       entry whose ``id`` matches *model_name*.
+    3. *fallback_max_model_len* — the caller-supplied default.
+
+    Results are cached per ``(endpoint, model_name)`` pair so that subsequent
+    calls within the same process incur no network round-trips.
+    """
+    from common.llm_utils import query_litellm_model_info, query_vllm_models
+
     cache_key = (endpoint, model_name)
     if cache_key in _model_max_len_cache:
         return _model_max_len_cache[cache_key]
 
+    # --- 1. Try /model/info (LiteLLM) ---
+    try:
+        resp_json = query_litellm_model_info(endpoint, api_key)
+        for entry in resp_json.get("data", []):
+            if entry.get("model_name") == model_name:
+                max_tokens = entry.get("model_info", {}).get("max_tokens")
+                if isinstance(max_tokens, int) and max_tokens > 0:
+                    _model_max_len_cache[cache_key] = max_tokens
+                    return max_tokens
+                break
+    except Exception:
+        pass
+
+    # --- 2. Try /v1/models (vLLM / OpenAI-compatible) ---
     try:
         resp_json = query_vllm_models(endpoint, api_key)
         for model_info in resp_json.get("data", []):
@@ -206,6 +230,7 @@ def resolve_model_max_len(endpoint: str, model_name: str, fallback_max_model_len
     except Exception:
         pass
 
+    # --- 3. Fallback ---
     _model_max_len_cache[cache_key] = fallback_max_model_len
     return fallback_max_model_len
 


### PR DESCRIPTION
-Fetch correct max_length in following failover order - litellm (/model/info) > vLLM (/v1/models) > Fallback param passed
-Ratio multiplier on history and query rephrasing budget