### PR TITLE
AISERVICES-1350: consolidate duplicate YAML and term libraries

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.179
+TAG?=v0.0.180
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.179
+  image: icr.io/ai-services-cicd/ai-services:v0.0.180
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/go.mod
+++ b/ai-services/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/huh v0.7.0
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/charmbracelet/x/term v0.2.1
 	github.com/containers/podman/v5 v5.8.2
 	github.com/creack/pty v1.1.24
 	github.com/gin-gonic/gin v1.11.0
@@ -33,7 +32,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.52.0
 	golang.org/x/term v0.43.0
-	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v4 v4.1.4
 	k8s.io/api v0.35.1
 	k8s.io/apimachinery v0.35.1
@@ -74,6 +72,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
+	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.6.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
@@ -287,6 +286,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v1.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.1 // indirect
 	k8s.io/apiserver v0.35.1 // indirect

--- a/ai-services/internal/pkg/catalog/catalog.go
+++ b/ai-services/internal/pkg/catalog/catalog.go
@@ -17,7 +17,7 @@ import (
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // catalogItem represents a cached catalog item with its metadata and path.

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/password_helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/password_helpers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/charmbracelet/x/term"
+	"golang.org/x/term"
 	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
@@ -68,7 +68,7 @@ func promptForPassword() (string, error) {
 // readPasswordFromTerminal reads a password from the terminal without echoing.
 func readPasswordFromTerminal(prompt string) (string, error) {
 	fmt.Print(prompt)
-	passwordBytes, err := term.ReadPassword(uintptr(syscall.Stdin))
+	passwordBytes, err := term.ReadPassword(int(syscall.Stdin))
 	fmt.Println() // Print newline after password input
 	if err != nil {
 		return "", err

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/password_helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/password_helpers.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"syscall"
 
-	"golang.org/x/term"
 	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"golang.org/x/term"
 )
 
 // collectAndHashPassword collects the password from user and returns the hashed password.

--- a/ai-services/internal/pkg/catalog/types/types.go
+++ b/ai-services/internal/pkg/catalog/types/types.go
@@ -3,7 +3,7 @@ package types
 import (
 	"encoding/json"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const (

--- a/ai-services/internal/pkg/catalog/types/types_test.go
+++ b/ai-services/internal/pkg/catalog/types/types_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestArchitectureAboutOrderPreservation(t *testing.T) {


### PR DESCRIPTION
1. Two term libraries — golang.org/x/term and github.com/charmbracelet/x/term were both imported solely for ReadPassword. The charmbracelet one was only used in one file with a trivially different call signature (uintptr vs int).

2. Two YAML libraries — gopkg.in/yaml.v3 and go.yaml.in/yaml/v3 have an identical API. gopkg.in/yaml.v3 is the original, but its author [explicitly marked it unmaintained](https://github.com/go-yaml/yaml) in April 2025. go.yaml.in/yaml/v3 is the active successor maintained by the official YAML organization at github.com/yaml/go-yaml.