### PR TITLE
fix: use caddy subroutes to avoid hot reloads

### DIFF
--- a/ai-services/assets/catalog/podman/Caddyfile.tmpl
+++ b/ai-services/assets/catalog/podman/Caddyfile.tmpl
@@ -1,19 +1,26 @@
 {
 	admin 0.0.0.0:2019
 
-	servers :443 {
-		name {{ .CaddyServerName }}
-	}
+    servers :443 {
+        name {{ .CaddyServerName }}
+    }
+
+    # 1. Enable On-Demand TLS globally and point it to your local health check
+    on_demand_tls {
+        ask http://127.0.0.1:8080/health
+    }
 }
 
 :443 {
-	# 1. This initializes the routes array natively so it's never empty
-	handle /internal/health {
+    handle /internal/health {
         # @id internal-health
         respond "OK" 200
     }
 
-	tls internal
+    # 2. Tell the internal CA to generate certs when requested
+    tls internal {
+        on_demand
+    }
 }
 
 # Internal health check endpoint (Bypasses automatic HTTPS redirection)

--- a/ai-services/assets/catalog/podman/Caddyfile.tmpl
+++ b/ai-services/assets/catalog/podman/Caddyfile.tmpl
@@ -1,13 +1,16 @@
 {
-	admin 0.0.0.0:2019
+    admin 0.0.0.0:2019
 
     servers :443 {
         name {{ .CaddyServerName }}
     }
 
-    # 1. Enable On-Demand TLS globally and point it to your local health check
+    # Enable On-Demand TLS globally.
+    # Before issuing a certificate for any hostname Caddy calls the ask endpoint;
+    # 2xx = allow, non-2xx = deny. /tls/ask validates the requested domain query
+    # parameter against registered routes so certs are only issued for known hosts.
     on_demand_tls {
-        ask http://127.0.0.1:8080/health
+        ask {{ .CatalogBackendURL }}/tls/ask
     }
 }
 
@@ -17,13 +20,13 @@
         respond "OK" 200
     }
 
-    # 2. Tell the internal CA to generate certs when requested
+    # Tell the internal CA to generate certs on demand
     tls internal {
         on_demand
     }
 }
 
-# Internal health check endpoint (Bypasses automatic HTTPS redirection)
+# Internal endpoints (bypass automatic HTTPS redirection)
 :8080 {
     respond /health "OK" 200
 }

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -17,6 +17,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/proxy"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/spf13/cobra"
 )
@@ -119,12 +120,21 @@ func runAPIServer(port int, accessTTL, refreshTTL time.Duration, adminUser, admi
 	tokenMgr := auth.NewTokenManager(secretKey, accessTTL, refreshTTL)
 	authSvc := auth.NewAuthService(userRepo, tokenMgr, blacklist)
 
+	// ProxyManager is used by the /tls/ask endpoint to validate domains before cert issuance.
+	// If Caddy is not configured, the endpoint fails open so the server still starts cleanly.
+	proxyManager, err := proxy.GetCaddyProxyManager()
+	if err != nil {
+		logger.DebuglnCtx(ctx, fmt.Sprintf("Caddy proxy manager not available, /tls/ask will fail open: %v", err))
+		proxyManager = nil
+	}
+
 	return apiserver.NewAPIserver(apiserver.APIServerOptions{
 		Port:               port,
 		AuthService:        authSvc,
 		TokenManager:       tokenMgr,
 		Blacklist:          blacklist,
 		ApplicationService: applicationService,
+		ProxyManager:       proxyManager,
 	}).Start()
 }
 

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -126,6 +126,8 @@ func runAPIServer(port int, accessTTL, refreshTTL time.Duration, adminUser, admi
 	if err != nil {
 		logger.DebuglnCtx(ctx, fmt.Sprintf("Caddy proxy manager not available, /tls/ask will fail open: %v", err))
 		proxyManager = nil
+	} else if err := proxyManager.EnsureSubroute(ctx); err != nil {
+		return fmt.Errorf("failed to seed caddy subroute container: %w", err)
 	}
 
 	return apiserver.NewAPIserver(apiserver.APIServerOptions{

--- a/ai-services/internal/pkg/catalog/apiserver/apiserver.go
+++ b/ai-services/internal/pkg/catalog/apiserver/apiserver.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
+	"github.com/project-ai-services/ai-services/internal/pkg/proxy"
 )
 
 // APIServerOptions defines the configuration options for the API server such as the port to listen
@@ -46,6 +47,7 @@ type APIServerOptions struct {
 	TokenManager       *auth.TokenManager
 	Blacklist          repository.TokenBlacklist
 	ApplicationService *repository.ApplicationService
+	ProxyManager       proxy.ProxyManager
 }
 
 // APIserver represents the API server instance, holding the configuration and authentication provider.
@@ -55,6 +57,7 @@ type APIserver struct {
 	tokenManager       *auth.TokenManager
 	blacklist          repository.TokenBlacklist
 	applicationService *repository.ApplicationService
+	proxyManager       proxy.ProxyManager
 }
 
 // NewAPIserver creates a new instance of the API server with the provided options, setting default values where necessary.
@@ -70,13 +73,14 @@ func NewAPIserver(options APIServerOptions) *APIserver {
 		tokenManager:       options.TokenManager,
 		blacklist:          options.Blacklist,
 		applicationService: options.ApplicationService,
+		proxyManager:       options.ProxyManager,
 	}
 }
 
 // Start initializes the API server and begins listening for incoming requests on the configured port.
 // It sets up the router with authentication middleware and routes.
 func (a *APIserver) Start() error {
-	r := CreateRouter(a.authService, a.tokenManager, a.blacklist, a.applicationService)
+	r := CreateRouter(a.authService, a.tokenManager, a.blacklist, a.applicationService, a.proxyManager)
 
 	return r.Run(fmt.Sprintf(":%d", a.port))
 }

--- a/ai-services/internal/pkg/catalog/apiserver/router.go
+++ b/ai-services/internal/pkg/catalog/apiserver/router.go
@@ -10,12 +10,13 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/middleware"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
+	"github.com/project-ai-services/ai-services/internal/pkg/proxy"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 )
 
 // CreateRouter sets up the Gin router with the necessary routes and authentication middleware for the API server.
-func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist repository.TokenBlacklist, appService *repository.ApplicationService) *gin.Engine {
+func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist repository.TokenBlacklist, appService *repository.ApplicationService, proxyManager proxy.ProxyManager) *gin.Engine {
 	if mode := os.Getenv("GIN_MODE"); mode != "" {
 		gin.SetMode(mode)
 	}
@@ -32,6 +33,35 @@ func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist r
 	// Expose /health for liveness probes
 	router.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "ok"})
+	})
+
+	// TLS ask endpoint — called by Caddy's on_demand_tls before issuing a certificate.
+	// Validates the requested domain against registered routes; returns 200 to allow or
+	// 403 to deny. If no proxy manager is configured, fails open (200) to avoid blocking
+	// legitimate cert issuance during startup.
+	router.GET("/tls/ask", func(c *gin.Context) {
+		domain := c.Query("domain")
+		if domain == "" || proxyManager == nil {
+			c.Status(http.StatusOK)
+			return
+		}
+
+		// Route IDs are the subdomain portion (the part before the first dot).
+		// GetRouteByID returns an error if the route is not registered in Caddy.
+		routeID := domain
+		for i, ch := range domain {
+			if ch == '.' {
+				routeID = domain[:i]
+				break
+			}
+		}
+
+		if _, err := proxyManager.GetRouteByID(routeID); err != nil {
+			c.Status(http.StatusForbidden)
+			return
+		}
+
+		c.Status(http.StatusOK)
 	})
 
 	// Swagger documentation endpoint

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
@@ -107,9 +107,12 @@ func GenerateCaddyfile(baseDir string) error {
 		return fmt.Errorf("failed to parse Caddyfile template: %w", err)
 	}
 
-	// Prepare template data with the server name constant
+	// Prepare template data with the server name constant and catalog backend URL.
+	// The ask endpoint lives in the catalog backend pod, not in the Caddy pod, so
+	// 127.0.0.1 would not reach it — use the pod DNS name instead.
 	templateData := map[string]any{
-		"CaddyServerName": constants.CaddyServerName,
+		"CaddyServerName":    constants.CaddyServerName,
+		"CatalogBackendURL": fmt.Sprintf("http://%s--catalog:8080", catalogconstants.CatalogAppName),
 	}
 
 	// Execute the template

--- a/ai-services/internal/pkg/constants/common.go
+++ b/ai-services/internal/pkg/constants/common.go
@@ -3,18 +3,18 @@ package constants
 import "time"
 
 const (
-	AIServices           = "ai-services"
-	PodStartOn           = "on"
-	PodStartOff          = "off"
-	OperatorPollInterval = 5 * time.Second
-	OperatorPollTimeout  = 3 * time.Minute
-	VersionV2            = "v2"
-	DSCKind              = "DataScienceCluster"
-	DSCIKind             = "DSCInitialization"
-	SMTLevel             = 2
-	ErrSecretNotFound    = "no secret with name or id"
-	CaddyServerName          = "ai_services"      // Caddy server name used for route registration
-	CaddySubrouteHandlerID   = "app-routes-handler" // Stable @id of the subroute handler that owns all dynamic routes
+	AIServices             = "ai-services"
+	PodStartOn             = "on"
+	PodStartOff            = "off"
+	OperatorPollInterval   = 5 * time.Second
+	OperatorPollTimeout    = 3 * time.Minute
+	VersionV2              = "v2"
+	DSCKind                = "DataScienceCluster"
+	DSCIKind               = "DSCInitialization"
+	SMTLevel               = 2
+	ErrSecretNotFound      = "no secret with name or id"
+	CaddyServerName        = "ai_services"        // Caddy server name used for route registration
+	CaddySubrouteHandlerID = "app-routes-handler" // Stable @id of the subroute handler that owns all dynamic routes
 )
 
 const (

--- a/ai-services/internal/pkg/constants/common.go
+++ b/ai-services/internal/pkg/constants/common.go
@@ -13,7 +13,8 @@ const (
 	DSCIKind             = "DSCInitialization"
 	SMTLevel             = 2
 	ErrSecretNotFound    = "no secret with name or id"
-	CaddyServerName      = "ai_services" // Caddy server name used for route registration
+	CaddyServerName          = "ai_services"      // Caddy server name used for route registration
+	CaddySubrouteHandlerID   = "app-routes-handler" // Stable @id of the subroute handler that owns all dynamic routes
 )
 
 const (

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -113,9 +113,68 @@ func (c *caddyManager) RegisterRoute(ctx context.Context, route Route) error {
 	return c.createRoute(routeConfig)
 }
 
-// Helper to append a new route to the server's route array.
+// ensureSubroute guarantees the persistent subroute container exists in Caddy's live config.
+// It uses GET /id/app-routes-handler to check; if absent it creates the outer catch-all route
+// via a single POST to the top-level routes array (one reload, tolerated at first-use time).
+// On every subsequent call the GET returns 200 and the function is a no-op.
+func (c *caddyManager) ensureSubroute() error {
+	checkURL, err := url.JoinPath(c.adminURL, "id", constants.CaddySubrouteHandlerID)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.httpClient.R().Get(checkURL)
+	if err != nil {
+		return fmt.Errorf("failed to check subroute existence: %w", err)
+	}
+
+	if resp.StatusCode() == http.StatusOK {
+		// Already present — nothing to do.
+		return nil
+	}
+
+	// Subroute is absent; seed it via a single top-level POST.
+	// @id tags are JSON-only: Caddyfile has no syntax for them, so we create
+	// the subroute container here through the Admin API instead of the Caddyfile.
+	outerRoute := map[string]any{
+		"@id": "app-routes",
+		"handle": []map[string]any{{
+			"handler": "subroute",
+			"@id":     constants.CaddySubrouteHandlerID,
+			"routes":  []any{},
+		}},
+		"terminal": false,
+	}
+
+	topLevelURL, err := url.JoinPath(c.adminURL, "config", "apps", "http", "servers", c.serverName, "routes")
+	if err != nil {
+		return err
+	}
+
+	createResp, err := c.httpClient.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(outerRoute).
+		Post(topLevelURL)
+	if err != nil {
+		return fmt.Errorf("failed to seed subroute container: %w", err)
+	}
+
+	if createResp.StatusCode() != http.StatusOK && createResp.StatusCode() != http.StatusCreated {
+		return fmt.Errorf("caddy returned status %d seeding subroute: %s", createResp.StatusCode(), createResp.String())
+	}
+
+	return nil
+}
+
+// createRoute appends a route into the persistent subroute handler's inner routes array.
+// Posting to /id/<subrouteHandlerID>/routes mutates a handler's sub-config, which Caddy
+// applies in-place without a config reload — no connections are dropped on route add/remove.
 func (c *caddyManager) createRoute(routeConfig map[string]any) error {
-	routeURL, err := url.JoinPath(c.adminURL, "config", "apps", "http", "servers", c.serverName, "routes")
+	if err := c.ensureSubroute(); err != nil {
+		return fmt.Errorf("failed to ensure subroute container: %w", err)
+	}
+
+	routeURL, err := url.JoinPath(c.adminURL, "id", constants.CaddySubrouteHandlerID, "routes")
 	if err != nil {
 		return err
 	}
@@ -127,6 +186,7 @@ func (c *caddyManager) createRoute(routeConfig map[string]any) error {
 	if err != nil {
 		return fmt.Errorf("failed to create route: %w", err)
 	}
+
 	if resp.StatusCode() != http.StatusOK && resp.StatusCode() != http.StatusCreated {
 		return fmt.Errorf("caddy returned status %d on creation: %s", resp.StatusCode(), resp.String())
 	}

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -21,11 +20,9 @@ var ErrRouteNotFound = errors.New("route not found")
 
 // caddyManager implements ProxyManager interface for Caddy.
 type caddyManager struct {
-	httpClient      *resty.Client
-	adminURL        string
-	serverName      string
-	subrouteOnce    sync.Once
-	subrouteOnceErr error
+	httpClient *resty.Client
+	adminURL   string
+	serverName string
 }
 
 const (
@@ -79,19 +76,11 @@ func (c *caddyManager) HealthCheck() error {
 	return nil
 }
 
-// RegisterRoute registers a route with Caddy. It ensures the subroute container exists
-// before attempting to create the route — so this method is safe to call directly without
-// going through RegisterRoutesForAppAndReturn.
+// RegisterRoute registers a route with Caddy.
+// EnsureSubroute must have been called once at startup before invoking this method.
 func (c *caddyManager) RegisterRoute(ctx context.Context, route Route) error {
 	if route.ID == "" {
 		return fmt.Errorf("cannot register route: route ID is empty")
-	}
-
-	// Ensure the subroute container exists before the first route is added.
-	// sync.Once guarantees exactly one attempt regardless of concurrent callers;
-	// the outcome (including any error) is cached for all subsequent calls.
-	if err := c.ensureSubroute(); err != nil {
-		return fmt.Errorf("failed to ensure subroute container: %w", err)
 	}
 
 	routeConfig := map[string]any{
@@ -126,24 +115,11 @@ func (c *caddyManager) RegisterRoute(ctx context.Context, route Route) error {
 	return c.createRoute(routeConfig)
 }
 
-// ensureSubroute guarantees the persistent subroute container exists in Caddy's live config.
-// sync.Once ensures seedSubroute runs at most once per caddyManager instance, eliminating
-// the race condition when multiple goroutines register routes concurrently. The outcome
-// (success or error) is cached so all subsequent calls are pure no-ops.
-func (c *caddyManager) ensureSubroute() error {
-	c.subrouteOnce.Do(func() {
-		c.subrouteOnceErr = c.seedSubroute()
-	})
-
-	return c.subrouteOnceErr
-}
-
-// seedSubroute performs the actual one-time check-and-create of the subroute container.
-// It checks via GET /id/app-routes-handler; if absent it seeds the outer catch-all route
-// containing the subroute handler via a single top-level POST (one reload, first-use only).
-// On every subsequent call the GET returns 200 and the function is a no-op.
-// Called exactly once by ensureSubroute via sync.Once.
-func (c *caddyManager) seedSubroute() error {
+// EnsureSubroute checks whether the persistent subroute container already exists in
+// Caddy's live config and creates it if absent. It must be called once at startup
+// (after HealthCheck) before any RegisterRoute calls; doing it here instead of lazily
+// inside RegisterRoute removes the need for sync.Once and surfaces errors early.
+func (c *caddyManager) EnsureSubroute(_ context.Context) error {
 	checkURL, err := url.JoinPath(c.adminURL, "id", constants.CaddySubrouteHandlerID)
 	if err != nil {
 		return err
@@ -307,7 +283,6 @@ func (c *caddyManager) UnregisterRoute(routeID string) error {
 // RegisterRoutesForAppAndReturn registers routes for an application with Caddy proxy and returns the built routes.
 //
 // Parameters:
-//   - rt: Runtime interface for interacting with pods
 //   - appName: Name of the application (e.g., "ai-services" for catalog)
 //   - proxyManager: ProxyManager instance for route operations (reuse to avoid creating multiple instances)
 //   - routesAnnotation: Routes annotation value in format "port:subdomain,port:subdomain,..."
@@ -340,7 +315,7 @@ func RegisterRoutesForAppAndReturn(
 	}
 
 	// Step 3: Register each route with Caddy.
-	// ensureSubroute is called inside RegisterRoute on the first invocation.
+	// EnsureSubroute must have been called once at startup before reaching this point.
 	var registrationErrors []error
 	for _, route := range routes {
 		if err := proxyManager.RegisterRoute(ctx, route); err != nil {

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -134,7 +134,7 @@ func (c *caddyManager) ensureSubroute() error {
 	}
 
 	// Subroute is absent; seed it via a single top-level POST.
-	// @id tags are JSON-only: Caddyfile has no syntax for them, so we create
+	//	@id	tags are JSON-only: Caddyfile has no syntax for them, so we create
 	// the subroute container here through the Admin API instead of the Caddyfile.
 	outerRoute := map[string]any{
 		"@id": "app-routes",

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -20,9 +21,11 @@ var ErrRouteNotFound = errors.New("route not found")
 
 // caddyManager implements ProxyManager interface for Caddy.
 type caddyManager struct {
-	httpClient *resty.Client
-	adminURL   string
-	serverName string
+	httpClient      *resty.Client
+	adminURL        string
+	serverName      string
+	subrouteOnce    sync.Once
+	subrouteOnceErr error
 }
 
 const (
@@ -76,9 +79,19 @@ func (c *caddyManager) HealthCheck() error {
 	return nil
 }
 
+// RegisterRoute registers a route with Caddy. It ensures the subroute container exists
+// before attempting to create the route — so this method is safe to call directly without
+// going through RegisterRoutesForAppAndReturn.
 func (c *caddyManager) RegisterRoute(ctx context.Context, route Route) error {
 	if route.ID == "" {
 		return fmt.Errorf("cannot register route: route ID is empty")
+	}
+
+	// Ensure the subroute container exists before the first route is added.
+	// sync.Once guarantees exactly one attempt regardless of concurrent callers;
+	// the outcome (including any error) is cached for all subsequent calls.
+	if err := c.ensureSubroute(); err != nil {
+		return fmt.Errorf("failed to ensure subroute container: %w", err)
 	}
 
 	routeConfig := map[string]any{
@@ -114,10 +127,23 @@ func (c *caddyManager) RegisterRoute(ctx context.Context, route Route) error {
 }
 
 // ensureSubroute guarantees the persistent subroute container exists in Caddy's live config.
+// sync.Once ensures seedSubroute runs at most once per caddyManager instance, eliminating
+// the race condition when multiple goroutines register routes concurrently. The outcome
+// (success or error) is cached so all subsequent calls are pure no-ops.
+func (c *caddyManager) ensureSubroute() error {
+	c.subrouteOnce.Do(func() {
+		c.subrouteOnceErr = c.seedSubroute()
+	})
+
+	return c.subrouteOnceErr
+}
+
+// seedSubroute performs the actual one-time check-and-create of the subroute container.
 // It checks via GET /id/app-routes-handler; if absent it seeds the outer catch-all route
 // containing the subroute handler via a single top-level POST (one reload, first-use only).
 // On every subsequent call the GET returns 200 and the function is a no-op.
-func (c *caddyManager) ensureSubroute() error {
+// Called exactly once by ensureSubroute via sync.Once.
+func (c *caddyManager) seedSubroute() error {
 	checkURL, err := url.JoinPath(c.adminURL, "id", constants.CaddySubrouteHandlerID)
 	if err != nil {
 		return err
@@ -134,7 +160,7 @@ func (c *caddyManager) ensureSubroute() error {
 	}
 
 	// Subroute is absent; seed it via a single top-level POST.
-	//	@id	tags are JSON-only: Caddyfile has no syntax for them, so we create
+	// @id tags are JSON-only: Caddyfile has no syntax for them, so we create
 	// the subroute container here through the Admin API instead of the Caddyfile.
 	outerRoute := map[string]any{
 		"@id": "app-routes",
@@ -169,7 +195,6 @@ func (c *caddyManager) ensureSubroute() error {
 // createRoute appends a route into the persistent subroute handler's inner routes array.
 // Posting to /id/<subrouteHandlerID>/routes mutates a handler's sub-config, which Caddy
 // applies in-place without a config reload — no connections are dropped on route add/remove.
-// ensureSubroute must be called once before the first createRoute call in a batch.
 func (c *caddyManager) createRoute(routeConfig map[string]any) error {
 	routeURL, err := url.JoinPath(c.adminURL, "id", constants.CaddySubrouteHandlerID, "routes")
 	if err != nil {
@@ -314,14 +339,8 @@ func RegisterRoutesForAppAndReturn(
 		return nil, fmt.Errorf("failed to build routes: %w", err)
 	}
 
-	// Step 3: Ensure the subroute container exists exactly once before registering any routes.
-	if cm, ok := proxyManager.(*caddyManager); ok {
-		if err := cm.ensureSubroute(); err != nil {
-			return nil, fmt.Errorf("failed to ensure subroute container: %w", err)
-		}
-	}
-
-	// Step 4: Register each route with Caddy
+	// Step 3: Register each route with Caddy.
+	// ensureSubroute is called inside RegisterRoute on the first invocation.
 	var registrationErrors []error
 	for _, route := range routes {
 		if err := proxyManager.RegisterRoute(ctx, route); err != nil {

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -114,8 +114,8 @@ func (c *caddyManager) RegisterRoute(ctx context.Context, route Route) error {
 }
 
 // ensureSubroute guarantees the persistent subroute container exists in Caddy's live config.
-// It uses GET /id/app-routes-handler to check; if absent it creates the outer catch-all route
-// via a single POST to the top-level routes array (one reload, tolerated at first-use time).
+// It checks via GET /id/app-routes-handler; if absent it seeds the outer catch-all route
+// containing the subroute handler via a single top-level POST (one reload, first-use only).
 // On every subsequent call the GET returns 200 and the function is a no-op.
 func (c *caddyManager) ensureSubroute() error {
 	checkURL, err := url.JoinPath(c.adminURL, "id", constants.CaddySubrouteHandlerID)
@@ -169,11 +169,8 @@ func (c *caddyManager) ensureSubroute() error {
 // createRoute appends a route into the persistent subroute handler's inner routes array.
 // Posting to /id/<subrouteHandlerID>/routes mutates a handler's sub-config, which Caddy
 // applies in-place without a config reload — no connections are dropped on route add/remove.
+// ensureSubroute must be called once before the first createRoute call in a batch.
 func (c *caddyManager) createRoute(routeConfig map[string]any) error {
-	if err := c.ensureSubroute(); err != nil {
-		return fmt.Errorf("failed to ensure subroute container: %w", err)
-	}
-
 	routeURL, err := url.JoinPath(c.adminURL, "id", constants.CaddySubrouteHandlerID, "routes")
 	if err != nil {
 		return err
@@ -317,7 +314,14 @@ func RegisterRoutesForAppAndReturn(
 		return nil, fmt.Errorf("failed to build routes: %w", err)
 	}
 
-	// Step 3: Register each route with Caddy
+	// Step 3: Ensure the subroute container exists exactly once before registering any routes.
+	if cm, ok := proxyManager.(*caddyManager); ok {
+		if err := cm.ensureSubroute(); err != nil {
+			return nil, fmt.Errorf("failed to ensure subroute container: %w", err)
+		}
+	}
+
+	// Step 4: Register each route with Caddy
 	var registrationErrors []error
 	for _, route := range routes {
 		if err := proxyManager.RegisterRoute(ctx, route); err != nil {

--- a/ai-services/internal/pkg/proxy/types.go
+++ b/ai-services/internal/pkg/proxy/types.go
@@ -4,6 +4,10 @@ import "context"
 
 // ProxyManager defines the interface for managing reverse proxy routes.
 type ProxyManager interface {
+	// EnsureSubroute creates the subroute container in Caddy's live config if it does
+	// not already exist. Must be called once at startup before any RegisterRoute calls.
+	EnsureSubroute(ctx context.Context) error
+
 	// RegisterRoute registers a new route with the proxy
 	RegisterRoute(ctx context.Context, route Route) error
 


### PR DESCRIPTION
#### Summary
Optimizes proxy routing performance by eliminating Caddy hot-reloads during route changes and migrating certificate provisioning to a native, on-the-fly approach.

#### Changes
Zero-Reload Subroutes (Commit 1): Moved route operations to the subroute handler's inner array (`/id/app-routes-handler/routes`). This changes route updates into in-memory mutations, eliminating the 1-2s connection drops and intermittent 500 errors during app deletion.
On-Demand TLS (Commit 2): Solves the `ERR_SSL_PROTOCOL_ERROR` introduced by the subroute change. Because in-memory mutations bypass the engine reload, Caddy stopped eagerly generating certificates for new domains. Moving to native `on_demand `TLS inside the Caddyfile ensures certificates are generated instantly (under 10ms) on the first client request.

#### Impact
Zero downtime during application creation or deletion.

#### Testing
Able to access endpoints

Tested: remove the retries workaround and test if we still see any transient 500 errors during route registration/unregistration, there should not be any caddy downtime.
<img width="2888" height="1704" alt="image" src="https://github.com/user-attachments/assets/15500bbf-6851-4897-8bb1-52df5ddab068" />
