### PR TITLE
gha: Allowing GHA to run on release branch

### DIFF
--- a/.github/workflows/ai-services-image.yml
+++ b/.github/workflows/ai-services-image.yml
@@ -15,32 +15,14 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-  ICR_REGISTRY: icr.io
-  ICR_NAMESPACE: ai-services-cicd
-
 jobs:
   build-publish-image:
     name: Build and Publish Image
-    runs-on: ubuntu-24.04-ppc64le
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      working-directory: 'ai-services'
+    secrets: inherit
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Build ai-services image
-        working-directory: ai-services
-        run: |
-          make build REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }}
-
-      - name: Publish ai-services image
-        working-directory: ai-services
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
-        run: |
-          make push \
-            REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} \
-            REGISTRY_USER=${{ secrets.ICR_USERNAME }} \
-            REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
   scan:
     uses: ./.github/workflows/scanner.yml
     with:

--- a/.github/workflows/ai-services-image.yml
+++ b/.github/workflows/ai-services-image.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'ai-services/**'
       - .github/workflows/ai-services-image.yml
+    branches:
+      - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/ai-services-image.yml
+++ b/.github/workflows/ai-services-image.yml
@@ -5,12 +5,11 @@ on:
       - 'ai-services/**'
     branches:
       - main
+      - 'release-*'
   pull_request:
     paths:
       - 'ai-services/**'
       - .github/workflows/ai-services-image.yml
-    branches:
-      - main
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -36,7 +35,7 @@ jobs:
 
       - name: Publish ai-services image
         working-directory: ai-services
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
         run: |
           make push \
             REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} \

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04-ppc64le
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       
       - name: Build Image
         working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -10,6 +10,10 @@ on:
       working-directory:
        required: true
        type: string
+      runner:
+       required: false
+       type: string
+       default: 'ubuntu-24.04-ppc64le'
 
 env:
   ICR_REGISTRY: icr.io
@@ -17,7 +21,7 @@ env:
 
 jobs:
   build-publish-image:
-    runs-on: ubuntu-24.04-ppc64le
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -4,8 +4,9 @@ on:
   workflow_call:
     inputs:
       service:
-       required: true
+       required: false
        type: string
+       default: ''
       working-directory:
        required: true
        type: string
@@ -32,7 +33,7 @@ jobs:
       
       - name: Publish image
         working-directory: ${{ inputs.working-directory }}
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
         run: |
           make push \
             SERVICE=${{ inputs.service }} \

--- a/.github/workflows/bump-makefile-version.yml
+++ b/.github/workflows/bump-makefile-version.yml
@@ -13,6 +13,9 @@ on:
       - 'ai-services/**'
       - '.github/workflows/bump-makefile-version.yml'
       - '.github/scripts/check_make_version_tag.py'
+    branches:
+      - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -26,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/bump-makefile-version.yml
+++ b/.github/workflows/bump-makefile-version.yml
@@ -13,8 +13,6 @@ on:
       - 'ai-services/**'
       - '.github/workflows/bump-makefile-version.yml'
       - '.github/scripts/check_make_version_tag.py'
-    branches:
-      - main
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/caddy-image.yml
+++ b/.github/workflows/caddy-image.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'images/caddy/**'
       - '.github/workflows/caddy-image.yml'
+    branches:
+      - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/caddy-image.yml
+++ b/.github/workflows/caddy-image.yml
@@ -15,29 +15,13 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-  ICR_REGISTRY: icr.io
-  ICR_NAMESPACE: ai-services-cicd
-
 jobs:
   build-publish-image:
     name: Build and Publish Image
-    runs-on: ubuntu-24.04-ppc64le
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-      
-      - name: Build caddy image
-        working-directory: images/caddy
-        run: |
-          make build REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} REGISTRY_USER=${{ secrets.ICR_USERNAME }} REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
-
-      - name: Publish caddy image
-        working-directory: images/caddy
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
-        run: |
-          make push REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} REGISTRY_USER=${{ secrets.ICR_USERNAME }} REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      working-directory: 'images/caddy'
+    secrets: inherit
 
   scan:
     uses: ./.github/workflows/scanner.yml

--- a/.github/workflows/caddy-image.yml
+++ b/.github/workflows/caddy-image.yml
@@ -5,12 +5,11 @@ on:
       - 'images/caddy/**'
     branches:
       - main
+      - 'release-*'
   pull_request:
     paths:
       - 'images/caddy/**'
       - '.github/workflows/caddy-image.yml'
-    branches:
-      - main
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -36,7 +35,7 @@ jobs:
 
       - name: Publish caddy image
         working-directory: images/caddy
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
         run: |
           make push REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} REGISTRY_USER=${{ secrets.ICR_USERNAME }} REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
 

--- a/.github/workflows/catalog-ui-image.yml
+++ b/.github/workflows/catalog-ui-image.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'ui/catalog/**'
       - .github/workflows/catalog-ui-image.yml
+    branches:
+      - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/catalog-ui-image.yml
+++ b/.github/workflows/catalog-ui-image.yml
@@ -15,10 +15,6 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-  ICR_REGISTRY: icr.io
-  ICR_NAMESPACE: ai-services-cicd
-
 jobs:
   format:
     name: format
@@ -26,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -49,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Use Node.js
         uses: actions/setup-node@v6
@@ -69,25 +65,10 @@ jobs:
   build-publish-image:
     name: Build and Publish Image
     needs: [format, lint]
-    runs-on: ubuntu-24.04-ppc64le
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Build catalog-ui image
-        working-directory: ui/catalog
-        run: |
-          make build REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }}
-
-      - name: Publish catalog-ui image
-        working-directory: ui/catalog
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
-        run: |
-          make push \
-            REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} \
-            REGISTRY_USER=${{ secrets.ICR_USERNAME }} \
-            REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      working-directory: 'ui/catalog'
+    secrets: inherit
 
   scan:
     uses: ./.github/workflows/scanner.yml

--- a/.github/workflows/catalog-ui-image.yml
+++ b/.github/workflows/catalog-ui-image.yml
@@ -5,12 +5,11 @@ on:
       - 'ui/catalog/**'
     branches:
       - main
+      - 'release-*'
   pull_request:
     paths:
       - 'ui/catalog/**'
       - .github/workflows/catalog-ui-image.yml
-    branches:
-      - main
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -83,7 +82,7 @@ jobs:
 
       - name: Publish catalog-ui image
         working-directory: ui/catalog
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
         run: |
           make push \
             REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} \

--- a/.github/workflows/chatbot-service-image.yml
+++ b/.github/workflows/chatbot-service-image.yml
@@ -6,6 +6,7 @@ on:
       - 'services/chatbot/**'
     branches:
       - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/chatbot-ui.yml
+++ b/.github/workflows/chatbot-ui.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'ui/chatbot/**'
       - .github/workflows/chatbot-ui.yml
+    branches:
+      - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/chatbot-ui.yml
+++ b/.github/workflows/chatbot-ui.yml
@@ -5,20 +5,15 @@ on:
       - 'ui/chatbot/**'
     branches:
       - main
+      - 'release-*'
   pull_request:
     paths:
       - 'ui/chatbot/**'
       - .github/workflows/chatbot-ui.yml
-    branches:
-      - main
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
-env:
-  ICR_REGISTRY: icr.io
-  ICR_NAMESPACE: ai-services-cicd
 
 jobs:
   format:
@@ -27,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -50,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Use Node.js
         uses: actions/setup-node@v6
@@ -70,22 +65,10 @@ jobs:
   build-publish-image:
     name: Build and Publish Image
     needs: [lint, format]
-    runs-on: ubuntu-24.04-ppc64le
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-      
-      - name: Build chatbot-ui image
-        working-directory: ui/chatbot
-        run: |
-          make build REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }}
-
-      - name: Publish chatbot-ui image
-        working-directory: ui/chatbot
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          make push REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} REGISTRY_USER=${{ secrets.ICR_USERNAME }} REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      working-directory: 'ui/chatbot'
+    secrets: inherit
 
   scan:
     uses: ./.github/workflows/scanner.yml

--- a/.github/workflows/check-image-names.yml
+++ b/.github/workflows/check-image-names.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Run image name consistency check
         run: python3 .github/scripts/check_image_names.py

--- a/.github/workflows/check-image-names.yml
+++ b/.github/workflows/check-image-names.yml
@@ -12,6 +12,7 @@ on:
       - .github/scripts/check_image_names.py
     branches:
       - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/digitize-service.yml
+++ b/.github/workflows/digitize-service.yml
@@ -6,6 +6,7 @@ on:
       - 'services/digitize/**'
     branches:
       - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/digitize-ui-image.yml
+++ b/.github/workflows/digitize-ui-image.yml
@@ -5,20 +5,15 @@ on:
       - 'ui/digitize/**'
     branches:
       - main
+      - 'release-*'
   pull_request:
     paths:
       - 'ui/digitize/**'
       - .github/workflows/digitize-ui-image.yml
-    branches:
-      - main
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
-env:
-  ICR_REGISTRY: icr.io
-  ICR_NAMESPACE: ai-services-cicd
 
 jobs:
   lint:
@@ -27,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Use Node.js
         uses: actions/setup-node@v6
@@ -47,25 +42,10 @@ jobs:
   build-publish-image:
     name: Build and Publish Image
     needs: [lint]
-    runs-on: ubuntu-24.04-ppc64le
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Build digitize-ui image
-        working-directory: ui/digitize
-        run: |
-          make build REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }}
-
-      - name: Publish digitize-ui image
-        working-directory: ui/digitize
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          make push \
-            REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} \
-            REGISTRY_USER=${{ secrets.ICR_USERNAME }} \
-            REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      working-directory: 'ui/digitize'
+    secrets: inherit
 
   scan:
     uses: ./.github/workflows/scanner.yml
@@ -73,4 +53,4 @@ jobs:
       path: 'ui/digitize'
       image: 'digitize-ui'
 
- # Made with Bob
+# Made with Bob

--- a/.github/workflows/digitize-ui-image.yml
+++ b/.github/workflows/digitize-ui-image.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'ui/digitize/**'
       - .github/workflows/digitize-ui-image.yml
+    branches:
+      - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/go.yaml
     branches:
       - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup Go
         uses: actions/setup-go@v6

--- a/.github/workflows/litellm-image.yml
+++ b/.github/workflows/litellm-image.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'images/litellm/**'
       - .github/workflows/litellm-image.yml
+    branches:
+      - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/litellm-image.yml
+++ b/.github/workflows/litellm-image.yml
@@ -5,41 +5,24 @@ on:
       - 'images/litellm/**'
     branches:
       - main
+      - 'release-*'
   pull_request:
     paths:
       - 'images/litellm/**'
       - .github/workflows/litellm-image.yml
-    branches:
-      - main
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-  ICR_REGISTRY: icr.io
-  ICR_NAMESPACE: ai-services-cicd
-
 jobs:
   build-publish-image:
     name: Build and Publish Image
-    runs-on: ubuntu-24.04-ppc64le
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      working-directory: 'images/litellm'
+    secrets: inherit
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-      
-      - name: Build litellm image
-        working-directory: images/litellm
-        run: |
-          make build REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }}
-
-      - name: Publish litellm image
-        working-directory: images/litellm
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          make push REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} REGISTRY_USER=${{ secrets.ICR_USERNAME }} REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
-  
   scan:
     uses: ./.github/workflows/scanner.yml
     with:

--- a/.github/workflows/postgres-image.yml
+++ b/.github/workflows/postgres-image.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'images/postgres/**'
       - .github/workflows/postgres-image.yml
+    branches:
+      - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/postgres-image.yml
+++ b/.github/workflows/postgres-image.yml
@@ -5,41 +5,24 @@ on:
       - 'images/postgres/**'
     branches:
       - main
+      - 'release-*'
   pull_request:
     paths:
       - 'images/postgres/**'
       - .github/workflows/postgres-image.yml
-    branches:
-      - main
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-  ICR_REGISTRY: icr.io
-  ICR_NAMESPACE: ai-services-cicd
-
 jobs:
   build-publish-image:
     name: Build and Publish Image
-    runs-on: ubuntu-24.04-ppc64le
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      working-directory: 'images/postgres'
+    secrets: inherit
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-      
-      - name: Build postgres image
-        working-directory: images/postgres
-        run: |
-          make build REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }}
-
-      - name: Publish postgres image
-        working-directory: images/postgres
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          make push REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} REGISTRY_USER=${{ secrets.ICR_USERNAME }} REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
-  
   scan:
     uses: ./.github/workflows/scanner.yml
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       

--- a/.github/workflows/scanner.yml
+++ b/.github/workflows/scanner.yml
@@ -53,7 +53,7 @@ jobs:
     if: ${{ !inputs['skip-cves-scan'] }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       
       - name: Build image
         if: ${{ !inputs.skip-image-build }}
@@ -91,7 +91,7 @@ jobs:
     if: ${{ !inputs['skip-license-scan'] }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Build image
         if: ${{ !inputs.skip-image-build }}

--- a/.github/workflows/service-base.yml
+++ b/.github/workflows/service-base.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'images/service-base/**'
       - .github/workflows/service-base.yml
+    branches:
+      - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/service-base.yml
+++ b/.github/workflows/service-base.yml
@@ -15,29 +15,13 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-  ICR_REGISTRY: icr.io
-  ICR_NAMESPACE: ai-services-cicd
-
 jobs:
   build-publish-image:
     name: Build and Publish Image
-    runs-on: ubuntu-24.04-ppc64le-p10
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Build service-base image
-        working-directory: images/service-base
-        run: |
-          make build REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }}
-
-      - name: Publish service-base image
-        working-directory: images/service-base
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
-        run: |
-          make push REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} REGISTRY_USER=${{ secrets.ICR_USERNAME }} REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      working-directory: 'images/service-base'
+    secrets: inherit
 
   scan:
     uses: ./.github/workflows/scanner.yml

--- a/.github/workflows/service-base.yml
+++ b/.github/workflows/service-base.yml
@@ -5,12 +5,11 @@ on:
       - 'images/service-base/**'
     branches:
       - main
+      - 'release-*'
   pull_request:
     paths:
       - 'images/service-base/**'
       - .github/workflows/service-base.yml
-    branches:
-      - main
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -36,7 +35,7 @@ jobs:
 
       - name: Publish service-base image
         working-directory: images/service-base
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
         run: |
           make push REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} REGISTRY_USER=${{ secrets.ICR_USERNAME }} REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
 

--- a/.github/workflows/service-unit-tests.yml
+++ b/.github/workflows/service-unit-tests.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'services/**'
       - '.github/workflows/service-unit-tests.yml'
+    branches:
+      - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/service-unit-tests.yml
+++ b/.github/workflows/service-unit-tests.yml
@@ -2,8 +2,6 @@ name: Services Unit Tests
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - 'services/**'
       - '.github/workflows/service-unit-tests.yml'

--- a/.github/workflows/similarity-service-image.yml
+++ b/.github/workflows/similarity-service-image.yml
@@ -6,6 +6,7 @@ on:
       - 'services/similarity/**'
     branches:
       - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/summarize-service-image.yml
+++ b/.github/workflows/summarize-service-image.yml
@@ -6,6 +6,7 @@ on:
       - 'services/summarize/**'
     branches:
       - main
+      - 'release-*'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -10,45 +10,46 @@ on:
     paths:
       - 'images/tools/**'
       - .github/workflows/tools-image.yml
-
-concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    branches:
+      - main
+      - 'release-*'
 
 env:
   ICR_REGISTRY: icr.io
   ICR_NAMESPACE: ai-services-cicd
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  build-publish-image:
-    name: Build Arch Specific Image
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-24.04-ppc64le
-            arch: ppc64le
-          - os: ubuntu-24.04  # Standard amd64
-            arch: amd64
-          - os: ubuntu-24.04-arm
-            arch: arm64
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
+  build-publish-image-ppc64le:
+    name: Build and Publish Image (ppc64le)
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      working-directory: 'images/tools'
+      runner: 'ubuntu-24.04-ppc64le'
+    secrets: inherit
 
-      - name: Build tools image
-        working-directory: images/tools
-        run: |
-          make build REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }}
+  build-publish-image-amd64:
+    name: Build and Publish Image (amd64)
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      working-directory: 'images/tools'
+      runner: 'ubuntu-24.04'
+    secrets: inherit
 
-      - name: Publish tools image
-        working-directory: images/tools
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
-        run: |
-          make push REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} REGISTRY_USER=${{ secrets.ICR_USERNAME }} REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
+  build-publish-image-arm64:
+    name: Build and Publish Image (arm64)
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      working-directory: 'images/tools'
+      runner: 'ubuntu-24.04-arm'
+    secrets: inherit
+
   create-manifest:
     name: Create Multi-Arch Manifest
-    needs: build-publish-image
+    needs: [build-publish-image-ppc64le, build-publish-image-amd64, build-publish-image-arm64]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
     steps:
@@ -59,6 +60,7 @@ jobs:
         working-directory: images/tools
         run: |
           make manifest REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} REGISTRY_USER=${{ secrets.ICR_USERNAME }} REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
+
   scan:
     uses: ./.github/workflows/scanner.yml
     with:

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -24,27 +24,20 @@ concurrency:
 
 jobs:
   build-publish-image-ppc64le:
-    name: Build and Publish Image (ppc64le)
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-24.04-ppc64le
+            arch: ppc64le
+          - os: ubuntu-24.04  # Standard amd64
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    name: Build and Publish Image (${{ matrix.arch }})
     uses: ./.github/workflows/build-and-publish-image.yml
     with:
       working-directory: 'images/tools'
-      runner: 'ubuntu-24.04-ppc64le'
-    secrets: inherit
-
-  build-publish-image-amd64:
-    name: Build and Publish Image (amd64)
-    uses: ./.github/workflows/build-and-publish-image.yml
-    with:
-      working-directory: 'images/tools'
-      runner: 'ubuntu-24.04'
-    secrets: inherit
-
-  build-publish-image-arm64:
-    name: Build and Publish Image (arm64)
-    uses: ./.github/workflows/build-and-publish-image.yml
-    with:
-      working-directory: 'images/tools'
-      runner: 'ubuntu-24.04-arm'
+      runner: ${{ matrix.os }}
     secrets: inherit
 
   create-manifest:

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -5,12 +5,11 @@ on:
       - 'images/tools/**'
     branches:
       - main
+      - 'release-*'
   pull_request:
     paths:
       - 'images/tools/**'
       - .github/workflows/tools-image.yml
-    branches:
-      - main
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
@@ -35,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Build tools image
         working-directory: images/tools
@@ -44,17 +43,17 @@ jobs:
 
       - name: Publish tools image
         working-directory: images/tools
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
         run: |
           make push REGISTRY=${{ env.ICR_REGISTRY }}/${{ env.ICR_NAMESPACE }} REGISTRY_USER=${{ secrets.ICR_USERNAME }} REGISTRY_PASSWORD=${{ secrets.ICR_APIKEY }}
   create-manifest:
     name: Create Multi-Arch Manifest
     needs: build-publish-image
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Create and Push Manifest
         working-directory: images/tools

--- a/.github/workflows/tools-image.yml
+++ b/.github/workflows/tools-image.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build-publish-image-ppc64le:
+  build-publish-image:
     strategy:
       matrix:
         include:
@@ -42,7 +42,7 @@ jobs:
 
   create-manifest:
     name: Create Multi-Arch Manifest
-    needs: [build-publish-image-ppc64le, build-publish-image-amd64, build-publish-image-arm64]
+    needs: build-publish-image
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
     steps:


### PR DESCRIPTION
# Problem Statement:
GitHub Actions (GHA) isn't running for PRs raised against release branches, because of a branch filter configured in the workflow.

# Solution:

- Removed the branch filter on the `pull_request` trigger.
- Added a release branch pattern to the `push` trigger.
- Refactored the GHA workflow to reduce repeated steps.