### PR TITLE
[Design Proposal] Support for Custom Asset onboarding

### DIFF
--- a/docs/proposals/catalog/custom-service-templates-proposal.md
+++ b/docs/proposals/catalog/custom-service-templates-proposal.md
@@ -17,14 +17,14 @@
     - 4.3 [Custom service assets (proposed)](#43-custom-service-assets-proposed)
     - 4.4 [Custom component assets (proposed)](#44-custom-component-assets-proposed)
 5. [CatalogProvider Integration](#5-catalogprovider-integration)
-6. [API Upload](#6-api-upload)
+6. [API Create Bundle](#6-api-create-bundle)
     - 6.1 [Design goals](#61-design-goals)
     - 6.2 [New API endpoints](#62-new-api-endpoints)
     - 6.3 [Bundle format](#63-bundle-format)
     - 6.4 [Server-side processing pipeline](#64-server-side-processing-pipeline)
     - 6.5 [New database migration](#65-new-database-migration)
     - 6.6 [Storage per runtime](#66-storage-per-runtime)
-    - 6.7 [Upload flow diagrams](#67-upload-flow-diagrams)
+    - 6.7 [Create Bundle flow diagrams](#67-create-bundle-flow-diagrams)
     - 6.8 [Handler and service (Go)](#68-handler-and-service-go--as-implemented)
     - 6.9 [CLI bundle commands](#69-cli-bundle-commands)
 7. [Custom Template Directory Structure](#7-custom-template-directory-structure)
@@ -34,12 +34,12 @@
     - 9.2 [Services](#92-services)
     - 9.3 [Components](#93-components)
 10. [Usage Examples](#10-usage-examples)
-    - 10.1 [Upload a custom service bundle](#101-upload-a-custom-service-bundle)
-    - 10.2 [Upload a custom component bundle](#102-upload-a-custom-component-bundle)
+    - 10.1 [Create a custom service bundle](#101-create-a-custom-service-bundle)
+    - 10.2 [Create a custom component bundle](#102-create-a-custom-component-bundle)
     - 10.3 [Attempt to use a reserved built-in ID (rejected)](#103-attempt-to-use-a-reserved-built-in-id-rejected)
     - 10.4 [Create an application from the custom service](#104-create-an-application-from-the-custom-service)
     - 10.5 [List custom services via the catalog API](#105-list-custom-services-via-the-catalog-api)
-    - 10.6 [Validate a bundle before uploading](#106-validate-a-bundle-before-uploading)
+    - 10.6 [Validate a bundle before creating it](#106-validate-a-bundle-before-creating-it)
 11. [Future Enhancements](#11-future-enhancements)
 
 ---
@@ -48,20 +48,20 @@
 
 Enterprise customers deploying AI Services on their own infrastructure often bring proprietary workloads, domain-specific models, and internal service patterns that are not represented in the platform's built-in catalog. Today there is no supported path for customers to introduce their own services into a running deployment without modifying the platform binary itself — a process that is impractical at scale and incompatible with air-gapped or regulated environments.
 
-This proposal introduces **Custom Service Templates** — a first-class mechanism for customers to onboard their own AI service assets into the catalog at runtime. A customer packages their service definition as a `.tar.gz` bundle and uploads it to the running catalog backend over HTTPS. The platform validates, registers, and hot-reloads the new service immediately — with no pod restart, no host filesystem access, and no changes to the platform binary required. The mechanism is identical on Podman single-VM deployments and OpenShift clusters.
+This proposal introduces **Custom Service Templates** — a first-class mechanism for customers to onboard their own AI service assets into the catalog at runtime. A customer packages their service definition as a `.tar.gz` bundle and creates it through the running catalog backend over HTTPS. The platform validates, registers, and hot-reloads the new service immediately — with no pod restart, no host filesystem access, and no changes to the platform binary required. The mechanism is identical on Podman single-VM deployments and OpenShift clusters.
 
 Built-in platform services are protected: a bundle whose `id` conflicts with an embedded service is rejected at validation time, ensuring the integrity of the core catalog is never compromised.
 
 | Property | Detail |
 |---|---|
 | **Use case** | Onboard customer-authored **service and component** assets into a live catalog deployment |
-| **Delivery** | `POST /api/v1/catalog/bundles` — `.tar.gz` archive uploaded over HTTPS to the running catalog |
+| **Delivery** | `POST /api/v1/catalog/bundles` — `.tar.gz` archive sent over HTTPS to create a bundle in the running catalog |
 | **Bundle types** | `catalog_type: service` — custom services; `catalog_type: component` — custom LLM / embedding / reranker / vector_db providers |
-| **Naming** | Services: `<id>-<version>` on disk; components: `<component_type>-<id>-<version>` (e.g. `llm-my-provider-1.0.0`) |
+| **Naming** | Both types: `<catalog_id>-<version>` on disk (e.g. `my-service-1.0.0`, `llm--my-provider-1.0.0`); path derived at runtime, not stored in DB |
 | **Podman** | ✅ — bundle stored in dedicated named volume `catalog-bundles` |
 | **OpenShift** | ✅ — bundle stored in dedicated PVC `catalog-bundles` |
 | **Live reload** | Automatic — `CatalogProvider` hot-reloads after successful extraction, no pod restart |
-| **Audit trail** | `catalog_bundles` table in PostgreSQL — every upload is recorded with uploader identity and timestamp |
+| **Audit trail** | `catalog_bundles` table in PostgreSQL — every bundle creation is recorded with creator identity and timestamp |
 | **Best for** | Enterprise customers, air-gapped deployments, regulated environments, CI/CD-driven asset promotion |
 
 ---
@@ -89,14 +89,14 @@ Enterprise customers operate AI Services in environments where the built-in serv
 - **CI/CD asset promotion** — teams need to promote service definitions through staging and production deployments programmatically, without manual intervention on each host.
 - **Partner and ISV onboarding** — system integrators and technology partners need a supported path to register their own service assets alongside IBM-certified ones.
 
-Currently, there is no supported mechanism to extend the catalog at runtime. Custom assets are delivered by uploading a `.tar.gz` bundle to the running catalog API over HTTPS. The apiserver reads `id`, `type`, and `version` from `metadata.yaml` inside the archive, extracts it to isolated storage, validates it, and hot-reloads `CatalogProvider` — no pod restart, no CLI host access required, and no changes to the platform binary needed.
+Currently, there is no supported mechanism to extend the catalog at runtime. Custom assets are delivered by creating a bundle from a `.tar.gz` archive through the running catalog API over HTTPS. The apiserver reads `id`, `type`, and `version` from `metadata.yaml` inside the archive, extracts it to isolated storage, validates it, and hot-reloads `CatalogProvider` — no pod restart, no CLI host access required, and no changes to the platform binary needed.
 
 ### 2.3 Goals
 
 1. Provide a secure, authenticated API endpoint (`POST /api/v1/catalog/bundles`) through which customers can register new **service and component** assets into a live deployment without platform downtime.
-2. At apiserver startup, load customer-uploaded bundles alongside the embedded `CatalogFS`: `CatalogProvider` queries all `status='active'` bundle rows from the DB and mounts each one via `os.DirFS` rooted at the bundle's on-disk directory, presenting a unified catalog that includes both platform and customer items.
-3. Protect the integrity of built-in platform items — the embedded catalog is loaded first and is immutable at runtime. Custom bundles are loaded on top; a reserved-ID check to reject conflicting uploads (§11.1) is planned.
-4. Maintain full backward compatibility — in the absence of any uploaded bundles, behaviour is identical to the current release.
+2. At apiserver startup, load customer-created bundles alongside the embedded `CatalogFS`: `CatalogProvider` queries all `status='active'` bundle rows from the DB and mounts each one via `os.DirFS` rooted at the bundle's on-disk directory, presenting a unified catalog that includes both platform and customer items.
+3. Protect the integrity of built-in platform items — the embedded catalog is loaded first and is immutable at runtime. Custom bundles are loaded on top; a reserved-ID check to reject conflicting Create Bundle requests (§11.1) is planned.
+4. Maintain full backward compatibility — in the absence of any created bundles, behaviour is identical to the current release.
 
 ---
 
@@ -154,7 +154,7 @@ flowchart TD
 
 The catalog backend's `CatalogProvider` runs **inside the `ai-services--catalog` container**, not on the CLI host. `assets.CatalogFS` is baked into the binary at build time (via `go:embed`). For custom templates to be visible at runtime they must reach the container and be overlaid onto the embedded FS.
 
-Custom assets are delivered via the running catalog API: the client POSTs a `.tar.gz` bundle over HTTPS, and the apiserver writes the extracted contents to a dedicated named volume (`catalog-bundles` on both Podman and OpenShift) that it already owns. Both runtimes mount the volume at the well-known path `/data/catalog-bundles` inside the container. Bundles are stored under `<catalog_type>/<dir_name>/` where `dir_name` is `meta.DirName()` — for services `<id>-<version>` (e.g. `service/my-service-1.0.0/`), for components `<component_type>-<id>-<version>` (e.g. `component/llm-my-provider-1.0.0/`). **At most one bundle per `(catalog_type, catalog_id)` pair is active at any time** — uploading a new version via `PUT` replaces the existing one. At startup, `CatalogProvider` queries the DB for all `status = 'active'` rows, resolves each to its on-disk directory via the `dir_name` column, and loads it alongside the embedded assets using `os.DirFS`. Hot-reload happens in-process after every successful upload; no pod restart is needed.
+Custom assets are delivered via the running catalog API: the client POSTs a `.tar.gz` bundle over HTTPS, and the apiserver writes the extracted contents to a dedicated named volume (`catalog-bundles` on both Podman and OpenShift) that it already owns. Both runtimes mount the volume at the well-known path `/data/catalog-bundles` inside the container. Bundles are stored under `<catalog_type>/<catalog_id>-<version>/` — for services e.g. `service/my-service-1.0.0/`, for components e.g. `component/llm--my-provider-1.0.0/`. The directory path is derived at runtime from the DB `catalog_id` and `version` columns — it is never stored in the DB. **At most one bundle per `(catalog_type, catalog_id)` pair is active at any time** — updating to a new version via `PUT` replaces the existing one. At startup, `CatalogProvider` queries the DB for all `status = 'active'` rows, derives each on-disk path as `<catalog_id>-<version>`, and loads it alongside the embedded assets using `os.DirFS`. Hot-reload happens in-process after every successful bundle creation; no pod restart is needed.
 
 ### 3.3 OpenShift path
 
@@ -229,7 +229,7 @@ A user-supplied service bundle is a `.tar.gz` archive. Two layouts are accepted:
 - **Wrapped** — one top-level directory at the archive root; `metadata.yaml` sits inside it (e.g. `my-service/metadata.yaml`). The top-level directory name is **irrelevant** and is stripped during extraction.
 - **Flat** — no top-level directory; `metadata.yaml` sits at the archive root (e.g. produced by `tar -czf bundle.tar.gz -C my-service/ .`).
 
-In both cases the server writes extracted contents into the directory determined by `meta.DirName()` (i.e. `<id>-<version>`). Identity comes entirely from the `metadata.yaml` inside the archive.
+In both cases the server writes extracted contents into the directory `<catalog_id>-<version>`. Identity comes entirely from the `metadata.yaml` inside the archive.
 
 ```
 my-bundle.tar.gz
@@ -247,7 +247,7 @@ my-bundle.tar.gz
 
 ### 4.4 Custom component assets (proposed)
 
-Component bundles follow the same archive format but require the additional `component_type` field in `metadata.yaml`. The on-disk directory name is `<component_type>-<id>-<version>` (e.g. `llm-my-provider-1.0.0`) — encoding the component type prevents name collisions when the same `id` is used under different component types (e.g. `llm:my-provider` and `embedding:my-provider` are independent).
+Component bundles follow the same archive format but require the additional `component_type` field in `metadata.yaml`. The `catalog_id` is the composite `<component_type>--<id>` (e.g. `llm--my-provider`), making the on-disk directory `llm--my-provider-1.0.0`. This prevents collisions when the same bare `id` is used under different component types — `llm--my-provider` and `embedding--my-provider` are entirely independent.
 
 ```yaml
 # metadata.yaml inside the archive (component example)
@@ -270,23 +270,23 @@ my-component-bundle.tar.gz
             └── my-provider.yaml.tmpl
 ```
 
-Extracted on-disk as `component/llm-my-provider-1.0.0/` (i.e. `component/<component_type>-<id>-<version>/`). This naming scheme (`<component_type>-<catalog_id>-<version>`) is the canonical form used in both the `dir_name` DB column and the on-disk path.
+Extracted on-disk as `component/llm--my-provider-1.0.0/` — directory name is `<catalog_id>-<version>` (e.g. `llm--my-provider-1.0.0`), derived at runtime from the DB `catalog_id` and `version` columns.
 
 **Component type values** recognised by the server:
 
-| `component_type` | `DirName()` prefix | DB `catalog_id` |
-|---|---|---|
-| `llm` | `llm-` | `llm:<id>` |
-| `embedding` | `embedding-` | `embedding:<id>` |
-| `reranker` | `reranker-` | `reranker:<id>` |
-| `vector_db` | `vector_db-` | `vector_db:<id>` |
+| `component_type` | DB `catalog_id` format | example `catalog_id` | example on-disk dir |
+|---|---|---|---|
+| `llm` | `llm--<id>` | `llm--my-provider` | `llm--my-provider-1.0.0` |
+| `embedding` | `embedding--<id>` | `embedding--my-provider` | `embedding--my-provider-1.0.0` |
+| `reranker` | `reranker--<id>` | `reranker--my-provider` | `reranker--my-provider-1.0.0` |
+| `vector_db` | `vector_db--<id>` | `vector_db--my-provider` | `vector_db--my-provider-1.0.0` |
 
 Two component bundles with the same bare `id` but different `component_type` values are stored as entirely independent DB rows and on-disk directories:
 
 ```
 /data/catalog-bundles/component/
-├── llm-my-provider-1.0.0/          ← catalog_id: "llm:my-provider"
-└── embedding-my-provider-1.0.0/    ← catalog_id: "embedding:my-provider"  (independent)
+├── llm--my-provider-1.0.0/         ← catalog_id: "llm--my-provider"
+└── embedding--my-provider-1.0.0/   ← catalog_id: "embedding--my-provider"  (independent)
 ```
 
 The `component_type` field is required. Missing or unrecognised values are rejected with `422`.
@@ -309,8 +309,8 @@ func (p *CatalogProvider) loadBundleItems(ctx context.Context, items map[string]
     // ...
     for _, b := range bundles {
         if b.Status != "active" { continue }
-        // /data/catalog-bundles/<catalog_type>/<dir_name>/
-        bundleDir := filepath.Join(bundleStorageRoot, b.CatalogType, b.DirName)
+        // /data/catalog-bundles/<catalog_type>/<catalog_id>-<version>/
+        bundleDir := filepath.Join(bundleStorageRoot, b.CatalogType, b.CatalogID+"-"+b.Version)
         bundleFS  := os.DirFS(bundleDir)
         metaPath  := "metadata.yaml"
         data, _   := fs.ReadFile(bundleFS, metaPath)
@@ -327,7 +327,7 @@ func (p *CatalogProvider) loadBundleItems(ctx context.Context, items map[string]
 | Priority | Source | Condition |
 |---|---|---|
 | 1 | Embedded `assets.CatalogFS` | Always loaded first |
-| 2..N | `os.DirFS` per active bundle | DB has `status = 'active'` rows; paths are `/data/catalog-bundles/<catalog_type>/<dir_name>/` |
+| 2..N | `os.DirFS` per active bundle | DB has `status = 'active'` rows; paths are `/data/catalog-bundles/<catalog_type>/<catalog_id>-<version>/` |
 
 Bundle items are written into the same `items` map as embedded items. Services are keyed by bare `id`; components by `<component_type>:<id>`. If a bundle's `meta.CatalogID()` matches a built-in item of the same type, validation rejects it before insertion (`422`).
 
@@ -335,7 +335,7 @@ Bundle items are written into the same `items` map as embedded items. Services a
 
 ```go
 // NewCatalogProvider creates a CatalogProvider, loading all embedded items and any
-// active customer-uploaded bundles from the DB (bundleRepo may be nil for CLI paths).
+// active customer-created bundles from the DB (bundleRepo may be nil for CLI paths).
 func NewCatalogProvider(bundleRepo dbrepo.BundleRepository) (*CatalogProvider, error)
 ```
 
@@ -343,22 +343,22 @@ When `bundleRepo` is `nil` (CLI / test paths), only embedded items are loaded.
 
 ### 5.4 Hot-reload
 
-`CatalogProvider.Reload(ctx)` rebuilds the items map from scratch under a `sync.RWMutex` — re-walking the embedded FS and re-querying all active bundles from the DB. It is called synchronously at the end of every successful `ProcessBundle` / `DeleteBundle`, and asynchronously at the end of `runReplaceAsync` for PUT updates.
+`CatalogProvider.Reload(ctx)` rebuilds the items map from scratch under a `sync.RWMutex` — re-walking the embedded FS and re-querying all active bundles from the DB. It is called synchronously at the end of every successful `ProcessBundle`, `ReplaceBundle`, and `DeleteBundle` operation.
 
 ---
 
-## 6. API Upload
+## 6. API Create Bundle
 
-Custom catalog assets are delivered by uploading a `.tar.gz` bundle to the running catalog backend over its existing HTTPS endpoint. The archive must contain exactly one top-level directory (the service directory) with a `metadata.yaml` at its root declaring `id`, `type`, and `version`. The archive is extracted, validated, written to the bundle volume, and hot-reloaded into `CatalogProvider` — with no pod restart required for either Podman or OpenShift.
+Custom catalog assets are delivered by creating a bundle from a `.tar.gz` archive through the running catalog backend over its existing HTTPS endpoint. The archive must contain exactly one top-level directory (the service directory) with a `metadata.yaml` at its root declaring `id`, `type`, and `version`. The archive is extracted, validated, written to the bundle volume, and hot-reloaded into `CatalogProvider` — with no pod restart required for either Podman or OpenShift.
 
 ### 6.1 Design goals
 
 | Goal | Detail |
 |---|---|
-| No restart required | `CatalogProvider` reloads the custom layer in-process after a successful upload |
+| No restart required | `CatalogProvider` reloads the custom layer in-process after successful bundle creation |
 | Conflict-safe POST | `POST` raises `409 Conflict` if a bundle with the same `catalog_id` is already registered — use `PUT` to update |
 | Explicit update via PUT | `PUT /api/v1/catalog/bundles/:bundle_id` replaces the existing bundle; `catalog_id`, `catalog_type`, and `version` are all resolved from the archive and the existing DB record — not form fields |
-| Independent bundles | Each uploaded bundle exists separately; multiple bundles for different `catalog_id` values are all active simultaneously |
+| Independent bundles | Each created bundle exists separately; multiple bundles for different `catalog_id` values are all active simultaneously |
 | Authenticated | Uses the existing JWT `BearerAuth` middleware; only admin-role tokens are accepted |
 | Consistent across runtimes | Same API endpoint works for Podman and OpenShift; only the storage backend differs |
 | Bounded size | Configurable `MAX_BUNDLE_SIZE` (default 50 MB); enforced at the HTTP layer before extraction |
@@ -371,12 +371,12 @@ Six bundle endpoints are added to the existing router in [`apiserver/router.go`]
 
 | Method | Path | Description |
 |---|---|---|
-| `POST` | `/api/v1/catalog/bundles` | Upload a **new** bundle (`.tar.gz`). Returns `409 Conflict` if a bundle with the same `catalog_id` already exists. |
+| `POST` | `/api/v1/catalog/bundles` | Create a **new** bundle (`.tar.gz`). Returns `409 Conflict` if a bundle with the same `catalog_id` already exists. |
 | `POST` | `/api/v1/catalog/bundles/validate` | Validate a bundle archive without storing it. No DB record is written; `CatalogProvider` is not reloaded. |
 | `PUT` | `/api/v1/catalog/bundles/:bundle_id` | Replace an existing bundle identified by its internal record ID. Returns `404` if no bundle with that ID exists. `catalog_id` and `catalog_type` are resolved from the DB record. |
 | `DELETE` | `/api/v1/catalog/bundles/:bundle_id` | Delete a bundle by its internal record ID. Removes the on-disk directory and the DB record. Returns `404` if no bundle with that ID exists. |
-| `GET` | `/api/v1/catalog/bundles` | List all uploaded bundles (id, status, uploaded_at, size). |
-| `GET` | `/api/v1/catalog/bundles/:bundle_id` | Get the status and metadata for a specific bundle by ID. Used to poll after a `202 Accepted` PUT response. |
+| `GET` | `/api/v1/catalog/bundles` | List all created bundles (id, status, created_at, size). |
+| `GET` | `/api/v1/catalog/bundles/:bundle_id` | Get the status and metadata for a specific bundle by ID. |
 
 Five additional catalog-read endpoints are added under the authenticated `v1` catalog group for CLI and client use:
 
@@ -388,13 +388,17 @@ Five additional catalog-read endpoints are added under the authenticated `v1` ca
 | `GET` | `/api/v1/architectures/:id/images` | Return image metadata for an architecture. |
 | `GET` | `/api/v1/architectures/:id/models` | Return model metadata for an architecture. |
 
-#### 6.2.1 Upload bundle — `POST /api/v1/catalog/bundles`
+#### 6.2.1 Create Bundle — `POST /api/v1/catalog/bundles`
 
 The request uses `multipart/form-data` with a single field: `file` (required). **`id`, `type`, and `version` are not form fields** — they are all read from `metadata.yaml` inside the archive. This removes the possibility of a mismatch between declared metadata and archive contents.
 
-The upload is **fully synchronous**: the handler reads the archive, peeks `metadata.yaml`, checks for a conflict, extracts to the permanent directory, validates structure, inserts a DB row as `active`, and reloads `CatalogProvider` — all before returning. On success the response is `201 Created` (not `202 Accepted`); no polling is needed.
+The Create Bundle operation is **fully synchronous**: the handler reads the archive, peeks the minimal identity fields from root `metadata.yaml`, checks for a conflict, validates the bundle directly from the uploaded archive, extracts to the permanent directory, inserts a DB row as `processing`, reloads `CatalogProvider`, and then marks the row `active` — all before returning. On success the response is `201 Created` (not `202 Accepted`); no polling is needed.
 
-To validate a bundle before uploading use `POST /api/v1/catalog/bundles/validate` (see §6.2.5).
+Conflict detection happens immediately after the minimal metadata peek, before the deeper validation pass, so an already-existing active bundle is rejected with `409 Conflict` without paying the cost of full semantic validation.
+
+Validation is then performed from the archive contents themselves before persistence. This includes archive structure checks, root and runtime `metadata.yaml` parsing, `values.yaml` and schema/metadata consistency checks, template file parsing, service label and annotation checks, `steps.md` inspection, and line-by-line scanning of relevant bundle files.
+
+To validate a bundle before creating it use `POST /api/v1/catalog/bundles/validate` (see [`§6.2.5`](proposal.md:2105)).
 
 ```
 POST /api/v1/catalog/bundles
@@ -418,7 +422,7 @@ curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
 
 | Status | Meaning |
 |---|---|
-| `201 Created` | Bundle validated, extracted, inserted into the DB as `active`, and catalog reloaded — all synchronously. A `Location` header points to the new record. |
+| `201 Created` | Bundle validated, extracted, inserted into the DB as `processing`, catalog reloaded, and then marked `active` — all synchronously. A `Location` header points to the new record. |
 | `400 Bad Request` | Missing or unreadable `file` field; wrong content-type; archive exceeds size limit; or `metadata.yaml` is missing/malformed. |
 | `401 Unauthorized` | Missing or invalid JWT. |
 | `403 Forbidden` | Token does not carry admin role. |
@@ -437,14 +441,13 @@ Location: /api/v1/catalog/bundles/550e8400-e29b-41d4-a716-446655440000
 {
   "id":           "550e8400-e29b-41d4-a716-446655440000",
   "name":         "My Custom Service",
-  "dir_name":     "my-service-1.0.0",
   "status":       "active",
-  "uploaded_at":  "2026-05-12T09:14:02Z",
+  "created_at":   "2026-05-12T09:14:02Z",
   "size_bytes":   286720,
   "catalog_type": "service",
   "catalog_id":   "my-service",
   "version":      "1.0.0",
-  "uploaded_by":  "admin"
+  "created_by":   "admin"
 }
 ```
 
@@ -453,6 +456,8 @@ Location: /api/v1/catalog/bundles/550e8400-e29b-41d4-a716-446655440000
 Use `PUT` to replace an existing bundle identified by its internal record ID (`bundle_id`). The server looks up the record by `bundle_id` and derives `id`, `type`, and for components `component_type` from it — none are form fields. The only form field is `file`.
 
 **Version is not a form field.** The version of the replacement bundle is read from `metadata.yaml` inside the archive. If the metadata carries a new version the on-disk directory is named accordingly. The `id`, `type`, and (for components) `component_type` values inside the archive metadata must match the existing DB record — attempts to change them are rejected with `422`.
+
+Like `POST`, `PUT` performs validation directly from the uploaded archive before any state transition. The server validates archive structure, parses root and runtime metadata, checks `values.yaml` and schema/metadata consistency, parses template files, verifies service labels and annotations, reads `steps.md`, and scans relevant files line-by-line before proceeding with the replacement.
 
 Returns `404` if no bundle with that `bundle_id` exists.
 
@@ -469,7 +474,7 @@ Form fields:
   file        (required)  — .tar.gz archive containing the replacement assets
 ```
 
-> `id`, `type`, `component_type` (for components), and `version` are **not** form fields for `PUT`. `id`, `type`, and `component_type` are resolved from the DB record (`catalog_id` decodes the composite for components) and validated against the archive metadata — mismatches are rejected with `422`. `version` is read from the archive's `metadata.yaml` and used to derive the on-disk directory name via `meta.DirName()`.
+> `id`, `type`, `component_type` (for components), and `version` are **not** form fields for `PUT`. `id`, `type`, and `component_type` are resolved from the DB record (`catalog_id` decodes the composite for components) and validated against the archive metadata — mismatches are rejected with `422`. `version` is read from the archive's `metadata.yaml` and used to derive the on-disk directory name as `<catalog_id>-<version>`.
 
 **Example (curl):**
 ```bash
@@ -482,20 +487,20 @@ curl -X PUT https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2M8V
 
 | Status | Meaning |
 |---|---|
-| `202 Accepted` | Archive validated; the **existing DB row** is updated in-place by the async goroutine. Poll `GET /api/v1/catalog/bundles/:bundle_id` (same ID) until `status` is `active`. |
+| `200 OK` | Archive validated, existing bundle marked `processing`, replacement extracted into a staging directory, current final directory replaced by renaming the staging directory into place, bundle marked `active`, catalog reloaded, and old bundle directory removed at the end when different — all synchronously. The response body contains the updated bundle record with `status: active`. |
 | `400 Bad Request` | Missing `file` field; archive top-level directory does not match the resolved `id`; wrong content-type; or archive exceeds size limit. |
 | `401 Unauthorized` | Missing or invalid JWT. |
 | `403 Forbidden` | Token does not carry admin role. |
 | `404 Not Found` | No bundle with the given `bundle_id` exists. Use `POST` to create a new bundle first. |
-| `422 Unprocessable Entity` | Validation of the archive's `metadata.yaml` failed; or `id`, `type`, or `component_type` (for components) differs from the existing record. The DB row is not modified; the existing bundle remains active. |
+| `422 Unprocessable Entity` | Validation of the archive's `metadata.yaml` failed; or `id`, `type`, or `component_type` (for components) differs from the existing record. The replacement is rejected before any status transition. |
 
-The `202` response returns the **same bundle ID** the client already holds — no new ID is issued. The existing row is updated in-place by the async goroutine (`status=active`, `version`, `dir_name`, `name`, `size_bytes` set in a single UPDATE). The old on-disk directory is deleted only after the row is successfully updated. If extraction fails, the DB row is left unchanged — the existing bundle remains active and serving.
+The `200` response returns the updated bundle record with `status: active`, `version`, `name`, and `size_bytes` populated from the newly activated bundle. The existing row is first moved to `processing`, then the replacement is extracted into a staging directory (`<catalog_id>-<version>-new`), the current final directory is removed, and the staging directory is renamed into place before the row is updated in-place to `active`. The old on-disk directory is deleted only at the very end when it differs from the new final path. This keeps the replace flow simple and avoids stale files even when replacing a bundle with the same `catalog_id` and `version`. If extraction, rename, activation, reload, or final cleanup fails after the status transition, the row is marked `failed` and the error message is stored in the `error` column.
 
 ---
 
 #### 6.2.3 Delete bundle — `DELETE /api/v1/catalog/bundles/:bundle_id`
 
-Permanently removes a bundle: deletes the on-disk directory (`<catalog_type>/<dir_name>/`) from the bundle volume, removes the DB row, and triggers a `CatalogProvider.Reload()` so the item is no longer served. Any application that was deployed using this bundle's `catalog_id` is **not** affected — existing deployed resources are independent of the catalog once launched.
+Permanently removes a bundle: marks the row `deleting`, deletes the on-disk directory (`<catalog_type>/<catalog_id>-<version>/`) from the bundle volume, triggers a `CatalogProvider.Reload()` so the item is no longer served, and then removes the DB row. Any application that was deployed using this bundle's `catalog_id` is **not** affected — existing deployed resources are independent of the catalog once launched.
 
 ```
 DELETE /api/v1/catalog/bundles/:bundle_id
@@ -516,12 +521,12 @@ curl -X DELETE https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2
 
 | Status | Meaning |
 |---|---|
-| `204 No Content` | Bundle deleted; on-disk directory removed and `CatalogProvider` reloaded. |
+| `204 No Content` | Bundle marked `deleting`, on-disk directory removed, `CatalogProvider` reloaded, and DB row deleted. |
 | `401 Unauthorized` | Missing or invalid JWT. |
 | `403 Forbidden` | Token does not carry admin role. |
 | `404 Not Found` | No bundle with the given `bundle_id` exists. |
 
-> Deletion is **synchronous** — the directory removal and `CatalogProvider.Reload()` happen in-process before the `204` is returned. There is no async processing step and no polling needed.
+> Deletion is **synchronous** — the row is marked `deleting`, then the directory removal, `CatalogProvider.Reload()`, and DB delete happen in-process before the `204` is returned. There is no async processing step and no polling needed. If any of those steps fails before the final DB delete, the row is marked `failed`.
 
 ---
 
@@ -529,9 +534,9 @@ curl -X DELETE https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2
 
 Each bundle record carries `catalog_type` and `catalog_id` (derived from the archive's `id` and `type` fields). Multiple bundles for different items are all active simultaneously and each is listed independently.
 
-Two name-related fields appear in every response:
-- **`name`** — the human-readable display label from `metadata.yaml` `name:` field (e.g. `"My Custom LLM Provider"`). May be `null` if omitted from the archive.
-- **`dir_name`** — the server-determined on-disk directory name. Services: `<id>-<version>`; components: `<component_type>-<catalog_id>-<version>`.
+The `name` field is the human-readable display label from `metadata.yaml` `name:` field (e.g. `"My Custom LLM Provider"`). Omitted from the response if blank.
+
+The on-disk directory is derived at runtime as `<catalog_id>-<version>` — it is **not** stored in the DB. For components, `catalog_id` uses `--` as separator (e.g. `llm--my-provider`), giving a directory name of `llm--my-provider-1.0.0`.
 
 ```json
 {
@@ -539,26 +544,24 @@ Two name-related fields appear in every response:
     {
       "id":           "550e8400-e29b-41d4-a716-446655440000",
       "name":         "My Custom Service",
-      "dir_name":     "my-service-1.0.0",
       "status":       "active",
-      "uploaded_at":  "2026-05-12T09:14:02Z",
+      "created_at":  "2026-05-12T09:14:02Z",
       "size_bytes":   286720,
       "catalog_type": "service",
       "catalog_id":   "my-service",
       "version":      "1.0.0",
-      "uploaded_by":  "admin"
+      "created_by":  "admin"
     },
     {
       "id":           "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
       "name":         "My Custom LLM Provider",
-      "dir_name":     "llm-my-provider-1.0.0",
       "status":       "active",
-      "uploaded_at":  "2026-05-13T11:30:00Z",
+      "created_at":  "2026-05-13T11:30:00Z",
       "size_bytes":   196608,
       "catalog_type": "component",
-      "catalog_id":   "llm:my-provider",
+      "catalog_id":   "llm--my-provider",
       "version":      "1.0.0",
-      "uploaded_by":  "admin"
+      "created_by":  "admin"
     }
   ]
 }
@@ -568,7 +571,7 @@ Two name-related fields appear in every response:
 
 ### 6.3 Bundle format
 
-A bundle is scoped to **one catalog item**. The archive must be a gzip-compressed tar (`.tar.gz`). The identity of a bundle comes entirely from `metadata.yaml` content — **the archive top-level directory name is irrelevant and is not validated**. The server strips it during extraction and writes into the server-determined destination directory (`meta.DirName()`).
+A bundle is scoped to **one catalog item**. The archive must be a gzip-compressed tar (`.tar.gz`). The identity of a bundle comes entirely from `metadata.yaml` content — **the archive top-level directory name is irrelevant and is not validated**. The server strips it during extraction and writes into the server-determined destination directory (`<catalog_id>-<version>`).
 
 For **both POST and PUT**, `id`, `type`, `version` (and `component_type` for components) are read from `metadata.yaml` inside the archive — they are not form fields. For **PUT**, `meta.CatalogID()` and `meta.CatalogType()` must also match the existing DB record (immutable); a mismatch is rejected with `422`.
 
@@ -593,7 +596,7 @@ my-bundle.tar.gz
             └── my-service.yaml.tmpl
 ```
 
-Extracted on-disk as `service/my-service-1.0.0/` — `meta.DirName()` is the authoritative destination.
+Extracted on-disk as `service/my-service-1.0.0/` — directory is `<catalog_id>-<version>`.
 
 #### Component bundle
 
@@ -617,7 +620,7 @@ my-component-bundle.tar.gz
             └── my-provider.yaml.tmpl
 ```
 
-Extracted on-disk as `component/llm-my-provider-1.0.0/` — `meta.DirName()` is the authoritative destination.
+Extracted on-disk as `component/llm--my-provider-1.0.0/` — directory is `<catalog_id>-<version>`.
 
 **Rules (both types):**
 - Paths containing `..` or absolute paths are rejected immediately (path-traversal guard).
@@ -626,10 +629,12 @@ Extracted on-disk as `component/llm-my-provider-1.0.0/` — `meta.DirName()` is 
 - Total uncompressed size must not exceed 200 MB.
 - `meta.CatalogID()` must not match any built-in item already present in `assets.CatalogFS` — if it does, validation returns `422` and the extracted directory is deleted.
 - All `metadata.yaml` files must pass validation for the declared `type` before the bundle is marked `active`.
+- Validation is performed directly from the archive and covers archive structure, root and runtime metadata parsing, `values.yaml` and schema/metadata consistency checks, template parsing, service label checks, annotation checks, `steps.md` inspection, and line-by-line scanning of relevant files.
+- Lifecycle statuses are limited to `processing`, `active`, `failed`, and `deleting`.
 
 **Rules (component bundles only):**
 - `component_type` is required. Missing or unrecognised values are rejected with `422`.
-- Within a given `component_type`, no two active bundles may share the same `id`. The DB unique index on `(catalog_type, catalog_id) WHERE status='active'` enforces this since `"llm:my-provider"` is distinct from `"embedding:my-provider"`.
+- Within a given `component_type`, no two active bundles may share the same `id`. The DB unique index on `(catalog_type, catalog_id) WHERE status='active'` enforces this since `"llm--my-provider"` is distinct from `"embedding--my-provider"`.
 
 ---
 
@@ -641,25 +646,24 @@ Extracted on-disk as `component/llm-my-provider-1.0.0/` — `meta.DirName()` is 
 flowchart TD
     REQ["POST /api/v1/catalog/bundles<br/>multipart/form-data — file"]
     AUTH["AuthMiddleware<br/>JWT + admin role check"]
-    PEEK["Peek metadata.yaml<br/>read id, type, version + component_type for components<br/>→ 422 if missing/invalid"]
+    PEEK["Peek root metadata.yaml<br/>read id, type, version + component_type for components<br/>→ 422 if missing/invalid"]
     CONFLICT["Check catalog_bundles table<br/>active row for meta.CatalogID()?"]
+    VALIDATE["Validate directly from uploaded archive<br/>• archive structure + path checks<br/>• root/runtime metadata parsing<br/>• values.yaml + schema consistency<br/>• template parsing, labels, annotations<br/>• steps.md + line-by-line file scanning<br/>→ 422 if invalid<br/>(no extraction to disk)"]
     CONFLICT_RESP["409 Conflict<br/>use PUT /catalog/bundles/:bundle_id to update"]
-    SIZE["Size guard — 200 MB uncompressed"]
-    EXTRACT["Extract to meta.DirName()/ inside bundle volume<br/>(top-level dir stripped regardless of its name)"]
+    EXTRACT["Extract to &lt;catalog_id&gt;-&lt;version&gt;/ inside bundle volume<br/>(top-level dir stripped regardless of its name)"]
     PATHGUARD["Path-traversal guard<br/>reject .. and absolute paths"]
-    VALIDATE["validateBundleStructure<br/>metadata.yaml present at bundle root"]
     DBINSERT["Insert bundle record (status=processing)<br/>id generated by DB via gen_random_uuid()"]
-    ACTIVATE["Activate: status=active, size_bytes, version, dir_name<br/>single UPDATE"]
     RELOAD["CatalogProvider.Reload()"]
+    ACTIVATE["Activate: status=active, size_bytes, version, name<br/>single UPDATE"]
     RESP["201 Created — BundleResponse (re-fetched from DB)<br/>status: active, size_bytes populated<br/>Location: /api/v1/catalog/bundles/:uuid"]
-    FAIL["Delete meta.DirName()/ directory + DB row<br/>return 422/400"]
+    FAIL["Return 422/400 before persistence;<br/>or clean extracted dir and mark DB row failed if a later step fails"]
 
-    REQ --> AUTH --> PEEK
-    PEEK --> CONFLICT
+    REQ --> AUTH --> PEEK --> CONFLICT
     CONFLICT -->|"exists"| CONFLICT_RESP
-    CONFLICT -->|"new"| SIZE --> EXTRACT --> PATHGUARD --> VALIDATE
-    VALIDATE -->|"valid"| DBINSERT --> ACTIVATE --> RELOAD --> RESP
+    CONFLICT -->|"new"| VALIDATE
     VALIDATE -->|"invalid"| FAIL
+    VALIDATE -->|"valid"| EXTRACT --> PATHGUARD --> DBINSERT --> RELOAD --> ACTIVATE --> RESP
+    PATHGUARD -->|"invalid path"| FAIL
 ```
 
 #### PUT — replace existing bundle
@@ -669,58 +673,51 @@ flowchart TD
     REQ["PUT /api/v1/catalog/bundles/:bundle_id<br/>multipart/form-data — file"]
     AUTH["AuthMiddleware<br/>JWT + admin role check"]
     LOOKUP["Look up bundle_id in catalog_bundles → 404 if missing"]
-    PEEK["Peek metadata.yaml<br/>validate meta.CatalogID() + meta.CatalogType() unchanged<br/>→ 422 on mismatch"]
-    RESP["202 Accepted immediately<br/>same bundle_id, status: active (current)<br/>Location: /api/v1/catalog/bundles/:bundle_id"]
+    PEEK["Peek root metadata.yaml<br/>validate meta.CatalogID() + meta.CatalogType() unchanged<br/>→ 422 on mismatch"]
+    VALIDATE["Validate directly from uploaded archive<br/>• archive structure + path checks<br/>• root/runtime metadata parsing<br/>• values.yaml + schema consistency<br/>• template parsing, labels, annotations<br/>• steps.md + line-by-line file scanning<br/>→ 422 if invalid<br/>(no extraction to disk)"]
+    MARKPROC["Mark existing row processing<br/>clear prior error"]
+    EXTRACT["extractAndMeasure: extract to staging dir &lt;catalog_id&gt;-&lt;version&gt;-new<br/>• top-level dir stripped (wrapped or flat archive)<br/>• path-traversal guard + 200 MB size guard"]
+    SWAP["Remove current final dir if present<br/>rename staging dir into final &lt;catalog_id&gt;-&lt;version&gt;/ path"]
+    DBUPDATE["UPDATE existing row in-place<br/>status=active, version, name, size_bytes<br/>single UPDATE — no unique index conflict"]
+    RELOAD["CatalogProvider.Reload()"]
+    RMOLDDIR["Delete old directory at the end when different"]
+    RESP["200 OK<br/>updated bundle record, status: active<br/>Location: /api/v1/catalog/bundles/:bundle_id"]
+    FAIL["Return 422 before state transition;<br/>or clean staging/new dir and mark DB row failed if a later step fails"]
 
-    subgraph ASYNC["Goroutine — async after 202"]
-        EXTRACT["extractAndMeasure: extract to meta.DirName()/ inside bundle volume<br/>• top-level dir stripped (wrapped or flat archive)<br/>• path-traversal guard + 200 MB size guard"]
-        VALIDATE["validateBundleStructure"]
-
-        subgraph ACTIVATE["Activate — success path"]
-            direction LR
-            DBUPDATE["UPDATE existing row in-place<br/>status=active, version, dir_name, name, size_bytes<br/>single UPDATE — no unique index conflict"]
-            RMOLDDIR["Delete old directory<br/>(only if dir_name changed)"]
-            RELOAD["CatalogProvider.Reload()"]
-            DBUPDATE --> RMOLDDIR --> RELOAD
-        end
-
-        FAIL["Delete new meta.DirName()/ directory<br/>DB row left unchanged — existing bundle still active"]
-
-        EXTRACT --> VALIDATE
-        VALIDATE -->|"valid"| ACTIVATE
-        VALIDATE -->|"invalid"| FAIL
-    end
-
-    REQ --> AUTH --> LOOKUP --> PEEK --> RESP
-    RESP -.-> ASYNC
+    REQ --> AUTH --> LOOKUP --> PEEK
+    PEEK -->|"match"| VALIDATE
+    PEEK -->|"mismatch"| FAIL
+    VALIDATE -->|"invalid"| FAIL
+    VALIDATE -->|"valid"| MARKPROC --> EXTRACT --> SWAP --> DBUPDATE --> RELOAD --> RMOLDDIR --> RESP
 ```
 
 **Key implementation notes:**
 
-- **POST is fully synchronous.** Returns `201 Created` only after extraction, validation, DB activate, and `CatalogProvider.Reload()` all succeed. Response is re-fetched from DB — `status`, `size_bytes`, and `uploaded_at` are authoritative.
-- **PUT sync phase** validates the archive and immutable fields only. Returns `202 Accepted` immediately with the **same bundle ID** — no new row is inserted.
-- **PUT async phase** extracts, validates, then UPDATEs the existing row in-place (`status=active`, `version`, `dir_name`, `size_bytes` — single statement). No unique index conflict is possible since only one row ever exists for this `(catalog_type, catalog_id)`. If extraction fails the DB row is left unchanged — the existing bundle stays active. **Directory behaviour:** same version → overwritten in-place; new version → new `meta.DirName()/` directory created, old one deleted after activation.
+- **Validation from archive first.** All three entry points (`POST`, `PUT`, and the validate API) validate directly from the uploaded archive before any extraction to disk. This ensures fast failure with no disk overhead for invalid bundles. Validation covers archive structure, root and runtime `metadata.yaml` parsing, `values.yaml` and schema/metadata consistency checks, template file parsing, label checks, annotation checks, `steps.md` inspection, and line-by-line scanning of relevant files. The `validateBundleStructureFromArchive` function reads the tar.gz stream and checks that `metadata.yaml` exists in the archive root (supporting both wrapped and flat archive layouts).
+- **POST is fully synchronous.** Returns `201 Created` only after archive validation, metadata checks, conflict check, extraction, DB insert as `processing`, `CatalogProvider.Reload()`, and final activation all succeed. Response is re-fetched from DB — `status`, `size_bytes`, and `created_at` are authoritative.
+- **PUT is fully synchronous.** Validates archive and immutable fields, marks the existing row `processing`, extracts the replacement into a staging directory, removes the current final directory, renames the staging directory into the final bundle path, UPDATEs the existing row in-place back to `active` (`version`, `name`, `size_bytes` — single statement), reloads `CatalogProvider`, and only then removes the old directory when it differs before returning `200 OK` with the updated bundle record. No unique index conflict is possible since only one row ever exists for this `(catalog_type, catalog_id)`. The staging step avoids stale files even when replacing a bundle with the same `catalog_id` and `version`. If extraction, rename, activation, reload, or final cleanup fails after the status transition, the row is marked `failed` and the error is returned.
 - `id` (bundle UUID) is **generated by the DB** via `gen_random_uuid()` — the server never supplies it.
 - `id`, `type`, `version` (and `component_type` for components) are **never form fields** — all are read from `metadata.yaml` inside the archive by `peekMetadata()`. The **archive top-level directory name is never validated** — it is stripped blindly.
 - `peekMetadata()` infers the top-level directory from the first entry containing a `/` solely to locate `<topDir>/metadata.yaml`. The directory name itself is not compared against any metadata field.
-- `extractAndMeasure` takes no `catalogID` parameter — it strips the archive top-level directory and writes into the caller-supplied `destDir` (`bundleDirPath(meta.CatalogType(), meta.DirName())`).
-- On-disk layout:
-  - Services: `/data/catalog-bundles/service/<id>-<version>/` e.g. `/data/catalog-bundles/service/my-service-1.0.0/`
-  - Components: `/data/catalog-bundles/component/<component_type>-<id>-<version>/` e.g. `/data/catalog-bundles/component/llm-my-provider-1.0.0/`
+- `extractAndMeasure` strips the archive top-level directory and writes into the caller-supplied `destDir` (`bundleDirPath(meta.CatalogType(), meta.CatalogID(), meta.Version())`).
+- **On-disk layout** — directory name is always `<catalog_id>-<version>` (derived at runtime, never stored in DB):
+  - Services: `/data/catalog-bundles/service/my-service-1.0.0/`
+  - Components: `/data/catalog-bundles/component/llm--my-provider-1.0.0/`  (`catalog_id` uses `--` as separator)
 - **PUT** immutability check: `meta.CatalogID()` and `meta.CatalogType()` from the archive must match the existing DB record. `version` may differ. Mismatch → `422`, no extraction attempted.
 - `CatalogProvider.Reload()` re-queries the DB and rebuilds the in-memory catalog under `sync.RWMutex`.
 - Bundle files are stored in the **dedicated `catalog-bundles` volume** — isolated from `$BASE_DIR`.
+- The validate-only API uses the same archive-based validation approach as `POST` and `PUT`, but stops before any extraction to the permanent bundle directory, DB write, or catalog reload.
 - The `catalog_bundles` table is added via a Goose migration (`20260430094507_create_catalog_bundles_table.sql`).
 
 ---
 
 ### 6.5 New database migration
 
-Each row in `catalog_bundles` represents one uploaded bundle. The `id` is a UUID generated by the DB via `gen_random_uuid()` — the server never supplies it. Two name-related columns are stored:
-- **`name`** — the human-readable display label from `metadata.yaml` `name:` field (e.g. `"My Custom LLM Provider"`). Not unique — the same display name may appear across different component types.
-- **`dir_name`** — the server-determined on-disk directory name (`meta.DirName()`), used for routing to the bundle volume. Always unique per active `(catalog_type, catalog_id)`.
+Each row in `catalog_bundles` represents one created bundle. The `id` is a UUID generated by the DB via `gen_random_uuid()` — the server never supplies it.
 
-The `status` column tracks lifecycle: **POST** inserts a new row as `processing` then activates it with a single `Activate` UPDATE. **PUT** updates the existing row in-place — no new row is ever inserted. **Only one `active` row per `(catalog_type, catalog_id)` is permitted** — enforced by a partial composite unique index.
+The on-disk directory path is **derived at runtime** from `catalog_id` and `version` as `<catalog_id>-<version>` — it is **not stored** in the DB. No `dir_name` column exists in the table.
+
+The `status` column tracks lifecycle using only `processing`, `active`, `failed`, and `deleting`: **POST** inserts a new row as `processing`, reloads the catalog, then activates it with a single `Activate` UPDATE. **PUT** marks the existing row `processing`, extracts the replacement, reloads the catalog, re-activates the row in-place, and removes the old directory only at the end. **DELETE** marks the row `deleting`, removes the directory, reloads the catalog, and then deletes the row. If any post-transition step fails during POST, PUT, or DELETE, the row is marked `failed` and the error message is stored. **Only one `active` row per `(catalog_type, catalog_id)` is permitted** — enforced by a partial composite unique index.
 
 ```sql
 -- +goose Up
@@ -728,7 +725,8 @@ The `status` column tracks lifecycle: **POST** inserts a new row as `processing`
 CREATE TYPE bundle_status AS ENUM (
     'processing',
     'active',
-    'failed'
+    'failed',
+    'deleting'
 );
 
 CREATE TABLE catalog_bundles (
@@ -740,37 +738,32 @@ CREATE TABLE catalog_bundles (
     -- Not required to be unique — the same label may appear for different catalog_ids.
     name             VARCHAR(255),
 
-    -- Server-determined on-disk directory name: meta.DirName().
-    -- Services:   <id>-<version>                       e.g. "my-service-1.0.0"
-    -- Components: <component_type>-<id>-<version>       e.g. "llm-my-provider-1.0.0"
-    dir_name         VARCHAR(200)   NOT NULL,
-
     status           bundle_status  NOT NULL DEFAULT 'processing',
     -- Uncompressed on-disk size in bytes, populated after extraction completes.
-    -- NULL until the bundle reaches 'active' or 'failed'.
+    -- NULL until the bundle reaches 'active', 'failed', or 'deleting'.
     size_bytes       BIGINT,
 
     -- The catalog item type: "service" or "component".
     catalog_type     VARCHAR(50)    NOT NULL,
 
     -- Unique identity of the catalog item within its type.
-    -- Services:   bare id                              e.g. "my-service"
-    -- Components: composite <component_type>:<id>      e.g. "llm:my-provider"
+    -- Services:   bare id                               e.g. "my-service"
+    -- Components: composite <component_type>--<id>      e.g. "llm--my-provider"
     catalog_id       VARCHAR(200)   NOT NULL,
 
     -- Semantic version of this bundle: e.g. "1.0.0", "2.1.0"
     version          VARCHAR(50)    NOT NULL DEFAULT '',
 
     error            TEXT,
-    uploaded_by      VARCHAR(100),
-    uploaded_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW()
+    created_by       VARCHAR(100),
+    created_at       TIMESTAMPTZ    NOT NULL DEFAULT NOW()
 );
 
 -- Enforce at most one active bundle per (catalog_type, catalog_id) pair.
 -- Using the composite key makes the constraint explicit and future-proof:
 -- a new catalog_type with the same catalog_id string as an existing one
 -- is correctly treated as a distinct item.
--- 'processing' and 'failed' rows are exempt so a replacement in-flight
+-- 'processing', 'failed', and 'deleting' rows are exempt so a replacement in-flight
 -- does not block itself.
 CREATE UNIQUE INDEX uq_catalog_bundles_active
     ON catalog_bundles (catalog_type, catalog_id)
@@ -789,33 +782,33 @@ DROP TYPE   IF EXISTS bundle_status;
 
 ### 6.6 Storage per runtime
 
-Bundle storage is **intentionally isolated** from `$AI_SERVICES_BASE_DIR`. This prevents a `catalog delete` or application-data wipe from destroying uploaded bundles, and makes the storage unit independently snapshotable.
+Bundle storage is **intentionally isolated** from `$AI_SERVICES_BASE_DIR`. This prevents a `catalog delete` or application-data wipe from destroying created bundles, and makes the storage unit independently snapshotable.
 
 #### Volume directory layout
 
-The volume is organised as `<catalog_type>/<dir_name>/` where `dir_name` is `meta.DirName()`. At most **one versioned directory per `(catalog_type, catalog_id)` pair** exists on disk at any time — a `PUT` replaces the old directory with the new one once the replacement is marked `active`. Bundles for different `catalog_id` values (within or across types) coexist independently.
+The volume is organised as `<catalog_type>/<catalog_id>-<version>/`. The directory name is derived at runtime — it is never stored in the DB. At most **one versioned directory per `(catalog_type, catalog_id)` pair** exists on disk at any time — a `PUT` with a new version creates a new directory and deletes the old one after activation. Bundles for different `catalog_id` values (within or across types) coexist independently.
 
 ```
 /data/catalog-bundles/
 ├── service/
-│   ├── my-service-1.0.0/        ← dir_name: "my-service-1.0.0"  name: "My Custom Service"
+│   ├── my-service-1.0.0/          ← catalog_id: "my-service"  version: "1.0.0"
 │   │   ├── metadata.yaml
 │   │   └── podman/...
-│   └── my-service-2.0.0/        ← would replace the above on PUT
+│   └── my-service-2.0.0/          ← would replace the above on PUT with new version
 └── component/
-    ├── llm-my-provider-1.0.0/   ← dir_name: "llm-my-provider-1.0.0"  name: "My Custom LLM Provider"
+    ├── llm--my-provider-1.0.0/    ← catalog_id: "llm--my-provider"  version: "1.0.0"
     │   ├── metadata.yaml
     │   └── podman/...
-    └── embedding-my-provider-1.0.0/  ← same display name permitted, different catalog_id
+    └── embedding--my-provider-1.0.0/  ← same bare id, different component_type
         ├── metadata.yaml
         └── podman/...
 ```
 
 The `CatalogProvider` resolves each active item's path as:
 ```
-/data/catalog-bundles/<catalog_type>/<dir_name>/
+/data/catalog-bundles/<catalog_type>/<catalog_id>-<version>/
 ```
-where `dir_name` is taken directly from the DB `dir_name` column.
+derived from the DB `catalog_id` and `version` columns.
 
 #### Podman — named volume `catalog-bundles`
 
@@ -866,9 +859,9 @@ spec:
 
 ---
 
-### 6.7 Upload flow diagrams
+### 6.7 Create Bundle flow diagrams
 
-#### Podman — upload flow
+#### Podman — Create Bundle flow
 
 ```mermaid
 flowchart TD
@@ -880,7 +873,7 @@ flowchart TD
 
     subgraph CAT_POD["ai-services--catalog pod"]
         BE["backend container :8080"]
-        HANDLER["BundleHandler.UploadBundle()"]
+        HANDLER["BundleHandler.CreateBundle()"]
         PIPELINE["Dispatch → Validate → Swap"]
         CP["CatalogProvider.Reload()"]
     end
@@ -900,7 +893,7 @@ flowchart TD
     CP -- "reads templates from" --> BUNDLES
 ```
 
-#### OpenShift — upload flow
+#### OpenShift — Create Bundle flow
 
 ```mermaid
 flowchart TD
@@ -913,7 +906,7 @@ flowchart TD
             SVC["catalog-backend Service :8080"]
             DEP["catalog-backend Deployment"]
             BE["backend container"]
-            HANDLER["BundleHandler.UploadBundle()"]
+            HANDLER["BundleHandler.CreateBundle()"]
             PIPELINE["Dispatch → Validate → Swap"]
             CP["CatalogProvider.Reload()"]
             PVC["PVC: catalog-bundles<br/>dedicated, separate from catalog-db PVC<br/>mount: /data/catalog-bundles"]
@@ -939,7 +932,7 @@ The actual handler lives at [`apiserver/handlers/bundle_handler.go`](ai-services
 **`BundleHandler`** follows the same pattern as `ApplicationHandler` and `CatalogHandler`:
 
 ```go
-// BundleHandler handles catalog bundle upload, replacement, deletion, and listing.
+// BundleHandler handles catalog bundle creation, replacement, deletion, and listing.
 type BundleHandler struct {
     bundleService bundlesvc.BundleServiceInterface
 }
@@ -949,11 +942,11 @@ func NewBundleHandler(svc bundlesvc.BundleServiceInterface) *BundleHandler {
 }
 ```
 
-**`UploadBundle` (POST → 201)** — single form field: `file`. `catalog_id`, `catalog_type`,
+**`CreateBundle` (POST → 201)** — single form field: `file`. `catalog_id`, `catalog_type`,
 and `version` are read entirely from the archive's `metadata.yaml`:
 
 ```go
-func (h *BundleHandler) UploadBundle(c *gin.Context) {
+func (h *BundleHandler) CreateBundle(c *gin.Context) {
     c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBundleSizeBytes)
 
     file, header, err := c.Request.FormFile("file")
@@ -961,9 +954,9 @@ func (h *BundleHandler) UploadBundle(c *gin.Context) {
 
     userID := c.GetString(middleware.CtxUserIDKey)
 
-    // ProcessBundle: peek metadata → build BundleMetadata (ServiceMetadata or ComponentMetadata)
-    //                → conflict check (catalog_type + catalog_id) → extract to meta.DirName()
-    //                → validate → insert DB row as active → reload → return 201.
+    // ProcessBundle: peek minimal identity metadata → conflict check (catalog_type + catalog_id)
+    //                → validate directly from archive → extract to bundleDirPath()
+    //                → insert DB row as processing → reload → activate → return 201.
     resp, err := h.bundleService.ProcessBundle(c.Request.Context(), file, userID)
     // ... 409 / 422 / 500 handled by ValidationError.Code ...
     c.Header("Location", fmt.Sprintf("/api/v1/catalog/bundles/%s", resp.ID))
@@ -971,7 +964,7 @@ func (h *BundleHandler) UploadBundle(c *gin.Context) {
 }
 ```
 
-**`UpdateBundle` (PUT → 202)** — resolves existing record from `bundle_id` path param;
+**`UpdateBundle` (PUT → 200)** — resolves existing record from `bundle_id` path param;
 single form field: `file`. No `dry_run` — use `POST /catalog/bundles/validate` for that:
 
 ```go
@@ -983,13 +976,14 @@ func (h *BundleHandler) UpdateBundle(c *gin.Context) {
     file, header, err := c.Request.FormFile("file")
     // ... 400 if missing or not .tar.gz ...
 
-    // ReplaceBundle: peek metadata → validate meta.CatalogID()/meta.CatalogType() immutable →
-    //                return 202 immediately with existing ID →
-    //                goroutine: extract to meta.DirName(), UPDATE existing row in-place,
-    //                delete old dir if dir_name changed, reload. On failure DB row unchanged.
+    // ReplaceBundle: peek minimal identity metadata → validate meta.CatalogID()/meta.CatalogType() immutable →
+    //                validate directly from archive → mark existing row processing →
+    //                extract to staging dir, rename into final path, UPDATE existing row in-place,
+    //                reload, delete old dir when different, return 200 with updated bundle record.
+    //                On failure after the status transition, mark DB row failed.
     resp, err := h.bundleService.ReplaceBundle(c.Request.Context(), existing, file, userID)
     c.Header("Location", fmt.Sprintf("/api/v1/catalog/bundles/%s", resp.ID))
-    c.JSON(http.StatusAccepted, resp)
+    c.JSON(http.StatusOK, resp)
 }
 ```
 
@@ -998,24 +992,26 @@ func (h *BundleHandler) UpdateBundle(c *gin.Context) {
 ```go
 type BundleServiceInterface interface {
     // ValidateBundle — dedicated validate-only path (POST /catalog/bundles/validate).
-    // Reads id, type, version from metadata.yaml inside the archive,
-    // extracts to a temp directory, validates structure, then cleans up.
+    // Reads identity from metadata.yaml inside the archive and validates directly from the archive
+    // (structure, metadata, values/schema consistency, templates, labels, annotations,
+    // steps.md, and relevant file contents) without permanent extraction.
     // No DB row is written and no reload is triggered.
     // Returns a ServiceValidationResult or ComponentValidationResult (both implement ValidationResult).
     ValidateBundle(ctx context.Context, file io.Reader) (ValidationResult, error)
 
-    // ProcessBundle — synchronous POST upload.
-    // Reads metadata from archive, checks conflict, extracts to permanent dir,
-    // validates structure, inserts DB row then activates in one UPDATE, reloads catalog.
+    // ProcessBundle — synchronous POST bundle creation.
+    // Reads minimal identity metadata from archive, checks conflict, validates directly
+    // from archive, extracts to permanent dir, inserts DB row as processing,
+    // reloads catalog, then activates the row.
     // Returns *BundleResponse re-fetched from DB with status "active" (201).
     ProcessBundle(ctx context.Context, file io.Reader, userID string) (*BundleResponse, error)
 
-    // ReplaceBundle — async PUT update.
-    // Sync: validates archive and immutable fields, returns 202 immediately (same bundle ID).
-    // Async goroutine: extracts, validates, UPDATEs existing row in-place
-    //       (status=active, version, dir_name, name, size_bytes — single statement),
-    //       deletes old on-disk directory if dir_name changed, reloads catalog.
-    //       On failure: DB row left unchanged — existing bundle stays active.
+    // ReplaceBundle — synchronous PUT update.
+    // Validates directly from archive, marks existing row processing, extracts into a staging dir,
+    // renames staging into the final path, UPDATEs existing row in-place
+    // (status=active, version, name, size_bytes — single statement),
+    // reloads catalog, deletes old on-disk directory when different, and returns 200.
+    // On failure after the status transition: DB row is marked failed and error is returned.
     ReplaceBundle(ctx context.Context, existing *BundleRecord, file io.Reader, userID string) (*BundleResponse, error)
 
     GetByBundleID(ctx context.Context, bundleID string) (*BundleRecord, error)
@@ -1030,14 +1026,13 @@ type BundleServiceInterface interface {
 ```go
 // BundleRecord is the service-layer view of a DB row.
 type BundleRecord struct {
-    ID, Name, DirName, Status, CatalogType, CatalogID, Version, UploadedBy string
-    SizeBytes  *int64
-    UploadedAt time.Time
+    ID, Name, Status, CatalogType, CatalogID, Version, CreatedBy string
+    SizeBytes *int64
+    CreatedAt time.Time
 }
 
 // BundleMetadata is the interface returned by peekMetadata. Each concrete type
-// carries the scalar fields from its metadata.yaml and encodes all
-// type-specific derivations as methods — no type assertions needed in the pipeline.
+// carries the scalar fields from its metadata.yaml.
 //
 // Adding a new catalog type (e.g. "architecture") means:
 //   1. Define a new concrete struct implementing this interface.
@@ -1046,8 +1041,8 @@ type BundleRecord struct {
 //      is unchanged — it calls only these methods.
 type BundleMetadata interface {
     // CatalogID returns the globally unique value stored in the DB catalog_id column.
-    // Services:   bare id                         e.g. "my-service"
-    // Components: composite <component_type>:<id>  e.g. "llm:my-provider"
+    // Services:   bare id                              e.g. "my-service"
+    // Components: composite <component_type>--<id>     e.g. "llm--my-provider"
     //
     // This is what the DB unique index and conflict checks operate on.
     CatalogID() string
@@ -1057,15 +1052,6 @@ type BundleMetadata interface {
 
     // Version returns the semantic version string.
     Version() string
-
-    // DirName returns the server-determined on-disk directory name (DB dir_name column).
-    // Services:   <id>-<version>                       e.g. "my-service-1.0.0"
-    // Components: <component_type>-<id>-<version>       e.g. "llm-my-provider-1.0.0"
-    //
-    // This is what extractAndMeasure writes into — the archive top-level directory
-    // is stripped and discarded; DirName() is the authoritative destination.
-    // Always filesystem-safe (no "/" characters).
-    DirName() string
 
     // DisplayName returns the human-readable label from the metadata.yaml `name:` field.
     // e.g. "My Custom Service", "My Custom LLM Provider"
@@ -1080,21 +1066,20 @@ type ServiceMetadata struct {
     displayName string
 }
 
-func (m *ServiceMetadata) CatalogID() string    { return m.id }
-func (m *ServiceMetadata) CatalogType() string  { return "service" }
-func (m *ServiceMetadata) Version() string      { return m.version }
-func (m *ServiceMetadata) DirName() string      { return m.id + "-" + m.version }
-func (m *ServiceMetadata) DisplayName() string  { return m.displayName }
+func (m *ServiceMetadata) CatalogID() string   { return m.id }
+func (m *ServiceMetadata) CatalogType() string { return "service" }
+func (m *ServiceMetadata) Version() string     { return m.version }
+func (m *ServiceMetadata) DisplayName() string { return m.displayName }
 
 // ComponentMetadata is the BundleMetadata implementation for catalog_type="component".
 // ComponentType is required and must be one of the recognised component types
-// (llm, embedding, reranker, vector_store). The CatalogID is the composite
-// "<component_type>:<id>" and the on-disk DirName encodes both with a dash separator.
+// (llm, embedding, reranker, vector_store).
 //
-// The same id may exist under different component types — they produce different
-// CatalogID() values ("llm:my-provider" vs "embedding:my-provider") and are
+// CatalogID is the composite "<component_type>--<id>" value stored in the DB,
+// e.g. "llm--my-provider". The double-dash separator avoids filesystem conflicts.
+// The same bare id may exist under different component types — they produce different
+// CatalogID() values ("llm--my-provider" vs "embedding--my-provider") and are
 // stored as entirely independent DB rows and on-disk directories.
-// The same DisplayName() may also appear across types — it is not unique.
 type ComponentMetadata struct {
     id            string
     componentType string
@@ -1102,10 +1087,10 @@ type ComponentMetadata struct {
     displayName   string
 }
 
-func (m *ComponentMetadata) CatalogID() string   { return m.componentType + ":" + m.id }
+// CatalogID returns "<component_type>--<id>", e.g. "llm--my-provider".
+func (m *ComponentMetadata) CatalogID() string   { return m.componentType + "--" + m.id }
 func (m *ComponentMetadata) CatalogType() string { return "component" }
 func (m *ComponentMetadata) Version() string     { return m.version }
-func (m *ComponentMetadata) DirName() string     { return m.componentType + "-" + m.id + "-" + m.version }
 func (m *ComponentMetadata) DisplayName() string { return m.displayName }
 
 // ComponentType returns the component_type for this metadata.
@@ -1113,78 +1098,47 @@ func (m *ComponentMetadata) DisplayName() string { return m.displayName }
 func (m *ComponentMetadata) ComponentType() string { return m.componentType }
 ```
 
-`parseMetadataYAML` reads `id`, `type`, `name`, `version` (and `component_type` for components) as scalar fields. For `component`, `component_type` is required and rejected with `422` if absent or unrecognised. `ProcessBundle` and `ReplaceBundle` call only the `BundleMetadata` interface methods. `ValidateBundle` performs a single type-assertion `meta.(*ComponentMetadata)` to populate the `ComponentType` field on `ComponentValidationResult` — this is the only place where a type switch on the concrete metadata type occurs. `extractAndMeasure` takes no `catalogID` parameter — it strips the archive top-level directory blindly and writes into the caller-supplied `destDir` (`meta.DirName()`).
+`parseMetadataYAML` reads `id`, `type`, `name`, `version` (and `component_type` for components) as scalar fields. For `component`, `component_type` is required and rejected with `422` if absent or unrecognised. `ProcessBundle` and `ReplaceBundle` call only the `BundleMetadata` interface methods. `ValidateBundle` performs a single type-assertion `meta.(*ComponentMetadata)` to populate the `ComponentType` field on `ComponentValidationResult` — this is the only place where a type switch on the concrete metadata type occurs. `extractAndMeasure` strips the archive top-level directory blindly and writes into the caller-supplied `destDir` (`bundleDirPath(meta.CatalogType(), meta.CatalogID(), meta.Version())`).
 
 ```go
 // ValidationResult is the interface returned by ValidateBundle and serialised as the
 // 200 OK body for POST /catalog/bundles/validate.
 // Concrete types: ServiceValidationResult, ComponentValidationResult.
-//
-// Adding a new catalog type means:
-//   1. Define a new concrete struct implementing this interface.
-//   2. Add a case in parseMetadataYAML / ValidateBundle to construct it.
-//   3. MarshalJSON on the handler side serialises whichever concrete type is returned.
 type ValidationResult interface {
-    // IsValid reports whether the archive passed validation.
     IsValid() bool
-
-    // GetCatalogType returns "service" or "component".
     GetCatalogType() string
-
-    // GetCatalogID returns the same value as BundleMetadata.CatalogID():
-    // bare id for services, composite "<component_type>:<id>" for components.
+    // GetCatalogID returns bare id for services, "<component_type>--<id>" for components.
     GetCatalogID() string
-
-    // GetVersion returns the semantic version string from metadata.yaml.
     GetVersion() string
-
-    // GetDisplayName returns the human-readable label from metadata.yaml `name:`.
     GetDisplayName() string
-
-    // GetDirName returns the server-determined on-disk directory name.
-    // Services:   <id>-<version>                  e.g. "my-service-1.0.0"
-    // Components: <component_type>-<id>-<version>  e.g. "llm-my-provider-1.0.0"
-    GetDirName() string
 }
 
-// ServiceValidationResult is the ValidationResult implementation for catalog_type="service".
-// JSON shape:
+// ServiceValidationResult — JSON shape:
 //
 //	{
 //	  "valid":        true,
 //	  "catalog_type": "service",
 //	  "catalog_id":   "my-service",
 //	  "version":      "1.0.0",
-//	  "name":         "My Custom Service",
-//	  "dir_name":     "my-service-1.0.0"
+//	  "name":         "My Custom Service"
 //	}
 type ServiceValidationResult struct {
     Valid       bool   `json:"valid"`
     CatalogType string `json:"catalog_type"`
     CatalogID   string `json:"catalog_id"`
     Version     string `json:"version"`
-    Name        string `json:"name,omitempty"`  // display label; omitted if blank
-    DirName     string `json:"dir_name"`
+    Name        string `json:"name,omitempty"`
 }
 
-func (r *ServiceValidationResult) IsValid() bool          { return r.Valid }
-func (r *ServiceValidationResult) GetCatalogType() string { return r.CatalogType }
-func (r *ServiceValidationResult) GetCatalogID() string   { return r.CatalogID }
-func (r *ServiceValidationResult) GetVersion() string     { return r.Version }
-func (r *ServiceValidationResult) GetDisplayName() string { return r.Name }
-func (r *ServiceValidationResult) GetDirName() string     { return r.DirName }
-
-// ComponentValidationResult is the ValidationResult implementation for catalog_type="component".
-// JSON shape:
+// ComponentValidationResult — JSON shape:
 //
 //	{
 //	  "valid":          true,
 //	  "catalog_type":   "component",
 //	  "component_type": "llm",
-//	  "catalog_id":     "llm:my-provider",
+//	  "catalog_id":     "llm--my-provider",
 //	  "version":        "1.0.0",
-//	  "name":           "My Custom LLM Provider",
-//	  "dir_name":       "llm-my-provider-1.0.0"
+//	  "name":           "My Custom LLM Provider"
 //	}
 type ComponentValidationResult struct {
     Valid         bool   `json:"valid"`
@@ -1192,20 +1146,8 @@ type ComponentValidationResult struct {
     ComponentType string `json:"component_type"`
     CatalogID     string `json:"catalog_id"`
     Version       string `json:"version"`
-    Name          string `json:"name,omitempty"`  // display label; omitted if blank
-    DirName       string `json:"dir_name"`
+    Name          string `json:"name,omitempty"`
 }
-
-func (r *ComponentValidationResult) IsValid() bool          { return r.Valid }
-func (r *ComponentValidationResult) GetCatalogType() string { return r.CatalogType }
-func (r *ComponentValidationResult) GetCatalogID() string   { return r.CatalogID }
-func (r *ComponentValidationResult) GetVersion() string     { return r.Version }
-func (r *ComponentValidationResult) GetDisplayName() string { return r.Name }
-func (r *ComponentValidationResult) GetDirName() string     { return r.DirName }
-
-// ComponentType returns the component_type for this result.
-// Defined on the concrete type; callers that need it type-assert to *ComponentValidationResult.
-func (r *ComponentValidationResult) ComponentType() string { return r.ComponentType }
 
 // ValidationError carries an HTTP status code alongside its message.
 type ValidationError struct {
@@ -1218,21 +1160,21 @@ type ValidationError struct {
 
 #### Why the strategy collapses into the metadata type
 
-The `bundleTypeStrategy` interface described earlier (with `CatalogID`, `Name`, `ArchiveID` methods) and `BundleMetadata` are solving the same problem from two angles. With Option 3 they merge: the concrete metadata type **is** its own strategy. The pipeline calls `meta.CatalogID()`, `meta.DirName()`, `meta.DisplayName()`, `meta.CatalogType()` directly — no separate strategy object, no factory function, no second dispatch. Adding a new catalog type is a single step: implement the interface on a new struct and add one `case` in `parseMetadataYAML`.
+The `bundleTypeStrategy` interface and `BundleMetadata` are solving the same problem from two angles. With Option 3 they merge: the concrete metadata type **is** its own strategy. The pipeline calls `meta.CatalogID()`, `meta.DisplayName()`, `meta.CatalogType()`, `meta.Version()` directly — no separate strategy object, no factory function, no second dispatch. Adding a new catalog type is a single step: implement the interface on a new struct and add one `case` in `parseMetadataYAML`.
 
-Note: `ID()` (bare `id` field) is intentionally **not** in the `BundleMetadata` interface. Since the archive top-level directory name is no longer validated against `id`, there is no pipeline step that needs the bare `id` separately from `CatalogID()`. For services `CatalogID() == id` anyway. The `id` field is used internally by each concrete type to construct `CatalogID()` and `DirName()` but is not exposed.
+Note: `ID()` (bare `id` field) is intentionally **not** in the `BundleMetadata` interface. The archive top-level directory name is never validated against `id`; no pipeline step needs the bare `id` separately from `CatalogID()`. For services `CatalogID() == id` anyway. The `id` field is used internally by each concrete type to construct `CatalogID()` but is not exposed.
 
 #### `ApplicationClient` bundle methods (client/bundle.go)
 
 The CLI commands talk to the server through `ApplicationClient` in [`internal/pkg/catalog/client/bundle.go`](ai-services/internal/pkg/catalog/client/bundle.go). Beyond the existing `ListBundles` and `GetBundle`, the following methods are added:
 
 ```go
-// UploadBundle POSTs a .tar.gz archive as multipart/form-data.
+// CreateBundle POSTs a .tar.gz archive as multipart/form-data.
 // Returns the 201 BundleResponse (status always "active" on success).
-func (c *ApplicationClient) UploadBundle(filePath string) (*bundlesvc.BundleResponse, error)
+func (c *ApplicationClient) CreateBundle(filePath string) (*bundlesvc.BundleResponse, error)
 
 // UpdateBundle PUTs a replacement archive for the bundle identified by bundleID.
-// Returns the 202 BundleResponse immediately — poll with PollBundleActive.
+// Returns the 200 BundleResponse with status "active" (fully synchronous).
 func (c *ApplicationClient) UpdateBundle(bundleID, filePath string) (*bundlesvc.BundleResponse, error)
 
 // DeleteBundle sends DELETE /api/v1/catalog/bundles/:bundleID.
@@ -1242,10 +1184,6 @@ func (c *ApplicationClient) DeleteBundle(bundleID string) error
 // Returns a ServiceValidationResult or ComponentValidationResult (both implement
 // ValidationResult) on success, or a *ValidationError on 422.
 func (c *ApplicationClient) ValidateBundle(filePath string) (bundlesvc.ValidationResult, error)
-
-// PollBundleActive polls GET /api/v1/catalog/bundles/:bundleID until status == "active"
-// or the context is cancelled. Used after a 202 Accepted PUT response.
-func (c *ApplicationClient) PollBundleActive(ctx context.Context, bundleID string, interval time.Duration) (*bundlesvc.BundleResponse, error)
 ```
 
 ---
@@ -1268,9 +1206,9 @@ ai-services catalog bundle
 
 The `bundle` parent command requires an authenticated session (`ai-services catalog login` must have been run first). All subcommands call `client.New()` to load stored credentials — no `--server` or `--username` flags are needed.
 
-#### `bundle upload` — upload a new bundle
+#### `bundle upload` — create a new bundle
 
-Uploads a `.tar.gz` archive and blocks until the server returns `201 Created` (the POST endpoint is synchronous). `catalog_id`, `catalog_type`, and `version` are all read from `metadata.yaml` inside the archive — no additional flags needed.
+Creates a bundle from a `.tar.gz` archive and blocks until the server returns `201 Created` (the POST endpoint is synchronous). `catalog_id`, `catalog_type`, and `version` are all read from `metadata.yaml` inside the archive — no additional flags needed.
 
 ```
 ai-services catalog bundle upload --file <path-to-bundle.tar.gz>
@@ -1280,12 +1218,12 @@ ai-services catalog bundle upload --file <path-to-bundle.tar.gz>
 
 | Flag | Required | Description |
 |---|---|---|
-| `--file` | yes | Path to the `.tar.gz` archive to upload |
+| `--file` | yes | Path to the `.tar.gz` archive to create from |
 
 **Example output (service bundle):**
 ```
-Uploading bundle from my-bundle.tar.gz...
-✓ Bundle uploaded successfully
+Creating bundle from my-bundle.tar.gz...
+✓ Bundle created successfully
   ID:           550e8400-e29b-41d4-a716-446655440000
   Catalog type: service
   Catalog ID:   my-service
@@ -1297,13 +1235,12 @@ Uploading bundle from my-bundle.tar.gz...
 
 **Example output (component bundle — `component_type: llm`):**
 ```
-Uploading bundle from my-provider-bundle.tar.gz...
-✓ Bundle uploaded successfully
+Creating bundle from my-provider-bundle.tar.gz...
+✓ Bundle created successfully
   ID:             c3d4e5f6-...
   Catalog type:   component
   Component type: llm
-  Catalog ID:     llm:my-provider
-  Dir name:       llm-my-provider-1.0.0
+  Catalog ID:     llm--my-provider
   Version:        1.0.0
   Status:         active
   Size:           192 KB
@@ -1319,7 +1256,7 @@ Uploading bundle from my-provider-bundle.tar.gz...
 
 #### `bundle update` — replace an existing bundle
 
-Sends a `PUT` request (async `202 Accepted`) and polls until the bundle is `active`. The positional `<bundle_id>` is the internal UUID from `bundle list` or `bundle upload` output.
+Sends a synchronous `PUT` request (`200 OK`) that extracts, validates, activates, and reloads the catalog all in one go — no polling needed. The positional `<bundle_id>` is the internal UUID from `bundle list` or `bundle upload` output.
 
 ```
 ai-services catalog bundle update <bundle_id> --file <path-to-bundle.tar.gz>
@@ -1336,15 +1273,12 @@ ai-services catalog bundle update <bundle_id> --file <path-to-bundle.tar.gz>
 | Flag | Required | Description |
 |---|---|---|
 | `--file` | yes | Path to the replacement `.tar.gz` archive |
-| `--no-wait` | no | Return immediately after `202 Accepted` without polling |
-| `--timeout` | no | Maximum time to wait for `active` status (default: `5m`) |
 
 **Example output:**
 ```
 Updating bundle 550e8400-e29b-41d4-a716-446655440000 from my-bundle-v2.tar.gz...
   Catalog type: service  |  Catalog ID: my-service  |  Version: 2.0.0
   Dir name:     my-service-2.0.0
-Waiting for bundle to become active...
 ✓ Bundle updated successfully (status: active)
 ```
 
@@ -1353,8 +1287,7 @@ Waiting for bundle to become active...
 | Exit | Condition |
 |---|---|
 | `1` | `404 Not Found` — no bundle with that ID; use `bundle upload` to create one |
-| `1` | `422` — `catalog_id` or `catalog_type` in the archive doesn't match the existing record |
-| `1` | Timeout reached while polling (bundle stays in last known state) |
+| `1` | `422` — `catalog_id` or `catalog_type` in the archive doesn't match the existing record, or validation failed |
 
 #### `bundle delete` — delete a bundle
 
@@ -1384,7 +1317,7 @@ Delete bundle 550e8400-e29b-41d4-a716-446655440000 (my-service-1.0.0)? [y/N] y
 
 #### `bundle list` — list all bundles
 
-Prints a table of all registered bundles ordered by upload time (most recent first).
+Prints a table of all registered bundles ordered by creation time (most recent first).
 
 ```
 ai-services catalog bundle list
@@ -1392,12 +1325,12 @@ ai-services catalog bundle list
 
 **Example output:**
 ```
-ID                                     CATALOG TYPE  CATALOG ID       DIR NAME               VERSION  STATUS  UPLOADED AT
-550e8400-e29b-41d4-a716-446655440000   service       my-service       my-service-1.0.0       1.0.0    active  2026-05-12 09:14:02
-a1b2c3d4-e5f6-7890-abcd-ef1234567890   component     llm:my-provider  llm-my-provider-1.0.0  1.0.0    active  2026-05-13 11:30:00
+ID                                     CATALOG TYPE  CATALOG ID        VERSION  STATUS  CREATED AT
+550e8400-e29b-41d4-a716-446655440000   service       my-service        1.0.0    active  2026-05-12 09:14:02
+a1b2c3d4-e5f6-7890-abcd-ef1234567890   component     llm--my-provider  1.0.0    active  2026-05-13 11:30:00
 ```
 
-Note the `DIR NAME` column uses the `<component_type>-<catalog_id>-<version>` form for components, matching the on-disk path under `/data/catalog-bundles/component/`.
+The on-disk path is derived at runtime as `<catalog_id>-<version>` (e.g. `/data/catalog-bundles/component/llm--my-provider-1.0.0/`) — it is not stored in the DB or shown in this output.
 
 #### `bundle get` — get a single bundle
 
@@ -1417,11 +1350,11 @@ Catalog ID:   my-service
 Version:      1.0.0
 Status:       active
 Size:         280 KB
-Uploaded by:  admin
-Uploaded at:  2026-05-12 09:14:02
+Created by:   admin
+Created at:   2026-05-12 09:14:02
 ```
 
-#### `bundle validate` — validate a bundle without uploading
+#### `bundle validate` — validate a bundle without creating it
 
 Calls `POST /api/v1/catalog/bundles/validate`. No DB row is written and `CatalogProvider` is not reloaded. Use before `bundle upload` to verify the archive in CI/CD pipelines.
 
@@ -1452,8 +1385,7 @@ Validating bundle from my-provider-bundle.tar.gz...
 ✓ Bundle is valid
   Catalog type:   component
   Component type: llm
-  Catalog ID:     llm:my-provider
-  Dir name:       llm-my-provider-1.0.0
+  Catalog ID:     llm--my-provider
   Version:        1.0.0
   Name:           My Custom LLM Provider
 ```
@@ -1523,17 +1455,17 @@ resources:
 
 ### 7.4 Built-in IDs are reserved
 
-A bundle whose `catalog_id` (read from `metadata.yaml`) matches a built-in catalog item is rejected with a `422` error. For services, `catalog_id` is the bare `id`; for components it is the composite `<component_type>:<id>`. Custom bundles must use a unique `catalog_id` that does not conflict with any embedded item.
+A bundle whose `catalog_id` (read from `metadata.yaml`) matches a built-in catalog item is rejected with a `422` error. For services, `catalog_id` is the bare `id`; for components it is the composite `<component_type>--<id>`. Custom bundles must use a unique `catalog_id` that does not conflict with any embedded item.
 
 **Built-in service IDs reserved at this time:** `chat`, `digitize`, `similarity`, `summarize`, `rag`
 
-**Built-in component IDs reserved at this time** (by composite `<component_type>:<id>`):`llm:vllm-cpu`, `llm:vllm-spyre`, `llm:watsonx`, `embedding:vllm-cpu`, `reranker:vllm-cpu`, `reranker:vllm-spyre`, `vector_db:opensearch`
+**Built-in component IDs reserved at this time** (by composite `<component_type>--<id>`): `llm--vllm-cpu`, `llm--vllm-spyre`, `llm--watsonx`, `embedding--vllm-cpu`, `reranker--vllm-cpu`, `reranker--vllm-spyre`, `vector_db--opensearch`
 
 ---
 
 ## 8. Remote Deployment
 
-The control-plane catalog server acts as the authoritative bundle registry. Custom service assets are uploaded once to the control plane and stored there. Remote agents do not need to read assets directly — the control-plane catalog backend orchestrates all template resolution and service rendering on their behalf. No `.tar.gz` retention is required; only the extracted asset files are kept on the control-plane volume.
+The control-plane catalog server acts as the authoritative bundle registry. Custom service assets are created once on the control plane and stored there. Remote agents do not need to read assets directly — the control-plane catalog backend orchestrates all template resolution and service rendering on their behalf. No `.tar.gz` retention is required; only the extracted asset files are kept on the control-plane volume.
 
 ---
 
@@ -2012,7 +1944,7 @@ Custom component templates may adopt the same pattern for any key name. The `.en
 
 ## 10. Usage Examples
 
-### 10.1 Upload a custom service bundle
+### 10.1 Create a custom service bundle
 
 **Using the CLI (recommended):**
 
@@ -2023,9 +1955,9 @@ ai-services catalog login --server https://catalog-api.<domain> --username admin
 # Package the service directory (top-level dir name is irrelevant)
 COPYFILE_DISABLE=1 tar -czf my-bundle.tar.gz my-service/
 
-# Upload — synchronous; prints status once the bundle is active
+# Create Bundle — synchronous; prints status once the bundle is active
 ai-services catalog bundle upload --file my-bundle.tar.gz
-# ✓ Bundle uploaded successfully
+# ✓ Bundle created successfully
 #   ID:           550e8400-e29b-41d4-a716-446655440000
 #   Catalog type: service
 #   Catalog ID:   my-service
@@ -2051,27 +1983,23 @@ curl -X POST https://catalog-api.<domain>/api/v1/auth/login \
 COPYFILE_DISABLE=1 tar -czf my-bundle.tar.gz my-service/   # macOS
 # tar -czf my-bundle.tar.gz my-service/                     # Linux / WSL
 
-# Upload (synchronous; returns 201 when active)
+# Create Bundle (synchronous; returns 201 when active)
 curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
   -H "Authorization: Bearer $(cat token.txt)" \
   -F "file=@my-bundle.tar.gz"
-# 201 Created — {"id":"550e8400-...","status":"active","catalog_id":"my-service","dir_name":"my-service-1.0.0",...}
+# 201 Created — {"id":"550e8400-...","status":"active","catalog_id":"my-service","version":"1.0.0",...}
 
-# Update (async; poll until active)
+# Update (synchronous)
 COPYFILE_DISABLE=1 tar -czf my-bundle-v2.tar.gz my-service/
 curl -X PUT https://catalog-api.<domain>/api/v1/catalog/bundles/550e8400-e29b-41d4-a716-446655440000 \
   -H "Authorization: Bearer $(cat token.txt)" \
   -F "file=@my-bundle-v2.tar.gz"
-# 202 Accepted
-
-curl -s https://catalog-api.<domain>/api/v1/catalog/bundles/550e8400-e29b-41d4-a716-446655440000 \
-  -H "Authorization: Bearer $(cat token.txt)" | jq .status
-# "active"
+# 200 OK — {"id":"550e8400-...","status":"active","catalog_id":"my-service","version":"2.0.0",...}
 ```
 
-### 10.2 Upload a custom component bundle
+### 10.2 Create a custom component bundle
 
-Component bundles follow the same upload API. The `component_type` field in `metadata.yaml` is required — `parseMetadataYAML` constructs a `*ComponentMetadata` which encodes `catalog_id` as `llm:my-provider` and `dir_name` as `llm-my-provider-1.0.0`. Two providers with the same bare `id` but different `component_type` values are entirely independent bundles and can coexist.
+Component bundles follow the same Create Bundle API. The `component_type` field in `metadata.yaml` is required — `parseMetadataYAML` constructs a `*ComponentMetadata` which encodes `catalog_id` as `llm--my-provider`. The on-disk directory is derived at runtime as `<catalog_id>-<version>` (e.g. `llm--my-provider-1.0.0`). Two providers with the same bare `id` but different `component_type` values are entirely independent bundles and can coexist.
 
 **Using the CLI (recommended):**
 
@@ -2080,23 +2008,21 @@ Component bundles follow the same upload API. The `component_type` field in `met
 # metadata.yaml must declare: type: component, component_type: llm
 COPYFILE_DISABLE=1 tar -czf my-provider-bundle.tar.gz my-provider/
 
-# Upload — on success, dir_name uses the <component_type>-<id>-<version> scheme
+# Create Bundle — on success, catalog_id is "llm--my-provider", dir is llm--my-provider-1.0.0
 ai-services catalog bundle upload --file my-provider-bundle.tar.gz
-# ✓ Bundle uploaded successfully
+# ✓ Bundle created successfully
 #   ID:             c3d4e5f6-...
 #   Catalog type:   component
 #   Component type: llm
-#   Catalog ID:     llm:my-provider
-#   Dir name:       llm-my-provider-1.0.0
+#   Catalog ID:     llm--my-provider
 #   Version:        1.0.0
 
-# Upload the same id under a different component_type — independent bundle
+# Create the same id under a different component_type — independent bundle
 # metadata.yaml must declare: type: component, component_type: embedding
 COPYFILE_DISABLE=1 tar -czf my-provider-embedding-bundle.tar.gz my-provider/
 ai-services catalog bundle upload --file my-provider-embedding-bundle.tar.gz
-# ✓ Bundle uploaded successfully
-#   Catalog ID:     embedding:my-provider
-#   Dir name:       embedding-my-provider-1.0.0   ← entirely separate from the llm bundle
+# ✓ Bundle created successfully
+#   Catalog ID:     embedding--my-provider   ← entirely separate from the llm bundle
 ```
 
 **Using curl (API directly):**
@@ -2105,7 +2031,7 @@ ai-services catalog bundle upload --file my-provider-embedding-bundle.tar.gz
 # Package. metadata.yaml must declare: type: component, component_type: llm
 COPYFILE_DISABLE=1 tar -czf my-provider-bundle.tar.gz my-provider/
 
-# Upload — POST is synchronous; catalog_id in the response is the composite "llm:my-provider"
+# Create Bundle — POST is synchronous; catalog_id in the response is the composite "llm--my-provider"
 curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
   -H "Authorization: Bearer $(cat token.txt)" \
   -F "file=@my-provider-bundle.tar.gz"
@@ -2113,35 +2039,34 @@ curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
 # {
 #   "id":             "c3d4e5f6-...",
 #   "name":           "My Custom LLM Provider",
-#   "dir_name":       "llm-my-provider-1.0.0",
 #   "status":         "active",
 #   "catalog_type":   "component",
-#   "catalog_id":     "llm:my-provider",
+#   "catalog_id":     "llm--my-provider",
 #   "version":        "1.0.0",
-#   "uploaded_by":    "admin"
+#   "created_by":     "admin"
 # }
 
-# Second upload — same bare id, different component_type → independent bundle
+# Second create — same bare id, different component_type → independent bundle
 COPYFILE_DISABLE=1 tar -czf my-provider-embedding-bundle.tar.gz my-provider/
 curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
   -H "Authorization: Bearer $(cat token.txt)" \
   -F "file=@my-provider-embedding-bundle.tar.gz"
-# 201 Created — catalog_id: "embedding:my-provider", dir_name: "embedding-my-provider-1.0.0"
+# 201 Created — catalog_id: "embedding--my-provider"
 ```
 
-### 10.3 Uploading with a built-in ID (caution)
+### 10.3 Creating with a built-in ID (caution)
 
-Uploading a bundle whose `catalog_id` matches a built-in service is not currently rejected at the API level. When `CatalogProvider.Reload()` runs after upload, the bundle entry will overwrite the embedded entry in the items map (last write wins). Custom bundles should deliberately avoid `catalog_id` values that match built-in items.
+Creating a bundle whose `catalog_id` matches a built-in service is not currently rejected at the API level. When `CatalogProvider.Reload()` runs after creation, the bundle entry will overwrite the embedded entry in the items map (last write wins). Custom bundles should deliberately avoid `catalog_id` values that match built-in items.
 
 ```bash
-# Check which IDs are currently loaded in the catalog before uploading
+# Check which IDs are currently loaded in the catalog before creating a bundle
 curl -s https://catalog-api.<domain>/api/v1/services \
   -H "Authorization: Bearer $(cat token.txt)" | jq '.[].id'
 # "chat"
 # "digitize"
 # "similarity"
 # "summarize"
-# "my-service"   ← custom, safe to re-upload
+# "my-service"   ← custom, safe to create again only via PUT update if it already exists
 ```
 
 > A reserved-ID check (returning `422 Conflict` before extraction) is listed as a future enhancement.
@@ -2178,7 +2103,7 @@ curl -X POST https://catalog-api.<domain>/api/v1/applications/ \
 
 ### 10.5 List custom services via the catalog API
 
-After uploading a bundle, custom services appear alongside built-in ones. The `GET /api/v1/services` endpoint returns an array of `ServiceSummary` objects (not a wrapped object), so the `jq` filter uses `.[].id`:
+After creating a bundle, custom services appear alongside built-in ones. The `GET /api/v1/services` endpoint returns an array of `ServiceSummary` objects (not a wrapped object), so the `jq` filter uses `.[].id`:
 
 ```bash
 curl -s https://catalog-api.<domain>/api/v1/services \
@@ -2191,9 +2116,9 @@ curl -s https://catalog-api.<domain>/api/v1/services \
 # "my-service"   ← custom
 ```
 
-### 10.6 Validate a bundle before uploading
+### 10.6 Validate a bundle before creating it
 
-`POST /api/v1/catalog/bundles/validate` is a dedicated validate-only endpoint — the server extracts the archive to a temporary directory, validates structure, cleans up, and replies inline. No DB record is written and `CatalogProvider` is not reloaded.
+`POST /api/v1/catalog/bundles/validate` is a dedicated validate-only endpoint — the server validates the archive structure and replies inline. No DB record is written and `CatalogProvider` is not reloaded.
 
 ```bash
 # --- Validate a service bundle (returns ServiceValidationResult) ---
@@ -2206,8 +2131,7 @@ curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles/validate \
 #   "catalog_type": "service",
 #   "catalog_id":   "my-service",
 #   "version":      "1.0.0",
-#   "name":         "My Custom Service",
-#   "dir_name":     "my-service-1.0.0"
+#   "name":         "My Custom Service"
 # }
 
 # --- Validate a component bundle (returns ComponentValidationResult) ---
@@ -2219,10 +2143,9 @@ curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles/validate \
 #   "valid":          true,
 #   "catalog_type":   "component",
 #   "component_type": "llm",
-#   "catalog_id":     "llm:my-provider",
+#   "catalog_id":     "llm--my-provider",
 #   "version":        "1.0.0",
-#   "name":           "My Custom LLM Provider",
-#   "dir_name":       "llm-my-provider-1.0.0"
+#   "name":           "My Custom LLM Provider"
 # }
 
 # --- Validation failure example ---
@@ -2237,9 +2160,9 @@ curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles/validate \
 ## 11. Future Enhancements
 
 1. **Reserved-ID guard** — reject a `POST` (with `422`) whose `catalog_id` conflicts with a built-in embedded item. Currently the bundle is accepted and overwrites the embedded entry in the items map on reload. The check should run after `peekMetadata` and before extraction.
-2. **Scaffolding generator** — `ai-services catalog scaffold --service my-service --runtime podman` emits a minimal but correct directory skeleton ready to be tar'd and uploaded.
-3. **Remote catalog repositories** — fetch a bundle from an OCI registry or HTTPS URL; the server pulls and applies it directly, removing the need for a client upload.
+2. **Scaffolding generator** — `ai-services catalog scaffold --service my-service --runtime podman` emits a minimal but correct directory skeleton ready to be tar'd and created.
+3. **Remote catalog repositories** — fetch a bundle from an OCI registry or HTTPS URL; the server pulls and applies it directly, removing the need for a client create-bundle request.
 4. **Schema enforcement on custom `metadata.yaml`** — reuse the existing [`validators.ApplicationValidator`](ai-services/internal/pkg/catalog/validators/validation.go) to reject malformed custom metadata at validation time.
 5. **Version compatibility checks** — validate that a custom service's `version` satisfies any `>=x.y.z` constraint declared by the built-in architecture that references it.
-6. **Role-based upload access** — introduce a `catalog-editor` JWT role that can upload bundles but cannot perform `DELETE /applications` or other destructive operations.
+6. **Role-based create-bundle access** — introduce a `catalog-editor` JWT role that can create bundles but cannot perform `DELETE /applications` or other destructive operations.
 7. **New `BundleMetadata` implementations** — adding support for a new catalog type (e.g. `architecture`) requires only: (a) a new struct implementing the `BundleMetadata` interface, and (b) a new `case` in `parseMetadataYAML`. The entire processing pipeline (`ProcessBundle`, `ReplaceBundle`, `ValidateBundle`) is unchanged.

--- a/docs/proposals/catalog/custom-service-templates-proposal.md
+++ b/docs/proposals/catalog/custom-service-templates-proposal.md
@@ -1081,15 +1081,27 @@ curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
 5. **Version compatibility checks** — validate that a custom service's `version` satisfies any `>=x.y.z` constraint declared by the built-in architecture that references it.
 6. **Role-based upload access** — introduce a `catalog-editor` JWT role that can upload bundles but cannot perform `DELETE /applications` or other destructive operations.
 7. **Component support in bundles** — when `components/` is promoted from reserved to active in the bundle processor, users can ship custom component providers (e.g. a private LLM backend) alongside their services in the same archive.
-8. **Multi-VM deployment and object storage backing** — the current design stores bundles on a Podman named volume or OpenShift PVC that is **local to a single host**. This works well for single-VM Podman deployments and single-replica OpenShift pods. When the catalog needs to run across multiple VMs (e.g. a fleet of Podman hosts that all share the same catalog API), each VM has its own isolated named volume — a bundle uploaded to one host is invisible to the others.
+8. **Multi-VM deployment — Approach A: control-plane catalog server with existing worker agents** *(Recommended)* — a **hub-and-spoke** topology in which a single control-plane catalog server acts as the authoritative bundle registry. A worker agent is already present on each VM as part of the existing platform deployment. This agent can be extended to fetch bundles from the control plane on demand — specifically at the point when an Application creation is requested — with no shared storage infrastructure, no object store dependency, and no background synchronisation required.
 
-   **Why this is straightforward to add later:**
+   **How it works:**
 
-   The design deliberately isolates all bundle I/O behind two thin interfaces:
+   - A customer uploads a bundle once to the **control-plane catalog server** using the same `POST /api/v1/catalog/bundles` API defined in this proposal.
+   - When a request to **create an Application** arrives at a VM, the existing worker agent checks whether the required bundle is already present in its local bundle volume.
+   - If the bundle is not present locally, the agent queries the control-plane catalog server for the bundle, fetches the `.tar.gz` archive over HTTPS, extracts it to its local volume, and triggers `CatalogProvider.Reload()` — the same hot-reload path already defined in this proposal.
+   - The Application creation then proceeds using the locally loaded service template. There is no background polling or push notification — bundles are fetched **lazily, only when needed**.
+   - The local catalog process on each VM uses the extracted files via `FilesystemCatalogFS` — no new loading mechanism is needed on the VM side.
 
-   - **Read path** — `CatalogFS` interface (`§5.2`). `FilesystemCatalogFS` today calls `os.Open`. An `ObjectStoreCatalogFS` backed by S3, MinIO, or IBM COS would implement the same three methods (`Open`, `ReadFile`, `ReadDir`) against an object-store prefix instead of a local path. `CatalogProvider`, `loadCatalogItems`, and every existing handler are completely unaware of the change.
-   - **Write path** — `BundleService.ProcessBundle`. Today it extracts the archive to `/data/catalog-bundles/<type>/<name>/`. Swapping the write target to an object store bucket (with keys like `<type>/<name>/<file>`) is a single-function change. The DB row already stores `catalog_type`, `catalog_id`, `name`, and `version`; adding an `object_key` column (or deriving the key from `name`) requires only a minor migration.
+   **Storage implication for the current design:**
 
-   The only meaningful **design decision** deferred to that milestone is the local cache strategy: object-store reads have latency, so `CatalogProvider` would likely download bundle files to a local staging directory at startup and after each hot-reload, then serve from the local cache — preserving the zero-latency template rendering that `FilesystemCatalogFS` provides today.
+   Today, `BundleService.ProcessBundle` discards the original `.tar.gz` after extraction — only the extracted files are kept on the volume. For Approach A to work, the control-plane server must be able to serve the original archive to agents that request it. This means the **raw `.tar.gz` must also be retained** on the control-plane volume alongside the extracted directory. A `raw_archive` sub-path (e.g. `/data/catalog-bundles/raw/<name>.tar.gz`) or a dedicated `raw_path` column in `catalog_bundles` pointing to the stored archive would be sufficient. This is a minor additive change to `BundleService` that does not affect current single-VM behaviour.
 
-   For **OpenShift multi-replica** deployments the same object-store backing solves the shared-storage problem without requiring `ReadWriteMany` PVCs, which are not universally available across storage classes.
+9. **Multi-VM deployment — Approach B: object storage backing** — an alternative for environments that already operate object storage infrastructure. Rather than routing bundle fetches through the control plane, a shared object store (S3, MinIO, or IBM COS) acts as the distribution layer. All VMs read bundles directly from the bucket; no agent involvement is required for bundle delivery.
+
+   The design deliberately isolates all bundle I/O behind two thin interfaces, making this straightforward to introduce later:
+
+   - **Read path** — `CatalogFS` interface (`§5.2`). `FilesystemCatalogFS` today calls `os.Open`. An `ObjectStoreCatalogFS` would implement the same three methods (`Open`, `ReadFile`, `ReadDir`) against an object-store prefix. `CatalogProvider`, `loadCatalogItems`, and every existing handler are completely unaware of the change.
+   - **Write path** — `BundleService.ProcessBundle`. Swapping the write target to an object store bucket is a single-function change. The DB row already stores `catalog_type`, `catalog_id`, `name`, and `version`; adding an `object_key` column requires only a minor migration.
+
+   Object-store reads have latency, so `CatalogProvider` would cache bundle files to a local staging directory at startup and after each hot-reload, then serve from that cache — preserving the zero-latency template rendering that `FilesystemCatalogFS` provides today. For **OpenShift multi-replica** deployments this approach also eliminates the need for `ReadWriteMany` PVCs.
+
+   **Relationship to Approach A:** the two approaches are not mutually exclusive. A future architecture could use the control plane as the upload target and object storage as the distribution medium that worker agents pull from, combining the simplicity of Approach A with the scalability of Approach B.

--- a/docs/proposals/catalog/custom-service-templates-proposal.md
+++ b/docs/proposals/catalog/custom-service-templates-proposal.md
@@ -16,9 +16,13 @@
 6. [CatalogProvider Integration](#6-catalogprovider-integration)
 7. [API Upload](#7-api-upload)
 8. [Custom Template Directory Structure](#8-custom-template-directory-structure)
-9. [Usage Examples](#9-usage-examples)
-10. [Backward Compatibility](#10-backward-compatibility)
-11. [Future Enhancements](#11-future-enhancements)
+9. [Template Values Reference](#9-template-values-reference)
+   - 9.1 [Shared (services and components)](#91-shared-services-and-components)
+   - 9.2 [Services](#92-services)
+   - 9.3 [Components](#93-components)
+10. [Usage Examples](#10-usage-examples)
+11. [Backward Compatibility](#11-backward-compatibility)
+12. [Future Enhancements](#12-future-enhancements)
 
 ---
 
@@ -945,9 +949,482 @@ Built-in IDs reserved at this time: `chat`, `digitize`, `similarity`, `summarize
 
 ---
 
-## 9. Usage Examples
+## 9. Template Values Reference
 
-### 9.1 Upload a custom service bundle
+> **Scope: Podman only.**  The template values, `@generate` directives, and `ai-services.io/` labels/annotations described in this section apply to the **Podman** runtime, which uses Go-template `.yaml.tmpl` files.  OpenShift custom service templates use Helm charts and a different rendering pipeline; a full reference for that runtime is deferred.
+>
+> **TODO:** document the equivalent Helm-based template values, labels, and annotations for the OpenShift runtime.
+
+This section is split into three parts:
+
+- **§9.1 Shared** — context variables and lifecycle labels available in every `.yaml.tmpl` file, regardless of whether it belongs to a service or a component.
+- **§9.2 Services** — values, annotations, injected dependency keys, and schema extensions specific to service templates.
+- **§9.3 Components** — values, annotations, and env-override patterns specific to component templates.
+
+---
+
+### 9.1 Shared (services and components)
+
+#### 9.1.1 Built-in template context variables
+
+These variables are injected directly by the template engine into every `.yaml.tmpl` file. They are **not** defined in `values.yaml` and cannot be overridden by the user.
+
+| Variable | Type | Description |
+|---|---|---|
+| `{{ .InstanceSlug }}` | string | Unique slug for the deployed instance (e.g. `chat-abc123`). Used to name pods, secrets, volumes, and services so multiple instances can co-exist. |
+| `{{ .TemplateID }}` | string | Fully qualified template identifier (e.g. `services/chat`). Stamped onto every resource as the `ai-services.io/template` label. |
+| `{{ .BaseDir }}` | string | Host filesystem base directory for the deployment (e.g. `/opt/ai-services`). Used to resolve host-path mounts such as the shared `models/` directory. |
+| `{{ .Values }}` | object | Root object for all values sourced from `values.yaml` and any user-supplied overrides. Access fields with `{{ .Values.<key> }}`. |
+
+#### 9.1.2 Lifecycle labels
+
+These labels are placed on Pod `metadata.labels` and read by the runtime to manage lifecycle, secrets, and volumes. They apply equally to service and component pods.
+
+| Label | Required | Value | Description |
+|---|---|---|---|
+| `ai-services.io/template` | **yes** | `"{{ .TemplateID }}"` | Identifies which template produced this pod or secret. Must be present on every resource emitted by a template — used for ownership tracking and cleanup. |
+| `ai-services.io/secret` | no | Secret name(s), comma-separated | Marks the listed secrets as owned by this pod. The runtime creates and deletes them alongside the pod. |
+| `ai-services.io/secret-skip-cleanup` | no | `"true"` | Prevents the named secrets from being deleted on teardown. Set alongside `ai-services.io/secret` for credentials that must survive restarts (e.g. database passwords). |
+| `ai-services.io/volume` | no | PVC / secret-volume name(s), comma-separated | Declares persistent volumes or secret-backed volumes that the runtime provisions before starting the pod and deprovisions on teardown. |
+
+#### 9.1.3 `@generate` directive
+
+A `# @generate` comment immediately before a `values.yaml` field instructs the engine to produce a value at deploy time.
+
+| Directive | Behaviour |
+|---|---|
+| `# @generate:password` | Generates a cryptographically random password before template rendering. The value is persisted so restarts reuse the same credential. |
+
+#### 9.1.4 `podTemplateExecutions` execution order
+
+The `podTemplateExecutions` list in a runtime `metadata.yaml` controls template application order. Each inner list is a batch applied in parallel; batches run sequentially.
+
+```yaml
+# General pattern — sequential layers
+podTemplateExecutions:
+  - [secret.yaml.tmpl]       # layer 1: credential secret created first
+  - [dependency.yaml.tmpl]   # layer 2: dependency pod waits for secret
+  - [service.yaml.tmpl]      # layer 3: service pod waits for dependency
+```
+
+Templates in the same inner list run concurrently:
+
+```yaml
+podTemplateExecutions:
+  - [opensearch-secret.yaml.tmpl, vllm-secret.yaml.tmpl]  # both secrets in parallel
+  - [opensearch.yaml.tmpl, vllm-server.yaml.tmpl]          # both pods in parallel
+```
+
+---
+
+### 9.2 Services
+
+#### 9.2.1 `values.yaml` — service-owned values
+
+Each service defines its own `values.yaml` with the configuration defaults for its containers. Fields that require a generated credential use the shared `@generate` directive (§9.1.3):
+
+```yaml
+# services/digitize/podman/values.yaml
+digitize:
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.34
+  log_level: "INFO"
+  database: "digitize_metadata"
+
+postgres:
+  image: icr.io/ai-services-cicd/postgres:18-4
+  username: "postgres"
+  # @generate:password
+  password: ""
+```
+
+```yaml
+# services/chat/podman/values.yaml
+ui:
+  port: ""
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.48
+backend:
+  port: ""
+  image: icr.io/ai-services-cicd/chatbot-service:v0.0.25
+  log_level: "INFO"
+  chatbot:
+    searchMode: "hybrid"
+    numChunksPostReranker: 3
+    rerank: true
+    systemPrompt: ""
+```
+
+#### 9.2.2 Labels
+
+Service pods use the shared lifecycle labels from §9.1.2. The `ai-services.io/secret` and `ai-services.io/volume` labels appear on the sub-pods (e.g. the postgres pod) that own a credential secret or a PVC, not on the main service pod itself.
+
+```yaml
+# digitize postgres sub-pod — credential secret survives teardown, PVC owned by runtime
+labels:
+  ai-services.io/template: "{{ .TemplateID }}"
+  ai-services.io/secret: "digitize-db-secret-{{ .InstanceSlug }}"
+  ai-services.io/secret-skip-cleanup: "true"
+  ai-services.io/volume: "postgres-digitize-{{ .InstanceSlug }},digitize-db-secret-{{ .InstanceSlug }}"
+
+# summarize postgres sub-pod — same pattern
+labels:
+  ai-services.io/template: "{{ .TemplateID }}"
+  ai-services.io/secret: "summarize-db-secret-{{ .InstanceSlug }}"
+  ai-services.io/secret-skip-cleanup: "true"
+  ai-services.io/volume: "postgres-summarize-{{ .InstanceSlug }},summarize-db-secret-{{ .InstanceSlug }}"
+
+# chat / similarity / summarize main pods — no secrets or volumes owned at pod level
+labels:
+  ai-services.io/template: "{{ .TemplateID }}"
+```
+
+#### 9.2.3 Routing annotations
+
+Components run headlessly and are not directly reachable by users. Only service pods carry routing annotations — the Caddy reverse-proxy reads these to wire up UI and API endpoints for each deployed service instance.
+
+| Annotation | Description |
+|---|---|
+| `ai-services.io/routes` | Comma-separated `<containerPort>:<caddy-upstream-name>:<role>` tuples. `role` is `ui` (browser-facing) or `api` (machine-facing). |
+| `ai-services.io/ports` | Comma-separated `<hostPort>:<containerPort>` tuples. Exposes the port directly on the host, bypassing Caddy. Commented out by default — remove the comment to activate. |
+
+```yaml
+# chat — UI on 3000, API on 5000
+annotations:
+  ai-services.io/routes: "3000:chat-bot-ui-{{ .InstanceSlug }}:ui,5000:chat-bot-backend-{{ .InstanceSlug }}:api"
+  # ai-services.io/ports: "{{ .Values.ui.port }}:3000,{{ .Values.backend.port }}:5000"
+
+# digitize — UI on 4001, API on 4000
+annotations:
+  ai-services.io/routes: "4001:digitize-ui-{{ .InstanceSlug }}:ui,4000:digitize-backend-{{ .InstanceSlug }}:api"
+  # ai-services.io/ports: "{{ .Values.digitizeUi.port }}:4001,{{ .Values.digitize.port }}:4000"
+
+# similarity — API only on 7000
+annotations:
+  ai-services.io/routes: "7000:similarity-api-{{ .InstanceSlug }}:api"
+  # ai-services.io/ports: "{{ or .Values.similarity.port }}:7000"
+
+# summarize — API only on 6000
+annotations:
+  ai-services.io/routes: "6000:summarize-api-{{ .InstanceSlug }}:api"
+  # ai-services.io/ports: "{{ or .Values.summarize.port }}:6000"
+```
+
+#### 9.2.4 Injected dependency values (`.Values.<component>`)
+
+When a service declares dependencies in its top-level `metadata.yaml`, the engine injects connection details for each resolved component under well-known keys inside `.Values`. These keys are **read-only** and absent in component templates — they are populated by the runtime from the component's own running deployment.
+
+**LLM** (`dependencies: [{id: llm}]`)
+
+| Value path | Type | Description |
+|---|---|---|
+| `.Values.llm.host` | string | Hostname of the running LLM pod. |
+| `.Values.llm.port` | string | Container port (default `8000`). |
+| `.Values.llm.model` | string | Served model name as passed to vLLM / LiteLLM. |
+| `.Values.llm.maxModelLen` | int | Maximum token context length. |
+| `.Values.llm.maxBatchSize` | int | Maximum concurrent batch size. |
+| `.Values.llm.apiKey` | string | Optional API key; empty string when not configured. When non-empty, the secret is mounted at `/etc/secret/vllm-secret/apiKey`. |
+| `.Values.llm.instanceSlug` | string | Instance slug of the resolved LLM component (e.g. for referencing `vllm-secret-{{ .Values.llm.instanceSlug }}`). |
+
+**Embedding** (`dependencies: [{id: embedding}]`)
+
+| Value path | Type | Description |
+|---|---|---|
+| `.Values.embedding.host` | string | Hostname of the running embedding pod. |
+| `.Values.embedding.port` | string | Container port (default `8001`). |
+| `.Values.embedding.model` | string | Served embedding model name. |
+| `.Values.embedding.maxModelLen` | int | Maximum sequence length for the embedding model. |
+
+**Reranker** (`dependencies: [{id: reranker}]`)
+
+| Value path | Type | Description |
+|---|---|---|
+| `.Values.reranker.host` | string | Hostname of the running reranker pod. |
+| `.Values.reranker.port` | string | Container port (default `8002`). |
+| `.Values.reranker.model` | string | Served reranker model name. |
+
+**Vector store** (`dependencies: [{id: vector_store}]`)
+
+| Value path | Type | Description |
+|---|---|---|
+| `.Values.vector_store.host` | string | Hostname of the running vector-store pod (e.g. `opensearch-<slug>`). |
+| `.Values.vector_store.port` | string | Container port (default `9200` for OpenSearch). |
+| `.Values.vector_store.instanceSlug` | string | Instance slug of the resolved vector-store component (e.g. for referencing `opensearch-secret-{{ .Values.vector_store.instanceSlug }}`). |
+
+#### 9.2.5 `values.schema.json` — user-configurable parameters
+
+An optional `values.schema.json` (JSON Schema draft-07) alongside a service's `values.yaml` declares which fields the user can configure through the catalog UI. Fields absent from the schema are treated as internal defaults and not surfaced in the UI.
+
+Three custom `x-ui-*` extensions control form rendering:
+
+| Extension keyword | Description |
+|---|---|
+| `x-ui-only` | Field is rendered in the UI form but **not** passed into templates. Used for toggle controls that gate visibility of other fields. |
+| `x-ui-controls` | Names the field whose UI visibility this field controls. The named field is only shown when this field is `true`. |
+| `x-ui-controlled-by` | This field is hidden in the UI unless the field named here is `true`. |
+
+```json
+// services/chat/podman/values.schema.json
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "backend": {
+      "type": "object",
+      "properties": {
+        "editSystemPrompt": {
+          "type": "boolean",
+          "title": "Edit system prompt for queries",
+          "x-ui-only": true,
+          "x-ui-controls": "systemPrompt"
+        },
+        "systemPrompt": {
+          "type": "string",
+          "title": "Prompt text",
+          "default": "You are a helpful, conversational AI assistant...",
+          "minLength": 10,
+          "maxLength": 5000,
+          "x-ui-controlled-by": "editSystemPrompt"
+        }
+      }
+    }
+  }
+}
+```
+
+| Built-in service | Configurable parameters |
+|---|---|
+| `chat` | `backend.systemPrompt` (gated by `backend.editSystemPrompt` toggle) |
+| `digitize` | _(empty schema — no user-configurable parameters)_ |
+| `similarity` | _(empty schema — no user-configurable parameters)_ |
+| `summarize` | _(empty schema — no user-configurable parameters)_ |
+
+#### 9.2.6 `podTemplateExecutions` — service examples
+
+Services with a bundled database follow a three-layer pattern:
+
+```yaml
+# services/digitize/podman/metadata.yaml
+podTemplateExecutions:
+  - [postgres-secret.yaml.tmpl]   # layer 1: credential secret
+  - [postgres.yaml.tmpl]          # layer 2: postgres pod
+  - [digitize.yaml.tmpl]          # layer 3: digitize service pod
+
+# services/summarize/podman/metadata.yaml
+podTemplateExecutions:
+  - [postgres-secret.yaml.tmpl]
+  - [postgres.yaml.tmpl]
+  - [summarize-api.yaml.tmpl]
+```
+
+Services without a bundled database (chat, similarity) have no `podTemplateExecutions` — a single template is applied directly.
+
+---
+
+### 9.3 Components
+
+#### 9.3.1 Built-in component catalog
+
+The following components are shipped with ai-services and can be referenced as dependencies in a service's `metadata.yaml`. Values listed apply to the **Podman** runtime; OpenShift Helm values differ and are covered by the TODO above.
+
+**LLM providers** (`component_type: llm`)
+
+| ID | Default port | `values.yaml` keys | Spyre label |
+|---|---|---|---|
+| `vllm-cpu` | `8000` | `image`, `model`, `apiKey`, `maxNumBatchedTokens`, `maxModelLen`, `maxBatchSize` | — |
+| `vllm-spyre` | `8000` | `image`, `model`, `apiKey`, `maxModelLen`, `maxBatchSize` | `ai-services.io/llm--spyre-cards: "4"` |
+| `watsonx` | `8000` | `image`, `model`, `watsonxApiKey`, `watsonxProjectId`, `watsonxUrl`, `maxModelLen`, `maxBatchSize` | — |
+
+**Embedding providers** (`component_type: embedding`)
+
+| ID | Default port | `values.yaml` keys | Spyre label |
+|---|---|---|---|
+| `vllm-cpu` | `8001` | `image`, `model`, `maxModelLen` | — |
+
+**Reranker providers** (`component_type: reranker`)
+
+| ID | Default port | `values.yaml` keys | Spyre label |
+|---|---|---|---|
+| `vllm-cpu` | `8002` | `image`, `model` | — |
+| `vllm-spyre` | `8002` | `image`, `model` | `ai-services.io/reranker--spyre-cards: "1"` |
+
+**Vector-store providers** (`component_type: vector_db`)
+
+| ID | Default port | `values.yaml` keys | Credential handling |
+|---|---|---|---|
+| `opensearch` | `9200` | `image`, `memoryLimit`, `auth.username`, `auth.password` | `@generate:password` on `auth.password`; secret persists across restarts (`secret-skip-cleanup`) |
+
+#### 9.3.2 `values.yaml` — component-owned values
+
+Each component defines its own `values.yaml`. Fields that need auto-generated credentials use the `@generate` directive (§9.1.3):
+
+```yaml
+# components/vector_db/opensearch/podman/values.yaml
+image: icr.io/ppc64le-oss/opensearch-ppc64le:3.5.0
+memoryLimit: 8Gi
+auth:
+  username: "admin"
+  # @generate:password
+  password: ""
+```
+
+```yaml
+# components/llm/vllm-cpu/podman/values.yaml
+image: icr.io/ppc64le-oss/vllm-ppc64le:0.19.1
+model: ""
+apiKey: ""
+maxNumBatchedTokens: 26208
+maxModelLen: 26208
+maxBatchSize: 32
+```
+
+```yaml
+# components/llm/watsonx/podman/values.yaml
+image: "icr.io/ai-services-cicd/litellm:v1.89.3-1"
+model: "ibm/granite-4-h-small"
+watsonxApiKey: ""
+watsonxProjectId: ""
+watsonxUrl: ""
+maxModelLen: 26208
+maxBatchSize: 32
+```
+
+#### 9.3.3 Labels
+
+Component pods use the shared lifecycle labels from §9.1.2. In addition, Spyre-based component pods carry accelerator labels that the runtime uses for resource scheduling.
+
+| Label | Required | Value | Used by |
+|---|---|---|---|
+| `ai-services.io/llm--spyre-cards` | no | Quoted integer (e.g. `"4"`) | `vllm-spyre` LLM component only |
+| `ai-services.io/reranker--spyre-cards` | no | Quoted integer (e.g. `"1"`) | `vllm-spyre` reranker component only |
+
+```yaml
+# opensearch — secret and volume owned by runtime, credential persists on teardown
+labels:
+  ai-services.io/template: "{{ .TemplateID }}"
+  ai-services.io/secret: "opensearch-secret-{{ .InstanceSlug }}"
+  ai-services.io/secret-skip-cleanup: "true"
+  ai-services.io/volume: "opensearch-{{ .InstanceSlug }},opensearch-secret-{{ .InstanceSlug }}"
+
+# vllm-cpu LLM — secret and volume only when an API key is set
+labels:
+  ai-services.io/template: "{{ .TemplateID }}"
+  {{- if .Values.apiKey }}
+  ai-services.io/secret: "vllm-secret-{{ .InstanceSlug }}"
+  ai-services.io/volume: "vllm-secret-{{ .InstanceSlug }}"
+  {{- end }}
+
+# watsonx LLM — secret always present (API key is required)
+labels:
+  ai-services.io/template: "{{ .TemplateID }}"
+  ai-services.io/secret: "watsonx-secret-{{ .InstanceSlug }}"
+  ai-services.io/volume: "watsonx-secret-{{ .InstanceSlug }}"
+
+# vllm-spyre LLM — four Spyre cards required
+labels:
+  ai-services.io/template: "{{ .TemplateID }}"
+  ai-services.io/llm--spyre-cards: "4"
+
+# vllm-spyre reranker — one Spyre card required
+labels:
+  ai-services.io/template: "{{ .TemplateID }}"
+  ai-services.io/reranker--spyre-cards: "1"
+
+# vllm-cpu embedding / reranker-cpu — no secrets or volumes
+labels:
+  ai-services.io/template: "{{ .TemplateID }}"
+```
+
+#### 9.3.4 `io.podman.*` and OCI annotations
+
+These annotations tune low-level container behaviour and are passed straight through to the Podman runtime. They appear on component pods only — service pods do not use them.
+
+| Annotation | Used by | Value | Description |
+|---|---|---|---|
+| `io.podman.annotations.ulimit` | `vllm-cpu` LLM, `vllm-spyre` LLM, `vllm-cpu` embedding, `vllm-cpu` reranker, `vllm-spyre` reranker | `"nofile=134217728:134217728,memlock=-1:-1"` | Raises the open-file-descriptor and locked-memory ulimits required by vLLM. |
+| `io.podman.annotations.pids-limit/<container>` | `opensearch`, PostgreSQL (note: postgres pods are defined in service templates but the annotation applies to the postgres container within) | `"4096"` | Sets the PID limit for the named container within the pod. |
+| `io.podman.annotations.userns` | `vllm-spyre` LLM, `vllm-spyre` reranker | `"keep-id"` | Preserves the host user namespace mapping; required for Spyre device access. |
+| `run.oci.keep_original_groups` | `vllm-spyre` LLM, `vllm-spyre` reranker | `"1"` | Preserves host supplemental groups, enabling `/dev/vfio` access. |
+
+```yaml
+# vllm-cpu LLM / embedding / reranker-cpu — ulimit only
+annotations:
+  io.podman.annotations.ulimit: "nofile=134217728:134217728,memlock=-1:-1"
+
+# opensearch component — PID limit on the opensearch container
+annotations:
+  io.podman.annotations.pids-limit/opensearch: "4096"
+
+# vllm-spyre LLM / reranker — full Spyre set
+annotations:
+  io.podman.annotations.ulimit: "nofile=134217728:134217728,memlock=-1:-1"
+  io.podman.annotations.userns: "keep-id"
+  run.oci.keep_original_groups: "1"
+```
+
+#### 9.3.5 `podTemplateExecutions` — component examples
+
+Components that manage a credential secret run a two-layer pattern. Components without a secret apply a single template directly.
+
+```yaml
+# components/vector_db/opensearch/podman/metadata.yaml — two layers
+podTemplateExecutions:
+  - [opensearch-secret.yaml.tmpl]   # layer 1: credential secret
+  - [opensearch.yaml.tmpl]          # layer 2: opensearch pod
+
+# components/llm/vllm-cpu/podman/metadata.yaml — optional secret (empty if apiKey unset)
+podTemplateExecutions:
+  - [vllm-secret.yaml.tmpl]
+  - [vllm-server.yaml.tmpl]
+
+# components/llm/vllm-spyre/podman/metadata.yaml
+podTemplateExecutions:
+  - [vllm-secret.yaml.tmpl]
+  - [vllm-server.yaml.tmpl]
+
+# components/llm/watsonx/podman/metadata.yaml
+podTemplateExecutions:
+  - [watsonx-secret.yaml.tmpl]
+  - [watsonx-server.yaml.tmpl]
+
+# components/embedding/vllm-cpu and components/reranker/vllm-cpu — no secret template
+# podTemplateExecutions is omitted; the single pod template is applied directly
+```
+
+#### 9.3.6 `{{- with .env.<component> }}` — env injection override
+
+Spyre-based component templates support an env-override mechanism that lets the deployment layer inject extra environment variables into a container without modifying `values.yaml`.
+
+The Go template `with` action is scoped to a top-level `.env` map. If `.env.<component>` is absent or empty the block renders nothing; if it is a non-empty map every key–value pair is appended as an additional `env` entry.
+
+```yaml
+# vllm-spyre LLM template — env block with override hook
+env:
+  - name: MAX_MODEL_LEN
+    value: "{{ .Values.maxModelLen }}"
+  - name: MASTER_PORT
+    value: "12355"
+  {{- with .env.llm }}
+    {{- range $k, $v := . }}
+  - name: {{ $k }}
+    value: "{{ $v }}"
+    {{- end }}
+  {{- end }}
+```
+
+| Template | `.env` key |
+|---|---|
+| `components/llm/vllm-spyre/podman/templates/vllm-server.yaml.tmpl` | `.env.llm` |
+| `components/reranker/vllm-spyre/podman/templates/reranker-server.yaml.tmpl` | `.env.reranker` |
+| `applications/rag/podman/templates/vllm-server.yaml.tmpl` | `.env.instruct`, `.env.reranker` |
+| `applications/rag-dev/podman/templates/vllm-server.yaml.tmpl` | `.env.instruct` |
+
+Custom component templates may adopt the same pattern for any key name. The `.env` object is always safe to query with `with` — if the key is absent the block is silently skipped.
+
+---
+
+## 10. Usage Examples
+
+### 10.1 Upload a custom service bundle
 
 ```bash
 # Authenticate
@@ -972,7 +1449,7 @@ curl -s https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3
 # "active"
 ```
 
-### 9.2 Create an application from the custom service
+### 10.2 Create an application from the custom service
 
 The application creation endpoint (`POST /api/v1/applications/`) accepts a `CreateApplicationRequest` with `name`, `catalog_id`, `version`, and a `services` array. Each service entry requires its own `catalog_id`, `version`, and `components` list.
 
@@ -1002,7 +1479,7 @@ curl -X POST https://catalog-api.<domain>/api/v1/applications/ \
 # Returns 202 Accepted with {"id": "<application-uuid>"}
 ```
 
-### 9.3 Attempt to use a reserved built-in ID (rejected)
+### 10.3 Attempt to use a reserved built-in ID (rejected)
 
 Uploading a bundle whose `catalog_id` matches a built-in service is rejected at validation time — the extracted directory is cleaned up and no activation occurs:
 
@@ -1025,7 +1502,7 @@ curl -s https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_03EF9Z2GH4Q7RST5
 # }
 ```
 
-### 9.4 List custom services via the catalog API
+### 10.4 List custom services via the catalog API
 
 After uploading a bundle, custom services appear alongside built-in ones. The `GET /api/v1/services` endpoint returns an array of `ServiceSummary` objects (not a wrapped object), so the `jq` filter uses `.[].id`:
 
@@ -1040,7 +1517,7 @@ curl -s https://catalog-api.<domain>/api/v1/services \
 # "my-service"   ← custom
 ```
 
-### 9.5 Dry-run validation before applying
+### 10.5 Dry-run validation before applying
 
 ```bash
 # Validate without activating — useful in CI before promoting to production
@@ -1056,7 +1533,7 @@ curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
 
 ---
 
-## 10. Backward Compatibility
+## 11. Backward Compatibility
 
 | Scenario | Behaviour |
 |---|---|
@@ -1072,7 +1549,7 @@ curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
 
 ---
 
-## 11. Future Enhancements
+## 12. Future Enhancements
 
 1. **Scaffolding generator** — `ai-services catalog scaffold --service my-service --runtime podman` emits a minimal but correct directory skeleton ready to be tar'd and uploaded.
 2. **Template validation command** — `dry_run=true` already supported in §7.2.1; a dedicated CLI command `ai-services catalog validate --bundle <file>` wraps this for local use.

--- a/docs/proposals/catalog/custom-service-templates-proposal.md
+++ b/docs/proposals/catalog/custom-service-templates-proposal.md
@@ -135,7 +135,7 @@ flowchart TD
 
 The catalog backend's `CatalogProvider` runs **inside the `ai-services--catalog` container**, not on the CLI host. `assets.CatalogFS` is baked into the binary at build time (via `go:embed`). For custom templates to be visible at runtime they must reach the container and be overlaid onto the embedded FS.
 
-Custom assets are delivered via the running catalog API: the client POSTs a `.tar.gz` bundle over HTTPS, and the apiserver writes the extracted contents to a dedicated named volume (`ai-services-bundles` on Podman, `catalog-bundles-pvc` on OpenShift) that it already owns. Both runtimes mount the volume at the well-known path `/data/catalog-bundles` inside the container. Bundles are stored under `<catalog_type>/<name>/` where `name = <catalog_id>-<version>` (e.g. `service/chat-2.0.0/`). At startup, `CatalogProvider` queries the DB for all `status = 'active'` rows, resolves each to its named directory, and builds a `CompositeCatalogFS`. Hot-reload happens in-process after every successful upload; no pod restart is needed.
+Custom assets are delivered via the running catalog API: the client POSTs a `.tar.gz` bundle over HTTPS, and the apiserver writes the extracted contents to a dedicated named volume (`ai-services-bundles` on Podman, `catalog-bundles-pvc` on OpenShift) that it already owns. Both runtimes mount the volume at the well-known path `/data/catalog-bundles` inside the container. Bundles are stored under `<catalog_type>/<name>/` where `name = <catalog_id>-<version>` (e.g. `service/chat-2.0.0/`). **At most one bundle per `catalog_id` is active at any time** — uploading a new version via `PUT` replaces the existing one. At startup, `CatalogProvider` queries the DB for all `status = 'active'` rows, resolves each to its named directory, and builds a `CompositeCatalogFS`. Hot-reload happens in-process after every successful upload; no pod restart is needed.
 
 ### 3.3 OpenShift path
 
@@ -404,7 +404,8 @@ Custom catalog assets are delivered by uploading a `.tar.gz` bundle to the runni
 | Goal | Detail |
 |---|---|
 | No restart required | `CatalogProvider` reloads the custom layer in-process after a successful upload |
-| Idempotent | Re-uploading the same `catalog_id` + `version` replaces the existing directory in-place |
+| Conflict-safe POST | `POST` raises `409 Conflict` if a bundle with the same `catalog_id` is already registered — use `PUT` to update |
+| Explicit update via PUT | `PUT /api/v1/catalog/bundles/:bundle_id` replaces the existing bundle; `catalog_id`, `catalog_type`, and `version` are all resolved from the archive and the existing DB record — not form fields |
 | Independent bundles | Each uploaded bundle exists separately; multiple bundles for different `catalog_id` values are all active simultaneously |
 | Authenticated | Uses the existing JWT `BearerAuth` middleware; only admin-role tokens are accepted |
 | Consistent across runtimes | Same API endpoint works for Podman and OpenShift; only the storage backend differs |
@@ -414,17 +415,21 @@ Custom catalog assets are delivered by uploading a `.tar.gz` bundle to the runni
 
 ### 7.2 New API endpoints
 
-Three endpoints are added to the existing router in [`apiserver/router.go`](ai-services/internal/pkg/catalog/apiserver/router.go:18) under the authenticated `catalog` group:
+Five endpoints are added to the existing router in [`apiserver/router.go`](ai-services/internal/pkg/catalog/apiserver/router.go:18) under the authenticated `catalog` group:
 
 | Method | Path | Description |
 |---|---|---|
-| `POST` | `/api/v1/catalog/bundles` | Upload a new bundle (`.tar.gz`). Each bundle is registered independently and activated on success. |
+| `POST` | `/api/v1/catalog/bundles` | Upload a **new** bundle (`.tar.gz`). Returns `409 Conflict` if a bundle with the same `catalog_id` already exists. |
+| `PUT` | `/api/v1/catalog/bundles/:bundle_id` | Replace an existing bundle identified by its internal record ID. Returns `404` if no bundle with that ID exists. `catalog_id` and `catalog_type` are resolved from the DB record. |
+| `DELETE` | `/api/v1/catalog/bundles/:bundle_id` | Delete a bundle by its internal record ID. Removes the on-disk directory and the DB record. Returns `404` if no bundle with that ID exists. |
 | `GET` | `/api/v1/catalog/bundles` | List all uploaded bundles (id, status, uploaded_at, size). |
 | `GET` | `/api/v1/catalog/bundles/:id` | Get the status of a specific bundle by ID. Used to poll after a `202` upload response. |
 
 #### 7.2.1 Upload bundle — `POST /api/v1/catalog/bundles`
 
-The request uses `multipart/form-data` so that the binary `.tar.gz` file and the text fields can travel together in the same request. The server validates `catalog_type` and `version` before touching the archive, then extracts directly into the versioned directory on the bundle volume.
+The request uses `multipart/form-data` so that the binary `.tar.gz` file and the text fields can travel together in the same request. The server validates `catalog_id`, `catalog_type`, and `version` before touching the archive, then extracts directly into the versioned directory on the bundle volume. The `catalog_id` form field is used as the bundle name component and must match the top-level directory inside the archive — a mismatch is rejected with `400`.
+
+When `dry_run=true` the request is handled **synchronously**: the archive is extracted to a temporary directory, validated, then immediately cleaned up. No DB record is written, `CatalogProvider` is not reloaded, and the conflict check is skipped — so a dry-run against an already-registered `catalog_id` is always allowed. The response is `200 OK` (valid) or `422` (invalid), returned inline without polling.
 
 ```
 POST /api/v1/catalog/bundles
@@ -434,13 +439,18 @@ Authorization: Bearer <admin-jwt>
 Form fields:
   file         (required)  — .tar.gz archive containing the catalog item
                              assets; max 50 MB compressed
+  catalog_id   (required)  — identifier for this catalog item, e.g. "my-service";
+                             must match the top-level directory name inside the archive;
+                             combined with version to form the on-disk bundle name
+                             (<catalog_id>-<version>)
   catalog_type (required)  — type of the catalog item in this bundle;
                              accepted values: "service", "component"
   version      (required)  — semantic version of this bundle, e.g. "1.0.0";
-                             used as the directory name under
-                             /data/catalog-bundles/<type>/<name>/
-                             where name = <catalog_id>-<version>
-  dry_run      (optional)  — "true" validates the archive without activating it
+                             combined with catalog_id to form the on-disk bundle name
+                             (<catalog_id>-<version>)
+                             (ignored for storage purposes when dry_run=true)
+  dry_run      (optional)  — "true" runs a synchronous validate-only pass;
+                             no DB record is written and nothing is activated
 ```
 
 **Example (curl):**
@@ -448,6 +458,7 @@ Form fields:
 curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
   -H "Authorization: Bearer $TOKEN" \
   -F "file=@my-bundle.tar.gz" \
+  -F "catalog_id=my-service" \
   -F "catalog_type=service" \
   -F "version=1.0.0"
 ```
@@ -456,11 +467,13 @@ curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
 
 | Status | Meaning |
 |---|---|
+| `200 OK` | **`dry_run=true` only.** Validation passed; archive is safe to upload for real. No record was written. |
 | `202 Accepted` | Bundle accepted; extraction and validation running asynchronously. Use the `Location` header to poll for status. |
-| `400 Bad Request` | Missing `file`, `catalog_type`, or `version` field; unrecognised `catalog_type`; invalid version format; wrong content-type; or archive exceeds size limit. |
+| `400 Bad Request` | Missing `file`, `catalog_id`, `catalog_type`, or `version` field; `catalog_id` does not match the archive's top-level directory name; unrecognised `catalog_type`; invalid version format; wrong content-type; or archive exceeds size limit. |
 | `401 Unauthorized` | Missing or invalid JWT. |
 | `403 Forbidden` | Token does not carry admin role. |
-| `422 Unprocessable Entity` | Archive extracted but validation failed (structured error list returned). |
+| `409 Conflict` | A bundle with the same `catalog_id` is already registered (**non-dry-run only**). Use `PUT /api/v1/catalog/bundles/:catalog_id` to update it. |
+| `422 Unprocessable Entity` | Validation failed (structured error list returned). Returned synchronously for `dry_run=true`, or via poll for normal uploads. |
 
 The response includes a `Location` header pointing to the status resource:
 
@@ -469,7 +482,7 @@ HTTP/1.1 202 Accepted
 Location: /api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ
 ```
 
-`catalog_type` is known immediately from the request field. `catalog_id` is resolved from the directory name inside the archive during extraction and populated once the archive is unpacked. Both are present in the `202` body:
+`catalog_id`, `catalog_type`, and `version` are all known immediately from the request fields and are present in the `202` body:
 
 ```json
 // 202 response body
@@ -503,7 +516,89 @@ Once the bundle reaches `active` or `failed` status, the polled response reflect
 }
 ```
 
-#### 7.2.2 List bundles — `GET /api/v1/catalog/bundles`
+#### 7.2.2 Update bundle — `PUT /api/v1/catalog/bundles/:bundle_id`
+
+Use `PUT` to replace an existing bundle identified by its internal record ID (`bundle_id`). The server looks up the record by `bundle_id` and derives `catalog_id` and `catalog_type` from it — neither is a form field. The only form fields are `file` and optionally `dry_run`.
+
+**Version is not a form field.** The version of the replacement bundle is read from the `metadata.yaml` inside the archive after extraction. If the metadata carries a new version the on-disk directory is named accordingly (`<catalog_id>-<new_version>/`). The `catalog_id` and `catalog_type` values inside the archive metadata must match the existing DB record — attempts to change them are rejected with `422`.
+
+Returns `404` if no bundle with that `bundle_id` exists.
+
+When `dry_run=true` the request is handled **synchronously**: the archive is extracted to a temporary directory and validated, then immediately cleaned up. The `404` check **still runs** — a dry-run with an unknown `bundle_id` returns `404` just as a real PUT would. No DB record is updated, the old bundle directory is untouched, and `CatalogProvider` is not reloaded. The response is `200 OK` (valid) or `422` (invalid), returned inline without polling.
+
+```
+PUT /api/v1/catalog/bundles/:bundle_id
+Content-Type: multipart/form-data
+Authorization: Bearer <admin-jwt>
+
+Path parameter:
+  :bundle_id   (required)  — internal record ID of the bundle to replace,
+                             e.g. bnd_01JW4X9K2M8VQRP3T5YZ
+
+Form fields:
+  file         (required)  — .tar.gz archive containing the replacement assets
+  dry_run      (optional)  — "true" runs a synchronous validate-only pass;
+                             existing bundle is untouched, nothing is activated
+```
+
+> `catalog_id`, `catalog_type`, and `version` are **not** form fields for `PUT`. `catalog_id` and `catalog_type` are resolved from the DB record and validated against the archive metadata — mismatches are rejected with `422`. `version` is read from the archive's `metadata.yaml` and used to derive the on-disk bundle name (`<catalog_id>-<version>/`).
+
+**Example (curl):**
+```bash
+curl -X PUT https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "file=@my-bundle-v2.tar.gz"
+```
+
+**Responses:**
+
+| Status | Meaning |
+|---|---|
+| `200 OK` | **`dry_run=true` only.** Validation passed; replacement archive is safe to apply for real. Existing bundle unchanged. |
+| `202 Accepted` | Replacement bundle accepted; processing asynchronously. Poll `Location` header to get status. `version` and `name` in the response body are populated once the archive is extracted. |
+| `400 Bad Request` | Missing `file` field; archive top-level directory does not match the resolved `catalog_id`; wrong content-type; or archive exceeds size limit. |
+| `401 Unauthorized` | Missing or invalid JWT. |
+| `403 Forbidden` | Token does not carry admin role. |
+| `404 Not Found` | No bundle with the given `bundle_id` exists. Use `POST` to create a new bundle first. (Returned for both normal and `dry_run=true` requests.) |
+| `422 Unprocessable Entity` | Validation failed, or the archive's `catalog_id`/`catalog_type` metadata differs from the existing record. Returned synchronously for `dry_run=true`, or via poll for normal updates. The existing bundle remains active in both cases. |
+
+The `202` body has the same shape as `POST` but `version` and `name` are initially empty strings (populated on the polled response once extraction completes). The old bundle directory (`<type>/<catalog_id>-<old_version>/`) is deleted from the volume only after the replacement is marked `active` in the DB — the existing bundle continues to serve templates throughout the async processing window.
+
+---
+
+#### 7.2.3 Delete bundle — `DELETE /api/v1/catalog/bundles/:bundle_id`
+
+Permanently removes a bundle: deletes the on-disk directory (`<catalog_type>/<catalog_id>-<version>/`) from the bundle volume, removes the DB row, and triggers a `CatalogProvider.Reload()` so the item is no longer served. Any application that was deployed using this bundle's `catalog_id` is **not** affected — existing deployed resources are independent of the catalog once launched.
+
+```
+DELETE /api/v1/catalog/bundles/:bundle_id
+Authorization: Bearer <admin-jwt>
+
+Path parameter:
+  :bundle_id   (required)  — internal record ID of the bundle to delete,
+                             e.g. bnd_01JW4X9K2M8VQRP3T5YZ
+```
+
+**Example (curl):**
+```bash
+curl -X DELETE https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Responses:**
+
+| Status | Meaning |
+|---|---|
+| `204 No Content` | Bundle deleted; on-disk directory removed and `CatalogProvider` reloaded. |
+| `401 Unauthorized` | Missing or invalid JWT. |
+| `403 Forbidden` | Token does not carry admin role. |
+| `404 Not Found` | No bundle with the given `bundle_id` exists. |
+
+> Deletion is **synchronous** — the directory removal and `CatalogProvider.Reload()` happen in-process before the `204` is returned. There is no async processing step and no polling needed.
+
+---
+
+#### 7.2.4 List bundles — `GET /api/v1/catalog/bundles`
 
 Each bundle record carries `catalog_type` (the type declared by the uploader — `"service"` or `"component"`) and `catalog_id` (the item id within that type). Multiple bundles for different catalog items are all active simultaneously and each is listed independently.
 
@@ -540,11 +635,15 @@ Each bundle record carries `catalog_type` (the type declared by the uploader —
 
 ### 7.3 Bundle format
 
-A bundle is scoped to **one catalog item** — the type is declared by the client as a form field (`catalog_type`), and the `catalog_id` is derived from the top-level directory inside the archive. The archive must be a gzip-compressed tar (`.tar.gz`). The `version` form field combines with the `catalog_id` to form the unique on-disk directory name (`<catalog_id>-<version>`), ensuring each bundle has an isolated location on the volume.
+A bundle is scoped to **one catalog item**. The archive must be a gzip-compressed tar (`.tar.gz`). The `catalog_id` and `version` together form the unique on-disk directory name (`<catalog_id>-<version>`).
+
+For **POST**, `catalog_id`, `catalog_type`, and `version` are all declared as form fields. The server validates that the archive's top-level directory matches the supplied `catalog_id` — a mismatch is rejected with `400` before any extraction begins.
+
+For **PUT**, no form fields are needed beyond `file`. `catalog_id` and `catalog_type` are resolved from the existing DB record; `version` is read from `metadata.yaml` inside the archive after extraction. The `catalog_id` and `catalog_type` values inside the metadata are validated as immutable (must match the DB record) — a mismatch is rejected with `422`.
 
 ```
 my-bundle.tar.gz
-└── my-service/                     ← single item; directory name = catalog_id
+└── my-service/                     ← must match catalog_id form field
     ├── metadata.yaml
     └── podman/
         ├── metadata.yaml
@@ -553,24 +652,44 @@ my-bundle.tar.gz
             └── my-service.yaml.tmpl
 ```
 
-The server derives `catalog_id` from this top-level directory name and validates it matches the `catalog_type` form field. The `version` form field (e.g. `"1.0.0"`) determines where the extracted contents are stored on the volume.
+The `version` form field (e.g. `"1.0.0"`) combines with `catalog_id` to determine the on-disk bundle name (`my-service-1.0.0/`).
 
 **Rules:**
 - Paths containing `..` or absolute paths are rejected immediately (path-traversal guard, same principle as [`SanitizeFilePath`](ai-services/internal/pkg/catalog/utils/common.go:90)).
 - The archive must contain exactly one top-level directory; multiple items per archive are not supported.
+- The top-level directory name inside the archive must exactly equal the `catalog_id` form field — a mismatch is rejected with `400`.
 - Total uncompressed size must not exceed `MAX_BUNDLE_SIZE_UNCOMPRESSED` (default 200 MB).
-- The `catalog_id` derived from the top-level directory name must not match any built-in service already present in `assets.CatalogFS` — if it does, validation returns `422` and the extracted directory is deleted.
+- The `catalog_id` must not match any built-in service already present in `assets.CatalogFS` — if it does, validation returns `422` and the extracted directory is deleted.
 - All `metadata.yaml` files must pass validation for the declared `catalog_type` before the bundle is marked `active`.
 
 ---
 
 ### 7.4 Server-side processing pipeline
 
+#### POST — new bundle
+
 ```mermaid
 flowchart TD
-    REQ["POST /api/v1/catalog/bundles<br/>multipart/form-data<br/>file, catalog_type, version, dry_run"]
+    REQ["POST /api/v1/catalog/bundles<br/>multipart/form-data<br/>file, catalog_id, catalog_type, version, dry_run"]
     AUTH["AuthMiddleware<br/>JWT + admin role check"]
-    TYPECHECK["Validate catalog_type and version<br/>reject unknown type → 400"]
+    TYPECHECK["Validate catalog_id, catalog_type, version<br/>reject unknown type or missing fields → 400"]
+    DRYCHECK{"dry_run=true?"}
+
+    subgraph DRYPATH["Synchronous dry-run path"]
+        DR_SIZE["Size guard — max 50 MB compressed"]
+        DR_EXTRACT["Extract to /tmp/dryrun-uuid/"]
+        DR_PATHGUARD["Path-traversal guard"]
+        DR_VALIDATE["CatalogProvider.ValidateFS"]
+        DR_CLEANUP["Delete /tmp/dryrun-uuid/ (always)"]
+        DR_OK["200 OK — validation result"]
+        DR_FAIL["422 Unprocessable Entity — error list"]
+        DR_SIZE --> DR_EXTRACT --> DR_PATHGUARD --> DR_VALIDATE --> DR_CLEANUP
+        DR_CLEANUP -->|"valid"| DR_OK
+        DR_CLEANUP -->|"invalid"| DR_FAIL
+    end
+
+    CONFLICT["Check catalog_bundles table<br/>catalog_id already exists?"]
+    CONFLICT_RESP["409 Conflict<br/>use PUT to update"]
     RESP["202 Accepted immediately<br/>bundle_id, status: processing<br/>Location: /api/v1/catalog/bundles/:id"]
     SIZE["Size guard<br/>max 50 MB compressed"]
     EXTRACT["Extract to<br/>/data/catalog-bundles/type/name/<br/>name = catalog_id-version"]
@@ -593,7 +712,63 @@ flowchart TD
         VALIDATE -->|"invalid"| FAIL
     end
 
-    REQ --> AUTH --> TYPECHECK --> RESP
+    REQ --> AUTH --> TYPECHECK --> DRYCHECK
+    DRYCHECK -->|"yes"| DRYPATH
+    DRYCHECK -->|"no"| CONFLICT
+    CONFLICT -->|"exists"| CONFLICT_RESP
+    CONFLICT -->|"new"| RESP
+    RESP -.-> ASYNC
+```
+
+#### PUT — replace existing bundle
+
+```mermaid
+flowchart TD
+    REQ["PUT /api/v1/catalog/bundles/:bundle_id<br/>multipart/form-data<br/>file, dry_run"]
+    AUTH["AuthMiddleware<br/>JWT + admin role check"]
+    LOOKUP["Look up bundle_id in catalog_bundles<br/>resolve catalog_id + catalog_type from record<br/>not found → 404"]
+    DRYCHECK{"dry_run=true?"}
+
+    subgraph DRYPATH["Synchronous dry-run path"]
+        DR_SIZE["Size guard — max 50 MB compressed"]
+        DR_EXTRACT["Extract to /tmp/dryrun-uuid/"]
+        DR_PATHGUARD["Path-traversal guard"]
+        DR_VALIDATE["CatalogProvider.ValidateFS<br/>(catalog_id + catalog_type from DB record)"]
+        DR_CLEANUP["Delete /tmp/dryrun-uuid/ (always)"]
+        DR_OK["200 OK — validation result<br/>existing bundle untouched"]
+        DR_FAIL["422 Unprocessable Entity — error list<br/>existing bundle untouched"]
+        DR_SIZE --> DR_EXTRACT --> DR_PATHGUARD --> DR_VALIDATE --> DR_CLEANUP
+        DR_CLEANUP -->|"valid"| DR_OK
+        DR_CLEANUP -->|"invalid"| DR_FAIL
+    end
+
+    RESP["202 Accepted immediately<br/>bundle_id, status: processing<br/>version + name populated after extraction<br/>Location: /api/v1/catalog/bundles/:id"]
+    SIZE["Size guard<br/>max 50 MB compressed"]
+    EXTRACT["Extract to<br/>/data/catalog-bundles/type/new-name/<br/>new-name = catalog_id-version_from_metadata"]
+    PATHGUARD["Path-traversal guard<br/>reject .. and absolute paths<br/>verify exactly one top-level dir"]
+    METACHECK["Read version from metadata.yaml<br/>validate catalog_id + catalog_type unchanged<br/>mismatch → 422"]
+    VALIDATE["CatalogProvider.ValidateFS<br/>parse metadata for resolved catalog_type<br/>collect all errors"]
+
+    subgraph ASYNC["Goroutine — async after 202"]
+        SIZE --> EXTRACT --> PATHGUARD --> METACHECK --> VALIDATE
+
+        subgraph ACTIVATE["Activate — success path"]
+            direction LR
+            DBUPDATE["Update bundle record<br/>status = active, version + name from metadata"]
+            RMOLD["Delete old type/old-name/ directory"]
+            RELOAD["CatalogProvider.Reload()<br/>re-query active bundles from DB<br/>rebuild CompositeCatalogFS"]
+            DBUPDATE --> RMOLD --> RELOAD
+        end
+
+        FAIL["Delete new type/new-name/ directory<br/>update DB status = failed<br/>existing bundle remains active<br/>return 422 on poll"]
+
+        VALIDATE -->|"valid"| ACTIVATE
+        VALIDATE -->|"invalid"| FAIL
+    end
+
+    REQ --> AUTH --> LOOKUP --> DRYCHECK
+    DRYCHECK -->|"yes"| DRYPATH
+    DRYCHECK -->|"no"| RESP
     RESP -.-> ASYNC
 ```
 
@@ -601,7 +776,9 @@ flowchart TD
 
 - Extraction and validation run in a goroutine; the HTTP handler returns `202` immediately. The client polls `GET /api/v1/catalog/bundles/:id` until `status` is `active` or `failed`.
 - Each bundle gets its own named directory on the volume (`<type>/<name>/`) — uploading `service/my-service-1.0.0` and `service/chat-1.0.0` are entirely independent; neither touches the other.
-- Extraction goes directly into `<type>/<name>/` — no staging directory needed. Since the named directory is new and unique, there is nothing live to corrupt.
+- **POST** extraction goes directly into `<type>/<name>/` — no staging directory needed. Since the named directory is new and unique, there is nothing live to corrupt.
+- **PUT** extraction writes the new versioned directory alongside the old one. The old directory is removed only after the new bundle is marked `active` in the DB — the existing bundle continues to serve templates throughout the async window.
+- **PUT** METACHECK: after extraction, `metadata.yaml` is parsed to read `version` (used to construct the new directory name) and to assert that `catalog_id` and `catalog_type` are unchanged. A mismatch returns `422` and the extracted directory is deleted.
 - If validation fails, the newly written `<type>/<name>/` directory is deleted. All other active bundles remain unaffected.
 - The DB never marks a bundle `active` until validation passes — so even a partial extraction (e.g. process killed mid-way) is safe: `CatalogProvider` will not load a directory that has no `active` DB row.
 - `CatalogProvider.Reload()` re-queries the DB for all `status = 'active'` rows and rebuilds the `CompositeCatalogFS` under `sync.RWMutex`.
@@ -612,7 +789,7 @@ flowchart TD
 
 ### 7.5 New database migration
 
-Each row in `catalog_bundles` represents one uploaded bundle. The `name` column is derived server-side as `<catalog_id>-<version>` (e.g. `chat-2.0.0`) — it uniquely identifies a versioned bundle in a human-readable form and is used as the directory name on the volume. The `status` column tracks lifecycle: `processing → active` on success, `failed` on validation error. Multiple bundles for different `catalog_id` values are all `active` simultaneously; each exists independently.
+Each row in `catalog_bundles` represents one uploaded bundle. The `name` column is derived server-side as `<catalog_id>-<version>` (e.g. `chat-2.0.0`) — it identifies the specific versioned bundle and is used as the directory name on the volume. The `status` column tracks lifecycle: `processing → active` on success, `failed` on validation error. **Only one `active` row per `catalog_id` is permitted** — enforced by a partial unique index. Bundles for different `catalog_id` values are all `active` simultaneously; each exists independently.
 
 ```sql
 -- +goose Up
@@ -646,10 +823,18 @@ CREATE TABLE catalog_bundles (
     uploaded_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
     activated_at     TIMESTAMPTZ
 );
+
+-- Enforce one active bundle per catalog_id at the DB level.
+-- 'processing' and 'failed' rows are exempt so that a replacement upload
+-- in flight does not block itself.
+CREATE UNIQUE INDEX uq_catalog_bundles_active_catalog_id
+    ON catalog_bundles (catalog_id)
+    WHERE status = 'active';
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
+DROP INDEX  IF EXISTS uq_catalog_bundles_active_catalog_id;
 DROP TABLE  IF EXISTS catalog_bundles;
 DROP TYPE   IF EXISTS bundle_status;
 -- +goose StatementEnd
@@ -663,19 +848,19 @@ Bundle storage is **intentionally isolated** from `$AI_SERVICES_BASE_DIR`. This 
 
 #### Volume directory layout
 
-The volume is organised as `<catalog_type>/<name>/` where `name` is `<catalog_id>-<version>` (e.g. `chat-2.0.0`). Each uploaded bundle gets its own named directory. Bundles for different `catalog_id` values coexist on disk and are each independently `active`. Extraction writes directly into the named directory; no staging or rename step is needed.
+The volume is organised as `<catalog_type>/<name>/` where `name` is `<catalog_id>-<version>` (e.g. `chat-2.0.0`). At most **one versioned directory per `catalog_id`** exists on disk at any time — a `PUT` replaces the old directory with the new one once the replacement is marked `active`. Bundles for different `catalog_id` values coexist independently. Extraction writes directly into the new named directory; the old directory is removed only after the DB row is updated to `active`.
 
 ```
 /data/catalog-bundles/
 ├── service/
-│   ├── chat-2.0.0/              ← active
+│   ├── chat-2.0.0/              ← active (one version of "chat" at a time)
 │   │   ├── metadata.yaml
 │   │   └── podman/...
-│   └── my-service-1.0.0/        ← active (independent)
+│   └── my-service-1.0.0/        ← active (independent catalog_id)
 │       ├── metadata.yaml
 │       └── podman/...
 └── component/
-    └── my-llm-provider-1.0.0/   ← active (independent)
+    └── my-llm-provider-1.0.0/   ← active (independent catalog_id)
         └── metadata.yaml
 ```
 
@@ -820,30 +1005,39 @@ type BundleHandler struct {
 
 // UploadBundle godoc
 //
-//  @Summary     Upload a custom catalog bundle
-//  @Description Accepts a .tar.gz archive for a single catalog item. The
-//               caller declares the catalog_type ("service" or "component").
-//               The archive is validated and, if valid, hot-reloaded into
-//               the running CatalogProvider.
+//  @Summary     Upload a new custom catalog bundle
+//  @Description Accepts a .tar.gz archive for a single catalog item. The caller declares
+//               catalog_id, catalog_type, and version as form fields. The catalog_id must
+//               match the top-level directory name inside the archive. Returns 409 if a
+//               bundle with the same catalog_id is already registered — use PUT to update.
+//               The archive is validated and, if valid, hot-reloaded into CatalogProvider.
 //  @Tags        Catalog
 //  @Accept      multipart/form-data
 //  @Produce     json
 //  @Security    BearerAuth
 //  @Param       file         formData  file    true   ".tar.gz bundle archive (max 50 MB)"
+//  @Param       catalog_id   formData  string  true   "Catalog item identifier, e.g. my-service; must match archive top-level directory"
 //  @Param       catalog_type formData  string  true   "Catalog item type: service or component"
 //  @Param       version      formData  string  true   "Semantic version of this bundle, e.g. 1.0.0"
 //  @Param       dry_run      formData  string  false  "Validate only, do not apply (default: false)"
-//  @Success     202  {object}  BundleResponse   "Bundle accepted and processing"
-//  @Failure     400  {object}  ErrorResponse    "Invalid request or archive too large"
-//  @Failure     401  {object}  ErrorResponse    "Unauthorized"
-//  @Failure     403  {object}  ErrorResponse    "Admin role required"
+//  @Success     202  {object}  BundleResponse      "Bundle accepted and processing"
+//  @Failure     400  {object}  ErrorResponse       "Invalid request, catalog_id mismatch, or archive too large"
+//  @Failure     401  {object}  ErrorResponse       "Unauthorized"
+//  @Failure     403  {object}  ErrorResponse       "Admin role required"
+//  @Failure     409  {object}  ErrorResponse       "catalog_id already registered; use PUT"
 //  @Failure     422  {object}  BundleErrorResponse "Validation failed"
 //  @Router      /catalog/bundles [post]
 func (h *BundleHandler) UploadBundle(c *gin.Context) {
     // 1. Enforce size limit before reading into memory
     c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBundleSizeBytes)
 
-    // 2. Validate catalog_type before touching the archive
+    // 2. Validate all required fields before touching the archive
+    catalogID := c.PostForm("catalog_id")
+    if catalogID == "" {
+        c.JSON(http.StatusBadRequest, ErrorResponse{Error: "catalog_id is required"})
+        return
+    }
+
     catalogType := c.PostForm("catalog_type")
     if catalogType == "" {
         c.JSON(http.StatusBadRequest, ErrorResponse{Error: "catalog_type is required"})
@@ -875,7 +1069,37 @@ func (h *BundleHandler) UploadBundle(c *gin.Context) {
     dryRun := c.PostForm("dry_run") == "true"
     userID := c.GetString(middleware.CtxUserIDKey)
 
-    resp, err := h.bundleService.ProcessBundle(c.Request.Context(), file, header.Size, userID, catalogType, version, dryRun)
+    // 3. Dry-run: synchronous validate-only path — no DB write, no CatalogProvider reload,
+    //    conflict check skipped (the archive is never persisted).
+    //    catalog_id is passed so ValidateBundle can confirm the archive top-level dir matches.
+    if dryRun {
+        result, err := h.bundleService.ValidateBundle(c.Request.Context(), file, catalogID, catalogType)
+        if err != nil {
+            if valErr, ok := err.(*ValidationError); ok {
+                c.JSON(valErr.Code, valErr)
+                return
+            }
+            c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "dry-run validation failed unexpectedly"})
+            return
+        }
+        c.JSON(http.StatusOK, result)
+        return
+    }
+
+    // 4. Conflict check — only for real (non-dry-run) uploads.
+    exists, err := h.bundleService.CatalogIDExists(c.Request.Context(), catalogID)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "failed to check existing bundles"})
+        return
+    }
+    if exists {
+        c.JSON(http.StatusConflict, ErrorResponse{
+            Error: fmt.Sprintf("a bundle with catalog_id %q already exists; use PUT /api/v1/catalog/bundles/%s to update it", catalogID, catalogID),
+        })
+        return
+    }
+
+    resp, err := h.bundleService.ProcessBundle(c.Request.Context(), file, header.Size, userID, catalogID, catalogType, version)
     if err != nil {
         if valErr, ok := err.(*ValidationError); ok {
             c.JSON(valErr.Code, ErrorResponse{Error: valErr.Message})
@@ -886,6 +1110,192 @@ func (h *BundleHandler) UploadBundle(c *gin.Context) {
     }
 
     c.JSON(http.StatusAccepted, resp)
+}
+
+// UpdateBundle godoc
+//
+//  @Summary     Replace an existing catalog bundle
+//  @Description Replaces the bundle identified by bundle_id. catalog_id and catalog_type
+//               are resolved from the DB record — neither is a form field. Version is read
+//               from metadata.yaml inside the archive; catalog_id and catalog_type in the
+//               archive metadata must match the existing record (immutable). Returns 404 if
+//               no bundle with that bundle_id exists. The existing bundle remains active
+//               until the replacement is validated and activated.
+//  @Tags        Catalog
+//  @Accept      multipart/form-data
+//  @Produce     json
+//  @Security    BearerAuth
+//  @Param       bundle_id    path      string  true   "Internal record ID of the bundle to replace, e.g. bnd_01JW4X9K2M8VQRP3T5YZ"
+//  @Param       file         formData  file    true   ".tar.gz replacement archive (max 50 MB)"
+//  @Param       dry_run      formData  string  false  "Validate only, do not apply (default: false)"
+//  @Success     202  {object}  BundleResponse      "Replacement bundle accepted and processing; version populated after extraction"
+//  @Failure     400  {object}  ErrorResponse       "Missing file field or archive too large"
+//  @Failure     401  {object}  ErrorResponse       "Unauthorized"
+//  @Failure     403  {object}  ErrorResponse       "Admin role required"
+//  @Failure     404  {object}  ErrorResponse       "No bundle with this bundle_id; use POST to create a new one"
+//  @Failure     422  {object}  BundleErrorResponse "Validation failed or immutable fields differ; existing bundle unchanged"
+//  @Router      /catalog/bundles/{bundle_id} [put]
+func (h *BundleHandler) UpdateBundle(c *gin.Context) {
+    // 1. Enforce size limit before reading into memory
+    c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBundleSizeBytes)
+
+    bundleID := c.Param("bundle_id")
+
+    // 2. Resolve existing record by bundle_id — 404 if not found.
+    //    catalog_id and catalog_type are taken from the resolved record; neither
+    //    is supplied by the caller.
+    existing, err := h.bundleService.GetByBundleID(c.Request.Context(), bundleID)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "failed to look up bundle"})
+        return
+    }
+    if existing == nil {
+        c.JSON(http.StatusNotFound, ErrorResponse{
+            Error: fmt.Sprintf("no bundle with id %q; use POST /api/v1/catalog/bundles to create a new one", bundleID),
+        })
+        return
+    }
+
+    // version is NOT a form field — it is read from metadata.yaml inside the archive.
+
+    file, header, err := c.Request.FormFile("file")
+    if err != nil {
+        c.JSON(http.StatusBadRequest, ErrorResponse{Error: "missing or unreadable file field"})
+        return
+    }
+    defer file.Close()
+
+    if !strings.HasSuffix(header.Filename, ".tar.gz") {
+        c.JSON(http.StatusBadRequest, ErrorResponse{Error: "file must be a .tar.gz archive"})
+        return
+    }
+
+    dryRun := c.PostForm("dry_run") == "true"
+    userID := c.GetString(middleware.CtxUserIDKey)
+
+    // catalog_id and catalog_type are both taken from the resolved record.
+    // ValidateBundle and ReplaceBundle verify that the archive's top-level directory
+    // matches existing.CatalogID, and that catalog_id + catalog_type in metadata.yaml
+    // are unchanged (immutable). Version is read from metadata.yaml.
+
+    // 3. Dry-run: synchronous validate-only path — existing bundle is completely untouched.
+    //    The 404 check above still ran, so we know the bundle exists.
+    if dryRun {
+        result, err := h.bundleService.ValidateBundle(c.Request.Context(), file, existing.CatalogID, existing.CatalogType)
+        if err != nil {
+            if valErr, ok := err.(*ValidationError); ok {
+                c.JSON(valErr.Code, valErr)
+                return
+            }
+            c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "dry-run validation failed unexpectedly"})
+            return
+        }
+        c.JSON(http.StatusOK, result)
+        return
+    }
+
+    resp, err := h.bundleService.ReplaceBundle(c.Request.Context(), existing, file, header.Size, userID)
+    // existing carries CatalogID, CatalogType, and the old Name — ReplaceBundle uses all three.
+    // Version is extracted from the archive's metadata.yaml inside ReplaceBundle.
+    if err != nil {
+        if valErr, ok := err.(*ValidationError); ok {
+            c.JSON(valErr.Code, ErrorResponse{Error: valErr.Message})
+            return
+        }
+        c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "bundle replacement failed"})
+        return
+    }
+
+    c.JSON(http.StatusAccepted, resp)
+}
+
+// DeleteBundle godoc
+//
+//  @Summary     Delete a catalog bundle
+//  @Description Removes the bundle identified by bundle_id: deletes the on-disk directory
+//               and the DB record, then reloads CatalogProvider synchronously. Existing
+//               deployed applications are not affected.
+//  @Tags        Catalog
+//  @Produce     json
+//  @Security    BearerAuth
+//  @Param       bundle_id  path  string  true  "Internal record ID of the bundle to delete, e.g. bnd_01JW4X9K2M8VQRP3T5YZ"
+//  @Success     204  "Bundle deleted"
+//  @Failure     401  {object}  ErrorResponse  "Unauthorized"
+//  @Failure     403  {object}  ErrorResponse  "Admin role required"
+//  @Failure     404  {object}  ErrorResponse  "No bundle with this bundle_id"
+//  @Router      /catalog/bundles/{bundle_id} [delete]
+func (h *BundleHandler) DeleteBundle(c *gin.Context) {
+    bundleID := c.Param("bundle_id")
+
+    // 1. Resolve existing record — 404 if not found.
+    existing, err := h.bundleService.GetByBundleID(c.Request.Context(), bundleID)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "failed to look up bundle"})
+        return
+    }
+    if existing == nil {
+        c.JSON(http.StatusNotFound, ErrorResponse{
+            Error: fmt.Sprintf("no bundle with id %q", bundleID),
+        })
+        return
+    }
+
+    // 2. Delete on-disk directory, remove DB record, reload CatalogProvider — all synchronous.
+    if err := h.bundleService.DeleteBundle(c.Request.Context(), existing); err != nil {
+        c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "failed to delete bundle"})
+        return
+    }
+
+    c.Status(http.StatusNoContent)
+}
+```
+
+**`BundleServiceInterface` additions:**
+
+```go
+type BundleServiceInterface interface {
+    // ValidateBundle is the shared dry-run implementation used by both POST and PUT.
+    // It peeks at the archive's top-level directory, verifies it matches catalogID,
+    // extracts to a temp directory, runs CatalogProvider.ValidateFS for the given
+    // catalogType, then deletes the temp directory regardless of outcome.
+    // Returns a *ValidationResult on success (200) or a *ValidationError on failure (422).
+    // No DB row is written and CatalogProvider is never reloaded.
+    ValidateBundle(ctx context.Context, file io.Reader, catalogID, catalogType string) (*ValidationResult, error)
+
+    // ProcessBundle handles a real (non-dry-run) POST upload.
+    // The conflict check is performed by the handler before this is called.
+    // catalogID is the client-supplied identifier; the service verifies it matches
+    // the archive's top-level directory before extracting.
+    ProcessBundle(ctx context.Context, file io.Reader, size int64, userID, catalogID, catalogType, version string) (*BundleResponse, error)
+
+    // ReplaceBundle handles a real (non-dry-run) PUT update.
+    // existing is the current active bundle record; CatalogID, CatalogType, and Name
+    // are all read from it. Version is read from metadata.yaml inside the archive —
+    // it is not passed as a parameter. catalog_id and catalog_type in the archive
+    // metadata are validated to match existing.CatalogID and existing.CatalogType;
+    // a mismatch returns a ValidationError (422). The old on-disk directory is
+    // removed only after the new bundle is marked active.
+    ReplaceBundle(ctx context.Context, existing *Bundle, file io.Reader, size int64, userID string) (*BundleResponse, error)
+
+    // CatalogIDExists returns true if any active bundle row with the given catalog_id exists.
+    CatalogIDExists(ctx context.Context, catalogID string) (bool, error)
+
+    // GetByBundleID returns the bundle record for the given internal bundle ID, or nil.
+    // Used by PUT and DELETE to resolve the bundle from the path parameter.
+    GetByBundleID(ctx context.Context, bundleID string) (*Bundle, error)
+
+    // DeleteBundle removes the bundle's on-disk directory, deletes the DB record,
+    // and calls CatalogProvider.Reload() — all synchronously.
+    // existing must be the resolved record (provides CatalogType, Name for the path).
+    DeleteBundle(ctx context.Context, existing *Bundle) error
+}
+
+// ValidationResult is the 200 OK body returned by a successful dry-run.
+type ValidationResult struct {
+    Valid       bool     `json:"valid"`
+    CatalogID   string   `json:"catalog_id"`
+    CatalogType string   `json:"catalog_type"`
+    Warnings    []string `json:"warnings,omitempty"`
 }
 ```
 
@@ -1443,15 +1853,29 @@ curl -X POST https://catalog-api.<domain>/api/v1/auth/login \
 # Package the custom service directory
 tar -czf my-bundle.tar.gz services/
 
-# Upload the bundle (catalog_type and version are required fields)
+# Upload the bundle — POST creates a new entry (fails with 409 if catalog_id already exists)
 curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
   -H "Authorization: Bearer $(cat token.txt)" \
   -F "file=@my-bundle.tar.gz" \
+  -F "catalog_id=my-service" \
   -F "catalog_type=service" \
   -F "version=1.0.0"
 
 # Poll for activation using the bundle ID from the 202 response
 curl -s https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ \
+  -H "Authorization: Bearer $(cat token.txt)" | jq .status
+# "active"
+
+# Update the bundle — PUT uses the internal bundle_id from the 202 response above.
+# catalog_id, catalog_type, and version are all resolved from the archive metadata;
+# only the file is required. catalog_id and catalog_type are immutable.
+tar -czf my-bundle-v2.tar.gz services/
+curl -X PUT https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ \
+  -H "Authorization: Bearer $(cat token.txt)" \
+  -F "file=@my-bundle-v2.tar.gz"
+
+# Poll for the replacement to go active
+curl -s https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_02EF9Z4PG2Q0XRS5V7WB \
   -H "Authorization: Bearer $(cat token.txt)" | jq .status
 # "active"
 ```
@@ -1497,6 +1921,7 @@ tar -czf chat-bundle.tar.gz services/chat
 curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
   -H "Authorization: Bearer $(cat token.txt)" \
   -F "file=@chat-bundle.tar.gz" \
+  -F "catalog_id=chat" \
   -F "catalog_type=service" \
   -F "version=2.0.0"
 
@@ -1526,16 +1951,48 @@ curl -s https://catalog-api.<domain>/api/v1/services \
 
 ### 10.5 Dry-run validation before applying
 
+`dry_run=true` is **synchronous** — the server extracts the archive to a temporary directory, validates it, cleans up, and replies inline. No `202` + polling is involved; you get a direct `200 OK` or `422`.
+
 ```bash
-# Validate without activating — useful in CI before promoting to production
-# All required fields (catalog_type, version) must be present even for dry_run
+# --- Validate a new bundle (POST dry-run) ---
+# The conflict check is skipped, so this works even if my-service is already registered.
 curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
   -H "Authorization: Bearer $(cat token.txt)" \
   -F "file=@my-bundle.tar.gz" \
+  -F "catalog_id=my-service" \
   -F "catalog_type=service" \
   -F "version=1.0.0" \
   -F "dry_run=true"
-# Returns 202 with status: "validated" (not promoted to active)
+# 200 OK
+# {
+#   "valid": true,
+#   "catalog_id": "my-service",
+#   "catalog_type": "service"
+# }
+
+# --- Validate a replacement bundle before applying (PUT dry-run) ---
+# The 404 check still runs — my-service must be registered, otherwise 404.
+curl -X PUT https://catalog-api.<domain>/api/v1/catalog/bundles/my-service \
+  -H "Authorization: Bearer $(cat token.txt)" \
+  -F "file=@my-bundle-v2.tar.gz" \
+  -F "version=2.0.0" \
+  -F "dry_run=true"
+# 200 OK — existing my-service bundle is completely untouched
+# {
+#   "valid": true,
+#   "catalog_id": "my-service",
+#   "catalog_type": "service"
+# }
+
+# --- Validation failure example ---
+curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
+  -H "Authorization: Bearer $(cat token.txt)" \
+  -F "file=@broken-bundle.tar.gz" \
+  -F "catalog_id=my-service" \
+  -F "catalog_type=service" \
+  -F "version=1.0.0" \
+  -F "dry_run=true"
+# 422 Unprocessable Entity — nothing was written to disk or DB
 ```
 
 ---
@@ -1547,7 +2004,7 @@ curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
 | No bundle uploaded yet | Identical to current — `EmbeddedCatalogFS` only |
 | Volume mounted but no `status='active'` rows in DB | Only `EmbeddedCatalogFS` is used; behaviour identical to today |
 | Custom service has same `id` as built-in | Bundle is rejected with `422`; built-in is never shadowed |
-| Multiple bundles for different `catalog_id` values | All are `active` simultaneously; each is fully independent |
+| Multiple bundles for different `catalog_id` values | All are `active` simultaneously; each is fully independent. At most one bundle (one version) per `catalog_id` is active at any given time. |
 | Existing applications in the database | Unaffected; records reference `catalog_id` strings which remain stable |
 | `catalog_type` value not in the accepted list | Rejected immediately with `400` before the archive is touched |
 | New `catalog_type` value introduced in a future release | Existing clients that receive an unfamiliar `catalog_type` string are unaffected — they simply don't render that bundle type in their UI |

--- a/docs/proposals/catalog/custom-service-templates-proposal.md
+++ b/docs/proposals/catalog/custom-service-templates-proposal.md
@@ -16,13 +16,14 @@
 6. [CatalogProvider Integration](#6-catalogprovider-integration)
 7. [API Upload](#7-api-upload)
 8. [Custom Template Directory Structure](#8-custom-template-directory-structure)
-9. [Template Values Reference](#9-template-values-reference)
-   - 9.1 [Shared (services and components)](#91-shared-services-and-components)
-   - 9.2 [Services](#92-services)
-   - 9.3 [Components](#93-components)
-10. [Usage Examples](#10-usage-examples)
-11. [Backward Compatibility](#11-backward-compatibility)
-12. [Future Enhancements](#12-future-enhancements)
+9. [Remote Deployment](#9-remote-deployment)
+10. [Template Values Reference](#10-template-values-reference)
+    - 10.1 [Shared (services and components)](#101-shared-services-and-components)
+    - 10.2 [Services](#102-services)
+    - 10.3 [Components](#103-components)
+11. [Usage Examples](#11-usage-examples)
+12. [Backward Compatibility](#12-backward-compatibility)
+13. [Future Enhancements](#13-future-enhancements)
 
 ---
 
@@ -949,7 +950,13 @@ Built-in IDs reserved at this time: `chat`, `digitize`, `similarity`, `summarize
 
 ---
 
-## 9. Template Values Reference
+## 9. Remote Deployment
+
+The control-plane catalog server acts as the authoritative bundle registry. Custom service assets are uploaded once to the control plane and stored there. Remote agents do not need to read assets directly — the control-plane catalog backend orchestrates all template resolution and service rendering on their behalf. No `.tar.gz` retention is required; only the extracted asset files are kept on the control-plane volume.
+
+---
+
+## 10. Template Values Reference
 
 > **Scope: Podman only.**  The template values, `@generate` directives, and `ai-services.io/` labels/annotations described in this section apply to the **Podman** runtime, which uses Go-template `.yaml.tmpl` files.  OpenShift custom service templates use Helm charts and a different rendering pipeline; a full reference for that runtime is deferred.
 >
@@ -1422,7 +1429,7 @@ Custom component templates may adopt the same pattern for any key name. The `.en
 
 ---
 
-## 10. Usage Examples
+## 11. Usage Examples
 
 ### 10.1 Upload a custom service bundle
 
@@ -1533,7 +1540,7 @@ curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
 
 ---
 
-## 11. Backward Compatibility
+## 12. Backward Compatibility
 
 | Scenario | Behaviour |
 |---|---|
@@ -1549,7 +1556,7 @@ curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
 
 ---
 
-## 12. Future Enhancements
+## 13. Future Enhancements
 
 1. **Scaffolding generator** — `ai-services catalog scaffold --service my-service --runtime podman` emits a minimal but correct directory skeleton ready to be tar'd and uploaded.
 2. **Template validation command** — `dry_run=true` already supported in §7.2.1; a dedicated CLI command `ai-services catalog validate --bundle <file>` wraps this for local use.
@@ -1558,27 +1565,4 @@ curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
 5. **Version compatibility checks** — validate that a custom service's `version` satisfies any `>=x.y.z` constraint declared by the built-in architecture that references it.
 6. **Role-based upload access** — introduce a `catalog-editor` JWT role that can upload bundles but cannot perform `DELETE /applications` or other destructive operations.
 7. **Component support in bundles** — when `components/` is promoted from reserved to active in the bundle processor, users can ship custom component providers (e.g. a private LLM backend) alongside their services in the same archive.
-8. **Multi-VM deployment — Approach A: control-plane catalog server with existing worker agents** *(Recommended)* — a **hub-and-spoke** topology in which a single control-plane catalog server acts as the authoritative bundle registry. A worker agent is already present on each VM as part of the existing platform deployment. This agent can be extended to fetch bundles from the control plane on demand — specifically at the point when an Application creation is requested — with no shared storage infrastructure, no object store dependency, and no background synchronisation required.
 
-   **How it works:**
-
-   - A customer uploads a bundle once to the **control-plane catalog server** using the same `POST /api/v1/catalog/bundles` API defined in this proposal.
-   - When a request to **create an Application** arrives at a VM, the existing worker agent checks whether the required bundle is already present in its local bundle volume.
-   - If the bundle is not present locally, the agent queries the control-plane catalog server for the bundle, fetches the `.tar.gz` archive over HTTPS, extracts it to its local volume, and triggers `CatalogProvider.Reload()` — the same hot-reload path already defined in this proposal.
-   - The Application creation then proceeds using the locally loaded service template. There is no background polling or push notification — bundles are fetched **lazily, only when needed**.
-   - The local catalog process on each VM uses the extracted files via `FilesystemCatalogFS` — no new loading mechanism is needed on the VM side.
-
-   **Storage implication for the current design:**
-
-   Today, `BundleService.ProcessBundle` discards the original `.tar.gz` after extraction — only the extracted files are kept on the volume. For Approach A to work, the control-plane server must be able to serve the original archive to agents that request it. This means the **raw `.tar.gz` must also be retained** on the control-plane volume alongside the extracted directory. A `raw_archive` sub-path (e.g. `/data/catalog-bundles/raw/<name>.tar.gz`) or a dedicated `raw_path` column in `catalog_bundles` pointing to the stored archive would be sufficient. This is a minor additive change to `BundleService` that does not affect current single-VM behaviour.
-
-9. **Multi-VM deployment — Approach B: object storage backing** — an alternative for environments that already operate object storage infrastructure. Rather than routing bundle fetches through the control plane, a shared object store (S3, MinIO, or IBM COS) acts as the distribution layer. All VMs read bundles directly from the bucket; no agent involvement is required for bundle delivery.
-
-   The design deliberately isolates all bundle I/O behind two thin interfaces, making this straightforward to introduce later:
-
-   - **Read path** — `CatalogFS` interface (`§5.2`). `FilesystemCatalogFS` today calls `os.Open`. An `ObjectStoreCatalogFS` would implement the same three methods (`Open`, `ReadFile`, `ReadDir`) against an object-store prefix. `CatalogProvider`, `loadCatalogItems`, and every existing handler are completely unaware of the change.
-   - **Write path** — `BundleService.ProcessBundle`. Swapping the write target to an object store bucket is a single-function change. The DB row already stores `catalog_type`, `catalog_id`, `name`, and `version`; adding an `object_key` column requires only a minor migration.
-
-   Object-store reads have latency, so `CatalogProvider` would cache bundle files to a local staging directory at startup and after each hot-reload, then serve from that cache — preserving the zero-latency template rendering that `FilesystemCatalogFS` provides today. For **OpenShift multi-replica** deployments this approach also eliminates the need for `ReadWriteMany` PVCs.
-
-   **Relationship to Approach A:** the two approaches are not mutually exclusive. A future architecture could use the control plane as the upload target and object storage as the distribution medium that worker agents pull from, combining the simplicity of Approach A with the scalability of Approach B.

--- a/docs/proposals/catalog/custom-service-templates-proposal.md
+++ b/docs/proposals/catalog/custom-service-templates-proposal.md
@@ -12,8 +12,21 @@
 2. [Background and Motivation](#2-background-and-motivation)
 3. [Catalog Pod Architecture](#3-catalog-pod-architecture)
 4. [New Asset Structure](#4-new-asset-structure)
+    - 4.1 [Built-in service assets (existing)](#41-built-in-service-assets-existing)
+    - 4.2 [Architecture assets (existing)](#42-architecture-assets-existing)
+    - 4.3 [Custom service assets (proposed)](#43-custom-service-assets-proposed)
+    - 4.4 [Custom component assets (proposed)](#44-custom-component-assets-proposed)
 5. [CatalogProvider Integration](#5-catalogprovider-integration)
 6. [API Upload](#6-api-upload)
+    - 6.1 [Design goals](#61-design-goals)
+    - 6.2 [New API endpoints](#62-new-api-endpoints)
+    - 6.3 [Bundle format](#63-bundle-format)
+    - 6.4 [Server-side processing pipeline](#64-server-side-processing-pipeline)
+    - 6.5 [New database migration](#65-new-database-migration)
+    - 6.6 [Storage per runtime](#66-storage-per-runtime)
+    - 6.7 [Upload flow diagrams](#67-upload-flow-diagrams)
+    - 6.8 [Handler and service (Go)](#68-handler-and-service-go--as-implemented)
+    - 6.9 [CLI bundle commands](#69-cli-bundle-commands)
 7. [Custom Template Directory Structure](#7-custom-template-directory-structure)
 8. [Remote Deployment](#8-remote-deployment)
 9. [Template Values Reference](#9-template-values-reference)
@@ -21,8 +34,13 @@
     - 9.2 [Services](#92-services)
     - 9.3 [Components](#93-components)
 10. [Usage Examples](#10-usage-examples)
-11. [Backward Compatibility](#11-backward-compatibility)
-12. [Future Enhancements](#12-future-enhancements)
+    - 10.1 [Upload a custom service bundle](#101-upload-a-custom-service-bundle)
+    - 10.2 [Upload a custom component bundle](#102-upload-a-custom-component-bundle)
+    - 10.3 [Attempt to use a reserved built-in ID (rejected)](#103-attempt-to-use-a-reserved-built-in-id-rejected)
+    - 10.4 [Create an application from the custom service](#104-create-an-application-from-the-custom-service)
+    - 10.5 [List custom services via the catalog API](#105-list-custom-services-via-the-catalog-api)
+    - 10.6 [Validate a bundle before uploading](#106-validate-a-bundle-before-uploading)
+11. [Future Enhancements](#11-future-enhancements)
 
 ---
 
@@ -36,8 +54,10 @@ Built-in platform services are protected: a bundle whose `id` conflicts with an 
 
 | Property | Detail |
 |---|---|
-| **Use case** | Onboard customer-authored service assets into a live catalog deployment |
+| **Use case** | Onboard customer-authored **service and component** assets into a live catalog deployment |
 | **Delivery** | `POST /api/v1/catalog/bundles` — `.tar.gz` archive uploaded over HTTPS to the running catalog |
+| **Bundle types** | `catalog_type: service` — custom services; `catalog_type: component` — custom LLM / embedding / reranker / vector_db providers |
+| **Naming** | Services: `<id>-<version>` on disk; components: `<component_type>-<id>-<version>` (e.g. `llm-my-provider-1.0.0`) |
 | **Podman** | ✅ — bundle stored in dedicated named volume `catalog-bundles` |
 | **OpenShift** | ✅ — bundle stored in dedicated PVC `catalog-bundles` |
 | **Live reload** | Automatic — `CatalogProvider` hot-reloads after successful extraction, no pod restart |
@@ -73,9 +93,9 @@ Currently, there is no supported mechanism to extend the catalog at runtime. Cus
 
 ### 2.3 Goals
 
-1. Provide a secure, authenticated API endpoint (`POST /api/v1/catalog/bundles`) through which customers can register new service assets into a live deployment without platform downtime.
-2. At apiserver startup, compose customer-uploaded bundles with the embedded `CatalogFS` via a `CompositeCatalogFS`, presenting a unified catalog that includes both platform and customer services.
-3. Protect the integrity of built-in platform services — bundles that attempt to use a reserved `catalog_id` are rejected; the embedded catalog is immutable at runtime.
+1. Provide a secure, authenticated API endpoint (`POST /api/v1/catalog/bundles`) through which customers can register new **service and component** assets into a live deployment without platform downtime.
+2. At apiserver startup, load customer-uploaded bundles alongside the embedded `CatalogFS`: `CatalogProvider` queries all `status='active'` bundle rows from the DB and mounts each one via `os.DirFS` rooted at the bundle's on-disk directory, presenting a unified catalog that includes both platform and customer items.
+3. Protect the integrity of built-in platform items — the embedded catalog is loaded first and is immutable at runtime. Custom bundles are loaded on top; a reserved-ID check to reject conflicting uploads (§11.1) is planned.
 4. Maintain full backward compatibility — in the absence of any uploaded bundles, behaviour is identical to the current release.
 
 ---
@@ -134,7 +154,7 @@ flowchart TD
 
 The catalog backend's `CatalogProvider` runs **inside the `ai-services--catalog` container**, not on the CLI host. `assets.CatalogFS` is baked into the binary at build time (via `go:embed`). For custom templates to be visible at runtime they must reach the container and be overlaid onto the embedded FS.
 
-Custom assets are delivered via the running catalog API: the client POSTs a `.tar.gz` bundle over HTTPS, and the apiserver writes the extracted contents to a dedicated named volume (`catalog-bundles` on both Podman and OpenShift) that it already owns. Both runtimes mount the volume at the well-known path `/data/catalog-bundles` inside the container. Bundles are stored under `<catalog_type>/<name>/` where `name = <id>-<version>` (e.g. `service/chat-2.0.0/`). **At most one bundle per `id` is active at any time** — uploading a new version via `PUT` replaces the existing one. At startup, `CatalogProvider` queries the DB for all `status = 'active'` rows, resolves each to its on-disk directory, and loads it alongside the embedded assets using `os.DirFS`. Hot-reload happens in-process after every successful upload; no pod restart is needed.
+Custom assets are delivered via the running catalog API: the client POSTs a `.tar.gz` bundle over HTTPS, and the apiserver writes the extracted contents to a dedicated named volume (`catalog-bundles` on both Podman and OpenShift) that it already owns. Both runtimes mount the volume at the well-known path `/data/catalog-bundles` inside the container. Bundles are stored under `<catalog_type>/<dir_name>/` where `dir_name` is `meta.DirName()` — for services `<id>-<version>` (e.g. `service/my-service-1.0.0/`), for components `<component_type>-<id>-<version>` (e.g. `component/llm-my-provider-1.0.0/`). **At most one bundle per `(catalog_type, catalog_id)` pair is active at any time** — uploading a new version via `PUT` replaces the existing one. At startup, `CatalogProvider` queries the DB for all `status = 'active'` rows, resolves each to its on-disk directory via the `dir_name` column, and loads it alongside the embedded assets using `os.DirFS`. Hot-reload happens in-process after every successful upload; no pod restart is needed.
 
 ### 3.3 OpenShift path
 
@@ -204,12 +224,17 @@ services:
 
 ### 4.3 Custom service assets (proposed)
 
-A user-supplied bundle has the service directory at the **top level** of the archive — the `<service-id>/` directory is the archive root, not nested under `services/`.
+A user-supplied service bundle is a `.tar.gz` archive. Two layouts are accepted:
+
+- **Wrapped** — one top-level directory at the archive root; `metadata.yaml` sits inside it (e.g. `my-service/metadata.yaml`). The top-level directory name is **irrelevant** and is stripped during extraction.
+- **Flat** — no top-level directory; `metadata.yaml` sits at the archive root (e.g. produced by `tar -czf bundle.tar.gz -C my-service/ .`).
+
+In both cases the server writes extracted contents into the directory determined by `meta.DirName()` (i.e. `<id>-<version>`). Identity comes entirely from the `metadata.yaml` inside the archive.
 
 ```
 my-bundle.tar.gz
-└── my-service/                      ← top-level dir; name must match `id` in metadata.yaml
-    ├── metadata.yaml                 # required (id, type, version, ...)
+└── anything/                        ← top-level dir name is irrelevant; stripped on extract
+    ├── metadata.yaml                 # required: id, type, version, (name optional)
     └── podman/
         ├── metadata.yaml            # required (version, resources, podTemplateExecutions)
         ├── values.yaml              # required
@@ -218,7 +243,53 @@ my-bundle.tar.gz
             └── my-service.yaml.tmpl
 ```
 
-The `id` inside `metadata.yaml` must equal the top-level directory name and must **not** match any built-in service — if it does, validation rejects the bundle with a `422` error. `CatalogProvider` uses `os.DirFS` rooted at the extracted bundle directory to load the service's assets alongside the embedded catalog.
+`CatalogProvider` uses `os.DirFS` rooted at the extracted bundle directory (`service/<id>-<version>/`) to load the service's assets alongside the embedded catalog.
+
+### 4.4 Custom component assets (proposed)
+
+Component bundles follow the same archive format but require the additional `component_type` field in `metadata.yaml`. The on-disk directory name is `<component_type>-<id>-<version>` (e.g. `llm-my-provider-1.0.0`) — encoding the component type prevents name collisions when the same `id` is used under different component types (e.g. `llm:my-provider` and `embedding:my-provider` are independent).
+
+```yaml
+# metadata.yaml inside the archive (component example)
+id:             my-provider
+name:           "My Custom LLM Provider"   # optional display label
+type:           component
+component_type: llm                        # required: llm | embedding | reranker | vector_db
+version:        "1.0.0"
+```
+
+```
+my-component-bundle.tar.gz
+└── anything/                        ← wrapped layout (top-level dir stripped); flat layout also accepted
+    ├── metadata.yaml                 # required: id, type, component_type, version
+    └── podman/
+        ├── metadata.yaml            # required (version, resources, podTemplateExecutions)
+        ├── values.yaml              # required
+        ├── values.schema.json       # optional
+        └── templates/
+            └── my-provider.yaml.tmpl
+```
+
+Extracted on-disk as `component/llm-my-provider-1.0.0/` (i.e. `component/<component_type>-<id>-<version>/`). This naming scheme (`<component_type>-<catalog_id>-<version>`) is the canonical form used in both the `dir_name` DB column and the on-disk path.
+
+**Component type values** recognised by the server:
+
+| `component_type` | `DirName()` prefix | DB `catalog_id` |
+|---|---|---|
+| `llm` | `llm-` | `llm:<id>` |
+| `embedding` | `embedding-` | `embedding:<id>` |
+| `reranker` | `reranker-` | `reranker:<id>` |
+| `vector_db` | `vector_db-` | `vector_db:<id>` |
+
+Two component bundles with the same bare `id` but different `component_type` values are stored as entirely independent DB rows and on-disk directories:
+
+```
+/data/catalog-bundles/component/
+├── llm-my-provider-1.0.0/          ← catalog_id: "llm:my-provider"
+└── embedding-my-provider-1.0.0/    ← catalog_id: "embedding:my-provider"  (independent)
+```
+
+The `component_type` field is required. Missing or unrecognised values are rejected with `422`.
 
 ---
 
@@ -229,7 +300,7 @@ The `id` inside `metadata.yaml` must equal the top-level directory name and must
 [`CatalogProvider`](ai-services/internal/pkg/catalog/catalog.go) maintains two separate loading paths in a single `load` / `Reload` cycle:
 
 1. **Embedded items** — `loadEmbeddedItems` walks `assets.CatalogFS` (baked into the binary) and dispatches on the first path segment (`"architectures"`, `"services"`, `"components"`).
-2. **Bundle items** — `loadBundleItems` queries the DB for all `status = 'active'` rows, then for each bundle reads `<bundleDir>/<catalog_id>/metadata.yaml` via `os.DirFS` rooted at the bundle's on-disk directory.
+2. **Bundle items** — `loadBundleItems` queries the DB for all `status = 'active'` rows, then for each bundle reads `metadata.yaml` via `os.DirFS` rooted at the bundle's on-disk directory (`<bundleDir>/metadata.yaml`). Files are extracted with the archive's top-level directory stripped, so `metadata.yaml` lands directly at the bundle root.
 
 ```go
 // loadBundleItems — actual implementation in catalog.go
@@ -238,11 +309,14 @@ func (p *CatalogProvider) loadBundleItems(ctx context.Context, items map[string]
     // ...
     for _, b := range bundles {
         if b.Status != "active" { continue }
-        // /data/catalog-bundles/<catalog_type>s/<name>/
-        bundleDir := filepath.Join(bundleStorageRoot, b.CatalogType+"s", b.Name)
+        // /data/catalog-bundles/<catalog_type>/<dir_name>/
+        bundleDir := filepath.Join(bundleStorageRoot, b.CatalogType, b.DirName)
         bundleFS  := os.DirFS(bundleDir)
-        // reads <catalog_id>/metadata.yaml from the bundle FS
-        parseAndStoreMetadataWithFS(ctx, b.CatalogType+"s", metaPath, b.CatalogID, bundleFS, data, items)
+        metaPath  := "metadata.yaml"
+        data, _   := fs.ReadFile(bundleFS, metaPath)
+        // CatalogType "service"/"component" → "services"/"components" to match the embedded FS dispatch keys
+        catalogType := b.CatalogType + "s"
+        parseAndStoreMetadataWithFS(ctx, catalogType, metaPath, ".", bundleFS, data, items)
     }
     return nil
 }
@@ -253,9 +327,9 @@ func (p *CatalogProvider) loadBundleItems(ctx context.Context, items map[string]
 | Priority | Source | Condition |
 |---|---|---|
 | 1 | Embedded `assets.CatalogFS` | Always loaded first |
-| 2..N | `os.DirFS` per active bundle | DB has `status = 'active'` rows; paths are `/data/catalog-bundles/<catalog_type>s/<name>/` |
+| 2..N | `os.DirFS` per active bundle | DB has `status = 'active'` rows; paths are `/data/catalog-bundles/<catalog_type>/<dir_name>/` |
 
-Bundle items are written into the same `items` map as embedded items, keyed by `catalog_id`. If a bundle uses the same `id` as a built-in item, validation rejects it before insertion (`422`).
+Bundle items are written into the same `items` map as embedded items. Services are keyed by bare `id`; components by `<component_type>:<id>`. If a bundle's `meta.CatalogID()` matches a built-in item of the same type, validation rejects it before insertion (`422`).
 
 ### 5.3 NewCatalogProvider signature
 
@@ -362,7 +436,8 @@ Location: /api/v1/catalog/bundles/550e8400-e29b-41d4-a716-446655440000
 // 201 response body — bundle is already active; size_bytes reflects on-disk size
 {
   "id":           "550e8400-e29b-41d4-a716-446655440000",
-  "name":         "my-service-1.0.0",
+  "name":         "My Custom Service",
+  "dir_name":     "my-service-1.0.0",
   "status":       "active",
   "uploaded_at":  "2026-05-12T09:14:02Z",
   "size_bytes":   286720,
@@ -375,9 +450,9 @@ Location: /api/v1/catalog/bundles/550e8400-e29b-41d4-a716-446655440000
 
 #### 6.2.2 Update bundle — `PUT /api/v1/catalog/bundles/:bundle_id`
 
-Use `PUT` to replace an existing bundle identified by its internal record ID (`bundle_id`). The server looks up the record by `bundle_id` and derives `id` and `type` from it — neither is a form field. The only form field is `file`.
+Use `PUT` to replace an existing bundle identified by its internal record ID (`bundle_id`). The server looks up the record by `bundle_id` and derives `id`, `type`, and for components `component_type` from it — none are form fields. The only form field is `file`.
 
-**Version is not a form field.** The version of the replacement bundle is read from `metadata.yaml` inside the archive. If the metadata carries a new version the on-disk directory is named accordingly (`<id>-<new_version>/`). The `id` and `type` values inside the archive metadata must match the existing DB record — attempts to change them are rejected with `422`.
+**Version is not a form field.** The version of the replacement bundle is read from `metadata.yaml` inside the archive. If the metadata carries a new version the on-disk directory is named accordingly. The `id`, `type`, and (for components) `component_type` values inside the archive metadata must match the existing DB record — attempts to change them are rejected with `422`.
 
 Returns `404` if no bundle with that `bundle_id` exists.
 
@@ -394,7 +469,7 @@ Form fields:
   file        (required)  — .tar.gz archive containing the replacement assets
 ```
 
-> `id`, `type`, and `version` are **not** form fields for `PUT`. `id` and `type` are resolved from the DB record and validated against the archive metadata — mismatches are rejected with `422`. `version` is read from the archive's `metadata.yaml` and used to derive the on-disk bundle name (`<id>-<version>/`).
+> `id`, `type`, `component_type` (for components), and `version` are **not** form fields for `PUT`. `id`, `type`, and `component_type` are resolved from the DB record (`catalog_id` decodes the composite for components) and validated against the archive metadata — mismatches are rejected with `422`. `version` is read from the archive's `metadata.yaml` and used to derive the on-disk directory name via `meta.DirName()`.
 
 **Example (curl):**
 ```bash
@@ -412,15 +487,15 @@ curl -X PUT https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2M8V
 | `401 Unauthorized` | Missing or invalid JWT. |
 | `403 Forbidden` | Token does not carry admin role. |
 | `404 Not Found` | No bundle with the given `bundle_id` exists. Use `POST` to create a new bundle first. |
-| `422 Unprocessable Entity` | Validation of the archive's `metadata.yaml` failed, or `id`/`type` differs from the existing record. The DB row is not modified; the existing bundle remains active. |
+| `422 Unprocessable Entity` | Validation of the archive's `metadata.yaml` failed; or `id`, `type`, or `component_type` (for components) differs from the existing record. The DB row is not modified; the existing bundle remains active. |
 
-The `202` response returns the **same bundle ID** the client already holds — no new ID is issued. The existing row is updated in-place by the async goroutine (`status=active`, `version`, `name`, `size_bytes` set in a single UPDATE). The old on-disk directory is deleted only after the row is successfully updated. If extraction fails, the DB row is left unchanged — the existing bundle remains active and serving.
+The `202` response returns the **same bundle ID** the client already holds — no new ID is issued. The existing row is updated in-place by the async goroutine (`status=active`, `version`, `dir_name`, `name`, `size_bytes` set in a single UPDATE). The old on-disk directory is deleted only after the row is successfully updated. If extraction fails, the DB row is left unchanged — the existing bundle remains active and serving.
 
 ---
 
 #### 6.2.3 Delete bundle — `DELETE /api/v1/catalog/bundles/:bundle_id`
 
-Permanently removes a bundle: deletes the on-disk directory (`<catalog_type>/<catalog_id>-<version>/`) from the bundle volume, removes the DB row, and triggers a `CatalogProvider.Reload()` so the item is no longer served. Any application that was deployed using this bundle's `catalog_id` is **not** affected — existing deployed resources are independent of the catalog once launched.
+Permanently removes a bundle: deletes the on-disk directory (`<catalog_type>/<dir_name>/`) from the bundle volume, removes the DB row, and triggers a `CatalogProvider.Reload()` so the item is no longer served. Any application that was deployed using this bundle's `catalog_id` is **not** affected — existing deployed resources are independent of the catalog once launched.
 
 ```
 DELETE /api/v1/catalog/bundles/:bundle_id
@@ -454,15 +529,20 @@ curl -X DELETE https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2
 
 Each bundle record carries `catalog_type` and `catalog_id` (derived from the archive's `id` and `type` fields). Multiple bundles for different items are all active simultaneously and each is listed independently.
 
+Two name-related fields appear in every response:
+- **`name`** — the human-readable display label from `metadata.yaml` `name:` field (e.g. `"My Custom LLM Provider"`). May be `null` if omitted from the archive.
+- **`dir_name`** — the server-determined on-disk directory name. Services: `<id>-<version>`; components: `<component_type>-<catalog_id>-<version>`.
+
 ```json
 {
   "bundles": [
     {
       "id":           "550e8400-e29b-41d4-a716-446655440000",
+      "name":         "My Custom Service",
+      "dir_name":     "my-service-1.0.0",
       "status":       "active",
       "uploaded_at":  "2026-05-12T09:14:02Z",
       "size_bytes":   286720,
-      "name":         "my-service-1.0.0",
       "catalog_type": "service",
       "catalog_id":   "my-service",
       "version":      "1.0.0",
@@ -470,12 +550,13 @@ Each bundle record carries `catalog_type` and `catalog_id` (derived from the arc
     },
     {
       "id":           "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-      "name":         "my-llm-provider-1.0.0",
+      "name":         "My Custom LLM Provider",
+      "dir_name":     "llm-my-provider-1.0.0",
       "status":       "active",
       "uploaded_at":  "2026-05-13T11:30:00Z",
       "size_bytes":   196608,
       "catalog_type": "component",
-      "catalog_id":   "my-llm-provider",
+      "catalog_id":   "llm:my-provider",
       "version":      "1.0.0",
       "uploaded_by":  "admin"
     }
@@ -487,14 +568,14 @@ Each bundle record carries `catalog_type` and `catalog_id` (derived from the arc
 
 ### 6.3 Bundle format
 
-A bundle is scoped to **one catalog item**. The archive must be a gzip-compressed tar (`.tar.gz`). The `id` and `version` together form the unique on-disk directory name (`<id>-<version>`).
+A bundle is scoped to **one catalog item**. The archive must be a gzip-compressed tar (`.tar.gz`). The identity of a bundle comes entirely from `metadata.yaml` content — **the archive top-level directory name is irrelevant and is not validated**. The server strips it during extraction and writes into the server-determined destination directory (`meta.DirName()`).
 
-For **both POST and PUT**, `id`, `type`, and `version` are read from `metadata.yaml` inside the archive — they are not form fields. For **PUT**, `id` and `type` must also match the existing DB record (immutable); a mismatch is rejected with `422`.
+For **both POST and PUT**, `id`, `type`, `version` (and `component_type` for components) are read from `metadata.yaml` inside the archive — they are not form fields. For **PUT**, `meta.CatalogID()` and `meta.CatalogType()` must also match the existing DB record (immutable); a mismatch is rejected with `422`.
 
-The top-level `metadata.yaml` inside the archive uses standard service fields:
+#### Service bundle
 
 ```yaml
-# my-service/metadata.yaml
+# metadata.yaml (inside the archive top-level dir — dir name is irrelevant)
 id:      my-service
 name:    "My Custom Service"
 type:    service
@@ -503,8 +584,8 @@ version: "1.0.0"
 
 ```
 my-bundle.tar.gz
-└── my-service/                     ← directory name must match `id` in metadata.yaml
-    ├── metadata.yaml               ← declares id, type, version (and name, description, etc.)
+└── anything/                       ← top-level dir name is irrelevant; stripped on extract
+    ├── metadata.yaml               ← id, type, version are read from here
     └── podman/
         ├── metadata.yaml
         ├── values.yaml
@@ -512,15 +593,43 @@ my-bundle.tar.gz
             └── my-service.yaml.tmpl
 ```
 
-`id` and `version` from `metadata.yaml` are combined to determine the on-disk bundle name (`my-service-1.0.0/`).
+Extracted on-disk as `service/my-service-1.0.0/` — `meta.DirName()` is the authoritative destination.
 
-**Rules:**
+#### Component bundle
+
+```yaml
+# metadata.yaml
+id:             my-provider
+name:           "My Custom LLM Provider"
+type:           component
+component_type: llm
+version:        "1.0.0"
+```
+
+```
+my-component-bundle.tar.gz
+└── anything/                       ← top-level dir name is irrelevant; stripped on extract
+    ├── metadata.yaml               ← id, type, component_type, version are read from here
+    └── podman/
+        ├── metadata.yaml
+        ├── values.yaml
+        └── templates/
+            └── my-provider.yaml.tmpl
+```
+
+Extracted on-disk as `component/llm-my-provider-1.0.0/` — `meta.DirName()` is the authoritative destination.
+
+**Rules (both types):**
 - Paths containing `..` or absolute paths are rejected immediately (path-traversal guard).
 - The archive must contain exactly one top-level directory; multiple items per archive are not supported.
-- The top-level directory name inside the archive must exactly equal `id` from `metadata.yaml` — a mismatch is rejected with `422`.
+- The top-level directory name is **not validated** — it is stripped and discarded. Identity comes from `metadata.yaml` alone.
 - Total uncompressed size must not exceed 200 MB.
-- The `id` must not match any built-in service already present in `assets.CatalogFS` — if it does, validation returns `422` and the extracted directory is deleted.
+- `meta.CatalogID()` must not match any built-in item already present in `assets.CatalogFS` — if it does, validation returns `422` and the extracted directory is deleted.
 - All `metadata.yaml` files must pass validation for the declared `type` before the bundle is marked `active`.
+
+**Rules (component bundles only):**
+- `component_type` is required. Missing or unrecognised values are rejected with `422`.
+- Within a given `component_type`, no two active bundles may share the same `id`. The DB unique index on `(catalog_type, catalog_id) WHERE status='active'` enforces this since `"llm:my-provider"` is distinct from `"embedding:my-provider"`.
 
 ---
 
@@ -532,18 +641,18 @@ my-bundle.tar.gz
 flowchart TD
     REQ["POST /api/v1/catalog/bundles<br/>multipart/form-data — file"]
     AUTH["AuthMiddleware<br/>JWT + admin role check"]
-    PEEK["Peek metadata.yaml<br/>read id, type, version → 422 if missing/invalid"]
-    CONFLICT["Check catalog_bundles table<br/>active row for id?"]
+    PEEK["Peek metadata.yaml<br/>read id, type, version + component_type for components<br/>→ 422 if missing/invalid"]
+    CONFLICT["Check catalog_bundles table<br/>active row for meta.CatalogID()?"]
     CONFLICT_RESP["409 Conflict<br/>use PUT /catalog/bundles/:bundle_id to update"]
     SIZE["Size guard — 200 MB uncompressed"]
-    EXTRACT["Extract to /data/catalog-bundles/type/id-version/<br/>(top-level dir stripped; files land directly in id-version/)"]
+    EXTRACT["Extract to meta.DirName()/ inside bundle volume<br/>(top-level dir stripped regardless of its name)"]
     PATHGUARD["Path-traversal guard<br/>reject .. and absolute paths"]
     VALIDATE["validateBundleStructure<br/>metadata.yaml present at bundle root"]
     DBINSERT["Insert bundle record (status=processing)<br/>id generated by DB via gen_random_uuid()"]
-    ACTIVATE["Activate: status=active, size_bytes, version, name<br/>single UPDATE"]
+    ACTIVATE["Activate: status=active, size_bytes, version, dir_name<br/>single UPDATE"]
     RELOAD["CatalogProvider.Reload()"]
     RESP["201 Created — BundleResponse (re-fetched from DB)<br/>status: active, size_bytes populated<br/>Location: /api/v1/catalog/bundles/:uuid"]
-    FAIL["Delete id-version/ directory + DB row<br/>return 422/400"]
+    FAIL["Delete meta.DirName()/ directory + DB row<br/>return 422/400"]
 
     REQ --> AUTH --> PEEK
     PEEK --> CONFLICT
@@ -560,25 +669,24 @@ flowchart TD
     REQ["PUT /api/v1/catalog/bundles/:bundle_id<br/>multipart/form-data — file"]
     AUTH["AuthMiddleware<br/>JWT + admin role check"]
     LOOKUP["Look up bundle_id in catalog_bundles → 404 if missing"]
-    PEEK["Peek metadata.yaml<br/>validate id + type unchanged → 422 on mismatch"]
+    PEEK["Peek metadata.yaml<br/>validate meta.CatalogID() + meta.CatalogType() unchanged<br/>→ 422 on mismatch"]
     RESP["202 Accepted immediately<br/>same bundle_id, status: active (current)<br/>Location: /api/v1/catalog/bundles/:bundle_id"]
 
     subgraph ASYNC["Goroutine — async after 202"]
-        EXTRACT["Extract to /data/catalog-bundles/type/new-name/<br/>(top-level dir stripped)"]
-        PATHGUARD["Path-traversal guard"]
+        EXTRACT["extractAndMeasure: extract to meta.DirName()/ inside bundle volume<br/>• top-level dir stripped (wrapped or flat archive)<br/>• path-traversal guard + 200 MB size guard"]
         VALIDATE["validateBundleStructure"]
 
         subgraph ACTIVATE["Activate — success path"]
             direction LR
-            DBUPDATE["UPDATE existing row in-place<br/>status=active, version, name, size_bytes<br/>single UPDATE — no unique index conflict"]
-            RMOLDDIR["Delete old type/old-name/ directory<br/>(only if name changed)"]
+            DBUPDATE["UPDATE existing row in-place<br/>status=active, version, dir_name, name, size_bytes<br/>single UPDATE — no unique index conflict"]
+            RMOLDDIR["Delete old directory<br/>(only if dir_name changed)"]
             RELOAD["CatalogProvider.Reload()"]
             DBUPDATE --> RMOLDDIR --> RELOAD
         end
 
-        FAIL["Delete new type/new-name/ directory<br/>DB row left unchanged — existing bundle still active"]
+        FAIL["Delete new meta.DirName()/ directory<br/>DB row left unchanged — existing bundle still active"]
 
-        EXTRACT --> PATHGUARD --> VALIDATE
+        EXTRACT --> VALIDATE
         VALIDATE -->|"valid"| ACTIVATE
         VALIDATE -->|"invalid"| FAIL
     end
@@ -591,13 +699,15 @@ flowchart TD
 
 - **POST is fully synchronous.** Returns `201 Created` only after extraction, validation, DB activate, and `CatalogProvider.Reload()` all succeed. Response is re-fetched from DB — `status`, `size_bytes`, and `uploaded_at` are authoritative.
 - **PUT sync phase** validates the archive and immutable fields only. Returns `202 Accepted` immediately with the **same bundle ID** — no new row is inserted.
-- **PUT async phase** extracts, validates, then UPDATEs the existing row in-place (`status=active`, `version`, `name`, `size_bytes` — single statement). No unique index conflict is possible since only one row ever exists for this `catalog_id`. If extraction fails the DB row is left unchanged — the existing bundle stays active. **Directory behaviour:** same version → files overwritten in the existing directory, nothing deleted; new version → new `<id>-<new_version>/` directory created, old `<id>-<old_version>/` deleted after activation.
+- **PUT async phase** extracts, validates, then UPDATEs the existing row in-place (`status=active`, `version`, `dir_name`, `size_bytes` — single statement). No unique index conflict is possible since only one row ever exists for this `(catalog_type, catalog_id)`. If extraction fails the DB row is left unchanged — the existing bundle stays active. **Directory behaviour:** same version → overwritten in-place; new version → new `meta.DirName()/` directory created, old one deleted after activation.
 - `id` (bundle UUID) is **generated by the DB** via `gen_random_uuid()` — the server never supplies it.
-- `id`, `type`, and `version` are **never form fields** — all three are read from `metadata.yaml` inside the archive by `peekMetadata()`.
-- `peekMetadata()` infers the top-level directory from the first entry that contains a `/` — root-level loose files (macOS `._*`, `.DS_Store`, Windows `Thumbs.db`, etc.) are ignored for `topDir` inference.
-- The archive's top-level directory is **stripped during extraction** — files land directly in `<id>-<version>/` with no redundant subdirectory.
-- On-disk layout: `/data/catalog-bundles/<catalog_type>/<catalog_id>-<version>/` e.g. `/data/catalog-bundles/service/mayuka-service-1.0.0/`
-- **PUT** immutability check: `id` and `type` from the archive must match the existing DB record. `version` may differ. Mismatch → `422`, no extraction attempted.
+- `id`, `type`, `version` (and `component_type` for components) are **never form fields** — all are read from `metadata.yaml` inside the archive by `peekMetadata()`. The **archive top-level directory name is never validated** — it is stripped blindly.
+- `peekMetadata()` infers the top-level directory from the first entry containing a `/` solely to locate `<topDir>/metadata.yaml`. The directory name itself is not compared against any metadata field.
+- `extractAndMeasure` takes no `catalogID` parameter — it strips the archive top-level directory and writes into the caller-supplied `destDir` (`bundleDirPath(meta.CatalogType(), meta.DirName())`).
+- On-disk layout:
+  - Services: `/data/catalog-bundles/service/<id>-<version>/` e.g. `/data/catalog-bundles/service/my-service-1.0.0/`
+  - Components: `/data/catalog-bundles/component/<component_type>-<id>-<version>/` e.g. `/data/catalog-bundles/component/llm-my-provider-1.0.0/`
+- **PUT** immutability check: `meta.CatalogID()` and `meta.CatalogType()` from the archive must match the existing DB record. `version` may differ. Mismatch → `422`, no extraction attempted.
 - `CatalogProvider.Reload()` re-queries the DB and rebuilds the in-memory catalog under `sync.RWMutex`.
 - Bundle files are stored in the **dedicated `catalog-bundles` volume** — isolated from `$BASE_DIR`.
 - The `catalog_bundles` table is added via a Goose migration (`20260430094507_create_catalog_bundles_table.sql`).
@@ -606,7 +716,11 @@ flowchart TD
 
 ### 6.5 New database migration
 
-Each row in `catalog_bundles` represents one uploaded bundle. The `id` is a UUID generated by the DB via `gen_random_uuid()` — the server never supplies it. The `name` column is derived server-side as `<catalog_id>-<version>` (e.g. `my-service-1.0.0`) and is used as the on-disk directory name. The `status` column tracks lifecycle: **POST** inserts a new row as `processing` then activates it with a single `Activate` UPDATE. **PUT** updates the existing row in-place with the same `Activate` UPDATE — no new row is ever inserted for a replace operation. **Only one `active` row per `catalog_id` is permitted** — enforced by a partial unique index; the in-place UPDATE for PUT never violates it since only one row exists.
+Each row in `catalog_bundles` represents one uploaded bundle. The `id` is a UUID generated by the DB via `gen_random_uuid()` — the server never supplies it. Two name-related columns are stored:
+- **`name`** — the human-readable display label from `metadata.yaml` `name:` field (e.g. `"My Custom LLM Provider"`). Not unique — the same display name may appear across different component types.
+- **`dir_name`** — the server-determined on-disk directory name (`meta.DirName()`), used for routing to the bundle volume. Always unique per active `(catalog_type, catalog_id)`.
+
+The `status` column tracks lifecycle: **POST** inserts a new row as `processing` then activates it with a single `Activate` UPDATE. **PUT** updates the existing row in-place — no new row is ever inserted. **Only one `active` row per `(catalog_type, catalog_id)` is permitted** — enforced by a partial composite unique index.
 
 ```sql
 -- +goose Up
@@ -618,22 +732,32 @@ CREATE TYPE bundle_status AS ENUM (
 );
 
 CREATE TABLE catalog_bundles (
-    -- UUID generated by the DB — never supplied by the client.
+    -- UUID generated by the DB via gen_random_uuid() — never supplied by the client.
     id               UUID           PRIMARY KEY DEFAULT gen_random_uuid(),
 
-    -- Human-readable versioned name: <catalog_id>-<version>, e.g. "my-service-1.0.0"
-    -- Used as the directory name on the bundle volume.
-    name             VARCHAR(200)   NOT NULL,
+    -- Human-readable display label from metadata.yaml `name:` field.
+    -- e.g. "My Custom Service", "My Custom LLM Provider"
+    -- Not required to be unique — the same label may appear for different catalog_ids.
+    name             VARCHAR(255),
+
+    -- Server-determined on-disk directory name: meta.DirName().
+    -- Services:   <id>-<version>                       e.g. "my-service-1.0.0"
+    -- Components: <component_type>-<id>-<version>       e.g. "llm-my-provider-1.0.0"
+    dir_name         VARCHAR(200)   NOT NULL,
 
     status           bundle_status  NOT NULL DEFAULT 'processing',
     -- Uncompressed on-disk size in bytes, populated after extraction completes.
     -- NULL until the bundle reaches 'active' or 'failed'.
     size_bytes       BIGINT,
 
-    -- The catalog item type declared by the uploader: "service", "component", …
+    -- The catalog item type: "service" or "component".
     catalog_type     VARCHAR(50)    NOT NULL,
-    -- The id of the catalog item: e.g. "my-service", "my-llm-provider"
-    catalog_id       VARCHAR(100)   NOT NULL,
+
+    -- Unique identity of the catalog item within its type.
+    -- Services:   bare id                              e.g. "my-service"
+    -- Components: composite <component_type>:<id>      e.g. "llm:my-provider"
+    catalog_id       VARCHAR(200)   NOT NULL,
+
     -- Semantic version of this bundle: e.g. "1.0.0", "2.1.0"
     version          VARCHAR(50)    NOT NULL DEFAULT '',
 
@@ -642,17 +766,20 @@ CREATE TABLE catalog_bundles (
     uploaded_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW()
 );
 
--- Enforce one active bundle per catalog_id at the DB level.
--- 'processing' and 'failed' rows are exempt so that a replacement upload
--- in flight does not block itself.
-CREATE UNIQUE INDEX uq_catalog_bundles_active_catalog_id
-    ON catalog_bundles (catalog_id)
+-- Enforce at most one active bundle per (catalog_type, catalog_id) pair.
+-- Using the composite key makes the constraint explicit and future-proof:
+-- a new catalog_type with the same catalog_id string as an existing one
+-- is correctly treated as a distinct item.
+-- 'processing' and 'failed' rows are exempt so a replacement in-flight
+-- does not block itself.
+CREATE UNIQUE INDEX uq_catalog_bundles_active
+    ON catalog_bundles (catalog_type, catalog_id)
     WHERE status = 'active';
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
-DROP INDEX  IF EXISTS uq_catalog_bundles_active_catalog_id;
+DROP INDEX  IF EXISTS uq_catalog_bundles_active;
 DROP TABLE  IF EXISTS catalog_bundles;
 DROP TYPE   IF EXISTS bundle_status;
 -- +goose StatementEnd
@@ -666,30 +793,29 @@ Bundle storage is **intentionally isolated** from `$AI_SERVICES_BASE_DIR`. This 
 
 #### Volume directory layout
 
-The volume is organised as `<catalog_type>s/<name>/` where `name` is `<id>-<version>` (e.g. `chat-2.0.0`). At most **one versioned directory per `id`** exists on disk at any time — a `PUT` replaces the old directory with the new one once the replacement is marked `active`. Bundles for different `id` values coexist independently.
+The volume is organised as `<catalog_type>/<dir_name>/` where `dir_name` is `meta.DirName()`. At most **one versioned directory per `(catalog_type, catalog_id)` pair** exists on disk at any time — a `PUT` replaces the old directory with the new one once the replacement is marked `active`. Bundles for different `catalog_id` values (within or across types) coexist independently.
 
 ```
 /data/catalog-bundles/
-├── services/
-│   ├── chat-2.0.0/              ← active (one version of "chat" at a time)
-│   │   └── chat/
-│   │       ├── metadata.yaml
-│   │       └── podman/...
-│   └── my-service-1.0.0/        ← active (independent id)
-│       └── my-service/
-│           ├── metadata.yaml
-│           └── podman/...
-└── components/
-    └── my-llm-provider-1.0.0/   ← active (independent id)
-        └── my-llm-provider/
-            └── metadata.yaml
+├── service/
+│   ├── my-service-1.0.0/        ← dir_name: "my-service-1.0.0"  name: "My Custom Service"
+│   │   ├── metadata.yaml
+│   │   └── podman/...
+│   └── my-service-2.0.0/        ← would replace the above on PUT
+└── component/
+    ├── llm-my-provider-1.0.0/   ← dir_name: "llm-my-provider-1.0.0"  name: "My Custom LLM Provider"
+    │   ├── metadata.yaml
+    │   └── podman/...
+    └── embedding-my-provider-1.0.0/  ← same display name permitted, different catalog_id
+        ├── metadata.yaml
+        └── podman/...
 ```
 
 The `CatalogProvider` resolves each active item's path as:
 ```
-/data/catalog-bundles/<catalog_type>s/<name>/
+/data/catalog-bundles/<catalog_type>/<dir_name>/
 ```
-where `name = <id>-<version>` (derived from DB record).
+where `dir_name` is taken directly from the DB `dir_name` column.
 
 #### Podman — named volume `catalog-bundles`
 
@@ -760,7 +886,7 @@ flowchart TD
     end
 
     subgraph VOL["Podman named volume — catalog-bundles"]
-        BUNDLES["mount: /data/catalog-bundles<br/>services/id-version/<br/>components/id-version/"]
+        BUNDLES["mount: /data/catalog-bundles<br/>service/&lt;id&gt;-&lt;version&gt;/<br/>component/&lt;component_type&gt;-&lt;id&gt;-&lt;version&gt;/"]
     end
 
     PG["ai-services--db<br/>postgresql<br/>catalog_bundles table"]
@@ -835,8 +961,9 @@ func (h *BundleHandler) UploadBundle(c *gin.Context) {
 
     userID := c.GetString(middleware.CtxUserIDKey)
 
-    // ProcessBundle: peek metadata → conflict check → extract → validate →
-    //                insert DB row as active → reload → return 201.
+    // ProcessBundle: peek metadata → build BundleMetadata (ServiceMetadata or ComponentMetadata)
+    //                → conflict check (catalog_type + catalog_id) → extract to meta.DirName()
+    //                → validate → insert DB row as active → reload → return 201.
     resp, err := h.bundleService.ProcessBundle(c.Request.Context(), file, userID)
     // ... 409 / 422 / 500 handled by ValidationError.Code ...
     c.Header("Location", fmt.Sprintf("/api/v1/catalog/bundles/%s", resp.ID))
@@ -856,10 +983,10 @@ func (h *BundleHandler) UpdateBundle(c *gin.Context) {
     file, header, err := c.Request.FormFile("file")
     // ... 400 if missing or not .tar.gz ...
 
-    // ReplaceBundle: peek metadata → validate catalog_id/catalog_type immutable →
+    // ReplaceBundle: peek metadata → validate meta.CatalogID()/meta.CatalogType() immutable →
     //                return 202 immediately with existing ID →
-    //                goroutine: extract, UPDATE existing row in-place, delete old dir if
-    //                name changed, reload. On failure DB row is left unchanged.
+    //                goroutine: extract to meta.DirName(), UPDATE existing row in-place,
+    //                delete old dir if dir_name changed, reload. On failure DB row unchanged.
     resp, err := h.bundleService.ReplaceBundle(c.Request.Context(), existing, file, userID)
     c.Header("Location", fmt.Sprintf("/api/v1/catalog/bundles/%s", resp.ID))
     c.JSON(http.StatusAccepted, resp)
@@ -874,7 +1001,8 @@ type BundleServiceInterface interface {
     // Reads id, type, version from metadata.yaml inside the archive,
     // extracts to a temp directory, validates structure, then cleans up.
     // No DB row is written and no reload is triggered.
-    ValidateBundle(ctx context.Context, file io.Reader) (*ValidationResult, error)
+    // Returns a ServiceValidationResult or ComponentValidationResult (both implement ValidationResult).
+    ValidateBundle(ctx context.Context, file io.Reader) (ValidationResult, error)
 
     // ProcessBundle — synchronous POST upload.
     // Reads metadata from archive, checks conflict, extracts to permanent dir,
@@ -885,8 +1013,8 @@ type BundleServiceInterface interface {
     // ReplaceBundle — async PUT update.
     // Sync: validates archive and immutable fields, returns 202 immediately (same bundle ID).
     // Async goroutine: extracts, validates, UPDATEs existing row in-place
-    //       (status=active, version, name, size_bytes — single statement),
-    //       deletes old on-disk directory if name changed, reloads catalog.
+    //       (status=active, version, dir_name, name, size_bytes — single statement),
+    //       deletes old on-disk directory if dir_name changed, reloads catalog.
     //       On failure: DB row left unchanged — existing bundle stays active.
     ReplaceBundle(ctx context.Context, existing *BundleRecord, file io.Reader, userID string) (*BundleResponse, error)
 
@@ -902,23 +1030,182 @@ type BundleServiceInterface interface {
 ```go
 // BundleRecord is the service-layer view of a DB row.
 type BundleRecord struct {
-    ID, Name, Status, CatalogType, CatalogID, Version, UploadedBy string
+    ID, Name, DirName, Status, CatalogType, CatalogID, Version, UploadedBy string
     SizeBytes  *int64
     UploadedAt time.Time
 }
 
-// BundleMetadata holds the fields read from metadata.yaml inside an archive.
-type BundleMetadata struct {
-    CatalogID, CatalogType, Version string
+// BundleMetadata is the interface returned by peekMetadata. Each concrete type
+// carries the scalar fields from its metadata.yaml and encodes all
+// type-specific derivations as methods — no type assertions needed in the pipeline.
+//
+// Adding a new catalog type (e.g. "architecture") means:
+//   1. Define a new concrete struct implementing this interface.
+//   2. Add a case in parseMetadataYAML to construct it.
+//   3. The rest of the pipeline (ProcessBundle, ReplaceBundle, ValidateBundle)
+//      is unchanged — it calls only these methods.
+type BundleMetadata interface {
+    // CatalogID returns the globally unique value stored in the DB catalog_id column.
+    // Services:   bare id                         e.g. "my-service"
+    // Components: composite <component_type>:<id>  e.g. "llm:my-provider"
+    //
+    // This is what the DB unique index and conflict checks operate on.
+    CatalogID() string
+
+    // CatalogType returns "service" or "component".
+    CatalogType() string
+
+    // Version returns the semantic version string.
+    Version() string
+
+    // DirName returns the server-determined on-disk directory name (DB dir_name column).
+    // Services:   <id>-<version>                       e.g. "my-service-1.0.0"
+    // Components: <component_type>-<id>-<version>       e.g. "llm-my-provider-1.0.0"
+    //
+    // This is what extractAndMeasure writes into — the archive top-level directory
+    // is stripped and discarded; DirName() is the authoritative destination.
+    // Always filesystem-safe (no "/" characters).
+    DirName() string
+
+    // DisplayName returns the human-readable label from the metadata.yaml `name:` field.
+    // e.g. "My Custom Service", "My Custom LLM Provider"
+    // Not globally unique — the same label may appear for different catalog_ids.
+    DisplayName() string
 }
 
-// ValidationResult is the 200 OK body for POST /catalog/bundles/validate.
-type ValidationResult struct {
-    Valid       bool   `json:"valid"`
-    CatalogID   string `json:"catalog_id"`
-    CatalogType string `json:"catalog_type"`
-    Version     string `json:"version"`
+// ServiceMetadata is the BundleMetadata implementation for catalog_type="service".
+type ServiceMetadata struct {
+    id          string
+    version     string
+    displayName string
 }
+
+func (m *ServiceMetadata) CatalogID() string    { return m.id }
+func (m *ServiceMetadata) CatalogType() string  { return "service" }
+func (m *ServiceMetadata) Version() string      { return m.version }
+func (m *ServiceMetadata) DirName() string      { return m.id + "-" + m.version }
+func (m *ServiceMetadata) DisplayName() string  { return m.displayName }
+
+// ComponentMetadata is the BundleMetadata implementation for catalog_type="component".
+// ComponentType is required and must be one of the recognised component types
+// (llm, embedding, reranker, vector_store). The CatalogID is the composite
+// "<component_type>:<id>" and the on-disk DirName encodes both with a dash separator.
+//
+// The same id may exist under different component types — they produce different
+// CatalogID() values ("llm:my-provider" vs "embedding:my-provider") and are
+// stored as entirely independent DB rows and on-disk directories.
+// The same DisplayName() may also appear across types — it is not unique.
+type ComponentMetadata struct {
+    id            string
+    componentType string
+    version       string
+    displayName   string
+}
+
+func (m *ComponentMetadata) CatalogID() string   { return m.componentType + ":" + m.id }
+func (m *ComponentMetadata) CatalogType() string { return "component" }
+func (m *ComponentMetadata) Version() string     { return m.version }
+func (m *ComponentMetadata) DirName() string     { return m.componentType + "-" + m.id + "-" + m.version }
+func (m *ComponentMetadata) DisplayName() string { return m.displayName }
+
+// ComponentType returns the component_type for this metadata.
+// Defined on the concrete type — callers that need it type-assert to *ComponentMetadata.
+func (m *ComponentMetadata) ComponentType() string { return m.componentType }
+```
+
+`parseMetadataYAML` reads `id`, `type`, `name`, `version` (and `component_type` for components) as scalar fields. For `component`, `component_type` is required and rejected with `422` if absent or unrecognised. `ProcessBundle` and `ReplaceBundle` call only the `BundleMetadata` interface methods. `ValidateBundle` performs a single type-assertion `meta.(*ComponentMetadata)` to populate the `ComponentType` field on `ComponentValidationResult` — this is the only place where a type switch on the concrete metadata type occurs. `extractAndMeasure` takes no `catalogID` parameter — it strips the archive top-level directory blindly and writes into the caller-supplied `destDir` (`meta.DirName()`).
+
+```go
+// ValidationResult is the interface returned by ValidateBundle and serialised as the
+// 200 OK body for POST /catalog/bundles/validate.
+// Concrete types: ServiceValidationResult, ComponentValidationResult.
+//
+// Adding a new catalog type means:
+//   1. Define a new concrete struct implementing this interface.
+//   2. Add a case in parseMetadataYAML / ValidateBundle to construct it.
+//   3. MarshalJSON on the handler side serialises whichever concrete type is returned.
+type ValidationResult interface {
+    // IsValid reports whether the archive passed validation.
+    IsValid() bool
+
+    // GetCatalogType returns "service" or "component".
+    GetCatalogType() string
+
+    // GetCatalogID returns the same value as BundleMetadata.CatalogID():
+    // bare id for services, composite "<component_type>:<id>" for components.
+    GetCatalogID() string
+
+    // GetVersion returns the semantic version string from metadata.yaml.
+    GetVersion() string
+
+    // GetDisplayName returns the human-readable label from metadata.yaml `name:`.
+    GetDisplayName() string
+
+    // GetDirName returns the server-determined on-disk directory name.
+    // Services:   <id>-<version>                  e.g. "my-service-1.0.0"
+    // Components: <component_type>-<id>-<version>  e.g. "llm-my-provider-1.0.0"
+    GetDirName() string
+}
+
+// ServiceValidationResult is the ValidationResult implementation for catalog_type="service".
+// JSON shape:
+//
+//	{
+//	  "valid":        true,
+//	  "catalog_type": "service",
+//	  "catalog_id":   "my-service",
+//	  "version":      "1.0.0",
+//	  "name":         "My Custom Service",
+//	  "dir_name":     "my-service-1.0.0"
+//	}
+type ServiceValidationResult struct {
+    Valid       bool   `json:"valid"`
+    CatalogType string `json:"catalog_type"`
+    CatalogID   string `json:"catalog_id"`
+    Version     string `json:"version"`
+    Name        string `json:"name,omitempty"`  // display label; omitted if blank
+    DirName     string `json:"dir_name"`
+}
+
+func (r *ServiceValidationResult) IsValid() bool          { return r.Valid }
+func (r *ServiceValidationResult) GetCatalogType() string { return r.CatalogType }
+func (r *ServiceValidationResult) GetCatalogID() string   { return r.CatalogID }
+func (r *ServiceValidationResult) GetVersion() string     { return r.Version }
+func (r *ServiceValidationResult) GetDisplayName() string { return r.Name }
+func (r *ServiceValidationResult) GetDirName() string     { return r.DirName }
+
+// ComponentValidationResult is the ValidationResult implementation for catalog_type="component".
+// JSON shape:
+//
+//	{
+//	  "valid":          true,
+//	  "catalog_type":   "component",
+//	  "component_type": "llm",
+//	  "catalog_id":     "llm:my-provider",
+//	  "version":        "1.0.0",
+//	  "name":           "My Custom LLM Provider",
+//	  "dir_name":       "llm-my-provider-1.0.0"
+//	}
+type ComponentValidationResult struct {
+    Valid         bool   `json:"valid"`
+    CatalogType   string `json:"catalog_type"`
+    ComponentType string `json:"component_type"`
+    CatalogID     string `json:"catalog_id"`
+    Version       string `json:"version"`
+    Name          string `json:"name,omitempty"`  // display label; omitted if blank
+    DirName       string `json:"dir_name"`
+}
+
+func (r *ComponentValidationResult) IsValid() bool          { return r.Valid }
+func (r *ComponentValidationResult) GetCatalogType() string { return r.CatalogType }
+func (r *ComponentValidationResult) GetCatalogID() string   { return r.CatalogID }
+func (r *ComponentValidationResult) GetVersion() string     { return r.Version }
+func (r *ComponentValidationResult) GetDisplayName() string { return r.Name }
+func (r *ComponentValidationResult) GetDirName() string     { return r.DirName }
+
+// ComponentType returns the component_type for this result.
+// Defined on the concrete type; callers that need it type-assert to *ComponentValidationResult.
+func (r *ComponentValidationResult) ComponentType() string { return r.ComponentType }
 
 // ValidationError carries an HTTP status code alongside its message.
 type ValidationError struct {
@@ -927,6 +1214,258 @@ type ValidationError struct {
 }
 ```
 
+`ValidateBundle` constructs whichever concrete type matches the archive's `type` field and returns it as the `ValidationResult` interface. The handler serialises it directly to JSON — `ServiceValidationResult` omits `component_type`; `ComponentValidationResult` always includes it. Adding a new catalog type requires only a new concrete struct and one new `case` in `ValidateBundle` — the handler and `BundleServiceInterface` are unchanged.
+
+#### Why the strategy collapses into the metadata type
+
+The `bundleTypeStrategy` interface described earlier (with `CatalogID`, `Name`, `ArchiveID` methods) and `BundleMetadata` are solving the same problem from two angles. With Option 3 they merge: the concrete metadata type **is** its own strategy. The pipeline calls `meta.CatalogID()`, `meta.DirName()`, `meta.DisplayName()`, `meta.CatalogType()` directly — no separate strategy object, no factory function, no second dispatch. Adding a new catalog type is a single step: implement the interface on a new struct and add one `case` in `parseMetadataYAML`.
+
+Note: `ID()` (bare `id` field) is intentionally **not** in the `BundleMetadata` interface. Since the archive top-level directory name is no longer validated against `id`, there is no pipeline step that needs the bare `id` separately from `CatalogID()`. For services `CatalogID() == id` anyway. The `id` field is used internally by each concrete type to construct `CatalogID()` and `DirName()` but is not exposed.
+
+#### `ApplicationClient` bundle methods (client/bundle.go)
+
+The CLI commands talk to the server through `ApplicationClient` in [`internal/pkg/catalog/client/bundle.go`](ai-services/internal/pkg/catalog/client/bundle.go). Beyond the existing `ListBundles` and `GetBundle`, the following methods are added:
+
+```go
+// UploadBundle POSTs a .tar.gz archive as multipart/form-data.
+// Returns the 201 BundleResponse (status always "active" on success).
+func (c *ApplicationClient) UploadBundle(filePath string) (*bundlesvc.BundleResponse, error)
+
+// UpdateBundle PUTs a replacement archive for the bundle identified by bundleID.
+// Returns the 202 BundleResponse immediately — poll with PollBundleActive.
+func (c *ApplicationClient) UpdateBundle(bundleID, filePath string) (*bundlesvc.BundleResponse, error)
+
+// DeleteBundle sends DELETE /api/v1/catalog/bundles/:bundleID.
+func (c *ApplicationClient) DeleteBundle(bundleID string) error
+
+// ValidateBundle POSTs to the validate endpoint (no DB write, no reload).
+// Returns a ServiceValidationResult or ComponentValidationResult (both implement
+// ValidationResult) on success, or a *ValidationError on 422.
+func (c *ApplicationClient) ValidateBundle(filePath string) (bundlesvc.ValidationResult, error)
+
+// PollBundleActive polls GET /api/v1/catalog/bundles/:bundleID until status == "active"
+// or the context is cancelled. Used after a 202 Accepted PUT response.
+func (c *ApplicationClient) PollBundleActive(ctx context.Context, bundleID string, interval time.Duration) (*bundlesvc.BundleResponse, error)
+```
+
+---
+
+### 6.9 CLI bundle commands
+
+The `ai-services catalog bundle` subcommand group is implemented in [`cmd/ai-services/cmd/catalog/bundle.go`](ai-services/cmd/ai-services/cmd/catalog/bundle.go) and registered in [`catalog.go`](ai-services/cmd/ai-services/cmd/catalog/catalog.go) via `catalogCMD.AddCommand(NewBundleCmd())`.
+
+#### Command tree
+
+```
+ai-services catalog bundle
+├── upload    --file <path>
+├── update    <bundle_id>  --file <path>
+├── delete    <bundle_id>
+├── list
+├── get       <bundle_id>
+└── validate  --file <path>
+```
+
+The `bundle` parent command requires an authenticated session (`ai-services catalog login` must have been run first). All subcommands call `client.New()` to load stored credentials — no `--server` or `--username` flags are needed.
+
+#### `bundle upload` — upload a new bundle
+
+Uploads a `.tar.gz` archive and blocks until the server returns `201 Created` (the POST endpoint is synchronous). `catalog_id`, `catalog_type`, and `version` are all read from `metadata.yaml` inside the archive — no additional flags needed.
+
+```
+ai-services catalog bundle upload --file <path-to-bundle.tar.gz>
+```
+
+**Flags:**
+
+| Flag | Required | Description |
+|---|---|---|
+| `--file` | yes | Path to the `.tar.gz` archive to upload |
+
+**Example output (service bundle):**
+```
+Uploading bundle from my-bundle.tar.gz...
+✓ Bundle uploaded successfully
+  ID:           550e8400-e29b-41d4-a716-446655440000
+  Catalog type: service
+  Catalog ID:   my-service
+  Dir name:     my-service-1.0.0
+  Version:      1.0.0
+  Status:       active
+  Size:         280 KB
+```
+
+**Example output (component bundle — `component_type: llm`):**
+```
+Uploading bundle from my-provider-bundle.tar.gz...
+✓ Bundle uploaded successfully
+  ID:             c3d4e5f6-...
+  Catalog type:   component
+  Component type: llm
+  Catalog ID:     llm:my-provider
+  Dir name:       llm-my-provider-1.0.0
+  Version:        1.0.0
+  Status:         active
+  Size:           192 KB
+```
+
+**Errors:**
+
+| Exit | Condition |
+|---|---|
+| `1` | File not found or not a `.tar.gz` |
+| `1` | `409 Conflict` — bundle with the same `catalog_id` already exists; use `bundle update` |
+| `1` | `422 Unprocessable Entity` — `metadata.yaml` missing, malformed, or `catalog_id` is reserved |
+
+#### `bundle update` — replace an existing bundle
+
+Sends a `PUT` request (async `202 Accepted`) and polls until the bundle is `active`. The positional `<bundle_id>` is the internal UUID from `bundle list` or `bundle upload` output.
+
+```
+ai-services catalog bundle update <bundle_id> --file <path-to-bundle.tar.gz>
+```
+
+**Arguments:**
+
+| Argument | Required | Description |
+|---|---|---|
+| `<bundle_id>` | yes | Internal bundle UUID (from `bundle list` or a prior `bundle upload`) |
+
+**Flags:**
+
+| Flag | Required | Description |
+|---|---|---|
+| `--file` | yes | Path to the replacement `.tar.gz` archive |
+| `--no-wait` | no | Return immediately after `202 Accepted` without polling |
+| `--timeout` | no | Maximum time to wait for `active` status (default: `5m`) |
+
+**Example output:**
+```
+Updating bundle 550e8400-e29b-41d4-a716-446655440000 from my-bundle-v2.tar.gz...
+  Catalog type: service  |  Catalog ID: my-service  |  Version: 2.0.0
+  Dir name:     my-service-2.0.0
+Waiting for bundle to become active...
+✓ Bundle updated successfully (status: active)
+```
+
+**Errors:**
+
+| Exit | Condition |
+|---|---|
+| `1` | `404 Not Found` — no bundle with that ID; use `bundle upload` to create one |
+| `1` | `422` — `catalog_id` or `catalog_type` in the archive doesn't match the existing record |
+| `1` | Timeout reached while polling (bundle stays in last known state) |
+
+#### `bundle delete` — delete a bundle
+
+Synchronous `DELETE`. Removes the on-disk directory, the DB record, and triggers a `CatalogProvider.Reload()`.
+
+```
+ai-services catalog bundle delete <bundle_id>
+```
+
+**Arguments:**
+
+| Argument | Required | Description |
+|---|---|---|
+| `<bundle_id>` | yes | Internal bundle UUID |
+
+**Flags:**
+
+| Flag | Required | Description |
+|---|---|---|
+| `--yes` | no | Skip the confirmation prompt |
+
+**Example:**
+```
+Delete bundle 550e8400-e29b-41d4-a716-446655440000 (my-service-1.0.0)? [y/N] y
+✓ Bundle deleted.
+```
+
+#### `bundle list` — list all bundles
+
+Prints a table of all registered bundles ordered by upload time (most recent first).
+
+```
+ai-services catalog bundle list
+```
+
+**Example output:**
+```
+ID                                     CATALOG TYPE  CATALOG ID       DIR NAME               VERSION  STATUS  UPLOADED AT
+550e8400-e29b-41d4-a716-446655440000   service       my-service       my-service-1.0.0       1.0.0    active  2026-05-12 09:14:02
+a1b2c3d4-e5f6-7890-abcd-ef1234567890   component     llm:my-provider  llm-my-provider-1.0.0  1.0.0    active  2026-05-13 11:30:00
+```
+
+Note the `DIR NAME` column uses the `<component_type>-<catalog_id>-<version>` form for components, matching the on-disk path under `/data/catalog-bundles/component/`.
+
+#### `bundle get` — get a single bundle
+
+Prints full details for one bundle by ID. Primarily used to poll status after `bundle update`.
+
+```
+ai-services catalog bundle get <bundle_id>
+```
+
+**Example output:**
+```
+ID:           550e8400-e29b-41d4-a716-446655440000
+Name:         My Custom Service
+Dir name:     my-service-1.0.0
+Catalog type: service
+Catalog ID:   my-service
+Version:      1.0.0
+Status:       active
+Size:         280 KB
+Uploaded by:  admin
+Uploaded at:  2026-05-12 09:14:02
+```
+
+#### `bundle validate` — validate a bundle without uploading
+
+Calls `POST /api/v1/catalog/bundles/validate`. No DB row is written and `CatalogProvider` is not reloaded. Use before `bundle upload` to verify the archive in CI/CD pipelines.
+
+```
+ai-services catalog bundle validate --file <path-to-bundle.tar.gz>
+```
+
+**Flags:**
+
+| Flag | Required | Description |
+|---|---|---|
+| `--file` | yes | Path to the `.tar.gz` archive to validate |
+
+**Example output (valid service bundle)** — `ServiceValidationResult`:
+```
+Validating bundle from my-bundle.tar.gz...
+✓ Bundle is valid
+  Catalog type: service
+  Catalog ID:   my-service
+  Dir name:     my-service-1.0.0
+  Version:      1.0.0
+  Name:         My Custom Service
+```
+
+**Example output (valid component bundle)** — `ComponentValidationResult`:
+```
+Validating bundle from my-provider-bundle.tar.gz...
+✓ Bundle is valid
+  Catalog type:   component
+  Component type: llm
+  Catalog ID:     llm:my-provider
+  Dir name:       llm-my-provider-1.0.0
+  Version:        1.0.0
+  Name:           My Custom LLM Provider
+```
+
+**Example output (invalid):**
+```
+Validating bundle from broken-bundle.tar.gz...
+✗ Bundle validation failed: metadata.yaml is missing required field "component_type"
+```
+
+The CLI inspects the returned `ValidationResult` interface: if it type-asserts to `*ComponentValidationResult` it prints the extra `Component type` line; otherwise it uses the `ServiceValidationResult` path. No `switch` on string fields — the concrete type carries all the information needed.
+
 ---
 
 ## 7. Custom Template Directory Structure
@@ -934,21 +1473,23 @@ type ValidationError struct {
 ### 7.1 Minimum layout for a new service
 
 ```
-services/
-└── <service-id>/
-    ├── metadata.yaml                    # required
-    └── podman/                          # for podman runtime
-        ├── metadata.yaml                # required (version, resources, podTemplateExecutions)
-        ├── values.yaml                  # required
-        ├── values.schema.json           # optional – enables param validation
-        └── templates/
-            └── <service>.yaml.tmpl      # at least one required
+<service-id>/
+├── metadata.yaml                    # required
+└── podman/                          # for podman runtime
+    ├── metadata.yaml                # required (version, resources, podTemplateExecutions)
+    ├── values.yaml                  # required
+    ├── values.schema.json           # optional – enables param validation
+    └── templates/
+        └── <service>.yaml.tmpl      # at least one required
 ```
 
-Package as a `.tar.gz` with `services/` at the top level:
+Package as a `.tar.gz` — the top-level directory name is irrelevant (it is stripped by the server during extraction):
 
 ```bash
-tar -czf my-bundle.tar.gz services/
+# macOS — suppress Apple Double (._*) resource-fork entries
+COPYFILE_DISABLE=1 tar -czf my-bundle.tar.gz my-service/
+# Linux / WSL — plain tar
+# tar -czf my-bundle.tar.gz my-service/
 ```
 
 ### 7.2 Service top-level `metadata.yaml`
@@ -980,11 +1521,13 @@ resources:
   storage: 10737418240            # bytes
 ```
 
-### 7.4 Built-in service IDs are reserved
+### 7.4 Built-in IDs are reserved
 
-A bundle whose top-level directory name matches an existing built-in service (`chat`, `digitize`, `similarity`, `summarize`) will be rejected by the validation step with a `422` error. Custom bundles must use a unique `catalog_id` that does not conflict with any embedded service or architecture.
+A bundle whose `catalog_id` (read from `metadata.yaml`) matches a built-in catalog item is rejected with a `422` error. For services, `catalog_id` is the bare `id`; for components it is the composite `<component_type>:<id>`. Custom bundles must use a unique `catalog_id` that does not conflict with any embedded item.
 
-Built-in IDs reserved at this time: `chat`, `digitize`, `similarity`, `summarize`, `rag`.
+**Built-in service IDs reserved at this time:** `chat`, `digitize`, `similarity`, `summarize`, `rag`
+
+**Built-in component IDs reserved at this time** (by composite `<component_type>:<id>`):`llm:vllm-cpu`, `llm:vllm-spyre`, `llm:watsonx`, `embedding:vllm-cpu`, `reranker:vllm-cpu`, `reranker:vllm-spyre`, `vector_db:opensearch`
 
 ---
 
@@ -1471,6 +2014,32 @@ Custom component templates may adopt the same pattern for any key name. The `.en
 
 ### 10.1 Upload a custom service bundle
 
+**Using the CLI (recommended):**
+
+```bash
+# Log in once — credentials are stored for subsequent commands
+ai-services catalog login --server https://catalog-api.<domain> --username admin --runtime podman
+
+# Package the service directory (top-level dir name is irrelevant)
+COPYFILE_DISABLE=1 tar -czf my-bundle.tar.gz my-service/
+
+# Upload — synchronous; prints status once the bundle is active
+ai-services catalog bundle upload --file my-bundle.tar.gz
+# ✓ Bundle uploaded successfully
+#   ID:           550e8400-e29b-41d4-a716-446655440000
+#   Catalog type: service
+#   Catalog ID:   my-service
+#   Dir name:     my-service-1.0.0
+#   Version:      1.0.0
+
+# Update to a new version — polls until active
+COPYFILE_DISABLE=1 tar -czf my-bundle-v2.tar.gz my-service/
+ai-services catalog bundle update 550e8400-e29b-41d4-a716-446655440000 --file my-bundle-v2.tar.gz
+# ✓ Bundle updated successfully (status: active)
+```
+
+**Using curl (API directly):**
+
 ```bash
 # Authenticate
 curl -X POST https://catalog-api.<domain>/api/v1/auth/login \
@@ -1478,38 +2047,106 @@ curl -X POST https://catalog-api.<domain>/api/v1/auth/login \
   -d '{"username":"admin","password":"<password>"}' \
   | jq -r .access_token > token.txt
 
-# Package the custom service directory.
-# The archive must contain a top-level dir whose name matches catalog_id in metadata.yaml.
-#
-# macOS — suppress Apple Double (._*) resource-fork entries:
-COPYFILE_DISABLE=1 tar -czf my-bundle.tar.gz my-service/
-#
-# Linux / Windows (WSL / Git Bash) — plain tar, no extra flags needed:
-# tar -czf my-bundle.tar.gz my-service/
+# Package. The top-level dir name is irrelevant — stripped during extraction.
+COPYFILE_DISABLE=1 tar -czf my-bundle.tar.gz my-service/   # macOS
+# tar -czf my-bundle.tar.gz my-service/                     # Linux / WSL
 
-# Upload the bundle — POST is synchronous; returns 201 Created when the bundle is active.
-# catalog_id, catalog_type, and version are read from metadata.yaml inside the archive.
+# Upload (synchronous; returns 201 when active)
 curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
   -H "Authorization: Bearer $(cat token.txt)" \
   -F "file=@my-bundle.tar.gz"
-# 201 Created — {"id":"bnd_01JW4X9K2M8VQRP3T5YZ","status":"active","catalog_id":"my-service",...}
+# 201 Created — {"id":"550e8400-...","status":"active","catalog_id":"my-service","dir_name":"my-service-1.0.0",...}
 
-# Update the bundle — PUT is async (202). catalog_id and catalog_type are resolved from
-# the existing DB record and must match the archive metadata (immutable).
-# version is read from the replacement archive's metadata.yaml.
+# Update (async; poll until active)
 COPYFILE_DISABLE=1 tar -czf my-bundle-v2.tar.gz my-service/
-curl -X PUT https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ \
+curl -X PUT https://catalog-api.<domain>/api/v1/catalog/bundles/550e8400-e29b-41d4-a716-446655440000 \
   -H "Authorization: Bearer $(cat token.txt)" \
   -F "file=@my-bundle-v2.tar.gz"
-# 202 Accepted — {"id":"bnd_02EF9Z4PG2Q0XRS5V7WB","status":"processing",...}
+# 202 Accepted
 
-# Poll for the replacement to go active
-curl -s https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_02EF9Z4PG2Q0XRS5V7WB \
+curl -s https://catalog-api.<domain>/api/v1/catalog/bundles/550e8400-e29b-41d4-a716-446655440000 \
   -H "Authorization: Bearer $(cat token.txt)" | jq .status
 # "active"
 ```
 
-### 10.2 Create an application from the custom service
+### 10.2 Upload a custom component bundle
+
+Component bundles follow the same upload API. The `component_type` field in `metadata.yaml` is required — `parseMetadataYAML` constructs a `*ComponentMetadata` which encodes `catalog_id` as `llm:my-provider` and `dir_name` as `llm-my-provider-1.0.0`. Two providers with the same bare `id` but different `component_type` values are entirely independent bundles and can coexist.
+
+**Using the CLI (recommended):**
+
+```bash
+# Package the component. Top-level dir name is irrelevant — stripped on extract.
+# metadata.yaml must declare: type: component, component_type: llm
+COPYFILE_DISABLE=1 tar -czf my-provider-bundle.tar.gz my-provider/
+
+# Upload — on success, dir_name uses the <component_type>-<id>-<version> scheme
+ai-services catalog bundle upload --file my-provider-bundle.tar.gz
+# ✓ Bundle uploaded successfully
+#   ID:             c3d4e5f6-...
+#   Catalog type:   component
+#   Component type: llm
+#   Catalog ID:     llm:my-provider
+#   Dir name:       llm-my-provider-1.0.0
+#   Version:        1.0.0
+
+# Upload the same id under a different component_type — independent bundle
+# metadata.yaml must declare: type: component, component_type: embedding
+COPYFILE_DISABLE=1 tar -czf my-provider-embedding-bundle.tar.gz my-provider/
+ai-services catalog bundle upload --file my-provider-embedding-bundle.tar.gz
+# ✓ Bundle uploaded successfully
+#   Catalog ID:     embedding:my-provider
+#   Dir name:       embedding-my-provider-1.0.0   ← entirely separate from the llm bundle
+```
+
+**Using curl (API directly):**
+
+```bash
+# Package. metadata.yaml must declare: type: component, component_type: llm
+COPYFILE_DISABLE=1 tar -czf my-provider-bundle.tar.gz my-provider/
+
+# Upload — POST is synchronous; catalog_id in the response is the composite "llm:my-provider"
+curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
+  -H "Authorization: Bearer $(cat token.txt)" \
+  -F "file=@my-provider-bundle.tar.gz"
+# 201 Created
+# {
+#   "id":             "c3d4e5f6-...",
+#   "name":           "My Custom LLM Provider",
+#   "dir_name":       "llm-my-provider-1.0.0",
+#   "status":         "active",
+#   "catalog_type":   "component",
+#   "catalog_id":     "llm:my-provider",
+#   "version":        "1.0.0",
+#   "uploaded_by":    "admin"
+# }
+
+# Second upload — same bare id, different component_type → independent bundle
+COPYFILE_DISABLE=1 tar -czf my-provider-embedding-bundle.tar.gz my-provider/
+curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
+  -H "Authorization: Bearer $(cat token.txt)" \
+  -F "file=@my-provider-embedding-bundle.tar.gz"
+# 201 Created — catalog_id: "embedding:my-provider", dir_name: "embedding-my-provider-1.0.0"
+```
+
+### 10.3 Uploading with a built-in ID (caution)
+
+Uploading a bundle whose `catalog_id` matches a built-in service is not currently rejected at the API level. When `CatalogProvider.Reload()` runs after upload, the bundle entry will overwrite the embedded entry in the items map (last write wins). Custom bundles should deliberately avoid `catalog_id` values that match built-in items.
+
+```bash
+# Check which IDs are currently loaded in the catalog before uploading
+curl -s https://catalog-api.<domain>/api/v1/services \
+  -H "Authorization: Bearer $(cat token.txt)" | jq '.[].id'
+# "chat"
+# "digitize"
+# "similarity"
+# "summarize"
+# "my-service"   ← custom, safe to re-upload
+```
+
+> A reserved-ID check (returning `422 Conflict` before extraction) is listed as a future enhancement.
+
+### 10.4 Create an application from the custom service
 
 The application creation endpoint (`POST /api/v1/applications/`) accepts a `CreateApplicationRequest` with `name`, `catalog_id`, `version`, and a `services` array. Each service entry requires its own `catalog_id`, `version`, and `components` list.
 
@@ -1539,22 +2176,7 @@ curl -X POST https://catalog-api.<domain>/api/v1/applications/ \
 # Returns 202 Accepted with {"id": "<application-uuid>"}
 ```
 
-### 10.3 Attempt to use a reserved built-in ID (rejected)
-
-Uploading a bundle whose `catalog_id` (declared in `metadata.yaml`) matches a built-in service is rejected synchronously during POST — the extracted directory is cleaned up and a `422` is returned immediately:
-
-```bash
-# Attempting to upload a bundle with catalog_id "chat" (a built-in service)
-tar -czf chat-bundle.tar.gz chat/
-
-curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
-  -H "Authorization: Bearer $(cat token.txt)" \
-  -F "file=@chat-bundle.tar.gz"
-# 422 Unprocessable Entity
-# {"error":"catalog_id \"chat\" is reserved by a built-in service and cannot be overridden"}
-```
-
-### 10.4 List custom services via the catalog API
+### 10.5 List custom services via the catalog API
 
 After uploading a bundle, custom services appear alongside built-in ones. The `GET /api/v1/services` endpoint returns an array of `ServiceSummary` objects (not a wrapped object), so the `jq` filter uses `.[].id`:
 
@@ -1569,21 +2191,38 @@ curl -s https://catalog-api.<domain>/api/v1/services \
 # "my-service"   ← custom
 ```
 
-### 10.5 Validate a bundle before uploading
+### 10.6 Validate a bundle before uploading
 
 `POST /api/v1/catalog/bundles/validate` is a dedicated validate-only endpoint — the server extracts the archive to a temporary directory, validates structure, cleans up, and replies inline. No DB record is written and `CatalogProvider` is not reloaded.
 
 ```bash
-# --- Validate a bundle ---
+# --- Validate a service bundle (returns ServiceValidationResult) ---
 curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles/validate \
   -H "Authorization: Bearer $(cat token.txt)" \
   -F "file=@my-bundle.tar.gz"
 # 200 OK
 # {
 #   "valid":        true,
-#   "catalog_id":   "my-service",
 #   "catalog_type": "service",
-#   "version":      "1.0.0"
+#   "catalog_id":   "my-service",
+#   "version":      "1.0.0",
+#   "name":         "My Custom Service",
+#   "dir_name":     "my-service-1.0.0"
+# }
+
+# --- Validate a component bundle (returns ComponentValidationResult) ---
+curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles/validate \
+  -H "Authorization: Bearer $(cat token.txt)" \
+  -F "file=@my-provider-bundle.tar.gz"
+# 200 OK
+# {
+#   "valid":          true,
+#   "catalog_type":   "component",
+#   "component_type": "llm",
+#   "catalog_id":     "llm:my-provider",
+#   "version":        "1.0.0",
+#   "name":           "My Custom LLM Provider",
+#   "dir_name":       "llm-my-provider-1.0.0"
 # }
 
 # --- Validation failure example ---
@@ -1595,28 +2234,12 @@ curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles/validate \
 
 ---
 
-## 11. Backward Compatibility
+## 11. Future Enhancements
 
-| Scenario | Behaviour |
-|---|---|
-| No bundle uploaded yet | Identical to current — embedded assets only (`loadEmbeddedItems`) |
-| Volume mounted but no `status='active'` rows in DB | Only embedded assets are used; behaviour identical to today |
-| Custom service has same `id` as built-in | Bundle is rejected with `422`; built-in is never shadowed |
-| Multiple bundles for different `catalog_id` values | All are `active` simultaneously; each is fully independent. At most one bundle (one version) per `catalog_id` is active at any given time. |
-| Existing applications in the database | Unaffected; records reference `catalog_id` strings which remain stable |
-| `catalog_type` value not in the accepted list | Rejected with `422` when `metadata.yaml` inside the archive is parsed |
-| New `catalog_type` value introduced in a future release | Existing clients that receive an unfamiliar `catalog_type` string are unaffected — they simply don't render that bundle type in their UI |
-| `assets.ApplicationFS` and existing `application/` packages | Not touched; independent of `CatalogProvider` |
-| OpenShift deployment | Same API endpoint and bundle format; only the storage backend differs (PVC vs named volume) |
-
----
-
-## 12. Future Enhancements
-
-1. **Scaffolding generator** — `ai-services catalog scaffold --service my-service --runtime podman` emits a minimal but correct directory skeleton ready to be tar'd and uploaded.
-2. **Template validation CLI command** — `POST /api/v1/catalog/bundles/validate` already exists server-side; a dedicated CLI command `ai-services catalog validate --bundle <file>` that calls this endpoint would let operators validate locally before uploading.
+1. **Reserved-ID guard** — reject a `POST` (with `422`) whose `catalog_id` conflicts with a built-in embedded item. Currently the bundle is accepted and overwrites the embedded entry in the items map on reload. The check should run after `peekMetadata` and before extraction.
+2. **Scaffolding generator** — `ai-services catalog scaffold --service my-service --runtime podman` emits a minimal but correct directory skeleton ready to be tar'd and uploaded.
 3. **Remote catalog repositories** — fetch a bundle from an OCI registry or HTTPS URL; the server pulls and applies it directly, removing the need for a client upload.
 4. **Schema enforcement on custom `metadata.yaml`** — reuse the existing [`validators.ApplicationValidator`](ai-services/internal/pkg/catalog/validators/validation.go) to reject malformed custom metadata at validation time.
 5. **Version compatibility checks** — validate that a custom service's `version` satisfies any `>=x.y.z` constraint declared by the built-in architecture that references it.
 6. **Role-based upload access** — introduce a `catalog-editor` JWT role that can upload bundles but cannot perform `DELETE /applications` or other destructive operations.
-7. **Component support in bundles** — when `components/` is promoted from reserved to active in the bundle processor, users can ship custom component providers (e.g. a private LLM backend) alongside their services in the same archive.
+7. **New `BundleMetadata` implementations** — adding support for a new catalog type (e.g. `architecture`) requires only: (a) a new struct implementing the `BundleMetadata` interface, and (b) a new `case` in `parseMetadataYAML`. The entire processing pipeline (`ProcessBundle`, `ReplaceBundle`, `ValidateBundle`) is unchanged.

--- a/docs/proposals/catalog/custom-service-templates-proposal.md
+++ b/docs/proposals/catalog/custom-service-templates-proposal.md
@@ -546,6 +546,7 @@ The on-disk directory is derived at runtime as `<catalog_id>-<version>` — it i
       "name":         "My Custom Service",
       "status":       "active",
       "created_at":  "2026-05-12T09:14:02Z",
+      "updated_at":  "2026-05-14T10:00:00Z",
       "size_bytes":   286720,
       "catalog_type": "service",
       "catalog_id":   "my-service",
@@ -557,6 +558,7 @@ The on-disk directory is derived at runtime as `<catalog_id>-<version>` — it i
       "name":         "My Custom LLM Provider",
       "status":       "active",
       "created_at":  "2026-05-13T11:30:00Z",
+      "updated_at":  "2026-05-13T11:30:00Z",
       "size_bytes":   196608,
       "catalog_type": "component",
       "catalog_id":   "llm--my-provider",
@@ -719,6 +721,8 @@ The on-disk directory path is **derived at runtime** from `catalog_id` and `vers
 
 The `status` column tracks lifecycle using only `processing`, `active`, `failed`, and `deleting`: **POST** inserts a new row as `processing`, reloads the catalog, then activates it with a single `Activate` UPDATE. **PUT** marks the existing row `processing`, extracts the replacement, reloads the catalog, re-activates the row in-place, and removes the old directory only at the end. **DELETE** marks the row `deleting`, removes the directory, reloads the catalog, and then deletes the row. If any post-transition step fails during POST, PUT, or DELETE, the row is marked `failed` and the error message is stored. **Only one `active` row per `(catalog_type, catalog_id)` is permitted** — enforced by a partial composite unique index.
 
+`updated_at` is maintained automatically by the `set_updated_at` trigger — it fires `BEFORE UPDATE` on every row change, so the application never writes it explicitly. This means it is always accurate regardless of which code path mutates the row, and new mutations added in future require no extra consideration. On a freshly created bundle that has never been replaced, `updated_at` equals `created_at`.
+
 ```sql
 -- +goose Up
 -- +goose StatementBegin
@@ -756,7 +760,8 @@ CREATE TABLE catalog_bundles (
 
     error            TEXT,
     created_by       VARCHAR(100),
-    created_at       TIMESTAMPTZ    NOT NULL DEFAULT NOW()
+    created_at       TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ    NOT NULL DEFAULT NOW()
 );
 
 -- Enforce at most one active bundle per (catalog_type, catalog_id) pair.
@@ -1196,7 +1201,7 @@ The `ai-services catalog bundle` subcommand group is implemented in [`cmd/ai-ser
 
 ```
 ai-services catalog bundle
-├── upload    --file <path>
+├── create    --file <path>
 ├── update    <bundle_id>  --file <path>
 ├── delete    <bundle_id>
 ├── list
@@ -1206,12 +1211,12 @@ ai-services catalog bundle
 
 The `bundle` parent command requires an authenticated session (`ai-services catalog login` must have been run first). All subcommands call `client.New()` to load stored credentials — no `--server` or `--username` flags are needed.
 
-#### `bundle upload` — create a new bundle
+#### `bundle create` — create a new bundle
 
 Creates a bundle from a `.tar.gz` archive and blocks until the server returns `201 Created` (the POST endpoint is synchronous). `catalog_id`, `catalog_type`, and `version` are all read from `metadata.yaml` inside the archive — no additional flags needed.
 
 ```
-ai-services catalog bundle upload --file <path-to-bundle.tar.gz>
+ai-services catalog bundle create --file <path-to-bundle.tar.gz>
 ```
 
 **Flags:**
@@ -1256,7 +1261,7 @@ Creating bundle from my-provider-bundle.tar.gz...
 
 #### `bundle update` — replace an existing bundle
 
-Sends a synchronous `PUT` request (`200 OK`) that extracts, validates, activates, and reloads the catalog all in one go — no polling needed. The positional `<bundle_id>` is the internal UUID from `bundle list` or `bundle upload` output.
+Sends a synchronous `PUT` request (`200 OK`) that extracts, validates, activates, and reloads the catalog all in one go — no polling needed. The positional `<bundle_id>` is the internal UUID from `bundle list` or `bundle create` output.
 
 ```
 ai-services catalog bundle update <bundle_id> --file <path-to-bundle.tar.gz>
@@ -1266,7 +1271,7 @@ ai-services catalog bundle update <bundle_id> --file <path-to-bundle.tar.gz>
 
 | Argument | Required | Description |
 |---|---|---|
-| `<bundle_id>` | yes | Internal bundle UUID (from `bundle list` or a prior `bundle upload`) |
+| `<bundle_id>` | yes | Internal bundle UUID (from `bundle list` or a prior `bundle create`) |
 
 **Flags:**
 
@@ -1286,7 +1291,7 @@ Updating bundle 550e8400-e29b-41d4-a716-446655440000 from my-bundle-v2.tar.gz...
 
 | Exit | Condition |
 |---|---|
-| `1` | `404 Not Found` — no bundle with that ID; use `bundle upload` to create one |
+| `1` | `404 Not Found` — no bundle with that ID; use `bundle create` to create one |
 | `1` | `422` — `catalog_id` or `catalog_type` in the archive doesn't match the existing record, or validation failed |
 
 #### `bundle delete` — delete a bundle
@@ -1356,7 +1361,7 @@ Created at:   2026-05-12 09:14:02
 
 #### `bundle validate` — validate a bundle without creating it
 
-Calls `POST /api/v1/catalog/bundles/validate`. No DB row is written and `CatalogProvider` is not reloaded. Use before `bundle upload` to verify the archive in CI/CD pipelines.
+Calls `POST /api/v1/catalog/bundles/validate`. No DB row is written and `CatalogProvider` is not reloaded. Use before `bundle create` to verify the archive in CI/CD pipelines.
 
 ```
 ai-services catalog bundle validate --file <path-to-bundle.tar.gz>
@@ -1956,7 +1961,7 @@ ai-services catalog login --server https://catalog-api.<domain> --username admin
 COPYFILE_DISABLE=1 tar -czf my-bundle.tar.gz my-service/
 
 # Create Bundle — synchronous; prints status once the bundle is active
-ai-services catalog bundle upload --file my-bundle.tar.gz
+ai-services catalog bundle create --file my-bundle.tar.gz
 # ✓ Bundle created successfully
 #   ID:           550e8400-e29b-41d4-a716-446655440000
 #   Catalog type: service
@@ -2009,7 +2014,7 @@ Component bundles follow the same Create Bundle API. The `component_type` field 
 COPYFILE_DISABLE=1 tar -czf my-provider-bundle.tar.gz my-provider/
 
 # Create Bundle — on success, catalog_id is "llm--my-provider", dir is llm--my-provider-1.0.0
-ai-services catalog bundle upload --file my-provider-bundle.tar.gz
+ai-services catalog bundle create --file my-provider-bundle.tar.gz
 # ✓ Bundle created successfully
 #   ID:             c3d4e5f6-...
 #   Catalog type:   component
@@ -2020,7 +2025,7 @@ ai-services catalog bundle upload --file my-provider-bundle.tar.gz
 # Create the same id under a different component_type — independent bundle
 # metadata.yaml must declare: type: component, component_type: embedding
 COPYFILE_DISABLE=1 tar -czf my-provider-embedding-bundle.tar.gz my-provider/
-ai-services catalog bundle upload --file my-provider-embedding-bundle.tar.gz
+ai-services catalog bundle create --file my-provider-embedding-bundle.tar.gz
 # ✓ Bundle created successfully
 #   Catalog ID:     embedding--my-provider   ← entirely separate from the llm bundle
 ```

--- a/docs/proposals/catalog/custom-service-templates-proposal.md
+++ b/docs/proposals/catalog/custom-service-templates-proposal.md
@@ -485,13 +485,13 @@ Location: /api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ
 `catalog_id`, `catalog_type`, and `version` are all known immediately from the request fields and are present in the `202` body:
 
 ```json
-// 202 response body
+// 202 response body — size_bytes is null until extraction completes
 {
   "id":           "bnd_01JW4X9K2M8VQRP3T5YZ",
   "name":         "my-service-1.0.0",
   "status":       "processing",
   "uploaded_at":  "2026-05-12T09:14:02Z",
-  "size_bytes":   143360,
+  "size_bytes":   null,
   "catalog_type": "service",
   "catalog_id":   "my-service",
   "version":      "1.0.0",
@@ -499,7 +499,7 @@ Location: /api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ
 }
 ```
 
-Once the bundle reaches `active` or `failed` status, the polled response reflects the final outcome:
+Once the bundle reaches `active` or `failed` status, the polled response reflects the final outcome including the uncompressed on-disk size:
 
 ```json
 // after activation — GET /api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ
@@ -508,7 +508,7 @@ Once the bundle reaches `active` or `failed` status, the polled response reflect
   "name":         "my-service-1.0.0",
   "status":       "active",
   "uploaded_at":  "2026-05-12T09:14:02Z",
-  "size_bytes":   143360,
+  "size_bytes":   286720,
   "catalog_type": "service",
   "catalog_id":   "my-service",
   "version":      "1.0.0",
@@ -609,7 +609,7 @@ Each bundle record carries `catalog_type` (the type declared by the uploader —
       "id":           "bnd_01JW4X9K2M8VQRP3T5YZ",
       "status":       "active",
       "uploaded_at":  "2026-05-12T09:14:02Z",
-      "size_bytes":   143360,
+      "size_bytes":   286720,
       "name":         "my-service-1.0.0",
       "catalog_type": "service",
       "catalog_id":   "my-service",
@@ -621,7 +621,7 @@ Each bundle record carries `catalog_type` (the type declared by the uploader —
       "name":         "my-llm-provider-1.0.0",
       "status":       "active",
       "uploaded_at":  "2026-05-13T11:30:00Z",
-      "size_bytes":   98304,
+      "size_bytes":   196608,
       "catalog_type": "component",
       "catalog_id":   "my-llm-provider",
       "version":      "1.0.0",
@@ -809,6 +809,8 @@ CREATE TABLE catalog_bundles (
     name             VARCHAR(200)   NOT NULL,
 
     status           bundle_status  NOT NULL DEFAULT 'processing',
+    -- Uncompressed on-disk size in bytes, populated after extraction completes.
+    -- NULL on the immediate 202 response; set once the bundle reaches 'active' or 'failed'.
     size_bytes       BIGINT,
 
     -- The catalog item type declared by the uploader: "service", "component", …
@@ -820,8 +822,7 @@ CREATE TABLE catalog_bundles (
 
     error            TEXT,
     uploaded_by      VARCHAR(100),
-    uploaded_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
-    activated_at     TIMESTAMPTZ
+    uploaded_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW()
 );
 
 -- Enforce one active bundle per catalog_id at the DB level.

--- a/docs/proposals/catalog/custom-service-templates-proposal.md
+++ b/docs/proposals/catalog/custom-service-templates-proposal.md
@@ -12,18 +12,17 @@
 2. [Background and Motivation](#2-background-and-motivation)
 3. [Catalog Pod Architecture](#3-catalog-pod-architecture)
 4. [New Asset Structure](#4-new-asset-structure)
-5. [Template Provider Design](#5-template-provider-design)
-6. [CatalogProvider Integration](#6-catalogprovider-integration)
-7. [API Upload](#7-api-upload)
-8. [Custom Template Directory Structure](#8-custom-template-directory-structure)
-9. [Remote Deployment](#9-remote-deployment)
-10. [Template Values Reference](#10-template-values-reference)
-    - 10.1 [Shared (services and components)](#101-shared-services-and-components)
-    - 10.2 [Services](#102-services)
-    - 10.3 [Components](#103-components)
-11. [Usage Examples](#11-usage-examples)
-12. [Backward Compatibility](#12-backward-compatibility)
-13. [Future Enhancements](#13-future-enhancements)
+5. [CatalogProvider Integration](#5-catalogprovider-integration)
+6. [API Upload](#6-api-upload)
+7. [Custom Template Directory Structure](#7-custom-template-directory-structure)
+8. [Remote Deployment](#8-remote-deployment)
+9. [Template Values Reference](#9-template-values-reference)
+    - 9.1 [Shared (services and components)](#91-shared-services-and-components)
+    - 9.2 [Services](#92-services)
+    - 9.3 [Components](#93-components)
+10. [Usage Examples](#10-usage-examples)
+11. [Backward Compatibility](#11-backward-compatibility)
+12. [Future Enhancements](#12-future-enhancements)
 
 ---
 
@@ -33,14 +32,14 @@ Enterprise customers deploying AI Services on their own infrastructure often bri
 
 This proposal introduces **Custom Service Templates** — a first-class mechanism for customers to onboard their own AI service assets into the catalog at runtime. A customer packages their service definition as a `.tar.gz` bundle and uploads it to the running catalog backend over HTTPS. The platform validates, registers, and hot-reloads the new service immediately — with no pod restart, no host filesystem access, and no changes to the platform binary required. The mechanism is identical on Podman single-VM deployments and OpenShift clusters.
 
-Built-in platform services are protected: a bundle whose `catalog_id` conflicts with an embedded service is rejected at validation time, ensuring the integrity of the core catalog is never compromised.
+Built-in platform services are protected: a bundle whose `id` conflicts with an embedded service is rejected at validation time, ensuring the integrity of the core catalog is never compromised.
 
 | Property | Detail |
 |---|---|
 | **Use case** | Onboard customer-authored service assets into a live catalog deployment |
 | **Delivery** | `POST /api/v1/catalog/bundles` — `.tar.gz` archive uploaded over HTTPS to the running catalog |
-| **Podman** | ✅ — bundle stored in dedicated named volume `ai-services-bundles` |
-| **OpenShift** | ✅ — bundle stored in dedicated PVC `catalog-bundles-pvc` |
+| **Podman** | ✅ — bundle stored in dedicated named volume `catalog-bundles` |
+| **OpenShift** | ✅ — bundle stored in dedicated PVC `catalog-bundles` |
 | **Live reload** | Automatic — `CatalogProvider` hot-reloads after successful extraction, no pod restart |
 | **Audit trail** | `catalog_bundles` table in PostgreSQL — every upload is recorded with uploader identity and timestamp |
 | **Best for** | Enterprise customers, air-gapped deployments, regulated environments, CI/CD-driven asset promotion |
@@ -70,7 +69,7 @@ Enterprise customers operate AI Services in environments where the built-in serv
 - **CI/CD asset promotion** — teams need to promote service definitions through staging and production deployments programmatically, without manual intervention on each host.
 - **Partner and ISV onboarding** — system integrators and technology partners need a supported path to register their own service assets alongside IBM-certified ones.
 
-Currently, there is no supported mechanism to extend the catalog at runtime. Custom assets are delivered by uploading a `.tar.gz` bundle to the running catalog API over HTTPS. The apiserver extracts it to isolated storage, validates it, and hot-reloads `CatalogProvider` — no pod restart, no CLI host access required, and no changes to the platform binary needed.
+Currently, there is no supported mechanism to extend the catalog at runtime. Custom assets are delivered by uploading a `.tar.gz` bundle to the running catalog API over HTTPS. The apiserver reads `id`, `type`, and `version` from `metadata.yaml` inside the archive, extracts it to isolated storage, validates it, and hot-reloads `CatalogProvider` — no pod restart, no CLI host access required, and no changes to the platform binary needed.
 
 ### 2.3 Goals
 
@@ -95,7 +94,7 @@ flowchart TD
         IOMMU["/sys/kernel/iommu_groups<br/>hostPath read-only"]
     end
 
-    BUNDLE_VOL["Podman named volume<br/>ai-services-bundles<br/>mount: /data/catalog-bundles"]
+    BUNDLE_VOL["Podman named volume<br/>catalog-bundles<br/>mount: /data/catalog-bundles"]
 
     subgraph PODS["Podman pods — shared pod network"]
         subgraph CADDY_POD["ai-services--caddy pod"]
@@ -119,7 +118,7 @@ flowchart TD
     DIR_BASE    -- "volume mount" --> BE
     SOCK        -- "volume mount" --> BE
     IOMMU       -- "volume mount ro" --> BE
-    BUNDLE_VOL  -- "named volume → /data/catalog-bundles" --> BE
+    BUNDLE_VOL  -- "named volume catalog-bundles → /data/catalog-bundles" --> BE
 
     INIT -- "gates" --> UI
     INIT -- "gates" --> BE
@@ -135,11 +134,11 @@ flowchart TD
 
 The catalog backend's `CatalogProvider` runs **inside the `ai-services--catalog` container**, not on the CLI host. `assets.CatalogFS` is baked into the binary at build time (via `go:embed`). For custom templates to be visible at runtime they must reach the container and be overlaid onto the embedded FS.
 
-Custom assets are delivered via the running catalog API: the client POSTs a `.tar.gz` bundle over HTTPS, and the apiserver writes the extracted contents to a dedicated named volume (`ai-services-bundles` on Podman, `catalog-bundles-pvc` on OpenShift) that it already owns. Both runtimes mount the volume at the well-known path `/data/catalog-bundles` inside the container. Bundles are stored under `<catalog_type>/<name>/` where `name = <catalog_id>-<version>` (e.g. `service/chat-2.0.0/`). **At most one bundle per `catalog_id` is active at any time** — uploading a new version via `PUT` replaces the existing one. At startup, `CatalogProvider` queries the DB for all `status = 'active'` rows, resolves each to its named directory, and builds a `CompositeCatalogFS`. Hot-reload happens in-process after every successful upload; no pod restart is needed.
+Custom assets are delivered via the running catalog API: the client POSTs a `.tar.gz` bundle over HTTPS, and the apiserver writes the extracted contents to a dedicated named volume (`catalog-bundles` on both Podman and OpenShift) that it already owns. Both runtimes mount the volume at the well-known path `/data/catalog-bundles` inside the container. Bundles are stored under `<catalog_type>/<name>/` where `name = <id>-<version>` (e.g. `service/chat-2.0.0/`). **At most one bundle per `id` is active at any time** — uploading a new version via `PUT` replaces the existing one. At startup, `CatalogProvider` queries the DB for all `status = 'active'` rows, resolves each to its on-disk directory, and loads it alongside the embedded assets using `os.DirFS`. Hot-reload happens in-process after every successful upload; no pod restart is needed.
 
 ### 3.3 OpenShift path
 
-For OpenShift, `catalog configure` runs [`openshift.DeployCatalog`](ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go:24), which uses Helm to install/upgrade the catalog chart from `assets/catalog/openshift/`. No chart change is required for bundle support: once the catalog is deployed, users POST bundles to the Route-exposed API endpoint. The backend writes to the `catalog-bundles-pvc` PVC it already mounts (see §7.6).
+For OpenShift, `catalog configure` runs [`openshift.DeployCatalog`](ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go:24), which uses Helm to install/upgrade the catalog chart from `assets/catalog/openshift/`. No chart change is required for bundle support: once the catalog is deployed, users POST bundles to the Route-exposed API endpoint. The backend writes to the `catalog-bundles` PVC it already mounts (see §6.6).
 
 ---
 
@@ -205,201 +204,80 @@ services:
 
 ### 4.3 Custom service assets (proposed)
 
-A user-supplied bundle mirrors the same `services/` root. Only the entries present in the bundle are overlaid; everything else falls through to the embedded assets.
+A user-supplied bundle has the service directory at the **top level** of the archive — the `<service-id>/` directory is the archive root, not nested under `services/`.
 
 ```
 my-bundle.tar.gz
-└── services/
-    └── my-service/
-        ├── metadata.yaml           # required
-        └── podman/
-            ├── metadata.yaml       # required (version, resources, podTemplateExecutions)
-            ├── values.yaml         # required
-            ├── values.schema.json  # optional
-            └── templates/
-                └── my-service.yaml.tmpl
+└── my-service/                      ← top-level dir; name must match `id` in metadata.yaml
+    ├── metadata.yaml                 # required (id, type, version, ...)
+    └── podman/
+        ├── metadata.yaml            # required (version, resources, podTemplateExecutions)
+        ├── values.yaml              # required
+        ├── values.schema.json       # optional
+        └── templates/
+            └── my-service.yaml.tmpl
 ```
 
-Only `services/` is a valid top-level directory in a bundle; any other roots are silently skipped (forward-compatible for future `components/` support). The `catalog_id` inside the bundle must **not** match any built-in service — if it does, validation rejects the bundle with a `422` error.
+The `id` inside `metadata.yaml` must equal the top-level directory name and must **not** match any built-in service — if it does, validation rejects the bundle with a `422` error. `CatalogProvider` uses `os.DirFS` rooted at the extracted bundle directory to load the service's assets alongside the embedded catalog.
 
 ---
 
-## 5. Template Provider Design
+## 5. CatalogProvider Integration
 
-### 5.1 Provider hierarchy
+### 5.1 How bundle items are loaded
 
-```mermaid
-classDiagram
-    class fs_ReadDirFS {
-        <<interface>>
-        +ReadDir(name string) []DirEntry
-    }
+[`CatalogProvider`](ai-services/internal/pkg/catalog/catalog.go) maintains two separate loading paths in a single `load` / `Reload` cycle:
 
-    class CatalogFS {
-        <<interface>>
-        +Open(name string) File
-        +ReadFile(name string) []byte
-    }
-
-    class EmbeddedCatalogFS {
-        -fs embed.FS
-        +Open() File
-        +ReadFile() []byte
-        +ReadDir() []DirEntry
-    }
-
-    class FilesystemCatalogFS {
-        -root string
-        +Open() File
-        +ReadFile() []byte
-        +ReadDir() []DirEntry
-    }
-
-    class CompositeCatalogFS {
-        -sources []CatalogFS
-        +Open() File
-        +ReadFile() []byte
-        +ReadDir() []DirEntry
-    }
-
-    fs_ReadDirFS <|-- CatalogFS : embeds
-    CatalogFS <|.. EmbeddedCatalogFS : implements
-    CatalogFS <|.. FilesystemCatalogFS : implements
-    CatalogFS <|.. CompositeCatalogFS : implements
-    CompositeCatalogFS o-- EmbeddedCatalogFS : fallback
-    CompositeCatalogFS o-- FilesystemCatalogFS : priority
-```
-
-### 5.2 Interface
+1. **Embedded items** — `loadEmbeddedItems` walks `assets.CatalogFS` (baked into the binary) and dispatches on the first path segment (`"architectures"`, `"services"`, `"components"`).
+2. **Bundle items** — `loadBundleItems` queries the DB for all `status = 'active'` rows, then for each bundle reads `<bundleDir>/<catalog_id>/metadata.yaml` via `os.DirFS` rooted at the bundle's on-disk directory.
 
 ```go
-// CatalogFS abstracts the filesystem used by CatalogProvider.
-type CatalogFS interface {
-    fs.ReadDirFS
-    Open(name string) (fs.File, error)
-    ReadFile(name string) ([]byte, error)
+// loadBundleItems — actual implementation in catalog.go
+func (p *CatalogProvider) loadBundleItems(ctx context.Context, items map[string]*catalogItem) error {
+    bundles, err := p.bundleRepo.ListAll(ctx)
+    // ...
+    for _, b := range bundles {
+        if b.Status != "active" { continue }
+        // /data/catalog-bundles/<catalog_type>s/<name>/
+        bundleDir := filepath.Join(bundleStorageRoot, b.CatalogType+"s", b.Name)
+        bundleFS  := os.DirFS(bundleDir)
+        // reads <catalog_id>/metadata.yaml from the bundle FS
+        parseAndStoreMetadataWithFS(ctx, b.CatalogType+"s", metaPath, b.CatalogID, bundleFS, data, items)
+    }
+    return nil
 }
 ```
 
-### 5.3 FilesystemCatalogFS
-
-```go
-// FilesystemCatalogFS reads catalog assets from a local directory.
-// Inside the container this is the active bundle directory written by BundleService.
-type FilesystemCatalogFS struct {
-    root string // e.g. "/data/catalog-bundles/service/chat-2.0.0"
-}
-```
-
-Validates at construction that `services/` exists under `root`, providing an actionable early error. Entries other than `services/` are ignored.
-
-### 5.4 CompositeCatalogFS
-
-```go
-// CompositeCatalogFS merges multiple CatalogFS instances.
-// Lookup checks each source in order; the first hit wins.
-// WalkDir visits all sources and deduplicates paths.
-type CompositeCatalogFS struct {
-    sources []CatalogFS // [bundleFS, embeddedFS]
-}
-```
-
-When `WalkDir` encounters the same relative path (e.g. `services/chat/metadata.yaml`) in both sources, the first source (bundle) wins and the embedded version is silently skipped.
-
-### 5.5 Factory function
-
-At startup the apiserver builds one `FilesystemCatalogFS` per active bundle (see §6.3). The factory below is the helper used when there is exactly one bundle path to overlay — for example in tests or single-bundle tooling:
-
-```go
-// NewCatalogFS returns the CatalogFS to use.
-// bundlePath="" → returns the embedded FS only (no active bundle).
-// bundlePath set → returns a composite that overlays that single bundle directory.
-// For multiple active bundles use NewCompositeCatalogFS directly (see §6.3).
-func NewCatalogFS(bundlePath string) (CatalogFS, error) {
-    embedded := &EmbeddedCatalogFS{fs: &assets.CatalogFS}
-    if bundlePath == "" {
-        return embedded, nil
-    }
-    bundle, err := NewFilesystemCatalogFS(bundlePath)
-    if err != nil {
-        logger.Warningf("bundle path '%s' invalid, using built-in only: %v", bundlePath, err)
-        return embedded, nil
-    }
-    return NewCompositeCatalogFS(bundle, embedded), nil
-}
-```
-
-### 5.6 Resolution priority
-
-At startup, `CatalogProvider` reads active bundle versions from the DB and constructs one `FilesystemCatalogFS` per active item, all layered before the embedded FS:
+### 5.2 Resolution priority
 
 | Priority | Source | Condition |
 |---|---|---|
-| 1..N | `FilesystemCatalogFS` (one per active bundle) | DB has `status = 'active'` rows; paths are `/data/catalog-bundles/<catalog_type>/<name>/` |
-| N+1 | `EmbeddedCatalogFS` (built-in) | Always present as fallback |
+| 1 | Embedded `assets.CatalogFS` | Always loaded first |
+| 2..N | `os.DirFS` per active bundle | DB has `status = 'active'` rows; paths are `/data/catalog-bundles/<catalog_type>s/<name>/` |
+
+Bundle items are written into the same `items` map as embedded items, keyed by `catalog_id`. If a bundle uses the same `id` as a built-in item, validation rejects it before insertion (`422`).
+
+### 5.3 NewCatalogProvider signature
+
+```go
+// NewCatalogProvider creates a CatalogProvider, loading all embedded items and any
+// active customer-uploaded bundles from the DB (bundleRepo may be nil for CLI paths).
+func NewCatalogProvider(bundleRepo dbrepo.BundleRepository) (*CatalogProvider, error)
+```
+
+When `bundleRepo` is `nil` (CLI / test paths), only embedded items are loaded.
+
+### 5.4 Hot-reload
+
+`CatalogProvider.Reload(ctx)` rebuilds the items map from scratch under a `sync.RWMutex` — re-walking the embedded FS and re-querying all active bundles from the DB. It is called synchronously at the end of every successful `ProcessBundle` / `DeleteBundle`, and asynchronously at the end of `runReplaceAsync` for PUT updates.
 
 ---
 
-## 6. CatalogProvider Integration
+## 6. API Upload
 
-### 6.1 Current loading (single embedded FS)
+Custom catalog assets are delivered by uploading a `.tar.gz` bundle to the running catalog backend over its existing HTTPS endpoint. The archive must contain exactly one top-level directory (the service directory) with a `metadata.yaml` at its root declaring `id`, `type`, and `version`. The archive is extracted, validated, written to the bundle volume, and hot-reloaded into `CatalogProvider` — with no pod restart required for either Podman or OpenShift.
 
-[`loadCatalogItems`](ai-services/internal/pkg/catalog/catalog.go:56) today walks `assets.CatalogFS` directly, dispatching on the first path segment (`"architectures"`, `"services"`, `"components"`) and storing results in `sharedItems`:
-
-```go
-err := fs.WalkDir(&assets.CatalogFS, ".", func(path string, d fs.DirEntry, err error) error {
-    return processMetadataFile(ctx, path, items)
-})
-```
-
-### 6.2 Proposed: inject CatalogFS
-
-`NewCatalogProvider` gains an optional functional option:
-
-```go
-func NewCatalogProvider(opts ...Option) (*CatalogProvider, error)
-
-// WithBundlePath overlays the active bundle directory on top of the embedded catalog.
-func WithBundlePath(dir string) Option
-```
-
-When provided, `loadCatalogItems` receives the `CompositeCatalogFS` instead of `&assets.CatalogFS`. The `processMetadataFile`, `parseService`, `parseArchitecture`, `parseComponent` functions are unchanged — they work against any `CatalogFS`.
-
-### 6.3 Apiserver startup loads active bundle paths from the DB
-
-The bundle volume is always mounted at `/data/catalog-bundles`. No env var is needed. At startup, the apiserver queries the `catalog_bundles` table for all `status = 'active'` rows, resolves each one to its versioned directory on disk, and builds a `CompositeCatalogFS` with one `FilesystemCatalogFS` per active item:
-
-```go
-// catalogBundlesDir is the well-known container mount path for the bundles volume.
-// It is fixed by the pod spec (Podman named volume / OpenShift PVC).
-const catalogBundlesDir = "/data/catalog-bundles"
-
-// In the apiserver main/start path:
-activeBundles, err := bundleRepo.ListActive(ctx) // SELECT WHERE status='active'
-var fsList []CatalogFS
-for _, b := range activeBundles {
-    // path: /data/catalog-bundles/<catalog_type>/<name>/
-    // name is derived server-side as <catalog_id>-<version>
-    p := filepath.Join(catalogBundlesDir, b.CatalogType, b.Name)
-    if fs, err := NewFilesystemCatalogFS(p); err == nil {
-        fsList = append(fsList, fs)
-    }
-}
-fsList = append(fsList, &EmbeddedCatalogFS{fs: &assets.CatalogFS})
-provider, err := catalog.NewCatalogProvider(catalog.WithCompositeCatalogFS(fsList...))
-```
-
-If there are no active bundles, only `EmbeddedCatalogFS` is used — behaviour is identical to today.
-
----
-
-## 7. API Upload
-
-Custom catalog assets are delivered by uploading a `.tar.gz` bundle to the running catalog backend over its existing HTTPS endpoint. A bundle is a generic container — it can carry any mix of catalog root types (`services/`, `components/`, and others in future). The archive is extracted, validated per root type, and hot-reloaded into `CatalogProvider` — with no pod restart required for either Podman or OpenShift.
-
-> **Scope for this release:** only `services/` is processed. `components/` and other roots are accepted in the archive but skipped by the dispatcher — they will be activated in a future release without any change to the bundle format or API contract.
-
-### 7.1 Design goals
+### 6.1 Design goals
 
 | Goal | Detail |
 |---|---|
@@ -413,23 +291,36 @@ Custom catalog assets are delivered by uploading a `.tar.gz` bundle to the runni
 
 ---
 
-### 7.2 New API endpoints
+### 6.2 New API endpoints
 
-Five endpoints are added to the existing router in [`apiserver/router.go`](ai-services/internal/pkg/catalog/apiserver/router.go:18) under the authenticated `catalog` group:
+Six bundle endpoints are added to the existing router in [`apiserver/router.go`](ai-services/internal/pkg/catalog/apiserver/router.go:20) under the authenticated `catalog/bundles` group:
 
 | Method | Path | Description |
 |---|---|---|
 | `POST` | `/api/v1/catalog/bundles` | Upload a **new** bundle (`.tar.gz`). Returns `409 Conflict` if a bundle with the same `catalog_id` already exists. |
+| `POST` | `/api/v1/catalog/bundles/validate` | Validate a bundle archive without storing it. No DB record is written; `CatalogProvider` is not reloaded. |
 | `PUT` | `/api/v1/catalog/bundles/:bundle_id` | Replace an existing bundle identified by its internal record ID. Returns `404` if no bundle with that ID exists. `catalog_id` and `catalog_type` are resolved from the DB record. |
 | `DELETE` | `/api/v1/catalog/bundles/:bundle_id` | Delete a bundle by its internal record ID. Removes the on-disk directory and the DB record. Returns `404` if no bundle with that ID exists. |
 | `GET` | `/api/v1/catalog/bundles` | List all uploaded bundles (id, status, uploaded_at, size). |
-| `GET` | `/api/v1/catalog/bundles/:id` | Get the status of a specific bundle by ID. Used to poll after a `202` upload response. |
+| `GET` | `/api/v1/catalog/bundles/:bundle_id` | Get the status and metadata for a specific bundle by ID. Used to poll after a `202 Accepted` PUT response. |
 
-#### 7.2.1 Upload bundle — `POST /api/v1/catalog/bundles`
+Five additional catalog-read endpoints are added under the authenticated `v1` catalog group for CLI and client use:
 
-The request uses `multipart/form-data` so that the binary `.tar.gz` file and the text fields can travel together in the same request. The server validates `catalog_id`, `catalog_type`, and `version` before touching the archive, then extracts directly into the versioned directory on the bundle volume. The `catalog_id` form field is used as the bundle name component and must match the top-level directory inside the archive — a mismatch is rejected with `400`.
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/v1/services/:id/images` | Return image metadata for a service. |
+| `GET` | `/api/v1/services/:id/models` | Return model metadata for a service. |
+| `GET` | `/api/v1/services/:id/md` | Return the service's Markdown description. |
+| `GET` | `/api/v1/architectures/:id/images` | Return image metadata for an architecture. |
+| `GET` | `/api/v1/architectures/:id/models` | Return model metadata for an architecture. |
 
-When `dry_run=true` the request is handled **synchronously**: the archive is extracted to a temporary directory, validated, then immediately cleaned up. No DB record is written, `CatalogProvider` is not reloaded, and the conflict check is skipped — so a dry-run against an already-registered `catalog_id` is always allowed. The response is `200 OK` (valid) or `422` (invalid), returned inline without polling.
+#### 6.2.1 Upload bundle — `POST /api/v1/catalog/bundles`
+
+The request uses `multipart/form-data` with a single field: `file` (required). **`id`, `type`, and `version` are not form fields** — they are all read from `metadata.yaml` inside the archive. This removes the possibility of a mismatch between declared metadata and archive contents.
+
+The upload is **fully synchronous**: the handler reads the archive, peeks `metadata.yaml`, checks for a conflict, extracts to the permanent directory, validates structure, inserts a DB row as `active`, and reloads `CatalogProvider` — all before returning. On success the response is `201 Created` (not `202 Accepted`); no polling is needed.
+
+To validate a bundle before uploading use `POST /api/v1/catalog/bundles/validate` (see §6.2.5).
 
 ```
 POST /api/v1/catalog/bundles
@@ -437,74 +328,40 @@ Content-Type: multipart/form-data
 Authorization: Bearer <admin-jwt>
 
 Form fields:
-  file         (required)  — .tar.gz archive containing the catalog item
-                             assets; max 50 MB compressed
-  catalog_id   (required)  — identifier for this catalog item, e.g. "my-service";
-                             must match the top-level directory name inside the archive;
-                             combined with version to form the on-disk bundle name
-                             (<catalog_id>-<version>)
-  catalog_type (required)  — type of the catalog item in this bundle;
-                             accepted values: "service", "component"
-  version      (required)  — semantic version of this bundle, e.g. "1.0.0";
-                             combined with catalog_id to form the on-disk bundle name
-                             (<catalog_id>-<version>)
-                             (ignored for storage purposes when dry_run=true)
-  dry_run      (optional)  — "true" runs a synchronous validate-only pass;
-                             no DB record is written and nothing is activated
+  file  (required)  — .tar.gz archive containing the catalog item assets;
+                      max 50 MB compressed.
+                      id, type, and version are read from metadata.yaml inside the archive.
 ```
 
 **Example (curl):**
 ```bash
 curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
   -H "Authorization: Bearer $TOKEN" \
-  -F "file=@my-bundle.tar.gz" \
-  -F "catalog_id=my-service" \
-  -F "catalog_type=service" \
-  -F "version=1.0.0"
+  -F "file=@my-bundle.tar.gz"
 ```
 
 **Responses:**
 
 | Status | Meaning |
 |---|---|
-| `200 OK` | **`dry_run=true` only.** Validation passed; archive is safe to upload for real. No record was written. |
-| `202 Accepted` | Bundle accepted; extraction and validation running asynchronously. Use the `Location` header to poll for status. |
-| `400 Bad Request` | Missing `file`, `catalog_id`, `catalog_type`, or `version` field; `catalog_id` does not match the archive's top-level directory name; unrecognised `catalog_type`; invalid version format; wrong content-type; or archive exceeds size limit. |
+| `201 Created` | Bundle validated, extracted, inserted into the DB as `active`, and catalog reloaded — all synchronously. A `Location` header points to the new record. |
+| `400 Bad Request` | Missing or unreadable `file` field; wrong content-type; archive exceeds size limit; or `metadata.yaml` is missing/malformed. |
 | `401 Unauthorized` | Missing or invalid JWT. |
 | `403 Forbidden` | Token does not carry admin role. |
-| `409 Conflict` | A bundle with the same `catalog_id` is already registered (**non-dry-run only**). Use `PUT /api/v1/catalog/bundles/:catalog_id` to update it. |
-| `422 Unprocessable Entity` | Validation failed (structured error list returned). Returned synchronously for `dry_run=true`, or via poll for normal uploads. |
+| `409 Conflict` | A bundle with the same `id` (from the archive's `metadata.yaml`) is already registered. Use `PUT /api/v1/catalog/bundles/:bundle_id` to update it. |
+| `422 Unprocessable Entity` | Validation failed (bad metadata structure, reserved `id`, etc.). |
 
-The response includes a `Location` header pointing to the status resource:
+The `201` response includes a `Location` header and a body matching the `BundleResponse` shape:
 
 ```
-HTTP/1.1 202 Accepted
-Location: /api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ
+HTTP/1.1 201 Created
+Location: /api/v1/catalog/bundles/550e8400-e29b-41d4-a716-446655440000
 ```
-
-`catalog_id`, `catalog_type`, and `version` are all known immediately from the request fields and are present in the `202` body:
 
 ```json
-// 202 response body — size_bytes is null until extraction completes
+// 201 response body — bundle is already active; size_bytes reflects on-disk size
 {
-  "id":           "bnd_01JW4X9K2M8VQRP3T5YZ",
-  "name":         "my-service-1.0.0",
-  "status":       "processing",
-  "uploaded_at":  "2026-05-12T09:14:02Z",
-  "size_bytes":   null,
-  "catalog_type": "service",
-  "catalog_id":   "my-service",
-  "version":      "1.0.0",
-  "uploaded_by":  "admin"
-}
-```
-
-Once the bundle reaches `active` or `failed` status, the polled response reflects the final outcome including the uncompressed on-disk size:
-
-```json
-// after activation — GET /api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ
-{
-  "id":           "bnd_01JW4X9K2M8VQRP3T5YZ",
+  "id":           "550e8400-e29b-41d4-a716-446655440000",
   "name":         "my-service-1.0.0",
   "status":       "active",
   "uploaded_at":  "2026-05-12T09:14:02Z",
@@ -516,15 +373,13 @@ Once the bundle reaches `active` or `failed` status, the polled response reflect
 }
 ```
 
-#### 7.2.2 Update bundle — `PUT /api/v1/catalog/bundles/:bundle_id`
+#### 6.2.2 Update bundle — `PUT /api/v1/catalog/bundles/:bundle_id`
 
-Use `PUT` to replace an existing bundle identified by its internal record ID (`bundle_id`). The server looks up the record by `bundle_id` and derives `catalog_id` and `catalog_type` from it — neither is a form field. The only form fields are `file` and optionally `dry_run`.
+Use `PUT` to replace an existing bundle identified by its internal record ID (`bundle_id`). The server looks up the record by `bundle_id` and derives `id` and `type` from it — neither is a form field. The only form field is `file`.
 
-**Version is not a form field.** The version of the replacement bundle is read from the `metadata.yaml` inside the archive after extraction. If the metadata carries a new version the on-disk directory is named accordingly (`<catalog_id>-<new_version>/`). The `catalog_id` and `catalog_type` values inside the archive metadata must match the existing DB record — attempts to change them are rejected with `422`.
+**Version is not a form field.** The version of the replacement bundle is read from `metadata.yaml` inside the archive. If the metadata carries a new version the on-disk directory is named accordingly (`<id>-<new_version>/`). The `id` and `type` values inside the archive metadata must match the existing DB record — attempts to change them are rejected with `422`.
 
 Returns `404` if no bundle with that `bundle_id` exists.
-
-When `dry_run=true` the request is handled **synchronously**: the archive is extracted to a temporary directory and validated, then immediately cleaned up. The `404` check **still runs** — a dry-run with an unknown `bundle_id` returns `404` just as a real PUT would. No DB record is updated, the old bundle directory is untouched, and `CatalogProvider` is not reloaded. The response is `200 OK` (valid) or `422` (invalid), returned inline without polling.
 
 ```
 PUT /api/v1/catalog/bundles/:bundle_id
@@ -532,16 +387,14 @@ Content-Type: multipart/form-data
 Authorization: Bearer <admin-jwt>
 
 Path parameter:
-  :bundle_id   (required)  — internal record ID of the bundle to replace,
-                             e.g. bnd_01JW4X9K2M8VQRP3T5YZ
+  :bundle_id  (required)  — internal record ID of the bundle to replace,
+                            e.g. bnd_01JW4X9K2M8VQRP3T5YZ
 
 Form fields:
-  file         (required)  — .tar.gz archive containing the replacement assets
-  dry_run      (optional)  — "true" runs a synchronous validate-only pass;
-                             existing bundle is untouched, nothing is activated
+  file        (required)  — .tar.gz archive containing the replacement assets
 ```
 
-> `catalog_id`, `catalog_type`, and `version` are **not** form fields for `PUT`. `catalog_id` and `catalog_type` are resolved from the DB record and validated against the archive metadata — mismatches are rejected with `422`. `version` is read from the archive's `metadata.yaml` and used to derive the on-disk bundle name (`<catalog_id>-<version>/`).
+> `id`, `type`, and `version` are **not** form fields for `PUT`. `id` and `type` are resolved from the DB record and validated against the archive metadata — mismatches are rejected with `422`. `version` is read from the archive's `metadata.yaml` and used to derive the on-disk bundle name (`<id>-<version>/`).
 
 **Example (curl):**
 ```bash
@@ -554,19 +407,18 @@ curl -X PUT https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2M8V
 
 | Status | Meaning |
 |---|---|
-| `200 OK` | **`dry_run=true` only.** Validation passed; replacement archive is safe to apply for real. Existing bundle unchanged. |
-| `202 Accepted` | Replacement bundle accepted; processing asynchronously. Poll `Location` header to get status. `version` and `name` in the response body are populated once the archive is extracted. |
-| `400 Bad Request` | Missing `file` field; archive top-level directory does not match the resolved `catalog_id`; wrong content-type; or archive exceeds size limit. |
+| `202 Accepted` | Archive validated; the **existing DB row** is updated in-place by the async goroutine. Poll `GET /api/v1/catalog/bundles/:bundle_id` (same ID) until `status` is `active`. |
+| `400 Bad Request` | Missing `file` field; archive top-level directory does not match the resolved `id`; wrong content-type; or archive exceeds size limit. |
 | `401 Unauthorized` | Missing or invalid JWT. |
 | `403 Forbidden` | Token does not carry admin role. |
-| `404 Not Found` | No bundle with the given `bundle_id` exists. Use `POST` to create a new bundle first. (Returned for both normal and `dry_run=true` requests.) |
-| `422 Unprocessable Entity` | Validation failed, or the archive's `catalog_id`/`catalog_type` metadata differs from the existing record. Returned synchronously for `dry_run=true`, or via poll for normal updates. The existing bundle remains active in both cases. |
+| `404 Not Found` | No bundle with the given `bundle_id` exists. Use `POST` to create a new bundle first. |
+| `422 Unprocessable Entity` | Validation of the archive's `metadata.yaml` failed, or `id`/`type` differs from the existing record. The DB row is not modified; the existing bundle remains active. |
 
-The `202` body has the same shape as `POST` but `version` and `name` are initially empty strings (populated on the polled response once extraction completes). The old bundle directory (`<type>/<catalog_id>-<old_version>/`) is deleted from the volume only after the replacement is marked `active` in the DB — the existing bundle continues to serve templates throughout the async processing window.
+The `202` response returns the **same bundle ID** the client already holds — no new ID is issued. The existing row is updated in-place by the async goroutine (`status=active`, `version`, `name`, `size_bytes` set in a single UPDATE). The old on-disk directory is deleted only after the row is successfully updated. If extraction fails, the DB row is left unchanged — the existing bundle remains active and serving.
 
 ---
 
-#### 7.2.3 Delete bundle — `DELETE /api/v1/catalog/bundles/:bundle_id`
+#### 6.2.3 Delete bundle — `DELETE /api/v1/catalog/bundles/:bundle_id`
 
 Permanently removes a bundle: deletes the on-disk directory (`<catalog_type>/<catalog_id>-<version>/`) from the bundle volume, removes the DB row, and triggers a `CatalogProvider.Reload()` so the item is no longer served. Any application that was deployed using this bundle's `catalog_id` is **not** affected — existing deployed resources are independent of the catalog once launched.
 
@@ -598,15 +450,15 @@ curl -X DELETE https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2
 
 ---
 
-#### 7.2.4 List bundles — `GET /api/v1/catalog/bundles`
+#### 6.2.4 List bundles — `GET /api/v1/catalog/bundles`
 
-Each bundle record carries `catalog_type` (the type declared by the uploader — `"service"` or `"component"`) and `catalog_id` (the item id within that type). Multiple bundles for different catalog items are all active simultaneously and each is listed independently.
+Each bundle record carries `catalog_type` and `catalog_id` (derived from the archive's `id` and `type` fields). Multiple bundles for different items are all active simultaneously and each is listed independently.
 
 ```json
 {
   "bundles": [
     {
-      "id":           "bnd_01JW4X9K2M8VQRP3T5YZ",
+      "id":           "550e8400-e29b-41d4-a716-446655440000",
       "status":       "active",
       "uploaded_at":  "2026-05-12T09:14:02Z",
       "size_bytes":   286720,
@@ -617,7 +469,7 @@ Each bundle record carries `catalog_type` (the type declared by the uploader —
       "uploaded_by":  "admin"
     },
     {
-      "id":           "bnd_02CD8Y3NF1P9WQS4U6VA",
+      "id":           "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
       "name":         "my-llm-provider-1.0.0",
       "status":       "active",
       "uploaded_at":  "2026-05-13T11:30:00Z",
@@ -633,18 +485,26 @@ Each bundle record carries `catalog_type` (the type declared by the uploader —
 
 ---
 
-### 7.3 Bundle format
+### 6.3 Bundle format
 
-A bundle is scoped to **one catalog item**. The archive must be a gzip-compressed tar (`.tar.gz`). The `catalog_id` and `version` together form the unique on-disk directory name (`<catalog_id>-<version>`).
+A bundle is scoped to **one catalog item**. The archive must be a gzip-compressed tar (`.tar.gz`). The `id` and `version` together form the unique on-disk directory name (`<id>-<version>`).
 
-For **POST**, `catalog_id`, `catalog_type`, and `version` are all declared as form fields. The server validates that the archive's top-level directory matches the supplied `catalog_id` — a mismatch is rejected with `400` before any extraction begins.
+For **both POST and PUT**, `id`, `type`, and `version` are read from `metadata.yaml` inside the archive — they are not form fields. For **PUT**, `id` and `type` must also match the existing DB record (immutable); a mismatch is rejected with `422`.
 
-For **PUT**, no form fields are needed beyond `file`. `catalog_id` and `catalog_type` are resolved from the existing DB record; `version` is read from `metadata.yaml` inside the archive after extraction. The `catalog_id` and `catalog_type` values inside the metadata are validated as immutable (must match the DB record) — a mismatch is rejected with `422`.
+The top-level `metadata.yaml` inside the archive uses standard service fields:
+
+```yaml
+# my-service/metadata.yaml
+id:      my-service
+name:    "My Custom Service"
+type:    service
+version: "1.0.0"
+```
 
 ```
 my-bundle.tar.gz
-└── my-service/                     ← must match catalog_id form field
-    ├── metadata.yaml
+└── my-service/                     ← directory name must match `id` in metadata.yaml
+    ├── metadata.yaml               ← declares id, type, version (and name, description, etc.)
     └── podman/
         ├── metadata.yaml
         ├── values.yaml
@@ -652,144 +512,101 @@ my-bundle.tar.gz
             └── my-service.yaml.tmpl
 ```
 
-The `version` form field (e.g. `"1.0.0"`) combines with `catalog_id` to determine the on-disk bundle name (`my-service-1.0.0/`).
+`id` and `version` from `metadata.yaml` are combined to determine the on-disk bundle name (`my-service-1.0.0/`).
 
 **Rules:**
-- Paths containing `..` or absolute paths are rejected immediately (path-traversal guard, same principle as [`SanitizeFilePath`](ai-services/internal/pkg/catalog/utils/common.go:90)).
+- Paths containing `..` or absolute paths are rejected immediately (path-traversal guard).
 - The archive must contain exactly one top-level directory; multiple items per archive are not supported.
-- The top-level directory name inside the archive must exactly equal the `catalog_id` form field — a mismatch is rejected with `400`.
-- Total uncompressed size must not exceed `MAX_BUNDLE_SIZE_UNCOMPRESSED` (default 200 MB).
-- The `catalog_id` must not match any built-in service already present in `assets.CatalogFS` — if it does, validation returns `422` and the extracted directory is deleted.
-- All `metadata.yaml` files must pass validation for the declared `catalog_type` before the bundle is marked `active`.
+- The top-level directory name inside the archive must exactly equal `id` from `metadata.yaml` — a mismatch is rejected with `422`.
+- Total uncompressed size must not exceed 200 MB.
+- The `id` must not match any built-in service already present in `assets.CatalogFS` — if it does, validation returns `422` and the extracted directory is deleted.
+- All `metadata.yaml` files must pass validation for the declared `type` before the bundle is marked `active`.
 
 ---
 
-### 7.4 Server-side processing pipeline
+### 6.4 Server-side processing pipeline
 
 #### POST — new bundle
 
 ```mermaid
 flowchart TD
-    REQ["POST /api/v1/catalog/bundles<br/>multipart/form-data<br/>file, catalog_id, catalog_type, version, dry_run"]
+    REQ["POST /api/v1/catalog/bundles<br/>multipart/form-data — file"]
     AUTH["AuthMiddleware<br/>JWT + admin role check"]
-    TYPECHECK["Validate catalog_id, catalog_type, version<br/>reject unknown type or missing fields → 400"]
-    DRYCHECK{"dry_run=true?"}
+    PEEK["Peek metadata.yaml<br/>read id, type, version → 422 if missing/invalid"]
+    CONFLICT["Check catalog_bundles table<br/>active row for id?"]
+    CONFLICT_RESP["409 Conflict<br/>use PUT /catalog/bundles/:bundle_id to update"]
+    SIZE["Size guard — 200 MB uncompressed"]
+    EXTRACT["Extract to /data/catalog-bundles/type/id-version/<br/>(top-level dir stripped; files land directly in id-version/)"]
+    PATHGUARD["Path-traversal guard<br/>reject .. and absolute paths"]
+    VALIDATE["validateBundleStructure<br/>metadata.yaml present at bundle root"]
+    DBINSERT["Insert bundle record (status=processing)<br/>id generated by DB via gen_random_uuid()"]
+    ACTIVATE["Activate: status=active, size_bytes, version, name<br/>single UPDATE"]
+    RELOAD["CatalogProvider.Reload()"]
+    RESP["201 Created — BundleResponse (re-fetched from DB)<br/>status: active, size_bytes populated<br/>Location: /api/v1/catalog/bundles/:uuid"]
+    FAIL["Delete id-version/ directory + DB row<br/>return 422/400"]
 
-    subgraph DRYPATH["Synchronous dry-run path"]
-        DR_SIZE["Size guard — max 50 MB compressed"]
-        DR_EXTRACT["Extract to /tmp/dryrun-uuid/"]
-        DR_PATHGUARD["Path-traversal guard"]
-        DR_VALIDATE["CatalogProvider.ValidateFS"]
-        DR_CLEANUP["Delete /tmp/dryrun-uuid/ (always)"]
-        DR_OK["200 OK — validation result"]
-        DR_FAIL["422 Unprocessable Entity — error list"]
-        DR_SIZE --> DR_EXTRACT --> DR_PATHGUARD --> DR_VALIDATE --> DR_CLEANUP
-        DR_CLEANUP -->|"valid"| DR_OK
-        DR_CLEANUP -->|"invalid"| DR_FAIL
-    end
-
-    CONFLICT["Check catalog_bundles table<br/>catalog_id already exists?"]
-    CONFLICT_RESP["409 Conflict<br/>use PUT to update"]
-    RESP["202 Accepted immediately<br/>bundle_id, status: processing<br/>Location: /api/v1/catalog/bundles/:id"]
-    SIZE["Size guard<br/>max 50 MB compressed"]
-    EXTRACT["Extract to<br/>/data/catalog-bundles/type/name/<br/>name = catalog_id-version"]
-    PATHGUARD["Path-traversal guard<br/>reject .. and absolute paths<br/>verify exactly one top-level dir"]
-    VALIDATE["CatalogProvider.ValidateFS<br/>parse metadata for declared catalog_type<br/>collect all errors"]
-
-    subgraph ASYNC["Goroutine — async after 202"]
-        SIZE --> EXTRACT --> PATHGUARD --> VALIDATE
-
-        subgraph ACTIVATE["Activate — success path"]
-            direction LR
-            DBBUNDLE["Insert bundle record<br/>status = active"]
-            RELOAD["CatalogProvider.Reload()<br/>re-query active bundles from DB<br/>rebuild CompositeCatalogFS"]
-            DBBUNDLE --> RELOAD
-        end
-
-        FAIL["Delete type/name/ directory<br/>update DB status = failed<br/>return 422 on poll"]
-
-        VALIDATE -->|"valid"| ACTIVATE
-        VALIDATE -->|"invalid"| FAIL
-    end
-
-    REQ --> AUTH --> TYPECHECK --> DRYCHECK
-    DRYCHECK -->|"yes"| DRYPATH
-    DRYCHECK -->|"no"| CONFLICT
+    REQ --> AUTH --> PEEK
+    PEEK --> CONFLICT
     CONFLICT -->|"exists"| CONFLICT_RESP
-    CONFLICT -->|"new"| RESP
-    RESP -.-> ASYNC
+    CONFLICT -->|"new"| SIZE --> EXTRACT --> PATHGUARD --> VALIDATE
+    VALIDATE -->|"valid"| DBINSERT --> ACTIVATE --> RELOAD --> RESP
+    VALIDATE -->|"invalid"| FAIL
 ```
 
 #### PUT — replace existing bundle
 
 ```mermaid
 flowchart TD
-    REQ["PUT /api/v1/catalog/bundles/:bundle_id<br/>multipart/form-data<br/>file, dry_run"]
+    REQ["PUT /api/v1/catalog/bundles/:bundle_id<br/>multipart/form-data — file"]
     AUTH["AuthMiddleware<br/>JWT + admin role check"]
-    LOOKUP["Look up bundle_id in catalog_bundles<br/>resolve catalog_id + catalog_type from record<br/>not found → 404"]
-    DRYCHECK{"dry_run=true?"}
-
-    subgraph DRYPATH["Synchronous dry-run path"]
-        DR_SIZE["Size guard — max 50 MB compressed"]
-        DR_EXTRACT["Extract to /tmp/dryrun-uuid/"]
-        DR_PATHGUARD["Path-traversal guard"]
-        DR_VALIDATE["CatalogProvider.ValidateFS<br/>(catalog_id + catalog_type from DB record)"]
-        DR_CLEANUP["Delete /tmp/dryrun-uuid/ (always)"]
-        DR_OK["200 OK — validation result<br/>existing bundle untouched"]
-        DR_FAIL["422 Unprocessable Entity — error list<br/>existing bundle untouched"]
-        DR_SIZE --> DR_EXTRACT --> DR_PATHGUARD --> DR_VALIDATE --> DR_CLEANUP
-        DR_CLEANUP -->|"valid"| DR_OK
-        DR_CLEANUP -->|"invalid"| DR_FAIL
-    end
-
-    RESP["202 Accepted immediately<br/>bundle_id, status: processing<br/>version + name populated after extraction<br/>Location: /api/v1/catalog/bundles/:id"]
-    SIZE["Size guard<br/>max 50 MB compressed"]
-    EXTRACT["Extract to<br/>/data/catalog-bundles/type/new-name/<br/>new-name = catalog_id-version_from_metadata"]
-    PATHGUARD["Path-traversal guard<br/>reject .. and absolute paths<br/>verify exactly one top-level dir"]
-    METACHECK["Read version from metadata.yaml<br/>validate catalog_id + catalog_type unchanged<br/>mismatch → 422"]
-    VALIDATE["CatalogProvider.ValidateFS<br/>parse metadata for resolved catalog_type<br/>collect all errors"]
+    LOOKUP["Look up bundle_id in catalog_bundles → 404 if missing"]
+    PEEK["Peek metadata.yaml<br/>validate id + type unchanged → 422 on mismatch"]
+    RESP["202 Accepted immediately<br/>same bundle_id, status: active (current)<br/>Location: /api/v1/catalog/bundles/:bundle_id"]
 
     subgraph ASYNC["Goroutine — async after 202"]
-        SIZE --> EXTRACT --> PATHGUARD --> METACHECK --> VALIDATE
+        EXTRACT["Extract to /data/catalog-bundles/type/new-name/<br/>(top-level dir stripped)"]
+        PATHGUARD["Path-traversal guard"]
+        VALIDATE["validateBundleStructure"]
 
         subgraph ACTIVATE["Activate — success path"]
             direction LR
-            DBUPDATE["Update bundle record<br/>status = active, version + name from metadata"]
-            RMOLD["Delete old type/old-name/ directory"]
-            RELOAD["CatalogProvider.Reload()<br/>re-query active bundles from DB<br/>rebuild CompositeCatalogFS"]
-            DBUPDATE --> RMOLD --> RELOAD
+            DBUPDATE["UPDATE existing row in-place<br/>status=active, version, name, size_bytes<br/>single UPDATE — no unique index conflict"]
+            RMOLDDIR["Delete old type/old-name/ directory<br/>(only if name changed)"]
+            RELOAD["CatalogProvider.Reload()"]
+            DBUPDATE --> RMOLDDIR --> RELOAD
         end
 
-        FAIL["Delete new type/new-name/ directory<br/>update DB status = failed<br/>existing bundle remains active<br/>return 422 on poll"]
+        FAIL["Delete new type/new-name/ directory<br/>DB row left unchanged — existing bundle still active"]
 
+        EXTRACT --> PATHGUARD --> VALIDATE
         VALIDATE -->|"valid"| ACTIVATE
         VALIDATE -->|"invalid"| FAIL
     end
 
-    REQ --> AUTH --> LOOKUP --> DRYCHECK
-    DRYCHECK -->|"yes"| DRYPATH
-    DRYCHECK -->|"no"| RESP
+    REQ --> AUTH --> LOOKUP --> PEEK --> RESP
     RESP -.-> ASYNC
 ```
 
 **Key implementation notes:**
 
-- Extraction and validation run in a goroutine; the HTTP handler returns `202` immediately. The client polls `GET /api/v1/catalog/bundles/:id` until `status` is `active` or `failed`.
-- Each bundle gets its own named directory on the volume (`<type>/<name>/`) — uploading `service/my-service-1.0.0` and `service/chat-1.0.0` are entirely independent; neither touches the other.
-- **POST** extraction goes directly into `<type>/<name>/` — no staging directory needed. Since the named directory is new and unique, there is nothing live to corrupt.
-- **PUT** extraction writes the new versioned directory alongside the old one. The old directory is removed only after the new bundle is marked `active` in the DB — the existing bundle continues to serve templates throughout the async window.
-- **PUT** METACHECK: after extraction, `metadata.yaml` is parsed to read `version` (used to construct the new directory name) and to assert that `catalog_id` and `catalog_type` are unchanged. A mismatch returns `422` and the extracted directory is deleted.
-- If validation fails, the newly written `<type>/<name>/` directory is deleted. All other active bundles remain unaffected.
-- The DB never marks a bundle `active` until validation passes — so even a partial extraction (e.g. process killed mid-way) is safe: `CatalogProvider` will not load a directory that has no `active` DB row.
-- `CatalogProvider.Reload()` re-queries the DB for all `status = 'active'` rows and rebuilds the `CompositeCatalogFS` under `sync.RWMutex`.
-- Bundle files are stored in a **dedicated named Podman volume** (`ai-services-bundles`) or **separate PVC** (`catalog-bundles-pvc`) — isolated from `$BASE_DIR` so that a `catalog delete --skip-cleanup` affecting application data never touches bundle storage.
-- The `catalog_bundles` table is added via a new Goose migration following the same pattern as [`20260430094502_create_applications_table.sql`](ai-services/internal/pkg/catalog/db/migrations/assets/20260430094502_create_applications_table.sql).
+- **POST is fully synchronous.** Returns `201 Created` only after extraction, validation, DB activate, and `CatalogProvider.Reload()` all succeed. Response is re-fetched from DB — `status`, `size_bytes`, and `uploaded_at` are authoritative.
+- **PUT sync phase** validates the archive and immutable fields only. Returns `202 Accepted` immediately with the **same bundle ID** — no new row is inserted.
+- **PUT async phase** extracts, validates, then UPDATEs the existing row in-place (`status=active`, `version`, `name`, `size_bytes` — single statement). No unique index conflict is possible since only one row ever exists for this `catalog_id`. If extraction fails the DB row is left unchanged — the existing bundle stays active. **Directory behaviour:** same version → files overwritten in the existing directory, nothing deleted; new version → new `<id>-<new_version>/` directory created, old `<id>-<old_version>/` deleted after activation.
+- `id` (bundle UUID) is **generated by the DB** via `gen_random_uuid()` — the server never supplies it.
+- `id`, `type`, and `version` are **never form fields** — all three are read from `metadata.yaml` inside the archive by `peekMetadata()`.
+- `peekMetadata()` infers the top-level directory from the first entry that contains a `/` — root-level loose files (macOS `._*`, `.DS_Store`, Windows `Thumbs.db`, etc.) are ignored for `topDir` inference.
+- The archive's top-level directory is **stripped during extraction** — files land directly in `<id>-<version>/` with no redundant subdirectory.
+- On-disk layout: `/data/catalog-bundles/<catalog_type>/<catalog_id>-<version>/` e.g. `/data/catalog-bundles/service/mayuka-service-1.0.0/`
+- **PUT** immutability check: `id` and `type` from the archive must match the existing DB record. `version` may differ. Mismatch → `422`, no extraction attempted.
+- `CatalogProvider.Reload()` re-queries the DB and rebuilds the in-memory catalog under `sync.RWMutex`.
+- Bundle files are stored in the **dedicated `catalog-bundles` volume** — isolated from `$BASE_DIR`.
+- The `catalog_bundles` table is added via a Goose migration (`20260430094507_create_catalog_bundles_table.sql`).
 
 ---
 
-### 7.5 New database migration
+### 6.5 New database migration
 
-Each row in `catalog_bundles` represents one uploaded bundle. The `name` column is derived server-side as `<catalog_id>-<version>` (e.g. `chat-2.0.0`) — it identifies the specific versioned bundle and is used as the directory name on the volume. The `status` column tracks lifecycle: `processing → active` on success, `failed` on validation error. **Only one `active` row per `catalog_id` is permitted** — enforced by a partial unique index. Bundles for different `catalog_id` values are all `active` simultaneously; each exists independently.
+Each row in `catalog_bundles` represents one uploaded bundle. The `id` is a UUID generated by the DB via `gen_random_uuid()` — the server never supplies it. The `name` column is derived server-side as `<catalog_id>-<version>` (e.g. `my-service-1.0.0`) and is used as the on-disk directory name. The `status` column tracks lifecycle: **POST** inserts a new row as `processing` then activates it with a single `Activate` UPDATE. **PUT** updates the existing row in-place with the same `Activate` UPDATE — no new row is ever inserted for a replace operation. **Only one `active` row per `catalog_id` is permitted** — enforced by a partial unique index; the in-place UPDATE for PUT never violates it since only one row exists.
 
 ```sql
 -- +goose Up
@@ -801,16 +618,16 @@ CREATE TYPE bundle_status AS ENUM (
 );
 
 CREATE TABLE catalog_bundles (
-    id               VARCHAR(30)    PRIMARY KEY,
-    -- e.g. bnd_01JW4X9K2M8VQRP3T5YZ
+    -- UUID generated by the DB — never supplied by the client.
+    id               UUID           PRIMARY KEY DEFAULT gen_random_uuid(),
 
-    -- Human-readable versioned name: <catalog_id>-<version>, e.g. "chat-2.0.0"
+    -- Human-readable versioned name: <catalog_id>-<version>, e.g. "my-service-1.0.0"
     -- Used as the directory name on the bundle volume.
     name             VARCHAR(200)   NOT NULL,
 
     status           bundle_status  NOT NULL DEFAULT 'processing',
     -- Uncompressed on-disk size in bytes, populated after extraction completes.
-    -- NULL on the immediate 202 response; set once the bundle reaches 'active' or 'failed'.
+    -- NULL until the bundle reaches 'active' or 'failed'.
     size_bytes       BIGINT,
 
     -- The catalog item type declared by the uploader: "service", "component", …
@@ -818,7 +635,7 @@ CREATE TABLE catalog_bundles (
     -- The id of the catalog item: e.g. "my-service", "my-llm-provider"
     catalog_id       VARCHAR(100)   NOT NULL,
     -- Semantic version of this bundle: e.g. "1.0.0", "2.1.0"
-    version          VARCHAR(50)    NOT NULL,
+    version          VARCHAR(50)    NOT NULL DEFAULT '',
 
     error            TEXT,
     uploaded_by      VARCHAR(100),
@@ -843,73 +660,69 @@ DROP TYPE   IF EXISTS bundle_status;
 
 ---
 
-### 7.6 Storage per runtime
+### 6.6 Storage per runtime
 
 Bundle storage is **intentionally isolated** from `$AI_SERVICES_BASE_DIR`. This prevents a `catalog delete` or application-data wipe from destroying uploaded bundles, and makes the storage unit independently snapshotable.
 
 #### Volume directory layout
 
-The volume is organised as `<catalog_type>/<name>/` where `name` is `<catalog_id>-<version>` (e.g. `chat-2.0.0`). At most **one versioned directory per `catalog_id`** exists on disk at any time — a `PUT` replaces the old directory with the new one once the replacement is marked `active`. Bundles for different `catalog_id` values coexist independently. Extraction writes directly into the new named directory; the old directory is removed only after the DB row is updated to `active`.
+The volume is organised as `<catalog_type>s/<name>/` where `name` is `<id>-<version>` (e.g. `chat-2.0.0`). At most **one versioned directory per `id`** exists on disk at any time — a `PUT` replaces the old directory with the new one once the replacement is marked `active`. Bundles for different `id` values coexist independently.
 
 ```
 /data/catalog-bundles/
-├── service/
+├── services/
 │   ├── chat-2.0.0/              ← active (one version of "chat" at a time)
-│   │   ├── metadata.yaml
-│   │   └── podman/...
-│   └── my-service-1.0.0/        ← active (independent catalog_id)
-│       ├── metadata.yaml
-│       └── podman/...
-└── component/
-    └── my-llm-provider-1.0.0/   ← active (independent catalog_id)
-        └── metadata.yaml
+│   │   └── chat/
+│   │       ├── metadata.yaml
+│   │       └── podman/...
+│   └── my-service-1.0.0/        ← active (independent id)
+│       └── my-service/
+│           ├── metadata.yaml
+│           └── podman/...
+└── components/
+    └── my-llm-provider-1.0.0/   ← active (independent id)
+        └── my-llm-provider/
+            └── metadata.yaml
 ```
 
 The `CatalogProvider` resolves each active item's path as:
 ```
-/data/catalog-bundles/<catalog_type>/<name>/
+/data/catalog-bundles/<catalog_type>s/<name>/
 ```
-where `name = <catalog_id>-<version>`.
+where `name = <id>-<version>` (derived from DB record).
 
-#### Podman — named volume `ai-services-bundles`
+#### Podman — named volume `catalog-bundles`
 
-A dedicated Podman named volume is created by `catalog configure` and mounted into the catalog backend container at `/data/catalog-bundles`. Because Podman named volumes are managed independently of `hostPath` directories, they survive `catalog delete --skip-cleanup` and do not depend on any host filesystem path.
-
-```
-Volume name:  ai-services-bundles
-Mount point (inside container):  /data/catalog-bundles/
-```
-
-**`catalog.yaml.tmpl` addition** (new volume entry alongside the existing `ai-services-data` mount):
+A dedicated Podman named volume (`catalog-bundles`) is declared in [`assets/catalog/podman/templates/catalog.yaml.tmpl`](ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl) and mounted at `/data/catalog-bundles` in the backend container. Because Podman named volumes are managed independently of `hostPath` directories, they survive `catalog delete --skip-cleanup`.
 
 ```yaml
-# new volume declaration
+# volumeMount on backend container (catalog.yaml.tmpl)
+- name: catalog-bundles
+  mountPath: /data/catalog-bundles
+
+# volume declaration
 - name: catalog-bundles
   persistentVolumeClaim:
-    claimName: "ai-services-bundles"   # Podman named volume, treated as PVC in pod spec
+    claimName: "catalog-bundles"
 ```
 
-```yaml
-# new container volumeMount on backend container
-- mountPath: /data/catalog-bundles
-  name: catalog-bundles
-```
+The volume name `catalog-bundles` is also listed in the `ai-services.io/volume` label so it is created and cleaned up by the lifecycle manager alongside other catalog volumes.
 
-#### OpenShift — dedicated PVC `catalog-bundles-pvc`
+#### OpenShift — dedicated PVC `catalog-bundles`
 
-A separate `PersistentVolumeClaim` is added to the catalog Helm chart (`assets/catalog/openshift/`) rather than reusing the existing `catalog-db` PVC. This keeps bundle lifecycle independent of the database and allows different storage classes (e.g. `ReadWriteMany` for multi-replica deployments in future).
+A separate `PersistentVolumeClaim` named `catalog-bundles` is added to the catalog Helm chart at [`assets/catalog/openshift/templates/catalog-bundles-pvc.yaml`](ai-services/assets/catalog/openshift/templates/catalog-bundles-pvc.yaml). It requests 5 Gi with `ReadWriteOnce` access mode and is mounted in the backend Deployment at `/data/catalog-bundles`.
 
 ```yaml
-# new PVC in catalog Helm chart
+# catalog-bundles-pvc.yaml
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: catalog-bundles-pvc
+  name: catalog-bundles
 spec:
   accessModes: [ReadWriteOnce]
   resources:
     requests:
-      storage: 1Gi     # tunable via chart values: catalog.bundleStorage
+      storage: 5Gi
 ```
 
 ```yaml
@@ -920,14 +733,14 @@ spec:
 # corresponding volume
 - name: catalog-bundles
   persistentVolumeClaim:
-    claimName: catalog-bundles-pvc
+    claimName: catalog-bundles
 ```
 
-**Layout inside the PVC** is identical to the Podman volume layout above, so `BundleService` needs no runtime-specific code paths. Both runtimes mount at `/data/catalog-bundles` — the same well-known constant the apiserver uses.
+**Layout inside both volumes** is identical, so `BundleService` needs no runtime-specific code paths. Both runtimes mount at `/data/catalog-bundles` — matching the `bundleStorageRoot` constant in the bundle service.
 
 ---
 
-### 7.7 Flow diagrams
+### 6.7 Upload flow diagrams
 
 #### Podman — upload flow
 
@@ -946,8 +759,8 @@ flowchart TD
         CP["CatalogProvider.Reload()"]
     end
 
-    subgraph VOL["Podman named volume — ai-services-bundles"]
-        BUNDLES["mount: /data/catalog-bundles<br/>service/name-version/<br/>component/name-version/"]
+    subgraph VOL["Podman named volume — catalog-bundles"]
+        BUNDLES["mount: /data/catalog-bundles<br/>services/id-version/<br/>components/id-version/"]
     end
 
     PG["ai-services--db<br/>postgresql<br/>catalog_bundles table"]
@@ -977,7 +790,7 @@ flowchart TD
             HANDLER["BundleHandler.UploadBundle()"]
             PIPELINE["Dispatch → Validate → Swap"]
             CP["CatalogProvider.Reload()"]
-            PVC["PVC: catalog-bundles-pvc<br/>dedicated, separate from catalog-db PVC<br/>mount: /data/catalog-bundles"]
+            PVC["PVC: catalog-bundles<br/>dedicated, separate from catalog-db PVC<br/>mount: /data/catalog-bundles"]
             PG["catalog-db StatefulSet<br/>postgresql :5432"]
         end
     end
@@ -993,318 +806,132 @@ flowchart TD
 
 ---
 
-### 7.8 Handler skeleton (Go)
+### 6.8 Handler and service (Go) — as implemented
 
-This shows how `BundleHandler` fits the existing handler pattern in [`apiserver/handlers/`](ai-services/internal/pkg/catalog/apiserver/handlers):
+The actual handler lives at [`apiserver/handlers/bundle_handler.go`](ai-services/internal/pkg/catalog/apiserver/handlers/bundle_handler.go) and the service at [`apiserver/services/bundle/`](ai-services/internal/pkg/catalog/apiserver/services/bundle/).
+
+**`BundleHandler`** follows the same pattern as `ApplicationHandler` and `CatalogHandler`:
 
 ```go
-// BundleHandler handles catalog bundle upload and listing.
-// It follows the same pattern as ApplicationHandler and CatalogHandler.
+// BundleHandler handles catalog bundle upload, replacement, deletion, and listing.
 type BundleHandler struct {
-    bundleService BundleServiceInterface
+    bundleService bundlesvc.BundleServiceInterface
 }
 
-// UploadBundle godoc
-//
-//  @Summary     Upload a new custom catalog bundle
-//  @Description Accepts a .tar.gz archive for a single catalog item. The caller declares
-//               catalog_id, catalog_type, and version as form fields. The catalog_id must
-//               match the top-level directory name inside the archive. Returns 409 if a
-//               bundle with the same catalog_id is already registered — use PUT to update.
-//               The archive is validated and, if valid, hot-reloaded into CatalogProvider.
-//  @Tags        Catalog
-//  @Accept      multipart/form-data
-//  @Produce     json
-//  @Security    BearerAuth
-//  @Param       file         formData  file    true   ".tar.gz bundle archive (max 50 MB)"
-//  @Param       catalog_id   formData  string  true   "Catalog item identifier, e.g. my-service; must match archive top-level directory"
-//  @Param       catalog_type formData  string  true   "Catalog item type: service or component"
-//  @Param       version      formData  string  true   "Semantic version of this bundle, e.g. 1.0.0"
-//  @Param       dry_run      formData  string  false  "Validate only, do not apply (default: false)"
-//  @Success     202  {object}  BundleResponse      "Bundle accepted and processing"
-//  @Failure     400  {object}  ErrorResponse       "Invalid request, catalog_id mismatch, or archive too large"
-//  @Failure     401  {object}  ErrorResponse       "Unauthorized"
-//  @Failure     403  {object}  ErrorResponse       "Admin role required"
-//  @Failure     409  {object}  ErrorResponse       "catalog_id already registered; use PUT"
-//  @Failure     422  {object}  BundleErrorResponse "Validation failed"
-//  @Router      /catalog/bundles [post]
-func (h *BundleHandler) UploadBundle(c *gin.Context) {
-    // 1. Enforce size limit before reading into memory
-    c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBundleSizeBytes)
-
-    // 2. Validate all required fields before touching the archive
-    catalogID := c.PostForm("catalog_id")
-    if catalogID == "" {
-        c.JSON(http.StatusBadRequest, ErrorResponse{Error: "catalog_id is required"})
-        return
-    }
-
-    catalogType := c.PostForm("catalog_type")
-    if catalogType == "" {
-        c.JSON(http.StatusBadRequest, ErrorResponse{Error: "catalog_type is required"})
-        return
-    }
-    if !isValidCatalogType(catalogType) {
-        c.JSON(http.StatusBadRequest, ErrorResponse{Error: fmt.Sprintf("unsupported catalog_type %q; accepted: service, component", catalogType)})
-        return
-    }
-
-    version := c.PostForm("version")
-    if version == "" {
-        c.JSON(http.StatusBadRequest, ErrorResponse{Error: "version is required"})
-        return
-    }
-
-    file, header, err := c.Request.FormFile("file")
-    if err != nil {
-        c.JSON(http.StatusBadRequest, ErrorResponse{Error: "missing or unreadable file field"})
-        return
-    }
-    defer file.Close()
-
-    if !strings.HasSuffix(header.Filename, ".tar.gz") {
-        c.JSON(http.StatusBadRequest, ErrorResponse{Error: "file must be a .tar.gz archive"})
-        return
-    }
-
-    dryRun := c.PostForm("dry_run") == "true"
-    userID := c.GetString(middleware.CtxUserIDKey)
-
-    // 3. Dry-run: synchronous validate-only path — no DB write, no CatalogProvider reload,
-    //    conflict check skipped (the archive is never persisted).
-    //    catalog_id is passed so ValidateBundle can confirm the archive top-level dir matches.
-    if dryRun {
-        result, err := h.bundleService.ValidateBundle(c.Request.Context(), file, catalogID, catalogType)
-        if err != nil {
-            if valErr, ok := err.(*ValidationError); ok {
-                c.JSON(valErr.Code, valErr)
-                return
-            }
-            c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "dry-run validation failed unexpectedly"})
-            return
-        }
-        c.JSON(http.StatusOK, result)
-        return
-    }
-
-    // 4. Conflict check — only for real (non-dry-run) uploads.
-    exists, err := h.bundleService.CatalogIDExists(c.Request.Context(), catalogID)
-    if err != nil {
-        c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "failed to check existing bundles"})
-        return
-    }
-    if exists {
-        c.JSON(http.StatusConflict, ErrorResponse{
-            Error: fmt.Sprintf("a bundle with catalog_id %q already exists; use PUT /api/v1/catalog/bundles/%s to update it", catalogID, catalogID),
-        })
-        return
-    }
-
-    resp, err := h.bundleService.ProcessBundle(c.Request.Context(), file, header.Size, userID, catalogID, catalogType, version)
-    if err != nil {
-        if valErr, ok := err.(*ValidationError); ok {
-            c.JSON(valErr.Code, ErrorResponse{Error: valErr.Message})
-            return
-        }
-        c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "bundle processing failed"})
-        return
-    }
-
-    c.JSON(http.StatusAccepted, resp)
-}
-
-// UpdateBundle godoc
-//
-//  @Summary     Replace an existing catalog bundle
-//  @Description Replaces the bundle identified by bundle_id. catalog_id and catalog_type
-//               are resolved from the DB record — neither is a form field. Version is read
-//               from metadata.yaml inside the archive; catalog_id and catalog_type in the
-//               archive metadata must match the existing record (immutable). Returns 404 if
-//               no bundle with that bundle_id exists. The existing bundle remains active
-//               until the replacement is validated and activated.
-//  @Tags        Catalog
-//  @Accept      multipart/form-data
-//  @Produce     json
-//  @Security    BearerAuth
-//  @Param       bundle_id    path      string  true   "Internal record ID of the bundle to replace, e.g. bnd_01JW4X9K2M8VQRP3T5YZ"
-//  @Param       file         formData  file    true   ".tar.gz replacement archive (max 50 MB)"
-//  @Param       dry_run      formData  string  false  "Validate only, do not apply (default: false)"
-//  @Success     202  {object}  BundleResponse      "Replacement bundle accepted and processing; version populated after extraction"
-//  @Failure     400  {object}  ErrorResponse       "Missing file field or archive too large"
-//  @Failure     401  {object}  ErrorResponse       "Unauthorized"
-//  @Failure     403  {object}  ErrorResponse       "Admin role required"
-//  @Failure     404  {object}  ErrorResponse       "No bundle with this bundle_id; use POST to create a new one"
-//  @Failure     422  {object}  BundleErrorResponse "Validation failed or immutable fields differ; existing bundle unchanged"
-//  @Router      /catalog/bundles/{bundle_id} [put]
-func (h *BundleHandler) UpdateBundle(c *gin.Context) {
-    // 1. Enforce size limit before reading into memory
-    c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBundleSizeBytes)
-
-    bundleID := c.Param("bundle_id")
-
-    // 2. Resolve existing record by bundle_id — 404 if not found.
-    //    catalog_id and catalog_type are taken from the resolved record; neither
-    //    is supplied by the caller.
-    existing, err := h.bundleService.GetByBundleID(c.Request.Context(), bundleID)
-    if err != nil {
-        c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "failed to look up bundle"})
-        return
-    }
-    if existing == nil {
-        c.JSON(http.StatusNotFound, ErrorResponse{
-            Error: fmt.Sprintf("no bundle with id %q; use POST /api/v1/catalog/bundles to create a new one", bundleID),
-        })
-        return
-    }
-
-    // version is NOT a form field — it is read from metadata.yaml inside the archive.
-
-    file, header, err := c.Request.FormFile("file")
-    if err != nil {
-        c.JSON(http.StatusBadRequest, ErrorResponse{Error: "missing or unreadable file field"})
-        return
-    }
-    defer file.Close()
-
-    if !strings.HasSuffix(header.Filename, ".tar.gz") {
-        c.JSON(http.StatusBadRequest, ErrorResponse{Error: "file must be a .tar.gz archive"})
-        return
-    }
-
-    dryRun := c.PostForm("dry_run") == "true"
-    userID := c.GetString(middleware.CtxUserIDKey)
-
-    // catalog_id and catalog_type are both taken from the resolved record.
-    // ValidateBundle and ReplaceBundle verify that the archive's top-level directory
-    // matches existing.CatalogID, and that catalog_id + catalog_type in metadata.yaml
-    // are unchanged (immutable). Version is read from metadata.yaml.
-
-    // 3. Dry-run: synchronous validate-only path — existing bundle is completely untouched.
-    //    The 404 check above still ran, so we know the bundle exists.
-    if dryRun {
-        result, err := h.bundleService.ValidateBundle(c.Request.Context(), file, existing.CatalogID, existing.CatalogType)
-        if err != nil {
-            if valErr, ok := err.(*ValidationError); ok {
-                c.JSON(valErr.Code, valErr)
-                return
-            }
-            c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "dry-run validation failed unexpectedly"})
-            return
-        }
-        c.JSON(http.StatusOK, result)
-        return
-    }
-
-    resp, err := h.bundleService.ReplaceBundle(c.Request.Context(), existing, file, header.Size, userID)
-    // existing carries CatalogID, CatalogType, and the old Name — ReplaceBundle uses all three.
-    // Version is extracted from the archive's metadata.yaml inside ReplaceBundle.
-    if err != nil {
-        if valErr, ok := err.(*ValidationError); ok {
-            c.JSON(valErr.Code, ErrorResponse{Error: valErr.Message})
-            return
-        }
-        c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "bundle replacement failed"})
-        return
-    }
-
-    c.JSON(http.StatusAccepted, resp)
-}
-
-// DeleteBundle godoc
-//
-//  @Summary     Delete a catalog bundle
-//  @Description Removes the bundle identified by bundle_id: deletes the on-disk directory
-//               and the DB record, then reloads CatalogProvider synchronously. Existing
-//               deployed applications are not affected.
-//  @Tags        Catalog
-//  @Produce     json
-//  @Security    BearerAuth
-//  @Param       bundle_id  path  string  true  "Internal record ID of the bundle to delete, e.g. bnd_01JW4X9K2M8VQRP3T5YZ"
-//  @Success     204  "Bundle deleted"
-//  @Failure     401  {object}  ErrorResponse  "Unauthorized"
-//  @Failure     403  {object}  ErrorResponse  "Admin role required"
-//  @Failure     404  {object}  ErrorResponse  "No bundle with this bundle_id"
-//  @Router      /catalog/bundles/{bundle_id} [delete]
-func (h *BundleHandler) DeleteBundle(c *gin.Context) {
-    bundleID := c.Param("bundle_id")
-
-    // 1. Resolve existing record — 404 if not found.
-    existing, err := h.bundleService.GetByBundleID(c.Request.Context(), bundleID)
-    if err != nil {
-        c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "failed to look up bundle"})
-        return
-    }
-    if existing == nil {
-        c.JSON(http.StatusNotFound, ErrorResponse{
-            Error: fmt.Sprintf("no bundle with id %q", bundleID),
-        })
-        return
-    }
-
-    // 2. Delete on-disk directory, remove DB record, reload CatalogProvider — all synchronous.
-    if err := h.bundleService.DeleteBundle(c.Request.Context(), existing); err != nil {
-        c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "failed to delete bundle"})
-        return
-    }
-
-    c.Status(http.StatusNoContent)
+func NewBundleHandler(svc bundlesvc.BundleServiceInterface) *BundleHandler {
+    return &BundleHandler{bundleService: svc}
 }
 ```
 
-**`BundleServiceInterface` additions:**
+**`UploadBundle` (POST → 201)** — single form field: `file`. `catalog_id`, `catalog_type`,
+and `version` are read entirely from the archive's `metadata.yaml`:
+
+```go
+func (h *BundleHandler) UploadBundle(c *gin.Context) {
+    c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBundleSizeBytes)
+
+    file, header, err := c.Request.FormFile("file")
+    // ... 400 if missing or not .tar.gz ...
+
+    userID := c.GetString(middleware.CtxUserIDKey)
+
+    // ProcessBundle: peek metadata → conflict check → extract → validate →
+    //                insert DB row as active → reload → return 201.
+    resp, err := h.bundleService.ProcessBundle(c.Request.Context(), file, userID)
+    // ... 409 / 422 / 500 handled by ValidationError.Code ...
+    c.Header("Location", fmt.Sprintf("/api/v1/catalog/bundles/%s", resp.ID))
+    c.JSON(http.StatusCreated, resp)
+}
+```
+
+**`UpdateBundle` (PUT → 202)** — resolves existing record from `bundle_id` path param;
+single form field: `file`. No `dry_run` — use `POST /catalog/bundles/validate` for that:
+
+```go
+func (h *BundleHandler) UpdateBundle(c *gin.Context) {
+    bundleID := c.Param("bundle_id")
+    existing, err := h.bundleService.GetByBundleID(c.Request.Context(), bundleID)
+    // ... 404 if nil ...
+
+    file, header, err := c.Request.FormFile("file")
+    // ... 400 if missing or not .tar.gz ...
+
+    // ReplaceBundle: peek metadata → validate catalog_id/catalog_type immutable →
+    //                return 202 immediately with existing ID →
+    //                goroutine: extract, UPDATE existing row in-place, delete old dir if
+    //                name changed, reload. On failure DB row is left unchanged.
+    resp, err := h.bundleService.ReplaceBundle(c.Request.Context(), existing, file, userID)
+    c.Header("Location", fmt.Sprintf("/api/v1/catalog/bundles/%s", resp.ID))
+    c.JSON(http.StatusAccepted, resp)
+}
+```
+
+**`BundleServiceInterface`** — as defined in [`services/bundle/types.go`](ai-services/internal/pkg/catalog/apiserver/services/bundle/types.go):
 
 ```go
 type BundleServiceInterface interface {
-    // ValidateBundle is the shared dry-run implementation used by both POST and PUT.
-    // It peeks at the archive's top-level directory, verifies it matches catalogID,
-    // extracts to a temp directory, runs CatalogProvider.ValidateFS for the given
-    // catalogType, then deletes the temp directory regardless of outcome.
-    // Returns a *ValidationResult on success (200) or a *ValidationError on failure (422).
-    // No DB row is written and CatalogProvider is never reloaded.
-    ValidateBundle(ctx context.Context, file io.Reader, catalogID, catalogType string) (*ValidationResult, error)
+    // ValidateBundle — dedicated validate-only path (POST /catalog/bundles/validate).
+    // Reads id, type, version from metadata.yaml inside the archive,
+    // extracts to a temp directory, validates structure, then cleans up.
+    // No DB row is written and no reload is triggered.
+    ValidateBundle(ctx context.Context, file io.Reader) (*ValidationResult, error)
 
-    // ProcessBundle handles a real (non-dry-run) POST upload.
-    // The conflict check is performed by the handler before this is called.
-    // catalogID is the client-supplied identifier; the service verifies it matches
-    // the archive's top-level directory before extracting.
-    ProcessBundle(ctx context.Context, file io.Reader, size int64, userID, catalogID, catalogType, version string) (*BundleResponse, error)
+    // ProcessBundle — synchronous POST upload.
+    // Reads metadata from archive, checks conflict, extracts to permanent dir,
+    // validates structure, inserts DB row then activates in one UPDATE, reloads catalog.
+    // Returns *BundleResponse re-fetched from DB with status "active" (201).
+    ProcessBundle(ctx context.Context, file io.Reader, userID string) (*BundleResponse, error)
 
-    // ReplaceBundle handles a real (non-dry-run) PUT update.
-    // existing is the current active bundle record; CatalogID, CatalogType, and Name
-    // are all read from it. Version is read from metadata.yaml inside the archive —
-    // it is not passed as a parameter. catalog_id and catalog_type in the archive
-    // metadata are validated to match existing.CatalogID and existing.CatalogType;
-    // a mismatch returns a ValidationError (422). The old on-disk directory is
-    // removed only after the new bundle is marked active.
-    ReplaceBundle(ctx context.Context, existing *Bundle, file io.Reader, size int64, userID string) (*BundleResponse, error)
+    // ReplaceBundle — async PUT update.
+    // Sync: validates archive and immutable fields, returns 202 immediately (same bundle ID).
+    // Async goroutine: extracts, validates, UPDATEs existing row in-place
+    //       (status=active, version, name, size_bytes — single statement),
+    //       deletes old on-disk directory if name changed, reloads catalog.
+    //       On failure: DB row left unchanged — existing bundle stays active.
+    ReplaceBundle(ctx context.Context, existing *BundleRecord, file io.Reader, userID string) (*BundleResponse, error)
 
-    // CatalogIDExists returns true if any active bundle row with the given catalog_id exists.
-    CatalogIDExists(ctx context.Context, catalogID string) (bool, error)
+    GetByBundleID(ctx context.Context, bundleID string) (*BundleRecord, error)
+    GetBundleByID(ctx context.Context, bundleID string) (*BundleResponse, error)
+    DeleteBundle(ctx context.Context, existing *BundleRecord) error
+    ListBundles(ctx context.Context) (*BundleListResponse, error)
+}
+```
 
-    // GetByBundleID returns the bundle record for the given internal bundle ID, or nil.
-    // Used by PUT and DELETE to resolve the bundle from the path parameter.
-    GetByBundleID(ctx context.Context, bundleID string) (*Bundle, error)
+**Key types** (defined in [`services/bundle/types.go`](ai-services/internal/pkg/catalog/apiserver/services/bundle/types.go)):
 
-    // DeleteBundle removes the bundle's on-disk directory, deletes the DB record,
-    // and calls CatalogProvider.Reload() — all synchronously.
-    // existing must be the resolved record (provides CatalogType, Name for the path).
-    DeleteBundle(ctx context.Context, existing *Bundle) error
+```go
+// BundleRecord is the service-layer view of a DB row.
+type BundleRecord struct {
+    ID, Name, Status, CatalogType, CatalogID, Version, UploadedBy string
+    SizeBytes  *int64
+    UploadedAt time.Time
 }
 
-// ValidationResult is the 200 OK body returned by a successful dry-run.
+// BundleMetadata holds the fields read from metadata.yaml inside an archive.
+type BundleMetadata struct {
+    CatalogID, CatalogType, Version string
+}
+
+// ValidationResult is the 200 OK body for POST /catalog/bundles/validate.
 type ValidationResult struct {
-    Valid       bool     `json:"valid"`
-    CatalogID   string   `json:"catalog_id"`
-    CatalogType string   `json:"catalog_type"`
-    Warnings    []string `json:"warnings,omitempty"`
+    Valid       bool   `json:"valid"`
+    CatalogID   string `json:"catalog_id"`
+    CatalogType string `json:"catalog_type"`
+    Version     string `json:"version"`
+}
+
+// ValidationError carries an HTTP status code alongside its message.
+type ValidationError struct {
+    Code    int
+    Message string
 }
 ```
 
 ---
 
-## 8. Custom Template Directory Structure
+## 7. Custom Template Directory Structure
 
-### 8.1 Minimum layout for a new service
+### 7.1 Minimum layout for a new service
 
 ```
 services/
@@ -1324,7 +951,7 @@ Package as a `.tar.gz` with `services/` at the top level:
 tar -czf my-bundle.tar.gz services/
 ```
 
-### 8.2 Service top-level `metadata.yaml`
+### 7.2 Service top-level `metadata.yaml`
 
 ```yaml
 id: my-service                   # unique across built-in + custom services
@@ -1339,7 +966,7 @@ dependencies:
 standalone: true
 ```
 
-### 8.3 Runtime `metadata.yaml` (Podman)
+### 7.3 Runtime `metadata.yaml` (Podman)
 
 ```yaml
 name: my-service
@@ -1353,7 +980,7 @@ resources:
   storage: 10737418240            # bytes
 ```
 
-### 8.4 Built-in service IDs are reserved
+### 7.4 Built-in service IDs are reserved
 
 A bundle whose top-level directory name matches an existing built-in service (`chat`, `digitize`, `similarity`, `summarize`) will be rejected by the validation step with a `422` error. Custom bundles must use a unique `catalog_id` that does not conflict with any embedded service or architecture.
 
@@ -1361,13 +988,13 @@ Built-in IDs reserved at this time: `chat`, `digitize`, `similarity`, `summarize
 
 ---
 
-## 9. Remote Deployment
+## 8. Remote Deployment
 
 The control-plane catalog server acts as the authoritative bundle registry. Custom service assets are uploaded once to the control plane and stored there. Remote agents do not need to read assets directly — the control-plane catalog backend orchestrates all template resolution and service rendering on their behalf. No `.tar.gz` retention is required; only the extracted asset files are kept on the control-plane volume.
 
 ---
 
-## 10. Template Values Reference
+## 9. Template Values Reference
 
 > **Scope: Podman only.**  The template values, `@generate` directives, and `ai-services.io/` labels/annotations described in this section apply to the **Podman** runtime, which uses Go-template `.yaml.tmpl` files.  OpenShift custom service templates use Helm charts and a different rendering pipeline; a full reference for that runtime is deferred.
 >
@@ -1840,7 +1467,7 @@ Custom component templates may adopt the same pattern for any key name. The `.en
 
 ---
 
-## 11. Usage Examples
+## 10. Usage Examples
 
 ### 10.1 Upload a custom service bundle
 
@@ -1851,29 +1478,30 @@ curl -X POST https://catalog-api.<domain>/api/v1/auth/login \
   -d '{"username":"admin","password":"<password>"}' \
   | jq -r .access_token > token.txt
 
-# Package the custom service directory
-tar -czf my-bundle.tar.gz services/
+# Package the custom service directory.
+# The archive must contain a top-level dir whose name matches catalog_id in metadata.yaml.
+#
+# macOS — suppress Apple Double (._*) resource-fork entries:
+COPYFILE_DISABLE=1 tar -czf my-bundle.tar.gz my-service/
+#
+# Linux / Windows (WSL / Git Bash) — plain tar, no extra flags needed:
+# tar -czf my-bundle.tar.gz my-service/
 
-# Upload the bundle — POST creates a new entry (fails with 409 if catalog_id already exists)
+# Upload the bundle — POST is synchronous; returns 201 Created when the bundle is active.
+# catalog_id, catalog_type, and version are read from metadata.yaml inside the archive.
 curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
   -H "Authorization: Bearer $(cat token.txt)" \
-  -F "file=@my-bundle.tar.gz" \
-  -F "catalog_id=my-service" \
-  -F "catalog_type=service" \
-  -F "version=1.0.0"
+  -F "file=@my-bundle.tar.gz"
+# 201 Created — {"id":"bnd_01JW4X9K2M8VQRP3T5YZ","status":"active","catalog_id":"my-service",...}
 
-# Poll for activation using the bundle ID from the 202 response
-curl -s https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ \
-  -H "Authorization: Bearer $(cat token.txt)" | jq .status
-# "active"
-
-# Update the bundle — PUT uses the internal bundle_id from the 202 response above.
-# catalog_id, catalog_type, and version are all resolved from the archive metadata;
-# only the file is required. catalog_id and catalog_type are immutable.
-tar -czf my-bundle-v2.tar.gz services/
+# Update the bundle — PUT is async (202). catalog_id and catalog_type are resolved from
+# the existing DB record and must match the archive metadata (immutable).
+# version is read from the replacement archive's metadata.yaml.
+COPYFILE_DISABLE=1 tar -czf my-bundle-v2.tar.gz my-service/
 curl -X PUT https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ \
   -H "Authorization: Bearer $(cat token.txt)" \
   -F "file=@my-bundle-v2.tar.gz"
+# 202 Accepted — {"id":"bnd_02EF9Z4PG2Q0XRS5V7WB","status":"processing",...}
 
 # Poll for the replacement to go active
 curl -s https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_02EF9Z4PG2Q0XRS5V7WB \
@@ -1913,26 +1541,17 @@ curl -X POST https://catalog-api.<domain>/api/v1/applications/ \
 
 ### 10.3 Attempt to use a reserved built-in ID (rejected)
 
-Uploading a bundle whose `catalog_id` matches a built-in service is rejected at validation time — the extracted directory is cleaned up and no activation occurs:
+Uploading a bundle whose `catalog_id` (declared in `metadata.yaml`) matches a built-in service is rejected synchronously during POST — the extracted directory is cleaned up and a `422` is returned immediately:
 
 ```bash
 # Attempting to upload a bundle with catalog_id "chat" (a built-in service)
-tar -czf chat-bundle.tar.gz services/chat
+tar -czf chat-bundle.tar.gz chat/
 
 curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
   -H "Authorization: Bearer $(cat token.txt)" \
-  -F "file=@chat-bundle.tar.gz" \
-  -F "catalog_id=chat" \
-  -F "catalog_type=service" \
-  -F "version=2.0.0"
-
-# Poll for result — validation rejects the bundle
-curl -s https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_03EF9Z2GH4Q7RST5V8WX \
-  -H "Authorization: Bearer $(cat token.txt)" | jq '{status, error}'
-# {
-#   "status": "failed",
-#   "error":  "catalog_id \"chat\" is reserved by a built-in service and cannot be overridden"
-# }
+  -F "file=@chat-bundle.tar.gz"
+# 422 Unprocessable Entity
+# {"error":"catalog_id \"chat\" is reserved by a built-in service and cannot be overridden"}
 ```
 
 ### 10.4 List custom services via the catalog API
@@ -1950,77 +1569,54 @@ curl -s https://catalog-api.<domain>/api/v1/services \
 # "my-service"   ← custom
 ```
 
-### 10.5 Dry-run validation before applying
+### 10.5 Validate a bundle before uploading
 
-`dry_run=true` is **synchronous** — the server extracts the archive to a temporary directory, validates it, cleans up, and replies inline. No `202` + polling is involved; you get a direct `200 OK` or `422`.
+`POST /api/v1/catalog/bundles/validate` is a dedicated validate-only endpoint — the server extracts the archive to a temporary directory, validates structure, cleans up, and replies inline. No DB record is written and `CatalogProvider` is not reloaded.
 
 ```bash
-# --- Validate a new bundle (POST dry-run) ---
-# The conflict check is skipped, so this works even if my-service is already registered.
-curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
+# --- Validate a bundle ---
+curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles/validate \
   -H "Authorization: Bearer $(cat token.txt)" \
-  -F "file=@my-bundle.tar.gz" \
-  -F "catalog_id=my-service" \
-  -F "catalog_type=service" \
-  -F "version=1.0.0" \
-  -F "dry_run=true"
+  -F "file=@my-bundle.tar.gz"
 # 200 OK
 # {
-#   "valid": true,
-#   "catalog_id": "my-service",
-#   "catalog_type": "service"
-# }
-
-# --- Validate a replacement bundle before applying (PUT dry-run) ---
-# The 404 check still runs — my-service must be registered, otherwise 404.
-curl -X PUT https://catalog-api.<domain>/api/v1/catalog/bundles/my-service \
-  -H "Authorization: Bearer $(cat token.txt)" \
-  -F "file=@my-bundle-v2.tar.gz" \
-  -F "version=2.0.0" \
-  -F "dry_run=true"
-# 200 OK — existing my-service bundle is completely untouched
-# {
-#   "valid": true,
-#   "catalog_id": "my-service",
-#   "catalog_type": "service"
+#   "valid":        true,
+#   "catalog_id":   "my-service",
+#   "catalog_type": "service",
+#   "version":      "1.0.0"
 # }
 
 # --- Validation failure example ---
-curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
+curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles/validate \
   -H "Authorization: Bearer $(cat token.txt)" \
-  -F "file=@broken-bundle.tar.gz" \
-  -F "catalog_id=my-service" \
-  -F "catalog_type=service" \
-  -F "version=1.0.0" \
-  -F "dry_run=true"
+  -F "file=@broken-bundle.tar.gz"
 # 422 Unprocessable Entity — nothing was written to disk or DB
 ```
 
 ---
 
-## 12. Backward Compatibility
+## 11. Backward Compatibility
 
 | Scenario | Behaviour |
 |---|---|
-| No bundle uploaded yet | Identical to current — `EmbeddedCatalogFS` only |
-| Volume mounted but no `status='active'` rows in DB | Only `EmbeddedCatalogFS` is used; behaviour identical to today |
+| No bundle uploaded yet | Identical to current — embedded assets only (`loadEmbeddedItems`) |
+| Volume mounted but no `status='active'` rows in DB | Only embedded assets are used; behaviour identical to today |
 | Custom service has same `id` as built-in | Bundle is rejected with `422`; built-in is never shadowed |
 | Multiple bundles for different `catalog_id` values | All are `active` simultaneously; each is fully independent. At most one bundle (one version) per `catalog_id` is active at any given time. |
 | Existing applications in the database | Unaffected; records reference `catalog_id` strings which remain stable |
-| `catalog_type` value not in the accepted list | Rejected immediately with `400` before the archive is touched |
+| `catalog_type` value not in the accepted list | Rejected with `422` when `metadata.yaml` inside the archive is parsed |
 | New `catalog_type` value introduced in a future release | Existing clients that receive an unfamiliar `catalog_type` string are unaffected — they simply don't render that bundle type in their UI |
 | `assets.ApplicationFS` and existing `application/` packages | Not touched; independent of `CatalogProvider` |
 | OpenShift deployment | Same API endpoint and bundle format; only the storage backend differs (PVC vs named volume) |
 
 ---
 
-## 13. Future Enhancements
+## 12. Future Enhancements
 
 1. **Scaffolding generator** — `ai-services catalog scaffold --service my-service --runtime podman` emits a minimal but correct directory skeleton ready to be tar'd and uploaded.
-2. **Template validation command** — `dry_run=true` already supported in §7.2.1; a dedicated CLI command `ai-services catalog validate --bundle <file>` wraps this for local use.
+2. **Template validation CLI command** — `POST /api/v1/catalog/bundles/validate` already exists server-side; a dedicated CLI command `ai-services catalog validate --bundle <file>` that calls this endpoint would let operators validate locally before uploading.
 3. **Remote catalog repositories** — fetch a bundle from an OCI registry or HTTPS URL; the server pulls and applies it directly, removing the need for a client upload.
 4. **Schema enforcement on custom `metadata.yaml`** — reuse the existing [`validators.ApplicationValidator`](ai-services/internal/pkg/catalog/validators/validation.go) to reject malformed custom metadata at validation time.
 5. **Version compatibility checks** — validate that a custom service's `version` satisfies any `>=x.y.z` constraint declared by the built-in architecture that references it.
 6. **Role-based upload access** — introduce a `catalog-editor` JWT role that can upload bundles but cannot perform `DELETE /applications` or other destructive operations.
 7. **Component support in bundles** — when `components/` is promoted from reserved to active in the bundle processor, users can ship custom component providers (e.g. a private LLM backend) alongside their services in the same archive.
-

--- a/docs/proposals/catalog/custom-service-templates-proposal.md
+++ b/docs/proposals/catalog/custom-service-templates-proposal.md
@@ -1,0 +1,1095 @@
+# Custom Service Templates for Customer Asset Onboarding
+
+**Version:** 1.0
+**Date:** Aug 2026
+**Status:** Draft
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Background and Motivation](#2-background-and-motivation)
+3. [Catalog Pod Architecture](#3-catalog-pod-architecture)
+4. [New Asset Structure](#4-new-asset-structure)
+5. [Template Provider Design](#5-template-provider-design)
+6. [CatalogProvider Integration](#6-catalogprovider-integration)
+7. [API Upload](#7-api-upload)
+8. [Custom Template Directory Structure](#8-custom-template-directory-structure)
+9. [Usage Examples](#9-usage-examples)
+10. [Backward Compatibility](#10-backward-compatibility)
+11. [Future Enhancements](#11-future-enhancements)
+
+---
+
+## 1. Executive Summary
+
+Enterprise customers deploying AI Services on their own infrastructure often bring proprietary workloads, domain-specific models, and internal service patterns that are not represented in the platform's built-in catalog. Today there is no supported path for customers to introduce their own services into a running deployment without modifying the platform binary itself — a process that is impractical at scale and incompatible with air-gapped or regulated environments.
+
+This proposal introduces **Custom Service Templates** — a first-class mechanism for customers to onboard their own AI service assets into the catalog at runtime. A customer packages their service definition as a `.tar.gz` bundle and uploads it to the running catalog backend over HTTPS. The platform validates, registers, and hot-reloads the new service immediately — with no pod restart, no host filesystem access, and no changes to the platform binary required. The mechanism is identical on Podman single-VM deployments and OpenShift clusters.
+
+Built-in platform services are protected: a bundle whose `catalog_id` conflicts with an embedded service is rejected at validation time, ensuring the integrity of the core catalog is never compromised.
+
+| Property | Detail |
+|---|---|
+| **Use case** | Onboard customer-authored service assets into a live catalog deployment |
+| **Delivery** | `POST /api/v1/catalog/bundles` — `.tar.gz` archive uploaded over HTTPS to the running catalog |
+| **Podman** | ✅ — bundle stored in dedicated named volume `ai-services-bundles` |
+| **OpenShift** | ✅ — bundle stored in dedicated PVC `catalog-bundles-pvc` |
+| **Live reload** | Automatic — `CatalogProvider` hot-reloads after successful extraction, no pod restart |
+| **Audit trail** | `catalog_bundles` table in PostgreSQL — every upload is recorded with uploader identity and timestamp |
+| **Best for** | Enterprise customers, air-gapped deployments, regulated environments, CI/CD-driven asset promotion |
+
+---
+
+## 2. Background and Motivation
+
+### 2.1 Current Asset Architecture
+
+The catalog uses a **service-oriented** decomposition. All platform assets are compiled into the binary at build time via `go:embed`, living under three roots in `assets.CatalogFS` (declared in [`ai-services/assets/fs.go`](ai-services/assets/fs.go:11)):
+
+| Root | Purpose |
+|---|---|
+| `ai-services/assets/architectures/` | Architecture metadata (e.g. `rag`) declaring which services compose it |
+| `ai-services/assets/services/` | Per-service assets: `chat`, `digitize`, `similarity`, `summarize` |
+| `ai-services/assets/components/` | Reusable component providers: `llm`, `embedding`, `vector_store`, `reranker` |
+
+All loading flows through [`CatalogProvider`](ai-services/internal/pkg/catalog/catalog.go:32), which walks `CatalogFS` at startup and caches every `metadata.yaml` it finds. Deployment is driven by the catalog **apiserver** running inside a pod — not by the CLI host process. Because the catalog is embedded in the binary, adding a new service today requires a full platform build and redeployment.
+
+### 2.2 Problem Statement
+
+Enterprise customers operate AI Services in environments where the built-in service catalog does not fully represent their workloads. Key pain points include:
+
+- **Proprietary services** — customers have internal AI workloads (custom RAG pipelines, domain-specific inference services, internal tooling) that need to be deployable through the same catalog-driven workflow as built-in services.
+- **Operational constraints** — air-gapped environments, regulated industries, and on-premises VM deployments make it impractical to request a platform rebuild each time a customer needs to register a new service.
+- **CI/CD asset promotion** — teams need to promote service definitions through staging and production deployments programmatically, without manual intervention on each host.
+- **Partner and ISV onboarding** — system integrators and technology partners need a supported path to register their own service assets alongside IBM-certified ones.
+
+Currently, there is no supported mechanism to extend the catalog at runtime. Custom assets are delivered by uploading a `.tar.gz` bundle to the running catalog API over HTTPS. The apiserver extracts it to isolated storage, validates it, and hot-reloads `CatalogProvider` — no pod restart, no CLI host access required, and no changes to the platform binary needed.
+
+### 2.3 Goals
+
+1. Provide a secure, authenticated API endpoint (`POST /api/v1/catalog/bundles`) through which customers can register new service assets into a live deployment without platform downtime.
+2. At apiserver startup, compose customer-uploaded bundles with the embedded `CatalogFS` via a `CompositeCatalogFS`, presenting a unified catalog that includes both platform and customer services.
+3. Protect the integrity of built-in platform services — bundles that attempt to use a reserved `catalog_id` are rejected; the embedded catalog is immutable at runtime.
+4. Maintain full backward compatibility — in the absence of any uploaded bundles, behaviour is identical to the current release.
+
+---
+
+## 3. Catalog Pod Architecture
+
+Understanding how the catalog runs as pods is essential context for where custom templates plug in.
+
+### 3.1 Catalog pod topology
+
+```mermaid
+flowchart TD
+    subgraph HOST["VM Host"]
+        DIR_BASE["$AI_SERVICES_BASE_DIR<br/>common/caddy · caddy-config · models<br/>hostPath volume"]
+        SOCK["/run/podman/podman.sock<br/>hostPath socket"]
+        IOMMU["/sys/kernel/iommu_groups<br/>hostPath read-only"]
+    end
+
+    BUNDLE_VOL["Podman named volume<br/>ai-services-bundles<br/>mount: /data/catalog-bundles"]
+
+    subgraph PODS["Podman pods — shared pod network"]
+        subgraph CADDY_POD["ai-services--caddy pod"]
+            C["container: caddy<br/>:443 HTTPS external<br/>:2019 admin API host-only"]
+        end
+
+        subgraph DB_POD["ai-services--db pod"]
+            PG["container: postgresql<br/>:5432"]
+        end
+
+        subgraph CAT_POD["ai-services--catalog pod"]
+            INIT["initContainer: db-migration<br/>gates UI and backend startup"]
+            UI["container: ui :8081"]
+            BE["container: backend :8080 apiserver<br/>mount: /data/catalog-bundles"]
+        end
+    end
+
+    EXT["External client"]
+
+    DIR_BASE    -- "volume mount" --> C
+    DIR_BASE    -- "volume mount" --> BE
+    SOCK        -- "volume mount" --> BE
+    IOMMU       -- "volume mount ro" --> BE
+    BUNDLE_VOL  -- "named volume → /data/catalog-bundles" --> BE
+
+    INIT -- "gates" --> UI
+    INIT -- "gates" --> BE
+    BE -- "SQL :5432" --> PG
+    BE -- "Admin API :2019" --> C
+
+    EXT -- "HTTPS :443" --> C
+    C   -- "catalog-ui route" --> UI
+    C   -- "catalog-api route" --> BE
+```
+
+### 3.2 Why this matters for custom templates
+
+The catalog backend's `CatalogProvider` runs **inside the `ai-services--catalog` container**, not on the CLI host. `assets.CatalogFS` is baked into the binary at build time (via `go:embed`). For custom templates to be visible at runtime they must reach the container and be overlaid onto the embedded FS.
+
+Custom assets are delivered via the running catalog API: the client POSTs a `.tar.gz` bundle over HTTPS, and the apiserver writes the extracted contents to a dedicated named volume (`ai-services-bundles` on Podman, `catalog-bundles-pvc` on OpenShift) that it already owns. Both runtimes mount the volume at the well-known path `/data/catalog-bundles` inside the container. Bundles are stored under `<catalog_type>/<name>/` where `name = <catalog_id>-<version>` (e.g. `service/chat-2.0.0/`). At startup, `CatalogProvider` queries the DB for all `status = 'active'` rows, resolves each to its named directory, and builds a `CompositeCatalogFS`. Hot-reload happens in-process after every successful upload; no pod restart is needed.
+
+### 3.3 OpenShift path
+
+For OpenShift, `catalog configure` runs [`openshift.DeployCatalog`](ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go:24), which uses Helm to install/upgrade the catalog chart from `assets/catalog/openshift/`. No chart change is required for bundle support: once the catalog is deployed, users POST bundles to the Route-exposed API endpoint. The backend writes to the `catalog-bundles-pvc` PVC it already mounts (see §7.6).
+
+---
+
+## 4. New Asset Structure
+
+### 4.1 Built-in service assets (existing)
+
+Each service under `ai-services/assets/services/` has the following layout, shown for `chat`:
+
+```
+ai-services/assets/services/chat/
+├── metadata.yaml              # Service identity & dependencies (id: chat)
+├── podman/
+│   ├── metadata.yaml          # Runtime metadata: version, resources, podTemplateExecutions
+│   ├── values.yaml            # Default parameter values
+│   ├── values.schema.json     # JSON Schema for parameter validation
+│   ├── templates/
+│   │   └── chat-bot.yaml.tmpl # Pod spec template
+│   └── steps/
+│       ├── info.md
+│       └── vars_file.yaml
+└── openshift/
+    ├── Chart.yaml
+    ├── metadata.yaml
+    ├── values.yaml
+    └── templates/
+        ├── chat-bot-backend-deployment.yaml
+        └── ...
+```
+
+Key fields from [`assets/services/chat/metadata.yaml`](ai-services/assets/services/chat/metadata.yaml:1):
+
+```yaml
+id: chat
+name: "Question and answer"
+type: service
+certified_by: "IBM"
+architectures:
+  - rag
+dependencies:
+  - id: vector_store
+  - id: embedding
+  - id: llm
+standalone: false
+```
+
+### 4.2 Architecture assets (existing)
+
+`assets/architectures/rag/metadata.yaml` declares which services compose the `rag` architecture and which components are shared globally across all services:
+
+```yaml
+id: rag
+name: "Digital Assistant"
+type: architecture
+global_components:
+  - type: vector_store
+  - type: embedding
+services:
+  - id: chat
+  - id: digitize
+  - id: similarity
+```
+
+### 4.3 Custom service assets (proposed)
+
+A user-supplied bundle mirrors the same `services/` root. Only the entries present in the bundle are overlaid; everything else falls through to the embedded assets.
+
+```
+my-bundle.tar.gz
+└── services/
+    └── my-service/
+        ├── metadata.yaml           # required
+        └── podman/
+            ├── metadata.yaml       # required (version, resources, podTemplateExecutions)
+            ├── values.yaml         # required
+            ├── values.schema.json  # optional
+            └── templates/
+                └── my-service.yaml.tmpl
+```
+
+Only `services/` is a valid top-level directory in a bundle; any other roots are silently skipped (forward-compatible for future `components/` support). The `catalog_id` inside the bundle must **not** match any built-in service — if it does, validation rejects the bundle with a `422` error.
+
+---
+
+## 5. Template Provider Design
+
+### 5.1 Provider hierarchy
+
+```mermaid
+classDiagram
+    class fs_ReadDirFS {
+        <<interface>>
+        +ReadDir(name string) []DirEntry
+    }
+
+    class CatalogFS {
+        <<interface>>
+        +Open(name string) File
+        +ReadFile(name string) []byte
+    }
+
+    class EmbeddedCatalogFS {
+        -fs embed.FS
+        +Open() File
+        +ReadFile() []byte
+        +ReadDir() []DirEntry
+    }
+
+    class FilesystemCatalogFS {
+        -root string
+        +Open() File
+        +ReadFile() []byte
+        +ReadDir() []DirEntry
+    }
+
+    class CompositeCatalogFS {
+        -sources []CatalogFS
+        +Open() File
+        +ReadFile() []byte
+        +ReadDir() []DirEntry
+    }
+
+    fs_ReadDirFS <|-- CatalogFS : embeds
+    CatalogFS <|.. EmbeddedCatalogFS : implements
+    CatalogFS <|.. FilesystemCatalogFS : implements
+    CatalogFS <|.. CompositeCatalogFS : implements
+    CompositeCatalogFS o-- EmbeddedCatalogFS : fallback
+    CompositeCatalogFS o-- FilesystemCatalogFS : priority
+```
+
+### 5.2 Interface
+
+```go
+// CatalogFS abstracts the filesystem used by CatalogProvider.
+type CatalogFS interface {
+    fs.ReadDirFS
+    Open(name string) (fs.File, error)
+    ReadFile(name string) ([]byte, error)
+}
+```
+
+### 5.3 FilesystemCatalogFS
+
+```go
+// FilesystemCatalogFS reads catalog assets from a local directory.
+// Inside the container this is the active bundle directory written by BundleService.
+type FilesystemCatalogFS struct {
+    root string // e.g. "/data/catalog-bundles/service/chat-2.0.0"
+}
+```
+
+Validates at construction that `services/` exists under `root`, providing an actionable early error. Entries other than `services/` are ignored.
+
+### 5.4 CompositeCatalogFS
+
+```go
+// CompositeCatalogFS merges multiple CatalogFS instances.
+// Lookup checks each source in order; the first hit wins.
+// WalkDir visits all sources and deduplicates paths.
+type CompositeCatalogFS struct {
+    sources []CatalogFS // [bundleFS, embeddedFS]
+}
+```
+
+When `WalkDir` encounters the same relative path (e.g. `services/chat/metadata.yaml`) in both sources, the first source (bundle) wins and the embedded version is silently skipped.
+
+### 5.5 Factory function
+
+At startup the apiserver builds one `FilesystemCatalogFS` per active bundle (see §6.3). The factory below is the helper used when there is exactly one bundle path to overlay — for example in tests or single-bundle tooling:
+
+```go
+// NewCatalogFS returns the CatalogFS to use.
+// bundlePath="" → returns the embedded FS only (no active bundle).
+// bundlePath set → returns a composite that overlays that single bundle directory.
+// For multiple active bundles use NewCompositeCatalogFS directly (see §6.3).
+func NewCatalogFS(bundlePath string) (CatalogFS, error) {
+    embedded := &EmbeddedCatalogFS{fs: &assets.CatalogFS}
+    if bundlePath == "" {
+        return embedded, nil
+    }
+    bundle, err := NewFilesystemCatalogFS(bundlePath)
+    if err != nil {
+        logger.Warningf("bundle path '%s' invalid, using built-in only: %v", bundlePath, err)
+        return embedded, nil
+    }
+    return NewCompositeCatalogFS(bundle, embedded), nil
+}
+```
+
+### 5.6 Resolution priority
+
+At startup, `CatalogProvider` reads active bundle versions from the DB and constructs one `FilesystemCatalogFS` per active item, all layered before the embedded FS:
+
+| Priority | Source | Condition |
+|---|---|---|
+| 1..N | `FilesystemCatalogFS` (one per active bundle) | DB has `status = 'active'` rows; paths are `/data/catalog-bundles/<catalog_type>/<name>/` |
+| N+1 | `EmbeddedCatalogFS` (built-in) | Always present as fallback |
+
+---
+
+## 6. CatalogProvider Integration
+
+### 6.1 Current loading (single embedded FS)
+
+[`loadCatalogItems`](ai-services/internal/pkg/catalog/catalog.go:56) today walks `assets.CatalogFS` directly, dispatching on the first path segment (`"architectures"`, `"services"`, `"components"`) and storing results in `sharedItems`:
+
+```go
+err := fs.WalkDir(&assets.CatalogFS, ".", func(path string, d fs.DirEntry, err error) error {
+    return processMetadataFile(ctx, path, items)
+})
+```
+
+### 6.2 Proposed: inject CatalogFS
+
+`NewCatalogProvider` gains an optional functional option:
+
+```go
+func NewCatalogProvider(opts ...Option) (*CatalogProvider, error)
+
+// WithBundlePath overlays the active bundle directory on top of the embedded catalog.
+func WithBundlePath(dir string) Option
+```
+
+When provided, `loadCatalogItems` receives the `CompositeCatalogFS` instead of `&assets.CatalogFS`. The `processMetadataFile`, `parseService`, `parseArchitecture`, `parseComponent` functions are unchanged — they work against any `CatalogFS`.
+
+### 6.3 Apiserver startup loads active bundle paths from the DB
+
+The bundle volume is always mounted at `/data/catalog-bundles`. No env var is needed. At startup, the apiserver queries the `catalog_bundles` table for all `status = 'active'` rows, resolves each one to its versioned directory on disk, and builds a `CompositeCatalogFS` with one `FilesystemCatalogFS` per active item:
+
+```go
+// catalogBundlesDir is the well-known container mount path for the bundles volume.
+// It is fixed by the pod spec (Podman named volume / OpenShift PVC).
+const catalogBundlesDir = "/data/catalog-bundles"
+
+// In the apiserver main/start path:
+activeBundles, err := bundleRepo.ListActive(ctx) // SELECT WHERE status='active'
+var fsList []CatalogFS
+for _, b := range activeBundles {
+    // path: /data/catalog-bundles/<catalog_type>/<name>/
+    // name is derived server-side as <catalog_id>-<version>
+    p := filepath.Join(catalogBundlesDir, b.CatalogType, b.Name)
+    if fs, err := NewFilesystemCatalogFS(p); err == nil {
+        fsList = append(fsList, fs)
+    }
+}
+fsList = append(fsList, &EmbeddedCatalogFS{fs: &assets.CatalogFS})
+provider, err := catalog.NewCatalogProvider(catalog.WithCompositeCatalogFS(fsList...))
+```
+
+If there are no active bundles, only `EmbeddedCatalogFS` is used — behaviour is identical to today.
+
+---
+
+## 7. API Upload
+
+Custom catalog assets are delivered by uploading a `.tar.gz` bundle to the running catalog backend over its existing HTTPS endpoint. A bundle is a generic container — it can carry any mix of catalog root types (`services/`, `components/`, and others in future). The archive is extracted, validated per root type, and hot-reloaded into `CatalogProvider` — with no pod restart required for either Podman or OpenShift.
+
+> **Scope for this release:** only `services/` is processed. `components/` and other roots are accepted in the archive but skipped by the dispatcher — they will be activated in a future release without any change to the bundle format or API contract.
+
+### 7.1 Design goals
+
+| Goal | Detail |
+|---|---|
+| No restart required | `CatalogProvider` reloads the custom layer in-process after a successful upload |
+| Idempotent | Re-uploading the same `catalog_id` + `version` replaces the existing directory in-place |
+| Independent bundles | Each uploaded bundle exists separately; multiple bundles for different `catalog_id` values are all active simultaneously |
+| Authenticated | Uses the existing JWT `BearerAuth` middleware; only admin-role tokens are accepted |
+| Consistent across runtimes | Same API endpoint works for Podman and OpenShift; only the storage backend differs |
+| Bounded size | Configurable `MAX_BUNDLE_SIZE` (default 50 MB); enforced at the HTTP layer before extraction |
+
+---
+
+### 7.2 New API endpoints
+
+Three endpoints are added to the existing router in [`apiserver/router.go`](ai-services/internal/pkg/catalog/apiserver/router.go:18) under the authenticated `catalog` group:
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/v1/catalog/bundles` | Upload a new bundle (`.tar.gz`). Each bundle is registered independently and activated on success. |
+| `GET` | `/api/v1/catalog/bundles` | List all uploaded bundles (id, status, uploaded_at, size). |
+| `GET` | `/api/v1/catalog/bundles/:id` | Get the status of a specific bundle by ID. Used to poll after a `202` upload response. |
+
+#### 7.2.1 Upload bundle — `POST /api/v1/catalog/bundles`
+
+The request uses `multipart/form-data` so that the binary `.tar.gz` file and the text fields can travel together in the same request. The server validates `catalog_type` and `version` before touching the archive, then extracts directly into the versioned directory on the bundle volume.
+
+```
+POST /api/v1/catalog/bundles
+Content-Type: multipart/form-data
+Authorization: Bearer <admin-jwt>
+
+Form fields:
+  file         (required)  — .tar.gz archive containing the catalog item
+                             assets; max 50 MB compressed
+  catalog_type (required)  — type of the catalog item in this bundle;
+                             accepted values: "service", "component"
+  version      (required)  — semantic version of this bundle, e.g. "1.0.0";
+                             used as the directory name under
+                             /data/catalog-bundles/<type>/<name>/
+                             where name = <catalog_id>-<version>
+  dry_run      (optional)  — "true" validates the archive without activating it
+```
+
+**Example (curl):**
+```bash
+curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "file=@my-bundle.tar.gz" \
+  -F "catalog_type=service" \
+  -F "version=1.0.0"
+```
+
+**Responses:**
+
+| Status | Meaning |
+|---|---|
+| `202 Accepted` | Bundle accepted; extraction and validation running asynchronously. Use the `Location` header to poll for status. |
+| `400 Bad Request` | Missing `file`, `catalog_type`, or `version` field; unrecognised `catalog_type`; invalid version format; wrong content-type; or archive exceeds size limit. |
+| `401 Unauthorized` | Missing or invalid JWT. |
+| `403 Forbidden` | Token does not carry admin role. |
+| `422 Unprocessable Entity` | Archive extracted but validation failed (structured error list returned). |
+
+The response includes a `Location` header pointing to the status resource:
+
+```
+HTTP/1.1 202 Accepted
+Location: /api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ
+```
+
+`catalog_type` is known immediately from the request field. `catalog_id` is resolved from the directory name inside the archive during extraction and populated once the archive is unpacked. Both are present in the `202` body:
+
+```json
+// 202 response body
+{
+  "id":           "bnd_01JW4X9K2M8VQRP3T5YZ",
+  "name":         "my-service-1.0.0",
+  "status":       "processing",
+  "uploaded_at":  "2026-05-12T09:14:02Z",
+  "size_bytes":   143360,
+  "catalog_type": "service",
+  "catalog_id":   "my-service",
+  "version":      "1.0.0",
+  "uploaded_by":  "admin"
+}
+```
+
+Once the bundle reaches `active` or `failed` status, the polled response reflects the final outcome:
+
+```json
+// after activation — GET /api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ
+{
+  "id":           "bnd_01JW4X9K2M8VQRP3T5YZ",
+  "name":         "my-service-1.0.0",
+  "status":       "active",
+  "uploaded_at":  "2026-05-12T09:14:02Z",
+  "size_bytes":   143360,
+  "catalog_type": "service",
+  "catalog_id":   "my-service",
+  "version":      "1.0.0",
+  "uploaded_by":  "admin"
+}
+```
+
+#### 7.2.2 List bundles — `GET /api/v1/catalog/bundles`
+
+Each bundle record carries `catalog_type` (the type declared by the uploader — `"service"` or `"component"`) and `catalog_id` (the item id within that type). Multiple bundles for different catalog items are all active simultaneously and each is listed independently.
+
+```json
+{
+  "bundles": [
+    {
+      "id":           "bnd_01JW4X9K2M8VQRP3T5YZ",
+      "status":       "active",
+      "uploaded_at":  "2026-05-12T09:14:02Z",
+      "size_bytes":   143360,
+      "name":         "my-service-1.0.0",
+      "catalog_type": "service",
+      "catalog_id":   "my-service",
+      "version":      "1.0.0",
+      "uploaded_by":  "admin"
+    },
+    {
+      "id":           "bnd_02CD8Y3NF1P9WQS4U6VA",
+      "name":         "my-llm-provider-1.0.0",
+      "status":       "active",
+      "uploaded_at":  "2026-05-13T11:30:00Z",
+      "size_bytes":   98304,
+      "catalog_type": "component",
+      "catalog_id":   "my-llm-provider",
+      "version":      "1.0.0",
+      "uploaded_by":  "admin"
+    }
+  ]
+}
+```
+
+---
+
+### 7.3 Bundle format
+
+A bundle is scoped to **one catalog item** — the type is declared by the client as a form field (`catalog_type`), and the `catalog_id` is derived from the top-level directory inside the archive. The archive must be a gzip-compressed tar (`.tar.gz`). The `version` form field combines with the `catalog_id` to form the unique on-disk directory name (`<catalog_id>-<version>`), ensuring each bundle has an isolated location on the volume.
+
+```
+my-bundle.tar.gz
+└── my-service/                     ← single item; directory name = catalog_id
+    ├── metadata.yaml
+    └── podman/
+        ├── metadata.yaml
+        ├── values.yaml
+        └── templates/
+            └── my-service.yaml.tmpl
+```
+
+The server derives `catalog_id` from this top-level directory name and validates it matches the `catalog_type` form field. The `version` form field (e.g. `"1.0.0"`) determines where the extracted contents are stored on the volume.
+
+**Rules:**
+- Paths containing `..` or absolute paths are rejected immediately (path-traversal guard, same principle as [`SanitizeFilePath`](ai-services/internal/pkg/catalog/utils/common.go:90)).
+- The archive must contain exactly one top-level directory; multiple items per archive are not supported.
+- Total uncompressed size must not exceed `MAX_BUNDLE_SIZE_UNCOMPRESSED` (default 200 MB).
+- The `catalog_id` derived from the top-level directory name must not match any built-in service already present in `assets.CatalogFS` — if it does, validation returns `422` and the extracted directory is deleted.
+- All `metadata.yaml` files must pass validation for the declared `catalog_type` before the bundle is marked `active`.
+
+---
+
+### 7.4 Server-side processing pipeline
+
+```mermaid
+flowchart TD
+    REQ["POST /api/v1/catalog/bundles<br/>multipart/form-data<br/>file, catalog_type, version, dry_run"]
+    AUTH["AuthMiddleware<br/>JWT + admin role check"]
+    TYPECHECK["Validate catalog_type and version<br/>reject unknown type → 400"]
+    RESP["202 Accepted immediately<br/>bundle_id, status: processing<br/>Location: /api/v1/catalog/bundles/:id"]
+    SIZE["Size guard<br/>max 50 MB compressed"]
+    EXTRACT["Extract to<br/>/data/catalog-bundles/type/name/<br/>name = catalog_id-version"]
+    PATHGUARD["Path-traversal guard<br/>reject .. and absolute paths<br/>verify exactly one top-level dir"]
+    VALIDATE["CatalogProvider.ValidateFS<br/>parse metadata for declared catalog_type<br/>collect all errors"]
+
+    subgraph ASYNC["Goroutine — async after 202"]
+        SIZE --> EXTRACT --> PATHGUARD --> VALIDATE
+
+        subgraph ACTIVATE["Activate — success path"]
+            direction LR
+            DBBUNDLE["Insert bundle record<br/>status = active"]
+            RELOAD["CatalogProvider.Reload()<br/>re-query active bundles from DB<br/>rebuild CompositeCatalogFS"]
+            DBBUNDLE --> RELOAD
+        end
+
+        FAIL["Delete type/name/ directory<br/>update DB status = failed<br/>return 422 on poll"]
+
+        VALIDATE -->|"valid"| ACTIVATE
+        VALIDATE -->|"invalid"| FAIL
+    end
+
+    REQ --> AUTH --> TYPECHECK --> RESP
+    RESP -.-> ASYNC
+```
+
+**Key implementation notes:**
+
+- Extraction and validation run in a goroutine; the HTTP handler returns `202` immediately. The client polls `GET /api/v1/catalog/bundles/:id` until `status` is `active` or `failed`.
+- Each bundle gets its own named directory on the volume (`<type>/<name>/`) — uploading `service/my-service-1.0.0` and `service/chat-1.0.0` are entirely independent; neither touches the other.
+- Extraction goes directly into `<type>/<name>/` — no staging directory needed. Since the named directory is new and unique, there is nothing live to corrupt.
+- If validation fails, the newly written `<type>/<name>/` directory is deleted. All other active bundles remain unaffected.
+- The DB never marks a bundle `active` until validation passes — so even a partial extraction (e.g. process killed mid-way) is safe: `CatalogProvider` will not load a directory that has no `active` DB row.
+- `CatalogProvider.Reload()` re-queries the DB for all `status = 'active'` rows and rebuilds the `CompositeCatalogFS` under `sync.RWMutex`.
+- Bundle files are stored in a **dedicated named Podman volume** (`ai-services-bundles`) or **separate PVC** (`catalog-bundles-pvc`) — isolated from `$BASE_DIR` so that a `catalog delete --skip-cleanup` affecting application data never touches bundle storage.
+- The `catalog_bundles` table is added via a new Goose migration following the same pattern as [`20260430094502_create_applications_table.sql`](ai-services/internal/pkg/catalog/db/migrations/assets/20260430094502_create_applications_table.sql).
+
+---
+
+### 7.5 New database migration
+
+Each row in `catalog_bundles` represents one uploaded bundle. The `name` column is derived server-side as `<catalog_id>-<version>` (e.g. `chat-2.0.0`) — it uniquely identifies a versioned bundle in a human-readable form and is used as the directory name on the volume. The `status` column tracks lifecycle: `processing → active` on success, `failed` on validation error. Multiple bundles for different `catalog_id` values are all `active` simultaneously; each exists independently.
+
+```sql
+-- +goose Up
+-- +goose StatementBegin
+CREATE TYPE bundle_status AS ENUM (
+    'processing',
+    'active',
+    'failed'
+);
+
+CREATE TABLE catalog_bundles (
+    id               VARCHAR(30)    PRIMARY KEY,
+    -- e.g. bnd_01JW4X9K2M8VQRP3T5YZ
+
+    -- Human-readable versioned name: <catalog_id>-<version>, e.g. "chat-2.0.0"
+    -- Used as the directory name on the bundle volume.
+    name             VARCHAR(200)   NOT NULL,
+
+    status           bundle_status  NOT NULL DEFAULT 'processing',
+    size_bytes       BIGINT,
+
+    -- The catalog item type declared by the uploader: "service", "component", …
+    catalog_type     VARCHAR(50)    NOT NULL,
+    -- The id of the catalog item: e.g. "my-service", "my-llm-provider"
+    catalog_id       VARCHAR(100)   NOT NULL,
+    -- Semantic version of this bundle: e.g. "1.0.0", "2.1.0"
+    version          VARCHAR(50)    NOT NULL,
+
+    error            TEXT,
+    uploaded_by      VARCHAR(100),
+    uploaded_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    activated_at     TIMESTAMPTZ
+);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE  IF EXISTS catalog_bundles;
+DROP TYPE   IF EXISTS bundle_status;
+-- +goose StatementEnd
+```
+
+---
+
+### 7.6 Storage per runtime
+
+Bundle storage is **intentionally isolated** from `$AI_SERVICES_BASE_DIR`. This prevents a `catalog delete` or application-data wipe from destroying uploaded bundles, and makes the storage unit independently snapshotable.
+
+#### Volume directory layout
+
+The volume is organised as `<catalog_type>/<name>/` where `name` is `<catalog_id>-<version>` (e.g. `chat-2.0.0`). Each uploaded bundle gets its own named directory. Bundles for different `catalog_id` values coexist on disk and are each independently `active`. Extraction writes directly into the named directory; no staging or rename step is needed.
+
+```
+/data/catalog-bundles/
+├── service/
+│   ├── chat-2.0.0/              ← active
+│   │   ├── metadata.yaml
+│   │   └── podman/...
+│   └── my-service-1.0.0/        ← active (independent)
+│       ├── metadata.yaml
+│       └── podman/...
+└── component/
+    └── my-llm-provider-1.0.0/   ← active (independent)
+        └── metadata.yaml
+```
+
+The `CatalogProvider` resolves each active item's path as:
+```
+/data/catalog-bundles/<catalog_type>/<name>/
+```
+where `name = <catalog_id>-<version>`.
+
+#### Podman — named volume `ai-services-bundles`
+
+A dedicated Podman named volume is created by `catalog configure` and mounted into the catalog backend container at `/data/catalog-bundles`. Because Podman named volumes are managed independently of `hostPath` directories, they survive `catalog delete --skip-cleanup` and do not depend on any host filesystem path.
+
+```
+Volume name:  ai-services-bundles
+Mount point (inside container):  /data/catalog-bundles/
+```
+
+**`catalog.yaml.tmpl` addition** (new volume entry alongside the existing `ai-services-data` mount):
+
+```yaml
+# new volume declaration
+- name: catalog-bundles
+  persistentVolumeClaim:
+    claimName: "ai-services-bundles"   # Podman named volume, treated as PVC in pod spec
+```
+
+```yaml
+# new container volumeMount on backend container
+- mountPath: /data/catalog-bundles
+  name: catalog-bundles
+```
+
+#### OpenShift — dedicated PVC `catalog-bundles-pvc`
+
+A separate `PersistentVolumeClaim` is added to the catalog Helm chart (`assets/catalog/openshift/`) rather than reusing the existing `catalog-db` PVC. This keeps bundle lifecycle independent of the database and allows different storage classes (e.g. `ReadWriteMany` for multi-replica deployments in future).
+
+```yaml
+# new PVC in catalog Helm chart
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: catalog-bundles-pvc
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 1Gi     # tunable via chart values: catalog.bundleStorage
+```
+
+```yaml
+# volumeMount on catalog-backend Deployment
+- mountPath: /data/catalog-bundles
+  name: catalog-bundles
+
+# corresponding volume
+- name: catalog-bundles
+  persistentVolumeClaim:
+    claimName: catalog-bundles-pvc
+```
+
+**Layout inside the PVC** is identical to the Podman volume layout above, so `BundleService` needs no runtime-specific code paths. Both runtimes mount at `/data/catalog-bundles` — the same well-known constant the apiserver uses.
+
+---
+
+### 7.7 Flow diagrams
+
+#### Podman — upload flow
+
+```mermaid
+flowchart TD
+    USER["User / CI pipeline<br/>POST /api/v1/catalog/bundles"]
+
+    subgraph CADDY_POD["ai-services--caddy pod"]
+        PROXY["caddy reverse proxy<br/>:443 HTTPS"]
+    end
+
+    subgraph CAT_POD["ai-services--catalog pod"]
+        BE["backend container :8080"]
+        HANDLER["BundleHandler.UploadBundle()"]
+        PIPELINE["Dispatch → Validate → Swap"]
+        CP["CatalogProvider.Reload()"]
+    end
+
+    subgraph VOL["Podman named volume — ai-services-bundles"]
+        BUNDLES["mount: /data/catalog-bundles<br/>service/name-version/<br/>component/name-version/"]
+    end
+
+    PG["ai-services--db<br/>postgresql<br/>catalog_bundles table"]
+
+    USER -- "HTTPS POST multipart" --> PROXY
+    PROXY -- "reverse proxy" --> BE
+    BE --> HANDLER --> PIPELINE
+    PIPELINE -- "extract + write isolated from BASE_DIR" --> BUNDLES
+    PIPELINE --> CP
+    PIPELINE -- "persist bundle record" --> PG
+    CP -- "reads templates from" --> BUNDLES
+```
+
+#### OpenShift — upload flow
+
+```mermaid
+flowchart TD
+    USER["User / CI pipeline<br/>POST /api/v1/catalog/bundles"]
+
+    subgraph OCP["OpenShift cluster"]
+        ROUTE["OpenShift Route<br/>TLS termination"]
+
+        subgraph NS["catalog namespace"]
+            SVC["catalog-backend Service :8080"]
+            DEP["catalog-backend Deployment"]
+            BE["backend container"]
+            HANDLER["BundleHandler.UploadBundle()"]
+            PIPELINE["Dispatch → Validate → Swap"]
+            CP["CatalogProvider.Reload()"]
+            PVC["PVC: catalog-bundles-pvc<br/>dedicated, separate from catalog-db PVC<br/>mount: /data/catalog-bundles"]
+            PG["catalog-db StatefulSet<br/>postgresql :5432"]
+        end
+    end
+
+    USER -- "HTTPS POST" --> ROUTE
+    ROUTE --> SVC --> DEP --> BE
+    BE --> HANDLER --> PIPELINE
+    PIPELINE -- "extract + write to dedicated PVC" --> PVC
+    PIPELINE --> CP
+    PIPELINE -- "persist bundle record" --> PG
+    CP -- "reads templates from" --> PVC
+```
+
+---
+
+### 7.8 Handler skeleton (Go)
+
+This shows how `BundleHandler` fits the existing handler pattern in [`apiserver/handlers/`](ai-services/internal/pkg/catalog/apiserver/handlers):
+
+```go
+// BundleHandler handles catalog bundle upload and listing.
+// It follows the same pattern as ApplicationHandler and CatalogHandler.
+type BundleHandler struct {
+    bundleService BundleServiceInterface
+}
+
+// UploadBundle godoc
+//
+//  @Summary     Upload a custom catalog bundle
+//  @Description Accepts a .tar.gz archive for a single catalog item. The
+//               caller declares the catalog_type ("service" or "component").
+//               The archive is validated and, if valid, hot-reloaded into
+//               the running CatalogProvider.
+//  @Tags        Catalog
+//  @Accept      multipart/form-data
+//  @Produce     json
+//  @Security    BearerAuth
+//  @Param       file         formData  file    true   ".tar.gz bundle archive (max 50 MB)"
+//  @Param       catalog_type formData  string  true   "Catalog item type: service or component"
+//  @Param       version      formData  string  true   "Semantic version of this bundle, e.g. 1.0.0"
+//  @Param       dry_run      formData  string  false  "Validate only, do not apply (default: false)"
+//  @Success     202  {object}  BundleResponse   "Bundle accepted and processing"
+//  @Failure     400  {object}  ErrorResponse    "Invalid request or archive too large"
+//  @Failure     401  {object}  ErrorResponse    "Unauthorized"
+//  @Failure     403  {object}  ErrorResponse    "Admin role required"
+//  @Failure     422  {object}  BundleErrorResponse "Validation failed"
+//  @Router      /catalog/bundles [post]
+func (h *BundleHandler) UploadBundle(c *gin.Context) {
+    // 1. Enforce size limit before reading into memory
+    c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBundleSizeBytes)
+
+    // 2. Validate catalog_type before touching the archive
+    catalogType := c.PostForm("catalog_type")
+    if catalogType == "" {
+        c.JSON(http.StatusBadRequest, ErrorResponse{Error: "catalog_type is required"})
+        return
+    }
+    if !isValidCatalogType(catalogType) {
+        c.JSON(http.StatusBadRequest, ErrorResponse{Error: fmt.Sprintf("unsupported catalog_type %q; accepted: service, component", catalogType)})
+        return
+    }
+
+    version := c.PostForm("version")
+    if version == "" {
+        c.JSON(http.StatusBadRequest, ErrorResponse{Error: "version is required"})
+        return
+    }
+
+    file, header, err := c.Request.FormFile("file")
+    if err != nil {
+        c.JSON(http.StatusBadRequest, ErrorResponse{Error: "missing or unreadable file field"})
+        return
+    }
+    defer file.Close()
+
+    if !strings.HasSuffix(header.Filename, ".tar.gz") {
+        c.JSON(http.StatusBadRequest, ErrorResponse{Error: "file must be a .tar.gz archive"})
+        return
+    }
+
+    dryRun := c.PostForm("dry_run") == "true"
+    userID := c.GetString(middleware.CtxUserIDKey)
+
+    resp, err := h.bundleService.ProcessBundle(c.Request.Context(), file, header.Size, userID, catalogType, version, dryRun)
+    if err != nil {
+        if valErr, ok := err.(*ValidationError); ok {
+            c.JSON(valErr.Code, ErrorResponse{Error: valErr.Message})
+            return
+        }
+        c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "bundle processing failed"})
+        return
+    }
+
+    c.JSON(http.StatusAccepted, resp)
+}
+```
+
+---
+
+## 8. Custom Template Directory Structure
+
+### 8.1 Minimum layout for a new service
+
+```
+services/
+└── <service-id>/
+    ├── metadata.yaml                    # required
+    └── podman/                          # for podman runtime
+        ├── metadata.yaml                # required (version, resources, podTemplateExecutions)
+        ├── values.yaml                  # required
+        ├── values.schema.json           # optional – enables param validation
+        └── templates/
+            └── <service>.yaml.tmpl      # at least one required
+```
+
+Package as a `.tar.gz` with `services/` at the top level:
+
+```bash
+tar -czf my-bundle.tar.gz services/
+```
+
+### 8.2 Service top-level `metadata.yaml`
+
+```yaml
+id: my-service                   # unique across built-in + custom services
+name: "My Custom Service"
+description: "..."
+type: service                    # must be "service"
+certified_by: "Custom"
+architectures:
+  - rag                          # reference an existing built-in architecture
+dependencies:
+  - id: llm                      # component types this service requires
+standalone: true
+```
+
+### 8.3 Runtime `metadata.yaml` (Podman)
+
+```yaml
+name: my-service
+version: "1.0.0"
+podTemplateExecutions:
+  - [dependency-secret.yaml.tmpl] # layer 1 – runs first
+  - [my-service.yaml.tmpl]        # layer 2 – runs after layer 1 is ready
+resources:
+  cpu: 4
+  memory: 8589934592              # bytes
+  storage: 10737418240            # bytes
+```
+
+### 8.4 Built-in service IDs are reserved
+
+A bundle whose top-level directory name matches an existing built-in service (`chat`, `digitize`, `similarity`, `summarize`) will be rejected by the validation step with a `422` error. Custom bundles must use a unique `catalog_id` that does not conflict with any embedded service or architecture.
+
+Built-in IDs reserved at this time: `chat`, `digitize`, `similarity`, `summarize`, `rag`.
+
+---
+
+## 9. Usage Examples
+
+### 9.1 Upload a custom service bundle
+
+```bash
+# Authenticate
+curl -X POST https://catalog-api.<domain>/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"<password>"}' \
+  | jq -r .access_token > token.txt
+
+# Package the custom service directory
+tar -czf my-bundle.tar.gz services/
+
+# Upload the bundle (catalog_type and version are required fields)
+curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
+  -H "Authorization: Bearer $(cat token.txt)" \
+  -F "file=@my-bundle.tar.gz" \
+  -F "catalog_type=service" \
+  -F "version=1.0.0"
+
+# Poll for activation using the bundle ID from the 202 response
+curl -s https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_01JW4X9K2M8VQRP3T5YZ \
+  -H "Authorization: Bearer $(cat token.txt)" | jq .status
+# "active"
+```
+
+### 9.2 Create an application from the custom service
+
+The application creation endpoint (`POST /api/v1/applications/`) accepts a `CreateApplicationRequest` with `name`, `catalog_id`, `version`, and a `services` array. Each service entry requires its own `catalog_id`, `version`, and `components` list.
+
+```bash
+curl -X POST https://catalog-api.<domain>/api/v1/applications/ \
+  -H "Authorization: Bearer $(cat token.txt)" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-deployment",
+    "catalog_id": "my-service",
+    "version": "1.0.0",
+    "services": [
+      {
+        "catalog_id": "my-service",
+        "version": "1.0.0",
+        "components": [
+          {
+            "component_type": "llm",
+            "provider_id": "vllm-cpu",
+            "version": "1.0.0",
+            "params": { "model": "granite-3.3-8b-instruct" }
+          }
+        ]
+      }
+    ]
+  }'
+# Returns 202 Accepted with {"id": "<application-uuid>"}
+```
+
+### 9.3 Attempt to use a reserved built-in ID (rejected)
+
+Uploading a bundle whose `catalog_id` matches a built-in service is rejected at validation time — the extracted directory is cleaned up and no activation occurs:
+
+```bash
+# Attempting to upload a bundle with catalog_id "chat" (a built-in service)
+tar -czf chat-bundle.tar.gz services/chat
+
+curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
+  -H "Authorization: Bearer $(cat token.txt)" \
+  -F "file=@chat-bundle.tar.gz" \
+  -F "catalog_type=service" \
+  -F "version=2.0.0"
+
+# Poll for result — validation rejects the bundle
+curl -s https://catalog-api.<domain>/api/v1/catalog/bundles/bnd_03EF9Z2GH4Q7RST5V8WX \
+  -H "Authorization: Bearer $(cat token.txt)" | jq '{status, error}'
+# {
+#   "status": "failed",
+#   "error":  "catalog_id \"chat\" is reserved by a built-in service and cannot be overridden"
+# }
+```
+
+### 9.4 List custom services via the catalog API
+
+After uploading a bundle, custom services appear alongside built-in ones. The `GET /api/v1/services` endpoint returns an array of `ServiceSummary` objects (not a wrapped object), so the `jq` filter uses `.[].id`:
+
+```bash
+curl -s https://catalog-api.<domain>/api/v1/services \
+  -H "Authorization: Bearer $(cat token.txt)" | jq '.[].id'
+
+# "chat"
+# "digitize"
+# "similarity"
+# "summarize"
+# "my-service"   ← custom
+```
+
+### 9.5 Dry-run validation before applying
+
+```bash
+# Validate without activating — useful in CI before promoting to production
+# All required fields (catalog_type, version) must be present even for dry_run
+curl -X POST https://catalog-api.<domain>/api/v1/catalog/bundles \
+  -H "Authorization: Bearer $(cat token.txt)" \
+  -F "file=@my-bundle.tar.gz" \
+  -F "catalog_type=service" \
+  -F "version=1.0.0" \
+  -F "dry_run=true"
+# Returns 202 with status: "validated" (not promoted to active)
+```
+
+---
+
+## 10. Backward Compatibility
+
+| Scenario | Behaviour |
+|---|---|
+| No bundle uploaded yet | Identical to current — `EmbeddedCatalogFS` only |
+| Volume mounted but no `status='active'` rows in DB | Only `EmbeddedCatalogFS` is used; behaviour identical to today |
+| Custom service has same `id` as built-in | Bundle is rejected with `422`; built-in is never shadowed |
+| Multiple bundles for different `catalog_id` values | All are `active` simultaneously; each is fully independent |
+| Existing applications in the database | Unaffected; records reference `catalog_id` strings which remain stable |
+| `catalog_type` value not in the accepted list | Rejected immediately with `400` before the archive is touched |
+| New `catalog_type` value introduced in a future release | Existing clients that receive an unfamiliar `catalog_type` string are unaffected — they simply don't render that bundle type in their UI |
+| `assets.ApplicationFS` and existing `application/` packages | Not touched; independent of `CatalogProvider` |
+| OpenShift deployment | Same API endpoint and bundle format; only the storage backend differs (PVC vs named volume) |
+
+---
+
+## 11. Future Enhancements
+
+1. **Scaffolding generator** — `ai-services catalog scaffold --service my-service --runtime podman` emits a minimal but correct directory skeleton ready to be tar'd and uploaded.
+2. **Template validation command** — `dry_run=true` already supported in §7.2.1; a dedicated CLI command `ai-services catalog validate --bundle <file>` wraps this for local use.
+3. **Remote catalog repositories** — fetch a bundle from an OCI registry or HTTPS URL; the server pulls and applies it directly, removing the need for a client upload.
+4. **Schema enforcement on custom `metadata.yaml`** — reuse the existing [`validators.ApplicationValidator`](ai-services/internal/pkg/catalog/validators/validation.go) to reject malformed custom metadata at validation time.
+5. **Version compatibility checks** — validate that a custom service's `version` satisfies any `>=x.y.z` constraint declared by the built-in architecture that references it.
+6. **Role-based upload access** — introduce a `catalog-editor` JWT role that can upload bundles but cannot perform `DELETE /applications` or other destructive operations.
+7. **Component support in bundles** — when `components/` is promoted from reserved to active in the bundle processor, users can ship custom component providers (e.g. a private LLM backend) alongside their services in the same archive.
+8. **Multi-VM deployment and object storage backing** — the current design stores bundles on a Podman named volume or OpenShift PVC that is **local to a single host**. This works well for single-VM Podman deployments and single-replica OpenShift pods. When the catalog needs to run across multiple VMs (e.g. a fleet of Podman hosts that all share the same catalog API), each VM has its own isolated named volume — a bundle uploaded to one host is invisible to the others.
+
+   **Why this is straightforward to add later:**
+
+   The design deliberately isolates all bundle I/O behind two thin interfaces:
+
+   - **Read path** — `CatalogFS` interface (`§5.2`). `FilesystemCatalogFS` today calls `os.Open`. An `ObjectStoreCatalogFS` backed by S3, MinIO, or IBM COS would implement the same three methods (`Open`, `ReadFile`, `ReadDir`) against an object-store prefix instead of a local path. `CatalogProvider`, `loadCatalogItems`, and every existing handler are completely unaware of the change.
+   - **Write path** — `BundleService.ProcessBundle`. Today it extracts the archive to `/data/catalog-bundles/<type>/<name>/`. Swapping the write target to an object store bucket (with keys like `<type>/<name>/<file>`) is a single-function change. The DB row already stores `catalog_type`, `catalog_id`, `name`, and `version`; adding an `object_key` column (or deriving the key from `name`) requires only a minor migration.
+
+   The only meaningful **design decision** deferred to that milestone is the local cache strategy: object-store reads have latency, so `CatalogProvider` would likely download bundle files to a local staging directory at startup and after each hot-reload, then serve from the local cache — preserving the zero-latency template rendering that `FilesystemCatalogFS` provides today.
+
+   For **OpenShift multi-replica** deployments the same object-store backing solves the shared-storage problem without requiring `ReadWriteMany` PVCs, which are not universally available across storage classes.


### PR DESCRIPTION
- Proposal for onboarding customer services.
- Proposes API endpoints with DB proposal to store the metadata information.
- The assets are being stored inside volumes (works both in podman and openshift).
- Also works seemlessly for remote deployments (Refer Section 9)
- Addition of CLI commands for bundles