### PR TITLE
docs: proposal document for remote podman setup

### DIFF
--- a/docs/proposals/catalog/remote-worker-agent-proposal.md
+++ b/docs/proposals/catalog/remote-worker-agent-proposal.md
@@ -1,0 +1,540 @@
+# Remote Worker Agent Proposal
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Background and Motivation](#2-background-and-motivation)
+   - 2.1 [Current State](#21-current-state)
+   - 2.2 [Problem Statement](#22-problem-statement)
+   - 2.3 [Goals](#23-goals)
+   - 2.4 [Non-Goals](#24-non-goals)
+3. [System Topology](#3-system-topology)
+4. [Architecture Overview](#4-architecture-overview)
+   - 4.1 [Key Components](#41-key-components)
+   - 4.2 [Component Interaction Diagram](#42-component-interaction-diagram)
+5. [gRPC Protocol](#5-grpc-protocol)
+   - 5.1 [Service Definition](#51-service-definition)
+   - 5.2 [Command Types](#52-command-types)
+6. [Bootstrap and Registration Flow](#6-bootstrap-and-registration-flow)
+7. [Deployment Execution Flow](#7-deployment-execution-flow)
+8. [Agent Registry State Machine](#8-agent-registry-state-machine)
+9. [Database Schema](#9-database-schema)
+10. [New CLI Commands](#10-new-cli-commands)
+    - 10.1 [Control Plane Commands](#101-control-plane-commands)
+    - 10.2 [Worker Agent Commands](#102-worker-agent-commands)
+11. [Configuration Files](#11-configuration-files)
+12. [Code Structure](#12-code-structure)
+13. [Before vs After Comparison](#13-before-vs-after-comparison)
+14. [Security Design](#14-security-design)
+15. [Future Work](#15-future-work)
+
+---
+
+## 1. Executive Summary
+
+This proposal describes the design and implementation of a **Remote Worker Agent** system for the AI Services Catalog. It enables the Catalog API Server (running on a Control Plane LPAR) to dispatch Podman runtime commands over a persistent bidirectional gRPC stream to one or more **Worker Agent daemons** running on separate LPARs (e.g. Power10 nodes with Spyre AI accelerators).
+
+The existing `runtime.Runtime` interface and all its callers (`PodmanDeployer`, `SyncService`, `DeletionService`) are **unchanged**. The remote execution path is a new implementation of the same interface, selected at request time by specifying `runtime=remote`.
+
+---
+
+## 2. Background and Motivation
+
+### 2.1 Current State
+
+The AI Services Catalog deploys and manages AI service containers (RAG pipelines, chat, summarization, etc.) by invoking Podman commands **locally** — the Catalog API Server and the Podman socket must reside on the same LPAR.
+
+```
+┌───────────────────────────────────────────────────────┐
+│  Single LPAR                                          │
+│                                                       │
+│  Catalog API Server  ──────►  Podman  ──►  Container  │
+└───────────────────────────────────────────────────────┘
+```
+
+### 2.2 Problem Statement
+
+There is currently no way to use a single AI Services Catalog installation as a control plane that manages deployments across multiple LPARs. Every deployment operation is executed locally — the Catalog API Server can only drive the Podman socket on the same LPAR it is running on.
+
+This means that to deploy AI workloads on a second or third LPAR, an operator must install and maintain a completely independent Catalog instance on each one. There is no shared view of applications, no unified CLI, and no way to target a specific LPAR (for example, one carrying IBM Spyre AI accelerators) from a central management node.
+
+### 2.3 Goals
+
+1. Allow the Control Plane to deploy containers on **remote LPARs** without changing any existing deployer code.
+2. Keep the local Podman path (`--runtime podman`) working with **zero regression**.
+3. Support **multiple worker LPARs** with per-request agent selection via label selectors.
+4. Provide **operational visibility** — list, status, and delete agents from the control plane CLI.
+5. Provide a **secure bootstrap** process using single-use HMAC tokens (mTLS follow-up planned).
+
+### 2.4 Non-Goals
+
+- mTLS between control plane and agents (reserved for a follow-up; stubs are present).
+- OpenShift-based remote deployment.
+- Cross-LPAR container networking / storage management.
+
+---
+
+## 3. System Topology
+
+```
+┌───────────────────────────────────────────────────────┐
+│                    Control Plane LPAR                 │
+│                                                       │
+│   ai-services CLI.                                    │
+│         │  REST                                       │
+│         ▼                                             │
+│   Catalog API Server  :8080 (gin)                     │
+│         │                                             │
+│         ▼                                             │
+│   AgentDispatcher                                     │
+│         │                                             │
+│         ▼                                             │
+│   RemoteRuntime  ◄──────────────────────────┐         │
+│         │                                   │         │
+│         ▼                                   │         │
+│   AgentGateway  :9090 (gRPC)                │         │
+│         │  bidirectional stream             │         │
+│         │                          AgentRegistry      │
+│         │                          in-memory + DB     │
+└─────────┼──────────────────────────────────┼──────────┘
+          │                                  │
+  ┌───────┴──────────┐              ┌────────┴─────────┐
+  │  Worker LPAR-1   │              │  Worker LPAR-2   │
+  │                  │              │                  │
+  │  agent daemon    │              │  agent daemon    │
+  │  (gRPC client)   │              │  (gRPC client)   │
+  │       │          │              │       │          │
+  │  Podman Socket   │              │  Podman Socket   │
+  │       │          │              │       │          │
+  │  Spyre / GPU     │              │  Spyre / GPU     │
+  └──────────────────┘              └──────────────────┘
+```
+
+---
+
+## 4. Architecture Overview
+
+### 4.1 Key Components
+
+| Component | Location | Responsibility |
+|---|---|---|
+| **AgentGateway** | Control Plane `:9090` | gRPC server; accepts `Register` and `CommandStream` RPCs from worker daemons |
+| **AgentRegistry** | Control Plane | In-memory + PostgreSQL store; tracks agent state, heartbeats, and active command slots |
+| **AgentDispatcher** | Control Plane | Selects the best available READY agent for a request, creates a `RemoteRuntime` bound to it |
+| **RemoteRuntime** | Control Plane | Implements `runtime.Runtime`; serialises each method call into a `Command` proto, sends it via the agent's `CommandCh`, and awaits the `CommandResult` |
+| **agent daemon** | Each Worker LPAR | Persistent process; opens a `CommandStream`, executes incoming `Command` messages against the local Podman socket, returns `CommandResult` messages |
+| **agentbootstrap** | Worker LPAR (run once) | Reads `agent.conf`, calls `AgentGateway.Register` with the pre-shared token, receives and persists TLS material (future mTLS) |
+
+### 4.2 Component Interaction Diagram
+
+```mermaid
+graph TD
+    Client["Client"] -->|POST /applications| AH[ApplicationHandler]
+    AH --> AS[ApplicationService]
+    AS --> DE[DeploymentExecutor]
+    DE -->|runtime=remote| AD[AgentDispatcher]
+    AD -->|SelectAgent| REG[(AgentRegistry)]
+    AD -->|New| RR[RemoteRuntime]
+    RR -->|Command| CH[agent CommandCh]
+    CH --> GW[AgentGateway gRPC]
+    GW -->|stream.Send| DAEMON[agent daemon]
+    DAEMON -->|podman exec| POD[Podman Socket]
+    POD -->|result| DAEMON
+    DAEMON -->|stream.Send result| GW
+    GW -->|DeliverResult| RR
+    RR -->|return| DE
+```
+
+---
+
+## 5. gRPC Protocol
+
+### 5.1 Service Definition
+
+Located at [`internal/pkg/agent/proto/agent.proto`](../../ai-services/internal/pkg/agent/proto/agent.proto):
+
+```protobuf
+service AgentGateway {
+  // Called once at bootstrap time by a new worker agent.
+  rpc Register(RegisterRequest) returns (RegisterResponse);
+
+  // Long-lived bidirectional stream.
+  // Agent sends CommandResult; control plane sends Command.
+  rpc CommandStream(stream CommandResult) returns (stream Command);
+}
+```
+
+The stream direction is **agent-initiated**: the worker daemon dials out to the control plane, which is important for firewall traversal — only outbound connections from the worker are required.
+
+### 5.2 Command Types
+
+Each `Command` proto carries a `CommandType` enum that maps 1-to-1 with every method on the `runtime.Runtime` interface:
+
+| CommandType | Runtime method |
+|---|---|
+| `PULL_IMAGE` | `PullImage(image)` |
+| `LIST_IMAGES` | `ListImages()` |
+| `LIST_PODS` | `ListPods(filters)` |
+| `CREATE_POD` | `CreatePod(spec, opts)` |
+| `DELETE_POD` | `DeletePod(id, force)` |
+| `START_POD` / `STOP_POD` | `StartPod` / `StopPod` |
+| `INSPECT_POD` | `InspectPod(nameOrID)` |
+| `POD_EXISTS` | `PodExists(nameOrID)` |
+| `POD_LOGS` | `PodLogs(nameOrID)` |
+| `GET_POD_RESOURCES` | `GetPodResources(nameOrID)` |
+| `LIST_SECRETS` | `ListSecrets(filters)` |
+| `DELETE_SECRET` | `DeleteSecret(name)` |
+| `SECRET_EXISTS` | `SecretExists(nameOrID)` |
+| `DELETE_VOLUME` | `DeleteVolume(name)` |
+| `VOLUME_EXISTS` | `VolumeExists(nameOrID)` |
+| `INSPECT_CONTAINER` | `InspectContainer(nameOrID)` |
+| `CONTAINER_EXISTS` | `ContainerExists(nameOrID)` |
+| `CONTAINER_LOGS` | `ContainerLogs(nameOrID)` |
+| `LIST_ROUTES` | `ListRoutes()` |
+| `DELETE_PVCS` | `DeletePVCs(appLabel)` |
+| `GET_SYSTEM_INFO` | `GetSystemInfo()` |
+| `RUNTIME_TYPE` | `RuntimeType()` |
+
+---
+
+## 6. Bootstrap and Registration Flow
+
+This flow runs **once per Worker LPAR** before the agent daemon can receive commands.
+
+```mermaid
+sequenceDiagram
+    actor Admin
+    participant Worker as PodmanBootstrap (Worker LPAR)
+    participant Reg as agentbootstrap.Register()
+    participant GW as AgentGateway :9090
+    participant AR as AgentRegistry
+
+    Note over Admin,AR: Pre-bootstrap: admin generates token
+    Admin->>GW: ai-services catalog agent issue-token lpar-1
+    GW-->>Admin: pre_shared_token (24h, single-use)
+    Admin->>Worker: write /etc/ai-services/agent.conf
+
+    Note over Worker,AR: Bootstrap registration (once)
+    Worker->>Reg: ai-services agent start
+    Reg->>Reg: read agent.conf
+    Reg->>GW: Register{agent_id, pre_shared_token, labels}
+    GW->>GW: validate token (single-use, 24h TTL)
+    GW->>AR: Upsert agent row (status=PENDING)
+    AR-->>GW: ok
+    GW->>AR: MarkReady(agent_id)
+    GW-->>Reg: RegisterResponse{agent_id}
+    Note over Worker,AR: mTLS cert/key returned in future release
+
+    Note over Worker,GW: All subsequent communication
+    Worker->>GW: CommandStream (persistent bidirectional gRPC)
+    GW->>AR: MarkReady / UpdateHeartbeat
+```
+
+**Key points:**
+
+- The `pre_shared_token` is **single-use and 24-hour TTL**. Consumed on first `Register` call.
+- `Register` is called **once** by `agentbootstrap.Register()` in `agent start`. The daemon's reconnect loop reconnects the `CommandStream` without re-registering.
+- If the agent process is restarted, it must have a freshly issued token (or mTLS cert in future).
+
+---
+
+## 7. Deployment Execution Flow
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant AH as ApplicationHandler
+    participant AS as ApplicationService
+    participant DE as DeploymentExecutor
+    participant RR as RemoteRuntime
+    participant AD as AgentDispatcher
+    participant GW as AgentGateway
+    participant DA as Worker Agent
+    participant PM as Podman
+
+    C->>AH: POST /applications (runtime=remote, agent_selector)
+    AH->>AS: CreateApplication(req)
+    AS->>DE: ExecuteWithPlan(plan, runtimeType=remote)
+    DE->>AD: SelectAgent(labelSelector)
+    AD-->>DE: agentID="lpar-1"
+    DE->>RR: NewRemoteRuntime(agentID)
+    Note over DE,RR: PodmanDeployer unchanged — uses runtime.Runtime interface
+    DE->>RR: PullImage("registry/model:latest")
+    RR->>GW: send Command{PULL_IMAGE, payload} via CommandCh
+    GW->>DA: stream.Send(Command)
+    DA->>PM: podman pull registry/model:latest
+    PM-->>DA: success
+    DA->>GW: stream.Send(CommandResult{success})
+    GW->>RR: DeliverResult → resultCh
+    RR-->>DE: nil error
+    DE->>RR: CreatePod(podSpec, opts)
+    Note over DE,PM: same pattern for every Runtime method
+    DE-->>AS: nil
+    AS-->>AH: CreateApplicationResponse
+    AH-->>C: 202 Accepted
+```
+
+---
+
+## 8. Agent Registry State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING : Register RPC received
+
+    PENDING --> READY : token validated
+    PENDING --> REJECTED : invalid token
+
+    READY --> BUSY : all command slots filled
+    BUSY --> READY : command slot freed
+
+    READY --> DISCONNECTED : heartbeat timeout (>90s)
+    BUSY --> DISCONNECTED : heartbeat timeout (>90s)
+
+    REJECTED --> PENDING : agent reconnects (re-Register)
+    DISCONNECTED --> PENDING : agent reconnects (re-Register)
+```
+
+**Heartbeat watcher:** A background goroutine (`StartHeartbeatWatcher`) sweeps all `READY`/`BUSY` agents every 30 seconds and transitions any whose `last_heartbeat` is older than 90 seconds to `DISCONNECTED`.
+
+**Agent selection:** `SelectAgent` only returns agents in `READY` status with a non-stale heartbeat matching the requested label selector.
+
+---
+
+## 9. Database Schema
+
+A new `agents` table persists agent state across catalog restarts:
+
+```sql
+-- Migration: 20260707000001_create_agents_table.sql
+CREATE TABLE agents (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id        TEXT        NOT NULL UNIQUE,
+    labels          JSONB       NOT NULL DEFAULT '{}',
+    capabilities    JSONB       NOT NULL DEFAULT '{}',
+    status          TEXT        NOT NULL DEFAULT 'pending',
+                    -- pending | ready | busy | draining | disconnected | rejected
+    last_heartbeat  TIMESTAMPTZ,
+    registered_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_agents_status ON agents (status);
+```
+
+The in-memory registry is the **source of truth** for live routing decisions. The database provides durability for `ai-services catalog agent list` after a catalog restart.
+
+---
+
+## 10. New CLI Commands
+
+### 10.1 Control Plane Commands
+
+```
+# Deploy the catalog with AgentGateway enabled on port 9090
+ai-services catalog configure --runtime podman --agentgateway-port 9090
+
+# Issue a bootstrap token for a new Worker LPAR (fills agent_id + pre_shared_token)
+ai-services catalog agent issue-token lpar-1
+
+# List all registered agents and their status
+ai-services catalog agent list
+
+# Show a specific agent's live status
+ai-services catalog agent list   # (includes all agents)
+
+# Remove an agent from the registry
+ai-services catalog agent delete lpar-1
+
+# Start the API server with AgentGateway
+ai-services catalog apiserver --agentgateway-port 9090
+```
+
+**`issue-token` output** (paste directly into Worker LPAR):
+
+```
+# Copy the block below to /etc/ai-services/agent.conf on the Worker LPAR.
+# Token expires in 24 h and is single-use.
+# Then run:  ai-services agent start
+#
+# ---- BEGIN agent.conf ----
+control_plane_url: <control-plane-host>:<agentgateway-port>
+agent_id: "lpar-1"
+pre_shared_token: "d3f1a2b4-..."
+labels: {}
+capabilities: {}
+# ---- END agent.conf ----
+```
+
+### 10.2 Worker Agent Commands
+
+```
+# Register with the control plane and start the daemon (blocking)
+ai-services agent start
+
+# Show local conf + live connectivity status from control plane
+ai-services agent status
+```
+
+**`agent status` output**:
+
+```
+Local Configuration
+-------------------
+Agent ID:       lpar-1
+Control Plane:  control-plane:9090
+Config file:    /etc/ai-services/agent.conf
+Token set:      true
+
+Live Status (from Control Plane)
+--------------------------------
+Status:         ready
+Active slots:   0
+Last heartbeat: 2026-07-14T10:23:01Z
+Checked at:     2026-07-14T10:23:05Z
+```
+
+---
+
+## 11. Configuration Files
+
+### `/etc/ai-services/agent.conf` (Worker LPAR)
+
+```yaml
+control_plane_url: "control-plane.example.com:9090"   # gRPC AgentGateway address
+agent_id: "lpar-1"                                     # unique identifier for this worker
+pre_shared_token: "d3f1a2b4-..."                       # single-use bootstrap token
+labels:
+  zone: "gpu"
+  model: "granite"
+capabilities: {}
+```
+
+The `pre_shared_token` field is only used on the first `agent start`. After registration it is no longer checked by the control plane. In a future mTLS release the agent will use its signed certificate for all subsequent connections.
+
+---
+
+## 12. Code Structure
+
+All new code is additive. No existing packages were deleted or renamed.
+
+```
+ai-services/
+├── internal/pkg/agent/                         NEW PACKAGE
+│   ├── proto/
+│   │   ├── agent.proto                         gRPC service + message definitions
+│   │   ├── agent.pb.go                         generated
+│   │   └── agent_grpc.pb.go                    generated
+│   ├── registry/
+│   │   └── registry.go                         AgentRegistry + TokenStore
+│   ├── gateway/
+│   │   └── gateway.go                          AgentGateway gRPC server
+│   ├── dispatcher/
+│   │   └── dispatcher.go                       AgentDispatcher (SelectAgent)
+│   ├── agentbootstrap/
+│   │   └── agentbootstrap.go                   worker-side Register + conf loader
+│   └── daemon/
+│       └── daemon.go                           worker daemon (CommandStream loop)
+│
+├── internal/pkg/runtime/
+│   ├── runtime.go                              MODIFIED: RuntimeTypeRemote added to switch
+│   ├── types/types.go                          MODIFIED: RuntimeTypeRemote constant
+│   └── remote/
+│       └── remote.go                           NEW: RemoteRuntime implementing runtime.Runtime
+│
+├── internal/pkg/catalog/
+│   ├── apiserver/
+│   │   ├── apiserver.go                        MODIFIED: wires Gateway + HeartbeatWatcher
+│   │   ├── router.go                           MODIFIED: /agents routes
+│   │   ├── handlers/
+│   │   │   └── agent_handler.go                NEW: IssueToken, ListAgents, GetAgent, DeleteAgent
+│   │   └── services/deployment/
+│   │       └── executor.go                     MODIFIED: executeRemoteDeployment case
+│   ├── cli/configure/podman/
+│   │   └── reset_agentgateway_port.go          NEW: hot-swap gateway port without full reinstall
+│   ├── client/
+│   │   └── client.go                           MODIFIED: IssueAgentToken, ListAgents, DeleteAgent, GetAgent
+│   ├── db/migrations/assets/
+│   │   └── 20260707000001_create_agents_table.sql  NEW
+│   └── utils/common.go                         MODIFIED: AgentGatewayPort in PodmanConfigureOptions
+│
+├── assets/catalog/podman/
+│   ├── values.yaml                             MODIFIED: backend.agentGatewayPort
+│   └── templates/catalog.yaml.tmpl            MODIFIED: hostPort for AgentGateway container
+│
+└── cmd/ai-services/cmd/
+    ├── root.go                                 MODIFIED: registers `agent` subcommand
+    ├── catalog/
+    │   ├── configure.go                        MODIFIED: --agentgateway-port flag
+    │   ├── apiserver.go                        MODIFIED: --agentgateway-port flag
+    │   └── agent/
+    │       ├── agent.go                        NEW: `catalog agent` subcommand group
+    │       ├── issue_token.go                  NEW: issue-token
+    │       ├── list.go                         NEW: list
+    │       └── delete.go                       NEW: delete
+    └── agent/
+        ├── agent.go                            NEW: `agent` subcommand group
+        ├── start.go                            NEW: agent start
+        └── status.go                           NEW: agent status
+```
+
+---
+
+## 13. Before vs After Comparison
+
+### Deployment path
+
+| Aspect | Before | After |
+|---|---|---|
+| Podman target | Same LPAR as catalog | Any registered Worker LPAR |
+| Runtime selection | `--runtime podman` only | `--runtime podman` (local) or `--runtime remote` (agent) |
+| `runtime.Runtime` interface | Unchanged | Unchanged |
+| Deployer code | Unchanged | Unchanged |
+| Agent selection | N/A | Label selector on request; round-robin READY agents |
+
+### Operational
+
+| Aspect | Before | After |
+|---|---|---|
+| Worker visibility | N/A | `ai-services catalog agent list` |
+| Worker health | N/A | Heartbeat every 30 s; auto-DISCONNECTED after 90 s |
+| Worker registration | N/A | `ai-services agent start` (token-based) |
+| Worker removal | N/A | `ai-services catalog agent delete <id>` |
+
+### Protocol
+
+```
+Before:
+  Catalog API ──► Podman socket (Unix socket, same host)
+
+After (remote path):
+  Catalog API ──► AgentGateway :9090 (gRPC, TCP) ──► agent daemon ──► Podman socket
+                                 bidirectional stream
+```
+
+---
+
+## 14. Security Design
+
+| Concern | Current implementation | Planned (future) |
+|---|---|---|
+| Bootstrap token | Single-use UUID, 24h TTL, in-memory store | Persist to DB for restart safety |
+| Transport | Plaintext gRPC (`insecure.NewCredentials()`) | mTLS — CA on control plane signs agent cert during `RegisterResponse` |
+| Command authorisation | Agent trusts any command arriving on the stream | Agent verifies peer cert CN matches control-plane hostname |
+| Secret payloads | Podman secrets passed inside gRPC payload | Encrypted in transit once mTLS is enabled |
+| Token rotation | Re-run `agent start` with a new token | Admin revokes cert; agent re-registers |
+
+The mTLS stubs are already present in the proto (`tls_cert_pem`, `tls_key_pem` fields in `RegisterResponse`) and in `agentbootstrap.writeTLSMaterial()`. The gateway currently returns empty strings for those fields.
+
+---
+
+## 15. Future Work
+
+| Item | Notes |
+|---|---|
+| **mTLS** | Control-plane CA signs a per-agent cert during `Register`; agent uses it for all subsequent `CommandStream` connections |
+| **Token DB persistence** | In-memory `TokenStore` is lost on catalog restart; persist issued tokens to PostgreSQL |
+| **Agent drain** | Admin-triggered graceful drain: accept no new commands, wait for in-flight to complete, then `DISCONNECTED` |
+| **Weighted selection** | Prefer agents with fewer active slots or specific capability labels |
+| **OpenShift remote** | Route + passthrough TLS instead of `hostPort` for OCP deployments |
+| **Metrics** | Prometheus counters for commands dispatched, errors, latency per agent |

--- a/docs/proposals/catalog/remote-worker-agent-proposal.md
+++ b/docs/proposals/catalog/remote-worker-agent-proposal.md
@@ -52,7 +52,7 @@ This means that to deploy AI workloads on a second or third LPAR, an operator mu
 - Allow AI application pods to be deployed on remote Worker LPARs from a single control plane.
 - Route external HTTPS traffic to deployed services via a per-worker Caddy proxy.
 - Allow the control plane to perform health checks and internal HTTP calls against remote pod endpoints over the gRPC stream, with no new exposed port.
-- Minimal operational overhead: a single daemon binary, one `join` workflow per Worker.
+- Minimal operational overhead: a single daemon binary, one `join` command per Worker — no separate bootstrap or configure step.
 - All communication over a single outbound TCP connection from Worker → control plane (firewall-friendly).
 
 ### 2.4 Non-Goals
@@ -239,8 +239,8 @@ The `CommandType` enum would cover all 29 operations needed to proxy the full `r
 # Start the WorkerGateway on the control plane (default port is 9090)
 ai-services catalog configure --runtime podman [--workergateway-port 9090]
 
-# Issue a single-use bootstrap token (24-hour expiry)
-ai-services catalog worker issue-token
+# Pre-register the worker by name and obtain a single-use bootstrap token
+ai-services catalog worker register <worker-name>
 # Output: <uuid-token>
 ```
 
@@ -249,19 +249,17 @@ Tokens would be stored in-memory in a `TokenStore`. Each token would be single-u
 ### 6.2 Worker setup
 
 ```bash
-# Step 1 — bootstrap the Worker LPAR (installs Podman, SELinux policies, etc.)
-ai-services bootstrap configure --runtime podman
-
-# Step 2 — join the worker to the control plane (installs Caddy, registers and starts the daemon)
-ai-services worker join \
-    --server lpar-0.example.com:9090 \
-    --name lpar-1 \
+# Single command — registers and starts the daemon (deploys Caddy if not already running)
+ai-services worker join <catalog-host>:9090 \
     --token <uuid-token> \
     --runtime podman \
     [--https-port 443] \
+    [--basedir /var/lib/ai-services]
     [--domain-name example.com] \
     [--ssl-cert /path/cert.pem --ssl-key /path/key.pem]
 ```
+
+There is no separate `bootstrap configure` or `worker configure` step. The `join` command handles everything in one shot: it deploys the Caddy proxy (if not already running), registers with the catalog gRPC gateway using the bootstrap token, and holds the connection open indefinitely.
 
 ### 6.3 Registration sequence
 
@@ -299,6 +297,7 @@ Each Worker LPAR would run its own Caddy instance for externally-visible HTTPS r
 ### 7.1 Design principles
 
 - **Same pattern as catalog Caddy.** The catalog configure command deploys a Caddy pod; the proposed `worker join` command would do the same for the worker.
+- **Deploy-once semantics.** The Caddy pod is deployed only if it is not already running. Once up, its configuration is considered immutable — re-running `worker join` will not redeploy or restart the pod.
 - **Admin port always random.** Setting `adminPort: "0"` in `values.yaml` would cause the OS to assign a random loopback port, resolved at runtime by inspecting the running pod.
 - **No `--resume`.** Worker Caddy would not use `caddy run --resume` to avoid stale autosave state from a previous server name.
 - **Server name `ai_services_worker`.** The Caddyfile global block would name the `:443` server `ai_services_worker`, so routes would be POSTed to `.../servers/ai_services_worker/routes`.
@@ -347,18 +346,18 @@ The proposed Caddyfile:
 
 ### 7.3 `DeployWorkerCaddy` execution
 
-**Proposed steps for `DeployWorkerCaddy()` (triggered inside `worker join`):**
+**Proposed steps for `Setup()` (triggered inside `worker join`):**
 
 1. Read `values.yaml` (image, adminPort, httpsPort). Apply `--https-port` CLI override if provided.
 2. Render the Caddyfile template and write to `<baseDir>/worker/caddy/Caddyfile`.
-3. Force-remove any existing `ai-services--worker-caddy` pod (to handle stale or failed pods).
-4. Render the pod template and deploy via readiness-checked pod deployment.
-5. Resolve the admin URL: inspect the running pod → find the `2019/tcp` host port → `http://localhost:<port>`.
-6. Health-check the Caddy admin API.
-7. Compute the domain suffix (cert CN > `--domain-name` > `workerIP.nip.io`).
-8. Keep `DomainSuffix` in-memory and pass it directly to the registration payload.
+3. Check whether `ai-services--worker-caddy` pod already exists.
+   - If **not running**: render the pod template and deploy via readiness-checked pod deployment.
+   - If **already running**: skip deployment — the existing pod and its port bindings are reused.
+4. Resolve the admin URL: inspect the running pod → find the `2019/tcp` host port → `http://localhost:<port>`.
+5. Health-check the Caddy admin API.
+6. Compute the domain suffix (`workerIP.nip.io`) and pass it directly to the registration payload.
 
-**This process would be idempotent.** Re-joining would always remove and redeploy the Caddy pod to ensure correct port bindings.
+**Idempotency.** Re-running `worker join` writes a fresh Caddyfile but leaves a running Caddy pod untouched. To force a re-deploy (e.g. after a port change), the operator must manually remove the pod first.
 
 ### 7.4 Admin URL resolution
 
@@ -631,11 +630,11 @@ The in-memory `Registry` would be the primary source of truth for live routing d
 
 ### 12.1 Control-plane commands
 
-**Issue a bootstrap token:**
+**Pre-register a worker and obtain a bootstrap token:**
 ```
-ai-services catalog worker issue-token
+ai-services catalog worker register <worker-name>
 ```
-Would output a single-use UUID token valid for 24 hours.
+Pre-registers the worker by name in the catalog and outputs a single-use UUID token valid for 24 hours.
 
 **List all registered workers:**
 ```
@@ -656,22 +655,21 @@ ai-services catalog configure --runtime podman --workergateway-port 9090
 
 ### 12.2 Worker commands
 
-**`worker join`** — Deploy the worker Caddy proxy, register, and start the daemon:
+**`worker join`** — Single command to deploy the worker Caddy proxy (if not already running), register with the catalog, and start the daemon:
 
 ```bash
-ai-services worker join \
-    --server lpar-0.example.com:9090   # required
-    --name   lpar-1                     # required
-    --token  <uuid>                     # required
-    --runtime podman                    # required; no default
-    [--https-port 443]                  # default from values.yaml; can be overridden
-    [--base-dir /var/lib/ai-services]
+ai-services worker join <gateway>        # required positional: host:port of catalog gRPC gateway
+    --token  <uuid>                      # required; single-use token from 'catalog worker register'
+    --runtime podman                     # required; no default
+    [--https-port 443]                   # default 443; overrides values.yaml httpsPort
+    [--basedir /var/lib/ai-services]
     [--domain-name example.com]
     [--ssl-cert /path/cert.pem --ssl-key /path/key.pem]
     [--tls-dir /var/lib/ai-services/worker/tls]
 ```
 
-- Would be idempotent: always removes and redeploys the Caddy pod.
+- **Single command, no pre-steps.** There is no `bootstrap configure` or `worker configure` to run first.
+- **Caddy is deployed only if not already running.** Re-joining leaves a live Caddy pod untouched.
 - `adminPort` would not be configurable via CLI — always from `values.yaml` (`"0"` = OS-assigned random port).
 - Would compute the domain suffix and keep it in-memory to send it directly as `labels["domain_suffix"]` in `RegisterRequest`.
 - Would inject a `LocalCaddyManager` into the Podman runtime by inspecting the running Caddy pod.

--- a/docs/proposals/catalog/remote-worker-agent-proposal.md
+++ b/docs/proposals/catalog/remote-worker-agent-proposal.md
@@ -1,4 +1,4 @@
-# Remote Worker Agent Proposal
+# Remote Worker Proposal
 
 ## Table of Contents
 
@@ -9,9 +9,9 @@
 5. [gRPC Protocol](#5-grpc-protocol)
 6. [Bootstrap and Registration Flow](#6-bootstrap-and-registration-flow)
 7. [Worker Caddy Proxy](#7-worker-caddy-proxy)
-8. [Agent HTTP Proxy](#8-agent-http-proxy)
+8. [Worker HTTP Proxy](#8-worker-http-proxy)
 9. [Deployment Execution Flow](#9-deployment-execution-flow)
-10. [Agent Registry and State Machine](#10-agent-registry-and-state-machine)
+10. [Worker Registry and State Machine](#10-worker-registry-and-state-machine)
 11. [Database Schema](#11-database-schema)
 12. [CLI Commands](#12-cli-commands)
 13. [Configuration Files and Assets](#13-configuration-files-and-assets)
@@ -24,14 +24,14 @@
 
 ## 1. Executive Summary
 
-This proposal describes the design of a **Remote Worker Agent** system for the AI Services platform. It would enable the Catalog API Server (running on a control-plane LPAR) to dispatch Podman runtime commands over a persistent bidirectional gRPC stream to one or more **Worker Agent daemons** running on separate IBM Power LPARs.
+This proposal describes the design of a **Remote Worker** system for the AI Services platform. It would enable the Catalog API Server (running on a control-plane LPAR) to dispatch Podman runtime commands over a persistent bidirectional gRPC stream to one or more **Worker daemons** running on separate IBM Power LPARs.
 
-Two additional networking features are proposed alongside the core agent:
+Two additional networking features are proposed alongside the core worker:
 
 | Feature | What it would do |
 |---|---|
 | **Worker Caddy Proxy** | Each Worker LPAR would run its own Caddy instance. Routes would be registered dynamically after each pod deployment so external HTTPS traffic reaches deployed service endpoints directly on that worker. |
-| **Agent HTTP Proxy** | The control plane would be able to tunnel HTTP requests to worker pod endpoints through the existing gRPC stream, with no new port required. |
+| **Worker HTTP Proxy** | The control plane would be able to tunnel HTTP requests to worker pod endpoints through the existing gRPC stream, with no new port required. |
 
 ---
 
@@ -52,14 +52,14 @@ This means that to deploy AI workloads on a second or third LPAR, an operator mu
 - Allow AI application pods to be deployed on remote Worker LPARs from a single control plane.
 - Route external HTTPS traffic to deployed services via a per-worker Caddy proxy.
 - Allow the control plane to perform health checks and internal HTTP calls against remote pod endpoints over the gRPC stream, with no new exposed port.
-- Minimal operational overhead: a single daemon binary, one `configure` + `start` workflow per Worker.
+- Minimal operational overhead: a single daemon binary, one `join` workflow per Worker.
 - All communication over a single outbound TCP connection from Worker → control plane (firewall-friendly).
 
 ### 2.4 Non-Goals
 
 - OpenShift runtime support for worker Caddy (Podman only in this proposal).
 - Streaming/chunked HTTP proxy responses (single request/response only).
-- mTLS between agent and gateway (reserved fields would be present; treated as future work).
+- mTLS between worker and gateway (reserved fields would be present; treated as future work).
 
 ---
 
@@ -69,14 +69,14 @@ This means that to deploy AI workloads on a second or third LPAR, an operator mu
 graph TB
     subgraph CP["Control-plane LPAR"]
         API["Catalog API\n(REST / gRPC)"]
-        GW["AgentGateway\n:9090 (gRPC)"]
+        GW["WorkerGateway\n:9090 (gRPC)"]
         API --> GW
     end
 
     subgraph WK["Worker LPAR"]
-        DAEMON["agent daemon\n(runtime.Runtime proxy)"]
+        DAEMON["worker daemon\n(runtime.Runtime proxy)"]
         subgraph PODS["Podman pods"]
-            CADDY["ai-services--agent-caddy\n:443 HTTPS"]
+            CADDY["ai-services--worker-caddy\n:443 HTTPS"]
             APP["my-app--chat-bot\n:8080"]
         end
         DAEMON --> PODS
@@ -94,13 +94,13 @@ graph TB
 
 | Component | Location | Role |
 |---|---|---|
-| **AgentGateway** | Control plane | gRPC server that would accept agent connections on `:9090` |
-| **Registry** | Control plane | In-memory + PostgreSQL state store for all registered agents |
+| **WorkerGateway** | Control plane | gRPC server that would accept worker connections on `:9090` |
+| **Registry** | Control plane | In-memory + PostgreSQL state store for all registered workers |
 | **RemoteRuntime** | Control plane | A `runtime.Runtime` implementation that would send commands over gRPC |
 | **DeploymentExecutor** | Control plane | Would select a `RemoteRuntime` when deploying to a Worker |
-| **AgentHTTPClient** | Control plane | Would tunnel HTTP requests through `RemoteRuntime.HTTPProxy` |
-| **Agent Daemon** | Worker LPAR | Would receive gRPC commands, execute them on local Podman, and return results |
-| **Worker Caddy** | Worker LPAR | Pod `ai-services--agent-caddy` — reverse proxy for deployed services |
+| **WorkerHTTPClient** | Control plane | Would tunnel HTTP requests through `RemoteRuntime.HTTPProxy` |
+| **Worker Daemon** | Worker LPAR | Would receive gRPC commands, execute them on local Podman, and return results |
+| **Worker Caddy** | Worker LPAR | Pod `ai-services--worker-caddy` — reverse proxy for deployed services |
 | **LocalCaddyManager** | Worker LPAR | Interface to be injected into `PodmanClient` for route management |
 
 ### 4.2 Component Interaction (deployment)
@@ -109,8 +109,8 @@ graph TB
 sequenceDiagram
     participant CP as Control Plane<br/>(DeploymentExecutor)
     participant RR as RemoteRuntime
-    participant GW as AgentGateway
-    participant DA as agent daemon
+    participant GW as WorkerGateway
+    participant DA as worker daemon
     participant PM as Podman
     participant CM as LocalCaddyManager
 
@@ -141,20 +141,20 @@ sequenceDiagram
 
 ### 5.1 Service Definition
 
-The proposed `AgentGateway` gRPC service would be defined as follows:
+The proposed `WorkerGateway` gRPC service would be defined as follows:
 
 ```protobuf
-service AgentGateway {
+service WorkerGateway {
   // One-time call at bootstrap time.
   rpc Register(RegisterRequest) returns (RegisterResponse);
 
   // Long-lived bidirectional stream.
-  // Agent initiates; sends CommandResult, receives Command.
+  // Worker initiates; sends CommandResult, receives Command.
   rpc CommandStream(stream CommandResult) returns (stream Command);
 }
 
 message RegisterRequest {
-  string agent_name       = 1;
+  string worker_name       = 1;
   string pre_shared_token = 2;
   map<string, string> labels       = 3;  // would include "domain_suffix"
   map<string, string> capabilities = 4;
@@ -172,7 +172,7 @@ message CommandResult {
   bytes  data         = 3; // JSON-encoded response
   string error        = 4;
   bool   is_heartbeat = 5;
-  string agent_name   = 6;
+  string worker_name   = 6;
 }
 ```
 
@@ -216,15 +216,15 @@ The `CommandType` enum would cover all 29 operations needed to proxy the full `r
 ### 5.3 Protocol Flow
 
 **Heartbeat mechanism:**
-- The agent would send a heartbeat `CommandResult{is_heartbeat: true}` immediately on stream open as the first message (used by the gateway to identify the agent).
-- A background goroutine on the agent would send heartbeats every **30 seconds**.
-- The gateway would mark an agent `DISCONNECTED` if no heartbeat is received for **90 seconds** (checked every 30 seconds).
+- The worker would send a heartbeat `CommandResult{is_heartbeat: true}` immediately on stream open as the first message (used by the gateway to identify the worker).
+- A background goroutine on the worker would send heartbeats every **30 seconds**.
+- The gateway would mark an worker `DISCONNECTED` if no heartbeat is received for **90 seconds** (checked every 30 seconds).
 
 **Command flow:**
 1. Control plane calls `RemoteRuntime.SomeMethod()`.
-2. `dispatch()` would generate a UUID command ID, marshal the payload to JSON, register a result channel, and push a `Command` to the agent's `CommandCh`.
+2. `dispatch()` would generate a UUID command ID, marshal the payload to JSON, register a result channel, and push a `Command` to the worker's `CommandCh`.
 3. The gateway goroutine would read from `CommandCh` and write to the gRPC stream.
-4. The agent daemon would call `executeCommand()` → `dispatchToRuntime()`, execute locally, and send back a `CommandResult`.
+4. The worker daemon would call `executeCommand()` → `dispatchToRuntime()`, execute locally, and send back a `CommandResult`.
 5. The gateway's receive goroutine would read the result and call `registry.DeliverResult()`.
 6. `dispatch()` would receive on the result channel and return.
 7. The default command timeout would be **5 minutes**, respecting `ctx.Deadline()` if shorter.
@@ -236,11 +236,11 @@ The `CommandType` enum would cover all 29 operations needed to proxy the full `r
 ### 6.1 Control-plane setup
 
 ```bash
-# Start the AgentGateway on the control plane
-ai-services catalog configure --runtime podman --agentgateway-port 9090
+# Start the WorkerGateway on the control plane (default port is 9090)
+ai-services catalog configure --runtime podman [--workergateway-port 9090]
 
 # Issue a single-use bootstrap token (24-hour expiry)
-ai-services catalog agent issue-token
+ai-services catalog worker issue-token
 # Output: <uuid-token>
 ```
 
@@ -252,16 +252,15 @@ Tokens would be stored in-memory in a `TokenStore`. Each token would be single-u
 # Step 1 — bootstrap the Worker LPAR (installs Podman, SELinux policies, etc.)
 ai-services bootstrap configure --runtime podman
 
-# Step 2 — deploy the worker Caddy proxy pod (run once)
-ai-services agent configure --runtime podman [--https-port 443] [--domain-name example.com] \
-    [--ssl-cert /path/cert.pem --ssl-key /path/key.pem]
-
-# Step 3 — register with the control plane and start the daemon
-ai-services agent start \
+# Step 2 — join the worker to the control plane (installs Caddy, registers and starts the daemon)
+ai-services worker join \
     --server lpar-0.example.com:9090 \
     --name lpar-1 \
     --token <uuid-token> \
-    --runtime podman
+    --runtime podman \
+    [--https-port 443] \
+    [--domain-name example.com] \
+    [--ssl-cert /path/cert.pem --ssl-key /path/key.pem]
 ```
 
 ### 6.3 Registration sequence
@@ -269,18 +268,18 @@ ai-services agent start \
 ```mermaid
 sequenceDiagram
     participant W as Worker LPAR
-    participant GW as AgentGateway
+    participant GW as WorkerGateway
     participant TS as TokenStore
     participant REG as Registry
 
-    W->>GW: Register(agent_name="lpar-1", token, labels={domain_suffix})
+    W->>GW: Register(worker_name="lpar-1", token, labels={domain_suffix})
     GW->>TS: Validate(token)
     TS-->>GW: OK (token marked used)
     GW->>REG: Upsert(req)
     GW->>REG: MarkReady("lpar-1")
-    GW-->>W: RegisterResponse{agent_name: "lpar-1"}
+    GW-->>W: RegisterResponse{worker_name: "lpar-1"}
 
-    W->>GW: CommandStream — Send(CommandResult{is_heartbeat:true, agent_name:"lpar-1"})
+    W->>GW: CommandStream — Send(CommandResult{is_heartbeat:true, worker_name:"lpar-1"})
     GW->>REG: SetWorkerIP("lpar-1", "192.168.1.5")
     GW->>REG: SetDomainSuffix("lpar-1", "192.168.1.5.nip.io")
     GW->>REG: MarkReady("lpar-1")
@@ -289,25 +288,25 @@ sequenceDiagram
 
 **Worker IP capture:** The gateway would read the TCP source IP from the gRPC peer info on the stream context. This would be the address of the Worker LPAR as seen from the control plane.
 
-**Domain suffix propagation:** `agent configure` would compute the domain suffix (cert CN > `--domain-name` > `workerIP.nip.io`) and persist it to `~/.config/ai-services/agent.json`. `agent start` would load this and send it as `labels["domain_suffix"]` in `RegisterRequest`. The gateway would extract it and store it in `AgentEntry.DomainSuffix`.
+**Domain suffix propagation:** `worker join` would compute the domain suffix (cert CN > `--domain-name` > `workerIP.nip.io`) and send it as `labels["domain_suffix"]` in `RegisterRequest` directly at startup. The gateway would extract it and store it in `WorkerEntry.DomainSuffix`. No configuration file is used to store this information on disk.
 
 ---
 
 ## 7. Worker Caddy Proxy
 
-Each Worker LPAR would run its own Caddy instance for externally-visible HTTPS routing to deployed service pods. Routes would be registered dynamically by the agent daemon after each successful pod deployment.
+Each Worker LPAR would run its own Caddy instance for externally-visible HTTPS routing to deployed service pods. Routes would be registered dynamically by the worker daemon after each successful pod deployment.
 
 ### 7.1 Design principles
 
-- **Same pattern as catalog Caddy.** The catalog configure command deploys a Caddy pod; the proposed `agent configure` command would do the same for the worker.
+- **Same pattern as catalog Caddy.** The catalog configure command deploys a Caddy pod; the proposed `worker join` command would do the same for the worker.
 - **Admin port always random.** Setting `adminPort: "0"` in `values.yaml` would cause the OS to assign a random loopback port, resolved at runtime by inspecting the running pod.
 - **No `--resume`.** Worker Caddy would not use `caddy run --resume` to avoid stale autosave state from a previous server name.
-- **Server name `ai_services_agent`.** The Caddyfile global block would name the `:443` server `ai_services_agent`, so routes would be POSTed to `.../servers/ai_services_agent/routes`.
+- **Server name `ai_services_worker`.** The Caddyfile global block would name the `:443` server `ai_services_worker`, so routes would be POSTed to `.../servers/ai_services_worker/routes`.
 - **Admin port only on loopback.** The pod port binding would be `127.0.0.1:<random>:2019` — unreachable from outside the LPAR.
 
 ### 7.2 Worker Caddy pod
 
-The proposed pod name would be `ai-services--agent-caddy`.
+The proposed pod name would be `ai-services--worker-caddy`.
 
 The pod template would render a port binding annotation such as:
 
@@ -330,7 +329,7 @@ The proposed Caddyfile:
 {
     admin 0.0.0.0:2019
     servers :443 {
-        name ai_services_agent
+        name ai_services_worker
     }
 }
 
@@ -346,35 +345,26 @@ The proposed Caddyfile:
 }
 ```
 
-### 7.3 `agent configure` command
+### 7.3 `DeployWorkerCaddy` execution
 
-```
-ai-services agent configure \
-    --runtime podman          # required; only podman supported
-    [--https-port 443]        # override caddy.httpsPort from values.yaml
-    [--domain-name example.com]
-    [--ssl-cert /path/cert.pem --ssl-key /path/key.pem]
-    [--base-dir /var/lib/ai-services]
-```
-
-**Proposed steps for `DeployAgentCaddy()`:**
+**Proposed steps for `DeployWorkerCaddy()` (triggered inside `worker join`):**
 
 1. Read `values.yaml` (image, adminPort, httpsPort). Apply `--https-port` CLI override if provided.
-2. Render the Caddyfile template and write to `<baseDir>/agent/caddy/Caddyfile`.
-3. Force-remove any existing `ai-services--agent-caddy` pod (to handle stale or failed pods).
+2. Render the Caddyfile template and write to `<baseDir>/worker/caddy/Caddyfile`.
+3. Force-remove any existing `ai-services--worker-caddy` pod (to handle stale or failed pods).
 4. Render the pod template and deploy via readiness-checked pod deployment.
 5. Resolve the admin URL: inspect the running pod → find the `2019/tcp` host port → `http://localhost:<port>`.
 6. Health-check the Caddy admin API.
 7. Compute the domain suffix (cert CN > `--domain-name` > `workerIP.nip.io`).
-8. Persist `DomainSuffix` to `~/.config/ai-services/agent.json`.
+8. Keep `DomainSuffix` in-memory and pass it directly to the registration payload.
 
-**This command would be idempotent.** Re-running would always remove and redeploy the Caddy pod to ensure correct port bindings.
+**This process would be idempotent.** Re-joining would always remove and redeploy the Caddy pod to ensure correct port bindings.
 
 ### 7.4 Admin URL resolution
 
 ```
-GetCaddyAdminPort(rt, "ai-services--agent-caddy")
-  └─ rt.InspectPod("ai-services--agent-caddy")
+GetCaddyAdminPort(rt, "ai-services--worker-caddy")
+  └─ rt.InspectPod("ai-services--worker-caddy")
        └─ pod.Ports["2019/tcp"][0]  →  e.g. "37249"
   └─ returns "37249"
 
@@ -386,16 +376,16 @@ A single shared `GetCaddyAdminPort` utility would be used by both the catalog Ca
 
 ### 7.5 Caddy manager injection at daemon start
 
-When `agent start` runs, it would call an `injectCaddyManager` function:
+When `worker join` runs, it would call an `injectCaddyManager` function:
 
 ```go
 adminURL, err := BuildAdminURL(pc)  // pod inspect → random port
-pm := NewCaddyManager(adminURL, AgentCaddyServerName)
+pm := NewCaddyManager(adminURL, WorkerCaddyServerName)
 caddyMgr := NewLocalCaddyManagerAdapter(pm)
 pc.SetCaddyManager(caddyMgr)
 ```
 
-If the Caddy pod is not running, a warning would be logged and the daemon would start normally — all other runtime operations would continue; only route registration would be unavailable until `agent configure` is run.
+If the Caddy pod is not running, the initialization must fail — we cannot warn and continue, as Caddy routing is a critical requirement for worker participation.
 
 ### 7.6 Route registration via gRPC
 
@@ -414,10 +404,10 @@ rt.RegisterProxyRoute(ctx, types.ProxyRoute{
 This would dispatch `COMMAND_TYPE_REGISTER_PROXY_ROUTE` over gRPC. The daemon would call `RegisterProxyRoute()` on the local `PodmanClient`, which would call `caddyMgr.RegisterRoute()`, hitting the Caddy Admin API:
 
 ```
-POST http://localhost:<port>/config/apps/http/servers/ai_services_agent/routes
+POST http://localhost:<port>/config/apps/http/servers/ai_services_worker/routes
 ```
 
-**Domain suffix for worker routes** would come from `RemoteRuntime.DomainSuffix()` — read from the agent's registry entry, populated from `labels["domain_suffix"]` at stream open. The worker's domain suffix would be independent of the control-plane's `DOMAIN_SUFFIX` env var.
+**Domain suffix for worker routes** would come from `RemoteRuntime.DomainSuffix()` — read from the worker's registry entry, populated from `labels["domain_suffix"]` at stream open. The worker's domain suffix would be independent of the control-plane's `DOMAIN_SUFFIX` env var.
 
 ### 7.7 Upstream uses pod IP, not pod name
 
@@ -430,19 +420,19 @@ Caddy would run as a Podman pod. Pod name DNS (Podman's internal resolver) is on
 
 | Constant | Proposed value | Package |
 |---|---|---|
-| `AgentCaddyServerName` | `"ai_services_agent"` | `constants` |
+| `WorkerCaddyServerName` | `"ai_services_worker"` | `constants` |
 | `CaddyServerName` (existing) | `"ai_services"` | `constants` |
-| `AgentCaddyPodName` | `"ai-services--agent-caddy"` | `agent/configure` |
+| `WorkerCaddyPodName` | `"ai-services--worker-caddy"` | `worker/configure` |
 
 ---
 
-## 8. Agent HTTP Proxy
+## 8. Worker HTTP Proxy
 
 The control plane cannot directly reach pod endpoints on the Worker LPAR (no direct network route; no extra port). The proposed `COMMAND_TYPE_HTTP_PROXY` (value 29) would tunnel a complete HTTP request/response through the existing gRPC stream.
 
 ### 8.1 Control-plane side
 
-An `AgentHTTPClient` helper would provide a clean API for callers:
+An `WorkerHTTPClient` helper would provide a clean API for callers:
 
 ```go
 client := httpclient.New(remoteRuntime)
@@ -507,7 +497,7 @@ If the hostname is already an IP address or `localhost`, it would be passed thro
 
 ### 8.4 Last-hop security note
 
-The HTTP proxy last hop (agent daemon → pod) would be plain HTTP on the host's Podman network. This would never leave the Worker LPAR. All traffic between control plane and agent — including HTTP proxy payloads — would be encrypted by the gRPC transport layer (or mTLS when enabled).
+The HTTP proxy last hop (worker daemon → pod) would be plain HTTP on the host's Podman network. This would never leave the Worker LPAR. All traffic between control plane and worker — including HTTP proxy payloads — would be encrypted by the gRPC transport layer (or mTLS when enabled).
 
 ---
 
@@ -520,15 +510,15 @@ sequenceDiagram
     participant DE as DeploymentExecutor
     participant REG as Registry
     participant RR as RemoteRuntime
-    participant GW as AgentGateway
-    participant DA as agent daemon
+    participant GW as WorkerGateway
+    participant DA as worker daemon
     participant PM as Podman
     participant CM as LocalCaddyManager
 
-    U->>AS: POST /api/applications {agent_selector}
-    AS->>AS: validateAgentSelector() + BuildDeploymentPlan()
+    U->>AS: POST /api/applications {worker_selector}
+    AS->>AS: validateWorkerSelector() + BuildDeploymentPlan()
     AS->>DE: ExecuteWithPlan(plan)
-    DE->>REG: SelectAgent(selector) → lpar-1
+    DE->>REG: SelectWorker(selector) → lpar-1
     DE->>RR: remote.New("lpar-1", registry)
 
     DE->>RR: PodExists(podName)
@@ -552,7 +542,7 @@ sequenceDiagram
     RR->>GW: COMMAND_TYPE_REGISTER_PROXY_ROUTE
     GW->>DA: stream.Send
     DA->>CM: RegisterRoute()
-    CM->>CM: POST /servers/ai_services_agent/routes
+    CM->>CM: POST /servers/ai_services_worker/routes
     CM-->>DA: success
     DA-->>GW: CommandResult{success}
     GW-->>RR: success
@@ -562,16 +552,16 @@ sequenceDiagram
 
 ---
 
-## 10. Agent Registry and State Machine
+## 10. Worker Registry and State Machine
 
-### 10.1 Proposed AgentEntry fields
+### 10.1 Proposed WorkerEntry fields
 
 ```go
-type AgentEntry struct {
-    AgentName     string
+type WorkerEntry struct {
+    WorkerName     string
     Labels        map[string]string  // would include "domain_suffix"
     Capabilities  map[string]string
-    Status        AgentStatus
+    Status        WorkerStatus
     LastHeartbeat time.Time
     RegisteredAt  time.Time
     WorkerIP      string    // TCP source IP from gRPC peer info
@@ -598,32 +588,32 @@ stateDiagram-v2
     BUSY --> DISCONNECTED : heartbeat timeout (90s)
     DISCONNECTED --> DISCONNECTED : stream closed
 
-    DISCONNECTED --> PENDING : agent re-registers
-    REJECTED --> PENDING : agent re-registers
+    DISCONNECTED --> PENDING : worker re-registers
+    REJECTED --> PENDING : worker re-registers
 ```
 
 Proposed status values: `pending`, `ready`, `busy`, `draining`, `disconnected`, `rejected`.
 
-### 10.3 Agent selection
+### 10.3 Worker selection
 
-`registry.SelectAgent(selector)` would iterate all in-memory agents. An agent would match if:
+`registry.SelectWorker(selector)` would iterate all in-memory workers. A worker would match if:
 - `Status == READY`
 - Last heartbeat within 90 seconds
-- All selector keys match: the reserved key `agent_name` would match against the agent's registered name directly; all other keys would match against `entry.Labels`.
+- All selector keys match: the reserved key `worker_name` would match against the worker's registered name directly; all other keys would match against `entry.Labels`.
 
 ### 10.4 Heartbeat watcher
 
-A background goroutine would sweep all `READY`/`BUSY` agents every 30 seconds. Any agent with `now - LastHeartbeat > 90s` would be transitioned to `DISCONNECTED` and the status persisted to PostgreSQL.
+A background goroutine would sweep all `READY`/`BUSY` workers every 30 seconds. Any worker with `now - LastHeartbeat > 90s` would be transitioned to `DISCONNECTED` and the status persisted to PostgreSQL.
 
 ---
 
 ## 11. Database Schema
 
-A new `agents` table would persist agent state across catalog restarts:
+A new `workers` table would persist worker state across catalog restarts:
 
 ```sql
-CREATE TABLE agents (
-    agent_name     TEXT PRIMARY KEY,
+CREATE TABLE workers (
+    worker_name     TEXT PRIMARY KEY,
     labels         JSONB        NOT NULL DEFAULT '{}',
     capabilities   JSONB        NOT NULL DEFAULT '{}',
     status         TEXT         NOT NULL DEFAULT 'pending',
@@ -633,7 +623,7 @@ CREATE TABLE agents (
 );
 ```
 
-The in-memory `Registry` would be the primary source of truth for live routing decisions. The database would provide durability so that `ai-services catalog agent list` works correctly after a catalog restart.
+The in-memory `Registry` would be the primary source of truth for live routing decisions. The database would provide durability so that `ai-services catalog worker list` works correctly after a catalog restart.
 
 ---
 
@@ -643,89 +633,70 @@ The in-memory `Registry` would be the primary source of truth for live routing d
 
 **Issue a bootstrap token:**
 ```
-ai-services catalog agent issue-token
+ai-services catalog worker issue-token
 ```
 Would output a single-use UUID token valid for 24 hours.
 
-**List all registered agents:**
+**List all registered workers:**
 ```
-ai-services catalog agent list
+ai-services catalog worker list
 ```
-Would display agent name, status, labels, last heartbeat, and active command slot count.
+Would display worker name, status, labels, last heartbeat, and active command slot count.
 
-**Delete an agent:**
+**Delete an worker:**
 ```
-ai-services catalog agent delete --name <agent-name>
+ai-services catalog worker delete --name <worker-name>
 ```
-Would remove the agent from the in-memory registry and PostgreSQL.
+Would remove the worker from the in-memory registry and PostgreSQL.
 
-**Start the AgentGateway:**
+**Start the WorkerGateway:**
 ```
-ai-services catalog configure --runtime podman --agentgateway-port 9090
-```
-
-### 12.2 Worker agent commands
-
-**`agent configure`** — Deploy the worker Caddy proxy pod (run once before `agent start`):
-
-```
-ai-services agent configure \
-    --runtime podman              # required; only podman supported
-    [--https-port 443]            # default from values.yaml; can be overridden
-    [--base-dir /var/lib/ai-services]
-    [--domain-name example.com]
-    [--ssl-cert /path/cert.pem --ssl-key /path/key.pem]
+ai-services catalog configure --runtime podman --workergateway-port 9090
 ```
 
-- Would be idempotent: always removes and redeploys the Caddy pod.
-- `adminPort` would not be configurable via CLI — always from `values.yaml` (`"0"` = OS-assigned random port).
-- Would persist `DomainSuffix` to `~/.config/ai-services/agent.json`.
+### 12.2 Worker commands
 
-**`agent start`** — Register and start the daemon:
+**`worker join`** — Deploy the worker Caddy proxy, register, and start the daemon:
 
-```
-ai-services agent start \
+```bash
+ai-services worker join \
     --server lpar-0.example.com:9090   # required
     --name   lpar-1                     # required
     --token  <uuid>                     # required
     --runtime podman                    # required; no default
-    [--tls-dir /var/lib/ai-services/agent/tls]
+    [--https-port 443]                  # default from values.yaml; can be overridden
+    [--base-dir /var/lib/ai-services]
+    [--domain-name example.com]
+    [--ssl-cert /path/cert.pem --ssl-key /path/key.pem]
+    [--tls-dir /var/lib/ai-services/worker/tls]
 ```
 
-- Would load `DomainSuffix` from `~/.config/ai-services/agent.json` and send it as `labels["domain_suffix"]`.
+- Would be idempotent: always removes and redeploys the Caddy pod.
+- `adminPort` would not be configurable via CLI — always from `values.yaml` (`"0"` = OS-assigned random port).
+- Would compute the domain suffix and keep it in-memory to send it directly as `labels["domain_suffix"]` in `RegisterRequest`.
 - Would inject a `LocalCaddyManager` into the Podman runtime by inspecting the running Caddy pod.
 - Would reconnect with exponential backoff (5s base, 120s max) on stream failure.
 
-**`agent status`** — Show current agent state:
-```
-ai-services agent status
+**`worker status`** — Show current worker state:
+```bash
+ai-services worker status
 ```
 
 ---
 
 ## 13. Configuration Files and Assets
 
-### 13.1 Worker agent config
+### 13.1 Worker config
 
-Proposed path: `~/.config/ai-services/agent.json`
-
-```json
-{
-  "agent_name":    "lpar-1",
-  "server":        "lpar-0.example.com:9090",
-  "domain_suffix": "192.168.1.5.nip.io"
-}
-```
-
-`agent configure` would write `domain_suffix`; `agent start` would write `agent_name` and `server`.
+*No configuration file is used or persisted on the worker host for worker registration or setup; all settings are provided directly via command-line flags.*
 
 ### 13.2 Worker Caddy assets
 
 | File | Purpose |
 |---|---|
-| `assets/agent/podman/values.yaml` | Default values for image, adminPort, httpsPort |
-| `assets/agent/podman/templates/agent-caddy.yaml.tmpl` | Kubernetes-style pod spec for the Caddy pod |
-| `assets/agent/podman/templates/agent-caddyfile.tmpl` | Static Caddyfile written to `<baseDir>/agent/caddy/Caddyfile` |
+| `assets/worker/podman/values.yaml` | Default values for image, adminPort, httpsPort |
+| `assets/worker/podman/templates/worker-caddy.yaml.tmpl` | Kubernetes-style pod spec for the Caddy pod |
+| `assets/worker/podman/templates/worker-caddyfile.tmpl` | Static Caddyfile written to `<baseDir>/worker/caddy/Caddyfile` |
 
 Assets would be embedded into the binary via `go:embed`.
 
@@ -749,41 +720,38 @@ The following new packages and files would be introduced. All additions are addi
 ```
 ai-services/
 ├── assets/
-│   ├── agent/
+│   ├── worker/
 │   │   └── podman/
 │   │       ├── values.yaml
 │   │       └── templates/
-│   │           ├── agent-caddy.yaml.tmpl
-│   │           └── agent-caddyfile.tmpl
-│   └── fs.go                           # AgentFS embed
+│   │           ├── worker-caddy.yaml.tmpl
+│   │           └── worker-caddyfile.tmpl
+│   └── fs.go                           # WorkerFS embed
 │
-├── cmd/ai-services/cmd/agent/
-│   ├── agent.go                        # agent subcommand root
-│   ├── configure.go                    # cobra command: agent configure
-│   ├── start.go                        # cobra command: agent start
-│   └── status.go                       # cobra command: agent status
+├── cmd/ai-services/cmd/worker/
+│   ├── worker.go                        # worker subcommand root
+│   ├── join.go                         # cobra command: worker join
+│   └── status.go                       # cobra command: worker status
 │
 └── internal/pkg/
-    ├── agent/
+    ├── worker/
     │   ├── proto/
-    │   │   └── agent.proto             # gRPC service + CommandType enum (29 types)
-    │   ├── agentbootstrap/
-    │   │   └── bootstrap.go            # Register() call at agent start
-    │   ├── agentconfig/
-    │   │   └── agentconfig.go          # Load/Save agent.json (AgentName, Server, DomainSuffix)
+    │   │   └── worker.proto             # gRPC service + CommandType enum (29 types)
+    │   ├── workerbootstrap/
+    │   │   └── bootstrap.go            # Register() call at worker join
     │   ├── configure/
-    │   │   └── configure.go            # DeployAgentCaddy(), BuildAdminURL()
+    │   │   └── configure.go            # DeployWorkerCaddy(), BuildAdminURL()
     │   ├── daemon/
     │   │   └── daemon.go               # Run() + dispatchToRuntime() (all 29 cases)
     │   ├── gateway/
-    │   │   └── gateway.go              # AgentGateway gRPC server; captures WorkerIP + DomainSuffix
+    │   │   └── gateway.go              # WorkerGateway gRPC server; captures WorkerIP + DomainSuffix
     │   ├── httpclient/
-    │   │   └── httpclient.go           # AgentHTTPClient (Get/Post/Do over HTTPProxy)
+    │   │   └── httpclient.go           # WorkerHTTPClient (Get/Post/Do over HTTPProxy)
     │   └── registry/
-    │       └── registry.go             # Registry, AgentEntry, TokenStore
+    │       └── registry.go             # Registry, WorkerEntry, TokenStore
     │
     ├── constants/
-    │   └── common.go                   # AgentCaddyServerName, CaddyServerName (additions)
+    │   └── common.go                   # WorkerCaddyServerName, CaddyServerName (additions)
     │
     ├── proxy/
     │   ├── caddy.go                    # CaddyManager: RegisterRoute, UnregisterRoute, etc.
@@ -812,7 +780,7 @@ ai-services/
 
 - UUID v4, single-use, 24-hour expiry.
 - Would be stored in-memory in a `TokenStore`; destroyed on process restart (operator would need to re-issue).
-- Not bound to an agent name at issuance: the agent would supply its own name at registration time.
+- Not bound to an worker name at issuance: the worker would supply its own name at registration time.
 - Operators should rotate tokens regularly; a leaked token could not be used twice.
 
 ### 15.2 Transport encryption
@@ -823,7 +791,7 @@ Once mTLS is in place, all traffic over the gRPC stream — including `COMMAND_T
 
 ### 15.3 Admin API isolation
 
-The worker Caddy admin port (`2019`) would be bound exclusively to `127.0.0.1` on the host. It would be unreachable from outside the Worker LPAR. Only the agent daemon (running on the same host) would be able to manage routes.
+The worker Caddy admin port (`2019`) would be bound exclusively to `127.0.0.1` on the host. It would be unreachable from outside the Worker LPAR. Only the worker daemon (running on the same host) would be able to manage routes.
 
 ### 15.4 Outbound-only from worker
 
@@ -831,7 +799,7 @@ The Worker LPAR would initiate all connections outbound to the control plane. No
 
 ### 15.5 Future: mTLS
 
-The gateway would be designed to issue a short-lived client certificate per agent upon registration. The daemon would then use this certificate for all subsequent `CommandStream` connections, replacing the plaintext transport.
+The gateway would be designed to issue a short-lived client certificate per worker upon registration. The daemon would then use this certificate for all subsequent `CommandStream` connections, replacing the plaintext transport.
 
 ---
 
@@ -842,7 +810,7 @@ The gateway would be designed to issue a short-lived client certificate per agen
 | | Current | Proposed |
 |---|---|---|
 | Target LPAR | Control-plane only | Any registered Worker LPAR |
-| Runtime dispatch | Direct Podman API call | gRPC command over agent stream |
+| Runtime dispatch | Direct Podman API call | gRPC command over worker stream |
 | Deployer selection | Fixed `PodmanDeployer` | `RemoteRuntime` wraps `PodmanDeployer` transparently |
 | Pod networking | Local Podman | Worker Podman via gRPC |
 
@@ -868,12 +836,12 @@ The gateway would be designed to issue a short-lived client certificate per agen
 
 | Item | Notes |
 |---|---|
-| mTLS | `RegisterResponse` would have reserved cert fields. The gateway should issue short-lived client certs per agent on registration. |
+| mTLS | `RegisterResponse` would have reserved cert fields. The gateway should issue short-lived client certs per worker on registration. |
 | Token persistence | The in-memory `TokenStore` would be lost on process restart. Consider a PostgreSQL-backed token store. |
-| `BUSY` status | `AgentStatusBusy` would be defined but not actively set. In-flight command count tracking should be added. |
-| Agent draining | `AgentStatusDraining` would be defined. Graceful drain before `agent stop` should be implemented. |
+| `BUSY` status | `WorkerStatusBusy` would be defined but not actively set. In-flight command count tracking should be added. |
+| Worker draining | `WorkerStatusDraining` would be defined. Graceful drain before `worker stop` should be implemented. |
 | Streaming logs | `POD_LOGS` / `CONTAINER_LOGS` would return once complete. True streaming would require a different wire protocol (server-side streaming RPC). |
 | OpenShift worker | `OpenshiftClient` proxy methods would return `unsupported`. Future iterations could add OpenShift-based worker LPAR support. |
 | Token UI | `issue-token` would output a raw token to stdout. Expiry display and active token listing should be added. |
-| Models directory | Each worker can have its own custom directory that can be set agent data and used during remote application deployment. |
+| Models directory | Each worker can have its own custom directory that can be set worker data and used during remote application deployment. |
 | Application management | Each application must have the target location which can be used by other applications related flow eg: delete, logs, etc. |

--- a/docs/proposals/catalog/remote-worker-agent-proposal.md
+++ b/docs/proposals/catalog/remote-worker-agent-proposal.md
@@ -4,37 +4,34 @@
 
 1. [Executive Summary](#1-executive-summary)
 2. [Background and Motivation](#2-background-and-motivation)
-   - 2.1 [Current State](#21-current-state)
-   - 2.2 [Problem Statement](#22-problem-statement)
-   - 2.3 [Goals](#23-goals)
-   - 2.4 [Non-Goals](#24-non-goals)
 3. [System Topology](#3-system-topology)
 4. [Architecture Overview](#4-architecture-overview)
-   - 4.1 [Key Components](#41-key-components)
-   - 4.2 [Component Interaction Diagram](#42-component-interaction-diagram)
 5. [gRPC Protocol](#5-grpc-protocol)
-   - 5.1 [Service Definition](#51-service-definition)
-   - 5.2 [Command Types](#52-command-types)
 6. [Bootstrap and Registration Flow](#6-bootstrap-and-registration-flow)
-7. [Deployment Execution Flow](#7-deployment-execution-flow)
-8. [Agent Registry State Machine](#8-agent-registry-state-machine)
-9. [Database Schema](#9-database-schema)
-10. [New CLI Commands](#10-new-cli-commands)
-    - 10.1 [Control Plane Commands](#101-control-plane-commands)
-    - 10.2 [Worker Agent Commands](#102-worker-agent-commands)
-11. [Configuration Files](#11-configuration-files)
-12. [Code Structure](#12-code-structure)
-13. [Before vs After Comparison](#13-before-vs-after-comparison)
-14. [Security Design](#14-security-design)
-15. [Future Work](#15-future-work)
+7. [Worker Caddy Proxy](#7-worker-caddy-proxy)
+8. [Agent HTTP Proxy](#8-agent-http-proxy)
+9. [Deployment Execution Flow](#9-deployment-execution-flow)
+10. [Agent Registry and State Machine](#10-agent-registry-and-state-machine)
+11. [Database Schema](#11-database-schema)
+12. [CLI Commands](#12-cli-commands)
+13. [Configuration Files and Assets](#13-configuration-files-and-assets)
+14. [Code Structure](#14-code-structure)
+15. [Security Design](#15-security-design)
+16. [Current vs Proposed Comparison](#16-current-vs-proposed-comparison)
+17. [Future Work](#17-future-work)
 
 ---
 
 ## 1. Executive Summary
 
-This proposal describes the design and implementation of a **Remote Worker Agent** system for the AI Services Catalog. It enables the Catalog API Server (running on a Control Plane LPAR) to dispatch Podman runtime commands over a persistent bidirectional gRPC stream to one or more **Worker Agent daemons** running on separate LPARs (e.g. Power10 nodes with Spyre AI accelerators).
+This proposal describes the design of a **Remote Worker Agent** system for the AI Services platform. It would enable the Catalog API Server (running on a control-plane LPAR) to dispatch Podman runtime commands over a persistent bidirectional gRPC stream to one or more **Worker Agent daemons** running on separate IBM Power LPARs.
 
-The existing `runtime.Runtime` interface and all its callers (`PodmanDeployer`, `SyncService`, `DeletionService`) are **unchanged**. The remote execution path is a new implementation of the same interface, selected at request time by specifying `runtime=remote`.
+Two additional networking features are proposed alongside the core agent:
+
+| Feature | What it would do |
+|---|---|
+| **Worker Caddy Proxy** | Each Worker LPAR would run its own Caddy instance. Routes would be registered dynamically after each pod deployment so external HTTPS traffic reaches deployed service endpoints directly on that worker. |
+| **Agent HTTP Proxy** | The control plane would be able to tunnel HTTP requests to worker pod endpoints through the existing gRPC stream, with no new port required. |
 
 ---
 
@@ -42,15 +39,7 @@ The existing `runtime.Runtime` interface and all its callers (`PodmanDeployer`, 
 
 ### 2.1 Current State
 
-The AI Services Catalog deploys and manages AI service containers (RAG pipelines, chat, summarization, etc.) by invoking Podman commands **locally** — the Catalog API Server and the Podman socket must reside on the same LPAR.
-
-```
-┌───────────────────────────────────────────────────────┐
-│  Single LPAR                                          │
-│                                                       │
-│  Catalog API Server  ──────►  Podman  ──►  Container  │
-└───────────────────────────────────────────────────────┘
-```
+The AI Services platform deploys AI application pods on the same LPAR that runs the control-plane Catalog service. The deployment engine calls the Podman API locally. This limits all compute to a single LPAR.
 
 ### 2.2 Problem Statement
 
@@ -60,54 +49,41 @@ This means that to deploy AI workloads on a second or third LPAR, an operator mu
 
 ### 2.3 Goals
 
-1. Allow the Control Plane to deploy containers on **remote LPARs** without changing any existing deployer code.
-2. Keep the local Podman path (`--runtime podman`) working with **zero regression**.
-3. Support **multiple worker LPARs** with per-request agent selection via label selectors.
-4. Provide **operational visibility** — list, status, and delete agents from the control plane CLI.
-5. Provide a **secure bootstrap** process using single-use HMAC tokens (mTLS follow-up planned).
+- Allow AI application pods to be deployed on remote Worker LPARs from a single control plane.
+- Route external HTTPS traffic to deployed services via a per-worker Caddy proxy.
+- Allow the control plane to perform health checks and internal HTTP calls against remote pod endpoints over the gRPC stream, with no new exposed port.
+- Minimal operational overhead: a single daemon binary, one `configure` + `start` workflow per Worker.
+- All communication over a single outbound TCP connection from Worker → control plane (firewall-friendly).
 
 ### 2.4 Non-Goals
 
-- mTLS between control plane and agents (reserved for a follow-up; stubs are present).
-- OpenShift-based remote deployment.
-- Cross-LPAR container networking / storage management.
+- OpenShift runtime support for worker Caddy (Podman only in this proposal).
+- Streaming/chunked HTTP proxy responses (single request/response only).
+- mTLS between agent and gateway (reserved fields would be present; treated as future work).
 
 ---
 
 ## 3. System Topology
 
-```
-┌───────────────────────────────────────────────────────┐
-│                    Control Plane LPAR                 │
-│                                                       │
-│   ai-services CLI.                                    │
-│         │  REST                                       │
-│         ▼                                             │
-│   Catalog API Server  :8080 (gin)                     │
-│         │                                             │
-│         ▼                                             │
-│   AgentDispatcher                                     │
-│         │                                             │
-│         ▼                                             │
-│   RemoteRuntime  ◄──────────────────────────┐         │
-│         │                                   │         │
-│         ▼                                   │         │
-│   AgentGateway  :9090 (gRPC)                │         │
-│         │  bidirectional stream             │         │
-│         │                          AgentRegistry      │
-│         │                          in-memory + DB     │
-└─────────┼──────────────────────────────────┼──────────┘
-          │                                  │
-  ┌───────┴──────────┐              ┌────────┴─────────┐
-  │  Worker LPAR-1   │              │  Worker LPAR-2   │
-  │                  │              │                  │
-  │  agent daemon    │              │  agent daemon    │
-  │  (gRPC client)   │              │  (gRPC client)   │
-  │       │          │              │       │          │
-  │  Podman Socket   │              │  Podman Socket   │
-  │       │          │              │       │          │
-  │  Spyre / GPU     │              │  Spyre / GPU     │
-  └──────────────────┘              └──────────────────┘
+```mermaid
+graph TB
+    subgraph CP["Control-plane LPAR"]
+        API["Catalog API\n(REST / gRPC)"]
+        GW["AgentGateway\n:9090 (gRPC)"]
+        API --> GW
+    end
+
+    subgraph WK["Worker LPAR"]
+        DAEMON["agent daemon\n(runtime.Runtime proxy)"]
+        subgraph PODS["Podman pods"]
+            CADDY["ai-services--agent-caddy\n:443 HTTPS"]
+            APP["my-app--chat-bot\n:8080"]
+        end
+        DAEMON --> PODS
+    end
+
+    GW -- "gRPC stream\n(outbound from worker)" --> DAEMON
+    EXTERNAL(("External\nHTTPS")) --> CADDY
 ```
 
 ---
@@ -116,33 +92,47 @@ This means that to deploy AI workloads on a second or third LPAR, an operator mu
 
 ### 4.1 Key Components
 
-| Component | Location | Responsibility |
+| Component | Location | Role |
 |---|---|---|
-| **AgentGateway** | Control Plane `:9090` | gRPC server; accepts `Register` and `CommandStream` RPCs from worker daemons |
-| **AgentRegistry** | Control Plane | In-memory + PostgreSQL store; tracks agent state, heartbeats, and active command slots |
-| **AgentDispatcher** | Control Plane | Selects the best available READY agent for a request, creates a `RemoteRuntime` bound to it |
-| **RemoteRuntime** | Control Plane | Implements `runtime.Runtime`; serialises each method call into a `Command` proto, sends it via the agent's `CommandCh`, and awaits the `CommandResult` |
-| **agent daemon** | Each Worker LPAR | Persistent process; opens a `CommandStream`, executes incoming `Command` messages against the local Podman socket, returns `CommandResult` messages |
-| **agentbootstrap** | Worker LPAR (run once) | Reads `agent.conf`, calls `AgentGateway.Register` with the pre-shared token, receives and persists TLS material (future mTLS) |
+| **AgentGateway** | Control plane | gRPC server that would accept agent connections on `:9090` |
+| **Registry** | Control plane | In-memory + PostgreSQL state store for all registered agents |
+| **RemoteRuntime** | Control plane | A `runtime.Runtime` implementation that would send commands over gRPC |
+| **DeploymentExecutor** | Control plane | Would select a `RemoteRuntime` when deploying to a Worker |
+| **AgentHTTPClient** | Control plane | Would tunnel HTTP requests through `RemoteRuntime.HTTPProxy` |
+| **Agent Daemon** | Worker LPAR | Would receive gRPC commands, execute them on local Podman, and return results |
+| **Worker Caddy** | Worker LPAR | Pod `ai-services--agent-caddy` — reverse proxy for deployed services |
+| **LocalCaddyManager** | Worker LPAR | Interface to be injected into `PodmanClient` for route management |
 
-### 4.2 Component Interaction Diagram
+### 4.2 Component Interaction (deployment)
 
 ```mermaid
-graph TD
-    Client["Client"] -->|POST /applications| AH[ApplicationHandler]
-    AH --> AS[ApplicationService]
-    AS --> DE[DeploymentExecutor]
-    DE -->|runtime=remote| AD[AgentDispatcher]
-    AD -->|SelectAgent| REG[(AgentRegistry)]
-    AD -->|New| RR[RemoteRuntime]
-    RR -->|Command| CH[agent CommandCh]
-    CH --> GW[AgentGateway gRPC]
-    GW -->|stream.Send| DAEMON[agent daemon]
-    DAEMON -->|podman exec| POD[Podman Socket]
-    POD -->|result| DAEMON
-    DAEMON -->|stream.Send result| GW
-    GW -->|DeliverResult| RR
-    RR -->|return| DE
+sequenceDiagram
+    participant CP as Control Plane<br/>(DeploymentExecutor)
+    participant RR as RemoteRuntime
+    participant GW as AgentGateway
+    participant DA as agent daemon
+    participant PM as Podman
+    participant CM as LocalCaddyManager
+
+    CP->>RR: resolveRuntime() → RemoteRuntime
+    CP->>RR: CreatePod(spec)
+    RR->>GW: dispatch(COMMAND_TYPE_CREATE_POD)
+    GW->>DA: stream.Send(Command)
+    DA->>PM: podman kube play
+    PM-->>DA: success
+    DA-->>GW: CommandResult{success}
+    GW-->>RR: DeliverResult
+    RR-->>CP: nil error
+
+    CP->>RR: RegisterProxyRoute(route)
+    RR->>GW: dispatch(COMMAND_TYPE_REGISTER_PROXY_ROUTE)
+    GW->>DA: stream.Send(Command)
+    DA->>CM: RegisterRoute()
+    CM->>CM: POST Caddy Admin API
+    CM-->>DA: success
+    DA-->>GW: CommandResult{success}
+    GW-->>RR: DeliverResult
+    RR-->>CP: nil error
 ```
 
 ---
@@ -151,390 +141,739 @@ graph TD
 
 ### 5.1 Service Definition
 
-Located at [`internal/pkg/agent/proto/agent.proto`](../../ai-services/internal/pkg/agent/proto/agent.proto):
+The proposed `AgentGateway` gRPC service would be defined as follows:
 
 ```protobuf
 service AgentGateway {
-  // Called once at bootstrap time by a new worker agent.
+  // One-time call at bootstrap time.
   rpc Register(RegisterRequest) returns (RegisterResponse);
 
   // Long-lived bidirectional stream.
-  // Agent sends CommandResult; control plane sends Command.
+  // Agent initiates; sends CommandResult, receives Command.
   rpc CommandStream(stream CommandResult) returns (stream Command);
+}
+
+message RegisterRequest {
+  string agent_name       = 1;
+  string pre_shared_token = 2;
+  map<string, string> labels       = 3;  // would include "domain_suffix"
+  map<string, string> capabilities = 4;
+}
+
+message Command {
+  string      command_id = 1;
+  CommandType type       = 2;
+  bytes       payload    = 3; // JSON-encoded
+}
+
+message CommandResult {
+  string command_id   = 1;
+  bool   success      = 2;
+  bytes  data         = 3; // JSON-encoded response
+  string error        = 4;
+  bool   is_heartbeat = 5;
+  string agent_name   = 6;
 }
 ```
 
-The stream direction is **agent-initiated**: the worker daemon dials out to the control plane, which is important for firewall traversal — only outbound connections from the worker are required.
-
 ### 5.2 Command Types
 
-Each `Command` proto carries a `CommandType` enum that maps 1-to-1 with every method on the `runtime.Runtime` interface:
+The `CommandType` enum would cover all 29 operations needed to proxy the full `runtime.Runtime` interface:
 
-| CommandType | Runtime method |
-|---|---|
-| `PULL_IMAGE` | `PullImage(image)` |
-| `LIST_IMAGES` | `ListImages()` |
-| `LIST_PODS` | `ListPods(filters)` |
-| `CREATE_POD` | `CreatePod(spec, opts)` |
-| `DELETE_POD` | `DeletePod(id, force)` |
-| `START_POD` / `STOP_POD` | `StartPod` / `StopPod` |
-| `INSPECT_POD` | `InspectPod(nameOrID)` |
-| `POD_EXISTS` | `PodExists(nameOrID)` |
-| `POD_LOGS` | `PodLogs(nameOrID)` |
-| `GET_POD_RESOURCES` | `GetPodResources(nameOrID)` |
-| `LIST_SECRETS` | `ListSecrets(filters)` |
-| `DELETE_SECRET` | `DeleteSecret(name)` |
-| `SECRET_EXISTS` | `SecretExists(nameOrID)` |
-| `DELETE_VOLUME` | `DeleteVolume(name)` |
-| `VOLUME_EXISTS` | `VolumeExists(nameOrID)` |
-| `INSPECT_CONTAINER` | `InspectContainer(nameOrID)` |
-| `CONTAINER_EXISTS` | `ContainerExists(nameOrID)` |
-| `CONTAINER_LOGS` | `ContainerLogs(nameOrID)` |
-| `LIST_ROUTES` | `ListRoutes()` |
-| `DELETE_PVCS` | `DeletePVCs(appLabel)` |
-| `GET_SYSTEM_INFO` | `GetSystemInfo()` |
-| `RUNTIME_TYPE` | `RuntimeType()` |
+| Value | Name | Payload | Description |
+|---|---|---|---|
+| 0 | `UNSPECIFIED` | — | Default / error |
+| 1 | `LIST_IMAGES` | `{}` | List local images |
+| 2 | `PULL_IMAGE` | `{Image}` | Pull an image |
+| 3 | `LIST_PODS` | `{Filters}` | List pods with optional filters |
+| 4 | `CREATE_POD` | `{Body, Opts}` | `podman kube play` |
+| 5 | `DELETE_POD` | `{ID, Force}` | Remove a pod |
+| 6 | `STOP_POD` | `{ID}` | Stop a pod |
+| 7 | `START_POD` | `{ID}` | Start a pod |
+| 8 | `INSPECT_POD` | `{NameOrID}` | Inspect pod details + port bindings |
+| 9 | `POD_EXISTS` | `{NameOrID}` | Boolean existence check |
+| 10 | `POD_LOGS` | `{NameOrID}` | Stream pod logs |
+| 11 | `GET_POD_RESOURCES` | `{NameOrID}` | CPU / memory / accelerator usage |
+| 12 | `LIST_SECRETS` | `{Filters}` | List secrets |
+| 13 | `DELETE_SECRET` | `{Name}` | Remove a secret |
+| 14 | `SECRET_EXISTS` | `{NameOrID}` | Boolean existence check |
+| 15 | `DELETE_VOLUME` | `{Name}` | Remove a volume |
+| 16 | `VOLUME_EXISTS` | `{NameOrID}` | Boolean existence check |
+| 17 | `INSPECT_CONTAINER` | `{NameOrID}` | Inspect container details |
+| 18 | `CONTAINER_EXISTS` | `{NameOrID}` | Boolean existence check |
+| 19 | `CONTAINER_LOGS` | `{ContainerNameOrID}` | Stream container logs |
+| 20 | `LIST_ROUTES` | `{}` | List OpenShift routes (stub on Podman) |
+| 21 | `DELETE_PVCS` | `{AppLabel}` | Delete PVCs (OpenShift only) |
+| 22 | `GET_SYSTEM_INFO` | `{}` | CPU / memory / Spyre card info |
+| 23 | `RUNTIME_TYPE` | `{}` | Returns `"podman"` or `"openshift"` |
+| 24 | `RUN_EPHEMERAL_CONTAINER` | `{Image, Cmd, Mounts}` | One-shot container |
+| 25 | `REGISTER_PROXY_ROUTE` | `{ID, Domain, Upstream, Terminal, Type}` | Add route to worker Caddy |
+| 26 | `UNREGISTER_PROXY_ROUTE` | `{RouteID}` | Remove route from worker Caddy |
+| 27 | `GET_PROXY_ROUTE` | `{RouteID}` | Fetch route from worker Caddy |
+| 28 | `PROXY_HEALTH_CHECK` | `{}` | Verify worker Caddy is reachable |
+| 29 | `HTTP_PROXY` | `{Method, TargetURL, Headers, Body}` | Tunnel HTTP request to worker pod |
+
+### 5.3 Protocol Flow
+
+**Heartbeat mechanism:**
+- The agent would send a heartbeat `CommandResult{is_heartbeat: true}` immediately on stream open as the first message (used by the gateway to identify the agent).
+- A background goroutine on the agent would send heartbeats every **30 seconds**.
+- The gateway would mark an agent `DISCONNECTED` if no heartbeat is received for **90 seconds** (checked every 30 seconds).
+
+**Command flow:**
+1. Control plane calls `RemoteRuntime.SomeMethod()`.
+2. `dispatch()` would generate a UUID command ID, marshal the payload to JSON, register a result channel, and push a `Command` to the agent's `CommandCh`.
+3. The gateway goroutine would read from `CommandCh` and write to the gRPC stream.
+4. The agent daemon would call `executeCommand()` → `dispatchToRuntime()`, execute locally, and send back a `CommandResult`.
+5. The gateway's receive goroutine would read the result and call `registry.DeliverResult()`.
+6. `dispatch()` would receive on the result channel and return.
+7. The default command timeout would be **5 minutes**, respecting `ctx.Deadline()` if shorter.
 
 ---
 
 ## 6. Bootstrap and Registration Flow
 
-This flow runs **once per Worker LPAR** before the agent daemon can receive commands.
+### 6.1 Control-plane setup
+
+```bash
+# Start the AgentGateway on the control plane
+ai-services catalog configure --runtime podman --agentgateway-port 9090
+
+# Issue a single-use bootstrap token (24-hour expiry)
+ai-services catalog agent issue-token
+# Output: <uuid-token>
+```
+
+Tokens would be stored in-memory in a `TokenStore`. Each token would be single-use: once consumed by `Register()` it would be marked used and rejected on any subsequent call.
+
+### 6.2 Worker setup
+
+```bash
+# Step 1 — bootstrap the Worker LPAR (installs Podman, SELinux policies, etc.)
+ai-services bootstrap configure --runtime podman
+
+# Step 2 — deploy the worker Caddy proxy pod (run once)
+ai-services agent configure --runtime podman [--https-port 443] [--domain-name example.com] \
+    [--ssl-cert /path/cert.pem --ssl-key /path/key.pem]
+
+# Step 3 — register with the control plane and start the daemon
+ai-services agent start \
+    --server lpar-0.example.com:9090 \
+    --name lpar-1 \
+    --token <uuid-token> \
+    --runtime podman
+```
+
+### 6.3 Registration sequence
 
 ```mermaid
 sequenceDiagram
-    actor Admin
-    participant Worker as PodmanBootstrap (Worker LPAR)
-    participant Reg as agentbootstrap.Register()
-    participant GW as AgentGateway :9090
-    participant AR as AgentRegistry
+    participant W as Worker LPAR
+    participant GW as AgentGateway
+    participant TS as TokenStore
+    participant REG as Registry
 
-    Note over Admin,AR: Pre-bootstrap: admin generates token
-    Admin->>GW: ai-services catalog agent issue-token lpar-1
-    GW-->>Admin: pre_shared_token (24h, single-use)
-    Admin->>Worker: write /etc/ai-services/agent.conf
+    W->>GW: Register(agent_name="lpar-1", token, labels={domain_suffix})
+    GW->>TS: Validate(token)
+    TS-->>GW: OK (token marked used)
+    GW->>REG: Upsert(req)
+    GW->>REG: MarkReady("lpar-1")
+    GW-->>W: RegisterResponse{agent_name: "lpar-1"}
 
-    Note over Worker,AR: Bootstrap registration (once)
-    Worker->>Reg: ai-services agent start
-    Reg->>Reg: read agent.conf
-    Reg->>GW: Register{agent_id, pre_shared_token, labels}
-    GW->>GW: validate token (single-use, 24h TTL)
-    GW->>AR: Upsert agent row (status=PENDING)
-    AR-->>GW: ok
-    GW->>AR: MarkReady(agent_id)
-    GW-->>Reg: RegisterResponse{agent_id}
-    Note over Worker,AR: mTLS cert/key returned in future release
-
-    Note over Worker,GW: All subsequent communication
-    Worker->>GW: CommandStream (persistent bidirectional gRPC)
-    GW->>AR: MarkReady / UpdateHeartbeat
+    W->>GW: CommandStream — Send(CommandResult{is_heartbeat:true, agent_name:"lpar-1"})
+    GW->>REG: SetWorkerIP("lpar-1", "192.168.1.5")
+    GW->>REG: SetDomainSuffix("lpar-1", "192.168.1.5.nip.io")
+    GW->>REG: MarkReady("lpar-1")
+    Note over W,GW: stream open — awaiting Commands
 ```
 
-**Key points:**
+**Worker IP capture:** The gateway would read the TCP source IP from the gRPC peer info on the stream context. This would be the address of the Worker LPAR as seen from the control plane.
 
-- The `pre_shared_token` is **single-use and 24-hour TTL**. Consumed on first `Register` call.
-- `Register` is called **once** by `agentbootstrap.Register()` in `agent start`. The daemon's reconnect loop reconnects the `CommandStream` without re-registering.
-- If the agent process is restarted, it must have a freshly issued token (or mTLS cert in future).
+**Domain suffix propagation:** `agent configure` would compute the domain suffix (cert CN > `--domain-name` > `workerIP.nip.io`) and persist it to `~/.config/ai-services/agent.json`. `agent start` would load this and send it as `labels["domain_suffix"]` in `RegisterRequest`. The gateway would extract it and store it in `AgentEntry.DomainSuffix`.
 
 ---
 
-## 7. Deployment Execution Flow
+## 7. Worker Caddy Proxy
+
+Each Worker LPAR would run its own Caddy instance for externally-visible HTTPS routing to deployed service pods. Routes would be registered dynamically by the agent daemon after each successful pod deployment.
+
+### 7.1 Design principles
+
+- **Same pattern as catalog Caddy.** The catalog configure command deploys a Caddy pod; the proposed `agent configure` command would do the same for the worker.
+- **Admin port always random.** Setting `adminPort: "0"` in `values.yaml` would cause the OS to assign a random loopback port, resolved at runtime by inspecting the running pod.
+- **No `--resume`.** Worker Caddy would not use `caddy run --resume` to avoid stale autosave state from a previous server name.
+- **Server name `ai_services_agent`.** The Caddyfile global block would name the `:443` server `ai_services_agent`, so routes would be POSTed to `.../servers/ai_services_agent/routes`.
+- **Admin port only on loopback.** The pod port binding would be `127.0.0.1:<random>:2019` — unreachable from outside the LPAR.
+
+### 7.2 Worker Caddy pod
+
+The proposed pod name would be `ai-services--agent-caddy`.
+
+The pod template would render a port binding annotation such as:
+
+```yaml
+ai-services.io/ports: "127.0.0.1:{{ .Values.caddy.adminPort }}:2019, {{ .Values.caddy.httpsPort }}:443"
+```
+
+The proposed `values.yaml` defaults:
+
+```yaml
+caddy:
+  image: icr.io/ai-services-cicd/caddy:v2.11.4-0
+  adminPort: "0"   # OS-assigned random loopback port
+  httpsPort: 443   # Default; overridden via --https-port
+```
+
+The proposed Caddyfile:
+
+```
+{
+    admin 0.0.0.0:2019
+    servers :443 {
+        name ai_services_agent
+    }
+}
+
+:443 {
+    handle /internal/health {
+        respond "OK" 200
+    }
+    tls internal
+}
+
+:8080 {
+    respond /health "OK" 200
+}
+```
+
+### 7.3 `agent configure` command
+
+```
+ai-services agent configure \
+    --runtime podman          # required; only podman supported
+    [--https-port 443]        # override caddy.httpsPort from values.yaml
+    [--domain-name example.com]
+    [--ssl-cert /path/cert.pem --ssl-key /path/key.pem]
+    [--base-dir /var/lib/ai-services]
+```
+
+**Proposed steps for `DeployAgentCaddy()`:**
+
+1. Read `values.yaml` (image, adminPort, httpsPort). Apply `--https-port` CLI override if provided.
+2. Render the Caddyfile template and write to `<baseDir>/agent/caddy/Caddyfile`.
+3. Force-remove any existing `ai-services--agent-caddy` pod (to handle stale or failed pods).
+4. Render the pod template and deploy via readiness-checked pod deployment.
+5. Resolve the admin URL: inspect the running pod → find the `2019/tcp` host port → `http://localhost:<port>`.
+6. Health-check the Caddy admin API.
+7. Compute the domain suffix (cert CN > `--domain-name` > `workerIP.nip.io`).
+8. Persist `DomainSuffix` to `~/.config/ai-services/agent.json`.
+
+**This command would be idempotent.** Re-running would always remove and redeploy the Caddy pod to ensure correct port bindings.
+
+### 7.4 Admin URL resolution
+
+```
+GetCaddyAdminPort(rt, "ai-services--agent-caddy")
+  └─ rt.InspectPod("ai-services--agent-caddy")
+       └─ pod.Ports["2019/tcp"][0]  →  e.g. "37249"
+  └─ returns "37249"
+
+BuildAdminURL(rt)
+  └─ "http://localhost:37249"
+```
+
+A single shared `GetCaddyAdminPort` utility would be used by both the catalog Caddy and the worker Caddy, with the catalog's local helper delegating to it.
+
+### 7.5 Caddy manager injection at daemon start
+
+When `agent start` runs, it would call an `injectCaddyManager` function:
+
+```go
+adminURL, err := BuildAdminURL(pc)  // pod inspect → random port
+pm := NewCaddyManager(adminURL, AgentCaddyServerName)
+caddyMgr := NewLocalCaddyManagerAdapter(pm)
+pc.SetCaddyManager(caddyMgr)
+```
+
+If the Caddy pod is not running, a warning would be logged and the daemon would start normally — all other runtime operations would continue; only route registration would be unavailable until `agent configure` is run.
+
+### 7.6 Route registration via gRPC
+
+When the control plane deploys a service to a Worker, the deployer would call:
+
+```go
+rt.RegisterProxyRoute(ctx, types.ProxyRoute{
+    ID:       "my-app-chat-bot",
+    Domain:   "my-app-chat-bot.192.168.1.5.nip.io",
+    Upstream: "10.88.0.5:8080",   // pod IP — see §7.7
+    Terminal: true,
+    Type:     "api",
+})
+```
+
+This would dispatch `COMMAND_TYPE_REGISTER_PROXY_ROUTE` over gRPC. The daemon would call `RegisterProxyRoute()` on the local `PodmanClient`, which would call `caddyMgr.RegisterRoute()`, hitting the Caddy Admin API:
+
+```
+POST http://localhost:<port>/config/apps/http/servers/ai_services_agent/routes
+```
+
+**Domain suffix for worker routes** would come from `RemoteRuntime.DomainSuffix()` — read from the agent's registry entry, populated from `labels["domain_suffix"]` at stream open. The worker's domain suffix would be independent of the control-plane's `DOMAIN_SUFFIX` env var.
+
+### 7.7 Upstream uses pod IP, not pod name
+
+Caddy would run as a Podman pod. Pod name DNS (Podman's internal resolver) is only available inside Podman network namespaces, not from within the Caddy container when reaching other pods on the same host. Therefore:
+
+- Route upstreams would use the **pod IP address** (e.g. `10.88.0.5:8080`), not the pod name.
+- The deployer would resolve the pod IP by inspecting the pod's infra container: `InspectPod` → `InfraContainerID` → `InspectContainer` → `NetworkSettings.IPAddress`.
+
+### 7.8 Proposed constants
+
+| Constant | Proposed value | Package |
+|---|---|---|
+| `AgentCaddyServerName` | `"ai_services_agent"` | `constants` |
+| `CaddyServerName` (existing) | `"ai_services"` | `constants` |
+| `AgentCaddyPodName` | `"ai-services--agent-caddy"` | `agent/configure` |
+
+---
+
+## 8. Agent HTTP Proxy
+
+The control plane cannot directly reach pod endpoints on the Worker LPAR (no direct network route; no extra port). The proposed `COMMAND_TYPE_HTTP_PROXY` (value 29) would tunnel a complete HTTP request/response through the existing gRPC stream.
+
+### 8.1 Control-plane side
+
+An `AgentHTTPClient` helper would provide a clean API for callers:
+
+```go
+client := httpclient.New(remoteRuntime)
+
+// GET
+resp, err := client.Get(ctx, "http://my-app--chat-bot:8080/health")
+
+// POST
+resp, err := client.Post(ctx, "http://my-app--chat-bot:8080/api/infer", jsonBody)
+
+// Arbitrary method
+resp, err := client.Do(ctx, "GET", url, headers, body)
+```
+
+`Do()` would call `rt.HTTPProxy(ctx, method, targetURL, headers, body)`.
+
+`RemoteRuntime.HTTPProxy()` would dispatch `COMMAND_TYPE_HTTP_PROXY` over gRPC with payload:
+
+```json
+{
+  "method":     "GET",
+  "target_url": "http://my-app--chat-bot:8080/health",
+  "headers":    {},
+  "body":       null
+}
+```
+
+The response would be an `HTTPProxyResponse{StatusCode, Headers, Body}`, returned as a single JSON blob in `CommandResult.Data`.
+
+### 8.2 Worker daemon side
+
+The daemon would dispatch to `rt.HTTPProxy(ctx, method, targetURL, headers, body)`. On the Worker, `PodmanClient.HTTPProxy` would run the actual HTTP call:
+
+```go
+// 1. Resolve pod name → IP  (pod name DNS not available on host OS)
+resolvedURL, err := pc.resolvePodNameInURL(targetURL)
+
+// 2. Execute the HTTP request
+req, _ := http.NewRequestWithContext(ctx, method, resolvedURL, body)
+resp, _ := http.DefaultClient.Do(req)
+```
+
+### 8.3 Pod name → IP resolution
+
+Pod name DNS (e.g. `my-app--chat-bot`) resolves inside Podman network namespaces but not from the host OS where `http.DefaultClient` runs. A `resolvePodNameInURL` helper would handle this transparently:
+
+```
+resolvePodNameInURL("http://my-app--chat-bot:8080/health")
+  └─ parse URL → host = "my-app--chat-bot"
+  └─ net.ParseIP("my-app--chat-bot") == nil  → not an IP
+  └─ podNameToIP("my-app--chat-bot")
+       └─ pods.Inspect(ctx, "my-app--chat-bot", nil)
+            └─ podReport.InfraContainerID = "abc123"
+       └─ containers.Inspect(ctx, "abc123", nil)
+            └─ ctr.NetworkSettings.IPAddress = "10.88.0.5"
+            └─ (fallback) ctr.NetworkSettings.Networks[n].IPAddress
+       └─ returns "10.88.0.5"
+  └─ URL rewritten → "http://10.88.0.5:8080/health"
+```
+
+If the hostname is already an IP address or `localhost`, it would be passed through unchanged.
+
+### 8.4 Last-hop security note
+
+The HTTP proxy last hop (agent daemon → pod) would be plain HTTP on the host's Podman network. This would never leave the Worker LPAR. All traffic between control plane and agent — including HTTP proxy payloads — would be encrypted by the gRPC transport layer (or mTLS when enabled).
+
+---
+
+## 9. Deployment Execution Flow
 
 ```mermaid
 sequenceDiagram
-    participant C as Client
-    participant AH as ApplicationHandler
+    participant U as User
     participant AS as ApplicationService
     participant DE as DeploymentExecutor
+    participant REG as Registry
     participant RR as RemoteRuntime
-    participant AD as AgentDispatcher
     participant GW as AgentGateway
-    participant DA as Worker Agent
+    participant DA as agent daemon
     participant PM as Podman
+    participant CM as LocalCaddyManager
 
-    C->>AH: POST /applications (runtime=remote, agent_selector)
-    AH->>AS: CreateApplication(req)
-    AS->>DE: ExecuteWithPlan(plan, runtimeType=remote)
-    DE->>AD: SelectAgent(labelSelector)
-    AD-->>DE: agentID="lpar-1"
-    DE->>RR: NewRemoteRuntime(agentID)
-    Note over DE,RR: PodmanDeployer unchanged — uses runtime.Runtime interface
-    DE->>RR: PullImage("registry/model:latest")
-    RR->>GW: send Command{PULL_IMAGE, payload} via CommandCh
-    GW->>DA: stream.Send(Command)
-    DA->>PM: podman pull registry/model:latest
+    U->>AS: POST /api/applications {agent_selector}
+    AS->>AS: validateAgentSelector() + BuildDeploymentPlan()
+    AS->>DE: ExecuteWithPlan(plan)
+    DE->>REG: SelectAgent(selector) → lpar-1
+    DE->>RR: remote.New("lpar-1", registry)
+
+    DE->>RR: PodExists(podName)
+    RR->>GW: COMMAND_TYPE_POD_EXISTS
+    GW->>DA: stream.Send
+    DA->>PM: podman pod exists
+    PM-->>DA: false
+    DA-->>GW: CommandResult
+    GW-->>RR: false
+
+    DE->>RR: CreatePod(spec)
+    RR->>GW: COMMAND_TYPE_CREATE_POD
+    GW->>DA: stream.Send
+    DA->>PM: podman kube play
     PM-->>DA: success
-    DA->>GW: stream.Send(CommandResult{success})
-    GW->>RR: DeliverResult → resultCh
-    RR-->>DE: nil error
-    DE->>RR: CreatePod(podSpec, opts)
-    Note over DE,PM: same pattern for every Runtime method
-    DE-->>AS: nil
-    AS-->>AH: CreateApplicationResponse
-    AH-->>C: 202 Accepted
+    DA-->>GW: CommandResult{success}
+    GW-->>RR: success
+
+    DE->>RR: DomainSuffix() → "192.168.1.5.nip.io"
+    DE->>RR: RegisterProxyRoute(Route{domain, upstream=podIP:8080})
+    RR->>GW: COMMAND_TYPE_REGISTER_PROXY_ROUTE
+    GW->>DA: stream.Send
+    DA->>CM: RegisterRoute()
+    CM->>CM: POST /servers/ai_services_agent/routes
+    CM-->>DA: success
+    DA-->>GW: CommandResult{success}
+    GW-->>RR: success
+    RR-->>DE: nil
+    DE-->>U: 202 Accepted
 ```
 
 ---
 
-## 8. Agent Registry State Machine
+## 10. Agent Registry and State Machine
+
+### 10.1 Proposed AgentEntry fields
+
+```go
+type AgentEntry struct {
+    AgentName     string
+    Labels        map[string]string  // would include "domain_suffix"
+    Capabilities  map[string]string
+    Status        AgentStatus
+    LastHeartbeat time.Time
+    RegisteredAt  time.Time
+    WorkerIP      string    // TCP source IP from gRPC peer info
+    DomainSuffix  string    // from labels["domain_suffix"] at stream open
+    CommandCh     chan *Command  // capacity 32
+    results       map[string]chan *CommandResult
+}
+```
+
+### 10.2 Status state machine
 
 ```mermaid
 stateDiagram-v2
-    [*] --> PENDING : Register RPC received
+    [*] --> PENDING : Register() called
 
-    PENDING --> READY : token validated
-    PENDING --> REJECTED : invalid token
+    PENDING --> READY : token validated\nCommandStream open
+    PENDING --> REJECTED : invalid / expired token
 
-    READY --> BUSY : all command slots filled
-    BUSY --> READY : command slot freed
+    READY --> BUSY : command in-flight
+    BUSY --> READY : result delivered
+    READY --> READY : heartbeat received
 
-    READY --> DISCONNECTED : heartbeat timeout (>90s)
-    BUSY --> DISCONNECTED : heartbeat timeout (>90s)
+    READY --> DISCONNECTED : heartbeat timeout (90s)
+    BUSY --> DISCONNECTED : heartbeat timeout (90s)
+    DISCONNECTED --> DISCONNECTED : stream closed
 
-    REJECTED --> PENDING : agent reconnects (re-Register)
-    DISCONNECTED --> PENDING : agent reconnects (re-Register)
+    DISCONNECTED --> PENDING : agent re-registers
+    REJECTED --> PENDING : agent re-registers
 ```
 
-**Heartbeat watcher:** A background goroutine (`StartHeartbeatWatcher`) sweeps all `READY`/`BUSY` agents every 30 seconds and transitions any whose `last_heartbeat` is older than 90 seconds to `DISCONNECTED`.
+Proposed status values: `pending`, `ready`, `busy`, `draining`, `disconnected`, `rejected`.
 
-**Agent selection:** `SelectAgent` only returns agents in `READY` status with a non-stale heartbeat matching the requested label selector.
+### 10.3 Agent selection
+
+`registry.SelectAgent(selector)` would iterate all in-memory agents. An agent would match if:
+- `Status == READY`
+- Last heartbeat within 90 seconds
+- All selector keys match: the reserved key `agent_name` would match against the agent's registered name directly; all other keys would match against `entry.Labels`.
+
+### 10.4 Heartbeat watcher
+
+A background goroutine would sweep all `READY`/`BUSY` agents every 30 seconds. Any agent with `now - LastHeartbeat > 90s` would be transitioned to `DISCONNECTED` and the status persisted to PostgreSQL.
 
 ---
 
-## 9. Database Schema
+## 11. Database Schema
 
-A new `agents` table persists agent state across catalog restarts:
+A new `agents` table would persist agent state across catalog restarts:
 
 ```sql
--- Migration: 20260707000001_create_agents_table.sql
 CREATE TABLE agents (
-    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-    agent_id        TEXT        NOT NULL UNIQUE,
-    labels          JSONB       NOT NULL DEFAULT '{}',
-    capabilities    JSONB       NOT NULL DEFAULT '{}',
-    status          TEXT        NOT NULL DEFAULT 'pending',
-                    -- pending | ready | busy | draining | disconnected | rejected
-    last_heartbeat  TIMESTAMPTZ,
-    registered_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+    agent_name     TEXT PRIMARY KEY,
+    labels         JSONB        NOT NULL DEFAULT '{}',
+    capabilities   JSONB        NOT NULL DEFAULT '{}',
+    status         TEXT         NOT NULL DEFAULT 'pending',
+    last_heartbeat TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    registered_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW()
 );
-
-CREATE INDEX idx_agents_status ON agents (status);
 ```
 
-The in-memory registry is the **source of truth** for live routing decisions. The database provides durability for `ai-services catalog agent list` after a catalog restart.
+The in-memory `Registry` would be the primary source of truth for live routing decisions. The database would provide durability so that `ai-services catalog agent list` works correctly after a catalog restart.
 
 ---
 
-## 10. New CLI Commands
+## 12. CLI Commands
 
-### 10.1 Control Plane Commands
+### 12.1 Control-plane commands
 
+**Issue a bootstrap token:**
 ```
-# Deploy the catalog with AgentGateway enabled on port 9090
-ai-services catalog configure --runtime podman --agentgateway-port 9090
+ai-services catalog agent issue-token
+```
+Would output a single-use UUID token valid for 24 hours.
 
-# Issue a bootstrap token for a new Worker LPAR (fills agent_id + pre_shared_token)
-ai-services catalog agent issue-token lpar-1
-
-# List all registered agents and their status
+**List all registered agents:**
+```
 ai-services catalog agent list
+```
+Would display agent name, status, labels, last heartbeat, and active command slot count.
 
-# Show a specific agent's live status
-ai-services catalog agent list   # (includes all agents)
+**Delete an agent:**
+```
+ai-services catalog agent delete --name <agent-name>
+```
+Would remove the agent from the in-memory registry and PostgreSQL.
 
-# Remove an agent from the registry
-ai-services catalog agent delete lpar-1
-
-# Start the API server with AgentGateway
-ai-services catalog apiserver --agentgateway-port 9090
+**Start the AgentGateway:**
+```
+ai-services catalog configure --runtime podman --agentgateway-port 9090
 ```
 
-**`issue-token` output** (paste directly into Worker LPAR):
+### 12.2 Worker agent commands
+
+**`agent configure`** — Deploy the worker Caddy proxy pod (run once before `agent start`):
 
 ```
-# Copy the block below to /etc/ai-services/agent.conf on the Worker LPAR.
-# Token expires in 24 h and is single-use.
-# Then run:  ai-services agent start
-#
-# ---- BEGIN agent.conf ----
-control_plane_url: <control-plane-host>:<agentgateway-port>
-agent_id: "lpar-1"
-pre_shared_token: "d3f1a2b4-..."
-labels: {}
-capabilities: {}
-# ---- END agent.conf ----
+ai-services agent configure \
+    --runtime podman              # required; only podman supported
+    [--https-port 443]            # default from values.yaml; can be overridden
+    [--base-dir /var/lib/ai-services]
+    [--domain-name example.com]
+    [--ssl-cert /path/cert.pem --ssl-key /path/key.pem]
 ```
 
-### 10.2 Worker Agent Commands
+- Would be idempotent: always removes and redeploys the Caddy pod.
+- `adminPort` would not be configurable via CLI — always from `values.yaml` (`"0"` = OS-assigned random port).
+- Would persist `DomainSuffix` to `~/.config/ai-services/agent.json`.
+
+**`agent start`** — Register and start the daemon:
 
 ```
-# Register with the control plane and start the daemon (blocking)
-ai-services agent start
+ai-services agent start \
+    --server lpar-0.example.com:9090   # required
+    --name   lpar-1                     # required
+    --token  <uuid>                     # required
+    --runtime podman                    # required; no default
+    [--tls-dir /var/lib/ai-services/agent/tls]
+```
 
-# Show local conf + live connectivity status from control plane
+- Would load `DomainSuffix` from `~/.config/ai-services/agent.json` and send it as `labels["domain_suffix"]`.
+- Would inject a `LocalCaddyManager` into the Podman runtime by inspecting the running Caddy pod.
+- Would reconnect with exponential backoff (5s base, 120s max) on stream failure.
+
+**`agent status`** — Show current agent state:
+```
 ai-services agent status
 ```
 
-**`agent status` output**:
+---
+
+## 13. Configuration Files and Assets
+
+### 13.1 Worker agent config
+
+Proposed path: `~/.config/ai-services/agent.json`
+
+```json
+{
+  "agent_name":    "lpar-1",
+  "server":        "lpar-0.example.com:9090",
+  "domain_suffix": "192.168.1.5.nip.io"
+}
+```
+
+`agent configure` would write `domain_suffix`; `agent start` would write `agent_name` and `server`.
+
+### 13.2 Worker Caddy assets
+
+| File | Purpose |
+|---|---|
+| `assets/agent/podman/values.yaml` | Default values for image, adminPort, httpsPort |
+| `assets/agent/podman/templates/agent-caddy.yaml.tmpl` | Kubernetes-style pod spec for the Caddy pod |
+| `assets/agent/podman/templates/agent-caddyfile.tmpl` | Static Caddyfile written to `<baseDir>/agent/caddy/Caddyfile` |
+
+Assets would be embedded into the binary via `go:embed`.
+
+### 13.3 Domain suffix priority
+
+Both catalog and worker would use the same `ComputeDomainConfig` function with the following priority:
 
 ```
-Local Configuration
--------------------
-Agent ID:       lpar-1
-Control Plane:  control-plane:9090
-Config file:    /etc/ai-services/agent.conf
-Token set:      true
-
-Live Status (from Control Plane)
---------------------------------
-Status:         ready
-Active slots:   0
-Last heartbeat: 2026-07-14T10:23:01Z
-Checked at:     2026-07-14T10:23:05Z
+Priority (highest to lowest):
+  1. SSL certificate CN/SAN  (--ssl-cert provided)
+  2. --domain-name flag
+  3. <workerIP>.nip.io        (auto-detected)
 ```
 
 ---
 
-## 11. Configuration Files
+## 14. Code Structure
 
-### `/etc/ai-services/agent.conf` (Worker LPAR)
-
-```yaml
-control_plane_url: "control-plane.example.com:9090"   # gRPC AgentGateway address
-agent_id: "lpar-1"                                     # unique identifier for this worker
-pre_shared_token: "d3f1a2b4-..."                       # single-use bootstrap token
-labels:
-  zone: "gpu"
-  model: "granite"
-capabilities: {}
-```
-
-The `pre_shared_token` field is only used on the first `agent start`. After registration it is no longer checked by the control plane. In a future mTLS release the agent will use its signed certificate for all subsequent connections.
-
----
-
-## 12. Code Structure
-
-All new code is additive. No existing packages were deleted or renamed.
+The following new packages and files would be introduced. All additions are additive — no existing packages would be deleted or renamed.
 
 ```
 ai-services/
-├── internal/pkg/agent/                         NEW PACKAGE
-│   ├── proto/
-│   │   ├── agent.proto                         gRPC service + message definitions
-│   │   ├── agent.pb.go                         generated
-│   │   └── agent_grpc.pb.go                    generated
-│   ├── registry/
-│   │   └── registry.go                         AgentRegistry + TokenStore
-│   ├── gateway/
-│   │   └── gateway.go                          AgentGateway gRPC server
-│   ├── dispatcher/
-│   │   └── dispatcher.go                       AgentDispatcher (SelectAgent)
-│   ├── agentbootstrap/
-│   │   └── agentbootstrap.go                   worker-side Register + conf loader
-│   └── daemon/
-│       └── daemon.go                           worker daemon (CommandStream loop)
+├── assets/
+│   ├── agent/
+│   │   └── podman/
+│   │       ├── values.yaml
+│   │       └── templates/
+│   │           ├── agent-caddy.yaml.tmpl
+│   │           └── agent-caddyfile.tmpl
+│   └── fs.go                           # AgentFS embed
 │
-├── internal/pkg/runtime/
-│   ├── runtime.go                              MODIFIED: RuntimeTypeRemote added to switch
-│   ├── types/types.go                          MODIFIED: RuntimeTypeRemote constant
-│   └── remote/
-│       └── remote.go                           NEW: RemoteRuntime implementing runtime.Runtime
+├── cmd/ai-services/cmd/agent/
+│   ├── agent.go                        # agent subcommand root
+│   ├── configure.go                    # cobra command: agent configure
+│   ├── start.go                        # cobra command: agent start
+│   └── status.go                       # cobra command: agent status
 │
-├── internal/pkg/catalog/
-│   ├── apiserver/
-│   │   ├── apiserver.go                        MODIFIED: wires Gateway + HeartbeatWatcher
-│   │   ├── router.go                           MODIFIED: /agents routes
-│   │   ├── handlers/
-│   │   │   └── agent_handler.go                NEW: IssueToken, ListAgents, GetAgent, DeleteAgent
-│   │   └── services/deployment/
-│   │       └── executor.go                     MODIFIED: executeRemoteDeployment case
-│   ├── cli/configure/podman/
-│   │   └── reset_agentgateway_port.go          NEW: hot-swap gateway port without full reinstall
-│   ├── client/
-│   │   └── client.go                           MODIFIED: IssueAgentToken, ListAgents, DeleteAgent, GetAgent
-│   ├── db/migrations/assets/
-│   │   └── 20260707000001_create_agents_table.sql  NEW
-│   └── utils/common.go                         MODIFIED: AgentGatewayPort in PodmanConfigureOptions
-│
-├── assets/catalog/podman/
-│   ├── values.yaml                             MODIFIED: backend.agentGatewayPort
-│   └── templates/catalog.yaml.tmpl            MODIFIED: hostPort for AgentGateway container
-│
-└── cmd/ai-services/cmd/
-    ├── root.go                                 MODIFIED: registers `agent` subcommand
-    ├── catalog/
-    │   ├── configure.go                        MODIFIED: --agentgateway-port flag
-    │   ├── apiserver.go                        MODIFIED: --agentgateway-port flag
-    │   └── agent/
-    │       ├── agent.go                        NEW: `catalog agent` subcommand group
-    │       ├── issue_token.go                  NEW: issue-token
-    │       ├── list.go                         NEW: list
-    │       └── delete.go                       NEW: delete
-    └── agent/
-        ├── agent.go                            NEW: `agent` subcommand group
-        ├── start.go                            NEW: agent start
-        └── status.go                           NEW: agent status
+└── internal/pkg/
+    ├── agent/
+    │   ├── proto/
+    │   │   └── agent.proto             # gRPC service + CommandType enum (29 types)
+    │   ├── agentbootstrap/
+    │   │   └── bootstrap.go            # Register() call at agent start
+    │   ├── agentconfig/
+    │   │   └── agentconfig.go          # Load/Save agent.json (AgentName, Server, DomainSuffix)
+    │   ├── configure/
+    │   │   └── configure.go            # DeployAgentCaddy(), BuildAdminURL()
+    │   ├── daemon/
+    │   │   └── daemon.go               # Run() + dispatchToRuntime() (all 29 cases)
+    │   ├── gateway/
+    │   │   └── gateway.go              # AgentGateway gRPC server; captures WorkerIP + DomainSuffix
+    │   ├── httpclient/
+    │   │   └── httpclient.go           # AgentHTTPClient (Get/Post/Do over HTTPProxy)
+    │   └── registry/
+    │       └── registry.go             # Registry, AgentEntry, TokenStore
+    │
+    ├── constants/
+    │   └── common.go                   # AgentCaddyServerName, CaddyServerName (additions)
+    │
+    ├── proxy/
+    │   ├── caddy.go                    # CaddyManager: RegisterRoute, UnregisterRoute, etc.
+    │   ├── caddy_adapter.go            # LocalCaddyManagerAdapter (proxy → podman interface)
+    │   ├── runtime_proxy_manager.go    # RuntimeProxyManager: routes over gRPC
+    │   ├── types.go                    # ProxyManager interface, Route type
+    │   └── utils.go                    # GetCaddyAdminPort, BuildRoutesFromAnnotation
+    │
+    └── runtime/
+        ├── interface.go                # Runtime interface (additions: proxy + HTTPProxy methods)
+        ├── types/
+        │   └── types.go                # ProxyRoute, HTTPProxyResponse (additions)
+        ├── podman/
+        │   └── podman.go               # HTTPProxy + resolvePodNameInURL (additions)
+        ├── remote/
+        │   └── remote.go               # RemoteRuntime: all 29 methods, WorkerIP(), DomainSuffix()
+        └── openshift/
+            └── openshift.go            # proxy + HTTPProxy stubs (unsupported, return error)
 ```
 
 ---
 
-## 13. Before vs After Comparison
+## 15. Security Design
+
+### 15.1 Bootstrap token
+
+- UUID v4, single-use, 24-hour expiry.
+- Would be stored in-memory in a `TokenStore`; destroyed on process restart (operator would need to re-issue).
+- Not bound to an agent name at issuance: the agent would supply its own name at registration time.
+- Operators should rotate tokens regularly; a leaked token could not be used twice.
+
+### 15.2 Transport encryption
+
+The initial implementation would use plaintext gRPC (`insecure.NewCredentials()`) for simplicity. `RegisterResponse` would include reserved `tls_cert_pem` / `tls_key_pem` fields for a future mTLS upgrade (see §17).
+
+Once mTLS is in place, all traffic over the gRPC stream — including `COMMAND_TYPE_HTTP_PROXY` payloads — would be encrypted end-to-end. No additional payload-level encryption would be needed.
+
+### 15.3 Admin API isolation
+
+The worker Caddy admin port (`2019`) would be bound exclusively to `127.0.0.1` on the host. It would be unreachable from outside the Worker LPAR. Only the agent daemon (running on the same host) would be able to manage routes.
+
+### 15.4 Outbound-only from worker
+
+The Worker LPAR would initiate all connections outbound to the control plane. No inbound ports would need to be opened on the Worker for the gRPC stream. Only `:443` would need to be reachable for external HTTPS traffic to deployed service pods.
+
+### 15.5 Future: mTLS
+
+The gateway would be designed to issue a short-lived client certificate per agent upon registration. The daemon would then use this certificate for all subsequent `CommandStream` connections, replacing the plaintext transport.
+
+---
+
+## 16. Current vs Proposed Comparison
 
 ### Deployment path
 
-| Aspect | Before | After |
+| | Current | Proposed |
 |---|---|---|
-| Podman target | Same LPAR as catalog | Any registered Worker LPAR |
-| Runtime selection | `--runtime podman` only | `--runtime podman` (local) or `--runtime remote` (agent) |
-| `runtime.Runtime` interface | Unchanged | Unchanged |
-| Deployer code | Unchanged | Unchanged |
-| Agent selection | N/A | Label selector on request; round-robin READY agents |
+| Target LPAR | Control-plane only | Any registered Worker LPAR |
+| Runtime dispatch | Direct Podman API call | gRPC command over agent stream |
+| Deployer selection | Fixed `PodmanDeployer` | `RemoteRuntime` wraps `PodmanDeployer` transparently |
+| Pod networking | Local Podman | Worker Podman via gRPC |
 
-### Operational
+### External routing
 
-| Aspect | Before | After |
+| | Current | Proposed |
 |---|---|---|
-| Worker visibility | N/A | `ai-services catalog agent list` |
-| Worker health | N/A | Heartbeat every 30 s; auto-DISCONNECTED after 90 s |
-| Worker registration | N/A | `ai-services agent start` (token-based) |
-| Worker removal | N/A | `ai-services catalog agent delete <id>` |
+| HTTPS entry point | Control-plane Caddy only | Per-worker Caddy instance |
+| Route registration | Local Caddy Admin API | `COMMAND_TYPE_REGISTER_PROXY_ROUTE` over gRPC |
+| Domain suffix | `DOMAIN_SUFFIX` env var (control plane) | `DomainSuffix` from `RegisterRequest.Labels["domain_suffix"]` |
 
-### Protocol
+### Internal HTTP access
 
-```
-Before:
-  Catalog API ──► Podman socket (Unix socket, same host)
-
-After (remote path):
-  Catalog API ──► AgentGateway :9090 (gRPC, TCP) ──► agent daemon ──► Podman socket
-                                 bidirectional stream
-```
+| | Current | Proposed |
+|---|---|---|
+| Control plane → pod | Direct TCP (same host) | `COMMAND_TYPE_HTTP_PROXY` over gRPC stream |
+| Pod name resolution | OS resolver | `InspectPod` → `InspectContainer` → `NetworkSettings.IPAddress` |
+| New port required | N/A | No — reuses existing gRPC stream |
 
 ---
 
-## 14. Security Design
-
-| Concern | Current implementation | Planned (future) |
-|---|---|---|
-| Bootstrap token | Single-use UUID, 24h TTL, in-memory store | Persist to DB for restart safety |
-| Transport | Plaintext gRPC (`insecure.NewCredentials()`) | mTLS — CA on control plane signs agent cert during `RegisterResponse` |
-| Command authorisation | Agent trusts any command arriving on the stream | Agent verifies peer cert CN matches control-plane hostname |
-| Secret payloads | Podman secrets passed inside gRPC payload | Encrypted in transit once mTLS is enabled |
-| Token rotation | Re-run `agent start` with a new token | Admin revokes cert; agent re-registers |
-
-The mTLS stubs are already present in the proto (`tls_cert_pem`, `tls_key_pem` fields in `RegisterResponse`) and in `agentbootstrap.writeTLSMaterial()`. The gateway currently returns empty strings for those fields.
-
----
-
-## 15. Future Work
+## 17. Future Work
 
 | Item | Notes |
 |---|---|
-| **mTLS** | Control-plane CA signs a per-agent cert during `Register`; agent uses it for all subsequent `CommandStream` connections |
-| **Token DB persistence** | In-memory `TokenStore` is lost on catalog restart; persist issued tokens to PostgreSQL |
-| **Agent drain** | Admin-triggered graceful drain: accept no new commands, wait for in-flight to complete, then `DISCONNECTED` |
-| **Weighted selection** | Prefer agents with fewer active slots or specific capability labels |
-| **OpenShift remote** | Route + passthrough TLS instead of `hostPort` for OCP deployments |
-| **Metrics** | Prometheus counters for commands dispatched, errors, latency per agent |
+| mTLS | `RegisterResponse` would have reserved cert fields. The gateway should issue short-lived client certs per agent on registration. |
+| Token persistence | The in-memory `TokenStore` would be lost on process restart. Consider a PostgreSQL-backed token store. |
+| `BUSY` status | `AgentStatusBusy` would be defined but not actively set. In-flight command count tracking should be added. |
+| Agent draining | `AgentStatusDraining` would be defined. Graceful drain before `agent stop` should be implemented. |
+| Streaming logs | `POD_LOGS` / `CONTAINER_LOGS` would return once complete. True streaming would require a different wire protocol (server-side streaming RPC). |
+| OpenShift worker | `OpenshiftClient` proxy methods would return `unsupported`. Future iterations could add OpenShift-based worker LPAR support. |
+| Token UI | `issue-token` would output a raw token to stdout. Expiry display and active token listing should be added. |
+| Models directory | Each worker can have its own custom directory that can be set agent data and used during remote application deployment. |
+| Application management | Each application must have the target location which can be used by other applications related flow eg: delete, logs, etc. |

--- a/docs/proposals/catalog/remote-worker-agent-proposal.md
+++ b/docs/proposals/catalog/remote-worker-agent-proposal.md
@@ -278,14 +278,14 @@ sequenceDiagram
     participant TS as TokenStore
     participant REG as Registry
 
-    W->>GW: Register(token, runtime_type, metadata={})
+    W->>GW: Register(token, runtime_type, metadata)
     GW->>TS: Validate(token)
-    TS-->>GW: OK (token marked used; worker_name bound to token)
+    TS-->>GW: OK (worker_name bound to token)
     GW->>REG: Upsert(worker_name, runtime_type, metadata)
-    GW-->>W: RegisterResponse{worker_name: "lpar-1"}
+    GW-->>W: RegisterResponse{worker_name}
 
-    W->>GW: CommandStream — Send(CommandResult{is_heartbeat:true, worker_name:"lpar-1"})
-    GW->>REG: MarkReady("lpar-1")
+    W->>GW: CommandStream.Send(heartbeat, worker_name)
+    GW->>REG: MarkReady(worker_name)
     Note over W,GW: stream open — awaiting Commands
 ```
 

--- a/docs/proposals/catalog/remote-worker-agent-proposal.md
+++ b/docs/proposals/catalog/remote-worker-agent-proposal.md
@@ -694,10 +694,19 @@ ai-services worker join <gateway>        # required positional: host:port of cat
 - Would inject a `LocalCaddyManager` into the Podman runtime by inspecting the running Caddy pod.
 - Would reconnect with exponential backoff (5s base, 120s max) on stream failure.
 
-**`worker status`** — Show current worker state:
+**`worker uninstall`** — Best-effort reversion of all changes made by `worker join`:
+
 ```bash
-ai-services worker status
+ai-services worker uninstall \
+    --runtime podman                     # required; no default
+    [--basedir /var/lib/ai-services]
+    [--yes]                              # skip confirmation prompt
 ```
+
+- Stops and removes the `ai-services--worker-caddy` Podman pod.
+- Removes the Caddy data and config directories under `<basedir>/worker/`.
+- Best-effort: failures on individual steps are logged as warnings and do not abort the overall uninstall.
+- Does **not** contact the control plane — run `ai-services catalog worker delete <id>` on the control plane separately to deregister the worker from the catalog.
 
 ### 12.3 REST API
 
@@ -796,7 +805,7 @@ ai-services/
 ├── cmd/ai-services/cmd/worker/
 │   ├── worker.go                        # worker subcommand root
 │   ├── join.go                         # cobra command: worker join
-│   └── status.go                       # cobra command: worker status
+│   └── uninstall.go                    # cobra command: worker uninstall
 │
 └── internal/pkg/
     ├── worker/

--- a/docs/proposals/catalog/remote-worker-agent-proposal.md
+++ b/docs/proposals/catalog/remote-worker-agent-proposal.md
@@ -141,84 +141,92 @@ sequenceDiagram
 
 ### 5.1 Service Definition
 
-The proposed `WorkerGateway` gRPC service would be defined as follows:
+The `WorkerGateway` gRPC service is defined as follows:
 
 ```protobuf
 service WorkerGateway {
-  // One-time call at bootstrap time.
+  // Register is called once by a new worker at bootstrap time.
   rpc Register(RegisterRequest) returns (RegisterResponse);
 
-  // Long-lived bidirectional stream.
-  // Worker initiates; sends CommandResult, receives Command.
+  // CommandStream is a long-lived bidirectional stream.
+  // The worker initiates the stream and sends CommandResult messages;
+  // the control plane sends Command messages.
   rpc CommandStream(stream CommandResult) returns (stream Command);
 }
 
 message RegisterRequest {
-  string worker_name       = 1;
-  string pre_shared_token = 2;
-  map<string, string> labels       = 3;  // would include "domain_suffix"
-  map<string, string> capabilities = 4;
+  string              worker_name      = 1;
+  string              pre_shared_token = 2;
+  map<string, string> metadata         = 3; // e.g. {"domain_suffix": "192.168.1.5.nip.io"}
+  string              runtime_type     = 4; // "podman" or "openshift"
+}
+
+message RegisterResponse {
+  string worker_name  = 1;
+  // Reserved for future mTLS support.
+  string tls_cert_pem = 2;
+  string tls_key_pem  = 3;
 }
 
 message Command {
   string      command_id = 1;
   CommandType type       = 2;
-  bytes       payload    = 3; // JSON-encoded
+  bytes       payload    = 3; // JSON-encoded type-specific payload
 }
 
 message CommandResult {
   string command_id   = 1;
   bool   success      = 2;
-  bytes  data         = 3; // JSON-encoded response
+  bytes  data         = 3; // JSON-encoded response payload
   string error        = 4;
   bool   is_heartbeat = 5;
-  string worker_name   = 6;
+  string worker_name  = 6; // set on first result and every heartbeat
 }
 ```
 
 ### 5.2 Command Types
 
-The `CommandType` enum would cover all 29 operations needed to proxy the full `runtime.Runtime` interface:
+The `CommandType` enum covers all 29 operations needed to proxy the full `runtime.Runtime` interface:
 
 | Value | Name | Payload | Description |
 |---|---|---|---|
-| 0 | `UNSPECIFIED` | — | Default / error |
-| 1 | `LIST_IMAGES` | `{}` | List local images |
-| 2 | `PULL_IMAGE` | `{Image}` | Pull an image |
-| 3 | `LIST_PODS` | `{Filters}` | List pods with optional filters |
-| 4 | `CREATE_POD` | `{Body, Opts}` | `podman kube play` |
-| 5 | `DELETE_POD` | `{ID, Force}` | Remove a pod |
-| 6 | `STOP_POD` | `{ID}` | Stop a pod |
-| 7 | `START_POD` | `{ID}` | Start a pod |
-| 8 | `INSPECT_POD` | `{NameOrID}` | Inspect pod details + port bindings |
-| 9 | `POD_EXISTS` | `{NameOrID}` | Boolean existence check |
-| 10 | `POD_LOGS` | `{NameOrID}` | Stream pod logs |
-| 11 | `GET_POD_RESOURCES` | `{NameOrID}` | CPU / memory / accelerator usage |
-| 12 | `LIST_SECRETS` | `{Filters}` | List secrets |
-| 13 | `DELETE_SECRET` | `{Name}` | Remove a secret |
-| 14 | `SECRET_EXISTS` | `{NameOrID}` | Boolean existence check |
-| 15 | `DELETE_VOLUME` | `{Name}` | Remove a volume |
-| 16 | `VOLUME_EXISTS` | `{NameOrID}` | Boolean existence check |
-| 17 | `INSPECT_CONTAINER` | `{NameOrID}` | Inspect container details |
-| 18 | `CONTAINER_EXISTS` | `{NameOrID}` | Boolean existence check |
-| 19 | `CONTAINER_LOGS` | `{ContainerNameOrID}` | Stream container logs |
-| 20 | `LIST_ROUTES` | `{}` | List OpenShift routes (stub on Podman) |
-| 21 | `DELETE_PVCS` | `{AppLabel}` | Delete PVCs (OpenShift only) |
-| 22 | `GET_SYSTEM_INFO` | `{}` | CPU / memory / Spyre card info |
-| 23 | `RUNTIME_TYPE` | `{}` | Returns `"podman"` or `"openshift"` |
-| 24 | `RUN_EPHEMERAL_CONTAINER` | `{Image, Cmd, Mounts}` | One-shot container |
-| 25 | `REGISTER_PROXY_ROUTE` | `{ID, Domain, Upstream, Terminal, Type}` | Add route to worker Caddy |
-| 26 | `UNREGISTER_PROXY_ROUTE` | `{RouteID}` | Remove route from worker Caddy |
-| 27 | `GET_PROXY_ROUTE` | `{RouteID}` | Fetch route from worker Caddy |
-| 28 | `PROXY_HEALTH_CHECK` | `{}` | Verify worker Caddy is reachable |
-| 29 | `HTTP_PROXY` | `{Method, TargetURL, Headers, Body}` | Tunnel HTTP request to worker pod |
+| 0 | `COMMAND_TYPE_UNSPECIFIED` | — | Default / error |
+| 1 | `COMMAND_TYPE_LIST_IMAGES` | `{}` | List local images |
+| 2 | `COMMAND_TYPE_PULL_IMAGE` | `{Image}` | Pull an image |
+| 3 | `COMMAND_TYPE_LIST_PODS` | `{Filters}` | List pods with optional filters |
+| 4 | `COMMAND_TYPE_CREATE_POD` | `{Body, Opts}` | `podman kube play` |
+| 5 | `COMMAND_TYPE_DELETE_POD` | `{ID, Force}` | Remove a pod |
+| 6 | `COMMAND_TYPE_STOP_POD` | `{ID}` | Stop a pod |
+| 7 | `COMMAND_TYPE_START_POD` | `{ID}` | Start a pod |
+| 8 | `COMMAND_TYPE_INSPECT_POD` | `{NameOrID}` | Inspect pod details + port bindings |
+| 9 | `COMMAND_TYPE_POD_EXISTS` | `{NameOrID}` | Boolean existence check |
+| 10 | `COMMAND_TYPE_POD_LOGS` | `{NameOrID}` | Stream pod logs |
+| 11 | `COMMAND_TYPE_GET_POD_RESOURCES` | `{NameOrID}` | CPU / memory / accelerator usage |
+| 12 | `COMMAND_TYPE_LIST_SECRETS` | `{Filters}` | List secrets |
+| 13 | `COMMAND_TYPE_DELETE_SECRET` | `{Name}` | Remove a secret |
+| 14 | `COMMAND_TYPE_SECRET_EXISTS` | `{NameOrID}` | Boolean existence check |
+| 15 | `COMMAND_TYPE_DELETE_VOLUME` | `{Name}` | Remove a volume |
+| 16 | `COMMAND_TYPE_VOLUME_EXISTS` | `{NameOrID}` | Boolean existence check |
+| 17 | `COMMAND_TYPE_INSPECT_CONTAINER` | `{NameOrID}` | Inspect container details |
+| 18 | `COMMAND_TYPE_CONTAINER_EXISTS` | `{NameOrID}` | Boolean existence check |
+| 19 | `COMMAND_TYPE_CONTAINER_LOGS` | `{ContainerNameOrID}` | Stream container logs |
+| 20 | `COMMAND_TYPE_LIST_ROUTES` | `{}` | List OpenShift routes (stub on Podman) |
+| 21 | `COMMAND_TYPE_DELETE_PVCS` | `{AppLabel}` | Delete PVCs (OpenShift only) |
+| 22 | `COMMAND_TYPE_GET_SYSTEM_INFO` | `{}` | CPU / memory / Spyre card info |
+| 23 | `COMMAND_TYPE_RUNTIME_TYPE` | `{}` | Returns `"podman"` or `"openshift"` |
+| 24 | `COMMAND_TYPE_RUN_EPHEMERAL_CONTAINER` | `{Image, Cmd, Mounts}` | One-shot container |
+| 25 | `COMMAND_TYPE_REGISTER_PROXY_ROUTE` | `{ID, Domain, Upstream, Terminal, Type}` | Add route to worker Caddy |
+| 26 | `COMMAND_TYPE_UNREGISTER_PROXY_ROUTE` | `{RouteID}` | Remove route from worker Caddy |
+| 27 | `COMMAND_TYPE_GET_PROXY_ROUTE` | `{RouteID}` | Fetch route from worker Caddy |
+| 28 | `COMMAND_TYPE_PROXY_HEALTH_CHECK` | `{}` | Verify worker Caddy is reachable |
+| 29 | `COMMAND_TYPE_HTTP_PROXY` | `{Method, TargetURL, Headers, Body}` | Tunnel HTTP request to worker pod |
 
 ### 5.3 Protocol Flow
 
 **Heartbeat mechanism:**
-- The worker would send a heartbeat `CommandResult{is_heartbeat: true}` immediately on stream open as the first message (used by the gateway to identify the worker).
-- A background goroutine on the worker would send heartbeats every **30 seconds**.
-- The gateway would mark an worker `DISCONNECTED` if no heartbeat is received for **90 seconds** (checked every 30 seconds).
+- The worker sends `CommandResult{is_heartbeat: true, worker_name: "<name>"}` as the very first message on stream open. The gateway uses `worker_name` from this message to identify and look up the registry entry.
+- A background goroutine on the worker sends heartbeats every **30 seconds** thereafter.
+- The gateway marks a worker `DISCONNECTED` if no heartbeat is received for **90 seconds** (sweeper runs every 30 seconds).
 
 **Command flow:**
 1. Control plane calls `RemoteRuntime.SomeMethod()`.

--- a/docs/proposals/catalog/remote-worker-agent-proposal.md
+++ b/docs/proposals/catalog/remote-worker-agent-proposal.md
@@ -13,7 +13,7 @@
 9. [Deployment Execution Flow](#9-deployment-execution-flow)
 10. [Worker Registry and State Machine](#10-worker-registry-and-state-machine)
 11. [Database Schema](#11-database-schema)
-12. [CLI Commands](#12-cli-commands)
+12. [CLI Commands and REST API](#12-cli-commands)
 13. [Configuration Files and Assets](#13-configuration-files-and-assets)
 14. [Code Structure](#14-code-structure)
 15. [Security Design](#15-security-design)
@@ -270,23 +270,18 @@ sequenceDiagram
     participant TS as TokenStore
     participant REG as Registry
 
-    W->>GW: Register(worker_name="lpar-1", token, labels={domain_suffix})
+    W->>GW: Register(token, runtime_type, metadata={})
     GW->>TS: Validate(token)
-    TS-->>GW: OK (token marked used)
-    GW->>REG: Upsert(req)
-    GW->>REG: MarkReady("lpar-1")
+    TS-->>GW: OK (token marked used; worker_name bound to token)
+    GW->>REG: Upsert(worker_name, runtime_type, metadata)
     GW-->>W: RegisterResponse{worker_name: "lpar-1"}
 
     W->>GW: CommandStream — Send(CommandResult{is_heartbeat:true, worker_name:"lpar-1"})
-    GW->>REG: SetWorkerIP("lpar-1", "192.168.1.5")
-    GW->>REG: SetDomainSuffix("lpar-1", "192.168.1.5.nip.io")
     GW->>REG: MarkReady("lpar-1")
     Note over W,GW: stream open — awaiting Commands
 ```
 
-**Worker IP capture:** The gateway would read the TCP source IP from the gRPC peer info on the stream context. This would be the address of the Worker LPAR as seen from the control plane.
-
-**Domain suffix propagation:** `worker join` would compute the domain suffix (cert CN > `--domain-name` > `workerIP.nip.io`) and send it as `labels["domain_suffix"]` in `RegisterRequest` directly at startup. The gateway would extract it and store it in `WorkerEntry.DomainSuffix`. No configuration file is used to store this information on disk.
+**Domain suffix:** The worker will send `domain_suffix` as `metadata["domain_suffix"]` in `RegisterRequest`. The gateway stores this directly in the `workers.metadata` column via `WorkerRepository`. The `RegisterRequest.metadata` map (proto field 3) is the designated carrier for this value.
 
 ---
 
@@ -355,7 +350,7 @@ The proposed Caddyfile:
    - If **already running**: skip deployment — the existing pod and its port bindings are reused.
 4. Resolve the admin URL: inspect the running pod → find the `2019/tcp` host port → `http://localhost:<port>`.
 5. Health-check the Caddy admin API.
-6. Compute the domain suffix (`workerIP.nip.io`) and pass it directly to the registration payload.
+6. The worker computes `<workerIP>.nip.io` and sends it as `metadata["domain_suffix"]` in `RegisterRequest`. The gateway persists it to the DB via `WorkerRepository`.
 
 **Idempotency.** Re-running `worker join` writes a fresh Caddyfile but leaves a running Caddy pod untouched. To force a re-deploy (e.g. after a port change), the operator must manually remove the pod first.
 
@@ -406,7 +401,7 @@ This would dispatch `COMMAND_TYPE_REGISTER_PROXY_ROUTE` over gRPC. The daemon wo
 POST http://localhost:<port>/config/apps/http/servers/ai_services_worker/routes
 ```
 
-**Domain suffix for worker routes** would come from `RemoteRuntime.DomainSuffix()` — read from the worker's registry entry, populated from `labels["domain_suffix"]` at stream open. The worker's domain suffix would be independent of the control-plane's `DOMAIN_SUFFIX` env var.
+**Domain suffix for worker routes** would come from `RemoteRuntime.DomainSuffix()` — read from the worker's DB entry, populated from `metadata["domain_suffix"]` sent by the worker in `RegisterRequest`. The worker's domain suffix is independent of the control-plane's `DOMAIN_SUFFIX` env var.
 
 ### 7.7 Upstream uses pod IP, not pod name
 
@@ -555,43 +550,42 @@ sequenceDiagram
 
 ### 10.1 Proposed WorkerEntry fields
 
+The in-memory `WorkerEntry` holds only the live gRPC plumbing. All durable fields live in the database.
+
 ```go
 type WorkerEntry struct {
-    WorkerName     string
-    Labels        map[string]string  // would include "domain_suffix"
-    Capabilities  map[string]string
-    Status        WorkerStatus
-    LastHeartbeat time.Time
-    RegisteredAt  time.Time
-    WorkerIP      string    // TCP source IP from gRPC peer info
-    DomainSuffix  string    // from labels["domain_suffix"] at stream open
-    CommandCh     chan *Command  // capacity 32
-    results       map[string]chan *CommandResult
+    DBID       uuid.UUID                       // UUID assigned by DB on first Upsert
+    WorkerName string
+
+    // CommandCh is written by RemoteRuntime to dispatch commands to the worker.
+    // The gateway goroutine drains it and writes to the gRPC stream.
+    CommandCh  chan *workerpb.Command           // capacity 32
+    results    map[string]chan *CommandResult   // result routing by command ID (mu-protected)
 }
 ```
+
+`Status`, `LastHeartbeat`, `Metadata` are **not** stored in `WorkerEntry`. Durable state (status, metadata, heartbeat) is owned by the `WorkerRepository` and the PostgreSQL `workers` table.
 
 ### 10.2 Status state machine
 
 ```mermaid
 stateDiagram-v2
-    [*] --> PENDING : Register() called
+    [*] --> PENDING : Preregister() called (CLI: catalog worker register)
 
-    PENDING --> READY : token validated\nCommandStream open
-    PENDING --> REJECTED : invalid / expired token
+    PENDING --> READY : token validated\nRegister() + CommandStream open
+    PENDING --> PENDING : invalid / expired token (worker retries)
 
-    READY --> BUSY : command in-flight
-    BUSY --> READY : result delivered
     READY --> READY : heartbeat received
 
     READY --> DISCONNECTED : heartbeat timeout (90s)
-    BUSY --> DISCONNECTED : heartbeat timeout (90s)
     DISCONNECTED --> DISCONNECTED : stream closed
 
-    DISCONNECTED --> PENDING : worker re-registers
-    REJECTED --> PENDING : worker re-registers
+    DISCONNECTED --> READY : worker re-registers (Register() + new stream)
 ```
 
-Proposed status values: `pending`, `ready`, `busy`, `draining`, `disconnected`, `rejected`.
+Implemented status values: `pending`, `ready`, `disconnected`.
+
+> `busy` and `draining` are defined as future work (§17); they are not set by the current implementation.
 
 ### 10.3 Worker selection
 
@@ -608,21 +602,46 @@ A background goroutine would sweep all `READY`/`BUSY` workers every 30 seconds. 
 
 ## 11. Database Schema
 
-A new `workers` table would persist worker state across catalog restarts:
+A new `workers` table would persist worker state across catalog restarts. Status and runtime type are typed PostgreSQL enums:
 
 ```sql
-CREATE TABLE workers (
-    worker_name     TEXT PRIMARY KEY,
-    labels         JSONB        NOT NULL DEFAULT '{}',
-    capabilities   JSONB        NOT NULL DEFAULT '{}',
-    status         TEXT         NOT NULL DEFAULT 'pending',
-    last_heartbeat TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
-    registered_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
-    updated_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+-- Worker runtime type enum
+CREATE TYPE worker_runtime_type AS ENUM (
+    'unknown',    -- initial value set at pre-registration; replaced when worker connects
+    'podman',
+    'openshift'
 );
+
+-- Worker status enum
+CREATE TYPE worker_status AS ENUM (
+    'pending',
+    'ready',
+    'disconnected'
+);
+
+CREATE TABLE workers (
+    id             UUID                PRIMARY KEY DEFAULT gen_random_uuid(),
+    name           TEXT                NOT NULL UNIQUE,
+    runtime_type   worker_runtime_type NOT NULL DEFAULT 'unknown',
+    status         worker_status       NOT NULL DEFAULT 'pending',
+    last_heartbeat TIMESTAMPTZ,                    -- NULL until first heartbeat
+    metadata       JSONB,                          -- arbitrary key/value (includes domain_suffix)
+    registered_at  TIMESTAMPTZ         NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMPTZ         NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX ON workers(status);
+CREATE INDEX ON workers(runtime_type);
 ```
 
-The in-memory `Registry` would be the primary source of truth for live routing decisions. The database would provide durability so that `ai-services catalog worker list` works correctly after a catalog restart.
+Key changes from the original sketch:
+- **`id UUID`** replaces `worker_name TEXT` as the primary key; `name` is `UNIQUE`.
+- **`runtime_type` enum** replaces a plain TEXT column; `'unknown'` is the value at pre-registration time, before the worker connects and declares its environment.
+- **`metadata JSONB`** (nullable) 
+Domain suffix and any other per-worker key/value pairs are stored here.
+- **`last_heartbeat` is nullable** — `NULL` until the first heartbeat arrives; no default `NOW()`.
+
+The in-memory `Registry` is the primary source of truth for live routing decisions. The database provides durability so that `ai-services catalog worker list` works correctly after a catalog restart.
 
 ---
 
@@ -640,13 +659,13 @@ Pre-registers the worker by name in the catalog and outputs a single-use UUID to
 ```
 ai-services catalog worker list
 ```
-Would display worker name, status, labels, last heartbeat, and active command slot count.
+Would display worker ID, name, runtime type, status, metadata, and last heartbeat.
 
-**Delete an worker:**
+**Delete a worker:**
 ```
-ai-services catalog worker delete --name <worker-name>
+ai-services catalog worker delete <worker-id>
 ```
-Would remove the worker from the in-memory registry and PostgreSQL.
+Would remove the worker from the in-memory registry and PostgreSQL by UUID.
 
 **Start the WorkerGateway:**
 ```
@@ -671,7 +690,7 @@ ai-services worker join <gateway>        # required positional: host:port of cat
 - **Single command, no pre-steps.** There is no `bootstrap configure` or `worker configure` to run first.
 - **Caddy is deployed only if not already running.** Re-joining leaves a live Caddy pod untouched.
 - `adminPort` would not be configurable via CLI — always from `values.yaml` (`"0"` = OS-assigned random port).
-- Would compute the domain suffix and keep it in-memory to send it directly as `labels["domain_suffix"]` in `RegisterRequest`.
+- Would compute the domain suffix (`<workerIP>.nip.io`) and send it as `metadata["domain_suffix"]` in `RegisterRequest`.
 - Would inject a `LocalCaddyManager` into the Podman runtime by inspecting the running Caddy pod.
 - Would reconnect with exponential backoff (5s base, 120s max) on stream failure.
 
@@ -679,6 +698,55 @@ ai-services worker join <gateway>        # required positional: host:port of cat
 ```bash
 ai-services worker status
 ```
+
+### 12.3 REST API
+
+The Catalog API Server exposes three worker management endpoints under `/api/v1/workers`:
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/v1/workers` | Pre-register a new worker; returns a single-use bootstrap token |
+| `GET` | `/api/v1/workers` | List all registered workers and their current status |
+| `DELETE` | `/api/v1/workers/{id}` | Deregister a worker by UUID |
+
+**`POST /api/v1/workers`**
+
+Request:
+```json
+{ "worker_name": "lpar-1" }
+```
+
+Response `201 Created`:
+```json
+{
+  "worker_name": "lpar-1",
+  "token": "<uuid>"
+}
+```
+
+**`GET /api/v1/workers`**
+
+Response `200 OK` — array of worker objects:
+```json
+[
+  {
+    "id":             "550e8400-e29b-41d4-a716-446655440000",
+    "name":           "lpar-1",
+    "runtime_type":   "podman",
+    "status":         "ready",
+    "last_heartbeat": "2026-08-21T12:00:00Z",
+    "metadata":       { "domain_suffix": "192.168.1.5.nip.io" },
+    "registered_at":  "2026-08-20T10:00:00Z",
+    "updated_at":     "2026-08-21T12:00:00Z"
+  }
+]
+```
+
+**`DELETE /api/v1/workers/{id}`**
+
+- Path parameter `id` is the UUID from the registration response.
+- Response `204 No Content` on success; `404` if not found.
+- Removes the worker from both the in-memory registry and PostgreSQL.
 
 ---
 
@@ -693,20 +761,19 @@ ai-services worker status
 | File | Purpose |
 |---|---|
 | `assets/worker/podman/values.yaml` | Default values for image, adminPort, httpsPort |
-| `assets/worker/podman/templates/worker-caddy.yaml.tmpl` | Kubernetes-style pod spec for the Caddy pod |
-| `assets/worker/podman/templates/worker-caddyfile.tmpl` | Static Caddyfile written to `<baseDir>/worker/caddy/Caddyfile` |
+| `assets/worker/podman/templates/caddy.yaml.tmpl` | Kubernetes-style pod spec for the Caddy pod |
+| `assets/worker/podman/Caddyfile.tmpl` | Static Caddyfile written to `<baseDir>/worker/caddy/Caddyfile` |
 
-Assets would be embedded into the binary via `go:embed`.
+Assets are embedded into the binary via `go:embed` using `assets.WorkerFS`.
 
-### 13.3 Domain suffix priority
+### 13.3 Domain suffix
 
-Both catalog and worker would use the same `ComputeDomainConfig` function with the following priority:
+The worker computes its domain suffix and sends it as `metadata["domain_suffix"]` inside `RegisterRequest` every time it registers. The gateway passes this through to `WorkerRepository.Upsert()`, where it is persisted in the `workers.metadata` JSONB column.
+
+The default value computed by the worker is:
 
 ```
-Priority (highest to lowest):
-  1. SSL certificate CN/SAN  (--ssl-cert provided)
-  2. --domain-name flag
-  3. <workerIP>.nip.io        (auto-detected)
+<workerIP>.nip.io
 ```
 
 ---
@@ -742,7 +809,7 @@ ai-services/
     │   ├── daemon/
     │   │   └── daemon.go               # Run() + dispatchToRuntime() (all 29 cases)
     │   ├── gateway/
-    │   │   └── gateway.go              # WorkerGateway gRPC server; captures WorkerIP + DomainSuffix
+    │   │   └── gateway.go              # WorkerGateway gRPC server; persists worker-supplied domain_suffix to DB
     │   ├── httpclient/
     │   │   └── httpclient.go           # WorkerHTTPClient (Get/Post/Do over HTTPProxy)
     │   └── registry/
@@ -765,7 +832,7 @@ ai-services/
         ├── podman/
         │   └── podman.go               # HTTPProxy + resolvePodNameInURL (additions)
         ├── remote/
-        │   └── remote.go               # RemoteRuntime: all 29 methods, WorkerIP(), DomainSuffix()
+        │   └── remote.go               # RemoteRuntime: all 29 methods, DomainSuffix()
         └── openshift/
             └── openshift.go            # proxy + HTTPProxy stubs (unsupported, return error)
 ```
@@ -778,7 +845,7 @@ ai-services/
 
 - UUID v4, single-use, 24-hour expiry.
 - Would be stored in-memory in a `TokenStore`; destroyed on process restart (operator would need to re-issue).
-- Not bound to an worker name at issuance: the worker would supply its own name at registration time.
+- Bound to a worker name at issuance via `Preregister()`: the worker name is set by the control-plane operator at token-issue time and is not trusted from the worker's `RegisterRequest`.
 - Operators should rotate tokens regularly; a leaked token could not be used twice.
 
 ### 15.2 Transport encryption
@@ -818,7 +885,7 @@ The gateway would be designed to issue a short-lived client certificate per work
 |---|---|---|
 | HTTPS entry point | Control-plane Caddy only | Per-worker Caddy instance |
 | Route registration | Local Caddy Admin API | `COMMAND_TYPE_REGISTER_PROXY_ROUTE` over gRPC |
-| Domain suffix | `DOMAIN_SUFFIX` env var (control plane) | `DomainSuffix` from `RegisterRequest.Labels["domain_suffix"]` |
+| Domain suffix | `DOMAIN_SUFFIX` env var (control plane) | `DomainSuffix` from `RegisterRequest.metadata["domain_suffix"]` (sent by worker) |
 
 ### Internal HTTP access
 

--- a/docs/proposals/catalog/remote-worker-agent-proposal.md
+++ b/docs/proposals/catalog/remote-worker-agent-proposal.md
@@ -302,7 +302,7 @@ Each Worker LPAR would run its own Caddy instance for externally-visible HTTPS r
 - **Same pattern as catalog Caddy.** The catalog configure command deploys a Caddy pod; the proposed `worker join` command would do the same for the worker.
 - **Deploy-once semantics.** The Caddy pod is deployed only if it is not already running. Once up, its configuration is considered immutable — re-running `worker join` will not redeploy or restart the pod.
 - **Admin port always random.** Setting `adminPort: "0"` in `values.yaml` would cause the OS to assign a random loopback port, resolved at runtime by inspecting the running pod.
-- **No `--resume`.** Worker Caddy would not use `caddy run --resume` to avoid stale autosave state from a previous server name.
+- **Uses `--resume`.** Worker Caddy runs with `caddy run --config /data/caddy/Caddyfile --resume`. On restart, Caddy reloads its autosaved config from `/config/caddy/autosave.json` (persisted to `<baseDir>/worker/caddy-config` on the host), so dynamically registered routes survive pod restarts without needing to be re-registered.
 - **Server name `ai_services_worker`.** The Caddyfile global block would name the `:443` server `ai_services_worker`, so routes would be POSTed to `.../servers/ai_services_worker/routes`.
 - **Admin port only on loopback.** The pod port binding would be `127.0.0.1:<random>:2019` — unreachable from outside the LPAR.
 
@@ -316,13 +316,13 @@ The pod template would render a port binding annotation such as:
 ai-services.io/ports: "127.0.0.1:{{ .Values.caddy.adminPort }}:2019, {{ .Values.caddy.httpsPort }}:443"
 ```
 
-The proposed `values.yaml` defaults:
+The `values.yaml` defaults:
 
 ```yaml
 caddy:
-  image: icr.io/ai-services-cicd/caddy:v2.11.4-0
-  adminPort: "0"   # OS-assigned random loopback port
-  httpsPort: 443   # Default; overridden via --https-port
+  image: icr.io/ai-services-cicd/caddy:v2.11.4-2
+  adminPort: ""    # empty → OS-assigned random loopback port at deploy time
+  httpsPort: ""    # empty → supplied via --https-port CLI flag (default 443)
 ```
 
 The proposed Caddyfile:
@@ -347,20 +347,19 @@ The proposed Caddyfile:
 }
 ```
 
-### 7.3 `DeployWorkerCaddy` execution
+### 7.3 `workerdeploy.Setup()` execution
 
-**Proposed steps for `Setup()` (triggered inside `worker join`):**
+**Steps executed by `workerdeploy.Setup()` (called inside `worker join`):**
 
-1. Read `values.yaml` (image, adminPort, httpsPort). Apply `--https-port` CLI override if provided.
-2. Render the Caddyfile template and write to `<baseDir>/worker/caddy/Caddyfile`.
-3. Check whether `ai-services--worker-caddy` pod already exists.
-   - If **not running**: render the pod template and deploy via readiness-checked pod deployment.
-   - If **already running**: skip deployment — the existing pod and its port bindings are reused.
-4. Resolve the admin URL: inspect the running pod → find the `2019/tcp` host port → `http://localhost:<port>`.
-5. Health-check the Caddy admin API.
-6. The worker computes `<workerIP>.nip.io` and sends it as `metadata["domain_suffix"]` in `RegisterRequest`. The gateway persists it to the DB via `WorkerRepository`.
+1. Call `rt.ListPods(label: "ai-services.io/component=worker-proxy")`.
+   - If any pod is returned: log and return early — worker is already set up.
+2. Write the embedded `Caddyfile.tmpl` verbatim to `<baseDir>/worker/caddy/Caddyfile` (directory created at `0750` if absent).
+3. Call `deployAll()`:
+   - Load `metadata.yaml` via `EmbedTemplateProvider` to get the ordered `podTemplateExecutions`.
+   - Load `values.yaml`, applying the `--https-port` CLI override to `caddy.httpsPort`.
+   - For each template in execution order (currently `[caddy.yaml.tmpl]`): render with `BaseDir` + `Values`, unmarshal to `PodSpec`, and deploy via `DeployPodAndReadinessCheck`.
 
-**Idempotency.** Re-running `worker join` writes a fresh Caddyfile but leaves a running Caddy pod untouched. To force a re-deploy (e.g. after a port change), the operator must manually remove the pod first.
+**Idempotency.** The running check is label-based (`ai-services.io/component=worker-proxy`) rather than by pod name, making it resilient to pod name changes. Re-running `worker join` is a no-op if the worker proxy pod is already running. To force a re-deploy, run `ai-services worker uninstall` first, then re-join.
 
 ### 7.4 Admin URL resolution
 
@@ -411,14 +410,7 @@ POST http://localhost:<port>/config/apps/http/servers/ai_services_worker/routes
 
 **Domain suffix for worker routes** would come from `RemoteRuntime.DomainSuffix()` — read from the worker's DB entry, populated from `metadata["domain_suffix"]` sent by the worker in `RegisterRequest`. The worker's domain suffix is independent of the control-plane's `DOMAIN_SUFFIX` env var.
 
-### 7.7 Upstream uses pod IP, not pod name
-
-Caddy would run as a Podman pod. Pod name DNS (Podman's internal resolver) is only available inside Podman network namespaces, not from within the Caddy container when reaching other pods on the same host. Therefore:
-
-- Route upstreams would use the **pod IP address** (e.g. `10.88.0.5:8080`), not the pod name.
-- The deployer would resolve the pod IP by inspecting the pod's infra container: `InspectPod` → `InfraContainerID` → `InspectContainer` → `NetworkSettings.IPAddress`.
-
-### 7.8 Proposed constants
+### 7.7 Proposed constants
 
 | Constant | Proposed value | Package |
 |---|---|---|
@@ -556,29 +548,58 @@ sequenceDiagram
 
 ## 10. Worker Registry and State Machine
 
-### 10.1 Proposed WorkerEntry fields
+### 10.1 WorkerEntry
 
 The in-memory `WorkerEntry` holds only the live gRPC plumbing. All durable fields live in the database.
 
 ```go
 type WorkerEntry struct {
-    DBID       uuid.UUID                       // UUID assigned by DB on first Upsert
+    // DBID is the UUID assigned by the database after the first Upsert.
+    DBID uuid.UUID
+
     WorkerName string
 
-    // CommandCh is written by RemoteRuntime to dispatch commands to the worker.
-    // The gateway goroutine drains it and writes to the gRPC stream.
-    CommandCh  chan *workerpb.Command           // capacity 32
-    results    map[string]chan *CommandResult   // result routing by command ID (mu-protected)
+    // CommandCh is written by RemoteRuntime to send commands to this worker.
+    // The gateway goroutine reads from it and writes to the gRPC stream.
+    // Buffer size: 32 (allows up to 32 concurrent in-flight deployments per worker).
+    CommandCh chan *workerpb.Command
+
+    resultsMu sync.Mutex
+    results   map[string]chan *workerpb.CommandResult // result routing by command ID
 }
 ```
 
-`Status`, `LastHeartbeat`, `Metadata` are **not** stored in `WorkerEntry`. Durable state (status, metadata, heartbeat) is owned by the `WorkerRepository` and the PostgreSQL `workers` table.
+`Status`, `LastHeartbeat`, and `Metadata` are **not** stored in `WorkerEntry` — durable state is owned by `WorkerRepository` and the PostgreSQL `workers` table.
 
-### 10.2 Status state machine
+### 10.2 Registry methods
+
+| Method | Description |
+|---|---|
+| `Preregister(ctx, workerName)` | Creates a `pending` DB row; issues a single-use 24-hour bootstrap token bound to the worker name |
+| `Register(ctx, workerName, runtimeType, metadata)` | Upserts worker to `ready` in DB; creates or reuses the in-memory `WorkerEntry`; sets `DBID` |
+| `ValidateToken(token)` | Marks token used; returns the worker name bound at issue time |
+| `Get(workerName)` | Returns the in-memory entry for a connected worker |
+| `List(ctx)` | Returns all worker rows from the DB ordered by `registered_at` |
+| `UpdateHeartbeat(ctx, workerName)` | Writes `now` to `last_heartbeat` in the DB |
+| `Disconnect(ctx, workerName)` | Removes from in-memory map; marks `disconnected` in DB (row kept for reconnect) |
+| `Deregister(ctx, id)` | Removes from in-memory map; hard-deletes the DB row by UUID |
+| `SweepStale(ctx, timeout)` | Sweeps all `ready` DB rows; marks any with `last_heartbeat` older than timeout as `disconnected` |
+| `WaitForResult(workerName, commandID)` | Returns a buffered channel (cap 1) that receives the `CommandResult` for a dispatched command |
+| `DeliverResult(res)` | Routes an incoming `CommandResult` to the waiting caller channel |
+
+### 10.3 TokenStore
+
+`TokenStore` is an in-memory single-use bootstrap token store embedded in the `Registry`. Tokens are UUID v4 strings, valid for **24 hours**, and bound to a specific worker name at issue time.
+
+- `IssueToken(workerName)` — generates a new token, stores a `TokenRecord{Token, WorkerName, ExpiresAt, Used: false}`.
+- `Validate(token)` — checks existence, expiry, and that the token has not already been used; marks `Used = true` and returns the bound worker name.
+- The store is in-memory only — tokens are lost on process restart; the operator must re-issue via `catalog worker register`.
+
+### 10.4 Status state machine
 
 ```mermaid
 stateDiagram-v2
-    [*] --> PENDING : Preregister() called (CLI: catalog worker register)
+    [*] --> PENDING : Preregister() called
 
     PENDING --> READY : token validated\nRegister() + CommandStream open
     PENDING --> PENDING : invalid / expired token (worker retries)
@@ -593,18 +614,10 @@ stateDiagram-v2
 
 Implemented status values: `pending`, `ready`, `disconnected`.
 
-> `busy` and `draining` are defined as future work (§17); they are not set by the current implementation.
 
-### 10.3 Worker selection
+### 10.5 Heartbeat sweeper
 
-`registry.SelectWorker(selector)` would iterate all in-memory workers. A worker would match if:
-- `Status == READY`
-- Last heartbeat within 90 seconds
-- All selector keys match: the reserved key `worker_name` would match against the worker's registered name directly; all other keys would match against `entry.Labels`.
-
-### 10.4 Heartbeat watcher
-
-A background goroutine would sweep all `READY`/`BUSY` workers every 30 seconds. Any worker with `now - LastHeartbeat > 90s` would be transitioned to `DISCONNECTED` and the status persisted to PostgreSQL.
+The gateway starts a background goroutine (`runSweeper`) that calls `registry.SweepStale(ctx, 90s)` every **30 seconds**. `SweepStale` fetches all DB rows, skips `pending` and already-`disconnected` workers, and marks any `ready` worker whose `last_heartbeat` is `nil` or older than 90 seconds as `disconnected`. The in-memory entry is not consulted — the sweep is DB-driven so it also catches workers that reconnected on a different gateway instance.
 
 ---
 
@@ -804,33 +817,31 @@ ai-services/
 ├── assets/
 │   ├── worker/
 │   │   └── podman/
-│   │       ├── values.yaml
+│   │       ├── metadata.yaml           # podTemplateExecutions: [caddy.yaml.tmpl]
+│   │       ├── values.yaml             # image, adminPort, httpsPort defaults
+│   │       ├── Caddyfile.tmpl          # static Caddyfile (no variables)
 │   │       └── templates/
-│   │           ├── worker-caddy.yaml.tmpl
-│   │           └── worker-caddyfile.tmpl
+│   │           └── caddy.yaml.tmpl     # Caddy pod spec template
 │   └── fs.go                           # WorkerFS embed
 │
 ├── cmd/ai-services/cmd/worker/
-│   ├── worker.go                        # worker subcommand root
+│   ├── worker.go                       # worker subcommand root
 │   ├── join.go                         # cobra command: worker join
 │   └── uninstall.go                    # cobra command: worker uninstall
 │
 └── internal/pkg/
     ├── worker/
     │   ├── proto/
-    │   │   └── worker.proto             # gRPC service + CommandType enum (29 types)
-    │   ├── workerbootstrap/
-    │   │   └── bootstrap.go            # Register() call at worker join
-    │   ├── configure/
-    │   │   └── configure.go            # DeployWorkerCaddy(), BuildAdminURL()
-    │   ├── daemon/
-    │   │   └── daemon.go               # Run() + dispatchToRuntime() (all 29 cases)
+    │   │   └── worker.proto            # gRPC service + CommandType enum (29 types)
+    │   ├── deploy/
+    │   │   └── deploy.go               # workerdeploy.Setup(): Caddyfile write + pod deploy via EmbedTemplateProvider
+    │   ├── join/
+    │   │   └── join.go                 # join.Run(): setup → register → CommandStream loop
     │   ├── gateway/
     │   │   └── gateway.go              # WorkerGateway gRPC server; persists worker-supplied domain_suffix to DB
-    │   ├── httpclient/
-    │   │   └── httpclient.go           # WorkerHTTPClient (Get/Post/Do over HTTPProxy)
     │   └── registry/
-    │       └── registry.go             # Registry, WorkerEntry, TokenStore
+    │       ├── registry.go             # Registry, WorkerEntry, TokenStore
+    │       └── token.go                # TokenStore: single-use UUID tokens
     │
     ├── constants/
     │   └── common.go                   # WorkerCaddyServerName, CaddyServerName (additions)


### PR DESCRIPTION
Introduces a design proposal for enabling a single AI Services Catalog installation to act as a control plane that manages AI workload deployments across multiple LPARs.

Currently, every deployment is executed locally. The Catalog API Server can only drive the Podman socket on the same LPAR it runs on, requiring a separate Catalog instance per LPAR with no unified management. This proposal addresses that by introducing a lightweight agent daemon on each Worker LPAR that connects back to the control plane over a persistent bidirectional gRPC stream, allowing the control plane to dispatch Podman runtime commands to any registered worker without changing the existing runtime.Runtime interface or any of its callers.

Routing external traffic to individual worker nodes will be handled by Caddy on each worker LPAR.

Scope note: This proposal covers Podman container lifecycle operations only. It does not address a common LLM gateway (e.g. LiteLLM).