### PR TITLE
bump setup-python to v6

### DIFF
--- a/.github/workflows/bump-makefile-version.yml
+++ b/.github/workflows/bump-makefile-version.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 


### PR DESCRIPTION

Check Makefile Version Bumps is throwing deprecation warning:

```Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/setup-python@v5. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/```

Updated [actions/setup-python@v5](vscode-webview://1oib9tqi8enmnn6jcmf486g15431kt819glrjb0m77i9s6s82c5o/.github/workflows/bump-makefile-version.yml:36) → actions/setup-python@v6. The v6 major release (v6.3.0 latest) migrated the action runtime to Node.js 24, which eliminates the deprecation warning.
