### PR TITLE
Propagate error status code in non-stream

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.169
+TAG?=v0.0.170
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services/chatbot-service:v0.0.21
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.23
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services/chatbot-service:v0.0.21
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.23
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services/chatbot-service:v0.0.21
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.23
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   # @hidden
-  image: icr.io/ai-services/chatbot-service:v0.0.21
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.23
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -8,7 +8,7 @@ backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
   port: "0"
   # @hidden
-  image: icr.io/ai-services/chatbot-service:v0.0.21
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.23
   # @hidden
   log_level: "INFO"
   # @description Custom initial system prompt for conversational RAG. Leave empty to use default. Must be at least 10 characters.

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.169
+  image: icr.io/ai-services-cicd/ai-services:v0.0.170
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/chat/podman/values.yaml
+++ b/ai-services/assets/services/chat/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.22
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.23
   log_level: "INFO"
   chatbot:
     searchMode: "hybrid"

--- a/services/chatbot/Makefile
+++ b/services/chatbot/Makefile
@@ -1,5 +1,5 @@
 IMAGE=chatbot-service
-TAG?=v0.0.22
+TAG?=v0.0.23
 
 run:
 	PORT=$${PORT:-5000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/chatbot/app.py
+++ b/services/chatbot/app.py
@@ -636,11 +636,7 @@ async def chat_completion(req: ChatCompletionRequest, credentials: Optional[HTTP
                 return response_data
 
             APIError.raise_error(ErrorCode.LLM_ERROR, "Unexpected response format from LLM")
-        except HTTPException:
-            # Re-raise HTTPException to preserve status codes
-            raise
         except requests.exceptions.HTTPError as e:
-            # Propagate upstream 4xx/5xx status codes (vLLM/LiteLLM) back to the caller
             status_code = e.response.status_code if e.response is not None else 502
             logger.error(f"Error in non-streaming response: {e}", exc_info=True)
             raise HTTPException(
@@ -654,11 +650,16 @@ async def chat_completion(req: ChatCompletionRequest, credentials: Optional[HTTP
                 },
             )
         except Exception as e:
-            # For non-streaming requests, return error in chat response format
-            error_message = f"Error: {str(e)}"
-            logger.error(f"Error in non-streaming response: {error_message}", exc_info=True)
-            return ChatCompletionResponse(
-                choices=[ChatChoice(message=ChatMessage(content=error_message))]
+            logger.error(f"Error in non-streaming response: {e}", exc_info=True)
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "error": {
+                        "code": ErrorCode.LLM_ERROR.value,
+                        "message": str(e),
+                        "status": 500,
+                    }
+                },
             )
         finally:
             # Release semaphore for non-streaming requests

--- a/services/chatbot/app.py
+++ b/services/chatbot/app.py
@@ -8,6 +8,7 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.responses import StreamingResponse, Response
 import json
+import requests
 from contextlib import asynccontextmanager
 from asyncio import BoundedSemaphore
 from functools import wraps
@@ -637,6 +638,20 @@ async def chat_completion(req: ChatCompletionRequest, credentials: Optional[HTTP
         except HTTPException:
             # Re-raise HTTPException to preserve status codes
             raise
+        except requests.exceptions.HTTPError as e:
+            # Propagate upstream 4xx/5xx status codes (vLLM/LiteLLM) back to the caller
+            status_code = e.response.status_code if e.response is not None else 502
+            logging.error(f"Error in non-streaming response: {e}", exc_info=True)
+            raise HTTPException(
+                status_code=status_code,
+                detail={
+                    "error": {
+                        "code": ErrorCode.LLM_ERROR.value,
+                        "message": f"Upstream service error: {e}",
+                        "status": status_code,
+                    }
+                },
+            )
         except Exception as e:
             # For non-streaming requests, return error in chat response format
             error_message = f"Error: {str(e)}"

--- a/services/chatbot/app.py
+++ b/services/chatbot/app.py
@@ -16,7 +16,7 @@ import uvicorn
 from starlette.concurrency import iterate_in_threadpool
 from lingua import Language
 
-from common.misc_utils import set_log_level
+from common.misc_utils import set_log_level, get_logger
 from common.lang_utils import detect_language, LanguageCodes, get_max_tokens_map
 
 from chatbot.settings import settings
@@ -24,6 +24,7 @@ from chatbot.conversation_utils import get_conversation_context, truncate_histor
 from chatbot.query_rephrasing import rephrase_query_with_context
 
 set_log_level(settings.common.app.log_level)
+logger = get_logger("chatbot")
 
 from common.diagnostic_logger import setup_comprehensive_crash_handler
 import common.db_utils as db
@@ -87,9 +88,9 @@ async def ensure_vectorstore_initialized():
         async with vectorstore_lock:
             # Double-check pattern to avoid race conditions
             if vectorstore is None:
-                logging.info("Initializing vectorstore on first request...")
+                logger.info("Initializing vectorstore on first request...")
                 initialize_vectorstore()
-                logging.info("Vectorstore initialized successfully")
+                logger.info("Vectorstore initialized successfully")
 
 diagnostic_logger, stderr_monitor, signal_handler = setup_comprehensive_crash_handler(logging.getLogger("chatbot"))
 
@@ -213,7 +214,7 @@ async def is_auth_required() -> bool:
             # If successful, auth is not required
             auth_required_cache["checked"] = True
             auth_required_cache["required"] = False
-            logging.debug("vLLM authentication is NOT required")
+            logger.debug("vLLM authentication is NOT required")
             return False
         except Exception as e:
             # Check if it's an authentication error
@@ -222,10 +223,10 @@ async def is_auth_required() -> bool:
                 # Auth is required
                 auth_required_cache["checked"] = True
                 auth_required_cache["required"] = True
-                logging.debug("vLLM authentication IS required")
+                logger.debug("vLLM authentication IS required")
                 return True
             # For other errors, allow subsequent calls
-            logging.debug(f"Error checking auth requirement: {e}, assuming auth is required")
+            logger.debug(f"Error checking auth requirement: {e}, assuming auth is required")
             auth_required_cache["checked"] = True
             auth_required_cache["required"] = True
             return False
@@ -241,7 +242,7 @@ async def is_auth_required() -> bool:
 )
 async def list_models(credentials: Optional[HTTPAuthorizationCredentials] = Depends(security)):
     """List available LLM models. Requires Authorization header with Bearer token if authentication is enabled."""
-    logging.debug("List models..")
+    logger.debug("List models..")
 
     # Extract API key from credentials
     api_key = credentials.credentials if credentials else None
@@ -297,7 +298,7 @@ async def locked_stream(stream_g, perf_stat_dict):
         async for chunk in iterate_in_threadpool(stream_g):
             yield chunk
     except Exception as e:
-        logging.error(f"Error in streaming response: {str(e)}", exc_info=True)
+        logger.error(f"Error in streaming response: {str(e)}", exc_info=True)
         
         # Determine error status code
         status_code = 500  # Default to internal server error
@@ -474,16 +475,16 @@ async def chat_completion(req: ChatCompletionRequest, credentials: Optional[HTTP
         
         # Fallback to English if unsupported language detected
         if query_lang not in LanguageCodes.supported_languages():
-            logging.debug(
+            logger.debug(
                 f"Unsupported language detected ({query_lang}). "
                 "Falling back to English."
             )
             query_lang = LanguageCodes.ENGLISH
         
-        logging.debug(f"Detected language for current message: {query_lang}")
+        logger.debug(f"Detected language for current message: {query_lang}")
         
     except Exception as e:
-        logging.warning(
+        logger.warning(
             f"Language detection failed: {e}. "
             "Falling back to English."
         )
@@ -641,7 +642,7 @@ async def chat_completion(req: ChatCompletionRequest, credentials: Optional[HTTP
         except requests.exceptions.HTTPError as e:
             # Propagate upstream 4xx/5xx status codes (vLLM/LiteLLM) back to the caller
             status_code = e.response.status_code if e.response is not None else 502
-            logging.error(f"Error in non-streaming response: {e}", exc_info=True)
+            logger.error(f"Error in non-streaming response: {e}", exc_info=True)
             raise HTTPException(
                 status_code=status_code,
                 detail={
@@ -655,7 +656,7 @@ async def chat_completion(req: ChatCompletionRequest, credentials: Optional[HTTP
         except Exception as e:
             # For non-streaming requests, return error in chat response format
             error_message = f"Error: {str(e)}"
-            logging.error(f"Error in non-streaming response: {error_message}", exc_info=True)
+            logger.error(f"Error in non-streaming response: {error_message}", exc_info=True)
             return ChatCompletionResponse(
                 choices=[ChatChoice(message=ChatMessage(content=error_message))]
             )

--- a/services/common/misc_utils.py
+++ b/services/common/misc_utils.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 import os
+import sys
 import shutil
 from pathlib import Path
 
@@ -137,7 +138,7 @@ def get_logger(name):
         # Add the filter to inject request_id
         logger.addFilter(RequestIDFilter())
 
-        console_handler = logging.StreamHandler()
+        console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setLevel(LOG_LEVEL)
 
         # Use custom formatter that conditionally includes request_id


### PR DESCRIPTION
-Earlier, in case of 4xx/5xx exceptions, chatbot would return the exception wrapped in a 200 (non-stream only)
-Enhanced to raise HTTPError as is for non-stream cases
-Fixed utility to use right logger and redirect to sys out (earlier used root logger)

<img width="1462" height="799" alt="Screenshot 2026-07-08 at 08 57 23" src="https://github.com/user-attachments/assets/e1713ab7-8126-402d-8c85-2fa79bf4cc8c" />

<img width="1722" height="824" alt="image" src="https://github.com/user-attachments/assets/c60e523f-a2e8-4945-bd24-fcfd9fddcdb8" />
