### PR TITLE
fix: cancel in-progress runs for pull_request events

### DIFF
--- a/.github/workflows/ai-services-image.yml
+++ b/.github/workflows/ai-services-image.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   ICR_REGISTRY: icr.io

--- a/.github/workflows/bump-makefile-version.yml
+++ b/.github/workflows/bump-makefile-version.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   check-version-bump:

--- a/.github/workflows/caddy-image.yml
+++ b/.github/workflows/caddy-image.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   ICR_REGISTRY: icr.io

--- a/.github/workflows/catalog-ui-image.yml
+++ b/.github/workflows/catalog-ui-image.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   ICR_REGISTRY: icr.io

--- a/.github/workflows/chatbot-service-image.yml
+++ b/.github/workflows/chatbot-service-image.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-publish-image:

--- a/.github/workflows/chatbot-ui.yml
+++ b/.github/workflows/chatbot-ui.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   ICR_REGISTRY: icr.io

--- a/.github/workflows/check-image-names.yml
+++ b/.github/workflows/check-image-names.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   check:

--- a/.github/workflows/digitize-service.yml
+++ b/.github/workflows/digitize-service.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-publish-image:

--- a/.github/workflows/digitize-ui-image.yml
+++ b/.github/workflows/digitize-ui-image.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   ICR_REGISTRY: icr.io

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/image-scanner.yml
+++ b/.github/workflows/image-scanner.yml
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   scan:

--- a/.github/workflows/litellm-image.yml
+++ b/.github/workflows/litellm-image.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   ICR_REGISTRY: icr.io

--- a/.github/workflows/postgres-image.yml
+++ b/.github/workflows/postgres-image.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   ICR_REGISTRY: icr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/service-base.yml
+++ b/.github/workflows/service-base.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   ICR_REGISTRY: icr.io

--- a/.github/workflows/service-unit-tests.yml
+++ b/.github/workflows/service-unit-tests.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:

--- a/.github/workflows/similarity-service-image.yml
+++ b/.github/workflows/similarity-service-image.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-publish-image:

--- a/.github/workflows/summarize-service-image.yml
+++ b/.github/workflows/summarize-service-image.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-publish-image:

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   ICR_REGISTRY: icr.io


### PR DESCRIPTION
## Summary

Added checks for cancelling in-progress runs only for pull requests and not for push to branches or tags.

## Behaviour

Trigger | github.ref value | cancel-in-progress | Effect
-- | -- | -- | --
pull_request | refs/pull/<PR_NUMBER>/merge | true | Redundant pushes to a PR branch cancel the previous run for that PR only
push to main | refs/heads/main | false  | Every run completes, every version's image gets pushed
push tag (v*) | refs/tags/v1.2.3 | false | Release build always completes
schedule | (image scanner) | false | Scheduled scans never cancelled