### PR TITLE
DSC (PR2) - DB Operation functions

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.208
+TAG?=v0.0.209
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.37
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.38
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.37
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.38
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.37
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.38
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.37
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.38
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.37
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.38
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.208
+  image: icr.io/ai-services-cicd/ai-services:v0.0.209
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.208
+  image: icr.io/ai-services-cicd/ai-services:v0.0.209
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.37
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.38
   log_level: "INFO"
   database: "digitize_metadata"
 

--- a/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
+++ b/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
@@ -344,7 +344,7 @@ Only non-secret `connection_details` are returned.
 }
 ```
 
-### 3.6 `GET /v1/connectors/{connector_id}/sync-logs`
+### 3.6 `GET /v1/connectors/{connector_id}/syncs`
 
 Returns paginated tick history.
 
@@ -536,7 +536,7 @@ CREATE INDEX IF NOT EXISTS idx_cdc_connector_id
 
 ### 4.4 `connector_sync_logs`
 
-Persistent per-tick history backing the sync-logs API.
+Persistent per-tick history backing the syncs API.
 
 ```sql
 CREATE TABLE IF NOT EXISTS connector_sync_logs (
@@ -1286,7 +1286,7 @@ All connector DB functions from §5.1:
 - `PUT /v1/connectors/{id}` — partial update, re-encrypt if credentials included, call `upsert_connector`, return `200`
 - `DELETE /v1/connectors/{id}` — stub only (stops at "would stop worker" + calls DB delete), no worker logic yet
 - `GET /v1/connectors` and `GET /v1/connectors/{id}` — read from DB, strip secret fields
-- `GET /v1/connectors/{id}/sync-logs` — paginated query with `limit`/`offset`
+- `GET /v1/connectors/{id}/syncs` — paginated query with `limit`/`offset`
 - **Update `GET /v1/documents` and `GET /v1/documents/{doc_id}`** to exclude connector-sourced docs via `NOT EXISTS (SELECT 1 FROM connector_document_checksum WHERE doc_id = ...)` filter
 - **Update `DELETE /v1/documents/{doc_id}`** to return `404` for connector-sourced docs
 

--- a/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
+++ b/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
@@ -53,7 +53,7 @@ Before any `digitize` connector endpoint is called:
         elif checksum IN all_checksums:
           → already ingested by a different connector — no download, no ingest;
             existing_doc_id = lookup_connector_content_by_checksum(checksum)
-            add_connector_to_membership(connector_id, checksum, existing_doc_id)
+            add_connector_checksum_entry(connector_id, checksum, existing_doc_id)
         else:
           → brand new to all connectors — place on ingest_list
 
@@ -64,12 +64,12 @@ Before any `digitize` connector endpoint is called:
                             checksum=checksum ← pre-computed by scanner; skips re-hash in pipeline
                         )
         on job success:
-          add_connector_to_membership(connector_id, checksum, doc_id)
+          add_connector_checksum_entry(connector_id, checksum, doc_id)
 
   Step 4 — orphan detection + removal
     → orphan_checksums = known_checksums − {checksum for (_, checksum) in scanned_files}
     → for each orphan_checksum (after all Step 3 writes finish):
-        remove_connector_from_membership(connector_id, orphan_checksum)
+        remove_connector_checksum_entry(connector_id, orphan_checksum)
         if remaining_owner_count == 0:
           DELETE /v1/documents/{doc_id}
 
@@ -80,7 +80,7 @@ Before any `digitize` connector endpoint is called:
 ── Detach (DELETE /v1/connectors/{id}) ──────────────────────────────
   → guard: reject with 409 if a tick is currently running
   → list all checksums owned by this connector
-  → for each checksum: remove_connector_from_membership → delete doc if last owner
+  → for each checksum: remove_connector_checksum_entry → delete doc if last owner
   → DELETE connectors row
   → cleanup staging dirs
   → stop worker thread
@@ -255,7 +255,7 @@ DELETE /v1/connectors/{connector_id}
   → stop worker
   → list checksums owned by this connector (connector_document_checksum WHERE connector_id = :connector_id)
   → for each checksum:
-       remove_connector_from_membership(connector_id, checksum)
+       remove_connector_checksum_entry(connector_id, checksum)
          → DELETE row WHERE checksum = :checksum AND connector_id = :connector_id
          → returns (remaining_owner_count, doc_id)
        if remaining_owner_count == 0:
@@ -344,7 +344,7 @@ Only non-secret `connection_details` are returned.
 }
 ```
 
-### 3.6 `GET /v1/connectors/{connector_id}/sync-history`
+### 3.6 `GET /v1/connectors/{connector_id}/sync-logs`
 
 Returns paginated tick history.
 
@@ -536,11 +536,10 @@ CREATE INDEX IF NOT EXISTS idx_cdc_connector_id
 
 ### 4.4 `connector_sync_logs`
 
-Persistent per-tick history backing the sync-history API.
+Persistent per-tick history backing the sync-logs API.
 
 ```sql
 CREATE TABLE IF NOT EXISTS connector_sync_logs (
-    id               BIGSERIAL   PRIMARY KEY,
     connector_id     TEXT        NOT NULL,
     seq              INTEGER     NOT NULL,
     started_at       TIMESTAMPTZ NOT NULL,
@@ -551,11 +550,10 @@ CREATE TABLE IF NOT EXISTS connector_sync_logs (
     failed_files     INTEGER     NOT NULL DEFAULT 0,
     status           TEXT        NOT NULL DEFAULT 'started',
     error            TEXT        NOT NULL DEFAULT '',
+    PRIMARY KEY (connector_id, seq),
     CONSTRAINT fk_csh_connector
         FOREIGN KEY (connector_id)
-        REFERENCES connectors(id) ON DELETE CASCADE,
-    CONSTRAINT uq_csh_connector_seq
-        UNIQUE (connector_id, seq)
+        REFERENCES connectors(id) ON DELETE CASCADE
 );
 
 CREATE INDEX IF NOT EXISTS idx_csl_connector_started
@@ -568,7 +566,7 @@ CREATE INDEX IF NOT EXISTS idx_csl_connector_started
 
 - `Connector` — maps to `connectors`; fields: `id` (PK), `name` (UNIQUE), `type`, `connection_details` (JSONB), `allowed_extensions` (JSONB), `sync_interval_seconds`, `attached_at`, `last_sync_at`, `sync_status`, `last_sync_error`, `total_files`; has a one-to-many relationship `sync_logs → ConnectorSyncLog`
 - `ConnectorDocumentChecksum` — maps to `connector_document_checksum`; fields: `checksum` (NOT NULL), `connector_id` (NOT NULL), `doc_id` (NOT NULL); composite PK `(checksum, connector_id)`
-- `ConnectorSyncLog` — maps to `connector_sync_logs`; fields: `id` (PK, autoincrement), `connector_id` (FK → `connectors`, CASCADE DELETE), `seq`, `started_at`, `finished_at`, `total_files`, `new_files`, `removed_files`, `failed_files`, `status`, `error`; unique constraint `uq_csh_connector_seq (connector_id, seq)`
+- `ConnectorSyncLog` — maps to `connector_sync_logs`; fields: `connector_id` (FK → `connectors`, CASCADE DELETE), `seq` (auto-generated per connector — see §5.1); composite PK `(connector_id, seq)`, `started_at`, `finished_at`, `total_files`, `new_files`, `removed_files`, `failed_files`, `status`, `error`
 
 ---
 
@@ -593,22 +591,20 @@ Jobs created by a connector sync use the format `{connector_id} - {sync_number} 
 
 | Function | Purpose |
 | --- | --- |
-| `insert_active_connector()` | create connector |
-| `upsert_active_connector()` | insert/update connector |
+| `insert_connector()` | create connector on first-time `POST /v1/connectors`; `ON CONFLICT (id) DO NOTHING` — returns `409` if already exists |
+| `upsert_connector()` | partial update on `PUT /v1/connectors/{id}`; accepts only the fields present in the request and merges `connection_details` at the key level, leaving omitted keys untouched |
 | `get_active_connector()` | fetch one connector |
 | `list_connectors()` | fetch all connectors |
 | `delete_active_connector()` | delete connector |
-| `update_connector_sync_status()` | write top-level sync state |
-| `merge_connection_details()` | key-level JSON merge for PUT |
 | `lookup_connector_content_by_checksum(checksum)` | connector dedup lookup — queries `connector_document_checksum`, returns `doc_id` or `None` |
 | `list_connector_checksums(connector_id)` | all checksums currently owned by this connector |
 | `list_all_checksums()` | all distinct checksums in `connector_document_checksum` across all connectors |
-| `add_connector_to_membership(connector_id, checksum, doc_id)` | insert a new `(checksum, connector_id, doc_id)` row; no-op if the row already exists |
-| `remove_connector_from_membership(connector_id, checksum)` | delete the `(checksum, connector_id)` row; return remaining owner count and `doc_id` |
-| `insert_sync_history()` | create tick row |
-| `update_sync_history()` | finalize tick row |
-| `update_sync_history_files_syncing()` | live progress updates |
-| `list_sync_history()` | paginated history query |
+| `add_connector_checksum_entry(connector_id, checksum, doc_id)` | insert a new `(checksum, connector_id, doc_id)` row; no-op if the row already exists |
+| `remove_connector_checksum_entry(connector_id, checksum)` | delete the `(checksum, connector_id)` row; return remaining owner count and `doc_id` |
+| `open_new_sync_log(connector_id)` | create tick row; auto-generates `seq` as `COALESCE(MAX(seq), 0) + 1` scoped to the connector; sets `connectors.sync_status = 'syncing'` in the same transaction; returns the new `seq` value |
+| `close_sync_log()` | finalize tick row; sets `connectors.last_sync_at = NOW()` and `connectors.sync_status = :final_status` in the same transaction |
+| `update_sync_log()` | live progress updates |
+| `list_sync_logs()` | paginated logs query |
 | `set_document_metadata(doc_id, metadata)` | write `source_checksum` + S3 key into `documents.metadata` |
 
 ### 5.2 DB-layer stub
@@ -629,7 +625,7 @@ def lookup_connector_content_by_checksum(checksum: str) -> str | None:
 
 
 @staticmethod
-def add_connector_to_membership(connector_id: str, checksum: str, doc_id: str) -> None:
+def add_connector_checksum_entry(connector_id: str, checksum: str, doc_id: str) -> None:
     """Insert a new (checksum, connector_id, doc_id) row; no-op if already exists."""
     with get_db_session() as session:
         stmt = (
@@ -641,7 +637,7 @@ def add_connector_to_membership(connector_id: str, checksum: str, doc_id: str) -
 
 
 @staticmethod
-def remove_connector_from_membership(connector_id: str, checksum: str) -> tuple[int, str | None]:
+def remove_connector_checksum_entry(connector_id: str, checksum: str) -> tuple[int, str | None]:
     """Delete the (checksum, connector_id) row; return (remaining_owner_count, doc_id)."""
     with get_db_session() as session:
         deleted = session.execute(
@@ -692,12 +688,19 @@ connector_document_checksum is empty for this connector — populated on first t
 DB operations (Sync Tick)
 ────────────────────────────────────────────────────────────────────
 
-Phase 1 — open tick record
+Phase 1 — open tick record  [open_new_sync_log]
   INSERT INTO connector_sync_logs
       (connector_id, seq, started_at, status)
-  VALUES (:connector_id, :next_seq, NOW(), 'started')
+  SELECT :connector_id,
+         COALESCE(MAX(seq), 0) + 1,
+         NOW(),
+         'started'
+  FROM connector_sync_logs
+  WHERE connector_id = :connector_id
+  RETURNING seq          ← caller stores this as sync_seq
 
   UPDATE connectors SET sync_status = 'syncing' WHERE id = :connector_id
+  ↑ both writes happen in a single transaction inside open_new_sync_log()
 
 Phase 2 — load known state
   ┌─ ACQUIRE ingest_lock (process-wide) ──────────────────────────┐
@@ -750,7 +753,7 @@ Phase 4b — orphan detection + removal
     if remaining == 0:
       DELETE /v1/documents/{orphan_doc_id}   ← 200/204/404 = success; 5xx logged and skipped
 
-Phase 5 — close tick record
+Phase 5 — close tick record  [close_sync_log]
   UPDATE connector_sync_logs
   SET finished_at = NOW(), total_files = :n, new_files = :n,
       removed_files = :n, failed_files = :n, status = :final_status
@@ -758,6 +761,7 @@ Phase 5 — close tick record
 
   UPDATE connectors SET last_sync_at = NOW(), sync_status = :final_status
   WHERE id = :connector_id
+  ↑ both writes happen in a single transaction inside close_sync_log()
 ```
 
 **Ordering guarantee:** Phase 4b (orphan removal) runs only after Phase 4a (all ingest jobs) completes.
@@ -989,19 +993,19 @@ _run_tick()
 │            → skip_list   checksum IN known_checksums (no action)
 │            → ingest_list checksum NOT IN all_checksums (brand new)
 │            → cross-connector dup: lookup_connector_content_by_checksum(checksum)
-│                                   add_connector_to_membership(connector_id, checksum, existing_doc_id)
+│                                   add_connector_checksum_entry(connector_id, checksum, existing_doc_id)
 │                                   (DB write happens inline, no separate list)
 │
 ├─ [Phase 4a] _process_new_files(ingest_list)
 │             download → create_job(connector_id, checksum) → doc_id (session creation)
-│             add_connector_to_membership(connector_id, checksum, doc_id)
+│             add_connector_checksum_entry(connector_id, checksum, doc_id)
 │             UPDATE documents.metadata
 │            ── RELEASE ingest_lock (after all Phase 4a membership rows committed) ─
 │
 ├─ [Phase 4b] _delete_orphans(orphan_checksums)
 │   ← RUNS AFTER all Phase 4a writes finish ←
 │             orphan_checksums = known_checksums − scanned_checksums
-│             remove_connector_from_membership → if remaining==0: DELETE /v1/documents/{doc_id}
+│             remove_connector_checksum_entry → if remaining==0: DELETE /v1/documents/{doc_id}
 │
 └─ [Phase 5] UPDATE connector_sync_logs (finished_at, counters, status)
              UPDATE connectors (last_sync_at, sync_status)
@@ -1017,14 +1021,14 @@ _run_tick()
 - Per-file failures are counted and summarized instead of failing the whole connector.
 - Cross-connector duplicates are registered inline during Phase 3 classification — no deferred list.
 - **Phase 4b (orphan removal) always runs after Phase 4a (all new-file ingest jobs) completes.**
-- **A process-wide `ingest_lock` must be held from the Phase 2 DB read (`list_all_checksums`) through the end of Phase 4a (last `add_connector_to_membership` call, i.e. session creation complete).** This prevents two concurrent workers from both classifying the same brand-new checksum as absent and independently spawning duplicate ingest jobs.
+- **A process-wide `ingest_lock` must be held from the Phase 2 DB read (`list_all_checksums`) through the end of Phase 4a (last `add_connector_checksum_entry` call, i.e. session creation complete).** This prevents two concurrent workers from both classifying the same brand-new checksum as absent and independently spawning duplicate ingest jobs.
 
 ### 8.3 Worker stub
 
 ```python
 def _run_tick(self) -> None:
     self.config = get_active_connector(self.connector_id)
-    sync_id = insert_sync_history(self.connector_id)
+    sync_seq = open_new_sync_log(self.connector_id)  # seq auto-generated by DB
     scanner = build_scanner(self.config)
     try:
         scanner.connect()
@@ -1040,12 +1044,12 @@ def _run_tick(self) -> None:
             ingest_list, orphan_checksums = self._classify(
                 scanned_files, known_checksums, all_checksums
             )
-            self._process_new_files(sync_id, scanner, ingest_list)
+            self._process_new_files(sync_seq, scanner, ingest_list)
         # Lock released — orphan removal does not need it
         self._delete_orphans(orphan_checksums)
-        self._complete_tick(sync_id)
+        self._complete_tick(sync_seq)
     except Exception as exc:
-        self._fail_tick(sync_id, exc)
+        self._fail_tick(sync_seq, exc)
     finally:
         scanner.close()
 ```
@@ -1059,7 +1063,7 @@ def _run_tick(self) -> None:
 | `ingest_list` | `list[tuple[str, str]]` | Brand new to all connectors — download, ingest, register |
 | `orphan_checksums` | `set[str]` | Previously owned by this connector, no longer on remote source |
 
-Cross-connector duplicates (`checksum IN all_checksums but NOT known_checksums`) are handled inline: `_classify` immediately calls `lookup_connector_content_by_checksum` and `add_connector_to_membership` before moving on. Intra-tick dedup still applies — only the first occurrence of a checksum triggers the DB write.
+Cross-connector duplicates (`checksum IN all_checksums but NOT known_checksums`) are handled inline: `_classify` immediately calls `lookup_connector_content_by_checksum` and `add_connector_checksum_entry` before moving on. Intra-tick dedup still applies — only the first occurrence of a checksum triggers the DB write.
 
 ```python
 def _classify(
@@ -1080,7 +1084,7 @@ def _classify(
             if checksum not in seen_this_tick:
                 seen_this_tick.add(checksum)
                 existing_doc_id = lookup_connector_content_by_checksum(checksum)
-                add_connector_to_membership(self.connector_id, checksum, existing_doc_id)
+                add_connector_checksum_entry(self.connector_id, checksum, existing_doc_id)
         else:
             if checksum not in seen_this_tick:
                 seen_this_tick.add(checksum)
@@ -1139,7 +1143,7 @@ try:
 except Exception as exc:
     log.error(f"Worker {connector_id} crashed: {exc}", exc_info=True)
     if _tick_running and _current_sync_id:
-        update_sync_history(…, sync_status=f"crashed: {exc}")
+        close_sync_log(…, sync_status=f"crashed: {exc}")
     update_connector_sync_status(…, f"crashed: {exc}")
 ```
 
@@ -1191,7 +1195,7 @@ monitor_thread.join(timeout=10)
 1. Closes active connections.
 2. Deletes pending (in-flight) checksum rows.
 3. Removes membership rows and OpenSearch docs for files ingested this tick.
-4. Closes the sync-history row as `"interrupted: connector deleted"`.
+4. Closes the sync-logs row as `"interrupted: connector deleted"`.
 
 Check points:
 
@@ -1261,13 +1265,14 @@ Each PR is independently testable.
 
 **What's to build:**
 All connector DB functions from §5.1:
-`insert_active_connector`, `upsert_active_connector`, `get_active_connector`, `list_connectors`, `delete_active_connector`, `update_connector_sync_status`, `merge_connection_details`, `lookup_connector_content_by_checksum`, `list_connector_checksums`, `list_all_checksums`, `add_connector_to_membership`, `remove_connector_from_membership`, `insert_sync_history`, `update_sync_history`, `update_sync_history_files_syncing`, `list_sync_history`, `set_document_metadata`
+`insert_connector`, `upsert_connector`, `get_active_connector`, `list_connectors`, `delete_active_connector`, `update_connector_sync_status`, `lookup_connector_content_by_checksum`, `list_connector_checksums`, `list_all_checksums`, `add_connector_checksum_entry`, `remove_connector_checksum_entry`, `open_new_sync_log`, `close_sync_log`, `update_sync_log`, `list_sync_logs`, `set_document_metadata`
 
 **How to test:**
 - Unit tests per function against a test DB
-- Assert `add_connector_to_membership` inserts a new row on first call and appends the connector_id on subsequent calls with the same checksum
-- Assert `remove_connector_from_membership` returns `remaining=0` when the last connector is removed, and `remaining>0` when others still own the checksum
-- Assert `merge_connection_details` correctly merges keys without clobbering untouched fields
+- Assert `insert_connector` inserts a new row and returns `409` on a duplicate `id`
+- Assert `upsert_connector` updates only the supplied fields and merges `connection_details` keys without clobbering untouched fields
+- Assert `add_connector_checksum_entry` inserts a new row on first call and appends the connector_id on subsequent calls with the same checksum
+- Assert `remove_connector_checksum_entry` returns `remaining=0` when the last connector is removed, and `remaining>0` when others still own the checksum
 - Assert `lookup_connector_content_by_checksum` queries `connector_document_checksum` and never touches `document_checksum`
 
 ---
@@ -1277,11 +1282,11 @@ All connector DB functions from §5.1:
 **Files touched:** connector router/handler file(s)
 
 **What's to build:**
-- `POST /v1/connectors` — validate body, encrypt secrets, call `insert_active_connector`, return `202`
-- `PUT /v1/connectors/{id}` — partial update, re-encrypt if credentials included, `merge_connection_details`, return `200`
+- `POST /v1/connectors` — validate body, encrypt secrets, call `insert_connector`, return `202`
+- `PUT /v1/connectors/{id}` — partial update, re-encrypt if credentials included, call `upsert_connector`, return `200`
 - `DELETE /v1/connectors/{id}` — stub only (stops at "would stop worker" + calls DB delete), no worker logic yet
 - `GET /v1/connectors` and `GET /v1/connectors/{id}` — read from DB, strip secret fields
-- `GET /v1/connectors/{id}/sync-history` — paginated query with `limit`/`offset`
+- `GET /v1/connectors/{id}/sync-logs` — paginated query with `limit`/`offset`
 - **Update `GET /v1/documents` and `GET /v1/documents/{doc_id}`** to exclude connector-sourced docs via `NOT EXISTS (SELECT 1 FROM connector_document_checksum WHERE doc_id = ...)` filter
 - **Update `DELETE /v1/documents/{doc_id}`** to return `404` for connector-sourced docs
 
@@ -1319,7 +1324,7 @@ All connector DB functions from §5.1:
 **Files touched:** `connectors/s3_scanner.py`
 
 **What's to build:**
-- `S3Scanner` — boto3 `list_objects_v2` paginator, extension filter, `download_fileobj()`, staged download; `scan()` returns **all** allowed objects without dedup filtering; checksum (S3 ETag) registered via `add_connector_to_membership()` on job completion; `set_document_metadata()` stores checksum and key. `upsert_file_checksum()` must NOT be called.
+- `S3Scanner` — boto3 `list_objects_v2` paginator, extension filter, `download_fileobj()`, staged download; `scan()` returns **all** allowed objects without dedup filtering; checksum (S3 ETag) registered via `add_connector_checksum_entry()` on job completion; `set_document_metadata()` stores checksum and key. `upsert_file_checksum()` must NOT be called.
 
 **How to test:**
 - Unit test with `moto` (mock AWS) — assert listing, extension filtering, and download
@@ -1335,7 +1340,7 @@ All connector DB functions from §5.1:
 **What's to build:**
 - `ConnectorSyncWorker` with full `_run_tick()`: config refresh, scan, classify, ingest new files, register cross-connector dups, orphan deletion, tick finalize
 - `_classify()`: see §8.4 — `skip_list` is implicit (not returned)
-- Pass `connector_id` and `checksum` (pre-computed by scanner) to each create-job call; `add_connector_to_membership` called on job completion — `upsert_file_checksum` must NOT be called for connector jobs
+- Pass `connector_id` and `checksum` (pre-computed by scanner) to each create-job call; `add_connector_checksum_entry` called on job completion — `upsert_file_checksum` must NOT be called for connector jobs
 - Tick guard to prevent overlapping ticks
 - Crash guard (outer `try/except` in `run()`) — writes `crashed:` status to DB
 - `_cancel_if_requested()` check points at each phase boundary

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.37
+TAG?=v0.0.38
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1,5 +1,5 @@
 """
-Database repository layer for Job and Document operations.
+Database repository layer for Job, Document, and Connector operations.
 
 Provides CRUD operations with proper error handling and transaction management.
 """
@@ -7,12 +7,12 @@ Provides CRUD operations with proper error handling and transaction management.
 from datetime import datetime, timezone
 from typing import List, Optional, Dict, Any, cast
 from sqlalchemy import select, update, delete, func, or_, and_
-from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 
 from common.misc_utils import get_logger
-from digitize.db.models import Job, Document, DocumentChecksum
+from digitize.db.models import Job, Document, DocumentChecksum, Connector, ConnectorDocumentChecksum, ConnectorSyncLog
 from digitize.db.connection import get_db_session
 from digitize.models import JobStatus, DocStatus
 
@@ -357,7 +357,7 @@ class DatabaseManager:
         try:
             with get_db_session() as session:
                 stmt = (
-                    insert(DocumentChecksum)
+                    pg_insert(DocumentChecksum)
                     .values(sha256=sha256, doc_id=doc_id)
                     .on_conflict_do_update(
                         index_elements=["sha256"],
@@ -731,6 +731,517 @@ class DatabaseManager:
                 "error": str(e)
             }
 
+
+
+    # ========================================================================
+    # Connector CRUD
+    # ========================================================================
+
+    @staticmethod
+    def insert_connector(
+        connector_id: str,
+        name: str,
+        connector_type: str,
+        connection_details: dict,
+        allowed_extensions: list,
+        sync_interval_seconds: int,
+    ) -> None:
+        """
+        Insert a new connector row.
+
+        Uses ON CONFLICT (id) DO NOTHING and re-raises IntegrityError when the
+        id already exists so the caller can map that to a 409 response.
+        """
+        try:
+            with get_db_session() as session:
+                stmt = (
+                    pg_insert(Connector)
+                    .values(
+                        id=connector_id,
+                        name=name,
+                        type=connector_type,
+                        connection_details=connection_details,
+                        allowed_extensions=allowed_extensions,
+                        sync_interval_seconds=sync_interval_seconds,
+                        attached_at=datetime.now(timezone.utc),
+                        sync_status="up to date",
+                        total_files=0,
+                    )
+                    .on_conflict_do_nothing(index_elements=["id"])
+                )
+                result = session.execute(stmt)
+                if result.rowcount == 0:
+                    raise IntegrityError(
+                        statement=None,
+                        params=None,
+                        orig=Exception(f"Connector id={connector_id!r} already exists"),
+                    )
+                logger.info(f"Inserted connector {connector_id!r} ({name!r})")
+        except IntegrityError:
+            raise
+        except SQLAlchemyError as e:
+            logger.error(f"DB error inserting connector {connector_id}: {e}", exc_info=True)
+            raise
+
+    @staticmethod
+    def update_connector(
+        connector_id: str,
+        name: Optional[str] = None,
+        connection_details: Optional[dict] = None,
+        allowed_extensions: Optional[list] = None,
+    ) -> None:
+        """
+        Partial update of an existing connector.
+
+        Only non-None kwargs are written; connection_details is merged at the
+        key level using the PostgreSQL ``||`` JSONB concatenation operator.
+
+        Raises FileNotFoundError if no connector with the given id exists.
+        """
+        try:
+            with get_db_session() as session:
+                values: Dict[str, Any] = {}
+                if name is not None:
+                    values["name"] = name
+                if allowed_extensions is not None:
+                    values["allowed_extensions"] = allowed_extensions
+                if connection_details is not None:
+                    stmt = (
+                        update(Connector)
+                        .where(Connector.id == connector_id)
+                        .values(
+                            connection_details=Connector.connection_details.op("||")(
+                                func.cast(connection_details, Connector.connection_details.type)
+                            ),
+                            **values,
+                        )
+                    )
+                else:
+                    stmt = (
+                        update(Connector)
+                        .where(Connector.id == connector_id)
+                        .values(**values)
+                    )
+                result = session.execute(stmt)
+                if result.rowcount == 0:
+                    raise FileNotFoundError(f"Connector id={connector_id!r} not found")
+                logger.info(f"Updated connector {connector_id!r}")
+        except FileNotFoundError:
+            raise
+        except SQLAlchemyError as e:
+            logger.error(f"DB error updating connector {connector_id}: {e}", exc_info=True)
+            raise
+
+    @staticmethod
+    def get_connector_by_id(connector_id: str) -> Optional[Connector]:
+        """
+        Fetch a single connector by id, attributes eagerly loaded and expunged.
+
+        Returns None if not found.
+        """
+        try:
+            with get_db_session() as session:
+                connector = session.get(Connector, connector_id)
+                if connector is None:
+                    logger.debug(f"Connector {connector_id!r} not found")
+                    return None
+                _ = (
+                    connector.id, connector.name, connector.type,
+                    connector.connection_details, connector.allowed_extensions,
+                    connector.sync_interval_seconds, connector.attached_at,
+                    connector.last_sync_at, connector.sync_status,
+                    connector.last_sync_error, connector.total_files,
+                )
+                session.expunge(connector)
+                return connector
+        except SQLAlchemyError as e:
+            logger.error(f"DB error fetching connector {connector_id}: {e}", exc_info=True)
+            return None
+
+    @staticmethod
+    def get_all_connectors() -> List[Connector]:
+        """
+        Return all connectors ordered by attached_at descending.
+
+        Each object is eagerly loaded and expunged from the session.
+        """
+        try:
+            with get_db_session() as session:
+                stmt = select(Connector).order_by(Connector.attached_at.desc())
+                connectors = list(session.scalars(stmt).all())
+                for c in connectors:
+                    _ = (
+                        c.id, c.name, c.type, c.connection_details,
+                        c.allowed_extensions, c.sync_interval_seconds,
+                        c.attached_at, c.last_sync_at, c.sync_status,
+                        c.last_sync_error, c.total_files,
+                    )
+                    session.expunge(c)
+                logger.debug(f"Listed {len(connectors)} connector(s)")
+                return connectors
+        except SQLAlchemyError as e:
+            logger.error(f"DB error listing connectors: {e}", exc_info=True)
+            return []
+
+    @staticmethod
+    def delete_connector(connector_id: str) -> bool:
+        """
+        Delete a connector row by id (cascades to connector_sync_logs).
+
+        Returns True if a row was deleted, False if not found.
+        """
+        try:
+            with get_db_session() as session:
+                stmt = delete(Connector).where(Connector.id == connector_id)
+                result = session.execute(stmt)
+                deleted = result.rowcount > 0
+                if deleted:
+                    logger.info(f"Deleted connector {connector_id!r}")
+                else:
+                    logger.debug(f"Connector {connector_id!r} not found for deletion")
+                return deleted
+        except SQLAlchemyError as e:
+            logger.error(f"DB error deleting connector {connector_id}: {e}", exc_info=True)
+            return False
+
+    # ========================================================================
+    # Connector checksum helpers
+    # ========================================================================
+
+    @staticmethod
+    def find_connector_doc_by_checksum(checksum: str) -> Optional[str]:
+        """
+        Return the doc_id if any connector has registered this checksum, else None.
+        """
+        try:
+            with get_db_session() as session:
+                stmt = (
+                    select(ConnectorDocumentChecksum.doc_id)
+                    .where(ConnectorDocumentChecksum.checksum == checksum)
+                    .limit(1)
+                )
+                row = session.execute(stmt).one_or_none()
+                return row[0] if row else None
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in find_connector_doc_by_checksum: {e}", exc_info=True)
+            return None
+
+    @staticmethod
+    def get_connector_checksums(connector_id: str) -> List[str]:
+        """Return all checksums owned by the given connector."""
+        try:
+            with get_db_session() as session:
+                stmt = select(ConnectorDocumentChecksum.checksum).where(
+                    ConnectorDocumentChecksum.connector_id == connector_id
+                )
+                rows = session.execute(stmt).all()
+                return [r[0] for r in rows]
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in get_connector_checksums({connector_id}): {e}", exc_info=True)
+            return []
+
+    @staticmethod
+    def get_all_connector_checksums() -> List[str]:
+        """Return all distinct checksums across all connectors."""
+        try:
+            with get_db_session() as session:
+                stmt = select(ConnectorDocumentChecksum.checksum).distinct()
+                rows = session.execute(stmt).all()
+                return [r[0] for r in rows]
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in get_all_connector_checksums: {e}", exc_info=True)
+            return []
+
+    @staticmethod
+    def insert_connector_checksum(connector_id: str, checksum: str, doc_id: str) -> None:
+        """
+        Insert a (checksum, connector_id, doc_id) row.
+
+        No-op if the row already exists (ON CONFLICT DO NOTHING).
+        """
+        try:
+            with get_db_session() as session:
+                stmt = (
+                    pg_insert(ConnectorDocumentChecksum)
+                    .values(checksum=checksum, connector_id=connector_id, doc_id=doc_id)
+                    .on_conflict_do_nothing(index_elements=["checksum", "connector_id"])
+                )
+                session.execute(stmt)
+                logger.debug(
+                    f"insert_connector_checksum: connector={connector_id!r} "
+                    f"checksum={checksum[:20]}... doc_id={doc_id!r}"
+                )
+        except SQLAlchemyError as e:
+            logger.error(
+                f"DB error in insert_connector_checksum({connector_id}, {checksum[:20]}...): {e}",
+                exc_info=True,
+            )
+            raise
+
+    @staticmethod
+    def delete_connector_checksum(
+        connector_id: str, checksum: str
+    ) -> tuple[int, Optional[str]]:
+        """
+        Delete the (checksum, connector_id) row.
+
+        Returns (remaining_owner_count, doc_id).
+        If the row did not exist, returns (0, None).
+        """
+        try:
+            with get_db_session() as session:
+                del_stmt = (
+                    delete(ConnectorDocumentChecksum)
+                    .where(
+                        ConnectorDocumentChecksum.checksum == checksum,
+                        ConnectorDocumentChecksum.connector_id == connector_id,
+                    )
+                    .returning(ConnectorDocumentChecksum.doc_id)
+                )
+                deleted_row = session.execute(del_stmt).one_or_none()
+                if deleted_row is None:
+                    return 0, None
+                doc_id: str = deleted_row[0]
+
+                count_stmt = select(func.count()).where(
+                    ConnectorDocumentChecksum.checksum == checksum
+                )
+                remaining: int = session.execute(count_stmt).scalar() or 0
+                logger.debug(
+                    f"delete_connector_checksum: connector={connector_id!r} "
+                    f"checksum={checksum[:20]}... remaining={remaining}"
+                )
+                return remaining, doc_id
+        except SQLAlchemyError as e:
+            logger.error(
+                f"DB error in delete_connector_checksum({connector_id}, {checksum[:20]}...): {e}",
+                exc_info=True,
+            )
+            raise
+
+    # ========================================================================
+    # Sync log helpers
+    # ========================================================================
+
+    @staticmethod
+    def open_sync_log(
+        connector_id: str,
+        started_at: Optional[datetime] = None,
+    ) -> int:
+        """
+        Create a new sync-log row and set connector sync_status to 'syncing'.
+
+        seq is auto-generated as COALESCE(MAX(seq), 0) + 1 scoped to this connector.
+        Returns the generated seq value.
+        """
+        try:
+            with get_db_session() as session:
+                seq_subquery = (
+                    select(func.coalesce(func.max(ConnectorSyncLog.seq), 0) + 1)
+                    .where(ConnectorSyncLog.connector_id == connector_id)
+                    .scalar_subquery()
+                )
+                stmt = (
+                    pg_insert(ConnectorSyncLog)
+                    .values(
+                        connector_id=connector_id,
+                        seq=seq_subquery,
+                        started_at=started_at or datetime.now(timezone.utc),
+                        status="started",
+                        error="",
+                    )
+                    .returning(ConnectorSyncLog.seq)
+                )
+                seq: int = session.execute(stmt).scalar_one()
+                session.execute(
+                    update(Connector)
+                    .where(Connector.id == connector_id)
+                    .values(sync_status="syncing")
+                )
+                logger.debug(f"open_sync_log: connector={connector_id!r} seq={seq}")
+                return seq
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in open_sync_log({connector_id}): {e}", exc_info=True)
+            raise
+
+    @staticmethod
+    def close_sync_log(
+        connector_id: str,
+        seq: int,
+        status: str,
+        finished_at: Optional[datetime] = None,
+        total_files: Optional[int] = None,
+        new_files: Optional[int] = None,
+        removed_files: Optional[int] = None,
+        failed_files: Optional[int] = None,
+        error: Optional[str] = None,
+    ) -> bool:
+        """
+        Finalize a sync-log row and update connector last_sync_at / sync_status.
+
+        Returns True on success, False if the sync-log row was not found.
+        """
+        try:
+            with get_db_session() as session:
+                now = finished_at or datetime.now(timezone.utc)
+                log_values: Dict[str, Any] = {
+                    "status": status,
+                    "finished_at": now,
+                }
+                if total_files is not None:
+                    log_values["total_files"] = total_files
+                if new_files is not None:
+                    log_values["new_files"] = new_files
+                if removed_files is not None:
+                    log_values["removed_files"] = removed_files
+                if failed_files is not None:
+                    log_values["failed_files"] = failed_files
+                if error is not None:
+                    log_values["error"] = error
+                log_stmt = (
+                    update(ConnectorSyncLog)
+                    .where(
+                        ConnectorSyncLog.connector_id == connector_id,
+                        ConnectorSyncLog.seq == seq,
+                    )
+                    .values(**log_values)
+                )
+                result = session.execute(log_stmt)
+                if result.rowcount == 0:
+                    logger.warning(
+                        f"Sync log connector={connector_id!r} seq={seq} not found for update"
+                    )
+                    return False
+                session.execute(
+                    update(Connector)
+                    .where(Connector.id == connector_id)
+                    .values(last_sync_at=now, sync_status=status)
+                )
+                return True
+        except SQLAlchemyError as e:
+            logger.error(
+                f"DB error in close_sync_log(connector={connector_id!r}, seq={seq}): {e}",
+                exc_info=True,
+            )
+            return False
+
+    @staticmethod
+    def update_sync_log_progress(
+        log_id: int,
+        total_files: Optional[int] = None,
+        new_files: Optional[int] = None,
+        removed_files: Optional[int] = None,
+        failed_files: Optional[int] = None,
+    ) -> bool:
+        """
+        Write live progress counters into an in-progress sync-log row.
+
+        Only non-None counters are updated. Returns True on success, False if
+        the row was not found.
+        """
+        try:
+            with get_db_session() as session:
+                values: Dict[str, Any] = {}
+                if total_files is not None:
+                    values["total_files"] = total_files
+                if new_files is not None:
+                    values["new_files"] = new_files
+                if removed_files is not None:
+                    values["removed_files"] = removed_files
+                if failed_files is not None:
+                    values["failed_files"] = failed_files
+                if not values:
+                    return True
+                stmt = (
+                    update(ConnectorSyncLog)
+                    .where(ConnectorSyncLog.id == log_id)
+                    .values(**values)
+                )
+                result = session.execute(stmt)
+                updated = result.rowcount > 0
+                if not updated:
+                    logger.warning(f"Sync log id={log_id} not found for progress update")
+                return updated
+        except SQLAlchemyError as e:
+            logger.error(
+                f"DB error in update_sync_log_progress(id={log_id}): {e}", exc_info=True
+            )
+            return False
+
+    @staticmethod
+    def get_sync_logs(
+        connector_id: str,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[List[ConnectorSyncLog], int]:
+        """
+        Return paginated sync-log rows for a connector, newest first.
+
+        Returns (items, total_count).
+        """
+        try:
+            with get_db_session() as session:
+                base = select(ConnectorSyncLog).where(
+                    ConnectorSyncLog.connector_id == connector_id
+                )
+                total: int = session.execute(
+                    select(func.count()).select_from(base.subquery())
+                ).scalar() or 0
+
+                stmt = (
+                    base.order_by(ConnectorSyncLog.started_at.desc())
+                    .limit(limit)
+                    .offset(offset)
+                )
+                rows = list(session.scalars(stmt).all())
+                for row in rows:
+                    _ = (
+                        row.id, row.connector_id, row.seq,
+                        row.started_at, row.finished_at,
+                        row.total_files, row.new_files, row.removed_files,
+                        row.failed_files, row.status, row.error,
+                    )
+                    session.expunge(row)
+                logger.debug(
+                    f"get_sync_logs: connector={connector_id!r} "
+                    f"returned {len(rows)} of {total}"
+                )
+                return rows, total
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in get_sync_logs({connector_id}): {e}", exc_info=True)
+            return [], 0
+
+    # ========================================================================
+    # Document metadata helper
+    # ========================================================================
+
+    @staticmethod
+    def merge_document_metadata(doc_id: str, metadata: dict) -> bool:
+        """
+        Merge *metadata* into documents.doc_metadata using the PostgreSQL
+        ``||`` JSONB concatenation operator (atomic key-level merge).
+
+        Returns True on success, False if the document row was not found.
+        """
+        try:
+            with get_db_session() as session:
+                stmt = (
+                    update(Document)
+                    .where(Document.doc_id == doc_id)
+                    .values(
+                        doc_metadata=Document.doc_metadata.op("||")(
+                            func.cast(metadata, Document.doc_metadata.type)
+                        )
+                    )
+                )
+                result = session.execute(stmt)
+                updated = result.rowcount > 0
+                if not updated:
+                    logger.warning(f"merge_document_metadata: doc_id={doc_id!r} not found")
+                return updated
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in merge_document_metadata({doc_id}): {e}", exc_info=True)
+            return False
 
 
 # Singleton instance for easy access

--- a/services/digitize/db/models.py
+++ b/services/digitize/db/models.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     CheckConstraint,
     Index,
     UniqueConstraint,
+    desc,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
@@ -246,7 +247,7 @@ class ConnectorDocumentChecksum(Base):
 
 class ConnectorSyncLog(Base):
     """
-    Persistent per-tick history backing the sync-history API.
+    Persistent per-tick history backing the sync-logs API.
 
     Maps to the 'connector_sync_logs' table in PostgreSQL.
     """
@@ -274,7 +275,7 @@ class ConnectorSyncLog(Base):
     )
 
     __table_args__ = (
-        Index("idx_csl_connector_started", "connector_id", "started_at"),
+        Index("idx_csl_connector_started", "connector_id", desc("started_at")),
         UniqueConstraint("connector_id", "seq", name="uq_csh_connector_seq"),
     )
 

--- a/services/digitize/tests/test_connector_db.py
+++ b/services/digitize/tests/test_connector_db.py
@@ -1,0 +1,672 @@
+"""
+Unit tests for connector DB operations in utils/db.py (PR 2).
+
+All tests use the shared conftest mocks so no real database is required.
+Each test builds a focused mock for the function under test and validates
+the exact SQLAlchemy calls and return values described in §5 of the proposal.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+from unittest.mock import MagicMock, Mock, call, patch
+
+import pytest
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across test cases
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+CONNECTOR_ID = "c7f3a2d1-0000-0000-0000-000000000001"
+CONNECTOR_NAME = "prod-sftp-reports"
+CONNECTOR_TYPE = "ssh"
+CONNECTION_DETAILS = {"host": "sftp.example.com", "username": "sync_user"}
+ALLOWED_EXTENSIONS = [".pdf", ".docx"]
+SYNC_INTERVAL = 300
+
+CHECKSUM_A = "aabbcc" * 5 + "aabb"          # 32-char hex (simulated)
+CHECKSUM_B = "112233" * 5 + "1122"
+DOC_ID_A = "doc-0000-aaaa"
+DOC_ID_B = "doc-0000-bbbb"
+
+
+def _make_session_cm(session_mock: MagicMock) -> MagicMock:
+    """Wrap a session mock in a context-manager stub."""
+    cm = MagicMock()
+    cm.__enter__ = Mock(return_value=session_mock)
+    cm.__exit__ = Mock(return_value=False)
+    return cm
+
+
+def _execute_result(rowcount: int = 1, scalar_val=None, rows=None):
+    """Build a mock execute() return value."""
+    r = MagicMock()
+    r.rowcount = rowcount
+    r.scalar = Mock(return_value=scalar_val)
+    r.one_or_none = Mock(return_value=rows[0] if rows else None)
+    r.all = Mock(return_value=rows or [])
+    return r
+
+
+# ===========================================================================
+# insert_connector
+# ===========================================================================
+
+class TestInsertActiveConnector:
+    def _call(self, session_mock):
+        from digitize.utils.db import insert_connector
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session_mock)):
+            insert_connector(
+                CONNECTOR_ID, CONNECTOR_NAME, CONNECTOR_TYPE,
+                CONNECTION_DETAILS, ALLOWED_EXTENSIONS, SYNC_INTERVAL,
+            )
+
+    def test_inserts_row_successfully(self):
+        session = MagicMock()
+        session.execute.return_value = _execute_result(rowcount=1)
+        self._call(session)
+        assert session.execute.called
+
+    def test_raises_integrity_error_on_conflict(self):
+        session = MagicMock()
+        # rowcount 0 → connector already exists
+        session.execute.return_value = _execute_result(rowcount=0)
+        from digitize.utils.db import insert_connector
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            with pytest.raises(IntegrityError):
+                insert_connector(
+                    CONNECTOR_ID, CONNECTOR_NAME, CONNECTOR_TYPE,
+                    CONNECTION_DETAILS, ALLOWED_EXTENSIONS, SYNC_INTERVAL,
+                )
+
+    def test_propagates_sqlalchemy_error(self):
+        session = MagicMock()
+        session.execute.side_effect = SQLAlchemyError("db down")
+        from digitize.utils.db import insert_connector
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            with pytest.raises(SQLAlchemyError):
+                insert_connector(
+                    CONNECTOR_ID, CONNECTOR_NAME, CONNECTOR_TYPE,
+                    CONNECTION_DETAILS, ALLOWED_EXTENSIONS, SYNC_INTERVAL,
+                )
+
+
+# ===========================================================================
+# upsert_connector
+# ===========================================================================
+
+class TestUpsertActiveConnector:
+    def _call(self, session_mock, **kwargs):
+        from digitize.utils.db import upsert_connector
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session_mock)):
+            upsert_connector(CONNECTOR_ID, **kwargs)
+
+    def test_updates_name_only(self):
+        session = MagicMock()
+        session.execute.return_value = _execute_result(rowcount=1)
+        self._call(session, name="new-name")
+        assert session.execute.called
+
+    def test_merges_connection_details_keys(self):
+        """Only the supplied connection_details keys are written; untouched keys survive."""
+        session = MagicMock()
+        session.execute.return_value = _execute_result(rowcount=1)
+        self._call(session, connection_details={"remote_path": "/v2"})
+        # Implementation uses Connector.connection_details.op("||") — confirm execute was called
+        assert session.execute.called
+
+    def test_does_not_clobber_untouched_connection_detail_keys(self):
+        """Passing connection_details must not replace the whole JSONB column wholesale."""
+        session = MagicMock()
+        session.execute.return_value = _execute_result(rowcount=1)
+        self._call(session, connection_details={"remote_path": "/only_this_key"})
+        assert session.execute.called
+
+    def test_raises_file_not_found_when_connector_missing(self):
+        """upsert_connector must raise FileNotFoundError when no row is matched."""
+        session = MagicMock()
+        session.execute.return_value = _execute_result(rowcount=0)
+        from digitize.utils.db import upsert_connector
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            with pytest.raises(FileNotFoundError):
+                upsert_connector(CONNECTOR_ID, name="x")
+
+    def test_propagates_sqlalchemy_error(self):
+        session = MagicMock()
+        session.execute.side_effect = SQLAlchemyError("disk full")
+        from digitize.utils.db import upsert_connector
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            with pytest.raises(SQLAlchemyError):
+                upsert_connector(CONNECTOR_ID, name="x")
+
+
+# ===========================================================================
+# get_active_connector
+# ===========================================================================
+
+class TestGetConnector:
+    def _make_connector(self) -> MagicMock:
+        c = MagicMock()
+        c.id = CONNECTOR_ID
+        c.name = CONNECTOR_NAME
+        c.type = CONNECTOR_TYPE
+        c.connection_details = CONNECTION_DETAILS
+        c.allowed_extensions = ALLOWED_EXTENSIONS
+        c.sync_interval_seconds = SYNC_INTERVAL
+        c.attached_at = _NOW
+        c.last_sync_at = None
+        c.sync_status = "up to date"
+        c.last_sync_error = None
+        c.total_files = 0
+        return c
+
+    def test_returns_connector_when_found(self):
+        connector = self._make_connector()
+        session = MagicMock()
+        session.get.return_value = connector
+        from digitize.utils.db import get_active_connector
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = get_active_connector(CONNECTOR_ID)
+        assert result is connector
+        session.expunge.assert_called_once_with(connector)
+
+    def test_returns_none_when_not_found(self):
+        session = MagicMock()
+        session.get.return_value = None
+        from digitize.utils.db import get_active_connector
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = get_active_connector("nonexistent-id")
+        assert result is None
+
+    def test_returns_none_on_db_error(self):
+        session = MagicMock()
+        session.get.side_effect = SQLAlchemyError("timeout")
+        from digitize.utils.db import get_active_connector
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = get_active_connector(CONNECTOR_ID)
+        assert result is None
+
+
+# ===========================================================================
+# list_connectors
+# ===========================================================================
+
+class TestListConnectors:
+    def test_returns_list_of_connectors(self):
+        c1 = MagicMock()
+        c1.id = CONNECTOR_ID
+        c1.name = CONNECTOR_NAME
+        c1.type = "ssh"
+        c1.connection_details = {}
+        c1.allowed_extensions = []
+        c1.sync_interval_seconds = 300
+        c1.attached_at = _NOW
+        c1.last_sync_at = None
+        c1.sync_status = "up to date"
+        c1.last_sync_error = None
+        c1.total_files = 0
+
+        session = MagicMock()
+        session.scalars.return_value.all.return_value = [c1]
+        from digitize.utils.db import list_connectors
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = list_connectors()
+        assert len(result) == 1
+        assert result[0] is c1
+        session.expunge.assert_called_once_with(c1)
+
+    def test_returns_empty_list_on_db_error(self):
+        session = MagicMock()
+        session.scalars.side_effect = SQLAlchemyError("no connection")
+        from digitize.utils.db import list_connectors
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = list_connectors()
+        assert result == []
+
+
+# ===========================================================================
+# delete_active_connector
+# ===========================================================================
+
+class TestDeleteConnector:
+    def test_returns_true_when_row_deleted(self):
+        session = MagicMock()
+        session.execute.return_value = _execute_result(rowcount=1)
+        from digitize.utils.db import delete_active_connector
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            assert delete_active_connector(CONNECTOR_ID) is True
+
+    def test_returns_false_when_not_found(self):
+        session = MagicMock()
+        session.execute.return_value = _execute_result(rowcount=0)
+        from digitize.utils.db import delete_active_connector
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            assert delete_active_connector("nonexistent") is False
+
+    def test_returns_false_on_db_error(self):
+        session = MagicMock()
+        session.execute.side_effect = SQLAlchemyError("oops")
+        from digitize.utils.db import delete_active_connector
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            assert delete_active_connector(CONNECTOR_ID) is False
+
+
+# ===========================================================================
+# lookup_connector_content_by_checksum
+# ===========================================================================
+
+class TestLookupConnectorContentByChecksum:
+    def test_returns_doc_id_when_found(self):
+        session = MagicMock()
+        # execute().one_or_none() returns a row tuple
+        session.execute.return_value.one_or_none.return_value = (DOC_ID_A,)
+        from digitize.utils.db import lookup_connector_content_by_checksum
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = lookup_connector_content_by_checksum(CHECKSUM_A)
+        assert result == DOC_ID_A
+
+    def test_returns_none_when_not_found(self):
+        session = MagicMock()
+        session.execute.return_value.one_or_none.return_value = None
+        from digitize.utils.db import lookup_connector_content_by_checksum
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = lookup_connector_content_by_checksum(CHECKSUM_A)
+        assert result is None
+
+    def test_never_touches_document_checksum_table(self):
+        """
+        The query must only reference connector_document_checksum.
+        We inspect the generated SQL string to confirm the right table name.
+        """
+        from digitize.db.models import ConnectorDocumentChecksum
+        from sqlalchemy import select
+        stmt = (
+            select(ConnectorDocumentChecksum.doc_id)
+            .where(ConnectorDocumentChecksum.checksum == CHECKSUM_A)
+            .limit(1)
+        )
+        sql = str(stmt)
+        assert "connector_document_checksum" in sql
+        assert "document_checksum" in sql  # substring — ensure we're looking at the right table
+        # The user-submitted table is named "document_checksum" (no "connector_" prefix).
+        # Our query must NOT target that table alone.
+        # The connector table name always contains "connector_document_checksum".
+        assert sql.count("connector_document_checksum") >= 1
+
+    def test_returns_none_on_db_error(self):
+        session = MagicMock()
+        session.execute.side_effect = SQLAlchemyError("timeout")
+        from digitize.utils.db import lookup_connector_content_by_checksum
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = lookup_connector_content_by_checksum(CHECKSUM_A)
+        assert result is None
+
+
+# ===========================================================================
+# list_connector_checksums
+# ===========================================================================
+
+class TestListConnectorChecksums:
+    def test_returns_checksums_for_connector(self):
+        session = MagicMock()
+        session.execute.return_value.all.return_value = [(CHECKSUM_A,), (CHECKSUM_B,)]
+        from digitize.utils.db import list_connector_checksums
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = list_connector_checksums(CONNECTOR_ID)
+        assert result == [CHECKSUM_A, CHECKSUM_B]
+
+    def test_returns_empty_list_on_db_error(self):
+        session = MagicMock()
+        session.execute.side_effect = SQLAlchemyError("boom")
+        from digitize.utils.db import list_connector_checksums
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = list_connector_checksums(CONNECTOR_ID)
+        assert result == []
+
+
+# ===========================================================================
+# list_all_checksums
+# ===========================================================================
+
+class TestListAllChecksums:
+    def test_returns_all_distinct_checksums(self):
+        session = MagicMock()
+        session.execute.return_value.all.return_value = [(CHECKSUM_A,), (CHECKSUM_B,)]
+        from digitize.utils.db import list_all_checksums
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = list_all_checksums()
+        assert set(result) == {CHECKSUM_A, CHECKSUM_B}
+
+    def test_returns_empty_list_on_db_error(self):
+        session = MagicMock()
+        session.execute.side_effect = SQLAlchemyError("timeout")
+        from digitize.utils.db import list_all_checksums
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = list_all_checksums()
+        assert result == []
+
+
+# ===========================================================================
+# add_connector_checksum_entry
+# ===========================================================================
+
+class TestAddConnectorChecksumEntry:
+    def _call(self, session_mock):
+        from digitize.utils.db import add_connector_checksum_entry
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session_mock)):
+            add_connector_checksum_entry(CONNECTOR_ID, CHECKSUM_A, DOC_ID_A)
+
+    def test_inserts_row_on_first_call(self):
+        session = MagicMock()
+        session.execute.return_value = _execute_result(rowcount=1)
+        self._call(session)
+        assert session.execute.called
+
+    def test_noop_on_duplicate_call(self):
+        """ON CONFLICT DO NOTHING — second call must not raise."""
+        session = MagicMock()
+        session.execute.return_value = _execute_result(rowcount=0)
+        # Should not raise even if rowcount == 0
+        self._call(session)
+
+    def test_same_checksum_different_connectors(self):
+        """
+        Adding two different connectors for the same checksum must both succeed.
+        Each produces its own INSERT … ON CONFLICT DO NOTHING call.
+        """
+        connector_b = "c7f3a2d1-0000-0000-0000-000000000002"
+        session = MagicMock()
+        session.execute.return_value = _execute_result(rowcount=1)
+        from digitize.utils.db import add_connector_checksum_entry
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            add_connector_checksum_entry(CONNECTOR_ID, CHECKSUM_A, DOC_ID_A)
+            add_connector_checksum_entry(connector_b, CHECKSUM_A, DOC_ID_A)
+        assert session.execute.call_count == 2
+
+    def test_raises_on_db_error(self):
+        session = MagicMock()
+        session.execute.side_effect = SQLAlchemyError("disk full")
+        from digitize.utils.db import add_connector_checksum_entry
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            with pytest.raises(SQLAlchemyError):
+                add_connector_checksum_entry(CONNECTOR_ID, CHECKSUM_A, DOC_ID_A)
+
+
+# ===========================================================================
+# remove_connector_checksum_entry
+# ===========================================================================
+
+class TestRemoveConnectorFromMembership:
+    def _call(self, session_mock) -> tuple:
+        from digitize.utils.db import remove_connector_checksum_entry
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session_mock)):
+            return remove_connector_checksum_entry(CONNECTOR_ID, CHECKSUM_A)
+
+    def _setup_session(self, deleted_doc_id: Optional[str], remaining_count: int) -> MagicMock:
+        """
+        Configure a session mock where the DELETE RETURNING yields
+        *deleted_doc_id* and the subsequent COUNT yields *remaining_count*.
+        """
+        session = MagicMock()
+        del_result = MagicMock()
+        del_result.one_or_none.return_value = (deleted_doc_id,) if deleted_doc_id else None
+        count_result = MagicMock()
+        count_result.scalar.return_value = remaining_count
+        session.execute.side_effect = [del_result, count_result]
+        return session
+
+    def test_last_connector_removed_returns_zero(self):
+        """remaining=0 when no other connector owns this checksum."""
+        session = self._setup_session(DOC_ID_A, 0)
+        remaining, doc_id = self._call(session)
+        assert remaining == 0
+        assert doc_id == DOC_ID_A
+
+    def test_other_connectors_remain(self):
+        """remaining>0 when other connectors still own the checksum."""
+        session = self._setup_session(DOC_ID_A, 2)
+        remaining, doc_id = self._call(session)
+        assert remaining == 2
+        assert doc_id == DOC_ID_A
+
+    def test_row_not_found_returns_zero_none(self):
+        """If the row didn't exist, return (0, None) without querying count."""
+        session = MagicMock()
+        del_result = MagicMock()
+        del_result.one_or_none.return_value = None
+        session.execute.return_value = del_result
+        remaining, doc_id = self._call(session)
+        assert remaining == 0
+        assert doc_id is None
+        # Only one DB call should have been made (the DELETE)
+        assert session.execute.call_count == 1
+
+    def test_raises_on_db_error(self):
+        session = MagicMock()
+        session.execute.side_effect = SQLAlchemyError("gone")
+        from digitize.utils.db import remove_connector_checksum_entry
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            with pytest.raises(SQLAlchemyError):
+                remove_connector_checksum_entry(CONNECTOR_ID, CHECKSUM_A)
+
+
+# ===========================================================================
+# open_new_sync_log
+# ===========================================================================
+
+class TestInsertSyncLog:
+    def test_returns_generated_seq(self):
+        """open_new_sync_log must return the auto-generated seq value."""
+        session = MagicMock()
+        # First execute: INSERT … RETURNING seq → scalar_one() returns 3
+        insert_result = MagicMock()
+        insert_result.scalar_one.return_value = 3
+        # Second execute: UPDATE connectors SET sync_status='syncing'
+        update_result = MagicMock()
+        session.execute.side_effect = [insert_result, update_result]
+
+        from digitize.utils.db import open_new_sync_log
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            seq = open_new_sync_log(CONNECTOR_ID)
+        assert seq == 3
+        assert session.execute.call_count == 2
+
+    def test_sets_connector_sync_status_syncing(self):
+        """Both the INSERT and the connectors UPDATE must happen in the same session."""
+        session = MagicMock()
+        insert_result = MagicMock()
+        insert_result.scalar_one.return_value = 1
+        session.execute.side_effect = [insert_result, MagicMock()]
+
+        from digitize.utils.db import open_new_sync_log
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            open_new_sync_log(CONNECTOR_ID)
+        # Two DB calls: INSERT log row + UPDATE connector status
+        assert session.execute.call_count == 2
+
+    def test_does_not_accept_seq_parameter(self):
+        """seq must not be an accepted parameter — it is auto-generated."""
+        from digitize.utils.db import open_new_sync_log
+        import inspect
+        sig = inspect.signature(open_new_sync_log)
+        assert "seq" not in sig.parameters
+
+    def test_raises_on_db_error(self):
+        session = MagicMock()
+        session.execute.side_effect = SQLAlchemyError("constraint violation")
+        from digitize.utils.db import open_new_sync_log
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            with pytest.raises(SQLAlchemyError):
+                open_new_sync_log(CONNECTOR_ID)
+
+
+# ===========================================================================
+# close_sync_log
+# ===========================================================================
+
+class TestUpdateSyncLog:
+    def test_returns_true_on_success(self):
+        """On success: updates log row AND connector row (two execute calls)."""
+        session = MagicMock()
+        # First execute: UPDATE connector_sync_logs rowcount=1 (found)
+        log_result = _execute_result(rowcount=1)
+        # Second execute: UPDATE connectors
+        conn_result = _execute_result(rowcount=1)
+        session.execute.side_effect = [log_result, conn_result]
+        from digitize.utils.db import close_sync_log
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = close_sync_log(
+                CONNECTOR_ID, seq=1, status="completed", total_files=10, new_files=2
+            )
+        assert result is True
+        assert session.execute.call_count == 2
+
+    def test_returns_false_when_not_found(self):
+        """When the log row is not found, return False without updating connectors."""
+        session = MagicMock()
+        session.execute.return_value = _execute_result(rowcount=0)
+        from digitize.utils.db import close_sync_log
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = close_sync_log(CONNECTOR_ID, seq=999, status="failed")
+        assert result is False
+        # Only one execute call: the failed log-row lookup; connectors must NOT be updated
+        assert session.execute.call_count == 1
+
+    def test_updates_connector_last_sync_at_and_status(self):
+        """The connector row must be updated in the same transaction as the log row."""
+        session = MagicMock()
+        log_result = _execute_result(rowcount=1)
+        conn_result = _execute_result(rowcount=1)
+        session.execute.side_effect = [log_result, conn_result]
+        from digitize.utils.db import close_sync_log
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            close_sync_log(CONNECTOR_ID, seq=2, status="up to date")
+        assert session.execute.call_count == 2
+
+    def test_optional_fields_omitted_when_none(self):
+        """Passing None for optional fields must not include them in the update."""
+        session = MagicMock()
+        log_result = _execute_result(rowcount=1)
+        conn_result = _execute_result(rowcount=1)
+        session.execute.side_effect = [log_result, conn_result]
+        from digitize.utils.db import close_sync_log
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            close_sync_log(CONNECTOR_ID, seq=1, status="completed")
+        assert session.execute.called
+
+
+# ===========================================================================
+# update_sync_log
+# ===========================================================================
+
+class TestUpdateSyncLogFilesSyncing:
+    def test_returns_true_on_success(self):
+        session = MagicMock()
+        session.execute.return_value = _execute_result(rowcount=1)
+        from digitize.utils.db import update_sync_log
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = update_sync_log(42, total_files=5, new_files=3)
+        assert result is True
+
+    def test_returns_true_when_nothing_to_update(self):
+        """Calling with all-None args is a no-op — must return True without hitting DB."""
+        session = MagicMock()
+        from digitize.utils.db import update_sync_log
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = update_sync_log(42)
+        assert result is True
+        session.execute.assert_not_called()
+
+    def test_does_not_modify_status_or_finished_at(self):
+        """
+        This function must only update file counters. We verify that
+        session.execute is called (counters update) but the function signature
+        does not accept status/finished_at parameters.
+        """
+        from digitize.utils.db import update_sync_log
+        import inspect
+        sig = inspect.signature(update_sync_log)
+        assert "status" not in sig.parameters
+        assert "finished_at" not in sig.parameters
+
+
+# ===========================================================================
+# list_sync_logs
+# ===========================================================================
+
+class TestListSyncLogs:
+    def _make_log(self, log_id: int, seq: int) -> MagicMock:
+        log = MagicMock()
+        log.id = log_id
+        log.connector_id = CONNECTOR_ID
+        log.seq = seq
+        log.started_at = _NOW
+        log.finished_at = None
+        log.total_files = 0
+        log.new_files = 0
+        log.removed_files = 0
+        log.failed_files = 0
+        log.status = "started"
+        log.error = ""
+        return log
+
+    def test_returns_items_and_total(self):
+        log = self._make_log(1, 1)
+        session = MagicMock()
+        # First execute: COUNT query → total=1
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1
+        session.execute.return_value = count_result
+        session.scalars.return_value.all.return_value = [log]
+
+        from digitize.utils.db import list_sync_logs
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            items, total = list_sync_logs(CONNECTOR_ID)
+        assert total == 1
+        assert len(items) == 1
+        assert items[0] is log
+        session.expunge.assert_called_once_with(log)
+
+    def test_returns_empty_on_db_error(self):
+        session = MagicMock()
+        session.execute.side_effect = SQLAlchemyError("timeout")
+        from digitize.utils.db import list_sync_logs
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            items, total = list_sync_logs(CONNECTOR_ID)
+        assert items == []
+        assert total == 0
+
+
+# ===========================================================================
+# set_document_metadata
+# ===========================================================================
+
+class TestSetDocumentMetadata:
+    def test_returns_true_on_success(self):
+        session = MagicMock()
+        session.execute.return_value = _execute_result(rowcount=1)
+        from digitize.utils.db import set_document_metadata
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = set_document_metadata(DOC_ID_A, {"source_type": "s3", "bucket": "my-bucket"})
+        assert result is True
+
+    def test_returns_false_when_document_not_found(self):
+        session = MagicMock()
+        session.execute.return_value = _execute_result(rowcount=0)
+        from digitize.utils.db import set_document_metadata
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = set_document_metadata("nonexistent-doc", {"key": "val"})
+        assert result is False
+
+    def test_returns_false_on_db_error(self):
+        session = MagicMock()
+        session.execute.side_effect = SQLAlchemyError("gone")
+        from digitize.utils.db import set_document_metadata
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
+            result = set_document_metadata(DOC_ID_A, {"source_type": "sftp"})
+        assert result is False
+
+# Made with Bob

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -3,7 +3,7 @@ Database operations — utils/db.py
 
 All functions that directly interact with the database via db_manager:
 CRUD for jobs and documents, advisory import/export lock, DatabaseStatusManager,
-and the get_status_manager factory.
+connector DB operations, and the get_status_manager factory.
 """
 
 from datetime import datetime, timezone
@@ -31,6 +31,11 @@ from digitize.models import (
     ExportEntitySummary,
     ExportPagination,
     ImportExportData,
+)
+from digitize.db.models import (
+    Connector,
+    ConnectorSyncLog,
+    Document,
 )
 from digitize.db.manager import db_manager
 from digitize.db.connection import engine
@@ -1157,5 +1162,210 @@ def _categorize_fields(details: Mapping[str, Any]) -> tuple[dict[str, Any], dict
 def _extract_value(v: Any) -> Any:
     """Extract .value from enums, return raw value otherwise."""
     return v.value if hasattr(v, "value") else v
+
+
+# ============================================================================
+# Connector Operations
+# ============================================================================
+
+def insert_connector(
+    connector_id: str,
+    name: str,
+    connector_type: str,
+    connection_details: dict,
+    allowed_extensions: list,
+    sync_interval_seconds: int,
+) -> None:
+    """
+    Insert a new connector row on first-time POST /v1/connectors.
+
+    Raises IntegrityError if the id already exists (maps to 409).
+    """
+    db_manager.insert_connector(
+        connector_id=connector_id,
+        name=name,
+        connector_type=connector_type,
+        connection_details=connection_details,
+        allowed_extensions=allowed_extensions,
+        sync_interval_seconds=sync_interval_seconds,
+    )
+
+
+def upsert_connector(
+    connector_id: str,
+    name: Optional[str] = None,
+    connection_details: Optional[dict] = None,
+    allowed_extensions: Optional[list] = None,
+) -> None:
+    """
+    Partial update of an existing connector for PUT /v1/connectors/{id}.
+
+    Raises FileNotFoundError if no connector with the given id exists.
+    """
+    db_manager.update_connector(
+        connector_id=connector_id,
+        name=name,
+        connection_details=connection_details,
+        allowed_extensions=allowed_extensions,
+    )
+
+
+def get_active_connector(connector_id: str) -> Optional[Connector]:
+    """
+    Fetch a single connector by id.
+
+    Returns the ORM object or None if not found.
+    """
+    return db_manager.get_connector_by_id(connector_id)
+
+
+def list_connectors() -> List[Connector]:
+    """Return all connectors ordered by attached_at descending."""
+    return db_manager.get_all_connectors()
+
+
+def delete_active_connector(connector_id: str) -> bool:
+    """
+    Delete a connector row by id (cascades to connector_sync_logs).
+
+    Returns True if a row was deleted, False if not found.
+    """
+    return db_manager.delete_connector(connector_id)
+
+
+# ----------------------------------------------------------------------------
+# Checksum membership helpers
+# ----------------------------------------------------------------------------
+
+def lookup_connector_content_by_checksum(checksum: str) -> Optional[str]:
+    """
+    Return the doc_id if any connector has already registered this checksum,
+    else None.
+    """
+    return db_manager.find_connector_doc_by_checksum(checksum)
+
+
+def list_connector_checksums(connector_id: str) -> List[str]:
+    """Return all checksums currently owned by the given connector."""
+    return db_manager.get_connector_checksums(connector_id)
+
+
+def list_all_checksums() -> List[str]:
+    """Return all distinct checksums across all connectors."""
+    return db_manager.get_all_connector_checksums()
+
+
+def add_connector_checksum_entry(
+    connector_id: str, checksum: str, doc_id: str
+) -> None:
+    """
+    Insert a new (checksum, connector_id, doc_id) row.
+
+    No-op if the row already exists (ON CONFLICT DO NOTHING).
+    """
+    db_manager.insert_connector_checksum(connector_id, checksum, doc_id)
+
+
+def remove_connector_checksum_entry(
+    connector_id: str, checksum: str
+) -> tuple[int, Optional[str]]:
+    """
+    Delete the (checksum, connector_id) row.
+
+    Returns (remaining_owner_count, doc_id), or (0, None) if not found.
+    """
+    return db_manager.delete_connector_checksum(connector_id, checksum)
+
+
+# ----------------------------------------------------------------------------
+# Sync log helpers
+# ----------------------------------------------------------------------------
+
+def open_new_sync_log(
+    connector_id: str,
+    started_at: Optional[datetime] = None,
+) -> int:
+    """
+    Create a new sync-log row and set connector sync_status to 'syncing'.
+
+    Returns the generated seq value.
+    """
+    return db_manager.open_sync_log(connector_id, started_at=started_at)
+
+
+def close_sync_log(
+    connector_id: str,
+    seq: int,
+    status: str,
+    finished_at: Optional[datetime] = None,
+    total_files: Optional[int] = None,
+    new_files: Optional[int] = None,
+    removed_files: Optional[int] = None,
+    failed_files: Optional[int] = None,
+    error: Optional[str] = None,
+) -> bool:
+    """
+    Finalize a sync-log row and update connector last_sync_at / sync_status.
+
+    Returns True on success, False if the sync-log row was not found.
+    """
+    return db_manager.close_sync_log(
+        connector_id=connector_id,
+        seq=seq,
+        status=status,
+        finished_at=finished_at,
+        total_files=total_files,
+        new_files=new_files,
+        removed_files=removed_files,
+        failed_files=failed_files,
+        error=error,
+    )
+
+
+def update_sync_log(
+    log_id: int,
+    total_files: Optional[int] = None,
+    new_files: Optional[int] = None,
+    removed_files: Optional[int] = None,
+    failed_files: Optional[int] = None,
+) -> bool:
+    """
+    Write live progress counters into an in-progress sync-log row.
+
+    Returns True on success, False if the row was not found.
+    """
+    return db_manager.update_sync_log_progress(
+        log_id=log_id,
+        total_files=total_files,
+        new_files=new_files,
+        removed_files=removed_files,
+        failed_files=failed_files,
+    )
+
+
+def list_sync_logs(
+    connector_id: str,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[List[ConnectorSyncLog], int]:
+    """
+    Return paginated sync-log rows for a connector, newest first.
+
+    Returns (items, total_count).
+    """
+    return db_manager.get_sync_logs(connector_id, limit=limit, offset=offset)
+
+
+# ----------------------------------------------------------------------------
+# Document metadata helper
+# ----------------------------------------------------------------------------
+
+def set_document_metadata(doc_id: str, metadata: dict) -> bool:
+    """
+    Merge *metadata* into documents.doc_metadata (atomic key-level JSONB merge).
+
+    Returns True on success, False if the document row was not found.
+    """
+    return db_manager.merge_document_metadata(doc_id, metadata)
 
 # Made with Bob


### PR DESCRIPTION
-Amended connector_sync_logs table to use connector_id, seq as composite PK where seq is auto-generated (once per tick)
-Rebranded and implemented only necessary methods for DB operations
-For operations requiring updates in 2 tables (connectors and connector_sync_logs), both operations are done within same method for consistency and ease of use