### PR TITLE
AISERVICES-1340 - changes for catalog backup

### DIFF
--- a/ai-services/cmd/ai-services/cmd/catalog/backup.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/backup.go
@@ -1,0 +1,99 @@
+package catalog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/project-ai-services/ai-services/cmd/ai-services/cmd/catalog/common"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/backup"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
+)
+
+var (
+	// backupFilename is an optional output path for the catalog backup archive.
+	catalogBackupFilename string
+)
+
+// NewBackupCmd creates the "catalog backup" CLI command.
+func NewBackupCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "backup",
+		Short: "Back up catalog infrastructure data to a tar.gz archive",
+		Long: `Back up all catalog infrastructure data required to restore the catalog service.
+
+The following data is included in the backup archive:
+  - PostgreSQL database dump
+  - Catalog admin-password secret
+  - Caddy config related data - certificates, routes, config etc.
+
+The catalog service must be running when this command is executed.`,
+		Example: `  # Backup with auto-generated filename
+  ai-services catalog backup --runtime podman
+
+  # Backup to a specific file
+  ai-services catalog backup --runtime podman --filename /backups/catalog_20240101.tar.gz`,
+		Args: cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+
+			if err := common.InitAndValidateRuntimeFlag(runtimeType); err != nil {
+				return err
+			}
+
+			return validateCatalogBackupFlags(catalogBackupFilename)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var absFilename string
+
+			if catalogBackupFilename != "" {
+				var err error
+
+				absFilename, err = filepath.Abs(catalogBackupFilename)
+				if err != nil {
+					return fmt.Errorf("failed to resolve backup file path: %w", err)
+				}
+			}
+
+			return backup.Run(vars.RuntimeFactory.GetRuntimeType(), absFilename)
+		},
+	}
+
+	common.ConfigureRuntimeFlag(cmd, &runtimeType)
+	cmd.Flags().StringVar(
+		&catalogBackupFilename,
+		"filename",
+		"",
+		"Path for the backup tar.gz file (optional; auto-generated as catalog_backup_<timestamp>.tar.gz if not specified).\n"+
+			"Example: --filename /backups/catalog_20240101.tar.gz\n",
+	)
+
+	return cmd
+}
+
+// validateCatalogBackupFlags validates the optional --filename flag.
+func validateCatalogBackupFlags(filename string) error {
+	if filename == "" {
+		return nil
+	}
+
+	if !strings.HasSuffix(filename, ".tar.gz") {
+		return fmt.Errorf("backup filename must have a .tar.gz extension, got: %s", filename)
+	}
+
+	absFilename, err := filepath.Abs(filename)
+	if err != nil {
+		return fmt.Errorf("failed to resolve backup file path: %w", err)
+	}
+
+	if _, err := os.Stat(absFilename); err == nil {
+		return fmt.Errorf("backup file already exists: %s", absFilename)
+	}
+
+	return nil
+}
+
+// Made with Bob

--- a/ai-services/cmd/ai-services/cmd/catalog/catalog.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/catalog.go
@@ -16,6 +16,7 @@ deploy them, and handle service metadata`,
 
 	catalogCMD.AddCommand(NewAPIServerCmd())
 	catalogCMD.AddCommand(NewConfigureCmd())
+	catalogCMD.AddCommand(NewBackupCmd())
 	catalogCMD.AddCommand(NewUninstallCmd())
 	catalogCMD.AddCommand(NewHashpwCmd())
 	catalogCMD.AddCommand(NewLoginCmd())

--- a/ai-services/internal/pkg/catalog/cli/backup/common.go
+++ b/ai-services/internal/pkg/catalog/cli/backup/common.go
@@ -1,0 +1,24 @@
+// Package backup provides the catalog backup functionality.
+// Currently only the Podman runtime is supported.
+package backup
+
+import (
+	"fmt"
+
+	backupPodman "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/backup/podman"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+)
+
+// Run dispatches the catalog backup to the appropriate runtime implementation.
+func Run(runtime types.RuntimeType, backupFile string) error {
+	switch runtime {
+	case types.RuntimeTypePodman:
+		return backupPodman.BackupCatalog(backupFile)
+	case types.RuntimeTypeOpenShift:
+		return fmt.Errorf("catalog backup is not yet supported for the OpenShift runtime")
+	default:
+		return fmt.Errorf("unsupported runtime type: %s", runtime)
+	}
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/backup/podman/backup.go
+++ b/ai-services/internal/pkg/catalog/cli/backup/podman/backup.go
@@ -1,0 +1,108 @@
+// Package podman implements the catalog backup operation for the Podman runtime.
+// It backs up:
+//  1. PostgreSQL database (pg_dump via exec into the running postgres container)
+//  2. Podman secret: catalog-secret     (admin password hash)
+//  3. Caddy autosave.json               (<BaseDir>/common/caddy-config/caddy/autosave.json)
+//  4. User-supplied TLS certs           (<BaseDir>/common/caddy/certs/tls-*.crt/.key)
+//     OR Caddy self-signed PKI          (<BaseDir>/common/caddy/pki/ + certificates/)
+//
+// catalog-db-secret is intentionally excluded: the postgres user password lives in
+// the database data-volume and must stay in sync with it across restore operations.
+package podman
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	commonBackup "github.com/project-ai-services/ai-services/internal/pkg/application/common/backup"
+	catalogpodman "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman"
+	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
+)
+
+// BackupCatalog is the top-level entry point for backing up all catalog infrastructure data.
+// It creates a single tar.gz archive containing the database dump, secrets, and Caddy config files.
+func BackupCatalog(backupFile string) error {
+	pc, err := podman.NewPodmanClient()
+	if err != nil {
+		return fmt.Errorf("failed to initialize podman client: %w", err)
+	}
+
+	// Retrieve running catalog pod config (BaseDir, domain, https port).
+	catalogConfig, _, err := catalogUtils.GetCatalogPodConfig(pc)
+	if err != nil {
+		return fmt.Errorf("catalog service is not running – cannot back up: %w", err)
+	}
+
+	backupFile = resolveBackupFile(backupFile)
+
+	logger.Infof("Starting catalog backup → %s\n", backupFile)
+
+	// Work inside a temp directory; only the final tar.gz is written to the
+	// user-requested path, so no partial state is ever left on disk.
+	tempDir, err := os.MkdirTemp("", "catalog-backup-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary working directory: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			logger.Warningf("failed to remove temporary directory %s: %v\n", tempDir, err)
+		}
+	}()
+
+	if err := runBackupSteps(pc.Context, pc, catalogConfig.BaseDir, tempDir); err != nil {
+		return err
+	}
+
+	// Pack everything into the final archive.
+	entries := []string{
+		catalogpodman.DirDB, catalogpodman.DirSecrets, catalogpodman.DirCaddy,
+	}
+	if err := commonBackup.CreateTarGzArchive(tempDir, backupFile, entries); err != nil {
+		return fmt.Errorf("failed to create backup archive: %w", err)
+	}
+
+	commonBackup.LogArchiveSize(backupFile)
+	logger.Infof("✅ Catalog backup completed: %s\n", backupFile)
+
+	return nil
+}
+
+// runBackupSteps executes each backup step in sequence.
+// A failure in any step aborts the backup cleanly (temp dir is cleaned up by the caller).
+func runBackupSteps(ctx context.Context, pc *podman.PodmanClient, baseDir, tempDir string) error {
+	steps := []struct {
+		name string
+		fn   func() error
+	}{
+		{"postgres", func() error { return backupPostgres(ctx, tempDir) }},
+		{"secrets", func() error { return backupSecrets(ctx, tempDir) }},
+		{"caddy", func() error { return backupCaddyFiles(ctx, baseDir, tempDir) }},
+	}
+
+	for _, step := range steps {
+		logger.Infof("Backup step: %s\n", step.name)
+
+		if err := step.fn(); err != nil {
+			return fmt.Errorf("backup step %q failed: %w", step.name, err)
+		}
+	}
+
+	return nil
+}
+
+// resolveBackupFile returns the provided filename or auto-generates one when empty.
+func resolveBackupFile(backupFile string) string {
+	if backupFile != "" {
+		return backupFile
+	}
+
+	timestamp := time.Now().Format("20060102_150405")
+
+	return fmt.Sprintf("catalog_backup_%s.tar.gz", timestamp)
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/backup/podman/files.go
+++ b/ai-services/internal/pkg/catalog/cli/backup/podman/files.go
@@ -1,0 +1,145 @@
+package podman
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	catalogpodman "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+)
+
+// backupCaddyFiles copies all Caddy state from the host BaseDir into tempDir/caddy/:
+//
+//  1. autosave.json  – Caddy's live config snapshot (mandatory)
+//  2. pki/           – Caddy's root CA and intermediate cert/key (always present)
+//  3. certificates/  – issued leaf certs per-domain (always present)
+//  4. certs/         – user-supplied staged TLS files (only when custom certs are used)
+//
+// The pki/ directory is backed up in both self-signed and custom-cert scenarios
+// because Caddy always maintains its own internal PKI regardless of the TLS mode.
+func backupCaddyFiles(ctx context.Context, baseDir, tempDir string) error {
+	logger.Infoln("  Backing up Caddy configuration files...")
+
+	caddyDir := filepath.Join(tempDir, catalogpodman.DirCaddy)
+	if err := os.MkdirAll(caddyDir, catalogpodman.DirPerm); err != nil {
+		return fmt.Errorf("failed to create caddy backup directory: %w", err)
+	}
+
+	if err := backupAutosave(baseDir, caddyDir); err != nil {
+		return err
+	}
+
+	if err := backupCaddyPKI(baseDir, caddyDir); err != nil {
+		return err
+	}
+
+	return backupStagedCerts(baseDir, caddyDir)
+}
+
+// backupAutosave copies <BaseDir>/common/caddy-config/caddy/autosave.json.
+func backupAutosave(baseDir, caddyDir string) error {
+	src := filepath.Join(baseDir, catalogpodman.CaddyConfigSubDir, catalogpodman.AutosaveFileName)
+
+	if _, err := os.Stat(src); os.IsNotExist(err) {
+		return fmt.Errorf("caddy autosave.json not found at %s – ensure the catalog is running before taking a backup", src)
+	}
+
+	dst := filepath.Join(caddyDir, catalogpodman.AutosaveFileName)
+	if err := catalogpodman.CopyFile(src, dst, catalogpodman.FilePerm); err != nil {
+		return fmt.Errorf("failed to copy autosave.json: %w", err)
+	}
+
+	logger.Infof("  ✓ autosave.json backed up\n")
+
+	return nil
+}
+
+// backupCaddyPKI backs up Caddy's internal PKI and leaf-cert store.
+// These directories are always present under <BaseDir>/common/caddy/ regardless
+// of TLS mode, because Caddy maintains its own root CA even when custom certs
+// are loaded via the Admin API.
+//
+//	pki/authorities/local/   – root CA cert + key (root.crt, root.key, intermediate.crt)
+//	certificates/local/      – issued leaf certs per-domain
+//
+// If a directory does not yet exist (catalog was never fully started) it is
+// skipped with a warning rather than failing the entire backup.
+func backupCaddyPKI(baseDir, caddyDir string) error {
+	caddyDataDir := filepath.Join(baseDir, catalogpodman.CaddyDataSubDir)
+
+	type pkiDir struct {
+		subDir string
+		label  string
+	}
+
+	dirs := []pkiDir{
+		{catalogpodman.CaddyPKISubDir, "PKI"},
+		{catalogpodman.CaddyLeafCertsSubDir, "leaf certificates"},
+	}
+
+	backedUpAny := false
+
+	for _, d := range dirs {
+		src := filepath.Join(caddyDataDir, d.subDir)
+
+		if _, err := os.Stat(src); os.IsNotExist(err) {
+			logger.Infof("  Caddy %s directory not found at %s – skipping\n", d.label, src)
+
+			continue
+		}
+
+		dst := filepath.Join(caddyDir, d.subDir)
+		if err := catalogpodman.CopyDir(src, dst); err != nil {
+			return fmt.Errorf("failed to back up Caddy %s: %w", d.label, err)
+		}
+
+		logger.Infof("  ✓ Backed up Caddy %s\n", d.label)
+
+		backedUpAny = true
+	}
+
+	if !backedUpAny {
+		logger.Warningln("  Caddy PKI directories not found – Caddy may not have fully started yet")
+	}
+
+	return nil
+}
+
+// backupStagedCerts copies user-supplied TLS files when custom certificates
+// are in use. If no staged files exist (self-signed mode) the step is a no-op.
+//
+//	<BaseDir>/common/caddy/certs/tls-*.crt
+//	<BaseDir>/common/caddy/certs/tls-*.key
+func backupStagedCerts(baseDir, caddyDir string) error {
+	certsDir := filepath.Join(baseDir, catalogpodman.CaddyDataSubDir, catalogpodman.CaddyCertsSubDir)
+
+	certMatches, _ := filepath.Glob(filepath.Join(certsDir, "tls-*.crt"))
+	keyMatches, _ := filepath.Glob(filepath.Join(certsDir, "tls-*.key"))
+
+	if len(certMatches) == 0 && len(keyMatches) == 0 {
+		logger.Infoln("  No staged TLS certificates found – self-signed mode active")
+
+		return nil
+	}
+
+	destCertsDir := filepath.Join(caddyDir, catalogpodman.CaddyCertsSubDir)
+	if err := os.MkdirAll(destCertsDir, catalogpodman.DirPerm); err != nil {
+		return fmt.Errorf("failed to create certs backup directory: %w", err)
+	}
+
+	for _, src := range append(certMatches, keyMatches...) {
+		dst := filepath.Join(destCertsDir, filepath.Base(src))
+		if err := catalogpodman.CopyFile(src, dst, catalogpodman.FilePerm); err != nil {
+			return fmt.Errorf("failed to copy certificate file %s: %w", filepath.Base(src), err)
+		}
+		logger.Infof("  ✓ Backed up: %s\n", filepath.Base(src))
+	}
+
+	logger.Infof("  ✓ Backed up %d user-supplied TLS file(s)\n", len(certMatches)+len(keyMatches))
+
+	return nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/backup/podman/postgres.go
+++ b/ai-services/internal/pkg/catalog/cli/backup/podman/postgres.go
@@ -1,0 +1,119 @@
+package podman
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	catalogpodman "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman"
+	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+)
+
+// backupPostgres runs pg_dump inside the running postgres container and copies
+// the SQL dump to tempDir/db/catalog-db.sql.
+//
+// The DB password is retrieved from the Podman secret and passed to pg_dump via
+// the PGPASSWORD environment variable set only for the duration of the exec call,
+// so it never appears in log output or error messages.
+func backupPostgres(ctx context.Context, tempDir string) error {
+	logger.Infoln("  Backing up PostgreSQL database...")
+
+	dbDir := filepath.Join(tempDir, catalogpodman.DirDB)
+	if err := os.MkdirAll(dbDir, catalogpodman.DirPerm); err != nil {
+		return fmt.Errorf("failed to create db backup directory: %w", err)
+	}
+
+	containerName := catalogConstants.CatalogAppName + "--db-" + catalogpodman.PostgresContainer
+	logger.Infof("  Using postgres container: %s\n", containerName)
+
+	dbPassword, err := catalogpodman.ReadSecretFromPodman(ctx, catalogConstants.CatalogDBSecretName, catalogConstants.CatalogDBSecretKey)
+	if err != nil {
+		return fmt.Errorf("failed to read DB password: %w", err)
+	}
+
+	dumpPath := filepath.Join(dbDir, catalogpodman.DBDumpFileName)
+	if err := runPGDump(ctx, containerName, dbPassword, dumpPath); err != nil {
+		return err
+	}
+
+	logger.Infoln("  ✓ PostgreSQL dump completed")
+
+	return nil
+}
+
+// runPGDump executes pg_dump inside the postgres container and streams the
+// result to dumpPath on the host.
+//
+// Security: PGPASSWORD is set only in the subprocess environment, never in
+// an argument list visible to `ps`, and is never included in any error message.
+func runPGDump(ctx context.Context, containerName, dbPassword, dumpPath string) error {
+	// Open the destination file before exec to avoid leaving a partial file on error.
+	out, err := os.OpenFile(dumpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, catalogpodman.FilePerm)
+	if err != nil {
+		return fmt.Errorf("failed to create dump file: %w", err)
+	}
+	defer func() {
+		_ = out.Close()
+	}()
+
+	// Build: podman exec -e PGPASSWORD=<pw> <container> pg_dump -U <user> --clean --if-exists <db>
+	// --clean:     emit DROP statements before each CREATE so the dump is idempotent.
+	// --if-exists: add IF EXISTS to each DROP to suppress errors when restoring
+	//              into a freshly initialised (empty) database.
+	// Using "-e" flag to pass the env var only to this exec, not via argument.
+	args := []string{
+		"exec",
+		"-e", "PGPASSWORD=" + dbPassword,
+		containerName,
+		"pg_dump",
+		"-U", catalogpodman.PostgresUser,
+		"--clean",
+		"--if-exists",
+		catalogpodman.PostgresDB,
+	}
+
+	// Clear the password from the args slice once the command object is built.
+	cmd := exec.CommandContext(ctx, "podman", args...)
+	// Zero out the password argument immediately after command construction.
+	for i, a := range args {
+		if len(a) > 9 && a[:9] == "PGPASSWD=" {
+			args[i] = ""
+		}
+	}
+
+	cmd.Stdout = out
+
+	// Capture stderr separately so it never contains the password and can be
+	// safely included in the error message.
+	stderrOutput, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start pg_dump: %w", err)
+	}
+
+	// Read stderr without blocking (small buffer is enough for error messages).
+	stderrBuf := make([]byte, catalogpodman.StderrBufferBytes)
+	n, _ := stderrOutput.Read(stderrBuf)
+	stderrMsg := string(stderrBuf[:n])
+
+	if err := cmd.Wait(); err != nil {
+		_ = out.Close()
+		_ = os.Remove(dumpPath) // remove partial dump
+
+		if stderrMsg != "" {
+			return fmt.Errorf("pg_dump failed: %w — %s", err, stderrMsg)
+		}
+
+		return fmt.Errorf("pg_dump failed: %w", err)
+	}
+
+	return nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/backup/podman/secrets.go
+++ b/ai-services/internal/pkg/catalog/cli/backup/podman/secrets.go
@@ -1,0 +1,59 @@
+package podman
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	catalogpodman "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman"
+	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+)
+
+// backupSecrets writes the admin-password hash (catalog-secret) to the temp directory.
+// It is stored as a JSON file so the restore operation can re-create the secret
+// without ambiguity.
+//
+// catalog-db-secret is intentionally NOT backed up: the postgres user password
+// lives in the database data-volume and is never modified by the SQL dump, so
+// restoring a different DB password would break the backend→postgres connection.
+//
+// Security: secret values are written to a 0600 file inside a 0700 temp directory
+// and are never logged or included in any error message.
+func backupSecrets(ctx context.Context, tempDir string) error {
+	secretsDir := filepath.Join(tempDir, catalogpodman.DirSecrets)
+	if err := os.MkdirAll(secretsDir, catalogpodman.DirPerm); err != nil {
+		return fmt.Errorf("failed to create secrets directory: %w", err)
+	}
+
+	return backupSingleSecret(ctx, secretsDir,
+		catalogConstants.CatalogSecretName, catalogConstants.CatalogSecretKey)
+}
+
+// backupSingleSecret fetches one Podman secret value and writes it as a JSON file.
+func backupSingleSecret(ctx context.Context, secretsDir, secretName, secretKey string) error {
+	logger.Infof("  Backing up secret: %s\n", secretName)
+
+	value, err := catalogpodman.ReadSecretFromPodman(ctx, secretName, secretKey)
+	if err != nil {
+		return err
+	}
+
+	data := map[string]string{secretKey: value}
+
+	encoded, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode secret %s: %w", secretName, err)
+	}
+
+	destPath := filepath.Join(secretsDir, secretName+".json")
+	if err := os.WriteFile(destPath, encoded, catalogpodman.FilePerm); err != nil {
+		return fmt.Errorf("failed to write secret backup for %s: %w", secretName, err)
+	}
+
+	return nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/common/podman/fileio.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/fileio.go
@@ -1,0 +1,98 @@
+// Package podman provides shared utilities for catalog CLI operations
+// that need access to the Podman runtime (backup, restore, etc.).
+package podman
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Permission bits used consistently for backup and restore operations.
+const (
+	DirPerm  = 0o700
+	FilePerm = 0o600
+)
+
+// Archive top-level directory names — identical in backup and restore archives.
+const (
+	DirDB      = "db"
+	DirSecrets = "secrets"
+	DirCaddy   = "caddy"
+)
+
+// Caddy path constants — relative paths inside BaseDir and inside the archive.
+const (
+	CaddyDataSubDir   = "common/caddy"
+	CaddyConfigSubDir = "common/caddy-config/caddy"
+	AutosaveFileName  = "autosave.json"
+	CaddyCertsSubDir  = "certs"
+	CaddyPKISubDir    = "pki"
+	CaddyLeafCertsSubDir = "certificates"
+)
+
+// Caddy pod name — constructed from CatalogAppName + "--caddy".
+const (
+	CaddyPodName = "ai-services--caddy"
+)
+
+// Postgres constants shared between backup and restore.
+const (
+	DBDumpFileName    = "catalog-db.sql"
+	PostgresContainer = "postgresql"
+	PostgresUser      = "admin"
+	PostgresDB        = "ai_services"
+	StderrBufferBytes = 4096
+)
+
+// CopyFile copies src to dst with the given permission bits.
+// The destination file is created (or truncated) atomically via O_TRUNC.
+func CopyFile(src, dst string, perm os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open source file: %w", err)
+	}
+	defer func() {
+		_ = in.Close()
+	}()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return fmt.Errorf("failed to create destination file: %w", err)
+	}
+	defer func() {
+		_ = out.Close()
+	}()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("failed to copy file contents: %w", err)
+	}
+
+	return nil
+}
+
+// CopyDir recursively copies the directory tree rooted at src into dst,
+// preserving the relative structure.  dst is created if it does not exist.
+func CopyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return fmt.Errorf("failed to compute relative path: %w", err)
+		}
+
+		target := filepath.Join(dst, rel)
+
+		if info.IsDir() {
+			return os.MkdirAll(target, DirPerm)
+		}
+
+		return CopyFile(path, target, FilePerm)
+	})
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/common/podman/secretsutil.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/secretsutil.go
@@ -1,0 +1,117 @@
+package podman
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/containers/podman/v5/pkg/bindings/secrets"
+)
+
+// ReadSecretFromPodman retrieves the value for a known key from a live Podman secret.
+// The secret data format stored by catalog configure is "key: value\n".
+// The returned value is never logged.
+func ReadSecretFromPodman(ctx context.Context, secretName, key string) (string, error) {
+	opts := &secrets.InspectOptions{}
+	opts.WithShowSecret(true)
+
+	info, err := secrets.Inspect(ctx, secretName, opts)
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect secret %s: %w", secretName, err)
+	}
+
+	if info.SecretData == "" {
+		return "", fmt.Errorf("secret %s is empty", secretName)
+	}
+
+	value, err := ExtractKeyFromSecretData(info.SecretData, key)
+	if err != nil {
+		return "", fmt.Errorf("secret %s: %w", secretName, err)
+	}
+
+	return value, nil
+}
+
+// ReadSecretValueFromFile reads a JSON secret backup file (written by backupSingleSecret)
+// and returns the value for the given key.  The returned value is never logged.
+func ReadSecretValueFromFile(secretsDir, secretName, secretKey string) (string, error) {
+	secretPath := filepath.Join(secretsDir, secretName+".json")
+
+	data, err := os.ReadFile(secretPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read secret backup for %s: %w", secretName, err)
+	}
+
+	var secretMap map[string]string
+	if err := json.Unmarshal(data, &secretMap); err != nil {
+		return "", fmt.Errorf("failed to parse secret backup for %s: %w", secretName, err)
+	}
+
+	value, ok := secretMap[secretKey]
+	if !ok || value == "" {
+		return "", fmt.Errorf("key %q not found in secret backup for %s", secretKey, secretName)
+	}
+
+	return value, nil
+}
+
+// ExtractKeyFromSecretData parses "key: value\n" lines and returns the value for
+// the requested key.  The raw secret data is never surfaced in error messages.
+func ExtractKeyFromSecretData(secretData, wantKey string) (string, error) {
+	for _, line := range splitLines(secretData) {
+		k, v, ok := splitKeyValue(line)
+		if ok && k == wantKey {
+			return v, nil
+		}
+	}
+
+	return "", fmt.Errorf("key %q not found in secret data", wantKey)
+}
+
+// splitLines splits a string into trimmed, non-empty lines.
+func splitLines(s string) []string {
+	var result []string
+
+	start := 0
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == '\n' {
+			line := trimSpaces(s[start:i])
+			if line != "" {
+				result = append(result, line)
+			}
+			start = i + 1
+		}
+	}
+
+	return result
+}
+
+// splitKeyValue splits "key: value" into its parts (trimmed).
+func splitKeyValue(line string) (key, value string, ok bool) {
+	for i := 0; i < len(line); i++ {
+		if line[i] == ':' {
+			return trimSpaces(line[:i]), trimSpaces(line[i+1:]), true
+		}
+	}
+
+	return "", "", false
+}
+
+// trimSpaces trims leading and trailing ASCII whitespace without importing strings.
+func trimSpaces(s string) string {
+	start := 0
+	for start < len(s) && (s[start] == ' ' || s[start] == '\t' || s[start] == '\r') {
+		start++
+	}
+
+	end := len(s)
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t' || s[end-1] == '\r') {
+		end--
+	}
+
+	return s[start:end]
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/constants/catalog.go
+++ b/ai-services/internal/pkg/catalog/constants/catalog.go
@@ -36,6 +36,12 @@ const (
 	PodmanAuthSecret = "podman-auth-secret"
 	// CatalogSecretName represents the catalog secret name.
 	CatalogSecretName = "catalog-secret"
+	// CatalogSecretKey is the data key inside catalog-secret that holds the bcrypt admin-password hash.
+	CatalogSecretKey = "admin-password"
+	// CatalogDBSecretName represents the catalog database secret name.
+	CatalogDBSecretName = "catalog-db-secret"
+	// CatalogDBSecretKey is the data key inside catalog-db-secret that holds the database password.
+	CatalogDBSecretKey = "db-password"
 	// CatalogPodmanAuthSecretName represent the podman auth secret name.
 	CatalogPodmanAuthSecretName = "podman-auth-secret"
 )


### PR DESCRIPTION
Changes for catalog backup:
- Backup for postgres db, catalog secret (admin password), caddy related configs - autosave.json, certs or certificates folder (depending on whether self signed or user certs are used), pki folder.

```
prachi_kurade:ai-services$ ./bin/ai-services-linux-amd64 catalog backup -h
Back up all catalog infrastructure data required to restore the catalog service.

The following data is included in the backup archive:
  - PostgreSQL database dump
  - Catalog admin-password secret
  - Caddy config related data - certificates, routes, config etc.

The catalog service must be running when this command is executed.

Usage:
  ai-services catalog backup [flags]

Examples:
  # Backup with auto-generated filename
  ai-services catalog backup --runtime podman

  # Backup to a specific file
  ai-services catalog backup --runtime podman --filename /backups/catalog_20240101.tar.gz

Flags:
      --filename string   Path for the backup tar.gz file (optional; auto-generated as catalog_backup_<timestamp>.tar.gz if not specified).
                          Example: --filename /backups/catalog_20240101.tar.gz
                          
  -h, --help              help for backup
  -r, --runtime string    runtime to use (options: podman, openshift) (required)


prachi_kurade:ai-services$ ./bin/ai-services-linux-amd64 catalog backup
Error: invalid runtime type:  (must be 'podman' or 'openshift'). Please specify runtime using --runtime flag
prachi_kurade:ai-services$ ./bin/ai-services-linux-amd64 catalog backup --runtime p
Error: invalid runtime type: p (must be 'podman' or 'openshift'). Please specify runtime using --runtime flag
prachi_kurade:ai-services$ ./bin/ai-services-linux-amd64 catalog backup --runtime openshift
Error: catalog cmd is not yet supported for OpenShift runtime
prachi_kurade:ai-services$ ./bin/ai-services-linux-amd64 catalog backup --runtime podman --filename
Error: flag needs an argument: --filename
Usage:
  ai-services catalog backup [flags]

Examples:
  # Backup with auto-generated filename
  ai-services catalog backup --runtime podman

  # Backup to a specific file
  ai-services catalog backup --runtime podman --filename /backups/catalog_20240101.tar.gz

Flags:
      --filename string   Path for the backup tar.gz file (optional; auto-generated as catalog_backup_<timestamp>.tar.gz if not specified).
                          Example: --filename /backups/catalog_20240101.tar.gz
                          
  -h, --help              help for backup
  -r, --runtime string    runtime to use (options: podman, openshift) (required)


[root@onprem133725229 ai-services]# ./bin/ai-services-linux-ppc64le catalog backup --runtime podman
Starting catalog backup → catalog_backup_20260716_031926.tar.gz
Backup step: postgres
  Backing up PostgreSQL database...
  Using postgres container: ai-services--db-postgresql
  ✓ PostgreSQL dump completed
Backup step: secrets
  Backing up secret: catalog-secret
Backup step: caddy
  Backing up Caddy configuration files...
  ✓ autosave.json backed up
  ✓ Backed up Caddy PKI
  ✓ Backed up Caddy leaf certificates
  No staged TLS certificates found – self-signed mode active
✓ Tar archive created: catalog_backup_20260716_031926.tar.gz (0.01 MB)
✅ Catalog backup completed: catalog_backup_20260716_031926.tar.gz


[root@onprem133725229 ai-services]# ./bin/ai-services-linux-ppc64le catalog backup --runtime podman --filename with_cert.tar.gz
Starting catalog backup → /root/prachi/public/project-ai-services/ai-services/with_cert.tar.gz
Backup step: postgres
  Backing up PostgreSQL database...
  Using postgres container: ai-services--db-postgresql
  ✓ PostgreSQL dump completed
Backup step: secrets
  Backing up secret: catalog-secret
Backup step: caddy
  Backing up Caddy configuration files...
  ✓ autosave.json backed up
  ✓ Backed up Caddy PKI
  Caddy leaf certificates directory not found at /var/lib/ai-services/common/caddy/certificates – skipping
  ✓ Backed up: tls-1784175432.crt
  ✓ Backed up: tls-1784175432.key
  ✓ Backed up 2 user-supplied TLS file(s)
✓ Tar archive created: /root/prachi/public/project-ai-services/ai-services/with_cert.tar.gz (0.01 MB)
✅ Catalog backup completed: /root/prachi/public/project-ai-services/ai-services/with_cert.tar.gz
```
