### PR TITLE
feat: add catalog info cmd for openshift

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.186
+TAG?=v0.0.187
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.186
+  image: icr.io/ai-services-cicd/ai-services:v0.0.187
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.186
+  image: icr.io/ai-services-cicd/ai-services:v0.0.187
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/catalog/info.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/info.go
@@ -21,7 +21,10 @@ func NewInfoCmd() *cobra.Command {
 - UI endpoint URL
 - Backend API endpoint URL`,
 		Example: `  # Display catalog service info for podman
-  ai-services catalog info --runtime podman`,
+  ai-services catalog info --runtime podman
+
+  # Display catalog service info for openshift
+  ai-services catalog info --runtime openshift`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 

--- a/ai-services/cmd/ai-services/cmd/catalog/info.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/info.go
@@ -31,7 +31,7 @@ func NewInfoCmd() *cobra.Command {
 			return common.InitAndValidateRuntimeFlag(runtimeType)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return info.Run(vars.RuntimeFactory.GetRuntimeType())
+			return info.Run(cmd.Context(), vars.RuntimeFactory.GetRuntimeType())
 		},
 	}
 

--- a/ai-services/internal/pkg/catalog/cli/info/common.go
+++ b/ai-services/internal/pkg/catalog/cli/info/common.go
@@ -3,6 +3,7 @@ package info
 import (
 	"fmt"
 
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/info/openshift"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/info/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 )
@@ -13,7 +14,7 @@ func Run(runtimeType types.RuntimeType) error {
 	case types.RuntimeTypePodman:
 		return podman.DisplayCatalogInfo()
 	case types.RuntimeTypeOpenShift:
-		return fmt.Errorf("catalog info is not yet supported for OpenShift runtime")
+		return openshift.DisplayCatalogInfo()
 	default:
 		return fmt.Errorf("unsupported runtime type: %s", runtimeType)
 	}

--- a/ai-services/internal/pkg/catalog/cli/info/common.go
+++ b/ai-services/internal/pkg/catalog/cli/info/common.go
@@ -1,6 +1,7 @@
 package info
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/info/openshift"
@@ -9,12 +10,12 @@ import (
 )
 
 // Run displays catalog service information based on the runtime type.
-func Run(runtimeType types.RuntimeType) error {
+func Run(ctx context.Context, runtimeType types.RuntimeType) error {
 	switch runtimeType {
 	case types.RuntimeTypePodman:
 		return podman.DisplayCatalogInfo()
 	case types.RuntimeTypeOpenShift:
-		return openshift.DisplayCatalogInfo()
+		return openshift.DisplayCatalogInfo(ctx)
 	default:
 		return fmt.Errorf("unsupported runtime type: %s", runtimeType)
 	}

--- a/ai-services/internal/pkg/catalog/cli/info/openshift/info.go
+++ b/ai-services/internal/pkg/catalog/cli/info/openshift/info.go
@@ -1,0 +1,49 @@
+package openshift
+
+import (
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/assets"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
+	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	oc "github.com/project-ai-services/ai-services/internal/pkg/runtime/openshift"
+)
+
+// DisplayCatalogInfo displays detailed information about the catalog service on OpenShift.
+func DisplayCatalogInfo() error {
+	// Initialize OpenShift client scoped to the catalog namespace
+	runtime, err := oc.NewOpenshiftClientWithNamespace(constants.CatalogAppName)
+	if err != nil {
+		return fmt.Errorf("failed to initialize openshift client: %w", err)
+	}
+
+	// Check if any catalog pods exist in the namespace
+	listFilters := map[string][]string{
+		"label": {fmt.Sprintf("ai-services.io/application=%s", constants.CatalogAppName)},
+	}
+
+	pods, err := runtime.ListPods(listFilters)
+	if err != nil {
+		return fmt.Errorf("failed to list pods: %w", err)
+	}
+
+	if len(pods) == 0 {
+		logger.Infof("Catalog service is not configured or running.\n")
+		logger.Infof("Run 'ai-services catalog configure --runtime openshift' to set up the catalog service.\n")
+
+		return nil
+	}
+
+	logger.Infoln("Catalog Service Name: " + constants.CatalogAppName)
+
+	tp := templates.NewEmbedTemplateProvider(&assets.CatalogFS, "")
+
+	if err := helpers.PrintInfo(tp, runtime, constants.CatalogAppName, constants.CatalogAppTemplate); err != nil {
+		// not failing overall info command if we cannot display Info
+		logger.Errorf("failed to display info: %v\n", err)
+	}
+
+	return nil
+}

--- a/ai-services/internal/pkg/catalog/cli/info/openshift/info.go
+++ b/ai-services/internal/pkg/catalog/cli/info/openshift/info.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/assets"
-	aiconst "github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
+	aiconst "github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	oc "github.com/project-ai-services/ai-services/internal/pkg/runtime/openshift"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"

--- a/ai-services/internal/pkg/catalog/cli/info/openshift/info.go
+++ b/ai-services/internal/pkg/catalog/cli/info/openshift/info.go
@@ -9,6 +9,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	oc "github.com/project-ai-services/ai-services/internal/pkg/runtime/openshift"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // DisplayCatalogInfo displays detailed information about the catalog service on OpenShift.
@@ -19,7 +20,7 @@ func DisplayCatalogInfo() error {
 		return fmt.Errorf("failed to initialize openshift client: %w", err)
 	}
 
-	// Check if any catalog pods exist in the namespace
+	// Step 1: Check if catalog pods exist in the namespace
 	listFilters := map[string][]string{
 		"label": {fmt.Sprintf("ai-services.io/application=%s", constants.CatalogAppName)},
 	}
@@ -38,9 +39,17 @@ func DisplayCatalogInfo() error {
 
 	logger.Infoln("Catalog Service Name: " + constants.CatalogAppName)
 
+	// Step 2: Fetch and print the template and version label values
+	catalogTemplate := pods[0].Labels[string(vars.TemplateLabel)]
+	logger.Infoln("Catalog Template: " + catalogTemplate)
+
+	version := pods[0].Labels[string(vars.VersionLabel)]
+	logger.Infoln("Version: " + version)
+
+	// Step 3: Read and print the info.md file
 	tp := templates.NewEmbedTemplateProvider(&assets.CatalogFS, "")
 
-	if err := helpers.PrintInfo(tp, runtime, constants.CatalogAppName, constants.CatalogAppTemplate); err != nil {
+	if err := helpers.PrintInfo(tp, runtime, constants.CatalogAppName, catalogTemplate); err != nil {
 		// not failing overall info command if we cannot display Info
 		logger.Errorf("failed to display info: %v\n", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/info/openshift/info.go
+++ b/ai-services/internal/pkg/catalog/cli/info/openshift/info.go
@@ -1,9 +1,11 @@
 package openshift
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/assets"
+	aiconst "github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
@@ -13,7 +15,7 @@ import (
 )
 
 // DisplayCatalogInfo displays detailed information about the catalog service on OpenShift.
-func DisplayCatalogInfo() error {
+func DisplayCatalogInfo(ctx context.Context) error {
 	// Initialize OpenShift client scoped to the catalog namespace
 	runtime, err := oc.NewOpenshiftClientWithNamespace(constants.CatalogAppName)
 	if err != nil {
@@ -22,7 +24,7 @@ func DisplayCatalogInfo() error {
 
 	// Step 1: Check if catalog pods exist in the namespace
 	listFilters := map[string][]string{
-		"label": {fmt.Sprintf("ai-services.io/application=%s", constants.CatalogAppName)},
+		"label": {fmt.Sprintf("%s=%s", aiconst.ApplicationAnnotationKey, constants.CatalogAppName)},
 	}
 
 	pods, err := runtime.ListPods(listFilters)
@@ -31,20 +33,20 @@ func DisplayCatalogInfo() error {
 	}
 
 	if len(pods) == 0 {
-		logger.Infof("Catalog service is not configured or running.\n")
-		logger.Infof("Run 'ai-services catalog configure --runtime openshift' to set up the catalog service.\n")
+		logger.InfofCtx(ctx, "Catalog service is not configured or running.\n")
+		logger.InfofCtx(ctx, "Run 'ai-services catalog configure --runtime openshift' to set up the catalog service.\n")
 
 		return nil
 	}
 
-	logger.Infoln("Catalog Service Name: " + constants.CatalogAppName)
+	logger.InfolnCtx(ctx, "Catalog Service Name: "+constants.CatalogAppName)
 
 	// Step 2: Fetch and print the template and version label values
 	catalogTemplate := pods[0].Labels[string(vars.TemplateLabel)]
-	logger.Infoln("Catalog Template: " + catalogTemplate)
+	logger.InfolnCtx(ctx, "Catalog Template: "+catalogTemplate)
 
 	version := pods[0].Labels[string(vars.VersionLabel)]
-	logger.Infoln("Version: " + version)
+	logger.InfolnCtx(ctx, "Version: "+version)
 
 	// Step 3: Read and print the info.md file
 	tp := templates.NewEmbedTemplateProvider(&assets.CatalogFS, "")


### PR DESCRIPTION
Added support for info cmd for openshift runtime. 

```
Catalog Service Name: ai-services
Catalog Template: catalog
Version: 0.0.1
Info:
-------
Day N:

- Catalog UI is available at https://catalog-ui-ai-services.apps.ais-orch-1.example.com

- Catalog Backend API is available at https://catalog-api-ai-services.apps.ais-orch-1.example.com
```