### PR TITLE
feat: stop in-flight deployment on application deletion

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.233
+TAG?=v0.0.234
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.233
+  image: icr.io/ai-services-cicd/ai-services:v0.0.234
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.233
+  image: icr.io/ai-services-cicd/ai-services:v0.0.234
   runtime: ""
   adminPasswordHash: ""
   # workerGatewayPort: port for the gRPC worker gateway. Always active; default is 9090.

--- a/ai-services/internal/pkg/application/openshift/create.go
+++ b/ai-services/internal/pkg/application/openshift/create.go
@@ -121,11 +121,11 @@ func deployApp(ctx context.Context, chart chart.Charter, timeout time.Duration, 
 	if !isAppExist {
 		// if App does not exist then perform install
 		logger.Infof("App: %s does not exist, proceeding with install...", app)
-		err = helmClient.Install(app, chart, &helm.InstallOpts{Values: values, Timeout: timeout})
+		err = helmClient.Install(context.Background(), app, chart, &helm.InstallOpts{Values: values, Timeout: timeout})
 	} else {
 		// if App exists, perform upgrade so that the actual state of the app meets the desired state
 		logger.Infof("App: %s already exist, proceeding with reconciling...", app)
-		err = helmClient.Upgrade(app, chart, &helm.UpgradeOpts{Values: values, Timeout: timeout})
+		err = helmClient.Upgrade(context.Background(), app, chart, &helm.UpgradeOpts{Values: values, Timeout: timeout})
 	}
 	if err != nil {
 		s.Fail("failed to create application")

--- a/ai-services/internal/pkg/application/openshift/create.go
+++ b/ai-services/internal/pkg/application/openshift/create.go
@@ -121,11 +121,11 @@ func deployApp(ctx context.Context, chart chart.Charter, timeout time.Duration, 
 	if !isAppExist {
 		// if App does not exist then perform install
 		logger.Infof("App: %s does not exist, proceeding with install...", app)
-		err = helmClient.Install(context.Background(), app, chart, &helm.InstallOpts{Values: values, Timeout: timeout})
+		err = helmClient.Install(ctx, app, chart, &helm.InstallOpts{Values: values, Timeout: timeout})
 	} else {
 		// if App exists, perform upgrade so that the actual state of the app meets the desired state
 		logger.Infof("App: %s already exist, proceeding with reconciling...", app)
-		err = helmClient.Upgrade(context.Background(), app, chart, &helm.UpgradeOpts{Values: values, Timeout: timeout})
+		err = helmClient.Upgrade(ctx, app, chart, &helm.UpgradeOpts{Values: values, Timeout: timeout})
 	}
 	if err != nil {
 		s.Fail("failed to create application")

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -53,7 +53,7 @@ func NewApplicationService(
 	case runtimeTypes.RuntimeTypePodman:
 		return appservice.NewPodmanApplicationService(base)
 	case runtimeTypes.RuntimeTypeOpenShift:
-		return &appservice.OpenShiftApplicationService{ApplicationServiceBase: base}
+		return appservice.NewOpenShiftApplicationService(base)
 	default:
 		panic(fmt.Sprintf("unsupported runtime type %q", runtimeType))
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -51,12 +51,10 @@ func NewApplicationService(
 
 	switch runtimeType {
 	case runtimeTypes.RuntimeTypePodman:
-		return &appservice.PodmanApplicationService{ApplicationServiceBase: base}
+		return appservice.NewPodmanApplicationService(base)
 	case runtimeTypes.RuntimeTypeOpenShift:
 		return &appservice.OpenShiftApplicationService{ApplicationServiceBase: base}
 	default:
 		panic(fmt.Sprintf("unsupported runtime type %q", runtimeType))
 	}
 }
-
-// Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -614,9 +614,10 @@ func (s *ApplicationServiceBase) ListApplications(ctx context.Context, req ListA
 	}, nil
 }
 
-// CreateApplication validates, plans, persists, and asynchronously deploys a new application
-// for the given runtime type.
-func (s *ApplicationServiceBase) CreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest, runtimeType runtimeTypes.RuntimeType) (*apimodels.CreateApplicationResponse, error) {
+// prepareCreateApplication runs phases 1–4 of application creation (duplicate check,
+// validation, deployment planning, and DB persistence) and returns the resulting plan.
+// It is shared by both the base CreateApplication and PodmanApplicationService.CreateApplication.
+func (s *ApplicationServiceBase) prepareCreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest, runtimeType runtimeTypes.RuntimeType) (*deployment.DeploymentPlan, error) {
 	// Phase 1: check for duplicate name
 	existingApp, err := s.AppRepo.GetByName(ctx, req.Name)
 	if err != nil {
@@ -645,7 +646,17 @@ func (s *ApplicationServiceBase) CreateApplication(ctx context.Context, req apim
 		return nil, fmt.Errorf("failed to insert deployment records: %w", err)
 	}
 
-	// Phase 5: async deployment
+	return plan, nil
+}
+
+// CreateApplication validates, plans, persists, and asynchronously deploys a new application
+// for the given runtime type.
+func (s *ApplicationServiceBase) CreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest, runtimeType runtimeTypes.RuntimeType) (*apimodels.CreateApplicationResponse, error) {
+	plan, err := s.prepareCreateApplication(ctx, req, runtimeType)
+	if err != nil {
+		return nil, err
+	}
+
 	go s.executeDeploymentAsync(ctx, plan, req, runtimeType)
 
 	return &apimodels.CreateApplicationResponse{ID: plan.ApplicationID.String()}, nil

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -21,10 +21,10 @@ import (
 	clitemplates "github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
 	consts "github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/common"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
-	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // ValidationError represents a validation error with HTTP status code.
@@ -618,88 +618,6 @@ func (s *ApplicationServiceBase) ListApplications(ctx context.Context, req ListA
 	}, nil
 }
 
-// DeleteApplication cancels any in-flight deployment, marks the application as deleting,
-// and kicks off async deletion. It is the shared implementation for all runtimes.
-func (s *ApplicationServiceBase) DeleteApplication(ctx context.Context, id uuid.UUID, user string, keepData bool) (*DeleteApplicationResponse, error) {
-	app, err := s.AppRepo.GetByID(ctx, id)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get application: %w", err)
-	}
-	if app == nil {
-		return nil, &ValidationError{
-			Code:    http.StatusNotFound,
-			Message: ErrMsgApplicationNotFound,
-		}
-	}
-
-	if app.CreatedBy != user {
-		return nil, &ValidationError{
-			Code:    http.StatusForbidden,
-			Message: ErrMsgUserNotOwner,
-		}
-	}
-
-	if app.Status == models.ApplicationStatusDeleting {
-		return nil, &ValidationError{
-			Code:    http.StatusConflict,
-			Message: ErrMsgApplicationAlreadyDeleting,
-		}
-	}
-
-	// Cancel any in-flight deployment before transitioning to Deleting.
-	// No-op when DeploymentRegistry is nil (e.g. OpenShift stub).
-	if s.DeploymentRegistry != nil {
-		s.DeploymentRegistry.Cancel(id)
-	}
-
-	if err := catalogutils.UpdateApplicationStatus(ctx, s.AppRepo, id, models.ApplicationStatusDeleting, "Deleting deployment..."); err != nil {
-		return nil, err
-	}
-
-	var requestID string
-	if reqID, ok := ctx.Value(logger.RequestIDKey).(string); ok {
-		requestID = reqID
-	}
-
-	deletionCtx := context.Background()
-	if requestID != "" {
-		deletionCtx = context.WithValue(deletionCtx, logger.RequestIDKey, requestID)
-	}
-
-	runtimeType := vars.RuntimeFactory.GetRuntimeType()
-
-	go func() {
-		orphanedComponentIDs, err := s.identifyOrphanedComponents(deletionCtx, id, app.Services)
-		if err != nil {
-			logger.ErrorfCtx(deletionCtx, "Failed to identify orphaned components for application %s: %v", id, err)
-
-			if updateErr := catalogutils.UpdateApplicationStatus(deletionCtx, s.AppRepo, id, models.ApplicationStatusError, err.Error()); updateErr != nil {
-				logger.ErrorfCtx(deletionCtx, "Failed to update application status to Error: %v", updateErr)
-			}
-
-			return
-		}
-
-		if err := s.DeletionExecutor.Execute(deletionCtx, id, app.Services, orphanedComponentIDs, keepData, runtimeType); err != nil {
-			logger.ErrorfCtx(deletionCtx, "Deletion failed for application %s: %v", id, err)
-
-			if updateErr := catalogutils.UpdateApplicationStatus(deletionCtx, s.AppRepo, id, models.ApplicationStatusError, err.Error()); updateErr != nil {
-				logger.ErrorfCtx(deletionCtx, "Failed to update application status to Error: %v", updateErr)
-			}
-
-			return
-		}
-
-		logger.InfolnCtx(deletionCtx, fmt.Sprintf("Deletion completed successfully for application id '%s'", id))
-	}()
-
-	return &DeleteApplicationResponse{
-		ID:      id.String(),
-		Status:  string(models.ApplicationStatusDeleting),
-		Message: "Deletion initiated successfully",
-	}, nil
-}
-
 // CreateApplication validates, plans, persists, and asynchronously deploys a new application
 // for the given runtime type.
 func (s *ApplicationServiceBase) CreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest, runtimeType runtimeTypes.RuntimeType) (*apimodels.CreateApplicationResponse, error) {
@@ -1134,6 +1052,108 @@ func loadApplicationPods(rt runtime.Runtime, appID string) ([]types.Pod, error) 
 	}
 
 	return appPodList, nil
+}
+
+func (s *ApplicationServiceBase) DeleteApplication(ctx context.Context, id uuid.UUID, user string, keepData bool, runtimeType runtimeTypes.RuntimeType) (*DeleteApplicationResponse, error) {
+	app, err := s.AppRepo.GetByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get application: %w", err)
+	}
+	if app == nil {
+		return nil, &ValidationError{
+			Code:    http.StatusNotFound,
+			Message: ErrMsgApplicationNotFound,
+		}
+	}
+
+	if app.CreatedBy != user {
+		return nil, &ValidationError{
+			Code:    http.StatusForbidden,
+			Message: ErrMsgUserNotOwner,
+		}
+	}
+
+	if app.Status == models.ApplicationStatusDeleting {
+		return nil, &ValidationError{
+			Code:    http.StatusConflict,
+			Message: ErrMsgApplicationAlreadyDeleting,
+		}
+	}
+
+	// Cancel any in-flight deployment before transitioning to Deleting.
+	// No-op when DeploymentRegistry is nil (e.g. OpenShift stub).
+	if s.DeploymentRegistry != nil {
+		s.DeploymentRegistry.Cancel(id)
+	}
+
+	if err := catalogutils.UpdateApplicationStatus(ctx, s.AppRepo, id, models.ApplicationStatusDeleting, "Deleting deployment..."); err != nil {
+		return nil, err
+	}
+
+	orphanedComponentIDs, err := s.identifyOrphanedComponents(ctx, id, app.Services)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get application components: %w", err)
+	}
+
+	var requestID string
+	if reqID, ok := ctx.Value(logger.RequestIDKey).(string); ok {
+		requestID = reqID
+	}
+
+	deletionCtx := context.Background()
+	if requestID != "" {
+		deletionCtx = context.WithValue(deletionCtx, logger.RequestIDKey, requestID)
+	}
+
+	go s.executeDeletionAsync(deletionCtx, id, app.Services, orphanedComponentIDs, keepData, runtimeType)
+
+	return &DeleteApplicationResponse{
+		ID:      id.String(),
+		Status:  string(models.ApplicationStatusDeleting),
+		Message: "Deletion initiated successfully",
+	}, nil
+}
+
+func (s *ApplicationServiceBase) executeDeletionAsync(
+	parentCtx context.Context,
+	appID uuid.UUID,
+	services []models.Service,
+	orphanedComponentIDs []uuid.UUID,
+	keepData bool,
+	runtimeType runtimeTypes.RuntimeType,
+) {
+	var requestID string
+	if id, ok := parentCtx.Value(logger.RequestIDKey).(string); ok {
+		requestID = id
+	}
+
+	ctx := context.Background()
+	if requestID != "" {
+		ctx = context.WithValue(ctx, logger.RequestIDKey, requestID)
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			logger.ErrorfCtx(ctx, "Panic recovered in deletion goroutine for application %s: %v", appID, r)
+
+			errMsg := fmt.Sprintf("Deletion panic: %v", r)
+			if updateErr := catalogutils.UpdateApplicationStatus(ctx, s.AppRepo, appID.String(), models.ApplicationStatusError, errMsg); updateErr != nil {
+				logger.ErrorfCtx(ctx, "Failed to update application status after panic: %v", updateErr)
+			}
+		}
+	}()
+
+	err := s.DeletionExecutor.Execute(ctx, appID, services, orphanedComponentIDs, keepData, runtimeType)
+	if err != nil {
+		logger.ErrorfCtx(ctx, "Deletion failed for application %s: %v", appID.String(), err)
+
+		if updateErr := catalogutils.UpdateApplicationStatus(ctx, s.AppRepo, appID.String(), models.ApplicationStatusError, err.Error()); updateErr != nil {
+			logger.ErrorfCtx(ctx, "Failed to update application status to Error: %v", updateErr)
+		}
+
+		return
+	}
+
+	logger.InfolnCtx(ctx, fmt.Sprintf("Deletion completed successfully for application id '%s'", appID.String()))
 }
 
 // identifyOrphanedComponents identifies components that will become orphaned after service deletion.

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -21,10 +21,10 @@ import (
 	clitemplates "github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
 	consts "github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/common"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // ValidationError represents a validation error with HTTP status code.

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -649,23 +649,32 @@ func (s *ApplicationServiceBase) CreateApplication(ctx context.Context, req apim
 		return nil, fmt.Errorf("failed to insert deployment records: %w", err)
 	}
 
-	// Phase 5: async deployment
-	go s.executeDeploymentAsync(ctx, plan, req, runtimeType)
+	// Phase 5: async deployment.
+	// Build the deployment context here, before launching the goroutine, so that
+	// Register is called synchronously. This closes the race where a concurrent
+	// DeleteApplication could call Cancel before the goroutine has had a chance
+	// to call Register, causing cancellation to be silently missed.
+	deployCtx := context.Background()
+	if id, ok := ctx.Value(logger.RequestIDKey).(string); ok && id != "" {
+		deployCtx = context.WithValue(deployCtx, logger.RequestIDKey, id)
+	}
+
+	if s.DeploymentRegistry != nil {
+		deployCtx = s.DeploymentRegistry.Register(deployCtx, plan.ApplicationID)
+	}
+
+	go s.executeDeploymentAsync(deployCtx, plan, req, runtimeType)
 
 	return &apimodels.CreateApplicationResponse{ID: plan.ApplicationID.String()}, nil
 }
 
 // executeDeploymentAsync runs the deployment in a background goroutine for the given runtime type.
-func (s *ApplicationServiceBase) executeDeploymentAsync(parentCtx context.Context, plan *deployment.DeploymentPlan, req apimodels.CreateApplicationRequest, runtimeType runtimeTypes.RuntimeType) {
-	ctx := context.Background()
-	if id, ok := parentCtx.Value(logger.RequestIDKey).(string); ok && id != "" {
-		ctx = context.WithValue(ctx, logger.RequestIDKey, id)
-	}
+// deployCtx is already derived and registered with the DeploymentRegistry by the caller.
+func (s *ApplicationServiceBase) executeDeploymentAsync(deployCtx context.Context, plan *deployment.DeploymentPlan, req apimodels.CreateApplicationRequest, runtimeType runtimeTypes.RuntimeType) {
+	ctx := deployCtx
 
-	// Register with the DeploymentRegistry so a concurrent delete can cancel this
-	// goroutine. Deregister on any exit path — success, error, or panic.
+	// Deregister on any exit path — success, error, or panic.
 	if s.DeploymentRegistry != nil {
-		ctx = s.DeploymentRegistry.Register(ctx, plan.ApplicationID)
 		defer s.DeploymentRegistry.Deregister(plan.ApplicationID)
 	}
 

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -90,6 +90,10 @@ type ApplicationServiceBase struct {
 	DeploymentExecutor    *deployment.DeploymentExecutor
 	DeletionExecutor      *deletion.DeletionExecutor
 	Validator             *validators.ApplicationValidator
+
+	// DeploymentRegistry tracks in-flight deployments so they can be cancelled
+	// by a concurrent delete request. Nil means no cancellation (e.g. OpenShift stub).
+	DeploymentRegistry *DeploymentRegistry
 }
 
 // ListApplications retrieves a paginated list of applications with filters.
@@ -614,10 +618,91 @@ func (s *ApplicationServiceBase) ListApplications(ctx context.Context, req ListA
 	}, nil
 }
 
-// prepareCreateApplication runs phases 1–4 of application creation (duplicate check,
-// validation, deployment planning, and DB persistence) and returns the resulting plan.
-// It is shared by both the base CreateApplication and PodmanApplicationService.CreateApplication.
-func (s *ApplicationServiceBase) prepareCreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest, runtimeType runtimeTypes.RuntimeType) (*deployment.DeploymentPlan, error) {
+// DeleteApplication cancels any in-flight deployment, marks the application as deleting,
+// and kicks off async deletion. It is the shared implementation for all runtimes.
+func (s *ApplicationServiceBase) DeleteApplication(ctx context.Context, id uuid.UUID, user string, keepData bool) (*DeleteApplicationResponse, error) {
+	app, err := s.AppRepo.GetByID(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get application: %w", err)
+	}
+	if app == nil {
+		return nil, &ValidationError{
+			Code:    http.StatusNotFound,
+			Message: ErrMsgApplicationNotFound,
+		}
+	}
+
+	if app.CreatedBy != user {
+		return nil, &ValidationError{
+			Code:    http.StatusForbidden,
+			Message: ErrMsgUserNotOwner,
+		}
+	}
+
+	if app.Status == models.ApplicationStatusDeleting {
+		return nil, &ValidationError{
+			Code:    http.StatusConflict,
+			Message: ErrMsgApplicationAlreadyDeleting,
+		}
+	}
+
+	// Cancel any in-flight deployment before transitioning to Deleting.
+	// No-op when DeploymentRegistry is nil (e.g. OpenShift stub).
+	if s.DeploymentRegistry != nil {
+		s.DeploymentRegistry.Cancel(id)
+	}
+
+	if err := catalogutils.UpdateApplicationStatus(ctx, s.AppRepo, id, models.ApplicationStatusDeleting, "Deleting deployment..."); err != nil {
+		return nil, err
+	}
+
+	var requestID string
+	if reqID, ok := ctx.Value(logger.RequestIDKey).(string); ok {
+		requestID = reqID
+	}
+
+	deletionCtx := context.Background()
+	if requestID != "" {
+		deletionCtx = context.WithValue(deletionCtx, logger.RequestIDKey, requestID)
+	}
+
+	runtimeType := vars.RuntimeFactory.GetRuntimeType()
+
+	go func() {
+		orphanedComponentIDs, err := s.identifyOrphanedComponents(deletionCtx, id, app.Services)
+		if err != nil {
+			logger.ErrorfCtx(deletionCtx, "Failed to identify orphaned components for application %s: %v", id, err)
+
+			if updateErr := catalogutils.UpdateApplicationStatus(deletionCtx, s.AppRepo, id, models.ApplicationStatusError, err.Error()); updateErr != nil {
+				logger.ErrorfCtx(deletionCtx, "Failed to update application status to Error: %v", updateErr)
+			}
+
+			return
+		}
+
+		if err := s.DeletionExecutor.Execute(deletionCtx, id, app.Services, orphanedComponentIDs, keepData, runtimeType); err != nil {
+			logger.ErrorfCtx(deletionCtx, "Deletion failed for application %s: %v", id, err)
+
+			if updateErr := catalogutils.UpdateApplicationStatus(deletionCtx, s.AppRepo, id, models.ApplicationStatusError, err.Error()); updateErr != nil {
+				logger.ErrorfCtx(deletionCtx, "Failed to update application status to Error: %v", updateErr)
+			}
+
+			return
+		}
+
+		logger.InfolnCtx(deletionCtx, fmt.Sprintf("Deletion completed successfully for application id '%s'", id))
+	}()
+
+	return &DeleteApplicationResponse{
+		ID:      id.String(),
+		Status:  string(models.ApplicationStatusDeleting),
+		Message: "Deletion initiated successfully",
+	}, nil
+}
+
+// CreateApplication validates, plans, persists, and asynchronously deploys a new application
+// for the given runtime type.
+func (s *ApplicationServiceBase) CreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest, runtimeType runtimeTypes.RuntimeType) (*apimodels.CreateApplicationResponse, error) {
 	// Phase 1: check for duplicate name
 	existingApp, err := s.AppRepo.GetByName(ctx, req.Name)
 	if err != nil {
@@ -646,17 +731,7 @@ func (s *ApplicationServiceBase) prepareCreateApplication(ctx context.Context, r
 		return nil, fmt.Errorf("failed to insert deployment records: %w", err)
 	}
 
-	return plan, nil
-}
-
-// CreateApplication validates, plans, persists, and asynchronously deploys a new application
-// for the given runtime type.
-func (s *ApplicationServiceBase) CreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest, runtimeType runtimeTypes.RuntimeType) (*apimodels.CreateApplicationResponse, error) {
-	plan, err := s.prepareCreateApplication(ctx, req, runtimeType)
-	if err != nil {
-		return nil, err
-	}
-
+	// Phase 5: async deployment
 	go s.executeDeploymentAsync(ctx, plan, req, runtimeType)
 
 	return &apimodels.CreateApplicationResponse{ID: plan.ApplicationID.String()}, nil
@@ -664,14 +739,16 @@ func (s *ApplicationServiceBase) CreateApplication(ctx context.Context, req apim
 
 // executeDeploymentAsync runs the deployment in a background goroutine for the given runtime type.
 func (s *ApplicationServiceBase) executeDeploymentAsync(parentCtx context.Context, plan *deployment.DeploymentPlan, req apimodels.CreateApplicationRequest, runtimeType runtimeTypes.RuntimeType) {
-	var requestID string
-	if id, ok := parentCtx.Value(logger.RequestIDKey).(string); ok {
-		requestID = id
+	ctx := context.Background()
+	if id, ok := parentCtx.Value(logger.RequestIDKey).(string); ok && id != "" {
+		ctx = context.WithValue(ctx, logger.RequestIDKey, id)
 	}
 
-	ctx := context.Background()
-	if requestID != "" {
-		ctx = context.WithValue(ctx, logger.RequestIDKey, requestID)
+	// Register with the DeploymentRegistry so a concurrent delete can cancel this
+	// goroutine. Deregister on any exit path — success, error, or panic.
+	if s.DeploymentRegistry != nil {
+		ctx = s.DeploymentRegistry.Register(ctx, plan.ApplicationID)
+		defer s.DeploymentRegistry.Deregister(plan.ApplicationID)
 	}
 
 	defer func() {
@@ -687,6 +764,13 @@ func (s *ApplicationServiceBase) executeDeploymentAsync(parentCtx context.Contex
 
 	err := s.DeploymentExecutor.ExecuteWithPlan(ctx, plan, req, runtimeType)
 	if err != nil {
+		// Context cancelled — deletion is in charge of status, exit silently.
+		if ctx.Err() != nil {
+			logger.InfofCtx(ctx, "Deployment cancelled for application %s (deletion in progress)", plan.ApplicationName)
+
+			return
+		}
+
 		logger.ErrorfCtx(ctx, "Deployment failed for application %s: %v", plan.ApplicationName, err)
 
 		if updateErr := catalogutils.UpdateApplicationStatus(ctx, s.AppRepo, plan.ApplicationID.String(), models.ApplicationStatusError, err.Error()); updateErr != nil {
@@ -1050,102 +1134,6 @@ func loadApplicationPods(rt runtime.Runtime, appID string) ([]types.Pod, error) 
 	}
 
 	return appPodList, nil
-}
-
-func (s *ApplicationServiceBase) DeleteApplication(ctx context.Context, id uuid.UUID, user string, keepData bool, runtimeType runtimeTypes.RuntimeType) (*DeleteApplicationResponse, error) {
-	app, err := s.AppRepo.GetByID(ctx, id)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get application: %w", err)
-	}
-	if app == nil {
-		return nil, &ValidationError{
-			Code:    http.StatusNotFound,
-			Message: ErrMsgApplicationNotFound,
-		}
-	}
-
-	if app.CreatedBy != user {
-		return nil, &ValidationError{
-			Code:    http.StatusForbidden,
-			Message: ErrMsgUserNotOwner,
-		}
-	}
-
-	if app.Status == models.ApplicationStatusDeleting {
-		return nil, &ValidationError{
-			Code:    http.StatusConflict,
-			Message: ErrMsgApplicationAlreadyDeleting,
-		}
-	}
-
-	if err := catalogutils.UpdateApplicationStatus(ctx, s.AppRepo, id, models.ApplicationStatusDeleting, "Deleting deployment..."); err != nil {
-		return nil, err
-	}
-
-	orphanedComponentIDs, err := s.identifyOrphanedComponents(ctx, id, app.Services)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get application components: %w", err)
-	}
-
-	var requestID string
-	if reqID, ok := ctx.Value(logger.RequestIDKey).(string); ok {
-		requestID = reqID
-	}
-
-	deletionCtx := context.Background()
-	if requestID != "" {
-		deletionCtx = context.WithValue(deletionCtx, logger.RequestIDKey, requestID)
-	}
-
-	go s.executeDeletionAsync(deletionCtx, id, app.Services, orphanedComponentIDs, keepData, runtimeType)
-
-	return &DeleteApplicationResponse{
-		ID:      id.String(),
-		Status:  string(models.ApplicationStatusDeleting),
-		Message: "Deletion initiated successfully",
-	}, nil
-}
-
-func (s *ApplicationServiceBase) executeDeletionAsync(
-	parentCtx context.Context,
-	appID uuid.UUID,
-	services []models.Service,
-	orphanedComponentIDs []uuid.UUID,
-	keepData bool,
-	runtimeType runtimeTypes.RuntimeType,
-) {
-	var requestID string
-	if id, ok := parentCtx.Value(logger.RequestIDKey).(string); ok {
-		requestID = id
-	}
-
-	ctx := context.Background()
-	if requestID != "" {
-		ctx = context.WithValue(ctx, logger.RequestIDKey, requestID)
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			logger.ErrorfCtx(ctx, "Panic recovered in deletion goroutine for application %s: %v", appID, r)
-
-			errMsg := fmt.Sprintf("Deletion panic: %v", r)
-			if updateErr := catalogutils.UpdateApplicationStatus(ctx, s.AppRepo, appID.String(), models.ApplicationStatusError, errMsg); updateErr != nil {
-				logger.ErrorfCtx(ctx, "Failed to update application status after panic: %v", updateErr)
-			}
-		}
-	}()
-
-	err := s.DeletionExecutor.Execute(ctx, appID, services, orphanedComponentIDs, keepData, runtimeType)
-	if err != nil {
-		logger.ErrorfCtx(ctx, "Deletion failed for application %s: %v", appID.String(), err)
-
-		if updateErr := catalogutils.UpdateApplicationStatus(ctx, s.AppRepo, appID.String(), models.ApplicationStatusError, err.Error()); updateErr != nil {
-			logger.ErrorfCtx(ctx, "Failed to update application status to Error: %v", updateErr)
-		}
-
-		return
-	}
-
-	logger.InfolnCtx(ctx, fmt.Sprintf("Deletion completed successfully for application id '%s'", appID.String()))
 }
 
 // identifyOrphanedComponents identifies components that will become orphaned after service deletion.

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/deployment_registry.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/deployment_registry.go
@@ -48,10 +48,17 @@ func (r *DeploymentRegistry) Cancel(appID uuid.UUID) {
 	}
 }
 
-// Deregister removes a completed deployment from the registry without
-// cancelling it. Called by the goroutine when deployment finishes normally.
+// Deregister removes a completed deployment from the registry and calls
+// cancel() to release the child context node from the parent's tree.
+// Not calling cancel() would leak the context until the parent (context.Background)
+// is itself cancelled — which never happens.
 func (r *DeploymentRegistry) Deregister(appID uuid.UUID) {
 	r.mu.Lock()
+	cancel, ok := r.entries[appID]
 	delete(r.entries, appID)
 	r.mu.Unlock()
+
+	if ok {
+		cancel()
+	}
 }

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/deployment_registry.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/deployment_registry.go
@@ -1,0 +1,57 @@
+package applicationservice
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// DeploymentRegistry tracks in-flight deployments so they can be cancelled
+// when a delete request arrives mid-deployment.
+type DeploymentRegistry struct {
+	mu      sync.Mutex
+	entries map[uuid.UUID]context.CancelFunc
+}
+
+// NewDeploymentRegistry creates a new registry.
+func NewDeploymentRegistry() *DeploymentRegistry {
+	return &DeploymentRegistry{
+		entries: make(map[uuid.UUID]context.CancelFunc),
+	}
+}
+
+// Register stores a cancel function for the given application and returns
+// a cancellable context derived from the provided parent.
+func (r *DeploymentRegistry) Register(parent context.Context, appID uuid.UUID) context.Context {
+	ctx, cancel := context.WithCancel(parent)
+
+	r.mu.Lock()
+	r.entries[appID] = cancel
+	r.mu.Unlock()
+
+	return ctx
+}
+
+// Cancel signals the in-flight deployment for appID to stop and removes it
+// from the registry. It is a no-op if appID is not registered.
+func (r *DeploymentRegistry) Cancel(appID uuid.UUID) {
+	r.mu.Lock()
+	cancel, ok := r.entries[appID]
+	if ok {
+		delete(r.entries, appID)
+	}
+	r.mu.Unlock()
+
+	if ok {
+		cancel()
+	}
+}
+
+// Deregister removes a completed deployment from the registry without
+// cancelling it. Called by the goroutine when deployment finishes normally.
+func (r *DeploymentRegistry) Deregister(appID uuid.UUID) {
+	r.mu.Lock()
+	delete(r.entries, appID)
+	r.mu.Unlock()
+}

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/openshift.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/openshift.go
@@ -12,10 +12,16 @@ import (
 
 // OpenShiftApplicationService implements ApplicationServiceInterface for the OpenShift runtime.
 // It embeds ApplicationServiceBase for all shared DB operations.
-//
-// TODO(OCP): set base.DeploymentRegistry = NewDeploymentRegistry() in the OpenShift constructor when CreateApplication is implemented.
 type OpenShiftApplicationService struct {
 	ApplicationServiceBase
+}
+
+// NewOpenShiftApplicationService creates a new OpenShiftApplicationService with a fresh DeploymentRegistry
+// wired into the base. This makes in-flight deployments cancellable by a concurrent DeleteApplication.
+func NewOpenShiftApplicationService(base ApplicationServiceBase) *OpenShiftApplicationService {
+	base.DeploymentRegistry = NewDeploymentRegistry()
+
+	return &OpenShiftApplicationService{ApplicationServiceBase: base}
 }
 
 func (s *OpenShiftApplicationService) DeleteApplication(ctx context.Context, id uuid.UUID, user string, keepData bool) (*DeleteApplicationResponse, error) {

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/openshift.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/openshift.go
@@ -13,11 +13,7 @@ import (
 // OpenShiftApplicationService implements ApplicationServiceInterface for the OpenShift runtime.
 // It embeds ApplicationServiceBase for all shared DB operations.
 //
-// NOTE: When CreateApplication is implemented here, wire in a DeploymentRegistry (same pattern
-// as PodmanApplicationService) so that mid-deployment deletion works on OCP too:
-//  1. Add deploymentRegistry *DeploymentRegistry field
-//  2. Call registry.Register in executeDeploymentAsync
-//  3. Call registry.Cancel in DeleteApplication before firing PerformDeletion
+// TODO(OCP): wire in a DeploymentRegistry (same pattern as PodmanApplicationService) when CreateApplication is implemented.
 type OpenShiftApplicationService struct {
 	ApplicationServiceBase
 }
@@ -44,4 +40,3 @@ func (s *OpenShiftApplicationService) ApplicationsPs(ctx context.Context, appID 
 	return s.ApplicationServiceBase.ApplicationsPs(ctx, appID, catalogutils.AppNamespace(appID))
 }
 
-// Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/openshift.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/openshift.go
@@ -19,7 +19,7 @@ type OpenShiftApplicationService struct {
 }
 
 func (s *OpenShiftApplicationService) DeleteApplication(ctx context.Context, id uuid.UUID, user string, keepData bool) (*DeleteApplicationResponse, error) {
-	return s.ApplicationServiceBase.DeleteApplication(ctx, id, user, keepData)
+	return s.ApplicationServiceBase.DeleteApplication(ctx, id, user, keepData, runtimeTypes.RuntimeTypeOpenShift)
 }
 
 // CreateApplication validates, plans, persists, and asynchronously deploys a new application

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/openshift.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/openshift.go
@@ -15,9 +15,9 @@ import (
 //
 // NOTE: When CreateApplication is implemented here, wire in a DeploymentRegistry (same pattern
 // as PodmanApplicationService) so that mid-deployment deletion works on OCP too:
-//   1. Add deploymentRegistry *DeploymentRegistry field
-//   2. Call registry.Register in executeDeploymentAsync
-//   3. Call registry.Cancel in DeleteApplication before firing PerformDeletion
+//  1. Add deploymentRegistry *DeploymentRegistry field
+//  2. Call registry.Register in executeDeploymentAsync
+//  3. Call registry.Cancel in DeleteApplication before firing PerformDeletion
 type OpenShiftApplicationService struct {
 	ApplicationServiceBase
 }

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/openshift.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/openshift.go
@@ -13,13 +13,13 @@ import (
 // OpenShiftApplicationService implements ApplicationServiceInterface for the OpenShift runtime.
 // It embeds ApplicationServiceBase for all shared DB operations.
 //
-// TODO(OCP): wire in a DeploymentRegistry (same pattern as PodmanApplicationService) when CreateApplication is implemented.
+// TODO(OCP): set base.DeploymentRegistry = NewDeploymentRegistry() in the OpenShift constructor when CreateApplication is implemented.
 type OpenShiftApplicationService struct {
 	ApplicationServiceBase
 }
 
 func (s *OpenShiftApplicationService) DeleteApplication(ctx context.Context, id uuid.UUID, user string, keepData bool) (*DeleteApplicationResponse, error) {
-	return s.ApplicationServiceBase.DeleteApplication(ctx, id, user, keepData, runtimeTypes.RuntimeTypeOpenShift)
+	return s.ApplicationServiceBase.DeleteApplication(ctx, id, user, keepData)
 }
 
 // CreateApplication validates, plans, persists, and asynchronously deploys a new application
@@ -39,4 +39,3 @@ func (s *OpenShiftApplicationService) GetApplicationResources(ctx context.Contex
 func (s *OpenShiftApplicationService) ApplicationsPs(ctx context.Context, appID uuid.UUID) (*types.ApplicationPSResponse, error) {
 	return s.ApplicationServiceBase.ApplicationsPs(ctx, appID, catalogutils.AppNamespace(appID))
 }
-

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/openshift.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/openshift.go
@@ -12,6 +12,12 @@ import (
 
 // OpenShiftApplicationService implements ApplicationServiceInterface for the OpenShift runtime.
 // It embeds ApplicationServiceBase for all shared DB operations.
+//
+// NOTE: When CreateApplication is implemented here, wire in a DeploymentRegistry (same pattern
+// as PodmanApplicationService) so that mid-deployment deletion works on OCP too:
+//   1. Add deploymentRegistry *DeploymentRegistry field
+//   2. Call registry.Register in executeDeploymentAsync
+//   3. Call registry.Cancel in DeleteApplication before firing PerformDeletion
 type OpenShiftApplicationService struct {
 	ApplicationServiceBase
 }

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/podman.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/podman.go
@@ -24,6 +24,10 @@ func NewPodmanApplicationService(base ApplicationServiceBase) *PodmanApplication
 	return &PodmanApplicationService{ApplicationServiceBase: base}
 }
 
+func (s *PodmanApplicationService) DeleteApplication(ctx context.Context, id uuid.UUID, user string, keepData bool) (*DeleteApplicationResponse, error) {
+	return s.ApplicationServiceBase.DeleteApplication(ctx, id, user, keepData, runtimeTypes.RuntimeTypePodman)
+}
+
 // CreateApplication satisfies ApplicationServiceInterface by delegating to the base with
 // the Podman runtime type fixed.
 func (s *PodmanApplicationService) CreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest) (*apimodels.CreateApplicationResponse, error) {

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/podman.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/podman.go
@@ -42,35 +42,11 @@ func (s *PodmanApplicationService) DeleteApplication(ctx context.Context, id uui
 // CreateApplication validates, plans, persists, and asynchronously deploys a new application
 // using the Podman runtime executor.
 func (s *PodmanApplicationService) CreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest) (*apimodels.CreateApplicationResponse, error) {
-	// Phase 1: check for duplicate name
-	existingApp, err := s.AppRepo.GetByName(ctx, req.Name)
+	plan, err := s.prepareCreateApplication(ctx, req, runtimeTypes.RuntimeTypePodman)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check for existing application: %w", err)
-	}
-	if existingApp != nil {
-		return nil, &ValidationError{
-			Code:    http.StatusConflict,
-			Message: fmt.Sprintf(ErrMsgApplicationNameExists, req.Name),
-		}
-	}
-
-	// Phase 2: validate payload
-	if err := s.Validator.ValidateDeploymentRequest(ctx, req); err != nil {
 		return nil, err
 	}
 
-	// Phase 3: create deployment plan
-	plan, err := s.DeploymentPlanner.PlanDeployment(ctx, req, runtimeTypes.RuntimeTypePodman.String())
-	if err != nil {
-		return nil, fmt.Errorf("failed to create deployment plan: %w", err)
-	}
-
-	// Phase 4: persist DB records
-	if err := s.InsertDeploymentRecords(ctx, plan, req.CreatedBy); err != nil {
-		return nil, fmt.Errorf("failed to insert deployment records: %w", err)
-	}
-
-	// Phase 5: async deployment
 	go s.executeDeploymentAsync(ctx, plan, req)
 
 	return &apimodels.CreateApplicationResponse{ID: plan.ApplicationID.String()}, nil

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/podman.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/podman.go
@@ -2,10 +2,16 @@ package applicationservice
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 
 	"github.com/google/uuid"
 	apimodels "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/deployment"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 )
 
@@ -14,17 +20,111 @@ import (
 // deployment, pod-status, and resource-inspection logic.
 type PodmanApplicationService struct {
 	ApplicationServiceBase
+	deploymentRegistry *DeploymentRegistry
 }
 
-// DeleteApplication initiates async deletion of an application and returns immediately.
+// NewPodmanApplicationService creates a new PodmanApplicationService with a fresh registry.
+func NewPodmanApplicationService(base ApplicationServiceBase) *PodmanApplicationService {
+	return &PodmanApplicationService{
+		ApplicationServiceBase: base,
+		deploymentRegistry:     NewDeploymentRegistry(),
+	}
+}
+
+// DeleteApplication cancels any in-flight deployment then delegates to the shared base implementation.
 func (s *PodmanApplicationService) DeleteApplication(ctx context.Context, id uuid.UUID, user string, keepData bool) (*DeleteApplicationResponse, error) {
+	// Cancel any in-flight deployment for this application before deletion.
+	// This is a no-op if the app is not currently deploying.
+	s.deploymentRegistry.Cancel(id)
 	return s.ApplicationServiceBase.DeleteApplication(ctx, id, user, keepData, runtimeTypes.RuntimeTypePodman)
 }
 
 // CreateApplication validates, plans, persists, and asynchronously deploys a new application
 // using the Podman runtime executor.
 func (s *PodmanApplicationService) CreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest) (*apimodels.CreateApplicationResponse, error) {
-	return s.ApplicationServiceBase.CreateApplication(ctx, req, runtimeTypes.RuntimeTypePodman)
+	// Phase 1: check for duplicate name
+	existingApp, err := s.AppRepo.GetByName(ctx, req.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check for existing application: %w", err)
+	}
+	if existingApp != nil {
+		return nil, &ValidationError{
+			Code:    http.StatusConflict,
+			Message: fmt.Sprintf(ErrMsgApplicationNameExists, req.Name),
+		}
+	}
+
+	// Phase 2: validate payload
+	if err := s.Validator.ValidateDeploymentRequest(ctx, req); err != nil {
+		return nil, err
+	}
+
+	// Phase 3: create deployment plan
+	plan, err := s.DeploymentPlanner.PlanDeployment(ctx, req, runtimeTypes.RuntimeTypePodman.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create deployment plan: %w", err)
+	}
+
+	// Phase 4: persist DB records
+	if err := s.InsertDeploymentRecords(ctx, plan, req.CreatedBy); err != nil {
+		return nil, fmt.Errorf("failed to insert deployment records: %w", err)
+	}
+
+	// Phase 5: async deployment
+	go s.executeDeploymentAsync(ctx, plan, req)
+
+	return &apimodels.CreateApplicationResponse{ID: plan.ApplicationID.String()}, nil
+}
+
+// executeDeploymentAsync runs the Podman deployment in a background goroutine.
+// It registers the deployment with the DeploymentRegistry so a concurrent delete
+// request can cancel it cleanly.
+func (s *PodmanApplicationService) executeDeploymentAsync(parentCtx context.Context, plan *deployment.DeploymentPlan, req apimodels.CreateApplicationRequest) {
+	var requestID string
+	if id, ok := parentCtx.Value(logger.RequestIDKey).(string); ok {
+		requestID = id
+	}
+
+	baseCtx := context.Background()
+	if requestID != "" {
+		baseCtx = context.WithValue(baseCtx, logger.RequestIDKey, requestID)
+	}
+
+	// Register this deployment so it can be cancelled by a concurrent delete request.
+	// Deregister when the goroutine exits (success, error, or panic).
+	ctx := s.deploymentRegistry.Register(baseCtx, plan.ApplicationID)
+	defer s.deploymentRegistry.Deregister(plan.ApplicationID)
+
+	defer func() {
+		if r := recover(); r != nil {
+			logger.ErrorfCtx(ctx, "Panic recovered in deployment goroutine for application %s: %v", plan.ApplicationName, r)
+
+			errMsg := fmt.Sprintf("Deployment panic: %v", r)
+			if updateErr := catalogutils.UpdateApplicationStatus(ctx, s.AppRepo, plan.ApplicationID.String(), models.ApplicationStatusError, errMsg); updateErr != nil {
+				logger.ErrorfCtx(ctx, "Failed to update application status after panic: %v", updateErr)
+			}
+		}
+	}()
+
+	err := s.DeploymentExecutor.ExecuteWithPlan(ctx, plan, req, runtimeTypes.RuntimeTypePodman)
+	if err != nil {
+		// Context was cancelled — deletion is in charge, exit silently.
+		if ctx.Err() != nil {
+			logger.InfofCtx(ctx, "Deployment cancelled for application %s (deletion in progress)", plan.ApplicationName)
+
+			return
+		}
+
+		logger.ErrorfCtx(ctx, "Deployment failed for application %s: %v", plan.ApplicationName, err)
+
+		if updateErr := catalogutils.UpdateApplicationStatus(ctx, s.AppRepo, plan.ApplicationID.String(), models.ApplicationStatusError, err.Error()); updateErr != nil {
+			logger.ErrorfCtx(ctx, "Failed to update application status to Error: %v", updateErr)
+		}
+
+		return
+	}
+
+	logger.InfolnCtx(ctx, fmt.Sprintf("Deployment completed successfully for application %s", plan.ApplicationName))
 }
 
 // ApplicationsPs retrieves pod/container status by querying Podman.

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/podman.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/podman.go
@@ -2,16 +2,10 @@ package applicationservice
 
 import (
 	"context"
-	"fmt"
-	"net/http"
 
 	"github.com/google/uuid"
 	apimodels "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/deployment"
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
-	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
-	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 )
 
@@ -20,87 +14,20 @@ import (
 // deployment, pod-status, and resource-inspection logic.
 type PodmanApplicationService struct {
 	ApplicationServiceBase
-	deploymentRegistry *DeploymentRegistry
 }
 
-// NewPodmanApplicationService creates a new PodmanApplicationService with a fresh registry.
+// NewPodmanApplicationService creates a new PodmanApplicationService with a fresh DeploymentRegistry
+// wired into the base. This makes in-flight deployments cancellable by a concurrent DeleteApplication.
 func NewPodmanApplicationService(base ApplicationServiceBase) *PodmanApplicationService {
-	return &PodmanApplicationService{
-		ApplicationServiceBase: base,
-		deploymentRegistry:     NewDeploymentRegistry(),
-	}
+	base.DeploymentRegistry = NewDeploymentRegistry()
+
+	return &PodmanApplicationService{ApplicationServiceBase: base}
 }
 
-// DeleteApplication cancels any in-flight deployment then delegates to the shared base implementation.
-func (s *PodmanApplicationService) DeleteApplication(ctx context.Context, id uuid.UUID, user string, keepData bool) (*DeleteApplicationResponse, error) {
-	// Cancel any in-flight deployment for this application before deletion.
-	// This is a no-op if the app is not currently deploying.
-	s.deploymentRegistry.Cancel(id)
-	return s.ApplicationServiceBase.DeleteApplication(ctx, id, user, keepData, runtimeTypes.RuntimeTypePodman)
-}
-
-// CreateApplication validates, plans, persists, and asynchronously deploys a new application
-// using the Podman runtime executor.
+// CreateApplication satisfies ApplicationServiceInterface by delegating to the base with
+// the Podman runtime type fixed.
 func (s *PodmanApplicationService) CreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest) (*apimodels.CreateApplicationResponse, error) {
-	plan, err := s.prepareCreateApplication(ctx, req, runtimeTypes.RuntimeTypePodman)
-	if err != nil {
-		return nil, err
-	}
-
-	go s.executeDeploymentAsync(ctx, plan, req)
-
-	return &apimodels.CreateApplicationResponse{ID: plan.ApplicationID.String()}, nil
-}
-
-// executeDeploymentAsync runs the Podman deployment in a background goroutine.
-// It registers the deployment with the DeploymentRegistry so a concurrent delete
-// request can cancel it cleanly.
-func (s *PodmanApplicationService) executeDeploymentAsync(parentCtx context.Context, plan *deployment.DeploymentPlan, req apimodels.CreateApplicationRequest) {
-	var requestID string
-	if id, ok := parentCtx.Value(logger.RequestIDKey).(string); ok {
-		requestID = id
-	}
-
-	baseCtx := context.Background()
-	if requestID != "" {
-		baseCtx = context.WithValue(baseCtx, logger.RequestIDKey, requestID)
-	}
-
-	// Register this deployment so it can be cancelled by a concurrent delete request.
-	// Deregister when the goroutine exits (success, error, or panic).
-	ctx := s.deploymentRegistry.Register(baseCtx, plan.ApplicationID)
-	defer s.deploymentRegistry.Deregister(plan.ApplicationID)
-
-	defer func() {
-		if r := recover(); r != nil {
-			logger.ErrorfCtx(ctx, "Panic recovered in deployment goroutine for application %s: %v", plan.ApplicationName, r)
-
-			errMsg := fmt.Sprintf("Deployment panic: %v", r)
-			if updateErr := catalogutils.UpdateApplicationStatus(ctx, s.AppRepo, plan.ApplicationID.String(), models.ApplicationStatusError, errMsg); updateErr != nil {
-				logger.ErrorfCtx(ctx, "Failed to update application status after panic: %v", updateErr)
-			}
-		}
-	}()
-
-	err := s.DeploymentExecutor.ExecuteWithPlan(ctx, plan, req, runtimeTypes.RuntimeTypePodman)
-	if err != nil {
-		// Context was cancelled — deletion is in charge, exit silently.
-		if ctx.Err() != nil {
-			logger.InfofCtx(ctx, "Deployment cancelled for application %s (deletion in progress)", plan.ApplicationName)
-
-			return
-		}
-
-		logger.ErrorfCtx(ctx, "Deployment failed for application %s: %v", plan.ApplicationName, err)
-
-		if updateErr := catalogutils.UpdateApplicationStatus(ctx, s.AppRepo, plan.ApplicationID.String(), models.ApplicationStatusError, err.Error()); updateErr != nil {
-			logger.ErrorfCtx(ctx, "Failed to update application status to Error: %v", updateErr)
-		}
-
-		return
-	}
-
-	logger.InfolnCtx(ctx, fmt.Sprintf("Deployment completed successfully for application %s", plan.ApplicationName))
+	return s.ApplicationServiceBase.CreateApplication(ctx, req, runtimeTypes.RuntimeTypePodman)
 }
 
 // ApplicationsPs retrieves pod/container status by querying Podman.

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/openshift/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/openshift/deployer.go
@@ -310,5 +310,5 @@ func helmInstallOrUpgrade(ctx context.Context, namespace, release, catalogPath s
 		overrides["templateID"] = templateID
 	}
 
-	return helmClient.InstallOrUpgrade(release, chart, overrides, defaultHelmTimeout)
+	return helmClient.InstallOrUpgrade(ctx, release, chart, overrides, defaultHelmTimeout)
 }

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -126,15 +126,13 @@ func (d *PodmanDeployer) ExecuteDeployment(
 
 	// Step 5: Update application status to Running.
 	// Skip if the context was cancelled — deletion is now in charge of the status.
-	if ctx.Err() != nil {
-		return nil
-	}
+	if ctx.Err() == nil {
+		if err := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusRunning, "Deployment completed successfully"); err != nil {
+			logger.ErrorfCtx(ctx, "Failed to update application status to Running: %v\n", err)
+		}
 
-	if err := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusRunning, "Deployment completed successfully"); err != nil {
-		logger.ErrorfCtx(ctx, "Failed to update application status to Running: %v\n", err)
+		logger.InfofCtx(ctx, "Deployment completed successfully for '%s'\n", plan.ApplicationName)
 	}
-
-	logger.InfofCtx(ctx, "Deployment completed successfully for '%s'\n", plan.ApplicationName)
 
 	return nil
 }

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -154,9 +154,12 @@ func (d *PodmanDeployer) prepareDeployment(ctx context.Context, plan *Deployment
 		return fmt.Errorf("failed to download models: %w", err)
 	}
 
-	// Transition status to Deploying before pod creation begins
-	if err := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusDeploying, catalogutils.DeployingStatusMessage(plan.IsArchitecture)); err != nil {
-		logger.ErrorfCtx(ctx, "Failed to update application status to Deploying: %v\n", err)
+	// Transition status to Deploying before pod creation begins.
+	// Skip if the context was cancelled — deletion is now in charge of the status.
+	if ctx.Err() == nil {
+		if err := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusDeploying, catalogutils.DeployingStatusMessage(plan.IsArchitecture)); err != nil {
+			logger.ErrorfCtx(ctx, "Failed to update application status to Deploying: %v\n", err)
+		}
 	}
 
 	return nil

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -95,14 +95,14 @@ func (d *PodmanDeployer) ExecuteDeployment(
 ) error {
 	logger.InfofCtx(ctx, "Starting deployment execution for '%s'\n", plan.ApplicationName)
 
-	// Step 1.a: Pull container images for all components and services
+	// Step 1a: Pull container images for all components and services
 	if err := d.pullImagesForDeployment(ctx, plan); err != nil {
 		catalogutils.HandleDeploymentStepError(ctx, d.appRepo, plan.ApplicationID, "Image pull failed", err)
 
 		return fmt.Errorf("failed to pull images: %w", err)
 	}
 
-	// Step 1.b: Download models specified in parameters
+	// Step 1b: Download models specified in parameters
 	if err := d.downloadModelsForDeployment(ctx, plan); err != nil {
 		catalogutils.HandleDeploymentStepError(ctx, d.appRepo, plan.ApplicationID, "Model download failed", err)
 
@@ -123,7 +123,7 @@ func (d *PodmanDeployer) ExecuteDeployment(
 		}
 	}
 
-	// Step 4: Deploy services if any
+	// Step 3: Deploy services if any
 	if len(plan.Services) > 0 {
 		if err := d.deployServices(ctx, plan); err != nil {
 			catalogutils.HandleDeploymentStepError(ctx, d.appRepo, plan.ApplicationID, "Service deployment failed", err)
@@ -132,14 +132,19 @@ func (d *PodmanDeployer) ExecuteDeployment(
 		}
 	}
 
-	// Step 5: Register routes with Caddy proxy
+	// Step 4: Register routes with Caddy proxy
 	if err := d.registerApplicationRoutes(ctx, plan); err != nil {
 		catalogutils.HandleDeploymentStepError(ctx, d.appRepo, plan.ApplicationID, "Failed to register application routes", err)
 
 		return fmt.Errorf("failed to register application routes: %w", err)
 	}
 
-	// Step 6: Update application status to Running
+	// Step 5: Update application status to Running.
+	// Skip if the context was cancelled — deletion is now in charge of the status.
+	if ctx.Err() != nil {
+		return nil
+	}
+
 	if err := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusRunning, "Deployment completed successfully"); err != nil {
 		logger.ErrorfCtx(ctx, "Failed to update application status to Running: %v\n", err)
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -95,23 +95,8 @@ func (d *PodmanDeployer) ExecuteDeployment(
 ) error {
 	logger.InfofCtx(ctx, "Starting deployment execution for '%s'\n", plan.ApplicationName)
 
-	// Step 1a: Pull container images for all components and services
-	if err := d.pullImagesForDeployment(ctx, plan); err != nil {
-		catalogutils.HandleDeploymentStepError(ctx, d.appRepo, plan.ApplicationID, "Image pull failed", err)
-
-		return fmt.Errorf("failed to pull images: %w", err)
-	}
-
-	// Step 1b: Download models specified in parameters
-	if err := d.downloadModelsForDeployment(ctx, plan); err != nil {
-		catalogutils.HandleDeploymentStepError(ctx, d.appRepo, plan.ApplicationID, "Model download failed", err)
-
-		return fmt.Errorf("failed to download models: %w", err)
-	}
-
-	// Update application status to Deploying before starting deployment
-	if err := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusDeploying, catalogutils.DeployingStatusMessage(plan.IsArchitecture)); err != nil {
-		logger.ErrorfCtx(ctx, "Failed to update application status to Deploying: %v\n", err)
+	if err := d.prepareDeployment(ctx, plan); err != nil {
+		return err
 	}
 
 	// Step 2: Deploy components if any
@@ -150,6 +135,31 @@ func (d *PodmanDeployer) ExecuteDeployment(
 	}
 
 	logger.InfofCtx(ctx, "Deployment completed successfully for '%s'\n", plan.ApplicationName)
+
+	return nil
+}
+
+// prepareDeployment pulls images, downloads models, and transitions the
+// application status to Deploying. It is a prerequisite for all deploy steps.
+func (d *PodmanDeployer) prepareDeployment(ctx context.Context, plan *DeploymentPlan) error {
+	// Step 1a: Pull container images for all components and services
+	if err := d.pullImagesForDeployment(ctx, plan); err != nil {
+		catalogutils.HandleDeploymentStepError(ctx, d.appRepo, plan.ApplicationID, "Image pull failed", err)
+
+		return fmt.Errorf("failed to pull images: %w", err)
+	}
+
+	// Step 1b: Download models specified in parameters
+	if err := d.downloadModelsForDeployment(ctx, plan); err != nil {
+		catalogutils.HandleDeploymentStepError(ctx, d.appRepo, plan.ApplicationID, "Model download failed", err)
+
+		return fmt.Errorf("failed to download models: %w", err)
+	}
+
+	// Transition status to Deploying before pod creation begins
+	if err := catalogutils.UpdateApplicationStatus(ctx, d.appRepo, plan.ApplicationID, models.ApplicationStatusDeploying, catalogutils.DeployingStatusMessage(plan.IsArchitecture)); err != nil {
+		logger.ErrorfCtx(ctx, "Failed to update application status to Deploying: %v\n", err)
+	}
 
 	return nil
 }

--- a/ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go
@@ -154,7 +154,7 @@ func deployCatalogHelm(ctx context.Context, chartData chart.Charter, timeout tim
 		return fmt.Errorf("failed to create Helm client: %w", err)
 	}
 
-	if err := helmClient.InstallOrUpgrade(catalogconstants.CatalogAppName, chartData, values, timeout); err != nil {
+	if err := helmClient.InstallOrUpgrade(ctx, catalogconstants.CatalogAppName, chartData, values, timeout); err != nil {
 		s.Fail("failed to deploy catalog")
 
 		return fmt.Errorf("failed to deploy catalog: %w", err)

--- a/ai-services/internal/pkg/catalog/utils/application_utils.go
+++ b/ai-services/internal/pkg/catalog/utils/application_utils.go
@@ -16,7 +16,15 @@ import (
 )
 
 // HandleDeploymentStepError updates the application status to Error and logs the failure.
+// If the context has already been cancelled (e.g. a mid-deployment delete), it exits
+// silently so the deletion goroutine retains ownership of the application status.
 func HandleDeploymentStepError(ctx context.Context, appRepo dbrepo.ApplicationRepository, appID uuid.UUID, stepContext string, err error) {
+	if ctx.Err() != nil {
+		logger.InfofCtx(ctx, "Deployment step %q for %s cancelled (deletion in progress)\n", stepContext, appID)
+
+		return
+	}
+
 	errMsg := fmt.Sprintf("%s: %v", stepContext, err)
 	if updateErr := UpdateApplicationStatus(ctx, appRepo, appID, models.ApplicationStatusError, errMsg); updateErr != nil {
 		logger.ErrorfCtx(ctx, "Failed to update application status: %v\n", updateErr)

--- a/ai-services/internal/pkg/catalog/utils/application_utils.go
+++ b/ai-services/internal/pkg/catalog/utils/application_utils.go
@@ -20,7 +20,7 @@ import (
 // silently so the deletion goroutine retains ownership of the application status.
 func HandleDeploymentStepError(ctx context.Context, appRepo dbrepo.ApplicationRepository, appID uuid.UUID, stepContext string, err error) {
 	if ctx.Err() != nil {
-		logger.InfofCtx(ctx, "Deployment step %q for %s cancelled (deletion in progress)\n", stepContext, appID)
+		logger.WarningfCtx(ctx, "Deployment step %q for %s cancelled (deletion in progress)\n", stepContext, appID)
 
 		return
 	}

--- a/ai-services/internal/pkg/catalog/utils/deployment_utils.go
+++ b/ai-services/internal/pkg/catalog/utils/deployment_utils.go
@@ -44,7 +44,6 @@ func RunConcurrently(
 				// Context cancelled — deletion is in charge of status, exit silently.
 				if ctx.Err() != nil {
 					logger.InfofCtx(ctx, "Deployment of %s cancelled (deletion in progress)\n", itemID)
-					errCh <- fmt.Errorf("failed to deploy %s: %w", itemID, err)
 
 					return
 				}

--- a/ai-services/internal/pkg/catalog/utils/deployment_utils.go
+++ b/ai-services/internal/pkg/catalog/utils/deployment_utils.go
@@ -41,6 +41,14 @@ func RunConcurrently(
 			logger.InfofCtx(ctx, "Deploying %s\n", itemID)
 
 			if err := deployFn(ctx, itemID); err != nil {
+				// Context cancelled — deletion is in charge of status, exit silently.
+				if ctx.Err() != nil {
+					logger.InfofCtx(ctx, "Deployment of %s cancelled (deletion in progress)\n", itemID)
+					errCh <- fmt.Errorf("failed to deploy %s: %w", itemID, err)
+
+					return
+				}
+
 				errMsg := fmt.Sprintf("Deployment failed: %v", err)
 				if updateErr := onError(ctx, databaseID, errMsg); updateErr != nil {
 					logger.ErrorfCtx(ctx, "Failed to update error status for %s: %v\n", itemID, updateErr)

--- a/ai-services/internal/pkg/cli/helpers/models.go
+++ b/ai-services/internal/pkg/cli/helpers/models.go
@@ -105,8 +105,9 @@ func DownloadModelContainer(ctx context.Context, model, targetDir string) error 
 		},
 	}
 
-	// Run container with spec
-	exitCode, err := runtimeClient.RunContainerWithSpec(s)
+	// Run container with spec, passing ctx so cancellation (e.g. mid-deployment delete)
+	// stops the download container immediately instead of blocking until it finishes.
+	exitCode, err := runtimeClient.RunContainerWithSpec(ctx, s)
 	if err != nil {
 		return fmt.Errorf("failed to run container: %w", err)
 	}

--- a/ai-services/internal/pkg/cli/podman/deploy.go
+++ b/ai-services/internal/pkg/cli/podman/deploy.go
@@ -23,7 +23,7 @@ const (
 // DeployPodAndReadinessCheck deploys a pod and performs readiness checks on its containers.
 func DeployPodAndReadinessCheck(ctx context.Context, rt runtime.Runtime, podSpec *models.PodSpec,
 	podTemplateName string, body io.Reader, opts map[string]string) error {
-	pods, err := rt.CreatePod(body, opts)
+	pods, err := rt.CreatePod(ctx, body, opts)
 	if err != nil {
 		return fmt.Errorf("failed pod creation: %w", err)
 	}

--- a/ai-services/internal/pkg/helm/helm.go
+++ b/ai-services/internal/pkg/helm/helm.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -50,7 +51,7 @@ type InstallOpts struct {
 	Timeout time.Duration
 }
 
-func (h *Helm) Install(release string, chart chart.Charter, opts *InstallOpts) error {
+func (h *Helm) Install(ctx context.Context, release string, chart chart.Charter, opts *InstallOpts) error {
 	// Configure the Installer client
 	installClient := action.NewInstall(h.actionConfig)
 	installClient.ReleaseName = release
@@ -61,7 +62,7 @@ func (h *Helm) Install(release string, chart chart.Charter, opts *InstallOpts) e
 	installClient.SkipSchemaValidation = true
 
 	// Perform helm install
-	_, err := installClient.Run(chart, opts.Values)
+	_, err := installClient.RunWithContext(ctx, chart, opts.Values)
 	if err != nil {
 		return fmt.Errorf("Install failed: %w", err)
 	}
@@ -74,7 +75,7 @@ type UpgradeOpts struct {
 	Timeout time.Duration
 }
 
-func (h *Helm) Upgrade(release string, chart chart.Charter, opts *UpgradeOpts) error {
+func (h *Helm) Upgrade(ctx context.Context, release string, chart chart.Charter, opts *UpgradeOpts) error {
 	// Configure the Upgrade client
 	upgradeClient := action.NewUpgrade(h.actionConfig)
 	upgradeClient.Namespace = h.namespace
@@ -86,7 +87,7 @@ func (h *Helm) Upgrade(release string, chart chart.Charter, opts *UpgradeOpts) e
 	upgradeClient.SkipSchemaValidation = true
 
 	// Perform helm upgrade
-	_, err := upgradeClient.Run(release, chart, opts.Values)
+	_, err := upgradeClient.RunWithContext(ctx, release, chart, opts.Values)
 	if err != nil {
 		return fmt.Errorf("Upgrade failed: %w", err)
 	}
@@ -95,17 +96,17 @@ func (h *Helm) Upgrade(release string, chart chart.Charter, opts *UpgradeOpts) e
 }
 
 // InstallOrUpgrade installs a release if it does not exist, or upgrades it if it does.
-func (h *Helm) InstallOrUpgrade(release string, chart chart.Charter, values map[string]any, timeout time.Duration) error {
+func (h *Helm) InstallOrUpgrade(ctx context.Context, release string, chart chart.Charter, values map[string]any, timeout time.Duration) error {
 	exists, err := h.IsReleaseExist(release)
 	if err != nil {
 		return fmt.Errorf("failed to check release existence: %w", err)
 	}
 
 	if !exists {
-		return h.Install(release, chart, &InstallOpts{Values: values, Timeout: timeout})
+		return h.Install(ctx, release, chart, &InstallOpts{Values: values, Timeout: timeout})
 	}
 
-	return h.Upgrade(release, chart, &UpgradeOpts{Values: values, Timeout: timeout})
+	return h.Upgrade(ctx, release, chart, &UpgradeOpts{Values: values, Timeout: timeout})
 }
 
 func (h *Helm) IsReleaseExist(release string) (bool, error) {

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -97,7 +97,7 @@ func (c *caddyManager) RegisterRoute(ctx context.Context, route Route) error {
 	}
 
 	// Check if route already exists
-	checkResp, err := c.httpClient.R().Get(idURL)
+	checkResp, err := c.httpClient.R().SetContext(ctx).Get(idURL)
 	if err != nil {
 		return fmt.Errorf("failed to check route existence: %w", err)
 	}
@@ -110,17 +110,18 @@ func (c *caddyManager) RegisterRoute(ctx context.Context, route Route) error {
 	}
 
 	// Route doesn't exist, create it
-	return c.createRoute(routeConfig)
+	return c.createRoute(ctx, routeConfig)
 }
 
 // Helper to append a new route to the server's route array.
-func (c *caddyManager) createRoute(routeConfig map[string]any) error {
+func (c *caddyManager) createRoute(ctx context.Context, routeConfig map[string]any) error {
 	routeURL, err := url.JoinPath(c.adminURL, "config", "apps", "http", "servers", c.serverName, "routes")
 	if err != nil {
 		return err
 	}
 
 	resp, err := c.httpClient.R().
+		SetContext(ctx).
 		SetHeader("Content-Type", "application/json").
 		SetBody(routeConfig).
 		Post(routeURL)

--- a/ai-services/internal/pkg/runtime/interface.go
+++ b/ai-services/internal/pkg/runtime/interface.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"context"
 	"io"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/models"
@@ -15,7 +16,7 @@ type Runtime interface {
 
 	// Pod operations
 	ListPods(filters map[string][]string) ([]types.Pod, error)
-	CreatePod(body io.Reader, opts map[string]string) ([]types.Pod, error)
+	CreatePod(ctx context.Context, body io.Reader, opts map[string]string) ([]types.Pod, error)
 	DeletePod(id string, force *bool) error
 	StopPod(id string) error
 	StartPod(id string) error

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -208,7 +208,8 @@ func (kc *OpenshiftClient) ListPods(filters map[string][]string) ([]types.Pod, e
 }
 
 // CreatePod creates a pod from YAML manifest.
-func (kc *OpenshiftClient) CreatePod(body io.Reader, opts map[string]string) ([]types.Pod, error) {
+// TODO(OCP): propagate ctx through the OCP deployment path once implemented.
+func (kc *OpenshiftClient) CreatePod(ctx context.Context, body io.Reader, opts map[string]string) ([]types.Pod, error) {
 	logger.Warningln("Not implemented")
 
 	return nil, nil

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -208,7 +208,6 @@ func (kc *OpenshiftClient) ListPods(filters map[string][]string) ([]types.Pod, e
 }
 
 // CreatePod creates a pod from YAML manifest.
-// TODO(OCP): propagate ctx through the OCP deployment path once implemented.
 func (kc *OpenshiftClient) CreatePod(ctx context.Context, body io.Reader, opts map[string]string) ([]types.Pod, error) {
 	logger.Warningln("Not implemented")
 

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -208,7 +208,7 @@ func (kc *OpenshiftClient) ListPods(filters map[string][]string) ([]types.Pod, e
 }
 
 // CreatePod creates a pod from YAML manifest.
-func (kc *OpenshiftClient) CreatePod(ctx context.Context, body io.Reader, opts map[string]string) ([]types.Pod, error) {
+func (kc *OpenshiftClient) CreatePod(_ context.Context, body io.Reader, opts map[string]string) ([]types.Pod, error) {
 	logger.Warningln("Not implemented")
 
 	return nil, nil

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -122,22 +122,22 @@ func (pc *PodmanClient) ListPods(filters map[string][]string) ([]types.Pod, erro
 // cancellation signals from the caller to propagate (e.g. mid-deployment deletion).
 func (pc *PodmanClient) podmanCtx(callerCtx context.Context) (context.Context, context.CancelFunc) {
 	// Child of pc.Context so the podman connection value is present.
-	mergedCtx, cancel := context.WithCancel(pc.Context)
+	ctx, cancel := context.WithCancel(pc.Context)
 
-	// Mirror cancellation from the caller into the merged context.
-	// The mergedCtx.Done() case handles normal exit: once CreatePod returns,
-	// its defer cancel() fires and closes mergedCtx, allowing this goroutine
+	// Mirror cancellation from the caller into the derived context.
+	// The ctx.Done() case handles normal exit: once CreatePod returns,
+	// its defer cancel() fires and closes ctx, allowing this goroutine
 	// to exit cleanly without leaking.
 	go func() {
 		select {
 		case <-callerCtx.Done():
 			cancel()
-		case <-mergedCtx.Done():
+		case <-ctx.Done():
 			// CreatePod returned normally (defer cancel() fired) — nothing to do.
 		}
 	}()
 
-	return mergedCtx, cancel
+	return ctx, cancel
 }
 
 func (pc *PodmanClient) CreatePod(ctx context.Context, body io.Reader, opts map[string]string) ([]types.Pod, error) {

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -117,23 +117,23 @@ func (pc *PodmanClient) ListPods(filters map[string][]string) ([]types.Pod, erro
 }
 
 // podmanCtx derives a child of pc.Context (which carries the podman connection) that
-// is cancelled when the caller's ctx is cancelled.  This is necessary because the
-// podman bindings SDK requires its own connection-carrying context, but we still want
-// cancellation signals from the caller to propagate (e.g. mid-deployment deletion).
+// is cancelled when the caller's ctx is cancelled.
+//
+// The Podman bindings SDK stores its connection handle under an unexported key in
+// pc.Context, so we cannot simply pass callerCtx to kube.PlayWithBody — it would
+// have no connection value. Instead we derive from pc.Context (preserving the
+// connection) and mirror cancellation from the caller via a short-lived goroutine.
+// The goroutine exits as soon as either context is done, so there is no leak.
 func (pc *PodmanClient) podmanCtx(callerCtx context.Context) (context.Context, context.CancelFunc) {
 	// Child of pc.Context so the podman connection value is present.
 	ctx, cancel := context.WithCancel(pc.Context)
 
-	// Mirror cancellation from the caller into the derived context.
-	// The ctx.Done() case handles normal exit: once CreatePod returns,
-	// its defer cancel() fires and closes ctx, allowing this goroutine
-	// to exit cleanly without leaking.
 	go func() {
 		select {
 		case <-callerCtx.Done():
 			cancel()
 		case <-ctx.Done():
-			// CreatePod returned normally (defer cancel() fired) — nothing to do.
+			// CreatePod returned (defer cancel() fired) — nothing to do.
 		}
 	}()
 

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -125,12 +125,15 @@ func (pc *PodmanClient) podmanCtx(callerCtx context.Context) (context.Context, c
 	mergedCtx, cancel := context.WithCancel(pc.Context)
 
 	// Mirror cancellation from the caller into the merged context.
+	// The mergedCtx.Done() case handles normal exit: once CreatePod returns,
+	// its defer cancel() fires and closes mergedCtx, allowing this goroutine
+	// to exit cleanly without leaking.
 	go func() {
 		select {
 		case <-callerCtx.Done():
 			cancel()
 		case <-mergedCtx.Done():
-			// merged context was cancelled by someone else — nothing to do
+			// CreatePod returned normally (defer cancel() fired) — nothing to do.
 		}
 	}()
 

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -122,22 +122,18 @@ func (pc *PodmanClient) ListPods(filters map[string][]string) ([]types.Pod, erro
 // The Podman bindings SDK stores its connection handle under an unexported key in
 // pc.Context, so we cannot simply pass callerCtx to kube.PlayWithBody — it would
 // have no connection value. Instead we derive from pc.Context (preserving the
-// connection) and mirror cancellation from the caller via a short-lived goroutine.
-// The goroutine exits as soon as either context is done, so there is no leak.
+// connection) and use context.AfterFunc to mirror cancellation without spawning a
+// long-lived goroutine that could leak if the Podman socket hangs indefinitely.
 func (pc *PodmanClient) podmanCtx(callerCtx context.Context) (context.Context, context.CancelFunc) {
 	// Child of pc.Context so the podman connection value is present.
 	ctx, cancel := context.WithCancel(pc.Context)
 
-	go func() {
-		select {
-		case <-callerCtx.Done():
-			cancel()
-		case <-ctx.Done():
-			// CreatePod returned (defer cancel() fired) — nothing to do.
-		}
-	}()
+	// AfterFunc arranges for cancel to be called in its own goroutine when
+	// callerCtx is done. The returned stop function unregisters the hook when
+	// CreatePod returns normally, preventing a dangling AfterFunc.
+	stop := context.AfterFunc(callerCtx, cancel)
 
-	return ctx, cancel
+	return ctx, func() { stop(); cancel() }
 }
 
 func (pc *PodmanClient) CreatePod(ctx context.Context, body io.Reader, opts map[string]string) ([]types.Pod, error) {

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -116,7 +116,28 @@ func (pc *PodmanClient) ListPods(filters map[string][]string) ([]types.Pod, erro
 	return toPodsList(podList), nil
 }
 
-func (pc *PodmanClient) CreatePod(body io.Reader, opts map[string]string) ([]types.Pod, error) {
+// podmanCtx derives a child of pc.Context (which carries the podman connection) that
+// is cancelled when the caller's ctx is cancelled.  This is necessary because the
+// podman bindings SDK requires its own connection-carrying context, but we still want
+// cancellation signals from the caller to propagate (e.g. mid-deployment deletion).
+func (pc *PodmanClient) podmanCtx(callerCtx context.Context) (context.Context, context.CancelFunc) {
+	// Child of pc.Context so the podman connection value is present.
+	mergedCtx, cancel := context.WithCancel(pc.Context)
+
+	// Mirror cancellation from the caller into the merged context.
+	go func() {
+		select {
+		case <-callerCtx.Done():
+			cancel()
+		case <-mergedCtx.Done():
+			// merged context was cancelled by someone else — nothing to do
+		}
+	}()
+
+	return mergedCtx, cancel
+}
+
+func (pc *PodmanClient) CreatePod(ctx context.Context, body io.Reader, opts map[string]string) ([]types.Pod, error) {
 	options := &kube.PlayOptions{}
 
 	// Handle start option
@@ -149,7 +170,12 @@ func (pc *PodmanClient) CreatePod(body io.Reader, opts map[string]string) ([]typ
 		}
 	}
 
-	kubeReport, err := kube.PlayWithBody(pc.Context, body, options)
+	// Use a context that carries the podman connection (from pc.Context) but is
+	// cancelled when the caller's ctx is cancelled.
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	kubeReport, err := kube.PlayWithBody(podCtx, body, options)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute podman kube play: %w", err)
 	}

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -378,8 +378,11 @@ func (pc *PodmanClient) ContainerExists(nameOrID string) (bool, error) {
 }
 
 // RunContainerWithSpec creates, starts, waits for, and removes a container with the given spec.
+// ctx is used to interrupt the wait: if cancelled, the container is stopped and ctx.Err() is
+// returned so callers can distinguish a cancellation from a real container failure.
+// pc.Context (the Podman connection context) is still used for all Podman API calls.
 // Returns the exit code of the container.
-func (pc *PodmanClient) RunContainerWithSpec(s *specgen.SpecGenerator) (int32, error) {
+func (pc *PodmanClient) RunContainerWithSpec(ctx context.Context, s *specgen.SpecGenerator) (int32, error) {
 	// Create container
 	createResponse, err := containers.CreateWithSpec(pc.Context, s, nil)
 	if err != nil {
@@ -393,13 +396,28 @@ func (pc *PodmanClient) RunContainerWithSpec(s *specgen.SpecGenerator) (int32, e
 		return -1, fmt.Errorf("failed to start container: %w", err)
 	}
 
-	// Wait for container to complete
-	exitCode, err := containers.Wait(pc.Context, containerID, nil)
-	if err != nil {
-		return -1, fmt.Errorf("failed to wait for container: %w", err)
+	// Wait in a goroutine so we can react to ctx cancellation while the container runs.
+	type waitResult struct {
+		exitCode int32
+		err      error
 	}
+	done := make(chan waitResult, 1)
 
-	return exitCode, nil
+	go func() {
+		code, err := containers.Wait(pc.Context, containerID, nil)
+		done <- waitResult{code, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		// Caller cancelled (e.g. mid-deployment delete) — stop the container so it is
+		// cleaned up immediately. The spec has Remove=true so it auto-removes on stop.
+		_ = containers.Stop(pc.Context, containerID, nil)
+
+		return -1, ctx.Err()
+	case r := <-done:
+		return r.exitCode, r.err
+	}
 }
 
 func (pc *PodmanClient) ListRoutes(_ string) ([]types.Route, error) {


### PR DESCRIPTION
Allows deletion of an application at any point during deployment with no orphaned resources.

## Features
- **DeploymentRegistry** (`deployment_registry.go`) — new; tracks in-flight deployment goroutines by app ID so `DeleteApplication` can cancel them before transitioning to Deleting

## Fixes
- **`RunContainerWithSpec`** — now accepts `ctx`; races `containers.Wait` against `ctx.Done()` and calls `containers.Stop` on cancellation so the model download container is terminated immediately instead of blocking
- **`DownloadModelContainer`** — threads `ctx` through to `RunContainerWithSpec` so the cancellation signal reaches the running container
- **`HandleDeploymentStepError`** — exits silently if `ctx.Err() != nil` so a cancelled deployment step doesn't overwrite the Deleting status with Error
- **`RunConcurrently`** — same silent-exit guard added for concurrent component/service deployment steps
- **`ExecuteDeployment`** — skips the final `Running` status update if `ctx.Err() != nil`; leaves DeletionService as sole status owner
- **`RegisterRoute` / `createRoute`** — ctx now propagated to Caddy HTTP calls so route registration is also interrupted on cancel
- **`Helm Install/Upgrade`** — `RunWithContext` replaces `Run` so in-flight
  Helm operations on OpenShift abort immediately on delete rather than
  blocking until the 10-minute timeout expires

## Refactor
- **`DeleteApplication`** — promoted from Podman-only to shared base method in `ApplicationServiceBase`; wires `DeploymentRegistry.Cancel` before marking app as Deleting
- **`executeDeploymentAsync`** — moved to base; registers/deregisters with `DeploymentRegistry` and exits silently on `ctx.Err()`
- **`CreatePod`** — signature updated to accept `ctx`; uses new `podmanCtx()` helper to bridge caller cancellation with the Podman connection context
- **`prepareDeployment`** — extracted from `ExecuteDeployment` to group image pull + model download + status transition into one step
- **`NewOpenShiftApplicationService`** — constructor added, wiring
  `DeploymentRegistry` into the base for full OCP cancellation parity

## Tested
- DELETE during model download → container stopped within stop timeout, app deleted ✅
- DELETE during image pull / pod creation → no orphaned pods, volumes or secrets ✅
- DELETE during Helm install/upgrade (OCP) → operation aborted at Helm level, namespace cleaned up ✅
- Normal deployment unaffected ✅

## Notes
- UI delete button during deployment deferred to follow-up PR