### PR TITLE
docs: add steps to rotate Watsonx API keys on Podman runtime

### DIFF
--- a/docs/rotate-watsonx-keys.md
+++ b/docs/rotate-watsonx-keys.md
@@ -5,13 +5,28 @@ How to rotate an IBM Watsonx API key for an AI Services application running on t
 ## Prerequisites
 
 - The Catalog UI is deployed and accessible. See [Configuring with PowerVS and IBM watsonx](https://www.ibm.com/docs/en/aiservices/2026.06.0?topic=podman-configuring-powervs-watsonx).
-- You have the new Watsonx API key, project ID, and Watsonx URL ready.
+- You have the new Watsonx API key ready.
 
-## Before you begin
+## Approach 1 — Script (no data loss)
 
-Rotating a key requires deleting and recreating the application. Each new application gets a new internal ID, so all Podman volumes (ingested documents, vector store) are created under a new name and the old data becomes unreachable.
+Rotates the key by replacing only the LiteLLM pod. All ingested data is preserved.
 
-**Back up your data before proceeding.** The backup and restore steps apply to the following deployments:
+```bash
+export WATSONX_APIKEY_NEW="<your-new-api-key>"
+./hack/rotate-watsonx-key/rotate-watsonx-key.sh <app-name>
+```
+
+The script must be run from within the repository. After it completes, access the Q&A interface and send a test query to confirm the application is working correctly with the new key.
+
+> **Note:** This approach is not available in the Catalog UI.
+
+## Approach 2 — Delete and recreate (data loss without backup)
+
+Deletes and recreates the entire application. Use this if the script approach is not available.
+
+### Before you begin
+
+Each new application gets a new internal ID so all data volumes become unreachable after deletion. Back up your data first if you have ingested documents to preserve.
 
 | Deployment | Backup needed | Targets |
 |---|---|---|
@@ -20,48 +35,38 @@ Rotating a key requires deleting and recreating the application. Each new applic
 | `summarize` standalone | ⚠️ No backup target available — data will be lost | — |
 | `chat` standalone | No persistent data | — |
 
-If you have no ingested data to preserve, skip to [Step 3](#3-delete-the-application).
+### Steps
 
-> **Note:** Backup and restore for the `summarize` standalone service is not currently supported. Job history stored in its Postgres database cannot be recovered after deletion.
-
-## Steps
-
-### 1. Back up your data
-
-Use the CLI to back up both OpenSearch and digitize data. Backup is not available in the Catalog UI.
+**1. Back up your data** (CLI only — skip if no data to preserve)
 
 ```bash
 ai-services application backup <app-name> --target opensearch --runtime podman
 ai-services application backup <app-name> --target digitize --runtime podman
 ```
 
-Note the generated `.tar.gz` filenames — you will need them to restore.
+**2. Set the new credentials**
 
-### 2. Set the new credentials
+Export your new Watsonx API key, project ID, and URL before proceeding. If using the Catalog UI, have these values ready to enter in the deploy form.
 
-Export your new Watsonx API key, project ID, and URL in the terminal before proceeding. This is required for the CLI path. If using the Catalog UI to redeploy, have these values ready to enter in the deploy form.
-
-### 3. Delete the application
+**3. Delete the application**
 
 **CLI:** Delete the application using the CLI.
 
 **Catalog UI:** Open the application, click the overflow menu, and select **Delete**.
 
-### 4. Recreate the application with the new key
+**4. Recreate the application with the new key**
 
 **CLI:** Create the application using the new exported credentials.
 
 **Catalog UI:** Deploy the application again from the Catalog and enter the new Watsonx API key in the deploy form.
 
-### 5. Restore your data
-
-Use the CLI to restore both targets into the newly created application. Restore is not available in the Catalog UI.
+**5. Restore your data** (CLI only — skip if no backup was taken)
 
 ```bash
 ai-services application restore <app-name> --target opensearch --filename <opensearch-backup>.tar.gz --runtime podman --yes
 ai-services application restore <app-name> --target digitize --filename <digitize-backup>.tar.gz --runtime podman --yes
 ```
 
-### 6. Verify
+**6. Verify**
 
 Access the Q&A interface and send a test query to confirm the application is working correctly with the new key.

--- a/docs/rotate-watsonx-keys.md
+++ b/docs/rotate-watsonx-keys.md
@@ -1,0 +1,67 @@
+# Rotating Watsonx API Keys
+
+How to rotate an IBM Watsonx API key for an AI Services application running on the Podman runtime (PowerVS).
+
+## Prerequisites
+
+- The Catalog UI is deployed and accessible. See [Configuring with PowerVS and IBM watsonx](https://www.ibm.com/docs/en/aiservices/2026.06.0?topic=podman-configuring-powervs-watsonx).
+- You have the new Watsonx API key, project ID, and Watsonx URL ready.
+
+## Before you begin
+
+Rotating a key requires deleting and recreating the application. Each new application gets a new internal ID, so all Podman volumes (ingested documents, vector store) are created under a new name and the old data becomes unreachable.
+
+**Back up your data before proceeding.** The backup and restore steps apply to the following deployments:
+
+| Deployment | Backup needed | Targets |
+|---|---|---|
+| `rag` (Digital Assistant) | ✅ Yes | `opensearch`, `digitize` |
+| `digitize` standalone | ✅ Yes | `opensearch`, `digitize` |
+| `summarize` standalone | ⚠️ No backup target available — data will be lost | — |
+| `chat` standalone | No persistent data | — |
+
+If you have no ingested data to preserve, skip to [Step 3](#3-delete-the-application).
+
+> **Note:** Backup and restore for the `summarize` standalone service is not currently supported. Job history stored in its Postgres database cannot be recovered after deletion.
+
+## Steps
+
+### 1. Back up your data
+
+Use the CLI to back up both OpenSearch and digitize data. Backup is not available in the Catalog UI.
+
+```bash
+ai-services application backup <app-name> --target opensearch --runtime podman
+ai-services application backup <app-name> --target digitize --runtime podman
+```
+
+Note the generated `.tar.gz` filenames — you will need them to restore.
+
+### 2. Set the new credentials
+
+Export your new Watsonx API key, project ID, and URL in the terminal before proceeding. This is required for the CLI path. If using the Catalog UI to redeploy, have these values ready to enter in the deploy form.
+
+### 3. Delete the application
+
+**CLI:** Delete the application using the CLI.
+
+**Catalog UI:** Open the application, click the overflow menu, and select **Delete**.
+
+### 4. Recreate the application with the new key
+
+**CLI:** Create the application using the new exported credentials.
+
+**Catalog UI:** Deploy the application again from the Catalog and enter the new Watsonx API key in the deploy form.
+
+### 5. Restore your data
+
+Use the CLI to restore both targets into the newly created application. Restore is not available in the Catalog UI.
+
+```bash
+ai-services application restore <app-name> --target opensearch --filename <opensearch-backup>.tar.gz --runtime podman --yes
+ai-services application restore <app-name> --target digitize --filename <digitize-backup>.tar.gz --runtime podman --yes
+```
+
+### 6. Verify
+
+Access the Q&A interface and send a test query to confirm the application is working correctly with the new key.

--- a/docs/rotate-watsonx-keys.md
+++ b/docs/rotate-watsonx-keys.md
@@ -1,72 +1,74 @@
 # Rotating Watsonx API Keys
 
-How to rotate an IBM Watsonx API key for an AI Services application running on the Podman runtime (PowerVS).
+How to replace an expired or compromised Watsonx API key for a RAG application
+running on the Podman (PowerVS) runtime without losing application data.
 
 ## Prerequisites
 
-- The Catalog UI is deployed and accessible. See [Configuring with PowerVS and IBM watsonx](https://www.ibm.com/docs/en/aiservices/2026.06.0?topic=podman-configuring-powervs-watsonx).
+- `ai-services` CLI installed and on `PATH`.
+- The AI Services catalog is running (`ai-services catalog configure` completed).
+- The RAG application is deployed and the LLM pod is in a running state.
 - You have the new Watsonx API key ready.
 
-## Approach 1 — Script (no data loss)
+## Steps
 
-Rotates the key by replacing only the LiteLLM pod. All ingested data is preserved.
+**1. Export the new API key**
 
-```bash
-export WATSONX_APIKEY_NEW="<your-new-api-key>"
+```sh
+export WATSONX_APIKEY_NEW="<new-api-key>"
+```
+
+The script reads the key from the environment so it is never written to shell history.
+
+**2. Run the rotation script**
+
+From the repository root:
+
+```sh
 ./hack/rotate-watsonx-key/rotate-watsonx-key.sh <app-name>
 ```
 
-The script must be run from within the repository. After it completes, access the Q&A interface and send a test query to confirm the application is working correctly with the new key.
+Replace `<app-name>` with the name of the application
+(visible in `ai-services application ps --runtime podman`).
 
-> **Note:** This approach is not available in the Catalog UI.
+**3. Verify**
 
-## Approach 2 — Delete and recreate (data loss without backup)
-
-Deletes and recreates the entire application. Use this if the script approach is not available.
-
-### Before you begin
-
-Each new application gets a new internal ID so all data volumes become unreachable after deletion. Back up your data first if you have ingested documents to preserve.
-
-| Deployment | Backup needed | Targets |
-|---|---|---|
-| `rag` (Digital Assistant) | ✅ Yes | `opensearch`, `digitize` |
-| `digitize` standalone | ✅ Yes | `opensearch`, `digitize` |
-| `summarize` standalone | ⚠️ No backup target available — data will be lost | — |
-| `chat` standalone | No persistent data | — |
-
-### Steps
-
-**1. Back up your data** (CLI only — skip if no data to preserve)
-
-```bash
-ai-services application backup <app-name> --target opensearch --runtime podman
-ai-services application backup <app-name> --target digitize --runtime podman
+```sh
+ai-services application ps <app-name> --runtime podman
 ```
 
-**2. Set the new credentials**
+Then test an end-to-end query through the Catalog UI to confirm Watsonx is
+responding with the new key.
 
-Export your new Watsonx API key, project ID, and URL before proceeding. If using the Catalog UI, have these values ready to enter in the deploy form.
+## Troubleshooting
 
-**3. Delete the application**
+**LLM pod not found** — confirm the application is deployed and the LLM pod is running:
 
-**CLI:** Delete the application using the CLI.
-
-**Catalog UI:** Open the application, click the overflow menu, and select **Delete**.
-
-**4. Recreate the application with the new key**
-
-**CLI:** Create the application using the new exported credentials.
-
-**Catalog UI:** Deploy the application again from the Catalog and enter the new Watsonx API key in the deploy form.
-
-**5. Restore your data** (CLI only — skip if no backup was taken)
-
-```bash
-ai-services application restore <app-name> --target opensearch --filename <opensearch-backup>.tar.gz --runtime podman --yes
-ai-services application restore <app-name> --target digitize --filename <digitize-backup>.tar.gz --runtime podman --yes
+```sh
+ai-services application ps <app-name> --runtime podman
 ```
 
-**6. Verify**
+**Pod is not a Watsonx pod** — the application may be using a different LLM
+provider (vLLM). This script only works with Watsonx. Check the pod labels to confirm:
 
-Access the Q&A interface and send a test query to confirm the application is working correctly with the new key.
+```sh
+podman pod inspect llm-<slug> --format '{{.Labels}}'
+```
+
+**Mounted key mismatch after rotation** — the container may still be starting.
+Wait a few more seconds then check:
+
+```sh
+podman exec llm-<slug>-litellm cat /etc/secret/watsonx-secret/apiKey | cut -c1-8
+podman logs llm-<slug>-litellm
+```
+
+**Script failed mid-rotation** — if failure occurred after the pod was removed,
+the rendered manifest is preserved at the path printed in the error output.
+Replay it to restore the LLM pod:
+
+```sh
+podman kube play /tmp/llm-rotate-XXXXXX.yaml
+```
+
+If the manifest was not preserved, re-run the script with the new key.

--- a/hack/rotate-watsonx-key/rotate-watsonx-key.sh
+++ b/hack/rotate-watsonx-key/rotate-watsonx-key.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# rotate-watsonx-key.sh
+#
+# Rotates the Watsonx API key for an AI Services RAG application on the Podman
+# runtime without deleting the application or its data.
+#
+# USAGE:
+#   export WATSONX_APIKEY_NEW="<new-key>"
+#   ./hack/rotate-watsonx-key/rotate-watsonx-key.sh <app-name>
+#
+# EXAMPLE:
+#   export WATSONX_APIKEY_NEW="<your-new-api-key>"
+#   ./hack/rotate-watsonx-key/rotate-watsonx-key.sh rag-test
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE_DIR="${SCRIPT_DIR}/../../ai-services/assets/components/llm/watsonx/podman/templates"
+SECRET_TMPL="${TEMPLATE_DIR}/watsonx-secret.yaml.tmpl"
+SERVER_TMPL="${TEMPLATE_DIR}/watsonx-server.yaml.tmpl"
+
+# ── Args ──────────────────────────────────────────────────────────────────────
+APP_NAME="${1:-}"
+if [[ -z "${APP_NAME}" ]]; then
+    echo "Usage: $0 <app-name>" >&2
+    exit 1
+fi
+
+if [[ -z "${WATSONX_APIKEY_NEW:-}" ]]; then
+    echo "Error: WATSONX_APIKEY_NEW is not set. Export the new API key before running." >&2
+    exit 1
+fi
+
+if [[ ! -f "${SECRET_TMPL}" || ! -f "${SERVER_TMPL}" ]]; then
+    echo "Error: Template files not found under ${TEMPLATE_DIR}" >&2
+    exit 1
+fi
+
+# ── Discover slug from running pod ────────────────────────────────────────────
+echo "→ Discovering LLM pod for application '${APP_NAME}'..."
+LLM_POD=$(podman pod ps --format "{{.Name}}" | grep "^llm-" | head -1)
+if [[ -z "${LLM_POD}" ]]; then
+    echo "Error: No running LLM pod found. Is the application deployed?" >&2
+    exit 1
+fi
+
+SLUG="${LLM_POD#llm-}"
+SECRET_NAME="watsonx-secret-${SLUG}"
+CONTAINER_NAME="${LLM_POD}-litellm"
+echo "  Pod:    ${LLM_POD}"
+echo "  Slug:   ${SLUG}"
+echo "  Secret: ${SECRET_NAME}"
+
+# ── Discover TemplateID from catalog DB ───────────────────────────────────────
+echo "→ Looking up TemplateID from catalog DB..."
+TEMPLATE_ID=$(podman exec ai-services--db-postgresql \
+    psql -U postgres -d ai_services -tAc \
+    "SELECT DISTINCT c.id FROM components c
+     JOIN service_dependencies sd ON sd.dependency_id = c.id
+     JOIN services s ON s.id = sd.service_id
+     JOIN applications a ON a.id = s.app_id
+     WHERE a.name = '${APP_NAME}' AND c.type = 'llm' AND c.provider = 'watsonx'
+     LIMIT 1;")
+
+if [[ -z "${TEMPLATE_ID}" ]]; then
+    echo "Error: Could not find LLM component for app '${APP_NAME}' in catalog DB." >&2
+    exit 1
+fi
+echo "  TemplateID: ${TEMPLATE_ID}"
+
+# ── Discover values from running container ────────────────────────────────────
+echo "→ Reading configuration from running container..."
+
+get_env() {
+    podman inspect "${CONTAINER_NAME}" \
+        --format '{{range .Config.Env}}{{.}}{{"\n"}}{{end}}' \
+        | grep "^${1}=" | cut -d= -f2-
+}
+
+WATSONX_PROJECT_ID=$(get_env "WATSONX_PROJECT_ID")
+WATSONX_URL=$(get_env "WATSONX_URL")
+INSTRUCT_MODEL_NAME=$(get_env "INSTRUCT_MODEL_NAME")
+IMAGE=$(podman inspect "${CONTAINER_NAME}" --format '{{.Config.Image}}')
+
+echo "  Image:              ${IMAGE}"
+echo "  WATSONX_PROJECT_ID: ${WATSONX_PROJECT_ID}"
+echo "  WATSONX_URL:        ${WATSONX_URL}"
+echo "  INSTRUCT_MODEL:     ${INSTRUCT_MODEL_NAME}"
+
+# ── Render templates ──────────────────────────────────────────────────────────
+echo "→ Rendering templates..."
+YAML_FILE=$(mktemp /tmp/llm-rotate-XXXXXX.yaml)
+trap 'rm -f "${YAML_FILE}"' EXIT INT TERM
+
+render_template() {
+    sed \
+        -e "s|{{ .InstanceSlug }}|${SLUG}|g" \
+        -e "s|{{ .TemplateID }}|${TEMPLATE_ID}|g" \
+        -e "s|{{ .Values.watsonxApiKey }}|${WATSONX_APIKEY_NEW}|g" \
+        -e "s|{{ .Values.watsonxProjectId }}|${WATSONX_PROJECT_ID}|g" \
+        -e "s|{{ .Values.watsonxUrl }}|${WATSONX_URL}|g" \
+        -e "s|{{ .Values.model }}|${INSTRUCT_MODEL_NAME}|g" \
+        -e "s|{{ .Values.image }}|${IMAGE}|g" \
+        "$1"
+}
+
+{
+    render_template "${SECRET_TMPL}"
+    echo "---"
+    render_template "${SERVER_TMPL}"
+} > "${YAML_FILE}"
+
+# ── Rotate ────────────────────────────────────────────────────────────────────
+echo "→ Stopping pod ${LLM_POD}..."
+podman pod stop "${LLM_POD}"
+
+echo "→ Removing pod ${LLM_POD}..."
+podman pod rm "${LLM_POD}"
+
+echo "→ Removing old secret ${SECRET_NAME}..."
+podman secret rm "${SECRET_NAME}"
+
+echo "→ Replaying pod with new key..."
+podman kube play "${YAML_FILE}"
+
+# ── Verify ────────────────────────────────────────────────────────────────────
+echo "→ Verifying new key..."
+sleep 3
+ACTIVE_KEY=$(podman exec "${CONTAINER_NAME}" cat /etc/secret/watsonx-secret/apiKey 2>/dev/null || echo "")
+EXPECTED_PREFIX="${WATSONX_APIKEY_NEW:0:8}"
+ACTIVE_PREFIX="${ACTIVE_KEY:0:8}"
+if [[ "${ACTIVE_PREFIX}" == "${EXPECTED_PREFIX}" ]]; then
+    echo "✓ Key rotated successfully (mounted key starts with: ${ACTIVE_PREFIX}...)."
+else
+    echo "⚠ Warning: mounted key does not match expected value. Check container logs." >&2
+fi
+
+echo "✓ Done. Test the application via the Q&A interface to confirm end-to-end functionality."

--- a/hack/rotate-watsonx-key/rotate-watsonx-key.sh
+++ b/hack/rotate-watsonx-key/rotate-watsonx-key.sh
@@ -9,7 +9,7 @@
 #   ./hack/rotate-watsonx-key/rotate-watsonx-key.sh <app-name>
 #
 # EXAMPLE:
-#   export WATSONX_APIKEY_NEW="<your-new-api-key>"
+#   export WATSONX_APIKEY_NEW="iamApiKey-..."
 #   ./hack/rotate-watsonx-key/rotate-watsonx-key.sh rag-test
 
 set -euo pipefail
@@ -36,40 +36,65 @@ if [[ ! -f "${SECRET_TMPL}" || ! -f "${SERVER_TMPL}" ]]; then
     exit 1
 fi
 
-# ── Discover slug from running pod ────────────────────────────────────────────
+# ── Discover LLM pod ─────────────────────────────────────────────────────────
+# `ai-services application ps` writes its table to stderr via klog, so 2>&1
+# captures it. grep -oE extracts the pod name directly regardless of column
+# position or padding.
 echo "→ Discovering LLM pod for application '${APP_NAME}'..."
-LLM_POD=$(podman pod ps --format "{{.Name}}" | grep "^llm-" | head -1)
+
+LLM_POD=$(ai-services application ps "${APP_NAME}" --runtime podman 2>&1 \
+    | grep -oE 'llm-[a-z0-9]+' \
+    | head -1)
+
 if [[ -z "${LLM_POD}" ]]; then
-    echo "Error: No running LLM pod found. Is the application deployed?" >&2
+    echo "Error: No LLM pod found for application '${APP_NAME}'." \
+         "Is the application deployed and running?" >&2
     exit 1
 fi
 
+# Derive slug: pod name is always "llm-<slug>"
 SLUG="${LLM_POD#llm-}"
 SECRET_NAME="watsonx-secret-${SLUG}"
-CONTAINER_NAME="${LLM_POD}-litellm"
-echo "  Pod:    ${LLM_POD}"
-echo "  Slug:   ${SLUG}"
-echo "  Secret: ${SECRET_NAME}"
 
-# ── Discover TemplateID from catalog DB ───────────────────────────────────────
-echo "→ Looking up TemplateID from catalog DB..."
-TEMPLATE_ID=$(podman exec ai-services--db-postgresql \
-    psql -U postgres -d ai_services -tAc \
-    "SELECT DISTINCT c.id FROM components c
-     JOIN service_dependencies sd ON sd.dependency_id = c.id
-     JOIN services s ON s.id = sd.service_id
-     JOIN applications a ON a.id = s.app_id
-     WHERE a.name = '${APP_NAME}' AND c.type = 'llm' AND c.provider = 'watsonx'
-     LIMIT 1;")
+# The litellm container inside the pod is named "litellm" in the template;
+# Podman prefixes it with the pod name: "<pod-name>-<container-name>"
+CONTAINER_NAME="${LLM_POD}-litellm"
+
+echo "  Pod:       ${LLM_POD}"
+echo "  Slug:      ${SLUG}"
+echo "  Secret:    ${SECRET_NAME}"
+echo "  Container: ${CONTAINER_NAME}"
+
+# ── Validate this is a Watsonx pod ───────────────────────────────────────────
+# All three Podman LLM providers (watsonx, vllm-cpu, vllm-spyre) name their pod
+# "llm-<slug>". The ai-services.io/secret label distinguishes them:
+#   watsonx  → watsonx-secret-<slug>
+#   vllm-*   → vllm-secret-<slug>  (or absent when no API key is configured)
+# Running this script against a vLLM pod would delete the wrong secret and
+# replay it with the Watsonx templates, corrupting the deployment.
+POD_SECRET_LABEL=$(podman pod inspect "${LLM_POD}" \
+    --format '{{index .Labels "ai-services.io/secret"}}' 2>/dev/null || true)
+
+if [[ "${POD_SECRET_LABEL}" != "${SECRET_NAME}" ]]; then
+    echo "Error: Pod '${LLM_POD}' is not a Watsonx pod." \
+         "(ai-services.io/secret='${POD_SECRET_LABEL}', expected '${SECRET_NAME}')" >&2
+    exit 1
+fi
+
+# ── Discover TemplateID via podman pod inspect ────────────────────────────────
+echo "→ Reading TemplateID from pod label..."
+TEMPLATE_ID=$(podman pod inspect "${LLM_POD}" \
+    --format '{{index .Labels "ai-services.io/template"}}')
 
 if [[ -z "${TEMPLATE_ID}" ]]; then
-    echo "Error: Could not find LLM component for app '${APP_NAME}' in catalog DB." >&2
+    echo "Error: Pod '${LLM_POD}' has no ai-services.io/template label." \
+         "The catalog will lose track of this pod." >&2
     exit 1
 fi
 echo "  TemplateID: ${TEMPLATE_ID}"
 
-# ── Discover values from running container ────────────────────────────────────
-echo "→ Reading configuration from running container..."
+# ── Discover config values from the running container ────────────────────────
+echo "→ Reading configuration from running container '${CONTAINER_NAME}'..."
 
 get_env() {
     podman inspect "${CONTAINER_NAME}" \
@@ -82,25 +107,50 @@ WATSONX_URL=$(get_env "WATSONX_URL")
 INSTRUCT_MODEL_NAME=$(get_env "INSTRUCT_MODEL_NAME")
 IMAGE=$(podman inspect "${CONTAINER_NAME}" --format '{{.Config.Image}}')
 
+if [[ -z "${WATSONX_PROJECT_ID}" || -z "${WATSONX_URL}" \
+      || -z "${INSTRUCT_MODEL_NAME}" || -z "${IMAGE}" ]]; then
+    echo "Error: Could not read one or more required values from container." \
+         "Check that '${CONTAINER_NAME}' is running." >&2
+    exit 1
+fi
+
 echo "  Image:              ${IMAGE}"
 echo "  WATSONX_PROJECT_ID: ${WATSONX_PROJECT_ID}"
 echo "  WATSONX_URL:        ${WATSONX_URL}"
 echo "  INSTRUCT_MODEL:     ${INSTRUCT_MODEL_NAME}"
 
-# ── Render templates ──────────────────────────────────────────────────────────
-echo "→ Rendering templates..."
+# ── Render templates to a secure temp file ───────────────────────────────────
+echo "→ Rendering pod templates..."
 YAML_FILE=$(mktemp /tmp/llm-rotate-XXXXXX.yaml)
-trap 'rm -f "${YAML_FILE}"' EXIT INT TERM
+chmod 600 "${YAML_FILE}"
+# ROTATION_STARTED is set just before the first destructive step.
+# Before that: any exit deletes the YAML (API key must not be left on disk).
+# After that: failure preserves the YAML so the operator can recover with:
+#   podman kube play <file>
+ROTATION_STARTED=0
+cleanup_yaml() {
+    local exit_code=$?
+    if [[ ${exit_code} -eq 0 || ${ROTATION_STARTED} -eq 0 ]]; then
+        rm -f "${YAML_FILE}"
+    else
+        echo "⚠ Rendered manifest preserved for manual recovery:" >&2
+        echo "    podman kube play ${YAML_FILE}" >&2
+    fi
+}
+trap cleanup_yaml EXIT
+trap 'exit 130' INT TERM
 
 render_template() {
+    # Use @ as the sed delimiter so that values containing | or / (e.g. image
+    # references and URLs) don't break the substitution.
     sed \
-        -e "s|{{ .InstanceSlug }}|${SLUG}|g" \
-        -e "s|{{ .TemplateID }}|${TEMPLATE_ID}|g" \
-        -e "s|{{ .Values.watsonxApiKey }}|${WATSONX_APIKEY_NEW}|g" \
-        -e "s|{{ .Values.watsonxProjectId }}|${WATSONX_PROJECT_ID}|g" \
-        -e "s|{{ .Values.watsonxUrl }}|${WATSONX_URL}|g" \
-        -e "s|{{ .Values.model }}|${INSTRUCT_MODEL_NAME}|g" \
-        -e "s|{{ .Values.image }}|${IMAGE}|g" \
+        -e "s@{{ .InstanceSlug }}@${SLUG}@g" \
+        -e "s@{{ .TemplateID }}@${TEMPLATE_ID}@g" \
+        -e "s@{{ .Values.watsonxApiKey }}@${WATSONX_APIKEY_NEW}@g" \
+        -e "s@{{ .Values.watsonxProjectId }}@${WATSONX_PROJECT_ID}@g" \
+        -e "s@{{ .Values.watsonxUrl }}@${WATSONX_URL}@g" \
+        -e "s@{{ .Values.model }}@${INSTRUCT_MODEL_NAME}@g" \
+        -e "s@{{ .Values.image }}@${IMAGE}@g" \
         "$1"
 }
 
@@ -110,29 +160,39 @@ render_template() {
     render_template "${SERVER_TMPL}"
 } > "${YAML_FILE}"
 
-# ── Rotate ────────────────────────────────────────────────────────────────────
-echo "→ Stopping pod ${LLM_POD}..."
+# ── Rotate: stop pod → remove pod → remove secret → replay ───────────────────
+# Podman secrets are immutable: UpdateSecret returns "unsupported method".
+# The pod must be recreated (not just restarted) because LiteLLM reads the
+# key once at startup via `export WATSONX_APIKEY=$(cat ...)`.
+ROTATION_STARTED=1
+echo "→ Stopping pod '${LLM_POD}'..."
 podman pod stop "${LLM_POD}"
 
-echo "→ Removing pod ${LLM_POD}..."
+echo "→ Removing pod '${LLM_POD}'..."
 podman pod rm "${LLM_POD}"
 
-echo "→ Removing old secret ${SECRET_NAME}..."
+echo "→ Removing old Podman secret '${SECRET_NAME}'..."
 podman secret rm "${SECRET_NAME}"
 
-echo "→ Replaying pod with new key..."
+echo "→ Replaying pod with new key (podman kube play)..."
 podman kube play "${YAML_FILE}"
 
 # ── Verify ────────────────────────────────────────────────────────────────────
-echo "→ Verifying new key..."
-sleep 3
+echo "→ Waiting for container to start..."
+sleep 5
 ACTIVE_KEY=$(podman exec "${CONTAINER_NAME}" cat /etc/secret/watsonx-secret/apiKey 2>/dev/null || echo "")
 EXPECTED_PREFIX="${WATSONX_APIKEY_NEW:0:8}"
 ACTIVE_PREFIX="${ACTIVE_KEY:0:8}"
+
 if [[ "${ACTIVE_PREFIX}" == "${EXPECTED_PREFIX}" ]]; then
     echo "✓ Key rotated successfully (mounted key starts with: ${ACTIVE_PREFIX}...)."
 else
-    echo "⚠ Warning: mounted key does not match expected value. Check container logs." >&2
+    echo "⚠ Warning: mounted key prefix '${ACTIVE_PREFIX}' does not match expected" \
+         "'${EXPECTED_PREFIX}'. Check container logs:" >&2
+    echo "    podman logs ${CONTAINER_NAME}" >&2
 fi
 
-echo "✓ Done. Test the application via the Q&A interface to confirm end-to-end functionality."
+echo ""
+echo "✓ Done. Verify end-to-end functionality via the Q&A interface."
+echo "  To confirm LiteLLM is healthy:"
+echo "    podman exec ${CONTAINER_NAME} curl -s http://localhost:8000/health/readiness"


### PR DESCRIPTION
Adds a doc with steps to rotate a Watsonx API key for an AI Services application on the Podman runtime (PowerVS), using application delete `delete+ backup + application create+ restore` to preserve data volumes while replacing the key.