### PR TITLE
fix : error out on non-running pod during catalog configure re-run

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.164
+TAG?=v0.0.165
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.164
+  image: icr.io/ai-services-cicd/ai-services:v0.0.165
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/cli/helpers/helper.go
+++ b/ai-services/internal/pkg/cli/helpers/helper.go
@@ -11,6 +11,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 const (
@@ -133,6 +134,9 @@ func CheckExistingResourcesForApplication(ctx context.Context, runtime runtime.R
 	return resourcesToSkip, nil
 }
 
+// existingRunningPods lists pods for the given application. Any pod that is not in
+// Running state is deleted so that the deployment layer can recreate it cleanly.
+// Only Running pod names are returned for the skip list.
 func existingRunningPods(ctx context.Context, runtime runtime.Runtime, appName string) ([]string, error) {
 	//nolint:prealloc // as capacity is unknown and depends on runtime.ListPods response
 	var podsToSkip []string
@@ -152,7 +156,13 @@ func existingRunningPods(ctx context.Context, runtime runtime.Runtime, appName s
 	for _, pod := range pods {
 		logger.InfofCtx(ctx, "Existing pod found: %s with status: %s\n", pod.Name, pod.Status)
 		if pod.Status != "Running" {
-			return nil, fmt.Errorf("pod %q is in %q state — uninstall and re-run configure", pod.Name, pod.Status)
+			logger.WarningfCtx(ctx, "Pod %q is in %q state — deleting it so it can be redeployed\n", pod.Name, pod.Status)
+
+			if err := runtime.DeletePod(pod.ID, utils.BoolPtr(true)); err != nil {
+				return nil, fmt.Errorf("failed to delete non-running pod %q: %w", pod.Name, err)
+			}
+
+			continue
 		}
 		podsToSkip = append(podsToSkip, pod.Name)
 	}

--- a/ai-services/internal/pkg/cli/helpers/helper.go
+++ b/ai-services/internal/pkg/cli/helpers/helper.go
@@ -117,7 +117,7 @@ func ParseSkipChecks(skipChecks []string) map[string]bool {
 // CheckExistingResourcesForApplication checks if there are resources already existing for the given application name.
 func CheckExistingResourcesForApplication(ctx context.Context, runtime runtime.Runtime, appName string, secretNames []string) ([]string, error) {
 	// check existing pods for the application
-	podsToSkip, err := existingPods(ctx, runtime, appName)
+	podsToSkip, err := existingRunningPods(ctx, runtime, appName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check existing pods: %w", err)
 	}
@@ -133,7 +133,7 @@ func CheckExistingResourcesForApplication(ctx context.Context, runtime runtime.R
 	return resourcesToSkip, nil
 }
 
-func existingPods(ctx context.Context, runtime runtime.Runtime, appName string) ([]string, error) {
+func existingRunningPods(ctx context.Context, runtime runtime.Runtime, appName string) ([]string, error) {
 	//nolint:prealloc // as capacity is unknown and depends on runtime.ListPods response
 	var podsToSkip []string
 	pods, err := runtime.ListPods(map[string][]string{
@@ -151,6 +151,9 @@ func existingPods(ctx context.Context, runtime runtime.Runtime, appName string) 
 	logger.InfolnCtx(ctx, "Checking status of existing pods...")
 	for _, pod := range pods {
 		logger.InfofCtx(ctx, "Existing pod found: %s with status: %s\n", pod.Name, pod.Status)
+		if pod.Status != "Running" {
+			return nil, fmt.Errorf("pod %q is in %q state — uninstall and re-run configure", pod.Name, pod.Status)
+		}
 		podsToSkip = append(podsToSkip, pod.Name)
 	}
 


### PR DESCRIPTION
#### Issue:

If ai-services catalog configure --runtime podman is run without logging into the registry, the catalog pod fails to pull the image and remains in the Created state.
After logging in and re-running catalog configure, the CLI reports:
`✔ Catalog service already deployed`
even though the catalog pod is not running

#### Expected behavior:
It should verify that the catalog pod is Running, not just that it exists.
If the pod is in Created (or any non-running) state, treat the deployment as incomplete and redeploy.