### PR TITLE
Remove shadow entries from checksum registry

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.203
+TAG?=v0.0.204
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.35
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.36
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.35
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.36
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.35
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.36
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.35
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.36
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.35
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.36
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.203
+  image: icr.io/ai-services-cicd/ai-services:v0.0.204
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.203
+  image: icr.io/ai-services-cicd/ai-services:v0.0.204
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.35
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.36
   log_level: "INFO"
   database: "digitize_metadata"
 

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.35
+TAG?=v0.0.36
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -577,6 +577,13 @@ class DatabaseManager:
         """
         Delete a document from the database.
 
+        Also removes:
+        - The checksum registry entry (so the hash can be re-registered on
+          re-ingestion of the same file).
+        - Any 'already_exists' shadow documents whose metadata points to this
+          doc_id as their existing_doc_id, since those placeholder rows have
+          no meaning once the original document is gone.
+
         Args:
             doc_id: Unique identifier for the document
 
@@ -590,6 +597,17 @@ class DatabaseManager:
                 session.execute(
                     delete(FileChecksumRegistry).where(FileChecksumRegistry.doc_id == doc_id)
                 )
+
+                # Remove any already_exists shadow docs that reference this document.
+                # These placeholder rows are created when a duplicate file is submitted;
+                # their metadata stores the original doc_id under 'existing_doc_id'.
+                # Once the original is deleted they become stale, so clean them up too.
+                session.execute(
+                    delete(Document).where(
+                        Document.doc_metadata["existing_doc_id"].as_string() == doc_id
+                    )
+                )
+
                 stmt = delete(Document).where(Document.doc_id == doc_id)
                 result = cast(CursorResult, session.execute(stmt))
 

--- a/services/digitize/tests/test_deduplication.py
+++ b/services/digitize/tests/test_deduplication.py
@@ -941,9 +941,9 @@ class TestDatabaseManagerFindCompletedDocumentByHash:
 
 @pytest.mark.unit
 class TestDatabaseManagerDeleteDocumentClearsChecksum:
-    """delete_document must remove the checksum registry entry before deleting the doc."""
+    """delete_document must remove the checksum registry entry and shadow docs before deleting the doc."""
 
-    def test_execute_called_twice(self):
+    def test_execute_called_three_times(self):
         session = MagicMock()
         session.execute.return_value = Mock(rowcount=1)
 
@@ -951,13 +951,15 @@ class TestDatabaseManagerDeleteDocumentClearsChecksum:
             from digitize.db.manager import DatabaseManager
             DatabaseManager.delete_document("doc-1")
 
-        # First execute: registry delete. Second execute: document delete.
-        assert session.execute.call_count == 2
+        # 1st execute: registry delete.
+        # 2nd execute: shadow already_exists docs delete.
+        # 3rd execute: document delete.
+        assert session.execute.call_count == 3
 
     def test_returns_true_when_deleted(self):
         session = MagicMock()
-        # registry delete (rowcount irrelevant), doc delete rowcount=1
-        session.execute.side_effect = [Mock(rowcount=0), Mock(rowcount=1)]
+        # registry delete, shadow docs delete (rowcount irrelevant), doc delete rowcount=1
+        session.execute.side_effect = [Mock(rowcount=0), Mock(rowcount=0), Mock(rowcount=1)]
 
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
             from digitize.db.manager import DatabaseManager
@@ -967,13 +969,34 @@ class TestDatabaseManagerDeleteDocumentClearsChecksum:
 
     def test_returns_false_when_not_found(self):
         session = MagicMock()
-        session.execute.side_effect = [Mock(rowcount=0), Mock(rowcount=0)]
+        session.execute.side_effect = [Mock(rowcount=0), Mock(rowcount=0), Mock(rowcount=0)]
 
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
             from digitize.db.manager import DatabaseManager
             result = DatabaseManager.delete_document("doc-missing")
 
         assert result is False
+
+    def test_shadow_docs_deleted_before_original(self):
+        """already_exists placeholder rows referencing this doc_id are removed."""
+        session = MagicMock()
+        session.execute.return_value = Mock(rowcount=1)
+
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
+            from digitize.db.manager import DatabaseManager
+            import sqlalchemy
+            DatabaseManager.delete_document("doc-orig")
+
+        # Verify the second call (index 1) targets Documents via a metadata JSONB lookup.
+        # The key 'existing_doc_id' is passed as a bind parameter, so check the params dict.
+        second_call_stmt = session.execute.call_args_list[1][0][0]
+        dialect = sqlalchemy.dialects.postgresql.dialect()
+        compiled = second_call_stmt.compile(dialect=dialect)
+        sql = str(compiled).lower()
+        assert "delete" in sql
+        assert "documents" in sql
+        # The JSONB key is passed as a bind param — confirm it appears in the compiled params.
+        assert "existing_doc_id" in compiled.params.values()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
-When a dup doc is ingested, it is saved in documents table like:

### `documents` Table

| doc_id | status | metadata | Note |
| :--- | :--- | :--- | :--- |
| `doc-123` | `completed` | `file_hash: sha256:abc` | *Original document* |
| `doc-456` | `already_exists` | `existing_doc_id: doc-123, file_hash: sha256:abc` | *Duplicate placeholder* |

### `file_checksum_registry` Table

| sha256 | doc_id | 
| :--- | :--- | 
| `sha256:abc` | `doc-123` | 

-When a doc is deleted, the shadow entry has to be deleted too. This is the new query introduced