### PR TITLE
Updating image namespace from ai-services to ai-services-cicd

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.173
+TAG?=v0.0.174
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -2,7 +2,7 @@ ui:
   # @description Host port for the RAG UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services/chatbot-ui:v0.0.46
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.46
 
 backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
@@ -28,7 +28,7 @@ digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services/digitize-ui:v0.0.26
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.26
 
 ingest:
   # @hidden
@@ -46,7 +46,7 @@ opensearch:
 
 postgres:
   # @hidden
-  image: icr.io/ai-services/postgres:18-3
+  image: icr.io/ai-services-cicd/postgres:18-3
   # @description Password for PostgreSQL default 'postgres' user authentication. Must be at least 8 characters. Use this to override the default password.
   password: "Aiservicesdb@1234"
 
@@ -85,7 +85,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services/summarize-service:v0.0.16
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.16
   # @hidden
   log_level: "INFO"
   database: "summarize_metadata"
@@ -94,7 +94,7 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services/similarity-service:v0.0.13
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.13
   # @hidden
   log_level: "INFO"
 
@@ -102,7 +102,7 @@ litellm:
   # @description Enable LiteLLM proxy for remote LLM service. When true, uses LiteLLM with WatsonX; when false, uses local vLLM server. Default: false
   enable: false
   # @hidden
-  image: icr.io/ai-services/litellm:v1.89.3-1
+  image: icr.io/ai-services-cicd/litellm:v1.89.3-1
   # @description WatsonX API Key for LiteLLM integration. Required when litellm.enable is true.
   watsonxApiKey: ""
   # @description WatsonX Project ID for LiteLLM integration. Required when litellm.enable is true.

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -1,6 +1,6 @@
 ui:
   # @hidden
-  image: icr.io/ai-services/chatbot-ui:v0.0.46
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.46
 
 backend:
   # @hidden
@@ -12,7 +12,7 @@ backend:
 
 summarize:
   # @hidden
-  image: icr.io/ai-services/summarize-service:v0.0.16
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.16
   # @hidden
   log_level: "INFO"
   # @description Database name for the SUMMARIZE service. Default is "summarize_metadata".
@@ -20,7 +20,7 @@ summarize:
 
 similarity:
   # @hidden
-  image: icr.io/ai-services/similarity-service:v0.0.13
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.13
   # @hidden
   log_level: "INFO"
 
@@ -34,7 +34,7 @@ digitize:
 
 digitizeUi:
   # @hidden
-  image: icr.io/ai-services/digitize-ui:v0.0.26
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.26
 
 instruct:
   # @description API key for vLLM instruct service authentication. If empty, authentication is disabled. Provide a key to enable authentication.
@@ -95,7 +95,7 @@ opensearch:
 
 postgres:
   # @hidden
-  image: icr.io/ai-services/postgres:18-3
+  image: icr.io/ai-services-cicd/postgres:18-3
   # @description Sets the storage limit for the PostgreSQL service (Default: 5Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   storage: 5Gi
   # @description Password for PostgreSQL default 'postgres' user authentication. Must be at least 8 characters. Use this to override the default password.

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -2,7 +2,7 @@ ui:
   # @description Host port for the RAG UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services/chatbot-ui:v0.0.46
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.46
 
 backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
@@ -28,7 +28,7 @@ digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services/digitize-ui:v0.0.26
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.26
 
 ingest:
   # @hidden
@@ -46,7 +46,7 @@ opensearch:
 
 postgres:
   # @hidden
-  image: icr.io/ai-services/postgres:18-3
+  image: icr.io/ai-services-cicd/postgres:18-3
   # @description Password for PostgreSQL default 'postgres' user authentication. Must be at least 8 characters. Use this to override the default password.
   password: "Aiservicesdb@1234"
 
@@ -83,7 +83,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services/summarize-service:v0.0.16
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.16
   # @hidden
   log_level: "INFO"
   database: "summarize_metadata"
@@ -92,7 +92,7 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services/similarity-service:v0.0.13
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.13
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -1,6 +1,6 @@
 ui:
   # @hidden
-  image: icr.io/ai-services/chatbot-ui:v0.0.46
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.46
 
 backend:
   # @hidden
@@ -12,7 +12,7 @@ backend:
 
 summarize:
   # @hidden
-  image: icr.io/ai-services/summarize-service:v0.0.16
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.16
   # @hidden
   log_level: "INFO"
   # @description Database name for the SUMMARIZE service. Default is "summarize_metadata".
@@ -20,7 +20,7 @@ summarize:
 
 similarity:
   # @hidden
-  image: icr.io/ai-services/similarity-service:v0.0.13
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.13
   # @hidden
   log_level: "INFO"
 
@@ -34,7 +34,7 @@ digitize:
 
 digitizeUi:
   # @hidden
-  image: icr.io/ai-services/digitize-ui:v0.0.26
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.26
 
 instruct:
   # @hidden
@@ -95,7 +95,7 @@ opensearch:
 
 postgres:
   # @hidden
-  image: icr.io/ai-services/postgres:18-3
+  image: icr.io/ai-services-cicd/postgres:18-3
   # @description Sets the storage limit for the PostgreSQL service (Default: 5Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   storage: 5Gi
   # @description Password for PostgreSQL default 'postgres' user authentication. Must be at least 8 characters. Use this to override the default password.

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -2,7 +2,7 @@ ui:
   # @description Host port for the RAG UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services/chatbot-ui:v0.0.46
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.46
 
 backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
@@ -28,7 +28,7 @@ digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services/digitize-ui:v0.0.26
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.26
 
 ingest:
   # @hidden
@@ -46,7 +46,7 @@ opensearch:
 
 postgres:
   # @hidden
-  image: icr.io/ai-services/postgres:18-3
+  image: icr.io/ai-services-cicd/postgres:18-3
   # @description Password for PostgreSQL default 'postgres' user authentication. Must be at least 8 characters. Use this to override the default password.
   password: "Aiservicesdb@1234"
 
@@ -83,7 +83,7 @@ summarize:
   # @description Host port for the Summarize API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services/summarize-service:v0.0.16
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.16
   # @hidden
   log_level: "INFO"
   database: "summarize_metadata"
@@ -92,7 +92,7 @@ similarity:
   # @description Host port for the Similarity Search API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services/similarity-service:v0.0.13
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.13
   # @hidden
   log_level: "INFO"
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,10 +1,10 @@
 ui:
   port: ""
-  image: icr.io/ai-services/catalog-ui:v0.0.42
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.42
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.173
+  image: icr.io/ai-services-cicd/ai-services:v0.0.174
   runtime: ""
   adminPasswordHash: ""
   podman:
@@ -13,7 +13,7 @@ backend:
 
 db:
   port: ""
-  image: icr.io/ai-services/postgres:18-3
+  image: icr.io/ai-services-cicd/postgres:18-3
   user: "admin"
   database: "ai_services"
   password: ""
@@ -24,7 +24,7 @@ db:
       memory: "1Gi"
 
 caddy:
-  image: icr.io/ai-services/caddy:v2.11.4-0
+  image: icr.io/ai-services-cicd/caddy:v2.11.4-0
   adminPort: ""
   # @description HTTPS port for caddy. Set by configure command via --https-port flag.
   httpsPort: ""

--- a/ai-services/assets/components/llm/watsonx/podman/values.yaml
+++ b/ai-services/assets/components/llm/watsonx/podman/values.yaml
@@ -1,4 +1,4 @@
-image: "icr.io/ai-services/litellm:v1.89.3-1"
+image: "icr.io/ai-services-cicd/litellm:v1.89.3-1"
 model: "ibm/granite-4-h-small"
 watsonxApiKey: ""
 watsonxProjectId: ""

--- a/ai-services/assets/services/chat/podman/values.yaml
+++ b/ai-services/assets/services/chat/podman/values.yaml
@@ -1,6 +1,6 @@
 ui:
   port: ""
-  image: icr.io/ai-services/chatbot-ui:v0.0.46
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.25
 
 backend:
   port: ""

--- a/ai-services/assets/services/chat/podman/values.yaml
+++ b/ai-services/assets/services/chat/podman/values.yaml
@@ -1,6 +1,6 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/chatbot-service:v0.0.25
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.46
 
 backend:
   port: ""

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -4,10 +4,10 @@ digitize:
   database: "digitize_metadata"
 
 digitizeUi:
-  image: icr.io/ai-services/digitize-ui:v0.0.26
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.26
 
 postgres:
-  image: icr.io/ai-services/postgres:18-3
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.26
   username: "postgres"
   # @generate:password
   password: ""

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -7,7 +7,7 @@ digitizeUi:
   image: icr.io/ai-services-cicd/digitize-ui:v0.0.26
 
 postgres:
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.26
+  image: icr.io/ai-services-cicd/postgres:18-3
   username: "postgres"
   # @generate:password
   password: ""

--- a/ai-services/assets/services/similarity/podman/values.yaml
+++ b/ai-services/assets/services/similarity/podman/values.yaml
@@ -1,3 +1,3 @@
 similarity:
-  image: icr.io/ai-services/similarity-service:v0.0.13
+  image: icr.io/ai-services-cicd/similarity-service:v0.0.13
   log_level: "INFO"

--- a/ai-services/assets/services/summarize/podman/values.yaml
+++ b/ai-services/assets/services/summarize/podman/values.yaml
@@ -1,11 +1,11 @@
 summarize:
   port: ""
-  image: icr.io/ai-services/summarize-service:v0.0.16
+  image: icr.io/ai-services-cicd/summarize-service:v0.0.16
   log_level: "INFO"
   database: "summarize_metadata"
 
 postgres:
-  image: icr.io/ai-services/postgres:18-3
+  image: icr.io/ai-services-cicd/postgres:18-3
   username: "postgres"
   # @generate:password
   password: ""

--- a/ai-services/internal/pkg/vars/var.go
+++ b/ai-services/internal/pkg/vars/var.go
@@ -15,7 +15,7 @@ var (
 var (
 	// SpyreCardAnnotationRegex -> ai-services.io/<containerName>--spyre-cards.
 	SpyreCardAnnotationRegex = regexp.MustCompile(`^ai-services\.io\/([A-Za-z0-9][-A-Za-z0-9_.]*)--spyre-cards$`)
-	ToolImage                = "icr.io/ai-services-cicd/tools:0.11"
+	ToolImage                = "icr.io/ai-services/tools:0.11"
 )
 
 type Label string

--- a/ai-services/internal/pkg/vars/var.go
+++ b/ai-services/internal/pkg/vars/var.go
@@ -15,7 +15,7 @@ var (
 var (
 	// SpyreCardAnnotationRegex -> ai-services.io/<containerName>--spyre-cards.
 	SpyreCardAnnotationRegex = regexp.MustCompile(`^ai-services\.io\/([A-Za-z0-9][-A-Za-z0-9_.]*)--spyre-cards$`)
-	ToolImage                = "icr.io/ai-services/tools:0.11"
+	ToolImage                = "icr.io/ai-services-cicd/tools:0.11"
 )
 
 type Label string


### PR DESCRIPTION
As per recent observations, developers are only bumping up the image version in the values.yaml file, but a couple of images are still pointing to the public namespace. This PR moves all the remaining images to point to the `ai-services-cicd` namespace.