### PR TITLE
fix: pass resolved base dir to catalog configure opts

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.181
+TAG?=v0.0.182
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.181
+  image: icr.io/ai-services-cicd/ai-services:v0.0.182
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.181
+  image: icr.io/ai-services-cicd/ai-services:v0.0.182
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -129,7 +129,7 @@ func runConfigure() error {
 		}
 
 		opts := catalogUtils.PodmanConfigureOptions{
-			BaseDir:     baseDir,
+			BaseDir:     aiServicesDir,
 			DomainName:  domainName,
 			SSLCertPath: catalogUtils.SanitizeFilePath(sslCertPath),
 			SSLKeyPath:  catalogUtils.SanitizeFilePath(sslKeyPath),


### PR DESCRIPTION
#### Description:
resolveBaseDir correctly fell back to `/var/lib/ai-services` but the resolved path was never assigned to `opts.BaseDir` , the raw (empty) flag value was used instead. This caused `GenerateCaddyfile` to write to a garbage path and the caddy volume mount to point nowhere, so the container failed to start with open `/data/caddy/Caddyfile`: no such file or directory.

#### Fix:
pass `aiServicesDir` (the resolved path) instead of `baseDir `(the raw flag) when constructing `PodmanConfigureOptions`.