### PR TITLE
Add missing init container for digitize template

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.174
+TAG?=v0.0.175
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.30
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.31
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.30
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.31
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.30
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.31
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/templates/digitize-api-deployment.yaml
+++ b/ai-services/assets/applications/rag/openshift/templates/digitize-api-deployment.yaml
@@ -21,6 +21,26 @@ spec:
         ai-services.io/version: {{ default .Chart.AppVersion | quote }}
     spec:
       automountServiceAccountToken: false
+      initContainers:
+        - name: digitize-db-init
+          image: "{{ .Values.digitize.image }}"
+          command:
+            - "/var/venv/bin/python"
+            - "db/scripts/init_db.py"
+          env:
+            - name: POSTGRES_HOST
+              value: "postgres"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_DB
+              value: "{{ .Values.digitize.database }}"
+            - name: POSTGRES_USER
+              value: "postgres"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "postgres-credentials"
+                  key: password
       containers:
         - name: digitize-api
           image: "{{ .Values.digitize.image }}"

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.30
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.31
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.30
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.31
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.174
+  image: icr.io/ai-services-cicd/ai-services:v0.0.175
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,13 +1,13 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.29
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.31
   log_level: "INFO"
   database: "digitize_metadata"
 
 digitizeUi:
-  image: icr.io/ai-services/digitize-ui:v0.0.26
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.26
 
 postgres:
-  image: icr.io/ai-services/postgres:18-3
+  image: icr.io/ai-services-cicd/postgres:18-3
   username: "postgres"
   # @generate:password
   password: ""

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,13 +1,13 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.30
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.29
   log_level: "INFO"
   database: "digitize_metadata"
 
 digitizeUi:
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.26
+  image: icr.io/ai-services/digitize-ui:v0.0.26
 
 postgres:
-  image: icr.io/ai-services-cicd/postgres:18-3
+  image: icr.io/ai-services/postgres:18-3
   username: "postgres"
   # @generate:password
   password: ""

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.29
+TAG?=v0.0.31
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.30
+TAG?=v0.0.29
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/app.py
+++ b/services/digitize/app.py
@@ -73,7 +73,10 @@ async def lifespan(app: FastAPI):
                 Base.metadata.create_all(bind=engine)
                 logger.info("✅ Database schema initialized")
             except Exception as schema_err:
-                logger.error(f"❌ Failed to initialize database schema: {schema_err}")
+                logger.error(
+                    f"❌ Failed to initialize database schema: {schema_err}",
+                    exc_info=True,
+                )
                 raise RuntimeError(
                     f"Database schema initialization failed: {schema_err}"
                 )
@@ -85,10 +88,11 @@ async def lifespan(app: FastAPI):
                 "Database connection required but not available. "
                 "Please check database configuration."
             )
-    except RuntimeError:
+    except RuntimeError as exc:
+        logger.error(f"❌ Startup aborted: {exc}", exc_info=True)
         raise
     except Exception as exc:
-        logger.error(f"❌ Database check failed: {exc}")
+        logger.error(f"❌ Database check failed: {exc}", exc_info=True)
         raise RuntimeError(f"Database connection required but failed: {exc}")
 
     # Orphan / zombie job recovery on startup.


### PR DESCRIPTION
Log the error in digitize lifespan

Fixes #1135 

**Root Cause:**
The crash happened because, since the init container did not run to create db, when the app starts and health checks the db and it crashed since its not created, due to missing error logging, the error messages were not displayed on the logs.
Fixed both.