### PR TITLE
refactor: extract shared SCSS module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ venv
 vendor
 .claude/
 .vscode/
+.bob/
 
 # Coverage reports
 .coverage

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -1,5 +1,5 @@
 ui:
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.49
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.50
   resources:
     requests:
       memory: "512Mi"

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,6 +1,6 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.49
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.50
 
 backend:
   port: ""

--- a/ui/catalog/Makefile
+++ b/ui/catalog/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= catalog-ui
-TAG ?= v0.0.49
+TAG ?= v0.0.50
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/catalog/src/components/DeployFlow/DigitalAssistant/DigitalAssistantDeployFlow.module.scss
+++ b/ui/catalog/src/components/DeployFlow/DigitalAssistant/DigitalAssistantDeployFlow.module.scss
@@ -1,225 +1,19 @@
-@use "@carbon/react/scss/spacing" as *;
-@use "@carbon/react/scss/theme" as *;
-@use "@carbon/react/scss/type" as *;
-@use "@carbon/react/scss/breakpoint" as *;
-@use "@carbon/colors" as *;
+@use "../Shared/tokens" as *;
+@use "../Shared/DeployFlow.shared.module" as *;
 
-// Add spacing around Tearsheet: 48px top (for header), 32px left/right
-:global(.c4p--tearsheet.customTearsheet) {
-  padding-top: $spacing-09; // 48px
-}
-
-:global(.c4p--tearsheet.customTearsheet .c4p--tearsheet__container) {
-  inline-size: calc(100% - 2 * #{$spacing-07}) !important; // 32px each side
-  max-block-size: calc(
-    100% - #{$spacing-07}
-  ) !important; // Account for top padding
-}
-
-.influencerContent {
-  padding: $spacing-07 $spacing-07;
-}
-
-.stepContent {
-  padding: $spacing-06 $spacing-07;
-}
-
-.stepHeader {
-  margin-bottom: $spacing-06;
-}
-
-.stepTitle {
-  @include type-style("heading-03");
-  margin: 0 0 $spacing-06 0;
-}
-
-.sectionTitle {
-  @include type-style("heading-compact-02");
-  margin-bottom: $spacing-05;
-}
-
-.formGrid {
-  row-gap: $spacing-07;
-  margin-left: 0;
-  padding-left: 0;
-}
-
-.formField {
-  max-width: 50%;
-
-  // Make dropdowns match text input background and border (light gray with underline)
-  :global {
-    .cds--dropdown,
-    .cds--list-box,
-    .cds--list-box__field {
-      background-color: $field-01 !important;
-      border-bottom: 1px solid $border-strong !important;
-    }
-  }
-}
-
-.labelWithInfo {
-  display: flex;
-  align-items: center;
-  gap: $spacing-03;
-
-  > span {
-    @include type-style("label-01");
-  }
-
-  :global(.cds--toggletip-button) {
-    padding: 0;
-    min-height: auto;
-    display: inline-flex;
-    align-items: center;
-    vertical-align: middle;
-    line-height: 1;
-
-    svg {
-      fill: $icon-secondary;
-      vertical-align: middle;
-    }
-  }
-}
-
-.textInputLabel {
-  @include type-style("label-01");
-  color: $text-secondary;
-  margin: 0;
-  display: inline-block;
-}
-
-.resourceGrid {
-  display: flex;
-  gap: $spacing-06;
-  flex-wrap: wrap;
-}
-
-.resourceItem {
-  display: flex;
-  flex-direction: column;
-  gap: $spacing-08;
-  min-height: 120px;
-  background-color: transparent;
-  border: 1px solid $border-subtle;
-  flex: 1;
-  min-width: 200px;
-}
-
-.resourceLabel {
-  @include type-style("body-compact-01");
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.resourceValue {
-  @include type-style("heading-04");
-
-  .unit {
-    @include type-style("heading-01");
-  }
-}
-
-.green {
-  fill: $support-success;
-  color: $support-success;
-}
-
-.warning {
-  fill: $support-warning;
-  color: $support-warning;
-}
-
-.iconButton {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  cursor: pointer;
-}
-
-.resourceLoading {
-  padding: $spacing-05 0;
-}
-
-.resourceTotal {
-  @include type-style("label-01");
-  color: $text-secondary;
-  margin-top: $spacing-03;
-}
-
-.required {
-  @include type-style("heading-04");
-}
-
-.serviceConfigCard {
-  margin-bottom: $spacing-05;
-  position: relative;
-
-  // Style the ProductiveCard description
-  :global(.c4p--card__description) {
-    @include type-style("body-compact-01");
-    margin: $spacing-05 0;
-    max-width: 75%;
-  }
-}
-
-.cardEditAction {
-  position: absolute;
-  top: $spacing-05;
-  right: $spacing-05;
-  z-index: 1;
-  display: flex;
-  gap: $spacing-03;
-}
-
-.cardActions {
-  display: flex;
-  gap: $spacing-03;
-  justify-content: flex-end;
-  margin-bottom: $spacing-05;
-  padding-top: $spacing-03;
-}
-
-.serviceConfigContent {
-  display: flex;
-  flex-direction: column;
-  gap: $spacing-05;
-}
-
-.serviceConfigItem {
-  display: flex;
-  flex-direction: row;
-  align-items: baseline;
-  gap: $spacing-05;
-}
-
-.serviceConfigItemLabel {
-  @include type-style("body-short-01");
-  color: $text-secondary;
-  min-width: 200px;
-  flex-shrink: 0;
-}
-
-.serviceConfigItemValue {
-  @include type-style("body-short-01");
-  color: $text-primary;
-  flex: 1;
-  word-break: break-word;
-}
-
-.serviceConfigField {
-  width: 100%;
-}
-
+// TODO PR 9: DOM structure aligns with Services when ServiceConfigCard is unified — move to shared then
 .serviceConfigFieldRow {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: $spacing-06;
   width: 100%;
+
+  // Credentials block spans both columns.
+  // Negative margin cancels the grid row-gap so spacing matches Services.
+  .fullWidth:has(> h4) {
+    grid-column: 1 / -1;
+    margin-top: -$spacing-06;
+  }
 
   // White background for dropdowns and text inputs in edit mode
   :global {
@@ -236,12 +30,13 @@
     }
   }
 
-  // Only make system prompt textarea full width
+  // System prompt textarea spans full width
   > div:has(.systemPromptTextArea) {
     grid-column: 1 / -1;
   }
 }
 
+// TODO PR 9: move to shared once ServiceConfigCard is unified
 .readonlyField {
   :global {
     .cds--text-input,
@@ -252,116 +47,7 @@
   }
 }
 
-.serviceConfigFieldSingle {
-  grid-column: 1 / 2; // Only takes left column, right side empty
-}
-
-.cloudCredentialsSection {
-  margin-top: $spacing-03;
-}
-
-.cloudCredentialsTitle {
-  @include type-style("heading-compact-01");
-  margin-top: -$spacing-05;
-  margin-bottom: $spacing-05;
-}
-
-.systemPromptSection {
-  grid-column: 1 / -1;
-}
-
-.apiKeyValue {
-  font-family: "IBM Plex Mono", monospace;
-  margin-right: $spacing-03;
-}
-
-.apiKeyToggle {
-  min-height: auto;
-  padding: 0;
-  margin-left: $spacing-02;
-  vertical-align: middle;
-
-  svg {
-    vertical-align: middle;
-  }
-}
-
-.systemPromptTextArea {
-  margin-top: 0;
-
-  :global(.cds--text-area) {
-    background-color: $field-02 !important;
-  }
-}
-
-.formSection {
-  margin-bottom: $spacing-07;
-}
-
-.loadingContainer {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 400px;
-}
-
-.errorContainer {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 400px;
-  color: $text-error;
-
-  p {
-    @include type-style("body-compact-01");
-  }
-}
-
-.customToast {
-  position: fixed;
-  top: $spacing-10;
-  right: $spacing-07;
-  z-index: 10000;
-}
-
-// ============================================================================
-// RESPONSIVE STYLES
-// Carbon Tearsheet does not provide default responsive behavior
-// ============================================================================
-
-@include breakpoint-down(lg) {
-  .formField {
-    max-width: 100%;
-  }
-
-  .serviceConfigFieldRow {
-    grid-template-columns: 1fr;
-  }
-
-  .serviceConfigFieldSingle {
-    grid-column: 1 / -1;
-  }
-}
-
-@include breakpoint-down(md) {
-  :global(.c4p--tearsheet.customTearsheet) {
-    padding-top: $spacing-09 !important;
-  }
-
-  :global(.c4p--tearsheet.customTearsheet .c4p--tearsheet__influencer) {
-    display: none;
-  }
-
-  :global(.c4p--tearsheet.customTearsheet .c4p--tearsheet__content) {
-    width: 100%;
-  }
-
-  :global(.c4p--tearsheet.customTearsheet .c4p--tearsheet__container) {
-    inline-size: calc(100% - 2 * #{$spacing-07}) !important;
-    max-block-size: calc(100% - #{$spacing-11}) !important;
-  }
-}
-
+// TODO PR 9: move to shared once DynamicSchemaFields is unified
 .dynamicSchemaFields {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -372,90 +58,42 @@
     min-width: 0;
   }
 
-  // Full width for textareas and controlled textareas
+  // Textareas span full width
   :global(.cds--text-area__wrapper),
   :global(.cds--text-area) {
     grid-column: 1 / -1;
   }
 
-  // Checkbox that controls other fields should be full width
+  // UI-only checkbox (e.g. system prompt toggle) spans full width
   :global(.cds--checkbox-wrapper) {
     grid-column: 1 / -1;
     margin-top: $spacing-07;
     margin-bottom: $spacing-03;
   }
 
-  // When containing controlled fields, use single column layout
+  // Single-column when a controlled field is present
   &:has(.systemPromptTextArea) {
     grid-template-columns: 1fr;
   }
 }
 
-// Controlled textarea (appears below checkbox) should be full width
-.systemPromptTextArea {
-  grid-column: 1 / -1 !important;
-  width: 100% !important;
-  max-width: 100% !important;
-
-  :global(.cds--text-area__wrapper) {
-    width: 100% !important;
-    max-width: 100% !important;
-  }
-
-  :global(.cds--text-area) {
-    width: 100% !important;
-    max-width: 100% !important;
-  }
-
-  :global(.cds--text-area__field-wrapper) {
-    width: 100% !important;
-    max-width: 100% !important;
-  }
+// TODO PR 9: unify with Services deployErrorNotification into one shared class
+.customToast {
+  position: fixed;
+  top: $spacing-10;
+  right: $spacing-07;
+  z-index: 10000;
 }
 
-// Model Description Accordion Styles
-.modelDescriptionSection {
-  margin-top: $spacing-03;
-  margin-bottom: $spacing-05;
-}
-
-.modelDescriptionContent {
-  display: flex;
-  flex-direction: column;
-  gap: $spacing-06;
-}
-
-.modelDescriptionFullWidth {
+// TODO PR 9: move to shared once serviceConfigFieldRow is unified
+.fullWidth {
+  grid-column: 1 / -1;
   width: 100%;
 }
 
-.modelDescriptionRow {
-  display: flex;
-  gap: $spacing-05;
-  width: 100%;
-
-  @include breakpoint-down(md) {
-    flex-direction: column;
+// TODO PR 9: move to shared @breakpoint-down(lg) block once serviceConfigFieldRow is unified
+@include breakpoint-down(lg) {
+  .serviceConfigFieldRow {
+    grid-template-columns: 1fr;
   }
-}
-
-.modelDescriptionHalf {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: $spacing-03;
-}
-
-.modelDescriptionTitle {
-  @include type-style("heading-compact-01");
-  margin: 0;
-  color: $text-primary;
-}
-
-.modelDescriptionText {
-  @include type-style("body-01");
-  margin: 0;
-  color: $text-secondary;
-  white-space: pre-line;
 }

--- a/ui/catalog/src/components/DeployFlow/DigitalAssistant/components/DynamicSchemaFields.tsx
+++ b/ui/catalog/src/components/DeployFlow/DigitalAssistant/components/DynamicSchemaFields.tsx
@@ -201,11 +201,7 @@ export const DynamicSchemaFields: React.FC<DynamicSchemaFieldsProps> = ({
         // Controlled textareas should span full width
         if (field.controlledBy) {
           return (
-            <div
-              key={fieldId}
-              className={styles.systemPromptTextArea}
-              style={{ gridColumn: "1 / -1" }}
-            >
+            <div key={fieldId} className={styles.systemPromptTextArea}>
               <TextArea
                 id={fieldId}
                 labelText={labelWithInfo}

--- a/ui/catalog/src/components/DeployFlow/DigitalAssistant/components/ServiceConfigCard.tsx
+++ b/ui/catalog/src/components/DeployFlow/DigitalAssistant/components/ServiceConfigCard.tsx
@@ -699,7 +699,7 @@ export const ServiceConfigCard: React.FC<ServiceConfigCardProps> = ({
                       return hasCredentialFields ? (
                         <>
                           <div />
-                          <div style={{ gridColumn: "1 / -1" }}>
+                          <div className={styles.fullWidth}>
                             <h4 className={styles.cloudCredentialsTitle}>
                               {(fieldValue || "")
                                 .toLowerCase()
@@ -767,7 +767,7 @@ export const ServiceConfigCard: React.FC<ServiceConfigCardProps> = ({
 
             {/* Render service-level schema fields in edit mode */}
             {serviceFields.length > 0 && serviceSchema && (
-              <div style={{ gridColumn: "1 / -1", width: "100%" }}>
+              <div className={styles.fullWidth}>
                 <DynamicSchemaFields
                   componentType={serviceId}
                   providerId={serviceId}
@@ -847,8 +847,7 @@ export const ServiceConfigCard: React.FC<ServiceConfigCardProps> = ({
 
                 return (
                   <div
-                    style={{ gridColumn: "1 / -1" }}
-                    className={styles.modelDescriptionSection}
+                    className={`${styles.modelDescriptionSection} ${styles.fullWidth}`}
                   >
                     <Accordion>
                       <AccordionItem title="What is this model good at?">

--- a/ui/catalog/src/components/DeployFlow/Services/ServicesDeployFlow.module.scss
+++ b/ui/catalog/src/components/DeployFlow/Services/ServicesDeployFlow.module.scss
@@ -1,397 +1,62 @@
-@use "@carbon/react/scss/spacing" as *;
-@use "@carbon/react/scss/theme" as *;
-@use "@carbon/react/scss/type" as *;
-@use "@carbon/react/scss/breakpoint" as *;
-@use "@carbon/colors" as *;
+@use "../Shared/tokens" as *;
+@use "../Shared/DeployFlow.shared.module" as *;
 
-// Add spacing around Tearsheet: 48px top (for header), 32px left/right
-:global(.c4p--tearsheet.customTearsheet) {
-  padding-top: $spacing-09; // 48px
-}
-
-:global(.c4p--tearsheet.customTearsheet .c4p--tearsheet__container) {
-  inline-size: calc(100% - 2 * #{$spacing-07}) !important; // 32px each side
-  max-block-size: calc(
-    100% - #{$spacing-07}
-  ) !important; // Account for top padding
-}
-
-.influencerContent {
-  padding: $spacing-07 $spacing-07;
-}
-
-.stepContent {
-  padding: $spacing-06 $spacing-07;
-}
-
-.stepHeader {
-  margin-bottom: $spacing-06;
-}
-
-.stepTitle {
-  @include type-style("heading-03");
-  margin: 0 0 $spacing-08 0;
-}
-
-.sectionTitle {
-  @include type-style("heading-compact-02");
-  margin-bottom: $spacing-05;
-}
-
-.formGrid {
-  row-gap: $spacing-07;
-  margin-left: 0;
-  padding-left: 0;
-}
-
-.formField {
-  max-width: 50%;
-
-  // Set dropdown background to match TextInput field color
-  :global(.cds--dropdown) {
-    background-color: $field;
-  }
-
-  :global(.cds--list-box__field) {
-    background-color: $field;
-    border-bottom: 1px solid $border-strong;
-  }
-}
-
-.labelWithInfo {
-  display: flex;
-  align-items: center;
-  gap: $spacing-03;
-
-  > span {
-    @include type-style("label-01");
-  }
-
-  :global(.cds--toggletip-button) {
-    padding: 0;
-    min-height: auto;
-    display: inline-flex;
-    align-items: center;
-    vertical-align: middle;
-    line-height: 1;
-
-    svg {
-      fill: $icon-secondary;
-      vertical-align: middle;
-    }
-  }
-}
-
-.resourceGrid {
-  display: flex;
-  gap: $spacing-05;
-  flex-wrap: wrap;
-}
-
-.resourceItem {
-  display: flex;
-  flex-direction: column;
-  gap: $spacing-08;
-  min-height: 120px;
-  background-color: transparent;
-  border: 1px solid $border-subtle;
-  flex: 1;
-  min-width: 200px;
-}
-
-.resourceLabel {
-  @include type-style("body-compact-01");
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.resourceValue {
-  @include type-style("heading-04");
-
-  .unit {
-    @include type-style("heading-01");
-  }
-}
-
-.green {
-  fill: $support-success;
-  color: $support-success;
-}
-
-.warning {
-  fill: $support-warning;
-  color: $support-warning;
-}
-
-.resourceLoading {
-  padding: $spacing-05 0;
-}
-
-.resourceTotal {
-  @include type-style("label-01");
-  color: $text-secondary;
-  margin-top: $spacing-03;
-}
-
-.required {
-  font-weight: 600;
-}
-
-.serviceConfigCard {
-  margin-bottom: $spacing-05;
-  position: relative;
-
-  // Style the ProductiveCard description
-  :global(.c4p--card__description) {
-    @include type-style("body-compact-01");
-    margin: $spacing-05 0;
-  }
-}
-
-.cardEditAction {
-  position: absolute;
-  top: $spacing-05;
-  right: $spacing-05;
-  z-index: 1;
-}
-
-.cardActions {
-  position: absolute;
-  top: $spacing-05;
-  right: $spacing-05;
-  z-index: 1;
-  display: flex;
-  gap: $spacing-03;
-}
-
-.serviceConfigContent {
-  display: flex;
-  flex-direction: column;
-  gap: $spacing-05;
-}
-
-.serviceConfigItem {
-  display: flex;
-  flex-direction: row;
-  align-items: baseline;
-  gap: $spacing-05;
-}
-
-.serviceConfigItemLabel {
-  @include type-style("caption-01");
-  color: $text-secondary;
-  min-width: 200px;
-  flex-shrink: 0;
-}
-
-.serviceConfigItemValue {
-  @include type-style("body-01");
-  color: $text-primary;
-  flex: 1;
-  word-break: break-word;
-}
-
-.serviceConfigField {
-  width: 100%;
-
-  // Add white background to editable dropdowns
-  :global(.cds--dropdown) {
-    background-color: $field;
-  }
-}
-
-.serviceConfigRow {
-  display: flex;
-  gap: $spacing-05;
-  width: 100%;
-}
-
+// TODO PR 9: DOM structure aligns with DA when StepTwo is unified — move to shared then
 .serviceConfigFieldRow {
   display: flex;
   gap: $spacing-05;
   width: 100%;
   margin-bottom: $spacing-05;
+
+  // White background for dropdowns and text inputs in edit mode
+  // (mirrors DA's serviceConfigFieldRow override — duplicate is intentional until PR 9 unifies layout)
+  :global {
+    .cds--dropdown,
+    .cds--list-box,
+    .cds--list-box__field {
+      background-color: $field-02 !important;
+      border-bottom: 1px solid $border-strong !important;
+    }
+
+    .cds--text-input,
+    .cds--text-input__field-wrapper input {
+      background-color: $field-02 !important;
+    }
+  }
 }
 
+// TODO PR 9: move to shared once StepTwo is unified
 .serviceConfigFieldHalf {
   flex: 1;
   min-width: 0;
   max-width: 50%;
-
-  // Add white background to editable dropdowns in half-width fields
-  :global(.cds--dropdown) {
-    background-color: var(--cds-field2, #ffffff);
-  }
 }
 
-.nonEditableLabel {
-  @include type-style("label-01");
-  color: $text-secondary;
-  display: block;
-  margin-bottom: $spacing-03;
-}
-
-.nonEditableValue {
-  @include type-style("body-short-01");
-  color: $text-primary;
-  padding: $spacing-03 $spacing-05;
-  background-color: $field;
-  border-bottom: 1px solid $border-strong;
-  min-height: 40px;
-  display: flex;
-  align-items: center;
-}
-
-.formSection {
-  margin-bottom: $spacing-07;
-}
-
-.loadingContainer {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 400px;
-}
-
-.cds--list-box__menu {
-  background-color: var(--cds-field2, #ffffff);
-}
-
-.errorContainer {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 400px;
-  color: $text-error;
-
-  p {
-    @include type-style("body-compact-01");
-  }
-}
-
-.deployErrorNotification {
-  position: fixed;
-  top: $spacing-07; // 32px from top
-  right: $spacing-07; // 32px from right
-  z-index: 9999; // Ensure it appears above everything including the Tearsheet
-  max-width: 400px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-}
-
-// ============================================================================
-// RESPONSIVE STYLES
-// Carbon Tearsheet does not provide default responsive behavior
-// ============================================================================
-
+// Services owns the top-spacing for credentials (shared rule is intentionally empty).
 .cloudCredentialsSection {
   margin-top: $spacing-05;
-
-  :global(.cds--text-input) {
-    background-color: var(--cds-field2, #ffffff);
-  }
 }
 
+// TODO PR 9: remove once StepTwo imports from shared — defined in shared but @use does not re-export class names
 .cloudCredentialsTitle {
   @include type-style("heading-compact-01");
   margin-bottom: $spacing-05;
 }
 
-.textInputLabel {
-  @include type-style("label-01");
-  color: $text-secondary;
+// TODO PR 9: unify with DA customToast into one shared class
+.deployErrorNotification {
+  position: fixed;
+  top: $spacing-07;
+  right: $spacing-07;
+  z-index: 9999;
+  max-width: 400px;
 }
 
-.labelWithTooltip {
-  display: flex;
-  align-items: center;
-  gap: $spacing-02;
+// StepZero — service selection
+.selected {
+  border: 2px solid $border-interactive;
+  padding: calc(#{$spacing-05} - 1px);
 }
-
-.tooltipButton {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: none;
-  background: none;
-  cursor: pointer;
-  color: $icon-secondary;
-
-  &:hover {
-    color: $icon-primary;
-  }
-
-  &:focus {
-    outline: 2px solid $focus;
-    outline-offset: 2px;
-  }
-
-  svg {
-    width: 16px;
-    height: 16px;
-  }
-}
-
-.fieldWithTooltip {
-  width: 100%;
-}
-
-.modelDescriptionSection {
-  margin-top: $spacing-05;
-  margin-bottom: $spacing-05;
-}
-
-.modelDescriptionContent {
-  display: flex;
-  flex-direction: column;
-  gap: $spacing-06;
-}
-
-.modelDescriptionFullWidth {
-  width: 100%;
-}
-
-.modelDescriptionRow {
-  display: flex;
-  gap: $spacing-05;
-  width: 100%;
-
-  @include breakpoint-down(md) {
-    flex-direction: column;
-  }
-}
-
-.modelDescriptionHalf {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: $spacing-03;
-}
-
-.modelDescriptionTitle {
-  @include type-style("heading-compact-01");
-  margin: 0;
-  color: $text-primary;
-}
-
-.modelDescriptionText {
-  @include type-style("body-compact-01");
-  margin: 0;
-  color: $text-secondary;
-  white-space: pre-line;
-}
-
-@include breakpoint-down(lg) {
-  .formField {
-    max-width: 100%;
-  }
-}
-
-// ============================================================================
-// SERVICE SELECTION STYLES (StepZero)
-// ============================================================================
 
 .serviceSelectionGrid {
   padding: 0;
@@ -401,16 +66,15 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  width: 100%; // Ensure tile fills the column width
+  width: 100%;
   min-height: 160px;
-  height: 100%; // Ensure tiles stretch to fill column height
+  height: 100%;
   padding: $spacing-05;
   border: 1px solid $border-subtle;
   background-color: $layer-01;
-  transition: border-color 0.15s ease-in-out;
-  text-decoration: none !important; // Override ClickableTile's link styling
+  transition: border-color $duration-moderate-01 motion(standard, productive);
+  text-decoration: none !important;
 
-  // Remove underlines in all states
   &,
   &:hover,
   &:focus,
@@ -425,13 +89,6 @@
   &:hover {
     border-color: $border-strong;
   }
-
-  &.selected {
-    border: 2px solid $border-interactive;
-    padding: calc(
-      #{$spacing-05} - 1px
-    ); // Adjust padding to account for thicker border
-  }
 }
 
 .selectedIndicator {
@@ -441,8 +98,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: $spacing-06;
+  height: $spacing-06;
   background-color: $background-inverse;
   border-radius: 50%;
 
@@ -454,30 +111,15 @@
 .serviceTileContent {
   display: flex;
   flex-direction: column;
-  gap: $spacing-03; // 8px spacing between elements
+  gap: $spacing-03;
 }
 
 .serviceTileName {
   @include type-style("heading-03");
   margin: 0;
-  padding-right: $spacing-07; // Space for selected indicator
-  color: $text-primary; // Override ClickableTile's link color
-  text-decoration: none; // Remove underline on hover from ClickableTile
-}
-
-.certifiedBadge {
-  display: flex;
-  align-items: center;
-  gap: $spacing-02;
+  padding-right: $spacing-07;
   color: $text-primary;
-
-  svg {
-    fill: $support-success;
-  }
-
-  span {
-    @include type-style("label-01");
-  }
+  text-decoration: none;
 }
 
 .certifiedBadge {
@@ -486,29 +128,14 @@
   align-items: center;
   gap: $spacing-02;
   margin-bottom: 0;
+
+  svg {
+    fill: $support-success;
+  }
 }
 
 .serviceTileDescription {
   @include type-style("body-compact-01");
   margin: 0;
   color: $text-primary;
-}
-
-@include breakpoint-down(md) {
-  :global(.c4p--tearsheet.customTearsheet) {
-    padding-top: $spacing-09 !important;
-  }
-
-  :global(.c4p--tearsheet.customTearsheet .c4p--tearsheet__influencer) {
-    display: none;
-  }
-
-  :global(.c4p--tearsheet.customTearsheet .c4p--tearsheet__content) {
-    width: 100%;
-  }
-
-  :global(.c4p--tearsheet.customTearsheet .c4p--tearsheet__container) {
-    inline-size: calc(100% - 2 * #{$spacing-07}) !important;
-    max-block-size: calc(100% - #{$spacing-11}) !important;
-  }
 }

--- a/ui/catalog/src/components/DeployFlow/Services/components/ServiceCredentialDisplay.tsx
+++ b/ui/catalog/src/components/DeployFlow/Services/components/ServiceCredentialDisplay.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Button } from "@carbon/react";
 import { View, ViewOff } from "@carbon/icons-react";
 import type { ProviderSchema } from "@/types/api.types";
-import styles from "../ServicesDeployFlow.module.scss";
+import styles from "../../Shared/DeployFlow.shared.module.scss";
 
 interface ServiceCredentialDisplayProps {
   providerId: string;
@@ -54,12 +54,12 @@ export const ServiceCredentialDisplay: React.FC<
             <span className={styles.serviceConfigItemLabel}>
               {field.title}
               {field.required && !fieldValue && (
-                <span style={{ color: "#da1e28", marginLeft: "4px" }}>*</span>
+                <span className={styles.requiredIndicator}>*</span>
               )}
             </span>
             <span className={styles.serviceConfigItemValue}>
               {!fieldValue ? (
-                <span style={{ color: "#da1e28", fontStyle: "italic" }}>
+                <span className={styles.requiredMessage}>
                   Required - Click Edit to add
                 </span>
               ) : isPasswordField ? (

--- a/ui/catalog/src/components/DeployFlow/Services/components/ServiceFieldLabel.tsx
+++ b/ui/catalog/src/components/DeployFlow/Services/components/ServiceFieldLabel.tsx
@@ -1,7 +1,8 @@
+import React from "react";
 import { Toggletip, ToggletipButton, ToggletipContent } from "@carbon/react";
 import { Information } from "@carbon/icons-react";
 import { parseMarkdownLinks } from "@/utils/string";
-import styles from "../ServicesDeployFlow.module.scss";
+import styles from "../../Shared/DeployFlow.shared.module.scss";
 
 interface ServiceFieldLabelProps {
   label: string;
@@ -26,7 +27,7 @@ export const ServiceFieldLabel: React.FC<ServiceFieldLabelProps> = ({
 
   // Return label with info tooltip
   return (
-    <div className={`${styles.serviceLabelWithInfo} ${className || ""}`}>
+    <div className={`${styles.labelWithInfo} ${className || ""}`}>
       <span>{label}</span>
       <Toggletip align="top">
         <ToggletipButton label="Additional information">

--- a/ui/catalog/src/components/DeployFlow/Services/steps/StepZero.tsx
+++ b/ui/catalog/src/components/DeployFlow/Services/steps/StepZero.tsx
@@ -69,11 +69,8 @@ export const StepZero: React.FC<StepZeroProps> = ({
                   <div className={styles.serviceTileContent}>
                     <h3 className={styles.serviceTileName}>{service.name}</h3>
                     <div className={styles.certifiedBadge}>
-                      {/* <Checkmark size={16} /> */}
-                      <span className={styles.certifiedBadge}>
-                        <Badge size={16} className={styles.badgeIcon} />
-                        <span className={styles.badgeName}>IBM certified</span>
-                      </span>
+                      <Badge size={16} />
+                      <span>IBM certified</span>
                     </div>
                     <p className={styles.serviceTileDescription}>
                       {service.description}

--- a/ui/catalog/src/components/DeployFlow/Shared/DeployFlow.shared.module.scss
+++ b/ui/catalog/src/components/DeployFlow/Shared/DeployFlow.shared.module.scss
@@ -1,0 +1,318 @@
+@use "./tokens" as *;
+
+// Tearsheet sizing — 48px top, 32px left/right
+:global(.c4p--tearsheet.customTearsheet) {
+  padding-top: $spacing-09;
+}
+
+:global(.c4p--tearsheet.customTearsheet .c4p--tearsheet__container) {
+  inline-size: calc(100% - 2 * #{$spacing-07}) !important;
+  max-block-size: calc(100% - #{$spacing-07}) !important;
+}
+
+.influencerContent {
+  padding: $spacing-07 $spacing-07;
+}
+
+.stepHeader {
+  @include type-style("label-01");
+  color: $text-secondary;
+  margin-bottom: $spacing-06;
+}
+
+.sectionTitle {
+  @include type-style("heading-compact-02");
+  margin-bottom: $spacing-05;
+}
+
+.formGrid {
+  row-gap: $spacing-07;
+  margin-left: 0;
+  padding-left: 0;
+}
+
+.stepContent {
+  padding: $spacing-06 $spacing-07;
+}
+
+.formField {
+  max-width: 50%;
+
+  :global {
+    .cds--dropdown,
+    .cds--list-box,
+    .cds--list-box__field {
+      background-color: $field-01 !important;
+      border-bottom: 1px solid $border-strong !important;
+    }
+  }
+}
+
+.formSection {
+  margin-bottom: $spacing-07;
+}
+
+.stepTitle {
+  @include type-style("heading-03");
+  margin: 0 0 $spacing-06 0;
+}
+
+.labelWithInfo {
+  display: flex;
+  align-items: center;
+  gap: $spacing-03;
+}
+
+.resourceLoading {
+  padding: $spacing-05 0;
+}
+
+.iconButton {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+}
+
+.resourceGrid {
+  display: flex;
+  gap: $spacing-06;
+  flex-wrap: wrap;
+}
+
+.required {
+  @include type-style("heading-04");
+}
+
+// Resource tiles
+.resourceItem {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-08;
+  flex: 1;
+  min-width: 200px;
+  min-height: 120px;
+  background-color: transparent;
+  border: 1px solid $border-subtle;
+}
+
+.resourceLabel {
+  @include type-style("body-compact-01");
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.resourceValue {
+  @include type-style("heading-04");
+}
+
+.unit {
+  @include type-style("heading-01");
+}
+
+.green {
+  fill: $support-success;
+  color: $support-success;
+}
+
+.warning {
+  fill: $support-warning;
+  color: $support-warning;
+}
+
+.serviceConfigCard {
+  margin-bottom: $spacing-05;
+  position: relative;
+
+  :global(.c4p--card__description) {
+    @include type-style("body-compact-01");
+    margin: $spacing-05 0;
+  }
+}
+
+.cardEditAction,
+.cardActions {
+  position: absolute;
+  top: $spacing-05;
+  right: $spacing-05;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: $spacing-03;
+}
+
+// Service config card — read-only display
+.serviceConfigContent {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-05;
+}
+
+.serviceConfigItem {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  gap: $spacing-05;
+}
+
+.serviceConfigItemLabel {
+  @include type-style("body-short-01");
+  color: $text-secondary;
+  min-width: 200px;
+  flex-shrink: 0;
+}
+
+.serviceConfigItemValue {
+  @include type-style("body-short-01");
+  color: $text-primary;
+  flex: 1;
+  word-break: break-word;
+}
+
+// Credential display
+.apiKeyValue {
+  @include font-family("mono");
+  margin-right: $spacing-03;
+}
+
+.apiKeyToggle {
+  min-height: auto;
+  padding: 0;
+  margin-left: $spacing-02;
+  vertical-align: middle;
+
+  svg {
+    vertical-align: middle;
+  }
+}
+
+.systemPromptTextArea {
+  margin-top: 0;
+  grid-column: 1 / -1 !important;
+  width: 100% !important;
+  max-width: 100% !important;
+
+  :global(.cds--text-area) {
+    background-color: $field-02 !important;
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+
+  :global(.cds--text-area__wrapper) {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+
+  :global(.cds--label) {
+    display: none;
+  }
+}
+
+.cloudCredentialsTitle {
+  @include type-style("heading-compact-01");
+  margin-bottom: $spacing-05;
+}
+
+// Model description accordion
+.modelDescriptionSection {
+  margin-top: $spacing-03;
+  margin-bottom: $spacing-05;
+}
+
+.modelDescriptionTitle {
+  @include type-style("heading-compact-01");
+}
+
+.modelDescriptionContent {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-06;
+}
+
+.modelDescriptionFullWidth {
+  width: 100%;
+}
+
+.modelDescriptionRow {
+  display: flex;
+  gap: $spacing-05;
+  width: 100%;
+
+  @include breakpoint-down(md) {
+    flex-direction: column;
+  }
+}
+
+.modelDescriptionHalf {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-03;
+}
+
+.modelDescriptionText {
+  @include type-style("body-01");
+  margin: 0;
+  color: $text-secondary;
+  white-space: pre-line;
+}
+
+.loadingContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+}
+
+.errorContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 400px;
+  color: $text-error;
+
+  p {
+    @include type-style("body-compact-01");
+  }
+}
+
+@include breakpoint-down(lg) {
+  .formField {
+    max-width: 100%;
+  }
+}
+
+// Required field indicators
+.requiredIndicator {
+  color: $support-error;
+  margin-left: $spacing-02;
+}
+
+.requiredMessage {
+  color: $support-error;
+  font-style: italic;
+}
+
+// Responsive — Carbon Tearsheet has no built-in responsive behaviour
+@include breakpoint-down(md) {
+  :global(.c4p--tearsheet.customTearsheet) {
+    padding-top: $spacing-09 !important;
+  }
+
+  :global(.c4p--tearsheet.customTearsheet .c4p--tearsheet__influencer) {
+    display: none;
+  }
+
+  :global(.c4p--tearsheet.customTearsheet .c4p--tearsheet__content) {
+    width: 100%;
+  }
+
+  :global(.c4p--tearsheet.customTearsheet .c4p--tearsheet__container) {
+    inline-size: calc(100% - 2 * #{$spacing-07}) !important;
+    max-block-size: calc(100% - #{$spacing-11}) !important;
+  }
+}

--- a/ui/catalog/src/components/DeployFlow/Shared/_tokens.scss
+++ b/ui/catalog/src/components/DeployFlow/Shared/_tokens.scss
@@ -1,0 +1,7 @@
+// DeployFlow token forwarder — no CSS output, forwards only.
+@forward "@carbon/react/scss/spacing";
+@forward "@carbon/react/scss/theme";
+@forward "@carbon/react/scss/type";
+@forward "@carbon/react/scss/breakpoint";
+@forward "@carbon/react/scss/motion";
+@forward "@carbon/colors";


### PR DESCRIPTION
- Add Shared/_tokens.scss — Carbon token forwarder for both flows
- Add Shared/DeployFlow.shared.module.scss — shared stylesheet; both flow files now @use it
- Remove all inline style={{}} props — replaced with CSS Module classes
- Replace hardcoded color/size values with Carbon tokens
- Flow-specific classes not yet unified carry // TODO PR 9 comments