### PR TITLE
[Automation] AISERVICES-1362: Adding E2E test cases for similarity search API.

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.198
+TAG?=v0.0.199
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.198
+  image: icr.io/ai-services-cicd/ai-services:v0.0.199
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.198
+  image: icr.io/ai-services-cicd/ai-services:v0.0.199
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/tests/e2e/e2e_suite_test.go
+++ b/ai-services/tests/e2e/e2e_suite_test.go
@@ -1654,7 +1654,7 @@ var _ = ginkgo.Describe("AI Services End-to-End Tests", ginkgo.Ordered, func() {
 
 				// Step 1: Create digitization job
 				logger.Infof("[TEST] Step 1: Creating ingestion job")
-				jobResp, err := digitization.CreateJob(ctx, digitizeBaseURL, pdfPath, "ingestion", "json", "e2e-combined-workflow")
+				jobResp, err := digitization.CreateJob(ctx, digitizeBaseURL, pdfPath, "ingestion", "json", "e2e-similarity-workflow")
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gomega.Expect(jobResp).NotTo(gomega.BeNil())
 				gomega.Expect(jobResp.JobID).NotTo(gomega.BeEmpty())

--- a/ai-services/tests/e2e/e2e_suite_test.go
+++ b/ai-services/tests/e2e/e2e_suite_test.go
@@ -1574,6 +1574,198 @@ var _ = ginkgo.Describe("AI Services End-to-End Tests", ginkgo.Ordered, func() {
 			logger.Infof("[TEST] ✓ Blank PDF ingestion completed successfully")
 		})
 	})
+	ginkgo.Context("Similarity Tests", ginkgo.Label("spyre-dependent", "similarity-tests"), func() {
+		var similarityBaseURL string
+		var digitizeBaseURL string
+		var createdJobIDs []string
+
+		ginkgo.BeforeAll(func() {
+			if appName == "" {
+				ginkgo.Fail("Application name is not set")
+			}
+
+			logger.Infof("[SIMILARITY] Setting up similarity tests")
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+			defer cancel()
+
+			infoOutput, err := cli.WaitForApplicationInfoURLs(ctx, cfg, appName, appRuntime, 8*time.Minute, 15*time.Second)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			if appRuntime == "podman" {
+				const similarityPollInterval = 15 * time.Second
+				for {
+					similarityBaseURL = cli.ExtractSimilarityAPIURL(infoOutput)
+					digitizeBaseURL = cli.ExtractCatalogDigitizeURL(infoOutput)
+					if similarityBaseURL != "" && digitizeBaseURL != "" {
+						break
+					}
+					if ctx.Err() != nil {
+						ginkgo.Fail("Timed out waiting for similarity-backend URL in 'application info' output")
+					}
+					logger.Infof("[SIMILARITY] similarity-backend URL not yet present — retrying in %s", similarityPollInterval)
+					select {
+					case <-ctx.Done():
+						ginkgo.Fail("Timed out waiting for similarity-backend URL in 'application info' output")
+					case <-time.After(similarityPollInterval):
+					}
+					infoOutput, err = cli.ApplicationInfo(ctx, cfg, appName, appRuntime)
+					if err != nil {
+						logger.Warningf("[SIMILARITY] application info error while polling for similarity URL: %v", err)
+					}
+				}
+			} else {
+				urlList := cli.ExtractURLsFromOutput(infoOutput)
+				if len(urlList) == 0 {
+					ginkgo.Fail("No urls extracted from application info output")
+				} else {
+					similarityBaseURL = urlList[0]
+					digitizeBaseURL = strings.Replace(urlList[0], "ui", "digitize-api", 1)
+				}
+			}
+
+			_ = err
+
+			gomega.Expect(similarityBaseURL).NotTo(gomega.BeEmpty(),
+				"could not determine similarity-api base URL")
+			logger.Infof("[SIMILARITY] Similarity Base URL: %s", similarityBaseURL)
+		})
+
+		ginkgo.It("should pass health check",
+			func() {
+				ctx, cancel := withTimeout(30 * time.Second)
+				defer cancel()
+
+				resp, err := similarity.VerifyHealthEndpoint(ctx, similarityBaseURL)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(resp).NotTo(gomega.BeNil())
+				gomega.Expect(resp.Status).NotTo(gomega.BeEmpty())
+				logger.Infof("[TEST] Similarity service health check passed status=%q", resp.Status)
+			})
+		
+		// Verify /v1/similarity-search with dense, sparse, and hybrid modes
+		ginkgo.It("Verify /v1/similarity-search endpoint by providing different search mode such as dense, sparse or hybrid",
+			func() {
+				ctx, cancel := withTimeout(20 * time.Minute)
+				defer cancel()
+
+				pdfPath := digitization.GetTestPDFPath()
+				gomega.Expect(pdfPath).NotTo(gomega.BeEmpty())
+
+				// Step 1: Create digitization job
+				logger.Infof("[TEST] Step 1: Creating ingestion job")
+				jobResp, err := digitization.CreateJob(ctx, digitizeBaseURL, pdfPath, "ingestion", "json", "e2e-combined-workflow")
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(jobResp).NotTo(gomega.BeNil())
+				gomega.Expect(jobResp.JobID).NotTo(gomega.BeEmpty())
+				createdJobIDs = append(createdJobIDs, jobResp.JobID)
+				logger.Infof("[TEST] Created ingestion job: %s", jobResp.JobID)
+
+				// Step 2: Get job status immediately after creation
+				logger.Infof("[TEST] Step 2: Getting job status")
+				status, err := digitization.GetJobStatus(ctx, digitizeBaseURL, jobResp.JobID)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(status.JobID).To(gomega.Equal(jobResp.JobID))
+				logger.Infof("[TEST] Job status retrieved: %s", status.Status)
+
+				// Step 3: Wait for job completion (only wait ONCE for all checks)
+				logger.Infof("[TEST] Step 3: Waiting for job completion")
+				finalStatus, err := digitization.WaitForJobCompletion(ctx, digitizeBaseURL, jobResp.JobID, 10*time.Minute)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(finalStatus.Status).To(gomega.Equal("completed"))
+				logger.Infof("[TEST] Ingestion job completed: %s", jobResp.JobID)
+
+				results := similarity.VerifySearchModes(ctx, similarityBaseURL)
+
+				//Step 4: Every mode that returned a response must carry the correct score_type.
+				logger.Infof("[TEST] Step 4: Verifying similarity search api")
+				expectedScoreTypes := map[string]string{
+					"dense":  "cosine",
+					"sparse": "bm25",
+					"hybrid": "hybrid",
+				}
+				for mode, resp := range results {
+					gomega.Expect(resp).NotTo(gomega.BeNil(),
+						"mode=%s: got nil response", mode)
+					gomega.Expect(resp.ScoreType).To(gomega.Equal(expectedScoreTypes[mode]),
+						"mode=%s: unexpected score_type", mode)
+					logger.Infof("[TEST] C82598625: mode=%s score_type=%s results=%d",
+						mode, resp.ScoreType, len(resp.Results))
+				}
+				// At least one mode must have responded successfully.
+				gomega.Expect(results).NotTo(gomega.BeEmpty(),
+					"all search modes failed — index may be empty or similarity-api is unreachable")
+			})
+		
+		// Timing test — Verify Similarity search API includes time info in response headers or body in podman runtime
+		ginkgo.It("Verify Similarity search API includes time info in response headers or body in podman runtime",
+			func() {
+				ctx, cancel := withTimeout(30 * time.Second)
+				defer cancel()
+
+				gomega.Expect(
+					similarity.VerifyTimeInfoInResponse(ctx, similarityBaseURL),
+				).To(gomega.Succeed())
+				logger.Infof("[TEST] Timing info verified in similarity-api response")
+			})
+
+		// Verify /v1/similarity-search returns 400 for invalid mode
+		ginkgo.It("Verify /v1/similarity-search endpoint by providing invalid parameter for mode field (400 error code)",
+			func() {
+				ctx, cancel := withTimeout(30 * time.Second)
+				defer cancel()
+
+				errResp, err := similarity.VerifyInvalidModeReturns400(ctx, similarityBaseURL)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(errResp).NotTo(gomega.BeNil())
+				gomega.Expect(errResp.Error.Message).NotTo(gomega.BeEmpty())
+				gomega.Expect(errResp.Error.Status).To(gomega.Equal(400))
+				gomega.Expect(errResp.Error.Message).To(gomega.ContainSubstring("mode must be one of"))
+				logger.Infof("[TEST] invalid mode correctly rejected with: %s", errResp.Error)
+			})
+
+
+		// Verify /v1/similarity-search with rerank=true
+		ginkgo.It("Verify /v1/similarity-search endpoint by providing rerank as true",
+			func() {
+				ctx, cancel := withTimeout(2 * time.Minute)
+				defer cancel()
+
+				resp, err := similarity.VerifyRerankTrue(ctx, similarityBaseURL)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(resp).NotTo(gomega.BeNil())
+				gomega.Expect(resp.ScoreType).To(gomega.Equal("relevance"))
+				logger.Infof("[TEST] rerank=true returned score_type=%s results=%d",
+					resp.ScoreType, len(resp.Results))
+			})
+
+		// Verify /v1/similarity-search returns 422 for invalid top_k
+		ginkgo.It("Verify /v1/similarity-search endpoint by providing invalid value for top_k",
+			func() {
+				ctx, cancel := withTimeout(30 * time.Second)
+				defer cancel()
+
+				errResp, err := similarity.VerifyInvalidTopKReturns422(ctx, similarityBaseURL)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(errResp).NotTo(gomega.BeNil())
+				gomega.Expect(errResp.Detail).NotTo(gomega.BeNil())
+				logger.Infof("[TEST] invalid top_k correctly rejected with: %s", errResp.Error)
+			})
+
+		// Reproduce 400: Validation Error
+		ginkgo.It("Reproduce 400 validation error code for similarity-search endpoint",
+			func() {
+				ctx, cancel := withTimeout(30 * time.Second)
+				defer cancel()
+
+				errResp, err := similarity.ReproduceValidationError(ctx, similarityBaseURL)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(errResp).NotTo(gomega.BeNil())
+				gomega.Expect(errResp.Error.Message).NotTo(gomega.BeEmpty())
+				gomega.Expect(errResp.Error.Status).To(gomega.Equal(400))
+				logger.Infof("[TEST] 400 reproduced with error: %s", errResp.Error)
+			})
+	})
 	ginkgo.Context("Application Teardown", ginkgo.Ordered, func() {
 		ginkgo.It("deletes the application", ginkgo.Label("spyre-dependent"), func() {
 			if providedAppName != "" {

--- a/ai-services/tests/e2e/e2e_suite_test.go
+++ b/ai-services/tests/e2e/e2e_suite_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/project-ai-services/ai-services/tests/e2e/digitization"
 	"github.com/project-ai-services/ai-services/tests/e2e/podman"
 	"github.com/project-ai-services/ai-services/tests/e2e/rag"
+	"github.com/project-ai-services/ai-services/tests/e2e/similarity"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	gomega "github.com/onsi/gomega"

--- a/ai-services/tests/e2e/similarity/similarity.go
+++ b/ai-services/tests/e2e/similarity/similarity.go
@@ -1,0 +1,452 @@
+package similarity
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+)
+
+// Transport tuning constants for the shared similarity HTTP client.
+const (
+	transportMaxIdleConnsPerHost   = 4                //nolint:mnd
+	transportIdleConnTimeout       = 90 * time.Second //nolint:mnd
+	transportResponseHeaderTimeout = 25 * time.Second //nolint:mnd
+	transportDialTimeout           = 15 * time.Second //nolint:mnd
+	transportDialKeepAlive         = 30 * time.Second //nolint:mnd
+
+	// postCallTimeout is the end-to-end deadline for a POST similarity-search request.
+	postCallTimeout = 60 * time.Second //nolint:mnd
+
+	// getCallTimeout is the end-to-end deadline for a GET health request.
+	getCallTimeout = 30 * time.Second //nolint:mnd
+)
+
+// sharedSimilarityTransport pools TLS connections and skips certificate verification
+// to support both plain http:// (legacy podman) and https:// nip.io self-signed certs.
+var sharedSimilarityTransport = &http.Transport{
+	TLSClientConfig:     &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+	MaxIdleConnsPerHost: transportMaxIdleConnsPerHost,
+	IdleConnTimeout:     transportIdleConnTimeout,
+	// ResponseHeaderTimeout guards against dead keep-alive sockets that never send response headers.
+	ResponseHeaderTimeout: transportResponseHeaderTimeout,
+	DialContext: (&net.Dialer{
+		Timeout:   transportDialTimeout,
+		KeepAlive: transportDialKeepAlive,
+	}).DialContext,
+}
+
+// getHTTPClient returns an HTTP client with the given timeout using the shared pooled transport.
+func getHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: sharedSimilarityTransport,
+	}
+}
+
+// drainAndClose drains and closes the body so the underlying TCP connection is returned to the pool.
+func drainAndClose(body io.ReadCloser) {
+	_, _ = io.Copy(io.Discard, body)
+	_ = body.Close()
+}
+
+// GetSimilarityBaseURL returns the base URL for the similarity-api service given a port.
+func GetSimilarityBaseURL(port string) string {
+	return fmt.Sprintf("http://localhost:%s", port)
+}
+
+// -----------------------------------------------------------------------
+// Request / Response types
+// -----------------------------------------------------------------------
+
+// SimilaritySearchRequest is the payload for POST /v1/similarity-search.
+type SimilaritySearchRequest struct {
+	Query  string `json:"query"`
+	Mode   string `json:"mode,omitempty"`
+	TopK   *int   `json:"top_k,omitempty"`
+	Rerank *bool  `json:"rerank,omitempty"`
+}
+
+// SimilarityResult represents a single document result in the search response.
+type SimilarityResult struct {
+	PageContent string  `json:"page_content"`
+	Filename    string  `json:"filename"`
+	Type        string  `json:"type"`
+	Source      string  `json:"source"`
+	ChunkID     string  `json:"chunk_id"`
+	Score       float64 `json:"score"`
+}
+
+// SimilaritySearchResponse is the successful 200 body of POST /v1/similarity-search.
+type SimilaritySearchResponse struct {
+	ScoreType string             `json:"score_type"`
+	Results   []SimilarityResult `json:"results"`
+}
+
+// SimilarityErrorResponse is the error body returned by the similarity-api.
+type SimilarityErrorResponse struct {
+	Error  ErrorResponse       `json:"error"`
+	Detail interface{} `json:"detail"`
+}
+
+type ErrorResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Status  int    `json:"status"`
+}
+
+// HealthResponse is the 200 body of GET /health.
+type HealthResponse struct {
+	Status string `json:"status"`
+}
+
+// -----------------------------------------------------------------------
+// HTTP helpers
+// -----------------------------------------------------------------------
+
+// doPost sends a JSON POST request and returns (body bytes, status code, error).
+func doPost(ctx context.Context, url string, payload any, timeout time.Duration) ([]byte, int, http.Header, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(raw))
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := getHTTPClient(timeout).Do(req)
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	defer drainAndClose(resp.Body)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, resp.Header, fmt.Errorf("read response: %w", err)
+	}
+
+	return body, resp.StatusCode, resp.Header, nil
+}
+
+// doGet sends a GET request and returns (body bytes, status code, response headers, error).
+func doGet(ctx context.Context, url string, timeout time.Duration) ([]byte, int, http.Header, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := getHTTPClient(timeout).Do(req)
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	defer drainAndClose(resp.Body)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, resp.Header, fmt.Errorf("read response: %w", err)
+	}
+
+	return body, resp.StatusCode, resp.Header, nil
+}
+
+// -----------------------------------------------------------------------
+// Public API helpers used by test specs
+// -----------------------------------------------------------------------
+
+// HealthCheck calls GET /health and returns an error if the service is not healthy.
+func HealthCheck(ctx context.Context, baseURL string) error {
+	url := strings.TrimRight(baseURL, "/") + "/health"
+	body, statusCode, _, err := doGet(ctx, url, getCallTimeout)
+	if err != nil {
+		return fmt.Errorf("health check request failed: %w", err)
+	}
+
+	if statusCode != http.StatusOK {
+		return fmt.Errorf("health check returned HTTP %d: %s", statusCode, string(body))
+	}
+
+	logger.Infof("[SIMILARITY] GET /health → HTTP %d", statusCode)
+
+	return nil
+}
+
+// HealthCheckWithResponse calls GET /health and returns the parsed response, status code, and headers.
+func HealthCheckWithResponse(ctx context.Context, baseURL string) (*HealthResponse, int, http.Header, error) {
+	url := strings.TrimRight(baseURL, "/") + "/health"
+	body, statusCode, headers, err := doGet(ctx, url, getCallTimeout)
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("health check request failed: %w", err)
+	}
+
+	var resp HealthResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, statusCode, headers, fmt.Errorf("parse health response: %w", err)
+	}
+
+	logger.Infof("[SIMILARITY] GET /health → HTTP %d", statusCode)
+
+	return &resp, statusCode, headers, nil
+}
+
+// SimilaritySearch calls POST /v1/similarity-search and returns the parsed success response,
+// the HTTP status code, response headers, and any transport error.
+func SimilaritySearch(ctx context.Context, baseURL string, req SimilaritySearchRequest) (*SimilaritySearchResponse, int, http.Header, error) {
+	url := strings.TrimRight(baseURL, "/") + "/v1/similarity-search"
+	body, statusCode, headers, err := doPost(ctx, url, req, postCallTimeout)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	if statusCode != http.StatusOK {
+		return nil, statusCode, headers, nil
+	}
+
+	var resp SimilaritySearchResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, statusCode, headers, fmt.Errorf("parse similarity response: %w", err)
+	}
+
+	logger.Infof("[SIMILARITY] POST /v1/similarity-search (mode=%s rerank=%v) → HTTP %d, score_type=%s, results=%d",
+		req.Mode, req.Rerank, statusCode, resp.ScoreType, len(resp.Results))
+
+	return &resp, statusCode, headers, nil
+}
+
+// SimilaritySearchExpectingError calls POST /v1/similarity-search and returns the error response body
+// along with the HTTP status code when the server returns a non-200 status.
+func SimilaritySearchExpectingError(ctx context.Context, baseURL string, req SimilaritySearchRequest) (*SimilarityErrorResponse, int, error) {
+	url := strings.TrimRight(baseURL, "/") + "/v1/similarity-search"
+	body, statusCode, _, err := doPost(ctx, url, req, postCallTimeout)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if statusCode == http.StatusOK {
+		return nil, statusCode, fmt.Errorf("expected error response but got HTTP 200")
+	}
+
+	var errResp SimilarityErrorResponse
+	if jsonErr := json.Unmarshal(body, &errResp); jsonErr != nil {
+		// Return raw body as the error message when JSON parsing fails.
+		fmt.Println(jsonErr)
+	}
+
+	logger.Infof("[SIMILARITY] POST /v1/similarity-search (error path) → HTTP %d: %s", statusCode, errResp.Error)
+
+	return &errResp, statusCode, nil
+}
+
+// intPtr returns a pointer to the given int — convenience helper for TopK in requests.
+func intPtr(i int) *int { return &i }
+
+// boolPtr returns a pointer to the given bool — convenience helper for Rerank in requests.
+func boolPtr(b bool) *bool { return &b }
+
+// VerifyHealthEndpoint calls GET /health and validates that the response is HTTP 200
+// with a non-empty status field.
+func VerifyHealthEndpoint(ctx context.Context, baseURL string) (*HealthResponse, error) {
+	resp, statusCode, _, err := HealthCheckWithResponse(ctx, baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("health check failed: %w", err)
+	}
+
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET /health returned HTTP %d, expected 200", statusCode)
+	}
+
+	if resp.Status == "" {
+		return nil, fmt.Errorf("GET /health response has empty status field")
+	}
+
+	logger.Infof("GET /health returned HTTP %d, status=%q", statusCode, resp.Status)
+
+	return resp, nil
+}
+
+// VerifyTimeInfoInResponse calls POST /v1/similarity-search and checks that the API
+// includes timing information either in the response headers (e.g. X-Response-Time,
+// X-Process-Time, X-Duration) or in the response body. This validates the podman
+// runtime timing instrumentation requirement.
+//
+// Corresponds to test case "Verify Similarity search API includes time info in response headers or body in podman runtime".
+func VerifyTimeInfoInResponse(ctx context.Context, baseURL string) error {
+	req := SimilaritySearchRequest{
+		Query: "what is network configuration",
+		Mode:  "dense",
+	}
+
+	url := strings.TrimRight(baseURL, "/") + "/v1/similarity-search"
+	raw, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(raw))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := getHTTPClient(postCallTimeout).Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+
+	// Check for timing headers (any of the commonly used names).
+	timingHeaders := []string{
+		"X-Retrieve-Time",
+		"X-Total-Time",
+	}
+
+	for _, h := range timingHeaders {
+		if val := resp.Header.Get(h); val != "" {
+			logger.Infof("[TIMING] Found timing header %s=%s", h, val)
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no timing information found in response headers (%v) or body", timingHeaders)
+}
+
+// VerifyInvalidModeReturns400 posts a similarity-search request with an invalid mode value
+// and asserts that the API returns HTTP 400 with an appropriate error message.
+func VerifyInvalidModeReturns400(ctx context.Context, baseURL string) (*SimilarityErrorResponse, error) {
+	req := SimilaritySearchRequest{
+		Query: "what is network configuration",
+		Mode:  "invalid_mode",
+	}
+
+	errResp, statusCode, err := SimilaritySearchExpectingError(ctx, baseURL, req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	if statusCode != http.StatusBadRequest {
+		return errResp, fmt.Errorf("expected HTTP 400 for invalid mode, got %d", statusCode)
+	}
+
+	logger.Infof("POST /v1/similarity-search with invalid mode → HTTP %d: %v", statusCode, errResp.Error)
+
+	return errResp, nil
+}
+
+// VerifySearchModes calls POST /v1/similarity-search for each of the three supported
+// modes and returns a map of mode → (response, error).
+func VerifySearchModes(ctx context.Context, baseURL string) map[string]*SimilaritySearchResponse {
+	modes := []string{"dense", "sparse", "hybrid"}
+	results := make(map[string]*SimilaritySearchResponse, len(modes))
+
+	for _, mode := range modes {
+		req := SimilaritySearchRequest{
+			Query: "how do I configure network settings",
+			Mode:  mode,
+		}
+
+		resp, statusCode, _, err := SimilaritySearch(ctx, baseURL, req)
+		if err != nil {
+			logger.Warningf("mode=%s request failed: %v", mode, err)
+
+			continue
+		}
+
+		if statusCode != http.StatusOK {
+			logger.Warningf("mode=%s returned HTTP %d (may indicate empty index)", mode, statusCode)
+
+			continue
+		}
+
+		logger.Infof("mode=%s → HTTP %d, score_type=%s, results=%d",
+			mode, statusCode, resp.ScoreType, len(resp.Results))
+		results[mode] = resp
+	}
+
+	return results
+}
+
+// VerifyRerankTrue posts a similarity-search request with rerank=true and asserts that
+// the response includes score_type "relevance" (the reranker output type).
+func VerifyRerankTrue(ctx context.Context, baseURL string) (*SimilaritySearchResponse, error) {
+	req := SimilaritySearchRequest{
+		Query:  "how do I configure network settings",
+		Mode:   "hybrid",
+		Rerank: boolPtr(true),
+	}
+
+	resp, statusCode, _, err := SimilaritySearch(ctx, baseURL, req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("expected HTTP 200, got %d", statusCode)
+	}
+
+	if resp.ScoreType != "relevance" {
+		return resp, fmt.Errorf("expected score_type=relevance when rerank=true, got %q", resp.ScoreType)
+	}
+
+	logger.Infof("rerank=true → HTTP %d, score_type=%s, results=%d",
+		statusCode, resp.ScoreType, len(resp.Results))
+
+	return resp, nil
+}
+
+// VerifyInvalidTopKReturns422 posts a similarity-search request with a negative top_k
+// value and asserts that the API returns HTTP 400.
+func VerifyInvalidTopKReturns422(ctx context.Context, baseURL string) (*SimilarityErrorResponse, error) {
+	req := SimilaritySearchRequest{
+		Query: "how do I configure network settings",
+		Mode:  "dense",
+		TopK:  intPtr(-1),
+	}
+
+	errResp, statusCode, err := SimilaritySearchExpectingError(ctx, baseURL, req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	if statusCode != http.StatusUnprocessableEntity {
+		return errResp, fmt.Errorf("expected HTTP 422 for invalid top_k, got %d", statusCode)
+	}
+
+	logger.Infof("invalid top_k=-1 → HTTP %d: %v", statusCode, errResp.Error)
+
+	return errResp, nil
+}
+
+// ReproduceValidationError posts a similarity-search request with a missing required
+// field (empty query) and asserts HTTP 400 is returned.
+func ReproduceValidationError(ctx context.Context, baseURL string) (*SimilarityErrorResponse, error) {
+	// Send an empty query — the API requires a non-empty query string.
+	req := SimilaritySearchRequest{
+		Query: "",
+		Mode:  "dense",
+	}
+
+	errResp, statusCode, err := SimilaritySearchExpectingError(ctx, baseURL, req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	if statusCode != http.StatusBadRequest {
+		return errResp, fmt.Errorf("expected HTTP 400, got %d", statusCode)
+	}
+
+	return errResp, nil
+}

--- a/ai-services/tests/e2e/similarity/similarity.go
+++ b/ai-services/tests/e2e/similarity/similarity.go
@@ -58,11 +58,6 @@ func drainAndClose(body io.ReadCloser) {
 	_ = body.Close()
 }
 
-// GetSimilarityBaseURL returns the base URL for the similarity-api service given a port.
-func GetSimilarityBaseURL(port string) string {
-	return fmt.Sprintf("http://localhost:%s", port)
-}
-
 // -----------------------------------------------------------------------
 // Request / Response types
 // -----------------------------------------------------------------------
@@ -163,30 +158,18 @@ func doGet(ctx context.Context, url string, timeout time.Duration) ([]byte, int,
 	return body, resp.StatusCode, resp.Header, nil
 }
 
-// -----------------------------------------------------------------------
-// Public API helpers used by test specs
-// -----------------------------------------------------------------------
+func getHealthEndpoint(baseURL string) string {
+	return strings.TrimRight(baseURL, "/") + "/health"
+}
 
-// HealthCheck calls GET /health and returns an error if the service is not healthy.
-func HealthCheck(ctx context.Context, baseURL string) error {
-	url := strings.TrimRight(baseURL, "/") + "/health"
-	body, statusCode, _, err := doGet(ctx, url, getCallTimeout)
-	if err != nil {
-		return fmt.Errorf("health check request failed: %w", err)
-	}
 
-	if statusCode != http.StatusOK {
-		return fmt.Errorf("health check returned HTTP %d: %s", statusCode, string(body))
-	}
-
-	logger.Infof("[SIMILARITY] GET /health → HTTP %d", statusCode)
-
-	return nil
+func getSimilaritySearchEndpoint(baseURL string) string {
+	return strings.TrimRight(baseURL, "/") + "/v1/similarity-search"
 }
 
 // HealthCheckWithResponse calls GET /health and returns the parsed response, status code, and headers.
 func HealthCheckWithResponse(ctx context.Context, baseURL string) (*HealthResponse, int, http.Header, error) {
-	url := strings.TrimRight(baseURL, "/") + "/health"
+	url := getHealthEndpoint(baseURL)
 	body, statusCode, headers, err := doGet(ctx, url, getCallTimeout)
 	if err != nil {
 		return nil, 0, nil, fmt.Errorf("health check request failed: %w", err)
@@ -205,7 +188,7 @@ func HealthCheckWithResponse(ctx context.Context, baseURL string) (*HealthRespon
 // SimilaritySearch calls POST /v1/similarity-search and returns the parsed success response,
 // the HTTP status code, response headers, and any transport error.
 func SimilaritySearch(ctx context.Context, baseURL string, req SimilaritySearchRequest) (*SimilaritySearchResponse, int, http.Header, error) {
-	url := strings.TrimRight(baseURL, "/") + "/v1/similarity-search"
+	url := getSimilaritySearchEndpoint(baseURL)
 	body, statusCode, headers, err := doPost(ctx, url, req, postCallTimeout)
 	if err != nil {
 		return nil, 0, nil, err
@@ -229,7 +212,7 @@ func SimilaritySearch(ctx context.Context, baseURL string, req SimilaritySearchR
 // SimilaritySearchExpectingError calls POST /v1/similarity-search and returns the error response body
 // along with the HTTP status code when the server returns a non-200 status.
 func SimilaritySearchExpectingError(ctx context.Context, baseURL string, req SimilaritySearchRequest) (*SimilarityErrorResponse, int, error) {
-	url := strings.TrimRight(baseURL, "/") + "/v1/similarity-search"
+	url := getSimilaritySearchEndpoint(baseURL)
 	body, statusCode, _, err := doPost(ctx, url, req, postCallTimeout)
 	if err != nil {
 		return nil, 0, err
@@ -278,8 +261,8 @@ func VerifyHealthEndpoint(ctx context.Context, baseURL string) (*HealthResponse,
 }
 
 // VerifyTimeInfoInResponse calls POST /v1/similarity-search and checks that the API
-// includes timing information either in the response headers (e.g. X-Response-Time,
-// X-Process-Time, X-Duration) or in the response body. This validates the podman
+// includes timing information either in the response headers (e.g. X-Retrieve-Time,
+// X-Total-Time) or in the response body. This validates the podman
 // runtime timing instrumentation requirement.
 //
 // Corresponds to test case "Verify Similarity search API includes time info in response headers or body in podman runtime".
@@ -289,7 +272,7 @@ func VerifyTimeInfoInResponse(ctx context.Context, baseURL string) error {
 		Mode:  "dense",
 	}
 
-	url := strings.TrimRight(baseURL, "/") + "/v1/similarity-search"
+	url := getSimilaritySearchEndpoint(baseURL)
 	raw, err := json.Marshal(req)
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)


### PR DESCRIPTION
# Add E2E tests for similarity search API

Introduces end-to-end test coverage for the similarity search API, validating behaviour after documents have been ingested.

## Changes include:

- `Happy-path tests` verifying search results across dense, sparse, and hybrid modes
- Rerank validation asserting `score_type=relevance `when `rerank=true`
- Health endpoint validation ensuring the service returns HTTP 200 with a non-empty status field
- Negative test cases covering invalid inputs:
  -   Invalid `mode` value → HTTP 400
  -   Negative `top_k` value → HTTP 422
  -   Empty `query` field → HTTP 400