### PR TITLE
De-duplication support for Digitize

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.199
+TAG?=v0.0.200
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.34
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.35
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
@@ -28,7 +28,7 @@ digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.28
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.29
 
 ingest:
   # @hidden

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.34
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.35
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
@@ -34,7 +34,7 @@ digitize:
 
 digitizeUi:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.28
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.29
 
 instruct:
   # @description API key for vLLM instruct service authentication. If empty, authentication is disabled. Provide a key to enable authentication.

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.34
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.35
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
@@ -28,7 +28,7 @@ digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.28
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.29
 
 ingest:
   # @hidden

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.34
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.35
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
@@ -34,7 +34,7 @@ digitize:
 
 digitizeUi:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.28
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.29
 
 instruct:
   # @hidden

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.34
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.35
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
@@ -28,7 +28,7 @@ digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.28
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.29
 
 ingest:
   # @hidden

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.199
+  image: icr.io/ai-services-cicd/ai-services:v0.0.200
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,10 +1,10 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.34
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.35
   log_level: "INFO"
   database: "digitize_metadata"
 
 digitizeUi:
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.28
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.29
 
 postgres:
   image: icr.io/ai-services-cicd/postgres:18-4

--- a/docs/proposals/digitize-file-hash-dedup/file-hash-dedup-implementation.md
+++ b/docs/proposals/digitize-file-hash-dedup/file-hash-dedup-implementation.md
@@ -1,0 +1,1133 @@
+# File-Hash Duplicate Detection — Implementation Specification
+
+**Branch:** `dupIndex`
+**Scope:** Both `operation=ingestion` and `operation=digitization`.
+**Strategy:** Option B — lenient batch dedup. Strip already-existing files from a
+multi-file submission, process only novel files, and record skipped files directly in
+the job's document list with status `already_exists`.
+
+### Diagrams
+
+| Flowchart | Sequence |
+|---|---|
+| ![Decision flowchart](flowchart.svg) | ![Sequence diagram](sequence.svg) |
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [New `ALREADY_EXISTS` Document Status](#2-new-already_exists-document-status)
+3. [New `JobCreatedResponse` Shape](#3-new-jobcreatedresponse-shape)
+4. [Touch-point 1 — Hash utility (`services/common/misc_utils.py`)](#4-touch-point-1--hash-utility)
+5. [Touch-point 2 — DB schema: `file_checksum_registry` table](#5-touch-point-2--db-schema-file_checksum_registry-table)
+6. [Touch-point 3 — `DatabaseManager.find_completed_document_by_hash` and `upsert_file_checksum`](#6-touch-point-3--databasemanager-hash-methods)
+7. [Touch-point 4 — `create_job` API handler (Option B gate)](#7-touch-point-4--create_job-api-handler-option-b-gate)
+8. [Touch-point 5 — `initialize_job_state` (record already-exists docs)](#8-touch-point-5--initialize_job_state-record-already-exists-docs)
+9. [Touch-point 6 — `_run_ingest` and `ingest()` (pass checksum dict)](#9-touch-point-6--_run_ingest-and-ingest-pass-checksum-dict)
+10. [Touch-point 7 — `_run_digitize` and `digitize()` (pass checksum dict)](#10-touch-point-7--_run_digitize-and-digitize-pass-checksum-dict)
+11. [Touch-point 8 — `create_indexing_handler` (persist hash on completion)](#11-touch-point-8--create_indexing_handler-persist-hash-on-completion)
+12. [Touch-point 9 — `_categorize_fields` (route `file_hash` to metadata)](#12-touch-point-9--_categorize_fields-route-file_hash-to-metadata)
+13. [Touch-point 10 — `_update_document` (register checksum on COMPLETED)](#13-touch-point-10--_update_document-register-checksum-on-completed)
+14. [Touch-point 11 — Deletion clears checksum registry](#14-touch-point-11--deletion-clears-checksum-registry)
+15. [Touch-point 12 — `get_all_documents` excludes `ALREADY_EXISTS` docs](#15-touch-point-12--get_all_documents-excludes-already_exists-docs)
+16. [Data Flow Diagram](#16-data-flow-diagram)
+17. [Timing Impact](#17-timing-impact)
+18. [Pros and Cons](#18-pros-and-cons)
+19. [Edge Cases](#19-edge-cases)
+
+---
+
+## 1. Overview
+
+When a caller submits a batch of files, each file's SHA-256 is computed
+**asynchronously (`asyncio.to_thread`) from the already-in-memory bytes** (zero
+additional I/O) before any staging or pipeline work begins. The hash is looked up
+via the dedicated `file_checksum_registry` table in PostgreSQL (indexed PK read,
+~2 ms).
+
+This feature applies to **both** `operation=ingestion` and `operation=digitization`.
+A digitization request is additionally blocked if the same file content has already
+been successfully ingested — there is no point re-digitizing content that is already
+in the vector store.
+
+**Option B behaviour:**
+
+| Scenario | Result |
+|---|---|
+| All files are new | Normal `202 Accepted` — full pipeline runs |
+| Some files already exist | `202 Accepted` — novel files processed, already-existing files recorded as `ALREADY_EXISTS` in the same job (visible via `GET /v1/jobs/{job_id}`) |
+| All files already exist | `409 Conflict` — no job created, no pipeline launched |
+
+A file is considered to already exist only if a **previous document** exists with:
+- `type = operation` (or `type = 'ingestion'` when the current operation is
+  `digitization`)
+- `status = 'completed'`
+- A matching entry in `file_checksum_registry`
+
+`failed` and `in_progress` records are **not** treated as already-existing —
+re-processing is allowed.
+
+---
+
+## 2. New `ALREADY_EXISTS` Document Status
+
+### 2a. `services/digitize/models.py`
+
+`ALREADY_EXISTS` is added to `DocStatus`:
+
+```python
+class DocStatus(str, Enum):
+    ACCEPTED = "accepted"
+    IN_PROGRESS = "in_progress"
+    DIGITIZED = "digitized"
+    PROCESSED = "processed"
+    CHUNKED = "chunked"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    ALREADY_EXISTS = "already_exists"   # ← NEW
+```
+
+### 2b. `services/digitize/db/scripts/init_schema.sql`
+
+The `chk_doc_status` CHECK constraint includes `'already_exists'`:
+
+```sql
+CONSTRAINT chk_doc_status CHECK (
+    status IN ('accepted', 'in_progress', 'digitized', 'processed',
+               'chunked', 'completed', 'failed', 'already_exists')
+)
+```
+
+⚠️ This is a schema migration. On existing databases drop and re-create the
+constraint before deploying:
+
+```sql
+ALTER TABLE documents
+    DROP CONSTRAINT chk_doc_status,
+    ADD CONSTRAINT chk_doc_status CHECK (
+        status IN ('accepted', 'in_progress', 'digitized', 'processed',
+                   'chunked', 'completed', 'failed', 'already_exists')
+    );
+```
+
+### 2c. `services/digitize/db/models.py`
+
+The `__table_args__` `CheckConstraint` on `Document` mirrors the SQL:
+
+```python
+CheckConstraint(
+    "status IN ('accepted', 'in_progress', 'digitized', 'processed',"
+    " 'chunked', 'completed', 'failed', 'already_exists')",
+    name="chk_doc_status"
+),
+```
+
+---
+
+## 3. `AlreadyExistsFile` and `JobCreatedResponse` Shape
+
+### 3a. `services/digitize/models.py`
+
+The `DuplicateSkippedFile` model from the original proposal was renamed to
+`AlreadyExistsFile`. It carries `existing_doc_name` internally so the
+`JobDocumentSummary` can construct a human-readable `message` field —
+`"Already ingested as <filename>"` — without an extra API call.
+
+`JobCreatedResponse` contains only `job_id` — the `warnings` field was removed.
+Skipped files are recorded directly in the job's document list with
+`status = already_exists` and `message = "Already ingested as <name>"`,
+visible via `GET /v1/jobs/{job_id}`.
+
+```python
+class AlreadyExistsFile(BaseModel):
+    """Describes a single file that was skipped because it already exists."""
+    filename: str = Field(..., description="Original filename of the skipped file")
+    existing_doc_id: str = Field(..., description="doc_id of the already-ingested document")
+    existing_doc_name: str = Field(..., description="Name of the already-ingested document")
+    file_hash: str = Field(..., description="SHA-256 hash that matched, e.g. 'sha256:e3b0...'")
+
+
+class JobDocumentSummary(BaseModel):
+    """Compact per-document entry for job status responses."""
+    id: str
+    name: str
+    status: str
+    message: Optional[str] = Field(
+        default=None,
+        description="Human-readable message; set when status is 'already_exists', e.g. 'Already ingested as <filename>'",
+    )
+
+
+class JobCreatedResponse(BaseModel):
+    """Response model for job creation."""
+    job_id: str
+```
+
+---
+
+## 4. Touch-point 1 — Hash Utility
+
+**File:** `services/common/misc_utils.py`
+
+Rather than a dedicated `services/digitize/utils/hash.py`, the hash function lives in
+the shared utilities module as `generate_file_checksum`. It accepts either raw `bytes`
+(hashed in one shot) or a file path (read in 128-block chunks to support large files
+without loading them into memory):
+
+```python
+def generate_file_checksum(file) -> str:
+    """Compute a prefixed SHA-256 hex digest of a file.
+
+    Accepts either a file path (str or Path) or raw bytes.  When passed bytes
+    the entire content is hashed in one shot; when passed a path the file is
+    read in chunks so arbitrarily large files can be processed without loading
+    them entirely into memory.
+
+    The ``sha256:`` prefix makes the algorithm explicit in stored values so
+    the hash algorithm can be upgraded in future without ambiguity.
+
+    Returns:
+        String in the form ``'sha256:<64-char-hex>'``.
+    """
+    sha256 = hashlib.sha256()
+    if isinstance(file, (bytes, bytearray)):
+        sha256.update(file)
+    else:
+        with open(file, 'rb') as f:
+            for chunk in iter(lambda: f.read(128 * sha256.block_size), b''):
+                sha256.update(chunk)
+    return f"sha256:{sha256.hexdigest()}"
+```
+
+**Usage at the API layer** (`services/digitize/api/v1/jobs.py`):
+
+```python
+from common.misc_utils import generate_file_checksum
+...
+file_hash = await asyncio.to_thread(generate_file_checksum, content)
+```
+
+Hashing is offloaded to a thread pool via `asyncio.to_thread` to avoid blocking the
+async event loop (addressing the Con identified in the earlier proposal).
+
+**Usage in the digitize pipeline** (`services/digitize/pipeline/digitize.py`): when
+a pre-computed checksum is not available in `file_checksum_dict`, the function
+re-hashes the staged file from disk as a fallback:
+
+```python
+file_hash = (
+    file_checksum_dict.get(filename)
+    if file_checksum_dict
+    else generate_file_checksum(file_path.read_bytes())
+)
+```
+
+> **Note:** The separate `services/digitize/utils/hash.py` described in the earlier
+> proposal was not created. The shared utility in `common/misc_utils.py` is used
+> everywhere.
+
+---
+
+## 5. Touch-point 2 — DB Schema: `file_checksum_registry` Table
+
+**File:** `services/digitize/db/scripts/init_schema.sql`
+
+Instead of the expression index on `metadata->>'file_hash'` described in the earlier
+proposal, the implementation uses a **dedicated lookup table**:
+
+```sql
+-- Checksum registry — one row per unique file content, points to the
+-- authoritative completed Document for duplicate detection.
+-- ON DELETE CASCADE ensures stale registry entries are automatically removed
+-- when the referenced document is deleted, preventing orphaned hash entries
+-- from blocking future re-ingestion of the same file.
+CREATE TABLE IF NOT EXISTS file_checksum_registry (
+    sha256        TEXT        PRIMARY KEY,
+    doc_id        TEXT        NOT NULL UNIQUE REFERENCES documents(doc_id) ON DELETE CASCADE
+);
+```
+
+**Why a separate table instead of the JSONB index?**
+
+| Concern | JSONB expression index | `file_checksum_registry` table |
+|---|---|---|
+| Lookup speed | O(log n) B-tree on expression | O(1) PK lookup |
+| Authoritative single source | No — multiple docs could share a hash | Yes — `sha256` is PRIMARY KEY, one row per unique content |
+| Cascade on delete | Requires app-level cleanup | `ON DELETE CASCADE` handles it automatically |
+| Hash stored in metadata too? | Required for storage | Yes — `file_hash` still stored in `doc.metadata` for visibility in `GET /v1/documents/{id}` responses |
+
+**ORM model** (`services/digitize/db/models.py`):
+
+```python
+class FileChecksumRegistry(Base):
+    """
+    Registry table that maps a SHA-256 digest to the authoritative completed
+    Document row for that content.
+
+    The FK to documents(doc_id) ON DELETE CASCADE means registry entries are
+    automatically removed when the referenced document is deleted, preventing
+    orphaned hashes from blocking future re-ingestion of the same file.
+    """
+    __tablename__ = "file_checksum_registry"
+
+    sha256: Mapped[str] = mapped_column(Text, primary_key=True)
+    doc_id: Mapped[str] = mapped_column(
+        Text,
+        ForeignKey("documents.doc_id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+```
+
+No additional index is needed — `sha256` is the primary key.
+
+> **Note:** The `idx_documents_file_hash` JSONB expression index described in the
+> earlier proposal was not created. The `file_checksum_registry` table supersedes it.
+
+---
+
+## 6. Touch-point 3 — `DatabaseManager` Hash Methods
+
+**File:** `services/digitize/db/manager.py`
+
+Two methods are added to `DatabaseManager`.
+
+### 6a. `find_completed_document_by_hash`
+
+Looks up the registry table rather than querying `metadata->>'file_hash'` directly.
+Now accepts an `operation` parameter so the same method handles both ingestion and
+digitization dedup checks:
+
+```python
+@staticmethod
+def find_completed_document_by_hash(
+    file_hash: str,
+    operation: str = "ingestion",
+) -> Optional[Document]:
+    """
+    Find the completed document of the given operation type with a matching
+    file hash, using the file_checksum_registry lookup table.
+
+    Only documents with status='completed' and the specified type are considered.
+    Failed and in-progress documents are deliberately excluded so that a previous
+    failed attempt does not prevent re-processing of the same file.
+
+    Args:
+        file_hash: Prefixed SHA-256 digest, e.g. 'sha256:e3b0c44...'
+        operation: Document type to match — 'ingestion' or 'digitization'.
+
+    Returns:
+        The matching Document ORM object (attributes eagerly loaded and
+        expunged from session), or None if no completed duplicate exists.
+    """
+    try:
+        with get_db_session() as session:
+            stmt = (
+                select(Document)
+                .join(
+                    FileChecksumRegistry,
+                    FileChecksumRegistry.doc_id == Document.doc_id,
+                )
+                .where(
+                    FileChecksumRegistry.sha256 == file_hash,
+                    Document.type == operation,
+                    Document.status == DocStatus.COMPLETED.value,
+                )
+                .limit(1)
+            )
+            doc = session.scalar(stmt)
+            if doc:
+                # Eagerly load all attributes before session closes to prevent
+                # DetachedInstanceError in the caller.
+                _ = (
+                    doc.doc_id, doc.job_id, doc.name, doc.type,
+                    doc.status, doc.output_format, doc.submitted_at,
+                    doc.completed_at, doc.error, doc.doc_metadata,
+                )
+                session.expunge(doc)
+                logger.debug(
+                    f"Duplicate detected: file_hash={file_hash[:20]}... "
+                    f"matches doc_id={doc.doc_id}"
+                )
+            return doc
+    except SQLAlchemyError as e:
+        logger.error(f"DB error in hash lookup for {file_hash[:20]}...: {e}", exc_info=True)
+        # Do NOT raise — a lookup failure must not block processing.
+        # If the DB is unavailable the caller treats the file as novel.
+        return None
+```
+
+> **Key difference from earlier proposal:** The query joins `file_checksum_registry`
+> instead of filtering on `func.jsonb_extract_path_text(Document.doc_metadata,
+> "file_hash")`. This is faster and simpler, and the `operation` parameter supports
+> both ingestion and digitization dedup in a single method.
+
+### 6b. `upsert_file_checksum`
+
+Registers a completed document in the registry. Called from `_update_document` in
+`utils/db.py` whenever a document transitions to `COMPLETED` status and has a
+`file_hash` in its metadata update:
+
+```python
+@staticmethod
+def upsert_file_checksum(sha256: str, doc_id: str) -> None:
+    """
+    Insert or update a (sha256, doc_id) pair in file_checksum_registry.
+
+    Called once a document reaches COMPLETED status so that subsequent
+    uploads of the same content are caught via find_completed_document_by_hash.
+
+    Args:
+        sha256: Prefixed SHA-256 digest, e.g. 'sha256:e3b0c44...'
+        doc_id: The completed document's primary key.
+    """
+    try:
+        with get_db_session() as session:
+            stmt = (
+                insert(FileChecksumRegistry)
+                .values(sha256=sha256, doc_id=doc_id)
+                .on_conflict_do_update(
+                    index_elements=["sha256"],
+                    set_={"doc_id": doc_id},
+                )
+            )
+            session.execute(stmt)
+            logger.debug(f"Upserted checksum registry: sha256={sha256[:20]}... doc_id={doc_id}")
+    except SQLAlchemyError as e:
+        logger.error(f"DB error upserting checksum for {sha256[:20]}...: {e}", exc_info=True)
+```
+
+---
+
+## 7. Touch-point 4 — `create_job` API Handler (Option B Gate)
+
+**File:** `services/digitize/api/v1/jobs.py`
+
+### 7a. Imports
+
+```python
+from common.misc_utils import get_logger, validate_document_file, cleanup_staging_directory, generate_file_checksum
+from digitize.db.manager import db_manager
+```
+
+No separate `digitize.utils.hash` import — `generate_file_checksum` comes from
+`common.misc_utils`.
+
+### 7b. Dedup check (step 5b) — key differences from earlier proposal
+
+The live implementation differs from the earlier proposal in the following ways:
+
+1. **Applies to both operations**, not ingestion-only.
+2. **Digitization cross-checks ingestion**: if the file is already indexed (ingestion
+   completed), a digitization request is also blocked — no point re-digitizing content
+   already in the vector store.
+3. **Hash is offloaded**: `await asyncio.to_thread(generate_file_checksum, content)`
+   prevents blocking the event loop.
+4. **`file_checksum_dict` is built in the same loop** (novel files only), eliminating
+   the separate post-loop construction step described in the earlier proposal.
+5. **Model names**: `AlreadyExistsFile` (not `DuplicateSkippedFile`);
+   `already_exists_files` (not `skipped_files`).
+
+```python
+        # 5b. File-hash already-exists detection.
+        #
+        # Each file is hashed and checked against completed documents of the same
+        # operation type. Files that already exist are removed from the batch; novel
+        # files continue. If ALL files already exist, return 409 immediately (no job
+        # created). If SOME files already exist, only novel files are processed;
+        # skipped files are recorded in the job's document list with status
+        # `already_exists` (visible via GET /v1/jobs/{job_id}).
+        #
+        # A file already exists only if a document with:
+        #   - type   = operation ('ingestion' or 'digitization')
+        #   - status = 'completed'
+        #   - sha256 in file_checksum_registry
+        # is found. Failed / in-progress records are NOT considered to already exist.
+        #
+        # For digitization, an ingestion-completed document also counts — no point
+        # re-digitizing content that is already indexed.
+
+        already_exists_files: list[models.AlreadyExistsFile] = []
+        file_checksum_dict: dict[str, str] = {}  # filename -> "sha256:..." (novel files only)
+
+        novel_filenames: list[str] = []
+        novel_contents:  list[bytes] = []
+
+        for filename, content in zip(filenames, file_contents):
+            file_hash = await asyncio.to_thread(generate_file_checksum, content)
+            existing = db_manager.find_completed_document_by_hash(file_hash, operation.value)
+
+            # A digitization request is also blocked by a completed ingestion of the
+            # same file — no point re-digitizing content that is already indexed.
+            if not existing and operation == models.OperationType.DIGITIZATION:
+                existing = db_manager.find_completed_document_by_hash(
+                    file_hash, models.OperationType.INGESTION.value
+                )
+
+            if existing:
+                logger.info(
+                    f"File '{filename}' already exists — matches completed "
+                    f"doc_id={existing.doc_id} (hash={file_hash[:20]}...)"
+                )
+                already_exists_files.append(
+                    models.AlreadyExistsFile(
+                        filename=filename,
+                        existing_doc_id=existing.doc_id,
+                        existing_doc_name=existing.name,
+                        file_hash=file_hash,
+                    )
+                )
+            else:
+                novel_filenames.append(filename)
+                novel_contents.append(content)
+                file_checksum_dict[filename] = file_hash  # built here, not in a separate step
+
+        # All files already exist → 409 Conflict, no job created.
+        if not novel_filenames:
+            skipped_summary = ", ".join(
+                f"'{s.filename}' (existing doc: {s.existing_doc_id})"
+                for s in already_exists_files
+            )
+            logger.warning(
+                f"All {len(already_exists_files)} submitted file(s) already exist. "
+                f"No job created. Files: {skipped_summary}"
+            )
+            APIError.raise_error(
+                ErrorCode.RESOURCE_LOCKED,
+                f"All submitted files have already been processed: {skipped_summary}. "
+                f"Delete the existing documents first if you want to re-process.",
+            )
+
+        # Replace filenames/file_contents with the novel subset only.
+        filenames     = novel_filenames
+        file_contents = novel_contents
+
+        # 6. Acquire semaphore slot.
+        await concurrency_manager.acquire(op_key)
+
+        # 7. Stage files and schedule background task.
+        try:
+            await dg_util.stage_upload_files(
+                job_id,
+                filenames,
+                str(settings.digitize.staging_dir / job_id),
+                file_contents,
+            )
+            doc_id_dict = dg_util.initialize_job_state(
+                job_id, operation, output_format, filenames, job_name,
+                already_exists_files=already_exists_files,
+            )
+            if operation == models.OperationType.INGESTION:
+                background_tasks.add_task(
+                    _run_ingest, job_id, filenames, doc_id_dict, file_checksum_dict
+                )
+            else:
+                background_tasks.add_task(
+                    _run_digitize, job_id, doc_id_dict, output_format, file_checksum_dict
+                )
+        except Exception as exc:
+            concurrency_manager.release(op_key)
+            logger.error(
+                f"Failed to schedule background task for job {job_id}, "
+                f"semaphore released: {exc}"
+            )
+            APIError.raise_error("INTERNAL_SERVER_ERROR", str(exc))
+
+        return {"job_id": job_id}
+```
+
+---
+
+## 8. Touch-point 5 — `initialize_job_state` (record already-exists docs)
+
+**File:** `services/digitize/utils/jobs.py`
+
+### 8a. Signature
+
+```python
+def initialize_job_state(
+    job_id: str,
+    operation: str,
+    output_format: OutputFormat,
+    documents_info: list[str],
+    job_name: Optional[str] = None,
+    already_exists_files: Optional[list] = None,   # list[AlreadyExistsFile]
+) -> dict[str, str]:
+```
+
+### 8b. Job creation: `total_documents` covers both novel and already-exists files
+
+```python
+all_filenames = list(documents_info) + (
+    [f.filename for f in already_exists_files] if already_exists_files else []
+)
+create_job(
+    job_id=job_id,
+    operation=operation,
+    submitted_at=submitted_at,
+    documents_info=all_filenames,
+    job_name=job_name
+)
+```
+
+### 8c. `ALREADY_EXISTS` docs are written in a single `create_document` call
+
+Unlike the earlier proposal (which called `create_document` at `ACCEPTED` then
+`update_doc_metadata` to set `ALREADY_EXISTS`), the live implementation passes
+`initial_status` and `extra_metadata` directly to `create_document`. There is no
+intermediate accepted state and no follow-up metadata update call:
+
+```python
+if already_exists_files:
+    from digitize.utils.db import get_status_manager
+    from digitize.models import JobStatus as _JobStatus
+    status_mgr = get_status_manager(job_id)
+    for skipped in already_exists_files:
+        skipped_doc_id = generate_uuid()
+        doc_id_dict[skipped.filename] = skipped_doc_id
+        logger.debug(
+            f"Recording already_exists doc {skipped_doc_id} "
+            f"for file '{skipped.filename}'"
+        )
+        create_document(
+            doc_name=skipped.filename,
+            doc_id=skipped_doc_id,
+            job_id=job_id,
+            output_format=output_format,
+            operation=operation,
+            submitted_at=submitted_at,
+            initial_status=DocStatus.ALREADY_EXISTS,   # written directly at creation
+            completed_at=submitted_at,                 # immediately terminal
+            extra_metadata={
+                "existing_doc_id": skipped.existing_doc_id,
+                "existing_doc_name": skipped.existing_doc_name,
+                "file_hash": skipped.file_hash,
+            },
+        )
+        # Update job progress stats — doc_id is empty string because the doc
+        # status was set at creation; only the job-level stats need refreshing.
+        status_mgr.update_job_progress(
+            "",
+            DocStatus.ALREADY_EXISTS,
+            _JobStatus.IN_PROGRESS,
+        )
+```
+
+> **Key difference from earlier proposal:**
+> - Parameter name is `already_exists_files`, not `skipped_files`.
+> - `create_document` accepts `initial_status`, `completed_at`, and `extra_metadata`
+>   parameters added as part of this feature.
+> - `update_job_progress` is called with an empty `doc_id` (job-level stats refresh
+>   only), not with the skipped doc's id.
+> - No `update_doc_metadata` call needed — the terminal state is written atomically.
+
+### 8d. `_update_job` stats recalculation
+
+`DatabaseStatusManager._update_job` (in `utils/db.py`) does **not** use incremental
+counters. Instead, it re-fetches all documents for the job and recomputes stats from
+scratch. `ALREADY_EXISTS` counts toward `completed`:
+
+```python
+stats = {
+    "total_documents": len(documents),
+    "completed": sum(
+        1 for d in documents
+        if d.status in (DocStatus.COMPLETED.value, DocStatus.ALREADY_EXISTS.value)
+    ),
+    "failed": sum(1 for d in documents if d.status == DocStatus.FAILED.value),
+    "in_progress": sum(
+        1 for d in documents if d.status in [
+            DocStatus.ACCEPTED.value,
+            DocStatus.IN_PROGRESS.value,
+            DocStatus.DIGITIZED.value,
+            DocStatus.PROCESSED.value,
+            DocStatus.CHUNKED.value
+        ]
+    )
+}
+```
+
+> **Difference from earlier proposal:** The proposal added a branch
+> `elif doc_status in (DocStatus.COMPLETED, DocStatus.DUPLICATE_SKIPPED)` to an
+> incremental counter. The live code recalculates from DB state on every update,
+> which is simpler and self-healing.
+
+---
+
+## 9. Touch-point 6 — `_run_ingest` and `ingest()` (pass checksum dict)
+
+### 9a. `services/digitize/api/v1/jobs.py` — `_run_ingest` signature
+
+```python
+async def _run_ingest(
+    job_id: str,
+    filenames: List[str],
+    doc_id_dict: dict,
+    file_checksum_dict: Optional[dict] = None,  # filename -> "sha256:..."
+) -> None:
+```
+
+Passes `file_checksum_dict` through to `ingest()`:
+
+```python
+await asyncio.to_thread(ingest, job_staging_path, job_id, doc_id_dict, file_checksum_dict)
+```
+
+> **Naming:** The parameter is `file_checksum_dict` throughout (not `file_hash_dict`
+> as named in the earlier proposal).
+
+### 9b. `services/digitize/pipeline/ingest.py` — `ingest()` signature
+
+```python
+def ingest(
+    directory_path: Path,
+    job_id: Optional[str] = None,
+    doc_id_dict: Optional[dict] = None,
+    file_checksum_dict: Optional[dict] = None,  # filename -> "sha256:..."
+):
+```
+
+Passed to `create_indexing_handler`:
+
+```python
+indexing_handler = create_indexing_handler(
+    emb_model_dict, status_mgr, doc_id_dict, file_checksum_dict
+)
+```
+
+---
+
+## 10. Touch-point 7 — `_run_digitize` and `digitize()` (pass checksum dict)
+
+This touch-point was not in the original proposal. The digitization pipeline also
+persists the file hash on completion.
+
+### 10a. `services/digitize/api/v1/jobs.py` — `_run_digitize` signature
+
+```python
+async def _run_digitize(
+    job_id: str,
+    doc_id_dict: dict,
+    output_format: models.OutputFormat,
+    file_checksum_dict: Optional[dict] = None,  # filename -> "sha256:..."
+) -> None:
+```
+
+Passed through to `digitize()`:
+
+```python
+await asyncio.to_thread(digitize, job_staging_path, job_id, doc_id_dict, output_format, file_checksum_dict)
+```
+
+### 10b. `services/digitize/pipeline/digitize.py` — `digitize()` signature
+
+```python
+def digitize(
+    directory_path: Path,
+    job_id: str,
+    doc_id_dict: dict,
+    output_format: OutputFormat,
+    file_checksum_dict: dict | None = None,  # filename -> "sha256:..." pre-computed at upload
+):
+```
+
+On `COMPLETED`, stores the hash (using the pre-computed value from
+`file_checksum_dict` if available, otherwise re-hashes from disk):
+
+```python
+file_hash = (
+    file_checksum_dict.get(filename)
+    if file_checksum_dict
+    else generate_file_checksum(file_path.read_bytes())
+)
+status_mgr.update_doc_metadata(doc_id, {
+    "status": DocStatus.COMPLETED,
+    "pages": page_count,
+    "completed_at": get_utc_timestamp(),
+    "timing_in_secs": {"digitizing": round(conversion_time, 2)},
+    "file_hash": file_hash,
+})
+```
+
+The disk-based fallback ensures that documents digitized without a pre-computed
+checksum (e.g. from a recovery path) still get their hash registered.
+
+---
+
+## 11. Touch-point 8 — `create_indexing_handler` (persist hash on completion)
+
+**File:** `services/digitize/pipeline/ingest.py`
+
+### 11a. Updated signature
+
+```python
+def create_indexing_handler(
+    emb_model_dict: dict,
+    status_mgr: Optional[DatabaseStatusManager],
+    doc_id_dict: Optional[dict],
+    file_checksum_dict: Optional[dict] = None,  # filename -> "sha256:..."
+):
+```
+
+### 11b. Inside `index_document_chunks`, success branch
+
+```python
+file_hash = (
+    file_checksum_dict.get(Path(path).name)
+    if file_checksum_dict else None
+)
+metadata_update = {
+    "status": DocStatus.COMPLETED,
+    "completed_at": get_utc_timestamp(),
+    "timing_in_secs": {"indexing": round(indexing_time, 2)},
+}
+if file_hash:
+    metadata_update["file_hash"] = file_hash
+
+status_mgr.update_doc_metadata(doc_id, metadata_update)
+```
+
+`Path` is already imported at the top of `ingest.py`.
+
+---
+
+## 12. Touch-point 9 — `_categorize_fields` (route `file_hash` to metadata)
+
+**File:** `services/digitize/utils/db.py`
+
+`METADATA_KEYS` includes both `file_hash` and `existing_doc_id` so neither key falls
+through to `top_level_fields` (which would result in silent data loss):
+
+```python
+METADATA_KEYS = {"pages", "tables", "chunks", "timing_in_secs", "file_hash", "existing_doc_id"}
+```
+
+---
+
+## 13. Touch-point 10 — `_update_document` (register checksum on COMPLETED)
+
+**File:** `services/digitize/utils/db.py` — `DatabaseStatusManager._update_document`
+
+After a successful `update_document` call, if the status just became `COMPLETED`
+**and** a `file_hash` was present in `metadata_fields`, the checksum is registered
+in `file_checksum_registry` via `upsert_file_checksum`:
+
+```python
+if (
+    update_params.get("status") == DocStatus.COMPLETED
+    and "file_hash" in metadata_fields
+):
+    db_manager.upsert_file_checksum(metadata_fields["file_hash"], doc_id)
+```
+
+This is the bridge between the pipeline's `update_doc_metadata(…, {"file_hash": …})`
+call and the `file_checksum_registry` table. It ensures the registry is populated
+atomically with (or just after) the document reaching `COMPLETED` status.
+
+---
+
+## 14. Touch-point 11 — Deletion clears checksum registry
+
+**File:** `services/digitize/db/manager.py`
+
+### 14a. `delete_document`
+
+Explicitly removes the registry row before deleting the document (though
+`ON DELETE CASCADE` would also handle it automatically, the explicit delete is a
+belt-and-suspenders guard):
+
+```python
+session.execute(
+    delete(FileChecksumRegistry).where(FileChecksumRegistry.doc_id == doc_id)
+)
+stmt = delete(Document).where(Document.doc_id == doc_id)
+```
+
+### 14b. `delete_all_documents`
+
+Wipes the entire checksum registry before deleting all documents, so a full reset
+does not leave orphaned hash entries that would block future re-ingestion:
+
+```python
+session.execute(delete(FileChecksumRegistry))
+stmt = delete(Document)
+```
+
+---
+
+## 15. Touch-point 12 — `get_all_documents` excludes `ALREADY_EXISTS` docs
+
+**File:** `services/digitize/db/manager.py` — `DatabaseManager.get_all_documents`
+
+`ALREADY_EXISTS` documents are job-scoped audit records, not real standalone
+documents. They are excluded from the global `GET /v1/documents` listing:
+
+```python
+# Exclude already_exists docs from the global listing — they are
+# job-scoped audit records, not real ingested documents.
+filters.append(Document.status != DocStatus.ALREADY_EXISTS.value)
+```
+
+They remain visible when fetching a specific job via `GET /v1/jobs/{job_id}`, where
+the full document list (including `ALREADY_EXISTS` entries) is returned.
+
+Similarly, `get_job_document_stats` in `utils/jobs.py` counts `ALREADY_EXISTS`
+alongside `COMPLETED` in the `completed_docs` list:
+
+```python
+completed_docs = [
+    doc for doc in documents
+    if doc.get("status") in (DocStatus.COMPLETED.value, DocStatus.ALREADY_EXISTS.value)
+]
+```
+
+---
+
+## 16. Data Flow Diagram
+
+```
+POST /v1/jobs?operation=ingestion|digitization
+         │
+         ▼
+ [1] Block if import/export in progress      ← existing
+         │
+         ▼
+ [2] Guard: empty submission / digitization  ← existing
+     multi-file guard
+         │
+         ▼
+ [3] Active-job guard (ingestion only)       ← existing
+         │
+         ▼
+ [4] Semaphore availability pre-check        ← existing
+         │
+         ▼
+ [5] Read & validate files (type, size)      ← existing
+         │
+         ▼
+ [5b] for each file:
+       asyncio.to_thread(generate_file_checksum, bytes)  ~40ms  ← NEW
+       db_manager.find_completed_document_by_hash(hash, op)     ← NEW
+       if digitization: also check ingestion hash               ← NEW
+         │
+    ┌────┴──────────────────────┐
+    │ all novel                 │ some / all already exist
+    ▼                           ▼
+[6] acquire               split batch:
+    semaphore                novel → continue
+                             already-exists → AlreadyExistsFile list
+                               │
+                          ┌────┴─────────────────┐
+                          │ novel files remain   │ no novel files remain
+                          ▼                      ▼
+                     stage + initialize     APIError 409 CONFLICT
+                     job (ALREADY_EXISTS    (no job created,
+                     docs written at        no semaphore acquired)
+                     creation with
+                     initial_status)
+                          │
+                          ▼
+        background: ingest(file_checksum_dict) / digitize(file_checksum_dict)
+                          │
+             ┌────────────┼──────────────────┐
+             ▼            ▼                  ▼
+          convert     process(LLM)        chunk
+             │                              │
+             └──────────────────────────► ──▼
+                                      embed + bulk-insert
+                                      on COMPLETED:
+                                        write file_hash to doc metadata
+                                        → upsert_file_checksum into
+                                          file_checksum_registry          ← NEW
+```
+
+---
+
+## 17. Timing Impact
+
+| Phase | First (new) processing | Already-exists |
+|---|---|---|
+| SHA-256 hash (async, in-process) | +40 ms | +40 ms |
+| PostgreSQL registry PK lookup | +1 ms | +1 ms |
+| File staging | unchanged | **0 ms** (skipped) |
+| Docling conversion | unchanged | **0 ms** (skipped) |
+| Text processing | unchanged | **0 ms** (skipped) |
+| LLM table summarisation | unchanged | **0 ms** (skipped) |
+| Chunking | unchanged | **0 ms** (skipped) |
+| Embedding | unchanged | **0 ms** (skipped) |
+| OpenSearch bulk insert | unchanged | **0 ms** (skipped) |
+| **Total** | ~64 s + 41 ms overhead | **~41 ms** (99.9% reduction) |
+
+The PK lookup on `file_checksum_registry.sha256` is faster than the JSONB expression
+index proposed earlier because it hits a dedicated B-tree index on a plain text
+column (not a function index on a JSONB blob).
+
+---
+
+## 18. Pros and Cons
+
+### Pros
+
+| # | Benefit |
+|---|---|
+| 1 | **Earliest possible short-circuit** — dedup fires before staging, semaphore acquisition, DB job creation, and all pipeline work. |
+| 2 | **Content-addressed, not name-addressed** — same bytes under a different filename are still caught; different bytes under the same filename are still accepted. |
+| 3 | **No pipeline changes for new files** — the full pipeline is completely unmodified for novel content. |
+| 4 | **Lenient batch handling** — partial batches are processed; a large upload is not entirely rejected because one file was re-submitted. |
+| 5 | **Transparent to caller** — skipped files appear in the job's document list with `status = already_exists` and `message = "Already ingested as <filename>"`, so the caller can inspect the result via `GET /v1/jobs/{job_id}` without an extra documents lookup. |
+| 6 | **Failed processing is re-triable** — only `status=completed` records trigger dedup. A previously failed file can be re-submitted freely. |
+| 7 | **No embedding server cost on already-existing files** — the embedding model is never called. |
+| 8 | **O(1) PK lookup** — `file_checksum_registry.sha256` is a primary key; lookup cost is constant regardless of total document count. |
+| 9 | **Cascade delete safety** — `ON DELETE CASCADE` on `file_checksum_registry` ensures registry entries are cleaned up automatically when a document is deleted. |
+| 10 | **Covers both operations** — digitization is also guarded; a file already indexed via ingestion is not re-digitized. |
+| 11 | **Event-loop safety** — hashing is offloaded via `asyncio.to_thread`, so a large file does not block the server. |
+
+### Cons
+
+| # | Concern | Mitigation |
+|---|---|---|
+| 1 | **Schema migration required** — `chk_doc_status` must be updated and `file_checksum_registry` table must be created on existing databases before deploying. | Include migration SQL in release notes (see Touch-points 2 and 5). `CREATE TABLE IF NOT EXISTS` is idempotent for new deployments. |
+| 2 | **Hash not stored for documents processed before this change** — existing completed documents have no entry in `file_checksum_registry`, so they will not be caught as duplicates until re-processed once. | Acceptable for initial rollout; a one-time backfill script could populate the registry from the existing `metadata->>'file_hash'` values. |
+| 3 | **Lenient mode creates partial jobs** — a job that contains both novel and already-existing docs is slightly harder to reason about in status checks. | The `ALREADY_EXISTS` status makes the distinction explicit and inspectable. `ALREADY_EXISTS` docs are excluded from the global documents listing but visible per-job via `GET /v1/jobs/{job_id}`. |
+| 4 | **SHA-256 collision is theoretically possible** | Astronomically unlikely (2^256 search space). Non-issue in practice. |
+| 5 | **`existing_doc_id` in metadata is not a foreign-key-enforced reference** | The referenced `doc_id` should be validated to exist before writing. Add a `db_manager.get_document_by_id(existing.doc_id)` check if strict integrity is required. |
+| 6 | **`file_checksum_registry` adds an extra write on every COMPLETED transition** | The `upsert_file_checksum` call is a single-row INSERT ON CONFLICT DO UPDATE — negligible overhead. |
+
+---
+
+## 19. Edge Cases
+
+### E1 — Concurrent duplicate submission (race condition)
+
+**Scenario:** Two identical files are submitted in parallel before either has completed
+processing, so neither has a `file_checksum_registry` entry when both do the hash
+lookup.
+
+**Result:** Both pass the dedup gate. Both run the full pipeline. Both end up indexed.
+This is the same situation that existed before this feature. It is acceptable because:
+- `ingestion_concurrency_limit = 1` (see `settings.py`) means only one ingestion job
+  runs at a time. A second identical submission while the first is `in_progress` will
+  receive a "An ingestion job is already running" `429` from the existing active-job
+  guard in `create_job` step 3 — **before** reaching the dedup check.
+
+**Conclusion:** No additional handling needed given the existing concurrency model.
+
+---
+
+### E2 — Caller deletes a document and re-submits the same file
+
+**Scenario:** File `A.pdf` is ingested, marked `completed`, then deleted via
+`DELETE /v1/documents/{doc_id}`. The same bytes are submitted again.
+
+**Result:** `delete_document` removes the `file_checksum_registry` row (via the
+explicit `DELETE` plus `ON DELETE CASCADE`). `find_completed_document_by_hash`
+returns `None`. The file is treated as novel and re-ingested. ✅
+
+---
+
+### E3 — Same file submitted in a multi-file batch alongside new files
+
+**Scenario:** `[new_file.pdf, existing_file.pdf]` submitted in one request.
+
+**Result (Option B):** `existing_file.pdf` is stripped. Job is created for
+`new_file.pdf` only. Response:
+```json
+{
+  "job_id": "abc-123"
+}
+```
+`existing_file.pdf` appears in `GET /v1/jobs/abc-123` with
+`"status": "already_exists"` and `"message": "Already ingested as <name of existing doc>"`.
+
+---
+
+### E4 — All files in a batch already exist
+
+**Scenario:** `[dup1.pdf, dup2.pdf]` — both already indexed.
+
+**Result:** `409 Conflict`. Error message lists both filenames and their existing
+`doc_id`s. No job created. No semaphore acquired. ✅
+
+---
+
+### E5 — Previous processing of same file failed
+
+**Scenario:** `A.pdf` was ingested, Docling conversion crashed, doc status = `failed`.
+Same bytes submitted again.
+
+**Result:** `find_completed_document_by_hash` returns `None` (the registry only
+contains rows for `COMPLETED` documents; a failed document is never registered).
+File is treated as novel. Full pipeline re-runs. ✅
+
+---
+
+### E6 — File modified between submissions (different content, same name)
+
+**Scenario:** `report.pdf` v1 ingested, then caller modifies the file and re-submits
+`report.pdf` v2 (different bytes, same filename).
+
+**Result:** SHA-256 of v2 ≠ SHA-256 of v1. No registry entry exists for v2's hash.
+`find_completed_document_by_hash` returns `None`. v2 is treated as novel and
+processed independently, resulting in two separate documents both named `report.pdf`
+in the DB. ✅ (This is intentional — dedup is content-addressed, not name-addressed.)
+
+---
+
+### E7 — Hash lookup DB failure (transient error)
+
+**Scenario:** PostgreSQL is briefly unavailable during the hash lookup.
+
+**Result:** `find_completed_document_by_hash` catches the `SQLAlchemyError`,
+logs it, and returns `None`. The file is treated as novel. Processing proceeds.
+A potential duplicate may be processed twice, but the service remains available. ✅
+
+**Trade-off:** Availability is prioritised over strict dedup. If strict dedup is
+required even under DB failure, change the `except` block to re-raise, which will
+propagate as a `500` to the caller.
+
+---
+
+### E8 — `ALREADY_EXISTS` doc appearing in job stats `completed` count
+
+**Scenario:** Caller checks `GET /v1/jobs/{job_id}` after a partial batch.
+
+**Result:** `ALREADY_EXISTS` documents count toward `stats.completed` (see
+Touch-point 5d). The `documents` list shows each file's status explicitly, so the
+caller can distinguish real completions from already-existing ones. The job reaches
+`JobStatus.COMPLETED` normally once all novel files finish. ✅
+
+---
+
+### E9 — `file_hash` not in `METADATA_KEYS` (silent data loss)
+
+**Scenario:** Developer adds `file_hash` to a metadata update but `METADATA_KEYS` is
+not updated.
+
+**Result:** `_categorize_fields` routes `file_hash` to `top_level_fields`.
+`update_document` receives `file_hash=...` as a kwarg but the SQLAlchemy `update()`
+call only knows about actual column names — the kwarg is silently ignored. The hash
+is never persisted. `upsert_file_checksum` is never called. Future dedup checks
+return `None`. Dedup silently stops working.
+
+**Mitigation:** `file_hash` is in `METADATA_KEYS` (Touch-point 9). Also add a unit
+test that verifies `file_hash` survives a round-trip through `update_doc_metadata`.
+
+---
+
+### E10 — Digitization of a file that is already ingested
+
+**Scenario:** `document.pdf` was previously ingested (type=`ingestion`,
+status=`completed`). The same file is submitted with `operation=digitization`.
+
+**Result:** `find_completed_document_by_hash(hash, "digitization")` returns `None`
+(no digitization-type completed document). The cross-check
+`find_completed_document_by_hash(hash, "ingestion")` returns the ingestion document.
+The file is treated as already-existing, and the digitization request returns `409`
+(if all files already exist) or records the file as `already_exists` in the job's
+document list (if part of a mixed batch). ✅ This prevents redundant digitization
+of content already in the vector store.
+
+---
+
+*Made with IBM Bob*

--- a/docs/proposals/digitize-file-hash-dedup/flowchart.svg
+++ b/docs/proposals/digitize-file-hash-dedup/flowchart.svg
@@ -1,0 +1,155 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 1180" width="900" height="1180" font-family="'Segoe UI', system-ui, sans-serif" font-size="13">
+  <!-- Background -->
+  <rect width="900" height="1180" fill="#1a1a1a"/>
+
+  <!-- Title -->
+  <text x="450" y="32" text-anchor="middle" fill="#e0e0e0" font-size="14" font-weight="bold">File-Hash Already-Exists Detection — Decision Flow</text>
+  <text x="450" y="52" text-anchor="middle" fill="#888" font-size="11">Applies to both operation=ingestion and operation=digitization</text>
+
+  <!-- ── NODE 1: POST /v1/jobs ── -->
+  <rect x="300" y="68" width="300" height="52" rx="4" fill="#2a2a2a" stroke="#555" stroke-width="1.5"/>
+  <text x="450" y="89" text-anchor="middle" fill="#e0e0e0">POST /v1/jobs</text>
+  <text x="450" y="107" text-anchor="middle" fill="#aaa" font-size="11">(file bytes already in memory)</text>
+
+  <!-- Arrow down -->
+  <line x1="450" y1="120" x2="450" y2="148" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- ── NODE 2: SHA-256 hash ── -->
+  <rect x="280" y="148" width="340" height="52" rx="4" fill="#2a2a2a" stroke="#555" stroke-width="1.5"/>
+  <text x="450" y="169" text-anchor="middle" fill="#e0e0e0">asyncio.to_thread(generate_file_checksum)</text>
+  <text x="450" y="187" text-anchor="middle" fill="#aaa" font-size="11">~40 ms per file — offloaded, non-blocking</text>
+
+  <!-- Arrow down -->
+  <line x1="450" y1="200" x2="450" y2="228" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- ── NODE 3: Registry lookup diamond ── -->
+  <!-- diamond centre 450,308 half-w=175 half-h=80 -->
+  <polygon points="450,228 625,308 450,388 275,308" fill="#2a2a2a" stroke="#555" stroke-width="1.5"/>
+  <text x="450" y="292" text-anchor="middle" fill="#e0e0e0">lookup in</text>
+  <text x="450" y="309" text-anchor="middle" fill="#e0e0e0">file_checksum_registry</text>
+  <text x="450" y="326" text-anchor="middle" fill="#aaa" font-size="11">WHERE sha256 = ? (PK, O(1))</text>
+
+  <!-- ── Digitization cross-check note ── -->
+  <rect x="636" y="272" width="230" height="52" rx="4" fill="#1e2a1e" stroke="#4a7a4a" stroke-width="1.2"/>
+  <text x="751" y="291" text-anchor="middle" fill="#8bc88b" font-size="11">Digitization also checks</text>
+  <text x="751" y="306" text-anchor="middle" fill="#8bc88b" font-size="11">operation=ingestion registry</text>
+  <text x="751" y="321" text-anchor="middle" fill="#666" font-size="10">(no point re-digitizing indexed content)</text>
+  <line x1="636" y1="298" x2="625" y2="308" stroke="#4a7a4a" stroke-width="1" stroke-dasharray="4,3"/>
+
+  <!-- Arrow left — No match -->
+  <line x1="275" y1="308" x2="130" y2="308" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="200" y="298" text-anchor="middle" fill="#aaa" font-size="11">No match</text>
+  <text x="200" y="313" text-anchor="middle" fill="#aaa" font-size="11">(novel file)</text>
+
+  <!-- Arrow down-right — Match completed -->
+  <line x1="450" y1="388" x2="450" y2="416" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="483" y="406" text-anchor="start" fill="#aaa" font-size="11">Match found</text>
+
+  <!-- Arrow right — status=failed/in_progress -->
+  <line x1="625" y1="308" x2="770" y2="308" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="695" y="298" text-anchor="middle" fill="#aaa" font-size="11">Match found but</text>
+  <text x="695" y="313" text-anchor="middle" fill="#aaa" font-size="11">status=failed/in_progress</text>
+
+  <!-- ── Right branch: allow re-processing ── -->
+  <rect x="770" y="282" width="106" height="52" rx="4" fill="#2a2a2a" stroke="#555" stroke-width="1.5"/>
+  <text x="823" y="303" text-anchor="middle" fill="#e0e0e0" font-size="11">allow</text>
+  <text x="823" y="318" text-anchor="middle" fill="#e0e0e0" font-size="11">re-processing</text>
+  <text x="823" y="333" text-anchor="middle" fill="#aaa" font-size="10">(treat as novel)</text>
+
+  <!-- right branch arrow down to novel -->
+  <line x1="823" y1="334" x2="823" y2="530" stroke="#555" stroke-width="1.2" stroke-dasharray="5,4"/>
+  <line x1="823" y1="530" x2="135" y2="530" stroke="#555" stroke-width="1.2" stroke-dasharray="5,4" marker-end="url(#arr)"/>
+
+  <!-- ── Centre-left branch: ALREADY_EXISTS ── -->
+  <!-- diamond: match found (status=completed) -->
+  <!-- split: all already-exist? -->
+  <rect x="300" y="416" width="300" height="52" rx="4" fill="#2a2a2a" stroke="#555" stroke-width="1.5"/>
+  <text x="450" y="437" text-anchor="middle" fill="#e0e0e0">All files already exist?</text>
+  <text x="450" y="455" text-anchor="middle" fill="#aaa" font-size="11">(novel_filenames is empty)</text>
+
+  <!-- Arrow left: yes → 409 -->
+  <line x1="300" y1="442" x2="220" y2="442" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="258" y="434" text-anchor="middle" fill="#aaa" font-size="11">YES</text>
+
+  <rect x="60" y="416" width="160" height="52" rx="4" fill="#2a1a1a" stroke="#7a3a3a" stroke-width="1.5"/>
+  <text x="140" y="437" text-anchor="middle" fill="#e07070">409 Conflict</text>
+  <text x="140" y="455" text-anchor="middle" fill="#aaa" font-size="11">no job created</text>
+
+  <!-- Arrow down: no → continue with novel subset -->
+  <line x1="450" y1="468" x2="450" y2="496" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="474" y="487" text-anchor="start" fill="#aaa" font-size="11">SOME already exist</text>
+
+  <!-- ── NODE: Novel subset continues ── -->
+  <rect x="280" y="496" width="340" height="52" rx="4" fill="#2a2a2a" stroke="#555" stroke-width="1.5"/>
+  <text x="450" y="517" text-anchor="middle" fill="#e0e0e0">Strip already-existing files from batch</text>
+  <text x="450" y="535" text-anchor="middle" fill="#aaa" font-size="11">novel files continue; already-exists → status=ALREADY_EXISTS in job docs</text>
+
+  <!-- Arrow down from left (novel) to stage+create -->
+  <line x1="130" y1="308" x2="130" y2="530" stroke="#555" stroke-width="1.5"/>
+  <line x1="130" y1="530" x2="280" y2="548" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- Arrow down from strip node -->
+  <line x1="450" y1="548" x2="450" y2="576" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- ── NODE: stage + initialize_job_state ── -->
+  <rect x="250" y="576" width="400" height="66" rx="4" fill="#2a2a2a" stroke="#555" stroke-width="1.5"/>
+  <text x="450" y="597" text-anchor="middle" fill="#e0e0e0">stage files + initialize_job_state()</text>
+  <text x="450" y="614" text-anchor="middle" fill="#aaa" font-size="11">novel docs → status=ACCEPTED</text>
+  <text x="450" y="630" text-anchor="middle" fill="#aaa" font-size="11">already-exists docs → status=ALREADY_EXISTS (written at creation)</text>
+
+  <!-- Arrow down -->
+  <line x1="450" y1="642" x2="450" y2="670" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- ── NODE: background pipeline ── -->
+  <rect x="250" y="670" width="400" height="52" rx="4" fill="#2a2a2a" stroke="#555" stroke-width="1.5"/>
+  <text x="450" y="691" text-anchor="middle" fill="#e0e0e0">background pipeline (novel files only)</text>
+  <text x="450" y="709" text-anchor="middle" fill="#aaa" font-size="11">ingest: convert → process → chunk → embed → index</text>
+
+  <!-- Arrow down -->
+  <line x1="450" y1="722" x2="450" y2="750" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- ── NODE: on COMPLETED ── -->
+  <rect x="250" y="750" width="400" height="80" rx="4" fill="#1e241e" stroke="#4a7a4a" stroke-width="1.5"/>
+  <text x="450" y="772" text-anchor="middle" fill="#8bc88b">on COMPLETED:</text>
+  <text x="450" y="790" text-anchor="middle" fill="#e0e0e0" font-size="11">write file_hash to doc.metadata</text>
+  <text x="450" y="807" text-anchor="middle" fill="#e0e0e0" font-size="11">upsert into file_checksum_registry</text>
+  <text x="450" y="824" text-anchor="middle" fill="#aaa" font-size="10">(sha256 PK → future lookups hit this row)</text>
+
+  <!-- Arrow down -->
+  <line x1="450" y1="830" x2="450" y2="858" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- ── NODE: 202 response ── -->
+  <rect x="250" y="858" width="400" height="66" rx="4" fill="#1e1e2a" stroke="#4a4a7a" stroke-width="1.5"/>
+  <text x="450" y="879" text-anchor="middle" fill="#7070e0">202 Accepted</text>
+  <text x="450" y="896" text-anchor="middle" fill="#e0e0e0" font-size="11">{ job_id: "..." }</text>
+  <text x="450" y="912" text-anchor="middle" fill="#aaa" font-size="10">skipped files visible in GET /v1/jobs/{job_id} with status=already_exists and message="Already ingested as &lt;filename&gt;"</text>
+
+  <!-- ── LEGEND ── -->
+  <rect x="30" y="960" width="840" height="180" rx="4" fill="#222" stroke="#444" stroke-width="1"/>
+  <text x="450" y="982" text-anchor="middle" fill="#888" font-size="12" font-weight="bold">Key differences from original proposal</text>
+  <line x1="30" y1="990" x2="870" y2="990" stroke="#444" stroke-width="1"/>
+
+  <text x="50" y="1012" fill="#8bc88b" font-size="11">▸</text>
+  <text x="65" y="1012" fill="#ccc" font-size="11">Hash utility: generate_file_checksum() in common/misc_utils.py (not a separate hash.py) — also accepts file paths, reads in chunks</text>
+  <text x="50" y="1032" fill="#8bc88b" font-size="11">▸</text>
+  <text x="65" y="1032" fill="#ccc" font-size="11">Hash is computed via asyncio.to_thread() to avoid blocking the event loop</text>
+  <text x="50" y="1052" fill="#8bc88b" font-size="11">▸</text>
+  <text x="65" y="1052" fill="#ccc" font-size="11">Lookup uses file_checksum_registry table (PK join) — not a JSONB expression index on metadata-&gt;&gt;'file_hash'</text>
+  <text x="50" y="1072" fill="#8bc88b" font-size="11">▸</text>
+  <text x="65" y="1072" fill="#ccc" font-size="11">Status is ALREADY_EXISTS (not DUPLICATE_SKIPPED); model is AlreadyExistsFile (not DuplicateSkippedFile)</text>
+  <text x="50" y="1092" fill="#8bc88b" font-size="11">▸</text>
+  <text x="65" y="1092" fill="#ccc" font-size="11">Applies to both ingestion and digitization; digitization additionally cross-checks the ingestion registry</text>
+  <text x="50" y="1112" fill="#8bc88b" font-size="11">▸</text>
+  <text x="65" y="1112" fill="#ccc" font-size="11">ALREADY_EXISTS docs written atomically at create_document() time — no intermediate ACCEPTED state</text>
+  <text x="50" y="1132" fill="#8bc88b" font-size="11">▸</text>
+  <text x="65" y="1132" fill="#ccc" font-size="11">Registry cleared on delete_document() / delete_all_documents() so re-ingestion is allowed after deletion</text>
+
+  <text x="450" y="1165" text-anchor="middle" fill="#444" font-size="10">Made with IBM Bob</text>
+
+  <!-- Arrow marker -->
+  <defs>
+    <marker id="arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#555"/>
+    </marker>
+  </defs>
+</svg>

--- a/docs/proposals/digitize-file-hash-dedup/sequence.svg
+++ b/docs/proposals/digitize-file-hash-dedup/sequence.svg
@@ -1,0 +1,186 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 920" width="1100" height="920" font-family="'Segoe UI', system-ui, sans-serif" font-size="12">
+  <!-- Background -->
+  <rect width="1100" height="920" fill="#1a1a1a"/>
+
+  <!-- Title -->
+  <text x="550" y="28" text-anchor="middle" fill="#e0e0e0" font-size="14" font-weight="bold">File-Hash Already-Exists Detection — Sequence Diagram</text>
+
+  <!-- ─────────── PARTICIPANT BOXES ─────────── -->
+  <!-- Columns: Client=110, create_job=310, PostgreSQL=590, file_checksum_registry=780 (overlay on PG), pipeline=1000 -->
+
+  <!-- BEFORE band -->
+  <rect x="20" y="44" width="1060" height="16" rx="3" fill="#333"/>
+  <text x="550" y="56" text-anchor="middle" fill="#bbb" font-size="11">BEFORE — every submission runs the full pipeline</text>
+
+  <!-- Participant headers -->
+  <rect x="50"  y="64" width="120" height="36" rx="3" fill="#2a2a2a" stroke="#555" stroke-width="1.2"/>
+  <text x="110" y="87" text-anchor="middle" fill="#ccc">Client</text>
+
+  <rect x="250" y="64" width="160" height="36" rx="3" fill="#2a2a2a" stroke="#555" stroke-width="1.2"/>
+  <text x="330" y="87" text-anchor="middle" fill="#ccc">jobs.py create_job</text>
+
+  <rect x="530" y="64" width="130" height="36" rx="3" fill="#2a2a2a" stroke="#555" stroke-width="1.2"/>
+  <text x="595" y="87" text-anchor="middle" fill="#ccc">PostgreSQL</text>
+
+  <rect x="790" y="64" width="180" height="36" rx="3" fill="#2a2a2a" stroke="#555" stroke-width="1.2"/>
+  <text x="880" y="87" text-anchor="middle" fill="#ccc">ingest / digitize pipeline</text>
+
+  <!-- Lifelines -->
+  <line x1="110" y1="100" x2="110" y2="440" stroke="#444" stroke-width="1" stroke-dasharray="5,4"/>
+  <line x1="330" y1="100" x2="330" y2="440" stroke="#444" stroke-width="1" stroke-dasharray="5,4"/>
+  <line x1="595" y1="100" x2="595" y2="440" stroke="#444" stroke-width="1" stroke-dasharray="5,4"/>
+  <line x1="880" y1="100" x2="880" y2="440" stroke="#444" stroke-width="1" stroke-dasharray="5,4"/>
+
+  <!-- BEFORE messages -->
+  <!-- 1. POST /v1/jobs -->
+  <line x1="110" y1="126" x2="327" y2="126" stroke="#6a9fd8" stroke-width="1.4" marker-end="url(#solid)"/>
+  <text x="218" y="120" text-anchor="middle" fill="#9ac0e8" font-size="11">POST /v1/jobs (file bytes)</text>
+
+  <!-- 2. stage + launch -->
+  <line x1="330" y1="150" x2="877" y2="150" stroke="#6a9fd8" stroke-width="1.4" marker-end="url(#solid)"/>
+  <text x="600" y="144" text-anchor="middle" fill="#9ac0e8" font-size="11">stage + launch</text>
+
+  <!-- 3. pipeline work (self-loop) -->
+  <path d="M880,174 C940,174 940,210 880,210" fill="none" stroke="#6a9fd8" stroke-width="1.4" marker-end="url(#solid)"/>
+  <text x="950" y="188" text-anchor="start" fill="#9ac0e8" font-size="10">convert (30s) + LLM tables (25s)</text>
+  <text x="950" y="202" text-anchor="start" fill="#9ac0e8" font-size="10">+ chunk (5s) + embed+index (4s)</text>
+
+  <!-- 4. status=COMPLETED -->
+  <line x1="880" y1="234" x2="333" y2="234" stroke="#6a9fd8" stroke-width="1.4" stroke-dasharray="6,3" marker-end="url(#open)"/>
+  <text x="600" y="228" text-anchor="middle" fill="#9ac0e8" font-size="11">status=COMPLETED + upsert file_checksum_registry</text>
+
+  <!-- 5. 202 Accepted -->
+  <line x1="330" y1="258" x2="113" y2="258" stroke="#6a9fd8" stroke-width="1.4" stroke-dasharray="6,3" marker-end="url(#open)"/>
+  <text x="218" y="252" text-anchor="middle" fill="#9ac0e8" font-size="11">202 Accepted { job_id }</text>
+
+  <!-- ─── AFTER band ─── -->
+  <rect x="20" y="276" width="1060" height="16" rx="3" fill="#333"/>
+  <text x="550" y="288" text-anchor="middle" fill="#bbb" font-size="11">AFTER — already-existing file detected at the API boundary</text>
+
+  <!-- Participant headers (bottom set) -->
+  <rect x="50"  y="296" width="120" height="36" rx="3" fill="#2a2a2a" stroke="#555" stroke-width="1.2"/>
+  <text x="110" y="319" text-anchor="middle" fill="#ccc">Client</text>
+
+  <rect x="250" y="296" width="160" height="36" rx="3" fill="#2a2a2a" stroke="#555" stroke-width="1.2"/>
+  <text x="330" y="319" text-anchor="middle" fill="#ccc">jobs.py create_job</text>
+
+  <rect x="470" y="296" width="130" height="36" rx="3" fill="#2a2a2a" stroke="#555" stroke-width="1.2"/>
+  <text x="535" y="309" text-anchor="middle" fill="#ccc" font-size="11">PostgreSQL</text>
+  <text x="535" y="323" text-anchor="middle" fill="#888" font-size="10">documents table</text>
+
+  <rect x="640" y="296" width="170" height="36" rx="3" fill="#1e2a1e" stroke="#4a7a4a" stroke-width="1.2"/>
+  <text x="725" y="309" text-anchor="middle" fill="#8bc88b" font-size="11">file_checksum_registry</text>
+  <text x="725" y="323" text-anchor="middle" fill="#666" font-size="10">sha256 (PK) → doc_id</text>
+
+  <rect x="850" y="296" width="180" height="36" rx="3" fill="#2a2a2a" stroke="#555" stroke-width="1.2"/>
+  <text x="940" y="319" text-anchor="middle" fill="#888">ingest / digitize pipeline</text>
+
+  <!-- Lifelines AFTER -->
+  <line x1="110" y1="332" x2="110" y2="810" stroke="#444" stroke-width="1" stroke-dasharray="5,4"/>
+  <line x1="330" y1="332" x2="330" y2="810" stroke="#444" stroke-width="1" stroke-dasharray="5,4"/>
+  <line x1="535" y1="332" x2="535" y2="810" stroke="#444" stroke-width="1" stroke-dasharray="5,4"/>
+  <line x1="725" y1="332" x2="725" y2="810" stroke="#4a7a4a" stroke-width="1" stroke-dasharray="5,4"/>
+  <line x1="940" y1="332" x2="940" y2="810" stroke="#444" stroke-width="1" stroke-dasharray="5,4"/>
+
+  <!-- 6. POST /v1/jobs same file bytes -->
+  <line x1="110" y1="358" x2="327" y2="358" stroke="#6a9fd8" stroke-width="1.4" marker-end="url(#solid)"/>
+  <text x="218" y="352" text-anchor="middle" fill="#9ac0e8" font-size="11">POST /v1/jobs (same file bytes)</text>
+
+  <!-- 7. asyncio.to_thread(generate_file_checksum) — self-loop on create_job -->
+  <path d="M330,382 C390,382 390,416 330,416" fill="none" stroke="#6a9fd8" stroke-width="1.4" marker-end="url(#solid)"/>
+  <text x="398" y="396" text-anchor="start" fill="#9ac0e8" font-size="11">asyncio.to_thread(</text>
+  <text x="398" y="410" text-anchor="start" fill="#9ac0e8" font-size="11">  generate_file_checksum, bytes) ~40 ms</text>
+
+  <!-- 8. SELECT via registry PK -->
+  <line x1="330" y1="440" x2="722" y2="440" stroke="#6a9fd8" stroke-width="1.4" marker-end="url(#solid)"/>
+  <text x="525" y="434" text-anchor="middle" fill="#9ac0e8" font-size="11">SELECT doc_id FROM file_checksum_registry WHERE sha256=? (PK, &lt;2ms)</text>
+
+  <!-- 9. doc_id found -->
+  <line x1="722" y1="464" x2="333" y2="464" stroke="#6a9fd8" stroke-width="1.4" stroke-dasharray="6,3" marker-end="url(#open)"/>
+  <text x="525" y="458" text-anchor="middle" fill="#8bc88b" font-size="11">doc_id found → join Document row (status=completed)</text>
+
+  <!-- Note: also cross-checks ingestion for digitization -->
+  <rect x="340" y="476" width="374" height="34" rx="3" fill="#1e2a1e" stroke="#4a7a4a" stroke-width="1"/>
+  <text x="527" y="490" text-anchor="middle" fill="#8bc88b" font-size="10">Digitization: also checks find_completed_document_by_hash(hash, "ingestion")</text>
+  <text x="527" y="504" text-anchor="middle" fill="#666" font-size="10">if ingestion doc already exists, digitization is also blocked</text>
+
+  <!-- 10. all novel? -->
+  <!-- Scenario A: some/all already exist -->
+  <!-- Scenario B: partial → 202, skipped files recorded as ALREADY_EXISTS in job docs -->
+
+  <!-- Scenario A label -->
+  <text x="110" y="534" text-anchor="middle" fill="#888" font-size="10">Scenario A</text>
+  <text x="110" y="547" text-anchor="middle" fill="#888" font-size="10">all files</text>
+  <text x="110" y="560" text-anchor="middle" fill="#888" font-size="10">already exist</text>
+
+  <!-- 11a. 409 Conflict (all duplicates) -->
+  <line x1="330" y1="570" x2="113" y2="570" stroke="#e07070" stroke-width="1.4" stroke-dasharray="6,3" marker-end="url(#open)"/>
+  <text x="218" y="563" text-anchor="middle" fill="#e07070" font-size="11">409 CONFLICT — no job created, no semaphore acquired</text>
+
+  <!-- Pipeline never runs box -->
+  <rect x="860" y="556" width="150" height="28" rx="3" fill="#2a2020" stroke="#7a3a3a" stroke-width="1.2"/>
+  <text x="935" y="574" text-anchor="middle" fill="#c07070" font-size="11">Pipeline never runs</text>
+
+  <!-- Divider -->
+  <line x1="40" y1="596" x2="1060" y2="596" stroke="#333" stroke-width="1" stroke-dasharray="3,5"/>
+  <text x="550" y="610" text-anchor="middle" fill="#666" font-size="10">— — — Scenario B: some files novel, some already-exist — — —</text>
+
+  <!-- 11b. strip already-exists from batch (self-loop on create_job) -->
+  <path d="M330,624 C390,624 390,654 330,654" fill="none" stroke="#6a9fd8" stroke-width="1.4" marker-end="url(#solid)"/>
+  <text x="398" y="636" text-anchor="start" fill="#9ac0e8" font-size="11">strip already-existing files from batch</text>
+  <text x="398" y="650" text-anchor="start" fill="#9ac0e8" font-size="11">novel_filenames / novel_contents remain</text>
+
+  <!-- 12. acquire semaphore + stage + initialize_job_state -->
+  <line x1="330" y1="674" x2="532" y2="674" stroke="#6a9fd8" stroke-width="1.4" marker-end="url(#solid)"/>
+  <text x="430" y="668" text-anchor="middle" fill="#9ac0e8" font-size="11">create job + novel docs (ACCEPTED)</text>
+
+  <!-- 13. create ALREADY_EXISTS doc rows -->
+  <line x1="330" y1="698" x2="532" y2="698" stroke="#8bc88b" stroke-width="1.4" marker-end="url(#solid)"/>
+  <text x="430" y="692" text-anchor="middle" fill="#8bc88b" font-size="11">create already-exists docs (status=ALREADY_EXISTS, written atomically)</text>
+
+  <!-- 14. background task launched -->
+  <line x1="330" y1="722" x2="937" y2="722" stroke="#6a9fd8" stroke-width="1.4" marker-end="url(#solid)"/>
+  <text x="630" y="716" text-anchor="middle" fill="#9ac0e8" font-size="11">background: ingest/digitize(file_checksum_dict) — novel files only</text>
+
+  <!-- 15. pipeline work self-loop -->
+  <path d="M940,746 C1000,746 1000,778 940,778" fill="none" stroke="#6a9fd8" stroke-width="1.4" marker-end="url(#solid)"/>
+  <text x="1006" y="758" text-anchor="start" fill="#9ac0e8" font-size="10">convert → chunk → embed → index</text>
+
+  <!-- 16. COMPLETED + upsert checksum -->
+  <line x1="940" y1="798" x2="728" y2="798" stroke="#8bc88b" stroke-width="1.4" stroke-dasharray="6,3" marker-end="url(#open)"/>
+  <text x="835" y="792" text-anchor="middle" fill="#8bc88b" font-size="11">upsert file_checksum_registry (sha256 → doc_id)</text>
+
+  <!-- 17. 202 Accepted -->
+  <line x1="330" y1="822" x2="113" y2="822" stroke="#6a9fd8" stroke-width="1.4" stroke-dasharray="6,3" marker-end="url(#open)"/>
+  <text x="218" y="815" text-anchor="middle" fill="#9ac0e8" font-size="11">202 Accepted { job_id } — skipped files in GET /v1/jobs/{job_id} with message="Already ingested as &lt;filename&gt;"</text>
+
+  <!-- Footer participant boxes -->
+  <rect x="50"  y="836" width="120" height="32" rx="3" fill="#2a2a2a" stroke="#555" stroke-width="1.2"/>
+  <text x="110" y="857" text-anchor="middle" fill="#ccc">Client</text>
+
+  <rect x="250" y="836" width="160" height="32" rx="3" fill="#2a2a2a" stroke="#555" stroke-width="1.2"/>
+  <text x="330" y="857" text-anchor="middle" fill="#ccc">jobs.py create_job</text>
+
+  <rect x="470" y="836" width="130" height="32" rx="3" fill="#2a2a2a" stroke="#555" stroke-width="1.2"/>
+  <text x="535" y="857" text-anchor="middle" fill="#ccc">PostgreSQL</text>
+
+  <rect x="640" y="836" width="170" height="32" rx="3" fill="#1e2a1e" stroke="#4a7a4a" stroke-width="1.2"/>
+  <text x="725" y="857" text-anchor="middle" fill="#8bc88b">file_checksum_registry</text>
+
+  <rect x="850" y="836" width="180" height="32" rx="3" fill="#2a2a2a" stroke="#555" stroke-width="1.2"/>
+  <text x="940" y="857" text-anchor="middle" fill="#888">ingest / digitize pipeline</text>
+
+  <!-- Footer note -->
+  <text x="550" y="898" text-anchor="middle" fill="#555" font-size="10">Lookup uses file_checksum_registry PK join (O(1)) — not a JSONB expression index.  Hash computed via asyncio.to_thread().  Applies to both ingestion and digitization.</text>
+  <text x="550" y="912" text-anchor="middle" fill="#444" font-size="10">Made with IBM Bob</text>
+
+  <!-- Arrow markers -->
+  <defs>
+    <marker id="solid" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#6a9fd8"/>
+    </marker>
+    <marker id="open" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="none" stroke="#6a9fd8" stroke-width="1.2"/>
+    </marker>
+  </defs>
+</svg>

--- a/services/common/misc_utils.py
+++ b/services/common/misc_utils.py
@@ -284,12 +284,28 @@ def setup_digitized_doc_dir():
     os.makedirs(settings.digitize.digitized_docs_dir, exist_ok=True)
     return settings.digitize.digitized_docs_dir
 
-def generate_file_checksum(file):
+def generate_file_checksum(file) -> str:
+    """Compute a prefixed SHA-256 hex digest of a file.
+
+    Accepts either a file path (str or Path) or raw bytes.  When passed bytes
+    the entire content is hashed in one shot; when passed a path the file is
+    read in chunks so arbitrarily large files can be processed without loading
+    them entirely into memory.
+
+    The ``sha256:`` prefix makes the algorithm explicit in stored values so
+    the hash algorithm can be upgraded in future without ambiguity.
+
+    Returns:
+        String in the form ``'sha256:<64-char-hex>'``.
+    """
     sha256 = hashlib.sha256()
-    with open(file, 'rb') as f:
-        for chunk in iter(lambda: f.read(128 * sha256.block_size), b''):
-            sha256.update(chunk)
-    return sha256.hexdigest()
+    if isinstance(file, (bytes, bytearray)):
+        sha256.update(file)
+    else:
+        with open(file, 'rb') as f:
+            for chunk in iter(lambda: f.read(128 * sha256.block_size), b''):
+                sha256.update(chunk)
+    return f"sha256:{sha256.hexdigest()}"
 
 def verify_checksum(file, checksum_file):
     file_sha256 = generate_file_checksum(file)

--- a/services/common/tests/test_lang_utils.py
+++ b/services/common/tests/test_lang_utils.py
@@ -184,7 +184,11 @@ class TestGetPromptForLanguage:
 @pytest.mark.unit
 class TestGetMaxTokensMap:
     """Tests for get_max_tokens_map function."""
-    
+    def setup_method(self):
+        """Reset cached max tokens map before each test."""
+        import common.lang_utils as lang_utils
+        lang_utils._max_tokens_map = None
+
     def test_get_max_tokens_map_returns_dict(self):
         """Test returns dictionary with language codes and max tokens."""
         from common.lang_utils import get_max_tokens_map, LanguageCodes
@@ -413,12 +417,16 @@ class TestLanguageUtilsIntegration:
     
     def test_max_tokens_map_integration(self):
         """Test max tokens map integration with language detection."""
+        import common.lang_utils as lang_utils
         from common.lang_utils import (
             setup_language_detector,
             detect_language,
             get_max_tokens_map,
             LanguageCodes
         )
+
+        # Reset cached map so the patch below takes effect
+        lang_utils._max_tokens_map = None
         
         # Setup
         setup_language_detector([Language.ENGLISH, Language.GERMAN])

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.34
+TAG?=v0.0.35
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/api/v1/jobs.py
+++ b/services/digitize/api/v1/jobs.py
@@ -14,7 +14,7 @@ from typing import List, Optional
 
 from fastapi import APIRouter, BackgroundTasks, File, HTTPException, Query, UploadFile, status
 
-from common.misc_utils import get_logger, validate_document_file, cleanup_staging_directory
+from common.misc_utils import get_logger, validate_document_file, cleanup_staging_directory, generate_file_checksum
 from common.error_utils import APIError, ErrorCode, http_error_responses
 import digitize.utils.jobs as dg_util
 import digitize.models as models
@@ -24,6 +24,7 @@ from digitize.pipeline.digitize import digitize
 from digitize.pipeline.ingest import ingest
 from digitize.settings import settings
 from digitize.workers.concurrency import concurrency_manager
+from digitize.db.manager import db_manager
 
 router = APIRouter()
 logger = get_logger("jobs_router")
@@ -37,6 +38,7 @@ async def _run_digitize(
     job_id: str,
     doc_id_dict: dict,
     output_format: models.OutputFormat,
+    file_checksum_dict: Optional[dict] = None,  # filename -> "sha256:..."
 ) -> None:
     """Run the digitization pipeline and release the semaphore slot."""
     status_mgr = get_status_manager(job_id)
@@ -44,7 +46,7 @@ async def _run_digitize(
 
     try:
         logger.info(f"🚀 Digitization started for job: {job_id}")
-        await asyncio.to_thread(digitize, job_staging_path, job_id, doc_id_dict, output_format)
+        await asyncio.to_thread(digitize, job_staging_path, job_id, doc_id_dict, output_format, file_checksum_dict)
         logger.info(f"Digitization for job {job_id} completed successfully")
     except Exception as exc:
         logger.error(f"Error in digitization job {job_id}: {exc}")
@@ -64,6 +66,7 @@ async def _run_ingest(
     job_id: str,
     filenames: List[str],
     doc_id_dict: dict,
+    file_checksum_dict: Optional[dict] = None,  # filename -> "sha256:..."
 ) -> None:
     """Run the ingestion pipeline and release the semaphore slot."""
     status_mgr = get_status_manager(job_id)
@@ -71,7 +74,7 @@ async def _run_ingest(
 
     try:
         logger.info(f"🚀 Ingestion started for job: {job_id}")
-        await asyncio.to_thread(ingest, job_staging_path, job_id, doc_id_dict)
+        await asyncio.to_thread(ingest, job_staging_path, job_id, doc_id_dict, file_checksum_dict)
         logger.info(f"Ingestion for job {job_id} completed successfully")
     except Exception as exc:
         logger.error(f"Error in ingestion job {job_id}: {exc}")
@@ -123,16 +126,36 @@ async def _validate_files(
     "",
     status_code=status.HTTP_202_ACCEPTED,
     response_model=models.JobCreatedResponse,
-    responses=http_error_responses,
+    responses={
+        **http_error_responses,
+        409: {
+            "description": (
+                "Conflict — all submitted files have already been processed as completed "
+                "documents of the same operation type (duplicate detection via SHA-256 hash). "
+            ),
+        },
+    },
     summary="Create async jobs to upload and process documents",
     description=(
         "Upload documents (PDF or DOCX) for processing. Supports two operation types:\n\n"
         "- **ingestion**: Process and index documents into vector database for semantic search\n"
         "- **digitization**: Convert document to text/markdown/JSON format (single file only)\n\n"
         "The operation runs asynchronously in the background. "
-        "Use the returned `job_id` to track progress."
+        "Use the returned `job_id` to track progress.\n\n"
+        "### Already-exists detection\n\n"
+        "Every submitted file is hashed (SHA-256) and compared against completed documents "
+        "of the same operation type already stored in the database.\n\n"
+        "| Scenario | Behaviour |\n"
+        "|---|---|\n"
+        "| All files already exist | **409 Conflict** — no job is created |\n"
+        "| Some files already exist | **202 Accepted** — only novel files are processed; "
+        "skipped files appear in the job's document list with `status=already_exists` and "
+        "a `message` field such as `\"Already ingested as <filename>\"` |\n"
+        "| No files already exist | **202 Accepted** |\n\n"
+        "Only *completed* documents trigger already-exists detection. Failed or in-progress records "
+        "are not considered to already exist."
     ),
-    response_description="Job ID for tracking the processing status",
+    response_description="Job accepted. `job_id` can be used to poll status.",
 )
 async def create_job(
     background_tasks: BackgroundTasks,
@@ -203,6 +226,76 @@ async def create_job(
 
         filenames, file_contents = await _validate_files(files, file_contents_raw)
 
+        # 5b. File-hash already-exists detection.
+        #
+        # Each file is hashed and checked against completed documents of the same
+        # operation type. Files that already exist are removed from the batch; novel
+        # files continue. If ALL files already exist, return 409 immediately (no job
+        # created). If SOME files already exist, only novel files are processed;
+        # skipped files are recorded in the job's document list with status
+        # `already_exists` (visible via GET /v1/jobs/{job_id}).
+        #
+        # A file already exists only if a document with:
+        #   - type   = operation ('ingestion' or 'digitization')
+        #   - status = 'completed'
+        #   - metadata->>'file_hash' = computed_hash
+        # is found. Failed / in-progress records are NOT considered to already exist.
+
+        already_exists_files: list[models.AlreadyExistsFile] = []
+        file_checksum_dict: dict[str, str] = {}  # filename -> "sha256:..." (novel files only)
+
+        novel_filenames: list[str] = []
+        novel_contents:  list[bytes] = []
+
+        for filename, content in zip(filenames, file_contents):
+            file_hash = await asyncio.to_thread(generate_file_checksum, content)
+            existing = db_manager.find_completed_document_by_hash(file_hash, operation.value)
+
+            # A digitization request is also blocked by a completed ingestion of the
+            # same file — no point re-digitizing content that is already indexed.
+            if not existing and operation == models.OperationType.DIGITIZATION:
+                existing = db_manager.find_completed_document_by_hash(
+                    file_hash, models.OperationType.INGESTION.value
+                )
+
+            if existing:
+                logger.info(
+                    f"File '{filename}' already exists — matches completed "
+                    f"doc_id={existing.doc_id} (hash={file_hash[:20]}...)"
+                )
+                already_exists_files.append(
+                    models.AlreadyExistsFile(
+                        filename=filename,
+                        existing_doc_id=existing.doc_id,
+                        existing_doc_name=existing.name,
+                        file_hash=file_hash,
+                    )
+                )
+            else:
+                novel_filenames.append(filename)
+                novel_contents.append(content)
+                file_checksum_dict[filename] = file_hash
+
+        # All files already exist → 409 Conflict, no job created.
+        if not novel_filenames:
+            skipped_summary = ", ".join(
+                f"'{s.filename}' (existing doc: {s.existing_doc_id})"
+                for s in already_exists_files
+            )
+            logger.warning(
+                f"All {len(already_exists_files)} submitted file(s) already exist. "
+                f"No job created. Files: {skipped_summary}"
+            )
+            APIError.raise_error(
+                ErrorCode.RESOURCE_LOCKED,
+                f"All submitted files have already been processed: {skipped_summary}. "
+                f"Delete the existing documents first if you want to re-process.",
+            )
+
+        # Replace filenames/file_contents with the novel subset only.
+        filenames     = novel_filenames
+        file_contents = novel_contents
+
         # 6. Acquire semaphore slot.
         await concurrency_manager.acquire(op_key)
 
@@ -215,12 +308,15 @@ async def create_job(
                 file_contents,
             )
             doc_id_dict = dg_util.initialize_job_state(
-                job_id, operation, output_format, filenames, job_name
+                job_id, operation, output_format, filenames, job_name,
+                already_exists_files=already_exists_files,
             )
             if operation == models.OperationType.INGESTION:
-                background_tasks.add_task(_run_ingest, job_id, filenames, doc_id_dict)
+                background_tasks.add_task(
+                    _run_ingest, job_id, filenames, doc_id_dict, file_checksum_dict
+                )
             else:
-                background_tasks.add_task(_run_digitize, job_id, doc_id_dict, output_format)
+                background_tasks.add_task(_run_digitize, job_id, doc_id_dict, output_format, file_checksum_dict)
         except Exception as exc:
             concurrency_manager.release(op_key)
             logger.error(

--- a/services/digitize/api/v1/jobs.py
+++ b/services/digitize/api/v1/jobs.py
@@ -129,10 +129,7 @@ async def _validate_files(
     responses={
         **http_error_responses,
         409: {
-            "description": (
-                "Conflict — all submitted files have already been processed as completed "
-                "documents of the same operation type (duplicate detection via SHA-256 hash). "
-            ),
+            "description": "All submitted files have already been processed.",
         },
     },
     summary="Create async jobs to upload and process documents",
@@ -142,18 +139,9 @@ async def _validate_files(
         "- **digitization**: Convert document to text/markdown/JSON format (single file only)\n\n"
         "The operation runs asynchronously in the background. "
         "Use the returned `job_id` to track progress.\n\n"
-        "### Already-exists detection\n\n"
-        "Every submitted file is hashed (SHA-256) and compared against completed documents "
-        "of the same operation type already stored in the database.\n\n"
-        "| Scenario | Behaviour |\n"
-        "|---|---|\n"
-        "| All files already exist | **409 Conflict** — no job is created |\n"
-        "| Some files already exist | **202 Accepted** — only novel files are processed; "
-        "skipped files appear in the job's document list with `status=already_exists` and "
-        "a `message` field such as `\"Already ingested as <filename>\"` |\n"
-        "| No files already exist | **202 Accepted** |\n\n"
-        "Only *completed* documents trigger already-exists detection. Failed or in-progress records "
-        "are not considered to already exist."
+        "Files are deduplicated using hash against completed documents. "
+        "If only some files are duplicates, the job proceeds with the novel files; "
+        "skipped files appear in the document list with `status=already_exists`."
     ),
     response_description="Job accepted. `job_id` can be used to poll status.",
 )

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -7,11 +7,12 @@ Provides CRUD operations with proper error handling and transaction management.
 from datetime import datetime, timezone
 from typing import List, Optional, Dict, Any, cast
 from sqlalchemy import select, update, delete, func, or_, and_
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 
 from common.misc_utils import get_logger
-from digitize.db.models import Job, Document
+from digitize.db.models import Job, Document, FileChecksumRegistry
 from digitize.db.connection import get_db_session
 from digitize.models import JobStatus, DocStatus
 
@@ -298,13 +299,13 @@ class DatabaseManager:
                 return document
         except IntegrityError as e:
             logger.error(f"Document {doc_id} already exists or invalid job_id: {e}")
-            return None
+            raise
         except SQLAlchemyError as e:
             logger.error(f"Database error creating document {doc_id}: {e}", exc_info=True)
-            return None
+            raise
         except Exception as e:
             logger.error(f"Unexpected error creating document {doc_id}: {e}", exc_info=True)
-            return None
+            raise
 
     @staticmethod
     def get_document_by_id(doc_id: str) -> Optional[Document]:
@@ -340,6 +341,92 @@ class DatabaseManager:
             logger.error(f"Unexpected error retrieving document {doc_id}: {e}", exc_info=True)
             return None
 
+
+    @staticmethod
+    def upsert_file_checksum(sha256: str, doc_id: str) -> None:
+        """
+        Insert or ignore a (sha256, doc_id) pair into file_checksum_registry.
+
+        Called once a document reaches COMPLETED status so that subsequent
+        uploads of the same content can be detected via find_completed_document_by_hash.
+
+        Args:
+            sha256: Prefixed SHA-256 digest, e.g. 'sha256:e3b0c44...'
+            doc_id: The completed document's primary key.
+        """
+        try:
+            with get_db_session() as session:
+                stmt = (
+                    insert(FileChecksumRegistry)
+                    .values(sha256=sha256, doc_id=doc_id)
+                    .on_conflict_do_update(
+                        index_elements=["sha256"],
+                        set_={"doc_id": doc_id},
+                    )
+                )
+                session.execute(stmt)
+                logger.debug(f"Upserted checksum registry: sha256={sha256[:20]}... doc_id={doc_id}")
+        except SQLAlchemyError as e:
+            logger.error(f"DB error upserting checksum for {sha256[:20]}...: {e}", exc_info=True)
+
+    @staticmethod
+    def find_completed_document_by_hash(
+        file_hash: str,
+        operation: str = "ingestion",
+    ) -> Optional[Document]:
+        """
+        Find the completed document of the given operation type with a matching
+        file hash, using the file_checksum_registry lookup table.
+
+        Only documents with status='completed' and the specified type are considered.
+        Failed and in-progress documents are deliberately excluded so that a previous
+        failed attempt does not prevent re-processing of the same file.
+
+        Args:
+            file_hash: Prefixed SHA-256 digest, e.g. 'sha256:e3b0c44...'
+            operation: Document type to match — 'ingestion' or 'digitization'.
+
+        Returns:
+            The matching Document ORM object (attributes eagerly loaded and
+            expunged from session), or None if no completed duplicate exists.
+        """
+        try:
+            with get_db_session() as session:
+                stmt = (
+                    select(Document)
+                    .join(
+                        FileChecksumRegistry,
+                        FileChecksumRegistry.doc_id == Document.doc_id,
+                    )
+                    .where(
+                        FileChecksumRegistry.sha256 == file_hash,
+                        Document.type == operation,
+                        Document.status == DocStatus.COMPLETED.value,
+                    )
+                    .limit(1)
+                )
+                doc = session.scalar(stmt)
+                if doc:
+                    # Eagerly load all attributes before session closes to prevent
+                    # DetachedInstanceError in the caller.
+                    _ = (
+                        doc.doc_id, doc.job_id, doc.name, doc.type,
+                        doc.status, doc.output_format, doc.submitted_at,
+                        doc.completed_at, doc.error, doc.doc_metadata,
+                    )
+                    session.expunge(doc)
+                    logger.debug(
+                        f"Duplicate detected: file_hash={file_hash[:20]}... "
+                        f"matches doc_id={doc.doc_id}"
+                    )
+                return doc
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in hash lookup for {file_hash[:20]}...: {e}", exc_info=True)
+            # Do NOT raise — a lookup failure must not block ingestion.
+            # If the DB is unavailable the caller treats the file as novel.
+            return None
+
+
     @staticmethod
     def get_all_documents(
         status: Optional[str] = None,
@@ -363,10 +450,14 @@ class DatabaseManager:
             with get_db_session() as session:
                 # Build query with filters
                 stmt = select(Document)
-                
+
                 filters = []
                 if status:
                     filters.append(Document.status == status)
+                else:
+                    # Exclude already_exists docs from the global listing — they are
+                    # job-scoped audit records, not real ingested documents.
+                    filters.append(Document.status != DocStatus.ALREADY_EXISTS.value)
                 if name:
                     filters.append(Document.name.ilike(f"%{name}%"))
                 
@@ -494,9 +585,14 @@ class DatabaseManager:
         """
         try:
             with get_db_session() as session:
+                # Remove checksum registry entry first so the hash can be re-registered
+                # if the same file is ingested again after deletion.
+                session.execute(
+                    delete(FileChecksumRegistry).where(FileChecksumRegistry.doc_id == doc_id)
+                )
                 stmt = delete(Document).where(Document.doc_id == doc_id)
                 result = cast(CursorResult, session.execute(stmt))
-                
+
                 if result.rowcount > 0:
                     logger.info(f"Deleted document from database: {doc_id}")
                     return True
@@ -554,10 +650,13 @@ class DatabaseManager:
         """
         try:
             with get_db_session() as session:
+                # Wipe the checksum registry so previously-seen hashes are no longer
+                # blocked after a full reset.
+                session.execute(delete(FileChecksumRegistry))
                 stmt = delete(Document)
                 result = cast(CursorResult, session.execute(stmt))
                 deleted_count = result.rowcount
-                
+
                 logger.info(f"Deleted all documents from database: {deleted_count} documents")
                 return {
                     "deleted_count": deleted_count,

--- a/services/digitize/db/models.py
+++ b/services/digitize/db/models.py
@@ -132,7 +132,8 @@ class Document(Base):
     # Constraints
     __table_args__ = (
         CheckConstraint(
-            "status IN ('accepted', 'in_progress', 'digitized', 'processed', 'chunked', 'completed', 'failed')",
+            "status IN ('accepted', 'in_progress', 'digitized', 'processed',"
+            " 'chunked', 'completed', 'failed', 'already_exists')",
             name="chk_doc_status"
         ),
         CheckConstraint(
@@ -149,5 +150,30 @@ class Document(Base):
 
     def __repr__(self) -> str:
         return f"<Document(doc_id='{self.doc_id}', name='{self.name}', status='{self.status}')>"
+
+
+class FileChecksumRegistry(Base):
+    """
+    Registry table that maps a SHA-256 digest to the authoritative completed
+    Document row for that content.
+
+    Maps to the 'file_checksum_registry' table in PostgreSQL.
+
+    The FK to documents(doc_id) ON DELETE CASCADE means registry entries are
+    automatically removed when the referenced document is deleted, preventing
+    orphaned hashes from blocking future re-ingestion of the same file.
+    """
+    __tablename__ = "file_checksum_registry"
+
+    sha256: Mapped[str] = mapped_column(Text, primary_key=True)
+    doc_id: Mapped[str] = mapped_column(
+        Text,
+        ForeignKey("documents.doc_id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+
+    def __repr__(self) -> str:
+        return f"<FileChecksumRegistry(sha256='{self.sha256[:20]}...', doc_id='{self.doc_id}')>"
 
 # Made with Bob

--- a/services/digitize/db/scripts/init_schema.sql
+++ b/services/digitize/db/scripts/init_schema.sql
@@ -27,9 +27,19 @@ CREATE TABLE IF NOT EXISTS documents (
     error TEXT,
     metadata JSONB NOT NULL DEFAULT '{}',
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,  -- Last modification time (UTC)
-    CONSTRAINT chk_doc_status CHECK (status IN ('accepted', 'in_progress', 'digitized', 'processed', 'chunked', 'completed', 'failed')),
+    CONSTRAINT chk_doc_status CHECK (status IN ('accepted', 'in_progress', 'digitized', 'processed', 'chunked', 'completed', 'failed', 'already_exists')),
     CONSTRAINT chk_doc_type CHECK (type IN ('ingestion', 'digitization')),
     CONSTRAINT chk_output_format CHECK (output_format IN ('txt', 'md', 'json'))
+);
+
+-- Checksum registry — one row per unique file content, points to the
+-- authoritative completed Document for duplicate detection.
+-- ON DELETE CASCADE ensures stale registry entries are automatically removed
+-- when the referenced document is deleted, preventing orphaned hash entries
+-- from blocking future re-ingestion of the same file.
+CREATE TABLE IF NOT EXISTS file_checksum_registry (
+    sha256        TEXT        PRIMARY KEY,
+    doc_id        TEXT        NOT NULL UNIQUE REFERENCES documents(doc_id) ON DELETE CASCADE
 );
 
 -- Create indexes with IF NOT EXISTS

--- a/services/digitize/models.py
+++ b/services/digitize/models.py
@@ -29,6 +29,16 @@ class DocStatus(str, Enum):
     CHUNKED = "chunked"
     COMPLETED = "completed"
     FAILED = "failed"
+    ALREADY_EXISTS = "already_exists"
+
+
+class AlreadyExistsFile(BaseModel):
+    """Describes a single file that was skipped because it already exists."""
+    filename: str = Field(..., description="Original filename of the skipped file")
+    existing_doc_id: str = Field(..., description="doc_id of the already-ingested document")
+    existing_doc_name: str = Field(..., description="Name of the already-ingested document")
+    file_hash: str = Field(..., description="SHA-256 hash that matched, e.g. 'sha256:e3b0...'")
+
 
 class PaginationInfo(BaseModel):
     total: int
@@ -81,10 +91,14 @@ class DocumentContentResponse(BaseModel):
 class JobDocumentSummary(BaseModel):
     """Compact per-document entry for job status responses."""
     model_config = ConfigDict(use_enum_values=True)
-    
+
     id: str
     name: str
     status: str
+    message: Optional[str] = Field(
+        default=None,
+        description="Human-readable message; set when status is 'already_exists'",
+    )
 
 
 class JobStats(BaseModel):

--- a/services/digitize/models.py
+++ b/services/digitize/models.py
@@ -97,7 +97,7 @@ class JobDocumentSummary(BaseModel):
     status: str
     message: Optional[str] = Field(
         default=None,
-        description="Human-readable message; set when status is 'already_exists'",
+        description="Human-readable message providing additional context about the document status",
     )
 
 

--- a/services/digitize/pipeline/digitize.py
+++ b/services/digitize/pipeline/digitize.py
@@ -6,7 +6,7 @@ convert → mark status → emit output file.
 """
 from common.misc_utils import *
 from pathlib import Path
-from common.misc_utils import get_utc_timestamp
+from common.misc_utils import get_utc_timestamp, generate_file_checksum
 from digitize.models import JobStatus, DocStatus, OutputFormat
 from digitize.parsing.pdf import get_pdf_page_count, get_document_page_count
 from digitize.parsing.converter import convert_document_format
@@ -15,7 +15,13 @@ from concurrent.futures import ProcessPoolExecutor
 
 logger = get_logger("digitize")
 
-def digitize(directory_path: Path, job_id: str, doc_id_dict: dict, output_format: OutputFormat):
+def digitize(
+    directory_path: Path,
+    job_id: str,
+    doc_id_dict: dict,
+    output_format: OutputFormat,
+    file_checksum_dict: dict | None = None,  # filename -> "sha256:..." pre-computed at upload
+):
     """
     Digitize a single document file (PDF or DOCX) in the staging directory.
 
@@ -25,6 +31,9 @@ def digitize(directory_path: Path, job_id: str, doc_id_dict: dict, output_format
         job_id: Job identifier for StatusManager
         doc_id_dict: Mapping from filename to document ID
         output_format: "json", "md", or "txt"
+        file_checksum_dict: Pre-computed SHA-256 checksums keyed by filename.
+                            When provided the hash is reused rather than
+                            re-reading the file from disk to recompute it.
 
     Raises:
         Exception: If conversion fails
@@ -73,11 +82,17 @@ def digitize(directory_path: Path, job_id: str, doc_id_dict: dict, output_format
         # Mark COMPLETED
         if status_mgr:
             logger.debug(f"Conversion Done: updating doc & job metadata for document: {doc_id}")
+            file_hash = (
+                file_checksum_dict.get(filename)
+                if file_checksum_dict
+                else generate_file_checksum(file_path.read_bytes())
+            )
             status_mgr.update_doc_metadata(doc_id, {
                 "status": DocStatus.COMPLETED,
                 "pages": page_count,
                 "completed_at": get_utc_timestamp(),
-                "timing_in_secs": {"digitizing": round(conversion_time, 2)}
+                "timing_in_secs": {"digitizing": round(conversion_time, 2)},
+                "file_hash": file_hash,
             })
             status_mgr.update_job_progress(doc_id, DocStatus.COMPLETED, JobStatus.COMPLETED)
 

--- a/services/digitize/pipeline/ingest.py
+++ b/services/digitize/pipeline/ingest.py
@@ -20,7 +20,12 @@ from common.misc_utils import get_utc_timestamp
 
 logger = get_logger("ingest")
 
-def create_indexing_handler(emb_model_dict: dict, status_mgr: Optional[DatabaseStatusManager], doc_id_dict: Optional[dict]):
+def create_indexing_handler(
+    emb_model_dict: dict,
+    status_mgr: Optional[DatabaseStatusManager],
+    doc_id_dict: Optional[dict],
+    file_checksum_dict: Optional[dict] = None,  # filename -> "sha256:..."
+):
     """
     Create an indexing handler that can be called immediately after chunking of a document.
 
@@ -28,6 +33,7 @@ def create_indexing_handler(emb_model_dict: dict, status_mgr: Optional[DatabaseS
         emb_model_dict: Dictionary containing embedding model configuration
         status_mgr: Status manager for updating document status
         doc_id_dict: Mapping of document names to IDs
+        file_checksum_dict: Optional mapping of filename -> sha256 hash string
 
     Returns:
         Callable that handles indexing of a single document's chunks
@@ -81,13 +87,20 @@ def create_indexing_handler(emb_model_dict: dict, status_mgr: Optional[DatabaseS
             # Update status to COMPLETED with indexing timing
             if status_mgr and doc_id_dict:
                 logger.debug(f"Indexing Done: updating doc metadata to COMPLETED for document: {doc_id}")
+                file_hash = (
+                    file_checksum_dict.get(Path(path).name)
+                    if file_checksum_dict else None
+                )
+                metadata_update = {
+                    "status": DocStatus.COMPLETED,
+                    "completed_at": get_utc_timestamp(),
+                    "timing_in_secs": {"indexing": round(indexing_time, 2)},
+                }
+                if file_hash:
+                    metadata_update["file_hash"] = file_hash
                 status_mgr.update_doc_metadata(
                     doc_id,
-                    {
-                        "status": DocStatus.COMPLETED,
-                        "completed_at": get_utc_timestamp(),
-                        "timing_in_secs": {"indexing": round(indexing_time, 2)}
-                    }
+                    metadata_update,
                 )
                 status_mgr.update_job_progress(doc_id, DocStatus.COMPLETED, JobStatus.IN_PROGRESS)
 
@@ -122,7 +135,12 @@ def create_indexing_handler(emb_model_dict: dict, status_mgr: Optional[DatabaseS
 
     return index_document_chunks
 
-def ingest(directory_path: Path, job_id: Optional[str] = None, doc_id_dict: Optional[dict] = None):
+def ingest(
+    directory_path: Path,
+    job_id: Optional[str] = None,
+    doc_id_dict: Optional[dict] = None,
+    file_checksum_dict: Optional[dict] = None,  # filename -> "sha256:..."
+):
 
     def ingestion_failed():
         logger.info("❌ Ingestion failed, please re-run the ingestion again, If the issue still persists, please report an issue in https://github.com/IBM/project-ai-services/issues")
@@ -146,7 +164,8 @@ def ingest(directory_path: Path, job_id: Optional[str] = None, doc_id_dict: Opti
         docx_files = list(directory_path.glob("*.docx"))
         input_file_paths = [str(p) for p in pdf_files + docx_files]
 
-        total_documents = len(input_file_paths)
+        # Total includes already-exists files (doc_id_dict covers all submitted files).
+        total_documents = len(doc_id_dict) if doc_id_dict else len(input_file_paths)
 
         logger.info(f"Processing {total_documents} document(s)")
 
@@ -156,7 +175,9 @@ def ingest(directory_path: Path, job_id: Optional[str] = None, doc_id_dict: Opti
         out_path = setup_digitized_doc_dir()
 
         # Create indexing handler for immediate indexing after chunking
-        indexing_handler = create_indexing_handler(emb_model_dict, status_mgr, doc_id_dict)
+        indexing_handler = create_indexing_handler(
+            emb_model_dict, status_mgr, doc_id_dict, file_checksum_dict
+        )
 
         start_time = time.time()
         # Reserve 100 tokens from embedding model's max_model_len to account for metadata
@@ -183,10 +204,11 @@ def ingest(directory_path: Path, job_id: Optional[str] = None, doc_id_dict: Opti
             failed_docs = doc_stats["failed_docs"]
             completed_docs = doc_stats["completed_docs"]
 
+            pct = (len(completed_docs) / total_documents * 100) if total_documents > 0 else 100.0
             logger.info(
-                    f"Ingestion summary: {len(completed_docs)}/{total_documents} files ingested "
-                    f"({len(completed_docs) / total_documents * 100:.2f}% of total documents)"
-                )
+                f"Ingestion summary: {len(completed_docs)}/{total_documents} files ingested "
+                f"({pct:.2f}% of total documents)"
+            )
 
             if len(failed_docs) > 0:
                 # At least one document failed

--- a/services/digitize/tests/conftest.py
+++ b/services/digitize/tests/conftest.py
@@ -28,6 +28,23 @@ def _stub_module(name: str) -> types.ModuleType:
     return sys.modules[name]
 
 
+# ---------------------------------------------------------------------------
+# Stub out StderrMonitor before digitize.app is imported.
+#
+# StderrMonitor.start() calls os.dup2() on stderr's file descriptor, replacing
+# it with a pipe.  pytest's capture backend holds a tmpfile open on that same
+# fd; after dup2 the tmpfile points to a pipe and seek() raises
+# OSError: [Errno 29] Illegal seek, crashing the entire collection phase.
+#
+# We patch common.diagnostic_logger.setup_comprehensive_crash_handler so it
+# returns harmless stubs instead of wiring up the real stderr monitor.
+# ---------------------------------------------------------------------------
+import common.diagnostic_logger as _diag_logger  # noqa: E402
+
+_real_noop_crash_handler = lambda logger: (MagicMock(), MagicMock(), MagicMock())
+_diag_logger.setup_comprehensive_crash_handler = _real_noop_crash_handler
+
+
 # Ensure all package levels exist first.
 for _pkg in [
     "docling",

--- a/services/digitize/tests/test_deduplication.py
+++ b/services/digitize/tests/test_deduplication.py
@@ -1,0 +1,1024 @@
+"""
+Unit tests for the de-duplication feature introduced across commits
+279309ca → 269f3d87 on branch dupIndex.
+
+# NOTE on patching strategy
+# --------------------------
+# conftest.py installs an autouse fixture `mock_db_operations` that replaces
+# several symbols on the `digitize.utils.db` module object **before** each test
+# runs.  Because Python module objects are shared singletons, any attempt to
+# re-import or re-lookup those symbols inside a test still sees the mock.
+#
+# To test the *internals* of create_document / get_job we therefore stash
+# references to the real implementations at collection time (below), before the
+# first fixture runs.  Those references bypass the per-test autouse patches.
+
+Coverage areas
+──────────────
+1. models.py          – AlreadyExistsFile, DocStatus.ALREADY_EXISTS, JobDocumentSummary.message
+2. utils/jobs.py      – initialize_job_state with already_exists_files
+                      – get_job_document_stats counting already_exists as completed
+3. utils/db.py        – create_document with initial_status / completed_at / extra_metadata
+                      – _categorize_fields recognising new metadata keys
+                      – get_job / get_all_jobs populate .message for already_exists docs
+                      – DatabaseStatusManager._update_job stats (already_exists = completed)
+                      – DatabaseStatusManager.update_doc_metadata triggers upsert_file_checksum
+4. api/v1/jobs.py     – 409 when ALL files already exist
+                      – 202 with mixed batch (some novel, some already-exist)
+                      – file_checksum_dict passed to initialize_job_state
+                      – digitization also checks ingestion hash
+5. db/manager.py      – upsert_file_checksum (insert + on-conflict update)
+                      – find_completed_document_by_hash (match / no-match / DB error)
+                      – delete_document removes checksum registry row first
+                      – delete_all_documents wipes checksum registry
+                      – get_all_documents excludes already_exists by default
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+# Stash real implementations before autouse fixtures can replace them.
+import digitize.utils.db as _db_mod
+_real_create_document = _db_mod.create_document
+_real_get_job = _db_mod.get_job
+
+from digitize.models import (
+    AlreadyExistsFile,
+    DocStatus,
+    JobDocumentSummary,
+    JobStatus,
+    OperationType,
+    OutputFormat,
+)
+from digitize.utils.db import _categorize_fields
+
+
+# ============================================================================
+# 1. Model tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestAlreadyExistsFileModel:
+    def test_fields_are_required(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            AlreadyExistsFile(filename="f.pdf")  # missing required fields
+
+    def test_valid_construction(self):
+        obj = AlreadyExistsFile(
+            filename="report.pdf",
+            existing_doc_id="doc-old-1",
+            existing_doc_name="old-report.pdf",
+            file_hash="sha256:abc123",
+        )
+        assert obj.filename == "report.pdf"
+        assert obj.existing_doc_id == "doc-old-1"
+        assert obj.existing_doc_name == "old-report.pdf"
+        assert obj.file_hash == "sha256:abc123"
+
+    def test_model_dump(self):
+        obj = AlreadyExistsFile(
+            filename="a.pdf",
+            existing_doc_id="d1",
+            existing_doc_name="a_orig.pdf",
+            file_hash="sha256:ff",
+        )
+        assert obj.model_dump() == {
+            "filename": "a.pdf",
+            "existing_doc_id": "d1",
+            "existing_doc_name": "a_orig.pdf",
+            "file_hash": "sha256:ff",
+        }
+
+
+@pytest.mark.unit
+class TestDocStatusAlreadyExists:
+    def test_already_exists_value(self):
+        assert DocStatus.ALREADY_EXISTS.value == "already_exists"
+
+    def test_already_exists_is_str_subclass(self):
+        assert DocStatus.ALREADY_EXISTS == "already_exists"
+
+    def test_already_exists_in_enum_set(self):
+        assert "already_exists" in {s.value for s in DocStatus}
+
+    def test_round_trip(self):
+        assert DocStatus("already_exists") is DocStatus.ALREADY_EXISTS
+
+
+@pytest.mark.unit
+class TestJobDocumentSummaryMessage:
+    def test_message_defaults_to_none(self):
+        summary = JobDocumentSummary(id="d1", name="f.pdf", status="completed")
+        assert summary.message is None
+
+    def test_message_accepts_string(self):
+        summary = JobDocumentSummary(
+            id="d1",
+            name="f.pdf",
+            status="already_exists",
+            message="Already ingested as old.pdf",
+        )
+        assert summary.message == "Already ingested as old.pdf"
+
+    def test_message_included_in_dump(self):
+        summary = JobDocumentSummary(
+            id="d1", name="f.pdf", status="already_exists", message="Already ingested as x.pdf"
+        )
+        assert summary.model_dump()["message"] == "Already ingested as x.pdf"
+
+    def test_message_none_included_in_dump_as_none(self):
+        summary = JobDocumentSummary(id="d1", name="f.pdf", status="completed")
+        assert summary.model_dump()["message"] is None
+
+
+# ============================================================================
+# 2. utils/jobs.py tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestGetJobDocumentStatsAlreadyExists:
+    """get_job_document_stats must count already_exists docs as completed.
+
+    We patch `digitize.utils.jobs.get_job` — the name as it is bound inside
+    jobs.py via `from digitize.utils.db import … get_job …`.
+    """
+
+    def test_already_exists_counted_in_completed(self):
+        job_data = {
+            "job_id": "job-1",
+            "documents": [
+                {"id": "d1", "name": "a.pdf", "status": "completed"},
+                {"id": "d2", "name": "b.pdf", "status": "already_exists"},
+                {"id": "d3", "name": "c.pdf", "status": "failed"},
+            ],
+        }
+        with patch("digitize.utils.jobs.get_job", return_value=job_data):
+            from digitize.utils.jobs import get_job_document_stats
+            stats = get_job_document_stats("job-1")
+
+        assert stats["completed_count"] == 2
+        assert stats["failed_count"] == 1
+        assert stats["total_docs"] == 3
+
+    def test_no_already_exists_docs(self):
+        job_data = {
+            "job_id": "job-1",
+            "documents": [{"id": "d1", "name": "a.pdf", "status": "completed"}],
+        }
+        with patch("digitize.utils.jobs.get_job", return_value=job_data):
+            from digitize.utils.jobs import get_job_document_stats
+            stats = get_job_document_stats("job-1")
+
+        assert stats["completed_count"] == 1
+
+    def test_all_already_exists_docs(self):
+        job_data = {
+            "job_id": "job-1",
+            "documents": [
+                {"id": "d1", "name": "a.pdf", "status": "already_exists"},
+                {"id": "d2", "name": "b.pdf", "status": "already_exists"},
+            ],
+        }
+        with patch("digitize.utils.jobs.get_job", return_value=job_data):
+            from digitize.utils.jobs import get_job_document_stats
+            stats = get_job_document_stats("job-1")
+
+        assert stats["completed_count"] == 2
+        assert stats["failed_count"] == 0
+
+
+@pytest.mark.unit
+class TestInitializeJobStateAlreadyExists:
+    """initialize_job_state with already_exists_files must create docs with
+    ALREADY_EXISTS status and include their filenames in the job total.
+
+    We patch `digitize.utils.jobs.create_job` and `digitize.utils.jobs.create_document`
+    — the names as bound inside jobs.py.
+    """
+
+    def _make_skipped(self, filename="old.pdf"):
+        return AlreadyExistsFile(
+            filename=filename,
+            existing_doc_id="doc-existing-1",
+            existing_doc_name="old.pdf",
+            file_hash="sha256:deadbeef",
+        )
+
+    def test_create_job_includes_already_exists_filenames(self):
+        mock_create_job = Mock()
+        mock_create_doc = Mock()
+
+        with patch("digitize.utils.jobs.create_job", mock_create_job), \
+             patch("digitize.utils.jobs.create_document", mock_create_doc):
+            from digitize.utils.jobs import initialize_job_state
+            skipped = self._make_skipped("already.pdf")
+            initialize_job_state(
+                job_id="job-1",
+                operation=OperationType.INGESTION,
+                output_format=OutputFormat.JSON,
+                documents_info=["novel.pdf"],
+                already_exists_files=[skipped],
+            )
+
+        create_job_call = mock_create_job.call_args
+        docs_info = create_job_call[1]["documents_info"]
+        assert "novel.pdf" in docs_info
+        assert "already.pdf" in docs_info
+
+    def test_already_exists_doc_created_with_correct_status(self):
+        mock_create_job = Mock()
+        mock_create_doc = Mock()
+
+        with patch("digitize.utils.jobs.create_job", mock_create_job), \
+             patch("digitize.utils.jobs.create_document", mock_create_doc):
+            from digitize.utils.jobs import initialize_job_state
+            skipped = self._make_skipped("already.pdf")
+            initialize_job_state(
+                job_id="job-1",
+                operation=OperationType.INGESTION,
+                output_format=OutputFormat.JSON,
+                documents_info=["novel.pdf"],
+                already_exists_files=[skipped],
+            )
+
+        assert mock_create_doc.call_count == 2
+        skipped_call = next(
+            c for c in mock_create_doc.call_args_list if c[1].get("doc_name") == "already.pdf"
+        )
+        assert skipped_call[1]["initial_status"] == DocStatus.ALREADY_EXISTS
+
+    def test_already_exists_doc_extra_metadata_passed(self):
+        mock_create_job = Mock()
+        mock_create_doc = Mock()
+
+        with patch("digitize.utils.jobs.create_job", mock_create_job), \
+             patch("digitize.utils.jobs.create_document", mock_create_doc):
+            from digitize.utils.jobs import initialize_job_state
+            skipped = self._make_skipped("already.pdf")
+            initialize_job_state(
+                job_id="job-1",
+                operation=OperationType.INGESTION,
+                output_format=OutputFormat.JSON,
+                documents_info=[],
+                already_exists_files=[skipped],
+            )
+
+        skipped_call = next(
+            c for c in mock_create_doc.call_args_list if c[1].get("doc_name") == "already.pdf"
+        )
+        meta = skipped_call[1]["extra_metadata"]
+        assert meta["existing_doc_id"] == "doc-existing-1"
+        assert meta["existing_doc_name"] == "old.pdf"
+        assert meta["file_hash"] == "sha256:deadbeef"
+
+    def test_no_already_exists_files_does_not_call_extra_create(self):
+        mock_create_job = Mock()
+        mock_create_doc = Mock()
+
+        with patch("digitize.utils.jobs.create_job", mock_create_job), \
+             patch("digitize.utils.jobs.create_document", mock_create_doc):
+            from digitize.utils.jobs import initialize_job_state
+            initialize_job_state(
+                job_id="job-1",
+                operation=OperationType.INGESTION,
+                output_format=OutputFormat.JSON,
+                documents_info=["novel.pdf"],
+                already_exists_files=None,
+            )
+
+        assert mock_create_doc.call_count == 1
+
+    def test_already_exists_doc_id_added_to_return_dict(self):
+        mock_create_job = Mock()
+        mock_create_doc = Mock()
+
+        with patch("digitize.utils.jobs.create_job", mock_create_job), \
+             patch("digitize.utils.jobs.create_document", mock_create_doc):
+            from digitize.utils.jobs import initialize_job_state
+            skipped = self._make_skipped("already.pdf")
+            result = initialize_job_state(
+                job_id="job-1",
+                operation=OperationType.INGESTION,
+                output_format=OutputFormat.JSON,
+                documents_info=["novel.pdf"],
+                already_exists_files=[skipped],
+            )
+
+        assert "already.pdf" in result
+        assert "novel.pdf" in result
+
+    def test_empty_already_exists_list_treated_same_as_none(self):
+        mock_create_job = Mock()
+        mock_create_doc = Mock()
+
+        with patch("digitize.utils.jobs.create_job", mock_create_job), \
+             patch("digitize.utils.jobs.create_document", mock_create_doc):
+            from digitize.utils.jobs import initialize_job_state
+            result = initialize_job_state(
+                job_id="job-1",
+                operation=OperationType.INGESTION,
+                output_format=OutputFormat.JSON,
+                documents_info=["novel.pdf"],
+                already_exists_files=[],
+            )
+
+        assert mock_create_doc.call_count == 1
+        assert "novel.pdf" in result
+
+
+# ============================================================================
+# 3. utils/db.py tests
+# ============================================================================
+
+@pytest.mark.unit
+class TestCreateDocumentNewParams:
+    """create_document accepts initial_status, completed_at, extra_metadata.
+
+    The autouse mock_db_operations fixture replaces the create_document symbol in
+    digitize.utils.db before our test runs, so we must also restore the real
+    function by importing it from source and calling it directly, with engine and
+    db_manager patched.
+    """
+
+    def _call(self, mock_dm, **kwargs):
+        """Call the real create_document with stubbed engine and db_manager.
+
+        Uses _real_create_document (stashed at collection time) to bypass the
+        autouse mock_db_operations fixture that replaces the module-level symbol.
+        """
+        defaults = dict(
+            doc_name="test.pdf",
+            doc_id="doc-1",
+            job_id="job-1",
+            output_format=OutputFormat.JSON,
+            operation="ingestion",
+            submitted_at="2024-01-01T00:00:00Z",
+        )
+        defaults.update(kwargs)
+
+        fake_engine = Mock()
+        with patch("digitize.utils.db.engine", fake_engine), \
+             patch("digitize.utils.db.db_manager", mock_dm):
+            _real_create_document(**defaults)
+
+        return mock_dm.create_document.call_args
+
+    def test_default_status_is_accepted(self):
+        mock_dm = Mock()
+        mock_dm.create_document.return_value = Mock()
+        call_args = self._call(mock_dm)
+        assert call_args[1]["status"] == DocStatus.ACCEPTED
+
+    def test_custom_initial_status(self):
+        mock_dm = Mock()
+        mock_dm.create_document.return_value = Mock()
+        call_args = self._call(mock_dm, initial_status=DocStatus.ALREADY_EXISTS)
+        assert call_args[1]["status"] == DocStatus.ALREADY_EXISTS
+
+    def test_completed_at_parsed_and_passed(self):
+        mock_dm = Mock()
+        mock_dm.create_document.return_value = Mock()
+        call_args = self._call(mock_dm, completed_at="2024-01-01T01:00:00Z")
+        completed_dt = call_args[1]["completed_at"]
+        assert completed_dt is not None
+        assert completed_dt.year == 2024
+
+    def test_completed_at_none_by_default(self):
+        mock_dm = Mock()
+        mock_dm.create_document.return_value = Mock()
+        call_args = self._call(mock_dm)
+        assert call_args[1]["completed_at"] is None
+
+    def test_extra_metadata_merged_into_base(self):
+        mock_dm = Mock()
+        mock_dm.create_document.return_value = Mock()
+        call_args = self._call(
+            mock_dm,
+            extra_metadata={
+                "existing_doc_id": "doc-old",
+                "existing_doc_name": "original.pdf",
+                "file_hash": "sha256:abc",
+            },
+        )
+        metadata = call_args[1]["metadata"]
+        assert metadata["existing_doc_id"] == "doc-old"
+        assert metadata["existing_doc_name"] == "original.pdf"
+        assert metadata["file_hash"] == "sha256:abc"
+        assert "pages" in metadata  # base fields preserved
+
+    def test_no_extra_metadata_keeps_base_fields(self):
+        mock_dm = Mock()
+        mock_dm.create_document.return_value = Mock()
+        call_args = self._call(mock_dm)
+        metadata = call_args[1]["metadata"]
+        assert metadata["pages"] == 0
+        assert metadata["tables"] == 0
+
+    def test_raises_when_db_manager_returns_none(self):
+        mock_dm = Mock()
+        mock_dm.create_document.return_value = None
+        fake_engine = Mock()
+
+        with patch("digitize.utils.db.engine", fake_engine), \
+             patch("digitize.utils.db.db_manager", mock_dm):
+            with pytest.raises(Exception):
+                _real_create_document(
+                    doc_name="x.pdf",
+                    doc_id="doc-x",
+                    job_id="job-1",
+                    output_format=OutputFormat.JSON,
+                    operation="ingestion",
+                    submitted_at="2024-01-01T00:00:00Z",
+                )
+
+
+@pytest.mark.unit
+class TestCategorizeFieldsNewKeys:
+    """_categorize_fields must route file_hash, existing_doc_id, existing_doc_name
+    into metadata_fields, not top_level_fields."""
+
+    def test_file_hash_goes_to_metadata(self):
+        meta, top = _categorize_fields({"file_hash": "sha256:abc"})
+        assert "file_hash" in meta
+        assert "file_hash" not in top
+
+    def test_existing_doc_id_goes_to_metadata(self):
+        meta, top = _categorize_fields({"existing_doc_id": "doc-x"})
+        assert "existing_doc_id" in meta
+        assert "existing_doc_id" not in top
+
+    def test_existing_doc_name_goes_to_metadata(self):
+        meta, top = _categorize_fields({"existing_doc_name": "orig.pdf"})
+        assert "existing_doc_name" in meta
+        assert "existing_doc_name" not in top
+
+    def test_status_goes_to_top_level(self):
+        meta, top = _categorize_fields({"status": DocStatus.COMPLETED})
+        assert "status" in top
+        assert "status" not in meta
+
+    def test_mixed_fields_split_correctly(self):
+        meta, top = _categorize_fields({
+            "status": DocStatus.COMPLETED,
+            "file_hash": "sha256:abc",
+            "pages": 5,
+        })
+        assert "file_hash" in meta
+        assert "pages" in meta
+        assert "status" in top
+        assert "status" not in meta
+
+
+@pytest.mark.unit
+class TestGetJobMessagePopulation:
+    """get_job must set message='Already ingested as <name>' for already_exists docs."""
+
+    def _make_doc_mock(self, status, existing_doc_name=None):
+        m = Mock()
+        m.doc_id = "d1"
+        m.name = "dup.pdf"
+        m.status = status
+        m.doc_metadata = {"existing_doc_name": existing_doc_name} if existing_doc_name else {}
+        return m
+
+    def _make_job_mock(self):
+        j = Mock()
+        j.job_id = "job-1"
+        j.job_name = None
+        j.operation = "ingestion"
+        j.status = "completed"
+        j.submitted_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        j.completed_at = datetime(2024, 1, 1, 1, tzinfo=timezone.utc)
+        j.error = None
+        j.stats = {"total_documents": 1, "completed": 1, "failed": 0, "in_progress": 0}
+        return j
+
+    def test_already_exists_doc_gets_message(self):
+        mock_dm = Mock()
+        mock_dm.get_job_by_id.return_value = self._make_job_mock()
+        mock_dm.get_documents_by_job_id.return_value = [
+            self._make_doc_mock("already_exists", "original.pdf")
+        ]
+        fake_engine = Mock()
+
+        # Use _real_get_job (stashed at collection time) to bypass the autouse
+        # mock_db_operations fixture which replaces the module-level get_job symbol.
+        with patch("digitize.utils.db.engine", fake_engine), \
+             patch("digitize.utils.db.db_manager", mock_dm):
+            result = _real_get_job("job-1")
+
+        assert result is not None
+        doc_summary = result["documents"][0]
+        assert doc_summary["message"] == "Already ingested as original.pdf"
+
+    def test_completed_doc_has_no_message(self):
+        mock_dm = Mock()
+        mock_dm.get_job_by_id.return_value = self._make_job_mock()
+        mock_dm.get_documents_by_job_id.return_value = [
+            self._make_doc_mock("completed")
+        ]
+        fake_engine = Mock()
+
+        with patch("digitize.utils.db.engine", fake_engine), \
+             patch("digitize.utils.db.db_manager", mock_dm):
+            result = _real_get_job("job-1")
+
+        assert result["documents"][0]["message"] is None
+
+
+@pytest.mark.unit
+class TestUpdateDocMetadataChecksumRegistration:
+    """update_doc_metadata must call upsert_file_checksum when status=COMPLETED
+    and file_hash is present in the update."""
+
+    def test_checksum_upserted_on_completed_with_file_hash(self, mock_db_manager):
+        mock_db_manager.get_document_by_id.return_value = Mock(
+            doc_metadata={"pages": 0, "tables": 0, "timing_in_secs": {}}
+        )
+        mock_db_manager.update_document.return_value = True
+
+        from digitize.utils.db import DatabaseStatusManager
+        mgr = DatabaseStatusManager("job-1")
+        mgr.update_doc_metadata("doc-1", {
+            "status": DocStatus.COMPLETED,
+            "file_hash": "sha256:abc123",
+        })
+
+        mock_db_manager.upsert_file_checksum.assert_called_once_with("sha256:abc123", "doc-1")
+
+    def test_checksum_not_upserted_without_file_hash(self, mock_db_manager):
+        mock_db_manager.get_document_by_id.return_value = Mock(
+            doc_metadata={"pages": 0, "tables": 0, "timing_in_secs": {}}
+        )
+        mock_db_manager.update_document.return_value = True
+
+        from digitize.utils.db import DatabaseStatusManager
+        mgr = DatabaseStatusManager("job-1")
+        mgr.update_doc_metadata("doc-1", {"status": DocStatus.COMPLETED, "pages": 3})
+
+        mock_db_manager.upsert_file_checksum.assert_not_called()
+
+    def test_checksum_not_upserted_when_status_not_completed(self, mock_db_manager):
+        mock_db_manager.get_document_by_id.return_value = Mock(
+            doc_metadata={"pages": 0, "tables": 0, "timing_in_secs": {}}
+        )
+        mock_db_manager.update_document.return_value = True
+
+        from digitize.utils.db import DatabaseStatusManager
+        mgr = DatabaseStatusManager("job-1")
+        mgr.update_doc_metadata("doc-1", {
+            "status": DocStatus.IN_PROGRESS,
+            "file_hash": "sha256:abc",
+        })
+
+        mock_db_manager.upsert_file_checksum.assert_not_called()
+
+
+@pytest.mark.unit
+class TestUpdateJobStatsAlreadyExists:
+    """_update_job must count already_exists documents as completed in job stats."""
+
+    def _make_docs(self, statuses):
+        docs = []
+        for i, s in enumerate(statuses):
+            m = Mock()
+            m.doc_id = f"d{i}"
+            m.status = s
+            docs.append(m)
+        return docs
+
+    def test_already_exists_counted_as_completed_in_stats(self, mock_db_manager):
+        mock_db_manager.get_job_by_id.return_value = Mock(
+            job_id="job-1",
+            status="in_progress",
+            stats={},
+        )
+        mock_db_manager.get_documents_by_job_id.return_value = self._make_docs([
+            "already_exists",
+            "completed",
+            "failed",
+            "accepted",
+        ])
+        mock_db_manager.update_job.return_value = True
+
+        from digitize.utils.db import DatabaseStatusManager
+        mgr = DatabaseStatusManager("job-1")
+        mgr.update_job_progress("d1", DocStatus.COMPLETED, JobStatus.IN_PROGRESS)
+
+        stats = mock_db_manager.update_job.call_args[1]["stats"]
+        assert stats["completed"] == 2   # already_exists + completed
+        assert stats["failed"] == 1
+        assert stats["in_progress"] == 1  # accepted
+
+    def test_accepted_doc_counted_in_in_progress_stats(self, mock_db_manager):
+        mock_db_manager.get_job_by_id.return_value = Mock(
+            job_id="job-1", status="in_progress", stats={}
+        )
+        mock_db_manager.get_documents_by_job_id.return_value = self._make_docs([
+            "accepted",
+            "in_progress",
+            "digitized",
+            "processed",
+            "chunked",
+        ])
+        mock_db_manager.update_job.return_value = True
+
+        from digitize.utils.db import DatabaseStatusManager
+        mgr = DatabaseStatusManager("job-1")
+        mgr.update_job_progress("", DocStatus.ACCEPTED, JobStatus.IN_PROGRESS)
+
+        stats = mock_db_manager.update_job.call_args[1]["stats"]
+        assert stats["in_progress"] == 5
+        assert stats["completed"] == 0
+
+
+# ============================================================================
+# 4. api/v1/jobs.py endpoint tests (duplicate-detection paths)
+# ============================================================================
+
+@pytest.fixture
+def jobs_test_client(monkeypatch, tmp_path, mock_db_operations):
+    """Thin test-client fixture focused on the de-duplication code paths."""
+    import digitize.app as digitize_app
+    import digitize.api.v1.documents as documents_router_module
+    from fastapi.testclient import TestClient
+    from digitize.workers.concurrency import concurrency_manager
+
+    digitized_dir = tmp_path / "digitized"
+    staging_dir = tmp_path / "staging"
+    for p in (digitized_dir, staging_dir):
+        p.mkdir(parents=True, exist_ok=True)
+
+    fake_settings = SimpleNamespace(
+        common=SimpleNamespace(app=SimpleNamespace(log_level="INFO")),
+        digitize=SimpleNamespace(
+            digitized_docs_dir=digitized_dir,
+            staging_dir=staging_dir,
+            digitization_concurrency_limit=2,
+            ingestion_concurrency_limit=1,
+        ),
+    )
+    monkeypatch.setattr(digitize_app, "settings", fake_settings, raising=False)
+    monkeypatch.setattr(digitize_app.dg_util, "settings", fake_settings, raising=False)
+    monkeypatch.setattr(concurrency_manager, "is_locked", Mock(return_value=False))
+    monkeypatch.setattr(concurrency_manager, "acquire", AsyncMock())
+    monkeypatch.setattr(concurrency_manager, "release", Mock())
+    monkeypatch.setattr(digitize_app.dg_util, "has_active_jobs", Mock(return_value=(False, [])))
+    monkeypatch.setattr(digitize_app.dg_util, "generate_uuid", Mock(return_value="job-x"))
+    monkeypatch.setattr(digitize_app.dg_util, "stage_upload_files", AsyncMock())
+    monkeypatch.setattr(
+        digitize_app.dg_util, "initialize_job_state", Mock(return_value={"novel.pdf": "doc-1"})
+    )
+    monkeypatch.setattr(documents_router_module, "reset_db", Mock())
+    monkeypatch.setattr(digitize_app, "configure_uvicorn_logging", Mock())
+
+    return TestClient(digitize_app.app)
+
+
+@pytest.mark.unit
+class TestDuplicateDetectionEndpoint:
+    """Tests for the hash-based already-exists detection in POST /v1/jobs."""
+
+    def _pdf(self, name="sample.pdf"):
+        return ("files", (name, b"%PDF-1.4 test", "application/pdf"))
+
+    def test_all_files_exist_returns_409(self, jobs_test_client, monkeypatch):
+        import digitize.api.v1.jobs as jobs_router_module
+
+        existing = Mock()
+        existing.doc_id = "old-doc"
+        existing.name = "sample.pdf"
+
+        mock_hash_db = Mock()
+        mock_hash_db.find_completed_document_by_hash = Mock(return_value=existing)
+        monkeypatch.setattr(jobs_router_module, "db_manager", mock_hash_db)
+
+        response = jobs_test_client.post(
+            "/v1/jobs?operation=ingestion",
+            files=[self._pdf("sample.pdf")],
+        )
+
+        assert response.status_code == 409
+
+    def test_409_body_mentions_existing_doc(self, jobs_test_client, monkeypatch):
+        import digitize.api.v1.jobs as jobs_router_module
+
+        existing = Mock()
+        existing.doc_id = "old-doc-id"
+        existing.name = "sample.pdf"
+
+        mock_hash_db = Mock()
+        mock_hash_db.find_completed_document_by_hash = Mock(return_value=existing)
+        monkeypatch.setattr(jobs_router_module, "db_manager", mock_hash_db)
+
+        response = jobs_test_client.post(
+            "/v1/jobs?operation=ingestion",
+            files=[self._pdf("sample.pdf")],
+        )
+
+        assert "old-doc-id" in response.text
+
+    def test_mixed_batch_returns_202(self, jobs_test_client, monkeypatch):
+        import digitize.api.v1.jobs as jobs_router_module
+
+        existing = Mock()
+        existing.doc_id = "old-doc"
+        existing.name = "old.pdf"
+
+        mock_hash_db = Mock()
+        # first file matches, second is novel
+        mock_hash_db.find_completed_document_by_hash = Mock(side_effect=[existing, None])
+        monkeypatch.setattr(jobs_router_module, "db_manager", mock_hash_db)
+
+        response = jobs_test_client.post(
+            "/v1/jobs?operation=ingestion",
+            files=[self._pdf("old.pdf"), self._pdf("new.pdf")],
+        )
+
+        assert response.status_code == 202
+
+    def test_mixed_batch_response_has_no_warnings_key(self, jobs_test_client, monkeypatch):
+        import digitize.api.v1.jobs as jobs_router_module
+
+        existing = Mock()
+        existing.doc_id = "old-doc"
+        existing.name = "old.pdf"
+
+        mock_hash_db = Mock()
+        mock_hash_db.find_completed_document_by_hash = Mock(side_effect=[existing, None])
+        monkeypatch.setattr(jobs_router_module, "db_manager", mock_hash_db)
+
+        response = jobs_test_client.post(
+            "/v1/jobs?operation=ingestion",
+            files=[self._pdf("old.pdf"), self._pdf("new.pdf")],
+        )
+
+        assert "warnings" not in response.json()
+
+    def test_mixed_batch_already_exists_passed_to_initialize(self, jobs_test_client, monkeypatch):
+        import digitize.api.v1.jobs as jobs_router_module
+        import digitize.app as digitize_app
+
+        existing = Mock()
+        existing.doc_id = "old-doc"
+        existing.name = "old.pdf"
+
+        mock_hash_db = Mock()
+        mock_hash_db.find_completed_document_by_hash = Mock(side_effect=[existing, None])
+        monkeypatch.setattr(jobs_router_module, "db_manager", mock_hash_db)
+
+        jobs_test_client.post(
+            "/v1/jobs?operation=ingestion",
+            files=[self._pdf("old.pdf"), self._pdf("new.pdf")],
+        )
+
+        init_call = cast(Mock, digitize_app.dg_util.initialize_job_state).call_args
+        already_exists_arg = init_call[1].get("already_exists_files", init_call[0][-1])
+        assert len(already_exists_arg) == 1
+        assert already_exists_arg[0].filename == "old.pdf"
+        assert already_exists_arg[0].existing_doc_id == "old-doc"
+
+    def test_novel_only_batch_passes_empty_already_exists(self, jobs_test_client, monkeypatch):
+        import digitize.api.v1.jobs as jobs_router_module
+        import digitize.app as digitize_app
+
+        mock_hash_db = Mock()
+        mock_hash_db.find_completed_document_by_hash = Mock(return_value=None)
+        monkeypatch.setattr(jobs_router_module, "db_manager", mock_hash_db)
+
+        jobs_test_client.post(
+            "/v1/jobs?operation=ingestion",
+            files=[self._pdf("new.pdf")],
+        )
+
+        init_call = cast(Mock, digitize_app.dg_util.initialize_job_state).call_args
+        already_exists_arg = init_call[1].get("already_exists_files", [])
+        assert already_exists_arg == []
+
+    def test_digitization_also_checks_ingestion_hash(self, jobs_test_client, monkeypatch):
+        """A file already ingested must block a digitization request of the same content."""
+        import digitize.api.v1.jobs as jobs_router_module
+
+        ingested_doc = Mock()
+        ingested_doc.doc_id = "ingested-doc"
+        ingested_doc.name = "report.pdf"
+
+        # digitization-type lookup returns None; ingestion fallback returns a match
+        mock_hash_db = Mock()
+        mock_hash_db.find_completed_document_by_hash = Mock(
+            side_effect=[None, ingested_doc]
+        )
+        monkeypatch.setattr(jobs_router_module, "db_manager", mock_hash_db)
+
+        response = jobs_test_client.post(
+            "/v1/jobs?operation=digitization&output_format=json",
+            files=[self._pdf("report.pdf")],
+        )
+
+        assert response.status_code == 409
+
+    def test_all_files_novel_returns_202(self, jobs_test_client, monkeypatch):
+        import digitize.api.v1.jobs as jobs_router_module
+
+        mock_hash_db = Mock()
+        mock_hash_db.find_completed_document_by_hash = Mock(return_value=None)
+        monkeypatch.setattr(jobs_router_module, "db_manager", mock_hash_db)
+
+        response = jobs_test_client.post(
+            "/v1/jobs?operation=ingestion",
+            files=[self._pdf("brand-new.pdf")],
+        )
+
+        assert response.status_code == 202
+
+
+# ============================================================================
+# 5. db/manager.py tests
+#
+# db/manager.py imports get_db_session at module level:
+#   from digitize.db.connection import get_db_session
+# so we must patch `digitize.db.manager.get_db_session` — not the connection module.
+# ============================================================================
+
+def _make_session_ctx(session):
+    """Return a context manager that yields `session`."""
+    ctx = MagicMock()
+    ctx.__enter__ = Mock(return_value=session)
+    ctx.__exit__ = Mock(return_value=None)
+    return ctx
+
+
+@pytest.mark.unit
+class TestDatabaseManagerUpsertFileChecksum:
+    """DatabaseManager.upsert_file_checksum uses INSERT … ON CONFLICT DO UPDATE."""
+
+    def test_upsert_executes_statement(self):
+        session = MagicMock()
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
+            from digitize.db.manager import DatabaseManager
+            DatabaseManager.upsert_file_checksum("sha256:abc", "doc-1")
+
+        session.execute.assert_called_once()
+
+    def test_upsert_handles_db_error_without_raising(self):
+        from sqlalchemy.exc import SQLAlchemyError
+
+        session = MagicMock()
+        session.execute.side_effect = SQLAlchemyError("boom")
+
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
+            from digitize.db.manager import DatabaseManager
+            # Must not propagate the error
+            DatabaseManager.upsert_file_checksum("sha256:abc", "doc-1")
+
+
+@pytest.mark.unit
+class TestDatabaseManagerFindCompletedDocumentByHash:
+    """find_completed_document_by_hash returns doc / None / None-on-error."""
+
+    def test_returns_none_when_not_found(self):
+        session = MagicMock()
+        session.scalar.return_value = None
+
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
+            from digitize.db.manager import DatabaseManager
+            result = DatabaseManager.find_completed_document_by_hash("sha256:missing", "ingestion")
+
+        assert result is None
+
+    def test_returns_document_when_found(self):
+        mock_doc = Mock()
+        mock_doc.doc_id = "d1"
+        mock_doc.job_id = "j1"
+        mock_doc.name = "found.pdf"
+        mock_doc.type = "ingestion"
+        mock_doc.status = "completed"
+        mock_doc.output_format = "json"
+        mock_doc.submitted_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        mock_doc.completed_at = datetime(2024, 1, 1, 1, tzinfo=timezone.utc)
+        mock_doc.error = None
+        mock_doc.doc_metadata = {}
+
+        session = MagicMock()
+        session.scalar.return_value = mock_doc
+
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
+            from digitize.db.manager import DatabaseManager
+            result = DatabaseManager.find_completed_document_by_hash("sha256:abc", "ingestion")
+
+        assert result is mock_doc
+        session.expunge.assert_called_once_with(mock_doc)
+
+    def test_returns_none_on_db_error(self):
+        from sqlalchemy.exc import SQLAlchemyError
+
+        session = MagicMock()
+        session.scalar.side_effect = SQLAlchemyError("connection lost")
+
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
+            from digitize.db.manager import DatabaseManager
+            # DB errors must NOT raise — caller treats file as novel
+            result = DatabaseManager.find_completed_document_by_hash("sha256:x", "ingestion")
+
+        assert result is None
+
+    def test_query_executes_against_session(self):
+        session = MagicMock()
+        session.scalar.return_value = None
+
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
+            from digitize.db.manager import DatabaseManager
+            DatabaseManager.find_completed_document_by_hash("sha256:abc", "digitization")
+
+        session.scalar.assert_called_once()
+
+
+@pytest.mark.unit
+class TestDatabaseManagerDeleteDocumentClearsChecksum:
+    """delete_document must remove the checksum registry entry before deleting the doc."""
+
+    def test_execute_called_twice(self):
+        session = MagicMock()
+        session.execute.return_value = Mock(rowcount=1)
+
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
+            from digitize.db.manager import DatabaseManager
+            DatabaseManager.delete_document("doc-1")
+
+        # First execute: registry delete. Second execute: document delete.
+        assert session.execute.call_count == 2
+
+    def test_returns_true_when_deleted(self):
+        session = MagicMock()
+        # registry delete (rowcount irrelevant), doc delete rowcount=1
+        session.execute.side_effect = [Mock(rowcount=0), Mock(rowcount=1)]
+
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
+            from digitize.db.manager import DatabaseManager
+            result = DatabaseManager.delete_document("doc-1")
+
+        assert result is True
+
+    def test_returns_false_when_not_found(self):
+        session = MagicMock()
+        session.execute.side_effect = [Mock(rowcount=0), Mock(rowcount=0)]
+
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
+            from digitize.db.manager import DatabaseManager
+            result = DatabaseManager.delete_document("doc-missing")
+
+        assert result is False
+
+
+@pytest.mark.unit
+class TestDatabaseManagerDeleteAllDocumentsClearsRegistry:
+    """delete_all_documents must wipe the checksum registry."""
+
+    def test_execute_called_twice(self):
+        session = MagicMock()
+        session.execute.return_value = Mock(rowcount=3)
+
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
+            from digitize.db.manager import DatabaseManager
+            DatabaseManager.delete_all_documents()
+
+        # First call: wipe registry. Second call: delete all documents.
+        assert session.execute.call_count == 2
+
+    def test_returns_deleted_count(self):
+        session = MagicMock()
+        session.execute.side_effect = [Mock(rowcount=0), Mock(rowcount=5)]
+
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
+            from digitize.db.manager import DatabaseManager
+            result = DatabaseManager.delete_all_documents()
+
+        assert result["deleted_count"] == 5
+
+
+@pytest.mark.unit
+class TestGetAllDocumentsExcludesAlreadyExists:
+    """get_all_documents must exclude already_exists docs when no explicit status filter."""
+
+    def test_no_status_filter_adds_exclusion(self):
+        session = MagicMock()
+        session.execute.return_value = Mock(
+            scalars=Mock(return_value=Mock(all=Mock(return_value=[]))),
+        )
+        session.scalar.return_value = 0
+
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
+            from digitize.db.manager import DatabaseManager
+            result = DatabaseManager.get_all_documents(status=None, name=None, limit=10, offset=0)
+
+        assert isinstance(result, tuple)
+        # The session must have been used — confirms the method ran to completion
+        assert session.execute.called or session.scalar.called
+
+# Made with IBM Bob

--- a/services/digitize/tests/test_digitize_app_endpoints.py
+++ b/services/digitize/tests/test_digitize_app_endpoints.py
@@ -16,6 +16,8 @@ from digitize.workers.concurrency import concurrency_manager
 
 @pytest.fixture
 def digitize_test_client(monkeypatch, tmp_path, mock_db_operations):
+    import digitize.api.v1.jobs as jobs_router_module
+
     digitized_dir = tmp_path / "digitized"
     staging_dir = tmp_path / "staging"
 
@@ -48,6 +50,12 @@ def digitize_test_client(monkeypatch, tmp_path, mock_db_operations):
     # reset_db is now imported inside documents_router_module, not in app.py
     monkeypatch.setattr(documents_router_module, "reset_db", Mock())
     monkeypatch.setattr(digitize_app, "configure_uvicorn_logging", Mock())
+
+    # Stub out hash-based duplicate detection so tests run without a real DB.
+    # find_completed_document_by_hash returns None → every file is treated as novel.
+    mock_hash_db_manager = Mock()
+    mock_hash_db_manager.find_completed_document_by_hash = Mock(return_value=None)
+    monkeypatch.setattr(jobs_router_module, "db_manager", mock_hash_db_manager)
 
     return TestClient(digitize_app.app)
 
@@ -98,7 +106,8 @@ class TestCreateJobs:
         )
 
         assert response.status_code == 202
-        assert response.json() == {"job_id": "job-123"}
+        assert response.json()["job_id"] == "job-123"
+        assert "warnings" not in response.json()
         stage_upload_files_mock.assert_awaited_once()
         initialize_job_state_mock.assert_called_once_with(
             "job-123",
@@ -106,6 +115,7 @@ class TestCreateJobs:
             OutputFormat.JSON,
             ["sample.pdf"],
             None,
+            already_exists_files=[],
         )
 
     def test_successful_ingestion_job_creation(self, digitize_test_client):
@@ -162,6 +172,7 @@ class TestCreateJobs:
             OutputFormat.MD,
             ["sample.pdf"],
             "My Job",
+            already_exists_files=[],
         )
 
     def test_successful_digitization_job_creation_with_docx(self, digitize_test_client):
@@ -178,7 +189,8 @@ class TestCreateJobs:
         )
 
         assert response.status_code == 202
-        assert response.json() == {"job_id": "job-123"}
+        assert response.json()["job_id"] == "job-123"
+        assert "warnings" not in response.json()
         stage_upload_files_mock.assert_awaited_once()
         initialize_job_state_mock.assert_called_once_with(
             "job-123",
@@ -186,6 +198,7 @@ class TestCreateJobs:
             OutputFormat.JSON,
             ["document.docx"],
             None,
+            already_exists_files=[],
         )
 
     def test_successful_ingestion_job_creation_with_docx(self, digitize_test_client):
@@ -237,6 +250,41 @@ class TestCreateJobs:
 
         assert response.status_code == 202
         assert response.json()["job_id"] == "job-123"
+
+    def test_mixed_batch_returns_202_without_warnings(self, digitize_test_client, monkeypatch):
+        """202 response for a mixed batch contains only job_id — no warnings field.
+
+        One file already exists in the DB (find_completed_document_by_hash returns a
+        match); the second is novel.  The endpoint must accept the job (202).
+        Skipped files are recorded directly on the job's document list with status
+        'already_exists'; the response body carries no warnings.
+        """
+        import digitize.api.v1.jobs as jobs_router_module
+
+        existing_doc = Mock()
+        existing_doc.doc_id = "existing-doc-id"
+        existing_doc.name = "old.pdf"
+
+        # First file already exists; second is novel.
+        mock_hash_db = Mock()
+        mock_hash_db.find_completed_document_by_hash = Mock(
+            side_effect=[existing_doc, None]
+        )
+        monkeypatch.setattr(jobs_router_module, "db_manager", mock_hash_db)
+
+        pdf_header = b"%PDF-1.4 test"
+        response = digitize_test_client.post(
+            "/v1/jobs?operation=ingestion",
+            files=[
+                ("files", ("old.pdf", pdf_header, "application/pdf")),
+                ("files", ("new.pdf", pdf_header, "application/pdf")),
+            ],
+        )
+
+        assert response.status_code == 202
+        body = response.json()
+        assert body["job_id"] == "job-123"
+        assert "warnings" not in body
 
 
 @pytest.mark.unit

--- a/services/digitize/tests/test_types_models.py
+++ b/services/digitize/tests/test_types_models.py
@@ -47,6 +47,7 @@ class TestEnums:
             "chunked",
             "completed",
             "failed",
+            "already_exists",
         }
 
     def test_enum_string_conversion(self):

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -235,7 +235,9 @@ def get_job(job_id: str) -> Optional[dict]:
                 JobDocumentSummary(
                     id=doc.doc_id,
                     name=doc.name,
-                    status=doc.status
+                    status=doc.status,
+                    message=f"Already ingested as {doc.doc_metadata.get('existing_doc_name')}"
+                    if doc.status == DocStatus.ALREADY_EXISTS.value else None,
                 )
                 for doc in documents
             ]
@@ -302,7 +304,9 @@ def get_all_jobs(
                 JobDocumentSummary(
                     id=doc.doc_id,
                     name=doc.name,
-                    status=doc.status
+                    status=doc.status,
+                    message=f"Already ingested as {doc.doc_metadata.get('existing_doc_name')}"
+                    if doc.status == DocStatus.ALREADY_EXISTS.value else None,
                 )
                 for doc in documents
             ]
@@ -338,7 +342,10 @@ def create_document(
     job_id: str,
     output_format: OutputFormat,
     operation: str,
-    submitted_at: str
+    submitted_at: str,
+    initial_status: DocStatus = DocStatus.ACCEPTED,
+    completed_at: Optional[str] = None,
+    extra_metadata: Optional[dict] = None,
 ) -> None:
     """
     Create document metadata in database.
@@ -350,34 +357,51 @@ def create_document(
         output_format: Output format for the document
         operation: Type of operation (ingestion/digitization)
         submitted_at: ISO timestamp when document was submitted
+        initial_status: Initial document status (defaults to ACCEPTED)
+        completed_at: Optional ISO timestamp for immediately-terminal documents
+        extra_metadata: Optional extra fields merged into the metadata JSONB
     """
     if engine is None:
         raise RuntimeError("Database not available. Cannot create document without database connection.")
 
     try:
-        # Parse ISO timestamp to datetime
+        # Parse ISO timestamps to datetime
         submitted_dt = datetime.fromisoformat(submitted_at.replace("Z", "+00:00"))
+        completed_dt = (
+            datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
+            if completed_at else None
+        )
+
+        metadata: dict = {
+            "pages": 0,
+            "tables": 0,
+            "timing_in_secs": {
+                "digitizing": None,
+                "processing": None,
+                "chunking": None,
+                "indexing": None,
+            },
+        }
+        if extra_metadata:
+            metadata.update(extra_metadata)
 
         # Create document in database
-        db_manager.create_document(
+        result = db_manager.create_document(
             doc_id=doc_id,
             name=doc_name,
             doc_type=operation,
-            status=DocStatus.ACCEPTED,
+            status=initial_status,
             output_format=output_format.value,
             submitted_at=submitted_dt,
+            completed_at=completed_dt,
             job_id=job_id,
-            metadata={
-                "pages": 0,
-                "tables": 0,
-                "timing_in_secs": {
-                    "digitizing": None,
-                    "processing": None,
-                    "chunking": None,
-                    "indexing": None
-                }
-            }
+            metadata=metadata,
         )
+        if result is None:
+            raise RuntimeError(
+                f"db_manager.create_document returned None for doc_id={doc_id} "
+                f"(name={doc_name!r}). Check logs for the underlying DB error."
+            )
         logger.info(f"Created document {doc_id} in database")
 
     except Exception as e:
@@ -996,6 +1020,14 @@ class DatabaseStatusManager:
             success = db_manager.update_document(doc_id, **update_params)
             if success:
                 logger.debug(f"Updated document {doc_id} in database")
+                # Register the checksum once the document is marked COMPLETED so
+                # that future uploads of the same content are caught via the
+                # file_checksum_registry table.
+                if (
+                    update_params.get("status") == DocStatus.COMPLETED
+                    and "file_hash" in metadata_fields
+                ):
+                    db_manager.upsert_file_checksum(metadata_fields["file_hash"], doc_id)
             else:
                 logger.warning(f"Document {doc_id} not found in database for update")
 
@@ -1029,12 +1061,17 @@ class DatabaseStatusManager:
         documents = db_manager.get_documents_by_job_id(self.job_id)
 
         # Recalculate statistics
+        # ALREADY_EXISTS is a terminal resolved state — count it with completed.
         stats = {
             "total_documents": len(documents),
-            "completed": sum(1 for d in documents if d.status == DocStatus.COMPLETED.value),
+            "completed": sum(
+                1 for d in documents
+                if d.status in (DocStatus.COMPLETED.value, DocStatus.ALREADY_EXISTS.value)
+            ),
             "failed": sum(1 for d in documents if d.status == DocStatus.FAILED.value),
             "in_progress": sum(
                 1 for d in documents if d.status in [
+                    DocStatus.ACCEPTED.value,
                     DocStatus.IN_PROGRESS.value,
                     DocStatus.DIGITIZED.value,
                     DocStatus.PROCESSED.value,
@@ -1102,7 +1139,7 @@ def _categorize_fields(details: Mapping[str, Any]) -> tuple[dict[str, Any], dict
     Returns:
         Tuple of (metadata_fields, top_level_fields)
     """
-    METADATA_KEYS = {"pages", "tables", "chunks", "timing_in_secs"}
+    METADATA_KEYS = {"pages", "tables", "chunks", "timing_in_secs", "file_hash", "existing_doc_id", "existing_doc_name"}
 
     metadata_fields = {
         k: v if k == "timing_in_secs" and isinstance(v, dict) else _extract_value(v)

--- a/services/digitize/utils/jobs.py
+++ b/services/digitize/utils/jobs.py
@@ -13,6 +13,7 @@ from digitize.models import (
     OutputFormat,
     DocumentContentResponse,
     JobStatus,
+    DocStatus,
 )
 from digitize.settings import settings
 from digitize.utils.db import (
@@ -56,7 +57,10 @@ def get_job_document_stats(job_id: str) -> dict:
 
         documents = job_data.get("documents", [])
         failed_docs = [doc for doc in documents if doc.get("status") == DocStatus.FAILED.value]
-        completed_docs = [doc for doc in documents if doc.get("status") == DocStatus.COMPLETED.value]
+        completed_docs = [
+            doc for doc in documents
+            if doc.get("status") in (DocStatus.COMPLETED.value, DocStatus.ALREADY_EXISTS.value)
+        ]
 
         return {
             "failed_docs": failed_docs,
@@ -87,7 +91,14 @@ def generate_uuid():
     return str(generated_uuid)
 
 
-def initialize_job_state(job_id: str, operation: str, output_format: OutputFormat, documents_info: list[str], job_name: Optional[str] = None) -> dict[str, str]:
+def initialize_job_state(
+    job_id: str,
+    operation: str,
+    output_format: OutputFormat,
+    documents_info: list[str],
+    job_name: Optional[str] = None,
+    already_exists_files: Optional[list] = None,   # list[AlreadyExistsFile]
+) -> dict[str, str]:
     """
     Initialize job state with both database and file system persistence.
 
@@ -100,6 +111,8 @@ def initialize_job_state(job_id: str, operation: str, output_format: OutputForma
         output_format: Output format for documents
         documents_info: List of filenames to be processed
         job_name: Optional human-readable name for the job
+        already_exists_files: Optional list of AlreadyExistsFile entries that were
+                              stripped from the batch before staging.
 
     Returns:
         dict[str, str]: Mapping of filename -> document_id
@@ -109,12 +122,17 @@ def initialize_job_state(job_id: str, operation: str, output_format: OutputForma
     # Generate document IDs upfront
     doc_id_dict = {doc: generate_uuid() for doc in documents_info}
 
-    # CRITICAL: Create job FIRST before documents (foreign key constraint)
+    # CRITICAL: Create job FIRST before documents (foreign key constraint).
+    # total_documents must cover both novel files AND any already-exists files so
+    # that the initial stats are accurate before the pipeline touches them.
+    all_filenames = list(documents_info) + (
+        [f.filename for f in already_exists_files] if already_exists_files else []
+    )
     create_job(
         job_id=job_id,
         operation=operation,
         submitted_at=submitted_at,
-        documents_info=documents_info,
+        documents_info=all_filenames,
         job_name=job_name
     )
 
@@ -130,6 +148,44 @@ def initialize_job_state(job_id: str, operation: str, output_format: OutputForma
             operation=operation,
             submitted_at=submitted_at
         )
+
+    # Record ALREADY_EXISTS entries for files stripped from the batch.
+    # Created AFTER the job row exists (foreign key constraint).
+    # Written directly as ALREADY_EXISTS in a single DB insert — there is no
+    # "accepted" window and no follow-up update_doc_metadata call needed.
+    if already_exists_files:
+        from digitize.utils.db import get_status_manager
+        from digitize.models import JobStatus as _JobStatus
+        status_mgr = get_status_manager(job_id)
+        for skipped in already_exists_files:
+            skipped_doc_id = generate_uuid()
+            doc_id_dict[skipped.filename] = skipped_doc_id
+            logger.debug(
+                f"Recording already_exists doc {skipped_doc_id} "
+                f"for file '{skipped.filename}'"
+            )
+            create_document(
+                doc_name=skipped.filename,
+                doc_id=skipped_doc_id,
+                job_id=job_id,
+                output_format=output_format,
+                operation=operation,
+                submitted_at=submitted_at,
+                initial_status=DocStatus.ALREADY_EXISTS,
+                completed_at=submitted_at,
+                extra_metadata={
+                    "existing_doc_id": skipped.existing_doc_id,
+                    "existing_doc_name": skipped.existing_doc_name,
+                    "file_hash": skipped.file_hash,
+                },
+            )
+            # Update job stats to include this resolved doc — no doc-level status
+            # write needed because it was already set correctly in create_document.
+            status_mgr.update_job_progress(
+                "",
+                DocStatus.ALREADY_EXISTS,
+                _JobStatus.IN_PROGRESS,
+            )
 
     return doc_id_dict
 

--- a/services/digitize/utils/jobs.py
+++ b/services/digitize/utils/jobs.py
@@ -154,9 +154,6 @@ def initialize_job_state(
     # Written directly as ALREADY_EXISTS in a single DB insert — there is no
     # "accepted" window and no follow-up update_doc_metadata call needed.
     if already_exists_files:
-        from digitize.utils.db import get_status_manager
-        from digitize.models import JobStatus as _JobStatus
-        status_mgr = get_status_manager(job_id)
         for skipped in already_exists_files:
             skipped_doc_id = generate_uuid()
             doc_id_dict[skipped.filename] = skipped_doc_id
@@ -178,13 +175,6 @@ def initialize_job_state(
                     "existing_doc_name": skipped.existing_doc_name,
                     "file_hash": skipped.file_hash,
                 },
-            )
-            # Update job stats to include this resolved doc — no doc-level status
-            # write needed because it was already set correctly in create_document.
-            status_mgr.update_job_progress(
-                "",
-                DocStatus.ALREADY_EXISTS,
-                _JobStatus.IN_PROGRESS,
             )
 
     return doc_id_dict

--- a/ui/digitize/Makefile
+++ b/ui/digitize/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= digitize-ui
-TAG ?= v0.0.28
+TAG ?= v0.0.29
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/digitize/src/constants/jobConstants.ts
+++ b/ui/digitize/src/constants/jobConstants.ts
@@ -15,6 +15,7 @@ export const DISPLAY_STATUS = {
   DIGITIZATION_ERROR: 'Digitization error',
   INGESTING: 'Ingesting...',
   DIGITIZING: 'Digitizing...',
+  ALREADY_EXISTS: 'already_exists',
 } as const;
 
 // Job operation types

--- a/ui/digitize/src/constants/jobConstants.ts
+++ b/ui/digitize/src/constants/jobConstants.ts
@@ -15,6 +15,10 @@ export const DISPLAY_STATUS = {
   DIGITIZATION_ERROR: 'Digitization error',
   INGESTING: 'Ingesting...',
   DIGITIZING: 'Digitizing...',
+} as const;
+
+// Document status constants (matching backend DocStatus enum values)
+export const DOC_STATUS = {
   ALREADY_EXISTS: 'already_exists',
 } as const;
 

--- a/ui/digitize/src/pages/DocumentListPage/DocumentListPage.module.scss
+++ b/ui/digitize/src/pages/DocumentListPage/DocumentListPage.module.scss
@@ -175,6 +175,10 @@
   fill: var(--cds-support-info);
 }
 
+.statusIconWarning {
+  fill: var(--cds-support-warning);
+}
+
 .errorInfoButton {
   display: inline-flex;
   align-items: center;

--- a/ui/digitize/src/pages/DocumentListPage/DocumentListPage.tsx
+++ b/ui/digitize/src/pages/DocumentListPage/DocumentListPage.tsx
@@ -308,6 +308,8 @@ const getStatusIcon = (status: string) => {
     case 'processed':
     case 'chunked':
       return <InProgress size={16} className={styles.statusIconProgress} />;
+    case 'already_exists':
+      return <CheckmarkFilled size={16} className={styles.statusIconWarning} />;
     default:
       return null;
   }

--- a/ui/digitize/src/pages/JobMonitorPage/JobMonitorPage.module.scss
+++ b/ui/digitize/src/pages/JobMonitorPage/JobMonitorPage.module.scss
@@ -187,6 +187,10 @@
   fill: var(--cds-support-info);
 }
 
+.statusIconWarning {
+  fill: var(--cds-support-warning);
+}
+
 .errorMessage {
   display: flex;
   align-items: center;

--- a/ui/digitize/src/pages/JobMonitorPage/JobMonitorPage.tsx
+++ b/ui/digitize/src/pages/JobMonitorPage/JobMonitorPage.tsx
@@ -294,6 +294,8 @@ const getStatusIcon = (status: string) => {
     case DISPLAY_STATUS.INGESTING:
     case DISPLAY_STATUS.DIGITIZING:
       return <InProgress size={16} className={styles.statusIconProgress} />;
+    case DISPLAY_STATUS.ALREADY_EXISTS:
+      return <CheckmarkFilled size={16} className={styles.statusIconWarning} />;
     default:
       return null;
   }
@@ -408,6 +410,25 @@ const JobMonitorPage = () => {
       }, 3000);
     } catch (error: any) {
       console.error('Error uploading documents:', error);
+
+      // 409 Conflict — ALL files are duplicates, no job was created
+      if (error.response?.status === 409) {
+        const detail = error.response?.data?.detail || 'All submitted files have already been ingested.';
+        dispatch({
+          type: 'SET_UPLOAD_STATUS',
+          payload: {
+            show: true,
+            kind: 'error',
+            title: 'All files are duplicates — no job created',
+            subtitle: detail,
+          },
+        });
+        setTimeout(() => {
+          dispatch({ type: 'HIDE_UPLOAD_STATUS' });
+        }, 8000);
+        // Re-throw so IngestSidePanel shows the inline error
+        throw new Error(detail);
+      }
       
       // Handle FastAPI validation errors (422) which return detail as an array
       let errorMessage = 'An error occurred';
@@ -439,6 +460,8 @@ const JobMonitorPage = () => {
       setTimeout(() => {
         dispatch({ type: 'HIDE_UPLOAD_STATUS' });
       }, 5000);
+
+      throw error;
     }
   };
 
@@ -986,7 +1009,9 @@ const JobMonitorPage = () => {
                           <span className={styles.documentName}>{doc.name}</span>
                           <div className={styles.documentStatus}>
                             {getStatusIcon(doc.status)}
-                            <span className={styles.statusText}>{doc.status}</span>
+                            <span className={styles.statusText}>
+                              {doc.message ?? doc.status}
+                            </span>
                           </div>
                         </div>
                       </div>

--- a/ui/digitize/src/pages/JobMonitorPage/JobMonitorPage.tsx
+++ b/ui/digitize/src/pages/JobMonitorPage/JobMonitorPage.tsx
@@ -32,7 +32,7 @@ import { getAllJobs, getJobById, uploadDocuments, deleteJob, Job } from '../../s
 import IngestSidePanel from '../../components/IngestSidePanel';
 import { calculateDuration } from '../../utils/dateUtils';
 import { exportToCSV, validateFilename } from '../../utils/csvExport';
-import { JOB_STATUS, DISPLAY_STATUS, JOB_OPERATION, JOB_TYPE_DISPLAY } from '../../constants/jobConstants';
+import { JOB_STATUS, DISPLAY_STATUS, DOC_STATUS, JOB_OPERATION, JOB_TYPE_DISPLAY } from '../../constants/jobConstants';
 import styles from './JobMonitorPage.module.scss';
 
 interface NotificationStatus {
@@ -294,7 +294,7 @@ const getStatusIcon = (status: string) => {
     case DISPLAY_STATUS.INGESTING:
     case DISPLAY_STATUS.DIGITIZING:
       return <InProgress size={16} className={styles.statusIconProgress} />;
-    case DISPLAY_STATUS.ALREADY_EXISTS:
+    case DOC_STATUS.ALREADY_EXISTS:
       return <CheckmarkFilled size={16} className={styles.statusIconWarning} />;
     default:
       return null;

--- a/ui/digitize/src/services/api.ts
+++ b/ui/digitize/src/services/api.ts
@@ -19,6 +19,7 @@ export interface Document {
   status: string;
   submitted_at?: string;
   output_format?: string;
+  message?: string | null;
 }
 
 export interface JobStats {


### PR DESCRIPTION
-Proposal - https://github.com/sats-23/project-ai-services/tree/dupIndex/docs/proposals/digitize-file-hash-dedup
-Why do we need this?
--With more data sources incoming to the digitize service, we have a necessity to hash files to be able to differentiate new duplicate files from already ingested files. 
--This will help us save huge time and resources by preventing re-ingestion of the same files
--This is the need of the hour considering multiple data sources can be connected to the same digitize instance and files could be common amongst sources

-Hash file (SHA256) when pipeline is triggered 
-If hash matches from PostgresDB, 
--If all files are duplicate, return 409, rejects the job
--If some files are duplicate, return 202, accepts the job and updates duplicate status
-Else, if non-duplicate
--Ingest as usual and save hash in DB 

Visuals:
-Some files are duplicate 
<img width="480" height="784" alt="Screenshot 2026-07-17 at 11 51 32" src="https://github.com/user-attachments/assets/baeab6a0-a62e-4583-a6a0-7befec2e6bd8" />

-All files are duplicate (rejects job)
<img width="482" height="751" alt="Screenshot 2026-07-17 at 11 51 09" src="https://github.com/user-attachments/assets/a6268a1c-9f66-4820-a573-7ff60619ecc6" />



