### PR TITLE
AISERVICES-1382 added CRUD endpoints for extract jobs

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.219
+TAG?=v0.0.220
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -118,7 +118,7 @@ extract:
   # @description Host port for the Extract API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/extract-service:v0.0.1
+  image: icr.io/ai-services-cicd/extract-service:v0.0.2
   # @hidden
   log_level: "INFO"
   database: "extract_metadata"

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.219
+  image: icr.io/ai-services-cicd/ai-services:v0.0.220
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.219
+  image: icr.io/ai-services-cicd/ai-services:v0.0.220
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/extract/podman/values.yaml
+++ b/ai-services/assets/services/extract/podman/values.yaml
@@ -1,6 +1,6 @@
 extract:
   port: ""
-  image: icr.io/ai-services-cicd/extract-service:v0.0.1
+  image: icr.io/ai-services-cicd/extract-service:v0.0.2
   log_level: "INFO"
   database: "extract_metadata"
 

--- a/services/extract/Makefile
+++ b/services/extract/Makefile
@@ -1,5 +1,5 @@
 IMAGE=extract-service
-TAG?=v0.0.1
+TAG?=v0.0.2
 
 run:
 	PORT=$${PORT:-6000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/extract/api/v1/jobs.py
+++ b/services/extract/api/v1/jobs.py
@@ -229,7 +229,7 @@ async def create_extract_job(
     """Validate, stage, record, and enqueue an async extraction job."""
     _check_job_admission()
     filename, source_type = _validate_and_resolve_file(file)
-    _validate_file_content(file)
+    await _validate_file_content(file)
     _resolve_schema(schema_id)
 
     job_id = str(uuid.uuid4())

--- a/services/extract/api/v1/jobs.py
+++ b/services/extract/api/v1/jobs.py
@@ -76,7 +76,7 @@ def _validate_and_resolve_file(file: UploadFile) -> tuple[str, str]:
             415, "UNSUPPORTED_FILE_TYPE",
             f"Only .txt and .md files are accepted. Received: {raw_ext}",
         )
-    return filename, ext.lstrip(".")
+    return filename, (ext or "").lstrip(".")
 
 
 def _resolve_schema(schema_id: str):
@@ -306,8 +306,8 @@ async def list_extract_jobs(
             schema_id=row.schema_id,
             status=row.status,
             document_name=row.document_name,
-            submitted_at=fmt_dt(row.submitted_at),
-            completed_at=fmt_dt(row.completed_at),
+            submitted_at=fmt_dt(row.submitted_at) or "",
+            completed_at=fmt_dt(row.completed_at) or "",
         )
         for row in rows
     ]
@@ -354,8 +354,8 @@ async def get_extract_job(job_id: str) -> JobDetailResponse:
             source_type=row.source_type
         ),
         metadata=row.job_metadata,
-        submitted_at=fmt_dt(row.submitted_at),
-        completed_at=fmt_dt(row.completed_at),
+        submitted_at=fmt_dt(row.submitted_at) or "",
+        completed_at=fmt_dt(row.completed_at) or "",
         error=row.error,
     )
 

--- a/services/extract/api/v1/jobs.py
+++ b/services/extract/api/v1/jobs.py
@@ -6,22 +6,56 @@ Exposes one router:
 - ``router`` → mounted at ``/v1/extract``
 """
 
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
 
+from fastapi import APIRouter, BackgroundTasks, File, Form, Query, UploadFile
+from fastapi.responses import JSONResponse, Response
 
-from fastapi import APIRouter
+from common.error_utils import http_error_responses
+from common.misc_utils import cleanup_staging_directory, get_logger
 
-from common.misc_utils import get_logger
-
-from extract.utils.schema import (
-    SchemaValidationError
+from extract.db.manager import db_repo
+from extract.models import (
+    DocumentInfo,
+    JobCreatedResponse,
+    JobDetailResponse,
+    JobListItem,
+    JobResultResponse,
+    JobsListResponse,
+    PaginationInfo,
 )
-
+from extract.settings import settings
+from extract.state import job_limiter
+from extract.utils.job import (
+    delete_all_job_files,
+    delete_job_files,
+    read_result_file,
+    stage_uploaded_file,
+    validate_file_extension,
+)
+from extract.utils.schema import SchemaValidationError
 
 router = APIRouter()
 logger = get_logger("jobs_router")
 
+
 # ---------------------------------------------------------------------------
-# Extraction stubs (POST /v1/extract, jobs CRUD) — implemented separately
+# Helper
+# ---------------------------------------------------------------------------
+
+def _fmt_dt(dt: Optional[datetime]) -> Optional[str]:
+    """Return an ISO-8601 string (UTC) or None."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/extract — Synchronous extraction stub
 # ---------------------------------------------------------------------------
 
 @router.post("", tags=["extraction"], include_in_schema=True)
@@ -30,33 +64,416 @@ async def extract_sync():
     raise SchemaValidationError("NOT_IMPLEMENTED", "POST /v1/extract not yet implemented.", status=501)
 
 
-@router.post("/jobs", status_code=202, tags=["jobs"], include_in_schema=True)
-async def create_extract_job():
-    """Async extraction job — implementation in follow-up iteration."""
-    raise SchemaValidationError("NOT_IMPLEMENTED", "POST /v1/extract/jobs not yet implemented.", status=501)
+# ---------------------------------------------------------------------------
+# POST /v1/extract/jobs — Submit an async extraction job
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "/jobs",
+    status_code=202,
+    response_model=JobCreatedResponse,
+    responses={
+        202: {"description": "Job accepted"},
+        400: http_error_responses[400],
+        404: http_error_responses[404],
+        415: http_error_responses[415],
+        429: http_error_responses[429],
+        500: http_error_responses[500],
+    },
+    summary="Create async extraction job",
+    description=(
+        "Submit a `.txt` or `.pdf` file for asynchronous entity extraction "
+        "against a registered schema.  Returns immediately with a `job_id`.\n\n"
+        "**Form parameters:**\n"
+        "- `file` (required): A single `.txt` or `.pdf` file\n"
+        "- `schema_id` (required): ID of a registered extraction schema\n"
+        "- `job_name` (optional): Human-readable label for the job\n"
+    ),
+    tags=["jobs"],
+)
+async def create_extract_job(
+    background_tasks: BackgroundTasks,
+    file: UploadFile = File(...),
+    schema_id: str = Form(...),
+    job_name: Optional[str] = Form(None),
+) -> JobCreatedResponse:
+    """Validate, stage, record, and enqueue an async extraction job."""
+    # --- Job admission check ---
+    if job_limiter.locked():
+        raise SchemaValidationError(
+            "RATE_LIMIT_EXCEEDED",
+            "Job concurrency limit reached. Please try again later.",
+            status=429,
+        )
+
+    # --- File extension validation ---
+    filename = file.filename or ""
+    is_valid, ext = validate_file_extension(filename)
+    if not is_valid:
+        raise SchemaValidationError(
+            "UNSUPPORTED_FILE_TYPE",
+            f"Only .txt and .md files are accepted. Received: {ext or 'unknown'}",
+            status=415,
+        )
+
+    # --- Schema existence check ---
+    schema_row = db_repo.get_schema_by_id(schema_id)
+    if schema_row is None:
+        raise SchemaValidationError(
+            "SCHEMA_NOT_FOUND",
+            f"No schema with id {schema_id!r}.",
+            status=404,
+        )
+
+    # --- Generate job ID ---
+    job_id = str(uuid.uuid4())
+    source_type = ext.lstrip(".")  # "txt" or "md"
+
+    # --- Stage the uploaded file ---
+    try:
+        stage_uploaded_file(job_id, file)
+    except IOError as exc:
+        logger.error(f"Failed to stage file for job {job_id}: {exc}")
+        raise SchemaValidationError(
+            "FILE_STAGING_ERROR",
+            "Failed to save uploaded file.",
+            status=500,
+        )
+
+    # --- Persist job record ---
+    row = db_repo.create_job(
+        job_id=job_id,
+        schema_id=schema_id,
+        document_name=filename,
+        source_type=source_type,
+        job_name=job_name,
+        submitted_at=datetime.now(timezone.utc),
+    )
+    if row is None:
+        cleanup_staging_directory(job_id, settings.extract.staging_dir)
+        raise SchemaValidationError(
+            "DATABASE_ERROR",
+            "Failed to create job record.",
+            status=500,
+        )
+
+    # --- Enqueue background worker ---
+    background_tasks.add_task(_process_extract_job, job_id)
+
+    logger.info(f"Accepted extraction job {job_id} (schema={schema_id}, file={filename!r})")
+    return JobCreatedResponse(job_id=job_id)
 
 
-@router.get("/jobs", tags=["jobs"], include_in_schema=True)
-async def list_extract_jobs():
-    raise SchemaValidationError("NOT_IMPLEMENTED", "GET /v1/extract/jobs not yet implemented.", status=501)
+async def _process_extract_job(job_id: str) -> None:
+    """
+    Background worker stub.
+
+    A full worker (tokenization, vLLM call,
+    schema validation) will be added in a follow-up iteration.
+    For now it simply acquires the job_limiter slot so the semaphore
+    accounting is correct and immediately releases it.
+    """
+    async with job_limiter:
+        logger.info(f"Background worker invoked for job {job_id} (stub — no processing yet)")
 
 
-@router.get("/jobs/{job_id}", tags=["jobs"], include_in_schema=True)
-async def get_extract_job(job_id: str):
-    raise SchemaValidationError("NOT_IMPLEMENTED", "GET /v1/extract/jobs/{job_id} not yet implemented.", status=501)
+# ---------------------------------------------------------------------------
+# GET /v1/extract/jobs — List jobs with pagination and filters
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/jobs",
+    response_model=JobsListResponse,
+    responses={
+        200: {"description": "Paginated job list"},
+        400: http_error_responses[400],
+        500: http_error_responses[500],
+    },
+    summary="List extraction jobs",
+    description=(
+        "Return a paginated list of extraction jobs.\n\n"
+        "**Query parameters:**\n"
+        "- `latest` (bool): Return only the most-recent job. Default: false\n"
+        "- `limit` (int): Records per page (1–100). Default: 20\n"
+        "- `offset` (int): Records to skip. Default: 0\n"
+        "- `status` (string): Filter by `accepted`, `in_progress`, `completed`, or `failed`\n"
+        "- `schema_id` (string): Filter jobs by the schema they extract against\n"
+    ),
+    tags=["jobs"],
+)
+async def list_extract_jobs(
+    latest: Optional[bool] = Query(default=None, description="Return only the most recent job"),
+    limit: int = Query(default=20, ge=1, le=100, description="Records per page"),
+    offset: int = Query(default=0, ge=0, description="Records to skip"),
+    status: Optional[str] = Query(default=None, description="Status filter"),
+    schema_id: Optional[str] = Query(default=None, description="Filter by schema_id"),
+) -> JobsListResponse:
+    _VALID_STATUSES = {"accepted", "in_progress", "completed", "failed"}
+    if status is not None and status not in _VALID_STATUSES:
+        raise SchemaValidationError(
+            "INVALID_PARAMETER",
+            f"Invalid status value. Must be one of: {', '.join(sorted(_VALID_STATUSES))}",
+            status=400,
+        )
+
+    rows, total = db_repo.list_jobs(
+        status=status,
+        schema_id=schema_id,
+        limit=limit,
+        offset=offset,
+        latest=bool(latest),
+    )
+
+    data = [
+        JobListItem(
+            job_id=row.job_id,
+            job_name=row.job_name,
+            schema_id=row.schema_id,
+            status=row.status,
+            document_name=row.document_name,
+            submitted_at=_fmt_dt(row.submitted_at),
+            completed_at=_fmt_dt(row.completed_at),
+        )
+        for row in rows
+    ]
+    effective_limit = 1 if latest else limit
+    effective_offset = 0 if latest else offset
+    return JobsListResponse(
+        pagination=PaginationInfo(total=total, limit=effective_limit, offset=effective_offset),
+        data=data,
+    )
 
 
-@router.get("/jobs/{job_id}/result", tags=["jobs"], include_in_schema=True)
+# ---------------------------------------------------------------------------
+# GET /v1/extract/jobs/{job_id} — Full job status
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/jobs/{job_id}",
+    response_model=JobDetailResponse,
+    responses={
+        200: {"description": "Job details"},
+        404: http_error_responses[404],
+        500: http_error_responses[500],
+    },
+    summary="Get job details",
+    description=(
+        "Retrieve the full status of a specific extraction job, including "
+        "the document block, current processing phase, error message, and "
+        "token diagnostics persisted in the job's `metadata` JSONB column."
+    ),
+    tags=["jobs"],
+)
+async def get_extract_job(job_id: str) -> JobDetailResponse:
+    row = db_repo.get_job_by_id(job_id)
+    if row is None:
+        raise SchemaValidationError(
+            "RESOURCE_NOT_FOUND",
+            f"Job {job_id!r} not found.",
+            status=404,
+        )
+
+    return JobDetailResponse(
+        job_id=row.job_id,
+        job_name=row.job_name,
+        schema_id=row.schema_id,
+        status=row.status,
+        document=DocumentInfo(
+            name=row.document_name,
+            source_type=row.source_type,
+            digitize_job_id=row.digitize_job_id,
+            digitize_doc_id=row.digitize_doc_id,
+        ),
+        metadata=row.job_metadata,
+        submitted_at=_fmt_dt(row.submitted_at),
+        completed_at=_fmt_dt(row.completed_at),
+        error=row.error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/extract/jobs/{job_id}/result — Retrieve extraction result
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/jobs/{job_id}/result",
+    response_model=JobResultResponse,
+    responses={
+        200: {"description": "Extraction result"},
+        202: {"description": "Job still in progress"},
+        404: http_error_responses[404],
+        409: {"description": "Job failed — result unavailable; inspect the job resource"},
+        500: http_error_responses[500],
+    },
+    summary="Get extraction result",
+    description=(
+        "Retrieve the extraction result for a completed job.\n\n"
+        "- **202** while the job is `accepted` or `in_progress`.\n"
+        "- **409** if the job exists but `failed` — the body points at the job "
+        "resource so the caller can inspect the error and diagnostics rather "
+        "than receiving a generic 404 that conflates 'gone' with 'failed'.\n"
+        "- **404** if no job with this ID exists at all.\n"
+        "- **200** with the result payload once the job is `completed`."
+    ),
+    tags=["jobs"],
+)
 async def get_extract_job_result(job_id: str):
-    raise SchemaValidationError("NOT_IMPLEMENTED", "GET /v1/extract/jobs/{job_id}/result not yet implemented.", status=501)
+    row = db_repo.get_job_by_id(job_id)
+    if row is None:
+        raise SchemaValidationError(
+            "RESOURCE_NOT_FOUND",
+            f"Job {job_id!r} not found.",
+            status=404,
+        )
+
+    if row.status in ("accepted", "in_progress"):
+        return JSONResponse(
+            status_code=202,
+            content={
+                "message": "Job is still in progress.",
+                "job_id": job_id,
+                "status": row.status,
+            },
+        )
+
+    if row.status == "failed":
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error": {
+                    "code": "JOB_FAILED",
+                    "message": (
+                        f"Job {job_id!r} failed and has no result. "
+                        f"Inspect GET /v1/extract/jobs/{job_id} for details."
+                    ),
+                    "status": 409,
+                    "job_id": job_id,
+                }
+            },
+        )
+
+    # status == "completed" — read result file from disk
+    result_data = read_result_file(job_id)
+    if result_data is None:
+        logger.error(f"Result file missing for completed job {job_id}")
+        raise SchemaValidationError(
+            "INTERNAL_SERVER_ERROR",
+            "Result file not found for completed job.",
+            status=500,
+        )
+
+    return JobResultResponse(
+        data=result_data.get("data", {}),
+        status=result_data.get("status", "completed"),
+        meta=result_data.get("meta", {}),
+        usage=result_data.get("usage", {}),
+    )
 
 
-@router.delete("/jobs/{job_id}", status_code=204, tags=["jobs"], include_in_schema=True)
-async def delete_extract_job(job_id: str):
-    raise SchemaValidationError("NOT_IMPLEMENTED", "DELETE /v1/extract/jobs/{job_id} not yet implemented.", status=501)
+# ---------------------------------------------------------------------------
+# DELETE /v1/extract/jobs/{job_id} — Delete a single job
+# ---------------------------------------------------------------------------
+
+@router.delete(
+    "/jobs/{job_id}",
+    status_code=204,
+    responses={
+        204: {"description": "Job and result deleted"},
+        404: http_error_responses[404],
+        409: {"description": "Job is still active (accepted or in_progress)"},
+        500: http_error_responses[500],
+    },
+    summary="Delete extraction job",
+    description=(
+        "Delete a job record and its result file.  "
+        "Returns **409 Conflict** if the job is `accepted` or `in_progress`. "
+        "Does **not** delete the digitized document in the Digitize service — "
+        "that lifecycle is managed independently via the Digitize API."
+    ),
+    tags=["jobs"],
+)
+async def delete_extract_job(job_id: str) -> Response:
+    row = db_repo.get_job_by_id(job_id)
+    if row is None:
+        raise SchemaValidationError(
+            "RESOURCE_NOT_FOUND",
+            f"Job {job_id!r} not found.",
+            status=404,
+        )
+
+    if row.status in ("accepted", "in_progress"):
+        raise SchemaValidationError(
+            "RESOURCE_LOCKED",
+            f"Cannot delete active job {job_id!r}. Current status: {row.status}.",
+            status=409,
+        )
+
+    delete_job_files(job_id)
+
+    success = db_repo.delete_job(job_id)
+    if not success:
+        raise SchemaValidationError(
+            "INTERNAL_SERVER_ERROR",
+            "Failed to delete job from database.",
+            status=500,
+        )
+
+    logger.info(f"Deleted job {job_id!r}")
+    return Response(status_code=204)
 
 
-@router.delete("/jobs", status_code=204, tags=["jobs"], include_in_schema=True)
-async def bulk_delete_extract_jobs():
-    raise SchemaValidationError("NOT_IMPLEMENTED", "DELETE /v1/extract/jobs not yet implemented.", status=501)
+# ---------------------------------------------------------------------------
+# DELETE /v1/extract/jobs — Bulk delete (confirm=true required)
+# ---------------------------------------------------------------------------
 
+@router.delete(
+    "/jobs",
+    status_code=204,
+    responses={
+        204: {"description": "All jobs and results deleted"},
+        400: http_error_responses[400],
+        409: {"description": "Active jobs exist"},
+        500: http_error_responses[500],
+    },
+    summary="Bulk delete all extraction jobs",
+    description=(
+        "Delete **all** extraction job records, result files, and any "
+        "remaining staging directories.\n\n"
+        "Requires `?confirm=true`.\n\n"
+        "Returns **409 Conflict** if any job is `accepted` or `in_progress`."
+    ),
+    tags=["jobs"],
+)
+async def bulk_delete_extract_jobs(
+    confirm: Optional[str] = Query(
+        default=None,
+        description="Must be 'true' to confirm destructive bulk deletion",
+    ),
+) -> Response:
+    if confirm != "true":
+        raise SchemaValidationError(
+            "CONFIRMATION_REQUIRED",
+            "Bulk delete requires ?confirm=true.",
+            status=400,
+        )
+
+    if db_repo.has_active_jobs():
+        raise SchemaValidationError(
+            "RESOURCE_LOCKED",
+            "Cannot bulk-delete: one or more active jobs exist. "
+            "Wait for them to complete or cancel them individually.",
+            status=409,
+        )
+
+    delete_all_job_files()
+
+    success = db_repo.delete_all_jobs()
+    if not success:
+        raise SchemaValidationError(
+            "INTERNAL_SERVER_ERROR",
+            "Failed to delete jobs from database.",
+            status=500,
+        )
+
+    logger.info("Bulk deleted all extraction jobs")
+    return Response(status_code=204)

--- a/services/extract/api/v1/jobs.py
+++ b/services/extract/api/v1/jobs.py
@@ -35,23 +35,12 @@ from extract.utils.job import (
     stage_uploaded_file,
     validate_file_extension,
 )
-from extract.utils.schema import SchemaValidationError
+from extract.utils.schema import SchemaValidationError, fmt_dt
 
 router = APIRouter()
 logger = get_logger("jobs_router")
 
 
-# ---------------------------------------------------------------------------
-# Helper
-# ---------------------------------------------------------------------------
-
-def _fmt_dt(dt: Optional[datetime]) -> Optional[str]:
-    """Return an ISO-8601 string (UTC) or None."""
-    if dt is None:
-        return None
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.isoformat()
 
 
 # ---------------------------------------------------------------------------
@@ -82,10 +71,10 @@ async def extract_sync():
     },
     summary="Create async extraction job",
     description=(
-        "Submit a `.txt` or `.pdf` file for asynchronous entity extraction "
+        "Submit a `.txt` or `.md` file for asynchronous entity extraction "
         "against a registered schema.  Returns immediately with a `job_id`.\n\n"
         "**Form parameters:**\n"
-        "- `file` (required): A single `.txt` or `.pdf` file\n"
+        "- `file` (required): A single `.txt` or `.md` file\n"
         "- `schema_id` (required): ID of a registered extraction schema\n"
         "- `job_name` (optional): Human-readable label for the job\n"
     ),
@@ -231,8 +220,8 @@ async def list_extract_jobs(
             schema_id=row.schema_id,
             status=row.status,
             document_name=row.document_name,
-            submitted_at=_fmt_dt(row.submitted_at),
-            completed_at=_fmt_dt(row.completed_at),
+            submitted_at=fmt_dt(row.submitted_at),
+            completed_at=fmt_dt(row.completed_at),
         )
         for row in rows
     ]
@@ -285,8 +274,8 @@ async def get_extract_job(job_id: str) -> JobDetailResponse:
             digitize_doc_id=row.digitize_doc_id,
         ),
         metadata=row.job_metadata,
-        submitted_at=_fmt_dt(row.submitted_at),
-        completed_at=_fmt_dt(row.completed_at),
+        submitted_at=fmt_dt(row.submitted_at),
+        completed_at=fmt_dt(row.completed_at),
         error=row.error,
     )
 
@@ -387,8 +376,6 @@ async def get_extract_job_result(job_id: str):
     description=(
         "Delete a job record and its result file.  "
         "Returns **409 Conflict** if the job is `accepted` or `in_progress`. "
-        "Does **not** delete the digitized document in the Digitize service — "
-        "that lifecycle is managed independently via the Digitize API."
     ),
     tags=["jobs"],
 )

--- a/services/extract/api/v1/jobs.py
+++ b/services/extract/api/v1/jobs.py
@@ -6,6 +6,8 @@ Exposes one router:
 - ``router`` → mounted at ``/v1/extract``
 """
 
+import os
+import unicodedata
 import uuid
 from datetime import datetime, timezone
 from typing import Optional
@@ -35,12 +37,102 @@ from extract.utils.job import (
     stage_uploaded_file,
     validate_file_extension,
 )
-from extract.utils.schema import SchemaValidationError, fmt_dt
+from extract.utils.exceptions import ExtractException
+from extract.utils.schema import fmt_dt
 
 router = APIRouter()
 logger = get_logger("jobs_router")
 
 
+
+
+# ---------------------------------------------------------------------------
+# create_extract_job — private helpers
+# ---------------------------------------------------------------------------
+
+def _check_job_admission() -> None:
+    """Raise 429 if the concurrency slot is exhausted."""
+    if job_limiter.locked():
+        raise ExtractException(
+            429, "RATE_LIMIT_EXCEEDED",
+            "Job concurrency limit reached. Please try again later.",
+        )
+
+
+def _validate_and_resolve_file(file: UploadFile) -> tuple[str, str]:
+    """Normalise the filename and validate its extension.
+
+    Returns:
+        (normalised_filename, source_type)  e.g. ("report.txt", "txt")
+
+    Raises:
+        ExtractException(415) on an unsupported or missing extension.
+    """
+    filename = (file.filename or "").lower()
+    is_valid, ext = validate_file_extension(filename)
+    if not is_valid:
+        raw_ext = os.path.splitext(filename)[1] or "unknown"
+        raise ExtractException(
+            415, "UNSUPPORTED_FILE_TYPE",
+            f"Only .txt and .md files are accepted. Received: {raw_ext}",
+        )
+    return filename, ext.lstrip(".")
+
+
+def _resolve_schema(schema_id: str):
+    """Return the schema row for *schema_id*.
+
+    Raises:
+        ExtractException(404) if the schema does not exist.
+    """
+    row = db_repo.get_schema_by_id(schema_id)
+    if row is None:
+        raise ExtractException(
+            404, "SCHEMA_NOT_FOUND",
+            f"No schema with id {schema_id!r}.",
+        )
+    return row
+
+
+def _stage_and_persist(
+    job_id: str,
+    file: UploadFile,
+    schema_id: str,
+    filename: str,
+    source_type: str,
+    job_name: Optional[str],
+):
+    """Stage the uploaded file then write the DB record.
+
+    Cleans up the staging directory on *any* failure after staging so no
+    orphaned files are left on disk.
+
+    Raises:
+        ExtractException(500) on staging or database failure.
+    """
+    try:
+        stage_uploaded_file(job_id, file)
+    except IOError as exc:
+        logger.error(f"Failed to stage file for job {job_id}: {exc}")
+        raise ExtractException(500, "FILE_STAGING_ERROR", "Failed to save uploaded file.")
+
+    try:
+        row = db_repo.create_job(
+            job_id=job_id,
+            schema_id=schema_id,
+            document_name=filename,
+            source_type=source_type,
+            job_name=job_name,
+            submitted_at=datetime.now(timezone.utc),
+        )
+    except Exception as exc:
+        logger.error(f"Unexpected DB error creating job {job_id}: {exc}")
+        cleanup_staging_directory(job_id, settings.extract.staging_dir)
+        raise ExtractException(500, "DATABASE_ERROR", "Failed to create job record.")
+
+    if row is None:
+        cleanup_staging_directory(job_id, settings.extract.staging_dir)
+        raise ExtractException(500, "DATABASE_ERROR", "Failed to create job record.")
 
 
 # ---------------------------------------------------------------------------
@@ -50,13 +142,61 @@ logger = get_logger("jobs_router")
 @router.post("", tags=["extraction"], include_in_schema=True)
 async def extract_sync():
     """Synchronous extraction — implementation in follow-up iteration."""
-    raise SchemaValidationError("NOT_IMPLEMENTED", "POST /v1/extract not yet implemented.", status=501)
+    raise ExtractException(501, "NOT_IMPLEMENTED", "POST /v1/extract not yet implemented.")
+
+# Probe size for binary-detection heuristics. 8 KB is large enough to catch
+# null bytes, invalid UTF-8, or control-character runs in virtually any
+# misnamed binary file, while aligning with the OS page size and Python's
+# default IO buffer. The full UTF-8 decode in the worker catches anything
+# deeper; this probe just moves obvious rejections to submission time.
+MAX_PROBE_BYTES = 8192
+
+async def _validate_file_content(file):
+    """
+        Validate that an uploaded file is a genuine text file.
+        Reads only the first 8 KB, then resets the file pointer.
+        Raises 415 if the content doesn't match expectations.
+        """
+    # Extension check
+    filename = file.filename or ""
+    ext = filename[filename.rfind("."):].lower() if "." in filename else ""
+
+    # Read probe and reset
+    probe = await file.read(MAX_PROBE_BYTES)
+    await file.seek(0)
+
+    if not probe:
+        raise ExtractException(400, "BAD_REQUEST", "File is empty.")
+
+    try:
+        decoded = probe.decode("utf-8")
+    except UnicodeDecodeError:
+        raise ExtractException(400, "BAD_REQUEST", "File content is not valid UTF-8 text.")
+
+    # Gate 2: no null bytes
+    if b"\x00" in probe:
+        raise ExtractException(415, "BAD_REQUEST", "File contains null bytes and appears to be binary.")
+
+    # Gate 3: low control character ratio
+    control_count = sum(
+        1 for ch in decoded
+        if unicodedata.category(ch).startswith("Cc")
+        and ch not in ("\n", "\r", "\t", "\f")
+    )
+    if len(decoded) > 0 and (control_count / len(decoded)) > 0.05:
+        raise ExtractException(415, "BAD_REQUEST", "File contains excessive control characters and appears to be binary.")
+
+    # Gate 4: reject text files that are actually PDFs
+    pdf_magic = b"%PDF"
+    if probe[:4].startswith(pdf_magic):
+        raise ExtractException(415, "BAD_REQUEST", f"File has {ext} extension but contains PDF content.")
+
+    return
 
 
 # ---------------------------------------------------------------------------
 # POST /v1/extract/jobs — Submit an async extraction job
 # ---------------------------------------------------------------------------
-
 @router.post(
     "/jobs",
     status_code=202,
@@ -87,68 +227,15 @@ async def create_extract_job(
     job_name: Optional[str] = Form(None),
 ) -> JobCreatedResponse:
     """Validate, stage, record, and enqueue an async extraction job."""
-    # --- Job admission check ---
-    if job_limiter.locked():
-        raise SchemaValidationError(
-            "RATE_LIMIT_EXCEEDED",
-            "Job concurrency limit reached. Please try again later.",
-            status=429,
-        )
+    _check_job_admission()
+    filename, source_type = _validate_and_resolve_file(file)
+    _validate_file_content(file)
+    _resolve_schema(schema_id)
 
-    # --- File extension validation ---
-    filename = file.filename or ""
-    is_valid, ext = validate_file_extension(filename)
-    if not is_valid:
-        raise SchemaValidationError(
-            "UNSUPPORTED_FILE_TYPE",
-            f"Only .txt and .md files are accepted. Received: {ext or 'unknown'}",
-            status=415,
-        )
-
-    # --- Schema existence check ---
-    schema_row = db_repo.get_schema_by_id(schema_id)
-    if schema_row is None:
-        raise SchemaValidationError(
-            "SCHEMA_NOT_FOUND",
-            f"No schema with id {schema_id!r}.",
-            status=404,
-        )
-
-    # --- Generate job ID ---
     job_id = str(uuid.uuid4())
-    source_type = ext.lstrip(".")  # "txt" or "md"
+    _stage_and_persist(job_id, file, schema_id, filename, source_type, job_name)
 
-    # --- Stage the uploaded file ---
-    try:
-        stage_uploaded_file(job_id, file)
-    except IOError as exc:
-        logger.error(f"Failed to stage file for job {job_id}: {exc}")
-        raise SchemaValidationError(
-            "FILE_STAGING_ERROR",
-            "Failed to save uploaded file.",
-            status=500,
-        )
-
-    # --- Persist job record ---
-    row = db_repo.create_job(
-        job_id=job_id,
-        schema_id=schema_id,
-        document_name=filename,
-        source_type=source_type,
-        job_name=job_name,
-        submitted_at=datetime.now(timezone.utc),
-    )
-    if row is None:
-        cleanup_staging_directory(job_id, settings.extract.staging_dir)
-        raise SchemaValidationError(
-            "DATABASE_ERROR",
-            "Failed to create job record.",
-            status=500,
-        )
-
-    # --- Enqueue background worker ---
     background_tasks.add_task(_process_extract_job, job_id)
-
     logger.info(f"Accepted extraction job {job_id} (schema={schema_id}, file={filename!r})")
     return JobCreatedResponse(job_id=job_id)
 
@@ -199,10 +286,9 @@ async def list_extract_jobs(
 ) -> JobsListResponse:
     _VALID_STATUSES = {"accepted", "in_progress", "completed", "failed"}
     if status is not None and status not in _VALID_STATUSES:
-        raise SchemaValidationError(
-            "INVALID_PARAMETER",
+        raise ExtractException(
+            400, "INVALID_PARAMETER",
             f"Invalid status value. Must be one of: {', '.join(sorted(_VALID_STATUSES))}",
-            status=400,
         )
 
     rows, total = db_repo.list_jobs(
@@ -256,11 +342,7 @@ async def list_extract_jobs(
 async def get_extract_job(job_id: str) -> JobDetailResponse:
     row = db_repo.get_job_by_id(job_id)
     if row is None:
-        raise SchemaValidationError(
-            "RESOURCE_NOT_FOUND",
-            f"Job {job_id!r} not found.",
-            status=404,
-        )
+        raise ExtractException(404, "RESOURCE_NOT_FOUND", f"Job {job_id!r} not found.")
 
     return JobDetailResponse(
         job_id=row.job_id,
@@ -269,9 +351,7 @@ async def get_extract_job(job_id: str) -> JobDetailResponse:
         status=row.status,
         document=DocumentInfo(
             name=row.document_name,
-            source_type=row.source_type,
-            digitize_job_id=row.digitize_job_id,
-            digitize_doc_id=row.digitize_doc_id,
+            source_type=row.source_type
         ),
         metadata=row.job_metadata,
         submitted_at=fmt_dt(row.submitted_at),
@@ -309,11 +389,7 @@ async def get_extract_job(job_id: str) -> JobDetailResponse:
 async def get_extract_job_result(job_id: str):
     row = db_repo.get_job_by_id(job_id)
     if row is None:
-        raise SchemaValidationError(
-            "RESOURCE_NOT_FOUND",
-            f"Job {job_id!r} not found.",
-            status=404,
-        )
+        raise ExtractException(404, "RESOURCE_NOT_FOUND", f"Job {job_id!r} not found.")
 
     if row.status in ("accepted", "in_progress"):
         return JSONResponse(
@@ -345,11 +421,7 @@ async def get_extract_job_result(job_id: str):
     result_data = read_result_file(job_id)
     if result_data is None:
         logger.error(f"Result file missing for completed job {job_id}")
-        raise SchemaValidationError(
-            "INTERNAL_SERVER_ERROR",
-            "Result file not found for completed job.",
-            status=500,
-        )
+        raise ExtractException(500, "INTERNAL_SERVER_ERROR", "Result file not found for completed job.")
 
     return JobResultResponse(
         data=result_data.get("data", {}),
@@ -382,28 +454,19 @@ async def get_extract_job_result(job_id: str):
 async def delete_extract_job(job_id: str) -> Response:
     row = db_repo.get_job_by_id(job_id)
     if row is None:
-        raise SchemaValidationError(
-            "RESOURCE_NOT_FOUND",
-            f"Job {job_id!r} not found.",
-            status=404,
-        )
+        raise ExtractException(404, "RESOURCE_NOT_FOUND", f"Job {job_id!r} not found.")
 
-    if row.status in ("accepted", "in_progress"):
-        raise SchemaValidationError(
-            "RESOURCE_LOCKED",
+    if row.status not in ("completed", "failed"):
+        raise ExtractException(
+            409, "RESOURCE_LOCKED",
             f"Cannot delete active job {job_id!r}. Current status: {row.status}.",
-            status=409,
         )
 
     delete_job_files(job_id)
 
     success = db_repo.delete_job(job_id)
     if not success:
-        raise SchemaValidationError(
-            "INTERNAL_SERVER_ERROR",
-            "Failed to delete job from database.",
-            status=500,
-        )
+        raise ExtractException(500, "INTERNAL_SERVER_ERROR", "Failed to delete job from database.")
 
     logger.info(f"Deleted job {job_id!r}")
     return Response(status_code=204)
@@ -438,29 +501,20 @@ async def bulk_delete_extract_jobs(
     ),
 ) -> Response:
     if confirm != "true":
-        raise SchemaValidationError(
-            "CONFIRMATION_REQUIRED",
-            "Bulk delete requires ?confirm=true.",
-            status=400,
-        )
+        raise ExtractException(400, "CONFIRMATION_REQUIRED", "Bulk delete requires ?confirm=true.")
 
     if db_repo.has_active_jobs():
-        raise SchemaValidationError(
-            "RESOURCE_LOCKED",
+        raise ExtractException(
+            409, "RESOURCE_LOCKED",
             "Cannot bulk-delete: one or more active jobs exist. "
             "Wait for them to complete or cancel them individually.",
-            status=409,
         )
 
     delete_all_job_files()
 
     success = db_repo.delete_all_jobs()
     if not success:
-        raise SchemaValidationError(
-            "INTERNAL_SERVER_ERROR",
-            "Failed to delete jobs from database.",
-            status=500,
-        )
+        raise ExtractException(500, "INTERNAL_SERVER_ERROR", "Failed to delete jobs from database.")
 
     logger.info("Bulk deleted all extraction jobs")
     return Response(status_code=204)

--- a/services/extract/api/v1/schema.py
+++ b/services/extract/api/v1/schema.py
@@ -172,7 +172,7 @@ async def list_schemas(
             schema_tokens=row.schema_tokens,
             examples_tokens=row.examples_tokens,
             custom_prompt_tokens=row.custom_prompt_tokens,
-            created_at=fmt_dt(row.created_at),
+            created_at=fmt_dt(row.created_at) or "",
         )
         for row in rows
     ]
@@ -218,7 +218,7 @@ async def get_schema(schema_id: str) -> SchemaDetailResponse:
         schema_tokens=row.schema_tokens,
         examples_tokens=row.examples_tokens,
         custom_prompt_tokens=row.custom_prompt_tokens,
-        created_at=fmt_dt(row.created_at),
+        created_at=fmt_dt(row.created_at) or "",
     )
 
 

--- a/services/extract/app.py
+++ b/services/extract/app.py
@@ -4,20 +4,13 @@ Extract Information Service — FastAPI application.
 
 import uuid
 from contextlib import asynccontextmanager
-from datetime import datetime, timezone
-from typing import Optional
 
 import uvicorn
-from fastapi import BackgroundTasks, FastAPI, File, Form, Query, Request, UploadFile
+from fastapi import FastAPI, Request
 from fastapi.openapi.docs import get_swagger_ui_html
-from fastapi.responses import JSONResponse, Response
-from sqlalchemy.exc import IntegrityError
-
+from fastapi.responses import JSONResponse
 from common.misc_utils import configure_uvicorn_logging, create_llm_session, get_llm_endpoint, get_logger, set_log_level, set_request_id
 from common.diagnostic_logger import setup_comprehensive_crash_handler
-from common.error_utils import http_error_responses
-from common.misc_utils import cleanup_staging_directory
-
 from extract.db.connection import check_db_connection, close_db_connections
 
 
@@ -37,9 +30,6 @@ logger = get_logger("app")
 
 diagnostic_logger, stderr_monitor, signal_handler = setup_comprehensive_crash_handler(logger)
 
-# Semaphores live in extract.state so that api/v1/jobs.py can import them
-# without creating a circular dependency (app → jobs → app).
-from extract.state import concurrency_limiter, job_limiter  # noqa: E402
 
 # Module-level model dict populated during lifespan startup.
 llm_model_dict: dict = {}
@@ -50,7 +40,7 @@ llm_model_dict: dict = {}
 # ---------------------------------------------------------------------------
 
 def ensure_directories() -> None:
-    """Create cache sub-directories if they do not already exist."""
+    """Create cache subdirectories if they do not already exist."""
     for d in [settings.extract.staging_dir, settings.extract.results_dir]:
         d.mkdir(parents=True, exist_ok=True)
         logger.debug(f"Ensured directory: {d}")

--- a/services/extract/app.py
+++ b/services/extract/app.py
@@ -11,11 +11,11 @@ from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.responses import JSONResponse
 from common.misc_utils import configure_uvicorn_logging, create_llm_session, get_llm_endpoint, get_logger, set_log_level, set_request_id
 from common.diagnostic_logger import setup_comprehensive_crash_handler
-from extract.db.connection import check_db_connection, close_db_connections
-
-
-from extract.utils.schema import SchemaValidationError
+from extract.db.connection import check_db_connection, close_db_connections, engine
+from extract.db.models import Base
+from extract.utils.schema import SchemaValidationError, calculate_prompt_overhead_tokens
 from extract.utils.exceptions import ExtractException
+from extract.utils.job import recover_zombie_jobs
 from extract.settings import settings
 
 set_log_level(settings.common.app.log_level)
@@ -45,42 +45,40 @@ def initialize_models() -> None:
     llm_model_dict = get_llm_endpoint()
 
 
+def _initialize_database() -> None:
+    """Connect to the database and create all schema tables.
+
+    Raises RuntimeError on any failure so the application refuses to start
+    with a clear message rather than failing later at request time.
+    """
+    try:
+        connected = check_db_connection()
+    except Exception as exc:
+        raise RuntimeError(f"Database connection check failed: {exc}") from exc
+
+    if not connected:
+        raise RuntimeError("Database connection required but not available.")
+
+    logger.info("✅ Database connection established")
+
+    try:
+        Base.metadata.create_all(bind=engine)
+        logger.info("✅ Database schema initialized")
+    except Exception as exc:
+        logger.error(f"❌ Failed to initialize database schema: {exc}")
+        raise RuntimeError(f"Database schema initialization failed: {exc}") from exc
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    filtered_paths = ["/health"]
-    configure_uvicorn_logging(settings.common.app.log_level, filtered_paths)
+    configure_uvicorn_logging(settings.common.app.log_level, ["/health"])
     create_llm_session(pool_maxsize=settings.common.llm.max_batch_size)
     initialize_models()
-
-    # Compute prompt scaffold token overhead now that the LLM session is ready.
-    from extract.utils.schema import calculate_prompt_overhead_tokens
-    llm_endpoint = llm_model_dict.get("llm_endpoint", "")
-    calculate_prompt_overhead_tokens(llm_endpoint)
-
-    # Database check (required for operation — fail fast if DB is unavailable).
-    try:
-        if check_db_connection():
-            logger.info("✅ Database connection established")
-            try:
-                from extract.db.models import Base
-                from extract.db.connection import engine
-                Base.metadata.create_all(bind=engine)
-                logger.info("✅ Database schema initialized")
-            except Exception as schema_error:
-                logger.error(f"❌ Failed to initialize database schema: {schema_error}")
-                raise RuntimeError(f"Database schema initialization failed: {schema_error}")
-        else:
-            raise RuntimeError("Database connection required but not available.")
-    except RuntimeError:
-        raise
-    except Exception as exc:
-        raise RuntimeError(f"Database connection required but failed: {exc}")
-
+    calculate_prompt_overhead_tokens(llm_model_dict.get("llm_endpoint", ""))
+    _initialize_database()
     ensure_directories()
 
-    # Zombie-job recovery scan on startup.
     logger.info("Running zombie job recovery scan...")
-    from extract.utils.job import recover_zombie_jobs
     recovered = recover_zombie_jobs()
     if recovered > 0:
         logger.warning(f"Recovered {recovered} zombie job(s) from previous session")

--- a/services/extract/app.py
+++ b/services/extract/app.py
@@ -14,14 +14,8 @@ from common.diagnostic_logger import setup_comprehensive_crash_handler
 from extract.db.connection import check_db_connection, close_db_connections
 
 
-from extract.utils.schema import (
-    SchemaValidationError,
-    check_schema_share_in_context,
-    compute_token_counts,
-    normalize_schema,
-    validate_examples,
-    validate_json_schema_structure
-)
+from extract.utils.schema import SchemaValidationError
+from extract.utils.exceptions import ExtractException
 from extract.settings import settings
 
 set_log_level(settings.common.app.log_level)
@@ -158,6 +152,14 @@ async def schema_validation_error_handler(request: Request, exc: SchemaValidatio
     if exc.details:
         body["error"]["details"] = exc.details
     return JSONResponse(status_code=exc.status, content=body)
+
+
+@app.exception_handler(ExtractException)
+async def extract_exception_handler(request: Request, exc: ExtractException):
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"error": {"code": exc.code, "message": exc.message, "status": exc.status_code}},
+    )
 
 
 from extract.api.v1.schema import router as schema_router

--- a/services/extract/app.py
+++ b/services/extract/app.py
@@ -2,13 +2,13 @@
 Extract Information Service — FastAPI application.
 """
 
-import asyncio
 import uuid
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from typing import Optional
 
 import uvicorn
-from fastapi import FastAPI, Query, Request
+from fastapi import BackgroundTasks, FastAPI, File, Form, Query, Request, UploadFile
 from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.responses import JSONResponse, Response
 from sqlalchemy.exc import IntegrityError
@@ -16,10 +16,19 @@ from sqlalchemy.exc import IntegrityError
 from common.misc_utils import configure_uvicorn_logging, create_llm_session, get_llm_endpoint, get_logger, set_log_level, set_request_id
 from common.diagnostic_logger import setup_comprehensive_crash_handler
 from common.error_utils import http_error_responses
+from common.misc_utils import cleanup_staging_directory
 
 from extract.db.connection import check_db_connection, close_db_connections
 
-from extract.utils.schema import SchemaValidationError
+
+from extract.utils.schema import (
+    SchemaValidationError,
+    check_schema_share_in_context,
+    compute_token_counts,
+    normalize_schema,
+    validate_examples,
+    validate_json_schema_structure
+)
 from extract.settings import settings
 
 set_log_level(settings.common.app.log_level)
@@ -28,11 +37,9 @@ logger = get_logger("app")
 
 diagnostic_logger, stderr_monitor, signal_handler = setup_comprehensive_crash_handler(logger)
 
-# Global vLLM concurrency limiter (shared by sync + async extraction paths).
-concurrency_limiter = asyncio.BoundedSemaphore(settings.common.llm.max_batch_size)
-
-# Async job admission semaphore (caps background workers).
-job_limiter = asyncio.BoundedSemaphore(settings.extract.max_concurrent_jobs)
+# Semaphores live in extract.state so that api/v1/jobs.py can import them
+# without creating a circular dependency (app → jobs → app).
+from extract.state import concurrency_limiter, job_limiter  # noqa: E402
 
 # Module-level model dict populated during lifespan startup.
 llm_model_dict: dict = {}

--- a/services/extract/db/models.py
+++ b/services/extract/db/models.py
@@ -116,7 +116,7 @@ class ExtractJob(Base):
             name="chk_extract_job_status",
         ),
         CheckConstraint(
-            "source_type IN ('txt', 'pdf')",
+            "source_type IN ('txt', 'md')",
             name="chk_extract_source_type",
         ),
         Index("idx_extract_jobs_submitted_at_status", "submitted_at", "status"),

--- a/services/extract/db/scripts/init_schema.sql
+++ b/services/extract/db/scripts/init_schema.sql
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS extract_jobs (
     CONSTRAINT chk_extract_job_status
         CHECK (status IN ('accepted', 'in_progress', 'completed', 'failed')),
     CONSTRAINT chk_extract_source_type
-        CHECK (source_type IN ('txt', 'pdf'))
+        CHECK (source_type IN ('txt', 'md'))
 );
 
 CREATE INDEX IF NOT EXISTS idx_extract_jobs_submitted_at_status

--- a/services/extract/models.py
+++ b/services/extract/models.py
@@ -125,8 +125,6 @@ class DocumentInfo(BaseModel):
     """Inline document info embedded in job detail responses."""
     name: str
     source_type: str
-    digitize_job_id: Optional[str] = None
-    digitize_doc_id: Optional[str] = None
 
 
 class JobDetailResponse(BaseModel):

--- a/services/extract/state.py
+++ b/services/extract/state.py
@@ -1,0 +1,16 @@
+"""
+Shared async semaphores for the Extract service.
+
+Defining these here (rather than in app.py) lets both app.py and the
+api/v1/jobs.py router import them without creating a circular dependency.
+"""
+
+import asyncio
+
+from extract.settings import settings
+
+# Global vLLM concurrency limiter (shared by sync + async extraction paths).
+concurrency_limiter = asyncio.BoundedSemaphore(settings.common.llm.max_batch_size)
+
+# Async job admission semaphore (caps background workers).
+job_limiter = asyncio.BoundedSemaphore(settings.extract.max_concurrent_jobs)

--- a/services/extract/tests/unit/test_job_endpoints.py
+++ b/services/extract/tests/unit/test_job_endpoints.py
@@ -225,6 +225,28 @@ class TestCreateExtractJob:
         assert response.status_code == 500
         mock_cleanup.assert_called_once()
 
+    def test_db_create_exception_cleans_up_staging(self, extract_test_client):
+        """When db.create_job raises unexpectedly, staging is still cleaned up."""
+        test_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+        with patch("extract.api.v1.jobs.job_limiter.locked", return_value=False), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.db_repo.get_schema_by_id", return_value=Mock()), \
+             patch("extract.api.v1.jobs.stage_uploaded_file"), \
+             patch("extract.api.v1.jobs.db_repo.create_job", side_effect=RuntimeError("DB timeout")), \
+             patch("extract.api.v1.jobs.cleanup_staging_directory") as mock_cleanup, \
+             patch("extract.api.v1.jobs.uuid.uuid4", return_value=uuid.UUID(test_uuid)):
+
+            response = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_id": "schema-001"},
+                files={"file": self._txt_file()},
+            )
+
+        assert response.status_code == 500
+        assert response.json()["error"]["code"] == "DATABASE_ERROR"
+        mock_cleanup.assert_called_once()
+
     def test_response_contains_valid_uuid(self, extract_test_client):
         """The returned job_id must be a valid UUID string."""
         with patch("extract.api.v1.jobs.job_limiter.locked", return_value=False), \
@@ -366,20 +388,14 @@ class TestGetExtractJob:
         assert body["status"] == job.status
 
     def test_response_includes_document_block(self, extract_test_client):
-        """The document sub-object must include name, source_type, digitize IDs."""
-        job = _mock_job(
-            source_type="pdf",
-            digitize_job_id="dj-999",
-            digitize_doc_id="dd-888",
-        )
+        """The document sub-object must include name and source_type."""
+        job = _mock_job(source_type="pdf")
         with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job):
             response = extract_test_client.get(f"/v1/extract/jobs/{job.job_id}")
 
         doc = response.json()["document"]
         assert doc["name"] == job.document_name
         assert doc["source_type"] == "pdf"
-        assert doc["digitize_job_id"] == "dj-999"
-        assert doc["digitize_doc_id"] == "dd-888"
 
     def test_response_includes_phase_from_metadata(self, extract_test_client):
         """metadata JSONB (phase, token_diagnostics, etc.) is surfaced."""

--- a/services/extract/tests/unit/test_job_endpoints.py
+++ b/services/extract/tests/unit/test_job_endpoints.py
@@ -1,0 +1,633 @@
+"""
+Unit tests for the extraction job HTTP endpoints.
+
+Covers all six job endpoints:
+  POST   /v1/extract/jobs
+  GET    /v1/extract/jobs
+  GET    /v1/extract/jobs/{job_id}
+  GET    /v1/extract/jobs/{job_id}/result
+  DELETE /v1/extract/jobs/{job_id}
+  DELETE /v1/extract/jobs
+
+All external boundaries (database, filesystem, vLLM) are mocked so the
+tests run without a real PostgreSQL instance or LLM endpoint.
+"""
+
+import io
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_job(
+    job_id="job-001",
+    schema_id="schema-001",
+    status="completed",
+    document_name="contract.pdf",
+    source_type="pdf",
+    job_name=None,
+    digitize_job_id=None,
+    digitize_doc_id=None,
+    job_metadata=None,
+    error=None,
+    submitted_at=None,
+    completed_at=None,
+):
+    """Return a Mock that looks like an ExtractJob ORM row."""
+    row = Mock()
+    row.job_id = job_id
+    row.schema_id = schema_id
+    row.status = status
+    row.document_name = document_name
+    row.source_type = source_type
+    row.job_name = job_name
+    row.digitize_job_id = digitize_job_id
+    row.digitize_doc_id = digitize_doc_id
+    row.job_metadata = job_metadata
+    row.error = error
+    row.submitted_at = submitted_at or datetime(2026, 7, 7, 10, 0, 0, tzinfo=timezone.utc)
+    row.completed_at = completed_at or datetime(2026, 7, 7, 10, 5, 0, tzinfo=timezone.utc)
+    return row
+
+
+_RESULT_DATA = {
+    "data": {
+        "extraction": {"invoice_number": "INV-001", "total_amount": 500.0},
+        "schema_id": "schema-001",
+        "source": {"input_type": "file", "document_name": "contract.pdf"},
+    },
+    "status": "completed",
+    "meta": {
+        "model": "test-model",
+        "processing_time_ms": 3000,
+        "validation_attempts": 1,
+    },
+    "usage": {"input_tokens": 800, "output_tokens": 60, "total_tokens": 860},
+}
+
+
+# =========================================================================
+# POST /v1/extract/jobs
+# =========================================================================
+
+@pytest.mark.unit
+class TestCreateExtractJob:
+    """Tests for POST /v1/extract/jobs."""
+
+    def _txt_file(self, content=b"Sample text for extraction.", name="doc.txt"):
+        return (name, io.BytesIO(content), "text/plain")
+
+    def _pdf_file(self, name="doc.pdf"):
+        return (name, io.BytesIO(b"%PDF-1.4 fake content"), "application/pdf")
+
+    def test_success_txt_returns_202(self, extract_test_client):
+        """Happy path: .txt file with a valid schema_id returns 202 with job_id."""
+        test_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+        with patch("extract.api.v1.jobs.job_limiter.locked", return_value=False), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.db_repo.get_schema_by_id", return_value=Mock()), \
+             patch("extract.api.v1.jobs.stage_uploaded_file"), \
+             patch("extract.api.v1.jobs.db_repo.create_job", return_value=_mock_job(job_id=test_uuid)), \
+             patch("extract.api.v1.jobs.uuid.uuid4", return_value=uuid.UUID(test_uuid)):
+
+            response = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_id": "schema-001"},
+                files={"file": self._txt_file()},
+            )
+
+        assert response.status_code == 202
+        assert response.json()["job_id"] == test_uuid
+
+    def test_success_pdf_returns_202(self, extract_test_client):
+        """A PDF file is also accepted and returns 202."""
+        test_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+        with patch("extract.api.v1.jobs.job_limiter.locked", return_value=False), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".pdf")), \
+             patch("extract.api.v1.jobs.db_repo.get_schema_by_id", return_value=Mock()), \
+             patch("extract.api.v1.jobs.stage_uploaded_file"), \
+             patch("extract.api.v1.jobs.db_repo.create_job", return_value=_mock_job(job_id=test_uuid)), \
+             patch("extract.api.v1.jobs.uuid.uuid4", return_value=uuid.UUID(test_uuid)):
+
+            response = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_id": "schema-001"},
+                files={"file": self._pdf_file()},
+            )
+
+        assert response.status_code == 202
+
+    def test_job_name_accepted(self, extract_test_client):
+        """Optional job_name is forwarded to db_repo.create_job."""
+        test_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+        with patch("extract.api.v1.jobs.job_limiter.locked", return_value=False), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.db_repo.get_schema_by_id", return_value=Mock()), \
+             patch("extract.api.v1.jobs.stage_uploaded_file"), \
+             patch("extract.api.v1.jobs.db_repo.create_job", return_value=_mock_job(job_id=test_uuid)) as mock_create, \
+             patch("extract.api.v1.jobs.uuid.uuid4", return_value=uuid.UUID(test_uuid)):
+
+            extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_id": "schema-001", "job_name": "Q3 audit"},
+                files={"file": self._txt_file()},
+            )
+
+        call_kwargs = mock_create.call_args[1]
+        assert call_kwargs.get("job_name") == "Q3 audit"
+
+    def test_rate_limit_returns_429(self, extract_test_client):
+        """When job_limiter is full, endpoint returns 429."""
+        with patch("extract.api.v1.jobs.job_limiter.locked", return_value=True):
+            response = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_id": "schema-001"},
+                files={"file": self._txt_file()},
+            )
+
+        assert response.status_code == 429
+        assert response.json()["error"]["code"] == "RATE_LIMIT_EXCEEDED"
+
+    def test_unsupported_extension_returns_415(self, extract_test_client):
+        """A .docx file is rejected with 415."""
+        with patch("extract.api.v1.jobs.job_limiter.locked", return_value=False), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(False, ".docx")):
+
+            response = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_id": "schema-001"},
+                files={"file": ("doc.docx", io.BytesIO(b"fake"), "application/octet-stream")},
+            )
+
+        assert response.status_code == 415
+
+    def test_unknown_schema_id_returns_404(self, extract_test_client):
+        """If the schema_id does not exist, endpoint returns 404."""
+        with patch("extract.api.v1.jobs.job_limiter.locked", return_value=False), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.db_repo.get_schema_by_id", return_value=None):
+
+            response = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_id": "nonexistent"},
+                files={"file": self._txt_file()},
+            )
+
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "SCHEMA_NOT_FOUND"
+
+    def test_file_staging_failure_returns_500(self, extract_test_client):
+        """An IOError during staging returns 500 and does not leave a DB row."""
+        with patch("extract.api.v1.jobs.job_limiter.locked", return_value=False), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.db_repo.get_schema_by_id", return_value=Mock()), \
+             patch("extract.api.v1.jobs.stage_uploaded_file", side_effect=IOError("Disk full")):
+
+            response = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_id": "schema-001"},
+                files={"file": self._txt_file()},
+            )
+
+        assert response.status_code == 500
+        assert "file" in response.json()["error"]["message"].lower() or \
+               "staging" in response.json()["error"]["message"].lower()
+
+    def test_db_create_failure_cleans_up_staging(self, extract_test_client):
+        """When db.create_job returns None, staging is cleaned up and 500 is returned."""
+        test_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+        with patch("extract.api.v1.jobs.job_limiter.locked", return_value=False), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.db_repo.get_schema_by_id", return_value=Mock()), \
+             patch("extract.api.v1.jobs.stage_uploaded_file"), \
+             patch("extract.api.v1.jobs.db_repo.create_job", return_value=None), \
+             patch("extract.api.v1.jobs.cleanup_staging_directory") as mock_cleanup, \
+             patch("extract.api.v1.jobs.uuid.uuid4", return_value=uuid.UUID(test_uuid)):
+
+            response = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_id": "schema-001"},
+                files={"file": self._txt_file()},
+            )
+
+        assert response.status_code == 500
+        mock_cleanup.assert_called_once()
+
+    def test_response_contains_valid_uuid(self, extract_test_client):
+        """The returned job_id must be a valid UUID string."""
+        with patch("extract.api.v1.jobs.job_limiter.locked", return_value=False), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.db_repo.get_schema_by_id", return_value=Mock()), \
+             patch("extract.api.v1.jobs.stage_uploaded_file"), \
+             patch("extract.api.v1.jobs.db_repo.create_job", return_value=_mock_job()):
+
+            response = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_id": "schema-001"},
+                files={"file": self._txt_file()},
+            )
+
+        assert response.status_code == 202
+        job_id = response.json()["job_id"]
+        assert uuid.UUID(job_id)  # Raises ValueError if invalid UUID
+
+    def test_missing_schema_id_returns_422(self, extract_test_client):
+        """schema_id is a required form field; omitting it yields FastAPI 422."""
+        response = extract_test_client.post(
+            "/v1/extract/jobs",
+            files={"file": self._txt_file()},
+        )
+        assert response.status_code == 422
+
+
+# =========================================================================
+# GET /v1/extract/jobs
+# =========================================================================
+
+@pytest.mark.unit
+class TestListExtractJobs:
+    """Tests for GET /v1/extract/jobs."""
+
+    def test_empty_list_returns_200(self, extract_test_client):
+        with patch("extract.api.v1.jobs.db_repo.list_jobs", return_value=([], 0)):
+            response = extract_test_client.get("/v1/extract/jobs")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pagination"]["total"] == 0
+        assert body["pagination"]["limit"] == 20
+        assert body["pagination"]["offset"] == 0
+        assert body["data"] == []
+
+    def test_list_with_jobs_returns_items(self, extract_test_client):
+        jobs = [_mock_job(job_id=f"job-{i}", status="completed") for i in range(3)]
+        with patch("extract.api.v1.jobs.db_repo.list_jobs", return_value=(jobs, 3)):
+            response = extract_test_client.get("/v1/extract/jobs")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pagination"]["total"] == 3
+        assert len(body["data"]) == 3
+
+    def test_pagination_parameters_forwarded(self, extract_test_client):
+        with patch("extract.api.v1.jobs.db_repo.list_jobs", return_value=([], 0)) as mock_list:
+            extract_test_client.get("/v1/extract/jobs?limit=5&offset=10")
+
+        mock_list.assert_called_once_with(
+            status=None, schema_id=None, limit=5, offset=10, latest=False
+        )
+
+    def test_status_filter_forwarded(self, extract_test_client):
+        with patch("extract.api.v1.jobs.db_repo.list_jobs", return_value=([], 0)) as mock_list:
+            extract_test_client.get("/v1/extract/jobs?status=completed")
+
+        mock_list.assert_called_once_with(
+            status="completed", schema_id=None, limit=20, offset=0, latest=False
+        )
+
+    def test_schema_id_filter_forwarded(self, extract_test_client):
+        with patch("extract.api.v1.jobs.db_repo.list_jobs", return_value=([], 0)) as mock_list:
+            extract_test_client.get("/v1/extract/jobs?schema_id=schema-001")
+
+        mock_list.assert_called_once_with(
+            status=None, schema_id="schema-001", limit=20, offset=0, latest=False
+        )
+
+    def test_latest_flag_sets_limit_1(self, extract_test_client):
+        job = _mock_job()
+        with patch("extract.api.v1.jobs.db_repo.list_jobs", return_value=([job], 1)):
+            response = extract_test_client.get("/v1/extract/jobs?latest=true")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pagination"]["limit"] == 1
+        assert body["pagination"]["offset"] == 0
+
+    def test_invalid_status_returns_400(self, extract_test_client):
+        response = extract_test_client.get("/v1/extract/jobs?status=unknown_status")
+
+        assert response.status_code == 400
+        assert response.json()["error"]["code"] == "INVALID_PARAMETER"
+
+    def test_limit_out_of_range_returns_422(self, extract_test_client):
+        response = extract_test_client.get("/v1/extract/jobs?limit=0")
+        assert response.status_code == 422
+
+    def test_limit_above_max_returns_422(self, extract_test_client):
+        response = extract_test_client.get("/v1/extract/jobs?limit=101")
+        assert response.status_code == 422
+
+    def test_negative_offset_returns_422(self, extract_test_client):
+        response = extract_test_client.get("/v1/extract/jobs?offset=-1")
+        assert response.status_code == 422
+
+    def test_response_fields_present(self, extract_test_client):
+        job = _mock_job()
+        with patch("extract.api.v1.jobs.db_repo.list_jobs", return_value=([job], 1)):
+            response = extract_test_client.get("/v1/extract/jobs")
+
+        item = response.json()["data"][0]
+        assert "job_id" in item
+        assert "schema_id" in item
+        assert "status" in item
+        assert "document_name" in item
+        assert "submitted_at" in item
+
+
+# =========================================================================
+# GET /v1/extract/jobs/{job_id}
+# =========================================================================
+
+@pytest.mark.unit
+class TestGetExtractJob:
+    """Tests for GET /v1/extract/jobs/{job_id}."""
+
+    def test_existing_job_returns_200(self, extract_test_client):
+        job = _mock_job()
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job):
+            response = extract_test_client.get(f"/v1/extract/jobs/{job.job_id}")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["job_id"] == job.job_id
+        assert body["schema_id"] == job.schema_id
+        assert body["status"] == job.status
+
+    def test_response_includes_document_block(self, extract_test_client):
+        """The document sub-object must include name, source_type, digitize IDs."""
+        job = _mock_job(
+            source_type="pdf",
+            digitize_job_id="dj-999",
+            digitize_doc_id="dd-888",
+        )
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job):
+            response = extract_test_client.get(f"/v1/extract/jobs/{job.job_id}")
+
+        doc = response.json()["document"]
+        assert doc["name"] == job.document_name
+        assert doc["source_type"] == "pdf"
+        assert doc["digitize_job_id"] == "dj-999"
+        assert doc["digitize_doc_id"] == "dd-888"
+
+    def test_response_includes_phase_from_metadata(self, extract_test_client):
+        """metadata JSONB (phase, token_diagnostics, etc.) is surfaced."""
+        job = _mock_job(
+            status="in_progress",
+            job_metadata={"phase": "digitizing"},
+        )
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job):
+            response = extract_test_client.get(f"/v1/extract/jobs/{job.job_id}")
+
+        assert response.status_code == 200
+        assert response.json()["metadata"]["phase"] == "digitizing"
+
+    def test_error_field_present_for_failed_job(self, extract_test_client):
+        job = _mock_job(status="failed", error="CONTEXT_LIMIT_EXCEEDED: too many tokens")
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job):
+            response = extract_test_client.get(f"/v1/extract/jobs/{job.job_id}")
+
+        assert response.status_code == 200
+        assert "CONTEXT_LIMIT_EXCEEDED" in response.json()["error"]
+
+    def test_unknown_job_returns_404(self, extract_test_client):
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=None):
+            response = extract_test_client.get("/v1/extract/jobs/nonexistent")
+
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "RESOURCE_NOT_FOUND"
+
+
+# =========================================================================
+# GET /v1/extract/jobs/{job_id}/result
+# =========================================================================
+
+@pytest.mark.unit
+class TestGetExtractJobResult:
+    """Tests for GET /v1/extract/jobs/{job_id}/result."""
+
+    def test_completed_job_returns_200_with_result(self, extract_test_client):
+        job = _mock_job(status="completed")
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job), \
+             patch("extract.api.v1.jobs.read_result_file", return_value=_RESULT_DATA):
+            response = extract_test_client.get(f"/v1/extract/jobs/{job.job_id}/result")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "data" in body
+        assert "meta" in body
+        assert "usage" in body
+        assert body["status"] == "completed"
+
+    def test_in_progress_job_returns_202(self, extract_test_client):
+        job = _mock_job(status="in_progress")
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job):
+            response = extract_test_client.get(f"/v1/extract/jobs/{job.job_id}/result")
+
+        assert response.status_code == 202
+        body = response.json()
+        assert "still in progress" in body["message"]
+        assert body["job_id"] == job.job_id
+        assert body["status"] == "in_progress"
+
+    def test_accepted_job_returns_202(self, extract_test_client):
+        job = _mock_job(status="accepted")
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job):
+            response = extract_test_client.get(f"/v1/extract/jobs/{job.job_id}/result")
+
+        assert response.status_code == 202
+
+    def test_failed_job_returns_409_not_404(self, extract_test_client):
+        """
+        A failed-but-existing job must return 409 (distinct from 'not found').
+        The response body points the caller at the job resource for diagnostics.
+        """
+        job = _mock_job(status="failed", error="Processing failed")
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job):
+            response = extract_test_client.get(f"/v1/extract/jobs/{job.job_id}/result")
+
+        assert response.status_code == 409
+        body = response.json()
+        assert body["error"]["code"] == "JOB_FAILED"
+        # Body must help the caller find the job resource
+        assert job.job_id in body["error"]["message"]
+
+    def test_nonexistent_job_returns_404(self, extract_test_client):
+        """A job that does not exist at all returns 404 (different from 409)."""
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=None):
+            response = extract_test_client.get("/v1/extract/jobs/no-such-job/result")
+
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "RESOURCE_NOT_FOUND"
+
+    def test_missing_result_file_returns_500(self, extract_test_client):
+        """If the result file is absent for a completed job, endpoint returns 500."""
+        job = _mock_job(status="completed")
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job), \
+             patch("extract.api.v1.jobs.read_result_file", return_value=None):
+            response = extract_test_client.get(f"/v1/extract/jobs/{job.job_id}/result")
+
+        assert response.status_code == 500
+        assert "result file" in response.json()["error"]["message"].lower()
+
+    def test_result_extraction_data_present(self, extract_test_client):
+        """Result payload must include extraction data from the result file."""
+        job = _mock_job(status="completed")
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job), \
+             patch("extract.api.v1.jobs.read_result_file", return_value=_RESULT_DATA):
+            response = extract_test_client.get(f"/v1/extract/jobs/{job.job_id}/result")
+
+        extraction = response.json()["data"]["extraction"]
+        assert extraction["invoice_number"] == "INV-001"
+        assert extraction["total_amount"] == 500.0
+
+
+# =========================================================================
+# DELETE /v1/extract/jobs/{job_id}
+# =========================================================================
+
+@pytest.mark.unit
+class TestDeleteExtractJob:
+    """Tests for DELETE /v1/extract/jobs/{job_id}."""
+
+    def test_delete_completed_job_returns_204(self, extract_test_client):
+        job = _mock_job(status="completed")
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job), \
+             patch("extract.api.v1.jobs.delete_job_files") as mock_del_files, \
+             patch("extract.api.v1.jobs.db_repo.delete_job", return_value=True):
+            response = extract_test_client.delete(f"/v1/extract/jobs/{job.job_id}")
+
+        assert response.status_code == 204
+        mock_del_files.assert_called_once_with(job.job_id)
+
+    def test_delete_failed_job_returns_204(self, extract_test_client):
+        """Failed jobs can be deleted (not active)."""
+        job = _mock_job(status="failed")
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job), \
+             patch("extract.api.v1.jobs.delete_job_files"), \
+             patch("extract.api.v1.jobs.db_repo.delete_job", return_value=True):
+            response = extract_test_client.delete(f"/v1/extract/jobs/{job.job_id}")
+
+        assert response.status_code == 204
+
+    def test_delete_in_progress_job_returns_409(self, extract_test_client):
+        job = _mock_job(status="in_progress")
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job):
+            response = extract_test_client.delete(f"/v1/extract/jobs/{job.job_id}")
+
+        assert response.status_code == 409
+        assert response.json()["error"]["code"] == "RESOURCE_LOCKED"
+        assert "active job" in response.json()["error"]["message"].lower()
+
+    def test_delete_accepted_job_returns_409(self, extract_test_client):
+        """Accepted jobs (queued but not yet running) are also blocked."""
+        job = _mock_job(status="accepted")
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job):
+            response = extract_test_client.delete(f"/v1/extract/jobs/{job.job_id}")
+
+        assert response.status_code == 409
+
+    def test_delete_nonexistent_job_returns_404(self, extract_test_client):
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=None):
+            response = extract_test_client.delete("/v1/extract/jobs/no-such-job")
+
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "RESOURCE_NOT_FOUND"
+
+    def test_delete_removes_result_file(self, extract_test_client):
+        """delete_job_files is always called before the DB delete."""
+        job = _mock_job(status="completed")
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job), \
+             patch("extract.api.v1.jobs.delete_job_files") as mock_del, \
+             patch("extract.api.v1.jobs.db_repo.delete_job", return_value=True):
+            extract_test_client.delete(f"/v1/extract/jobs/{job.job_id}")
+
+        mock_del.assert_called_once_with(job.job_id)
+
+    def test_db_delete_failure_returns_500(self, extract_test_client):
+        """If the DB delete fails, endpoint returns 500."""
+        job = _mock_job(status="completed")
+        with patch("extract.api.v1.jobs.db_repo.get_job_by_id", return_value=job), \
+             patch("extract.api.v1.jobs.delete_job_files"), \
+             patch("extract.api.v1.jobs.db_repo.delete_job", return_value=False):
+            response = extract_test_client.delete(f"/v1/extract/jobs/{job.job_id}")
+
+        assert response.status_code == 500
+
+
+# =========================================================================
+# DELETE /v1/extract/jobs (bulk)
+# =========================================================================
+
+@pytest.mark.unit
+class TestBulkDeleteExtractJobs:
+    """Tests for DELETE /v1/extract/jobs."""
+
+    def test_confirm_true_no_active_jobs_returns_204(self, extract_test_client):
+        with patch("extract.api.v1.jobs.db_repo.has_active_jobs", return_value=False), \
+             patch("extract.api.v1.jobs.delete_all_job_files") as mock_del_files, \
+             patch("extract.api.v1.jobs.db_repo.delete_all_jobs", return_value=True):
+            response = extract_test_client.delete("/v1/extract/jobs?confirm=true")
+
+        assert response.status_code == 204
+        mock_del_files.assert_called_once()
+
+    def test_missing_confirm_returns_400(self, extract_test_client):
+        response = extract_test_client.delete("/v1/extract/jobs")
+
+        assert response.status_code == 400
+        assert response.json()["error"]["code"] == "CONFIRMATION_REQUIRED"
+        assert "confirm=true" in response.json()["error"]["message"]
+
+    def test_confirm_false_returns_400(self, extract_test_client):
+        response = extract_test_client.delete("/v1/extract/jobs?confirm=false")
+
+        assert response.status_code == 400
+        assert response.json()["error"]["code"] == "CONFIRMATION_REQUIRED"
+
+    def test_confirm_wrong_value_returns_400(self, extract_test_client):
+        response = extract_test_client.delete("/v1/extract/jobs?confirm=yes")
+
+        assert response.status_code == 400
+
+    def test_active_jobs_exist_returns_409(self, extract_test_client):
+        with patch("extract.api.v1.jobs.db_repo.has_active_jobs", return_value=True):
+            response = extract_test_client.delete("/v1/extract/jobs?confirm=true")
+
+        assert response.status_code == 409
+        assert response.json()["error"]["code"] == "RESOURCE_LOCKED"
+        assert "active" in response.json()["error"]["message"].lower()
+
+    def test_db_delete_failure_returns_500(self, extract_test_client):
+        with patch("extract.api.v1.jobs.db_repo.has_active_jobs", return_value=False), \
+             patch("extract.api.v1.jobs.delete_all_job_files"), \
+             patch("extract.api.v1.jobs.db_repo.delete_all_jobs", return_value=False):
+            response = extract_test_client.delete("/v1/extract/jobs?confirm=true")
+
+        assert response.status_code == 500
+
+    def test_files_deleted_before_db(self, extract_test_client):
+        """
+        File deletion must be called even if the call order cannot be strictly
+        enforced by the test — verify both are called when confirm=true.
+        """
+        with patch("extract.api.v1.jobs.db_repo.has_active_jobs", return_value=False), \
+             patch("extract.api.v1.jobs.delete_all_job_files") as mock_files, \
+             patch("extract.api.v1.jobs.db_repo.delete_all_jobs", return_value=True) as mock_db:
+            extract_test_client.delete("/v1/extract/jobs?confirm=true")
+
+        mock_files.assert_called_once()
+        mock_db.assert_called_once()
+
+# Made with Bob

--- a/services/extract/tests/unit/test_job_endpoints.py
+++ b/services/extract/tests/unit/test_job_endpoints.py
@@ -85,8 +85,8 @@ class TestCreateExtractJob:
     def _txt_file(self, content=b"Sample text for extraction.", name="doc.txt"):
         return (name, io.BytesIO(content), "text/plain")
 
-    def _pdf_file(self, name="doc.pdf"):
-        return (name, io.BytesIO(b"%PDF-1.4 fake content"), "application/pdf")
+    def _md_file(self, name="doc.md"):
+        return (name, io.BytesIO(b"# Invoice\n\n**Vendor:** Northwind Traders\n**Total:** USD 8,420.0"), "md")
 
     def test_success_txt_returns_202(self, extract_test_client):
         """Happy path: .txt file with a valid schema_id returns 202 with job_id."""
@@ -108,12 +108,12 @@ class TestCreateExtractJob:
         assert response.status_code == 202
         assert response.json()["job_id"] == test_uuid
 
-    def test_success_pdf_returns_202(self, extract_test_client):
+    def test_success_md_returns_202(self, extract_test_client):
         """A PDF file is also accepted and returns 202."""
         test_uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
         with patch("extract.api.v1.jobs.job_limiter.locked", return_value=False), \
-             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".pdf")), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".md")), \
              patch("extract.api.v1.jobs.db_repo.get_schema_by_id", return_value=Mock()), \
              patch("extract.api.v1.jobs.stage_uploaded_file"), \
              patch("extract.api.v1.jobs.db_repo.create_job", return_value=_mock_job(job_id=test_uuid)), \
@@ -122,7 +122,7 @@ class TestCreateExtractJob:
             response = extract_test_client.post(
                 "/v1/extract/jobs",
                 data={"schema_id": "schema-001"},
-                files={"file": self._pdf_file()},
+                files={"file": self._md_file()},
             )
 
         assert response.status_code == 202

--- a/services/extract/utils/exceptions.py
+++ b/services/extract/utils/exceptions.py
@@ -1,0 +1,29 @@
+"""
+Extract service exception.
+
+Provides a single exception class for all API-level errors in the extract
+service.
+
+Usage::
+
+    raise ExtractException(404, "RESOURCE_NOT_FOUND", "Job 'x' not found.")
+
+The companion exception handler in ``extract.app`` converts this to the
+standard ``{"error": {"code": ..., "message": ..., "status": ...}}`` shape.
+"""
+
+
+class ExtractException(Exception):
+    """Raised to signal an API-level error in the extract service.
+
+    Args:
+        status_code: HTTP status code to return (e.g. 404, 429).
+        code:        Machine-readable string error code (e.g. ``"RESOURCE_NOT_FOUND"``).
+        message:     Human-readable description of the error.
+    """
+
+    def __init__(self, status_code: int, code: str, message: str) -> None:
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        super().__init__(message)

--- a/services/extract/utils/job.py
+++ b/services/extract/utils/job.py
@@ -18,7 +18,7 @@ from extract.settings import settings
 
 logger = get_logger("job_utils")
 
-ALLOWED_EXTENSIONS = {".txt", ".pdf"}
+ALLOWED_EXTENSIONS = {".txt", ".md"}
 
 
 # ---------------------------------------------------------------------------

--- a/services/extract/utils/schema.py
+++ b/services/extract/utils/schema.py
@@ -15,6 +15,7 @@ Responsibilities:
 import json
 import re
 import copy
+from datetime import timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import jsonschema
@@ -417,6 +418,8 @@ def check_extraction_budget(
 def fmt_dt(dt) -> Optional[str]:
     if dt is None:
         return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
     return dt.isoformat().replace("+00:00", "Z")
 
 # Made with Bob


### PR DESCRIPTION
In this PR:
- POST /v1/extract/jobs
- GET /v1/extract/jobs
- GET /v1/extract/jobs/{job_id}
- DELETE /v1/extract/jobs
- DELETE /v1/extract/jobs/{job_id}
- GET /v1/extract/jobs/{job_id}/result
- unit tests