### PR TITLE
AISERVICES-1501 json schema now gets inferred from examples if not provided by user

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.224
+TAG?=v0.0.225
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -118,7 +118,7 @@ extract:
   # @description Host port for the Extract API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/extract-service:v0.0.2
+  image: icr.io/ai-services-cicd/extract-service:v0.0.3
   # @hidden
   log_level: "INFO"
   database: "extract_metadata"

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.224
+  image: icr.io/ai-services-cicd/ai-services:v0.0.225
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.224
+  image: icr.io/ai-services-cicd/ai-services:v0.0.225
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/extract/podman/values.yaml
+++ b/ai-services/assets/services/extract/podman/values.yaml
@@ -1,6 +1,6 @@
 extract:
   port: ""
-  image: icr.io/ai-services-cicd/extract-service:v0.0.2
+  image: icr.io/ai-services-cicd/extract-service:v0.0.3
   log_level: "INFO"
   database: "extract_metadata"
 

--- a/services/extract/Makefile
+++ b/services/extract/Makefile
@@ -1,5 +1,5 @@
 IMAGE=extract-service
-TAG?=v0.0.2
+TAG?=v0.0.3
 
 run:
 	PORT=$${PORT:-6000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/extract/api/v1/schema.py
+++ b/services/extract/api/v1/schema.py
@@ -31,9 +31,11 @@ from extract.utils.schema import (
     SchemaValidationError,
     check_schema_share_in_context,
     compute_token_counts,
+    infer_schema_from_examples,
     normalize_schema,
     validate_examples,
-    validate_json_schema_structure, fmt_dt
+    validate_json_schema_structure,
+    fmt_dt,
 )
 
 
@@ -74,14 +76,30 @@ async def register_schema(body: SchemaRegisterRequest) -> SchemaCreatedResponse:
             f"A schema with name {body.name!r} already exists.",
             status=409,
         )
-    # --- Normalize per-property "required": true convention FIRST ---
-    normalized = normalize_schema(body.json_schema)
+
+    examples_raw = [ex.model_dump() for ex in body.examples] if body.examples else None
+
+    if body.json_schema is None and not examples_raw:
+        raise SchemaValidationError(
+            "MISSING_SCHEMA",
+            "Either json_schema or at least one example must be provided.",
+            status=400,
+        )
+
+    if body.json_schema is None:
+        # --- Infer schema from examples when no explicit schema is provided ---
+        inferred = infer_schema_from_examples(examples_raw or [])
+        normalized = normalize_schema(inferred)
+        is_inferred = True
+    else:
+        # --- Normalize per-property "required": true convention FIRST ---
+        normalized = normalize_schema(body.json_schema)
+        is_inferred = False
 
     # --- JSON Schema structural validation (against the normalized form) ---
     validate_json_schema_structure(normalized)
 
     # --- Validate example outputs against normalized schema ---
-    examples_raw = [ex.model_dump() for ex in body.examples] if body.examples else None
     validate_examples(examples_raw, normalized)
 
 
@@ -121,6 +139,7 @@ async def register_schema(body: SchemaRegisterRequest) -> SchemaCreatedResponse:
         description=body.description,
         examples=examples_raw,
         custom_prompt=body.custom_prompt,
+        is_schema_inferred=is_inferred,
     )
     if row is None:
         raise SchemaValidationError(

--- a/services/extract/api/v1/schema.py
+++ b/services/extract/api/v1/schema.py
@@ -230,6 +230,7 @@ async def get_schema(schema_id: str) -> SchemaDetailResponse:
         schema_id=row.schema_id,
         name=row.name,
         description=row.description,
+        is_schema_inferred=row.is_schema_inferred,
         json_schema=row.json_schema,
         examples=row.examples,
         custom_prompt=row.custom_prompt,

--- a/services/extract/api/v1/schema.py
+++ b/services/extract/api/v1/schema.py
@@ -88,8 +88,7 @@ async def register_schema(body: SchemaRegisterRequest) -> SchemaCreatedResponse:
 
     if body.json_schema is None:
         # --- Infer schema from examples when no explicit schema is provided ---
-        inferred = infer_schema_from_examples(examples_raw or [])
-        normalized = normalize_schema(inferred)
+        normalized = infer_schema_from_examples(examples_raw or [])
         is_inferred = True
     else:
         # --- Normalize per-property "required": true convention FIRST ---

--- a/services/extract/db/manager.py
+++ b/services/extract/db/manager.py
@@ -39,6 +39,7 @@ class DatabaseManager:
         description: Optional[str] = None,
         examples: Optional[list] = None,
         custom_prompt: Optional[str] = None,
+        is_schema_inferred: bool = False,
     ) -> Optional[ExtractionSchema]:
         """Insert a new schema row.  Returns the row or None on failure."""
         try:
@@ -53,6 +54,7 @@ class DatabaseManager:
                     schema_tokens=schema_tokens,
                     examples_tokens=examples_tokens,
                     custom_prompt_tokens=custom_prompt_tokens,
+                    is_schema_inferred=is_schema_inferred,
                     created_at=datetime.now(timezone.utc),
                 )
                 session.add(row)

--- a/services/extract/db/models.py
+++ b/services/extract/db/models.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from sqlalchemy import (
+    Boolean,
     CheckConstraint,
     DateTime,
     ForeignKey,
@@ -46,6 +47,10 @@ class ExtractionSchema(Base):
     json_schema: Mapped[dict] = mapped_column(JSONB, nullable=False)
     examples: Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
     custom_prompt: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    # True when json_schema was inferred from examples rather than supplied
+    # explicitly by the caller.
+    is_schema_inferred: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     # Token counts cached at registration time (schemas are immutable so these
     # never go stale and save one /tokenize call per extraction request).

--- a/services/extract/db/models.py
+++ b/services/extract/db/models.py
@@ -48,7 +48,7 @@ class ExtractionSchema(Base):
     examples: Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
     custom_prompt: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
-    # True when json_schema was inferred from examples rather than supplied
+    # True when json_schema is inferred from examples rather than supplied
     # explicitly by the caller.
     is_schema_inferred: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 

--- a/services/extract/db/scripts/init_schema.sql
+++ b/services/extract/db/scripts/init_schema.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS schemas (
     json_schema           JSONB NOT NULL,
     examples              JSONB,
     custom_prompt         TEXT,
+    is_schema_inferred    BOOLEAN NOT NULL DEFAULT FALSE,
     schema_tokens         INTEGER NOT NULL,
     examples_tokens       INTEGER NOT NULL DEFAULT 0,
     custom_prompt_tokens  INTEGER NOT NULL DEFAULT 0,

--- a/services/extract/models.py
+++ b/services/extract/models.py
@@ -43,8 +43,12 @@ class SchemaRegisterRequest(BaseModel):
     description: Optional[str] = Field(
         None, description="Free-text description of what the schema extracts"
     )
-    json_schema: Dict[str, Any] = Field(
-        ..., description="JSON Schema draft 2020-12.  Root must be type:object."
+    json_schema: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "JSON Schema draft 2020-12.  Root must be type:object.  "
+            "If omitted, the schema is inferred automatically from the provided examples."
+        ),
     )
     examples: Optional[List[ExampleItem]] = Field(
         None,

--- a/services/extract/models.py
+++ b/services/extract/models.py
@@ -107,6 +107,7 @@ class SchemaDetailResponse(BaseModel):
     schema_id: str
     name: str
     description: Optional[str] = None
+    is_schema_inferred: bool = False
     json_schema: Dict[str, Any]
     examples: Optional[List[Dict[str, Any]]] = None
     custom_prompt: Optional[str] = None

--- a/services/extract/tests/unit/test_schema_registry.py
+++ b/services/extract/tests/unit/test_schema_registry.py
@@ -68,6 +68,31 @@ _VALID_SCHEMA_BODY_WITH_EXAMPLE = {
     ],
 }
 
+# Body that omits json_schema — schema should be inferred from examples.
+_INFER_SCHEMA_BODY = {
+    "name": "invoice-inferred",
+    "description": "Schema inferred from examples",
+    "examples": [
+        {
+            "text": "Invoice #001 Total: 100",
+            "output": {"invoice_number": "001", "total_amount": 100.0},
+        },
+        {
+            "text": "Invoice #002 Total: 200",
+            "output": {"invoice_number": "002", "total_amount": 200.0},
+        },
+    ],
+}
+
+_INFERRED_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "invoice_number": {"type": "string"},
+        "total_amount": {"type": "number"},
+    },
+    "required": ["invoice_number", "total_amount"],
+}
+
 
 # =========================================================================
 # Health & root endpoints
@@ -211,6 +236,83 @@ class TestRegisterSchema:
             json={"name": "has space!", "json_schema": {"type": "object", "properties": {}}},
         )
         assert resp.status_code == 422
+
+    def test_neither_schema_nor_examples_returns_400(self, extract_test_client):
+        """Omitting both json_schema and examples must return 400 MISSING_SCHEMA."""
+        with patch("extract.api.v1.schema.db_repo.schema_name_exists", return_value=False):
+            resp = extract_test_client.post(
+                "/v1/schemas",
+                json={"name": "no-schema-no-examples"},
+            )
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "MISSING_SCHEMA"
+
+    def test_inferred_schema_from_examples_returns_201(self, extract_test_client, monkeypatch):
+        """When json_schema is absent, schema is inferred from examples and registered."""
+        monkeypatch.setattr(
+            "extract.api.v1.schema.asyncio.to_thread",
+            AsyncMock(return_value=(40, 60, 0)),
+        )
+        inferred_row = _mock_schema_row(
+            name="invoice-inferred",
+            json_schema=_INFERRED_SCHEMA,
+        )
+        with patch("extract.api.v1.schema.db_repo.schema_name_exists", return_value=False), \
+             patch("extract.api.v1.schema.infer_schema_from_examples", return_value=_INFERRED_SCHEMA) as mock_infer, \
+             patch("extract.utils.schema.normalize_schema", return_value=_INFERRED_SCHEMA), \
+             patch("extract.api.v1.schema.validate_json_schema_structure"), \
+             patch("extract.api.v1.schema.validate_examples"), \
+             patch("extract.api.v1.schema.check_schema_share_in_context"), \
+             patch("extract.api.v1.schema.db_repo.create_schema", return_value=inferred_row) as mock_create:
+            resp = extract_test_client.post("/v1/schemas", json=_INFER_SCHEMA_BODY)
+
+        assert resp.status_code == 201
+        # infer_schema_from_examples must have been called with the two example dicts.
+        mock_infer.assert_called_once()
+        # is_schema_inferred=True must be forwarded to the DB layer.
+        _, kwargs = mock_create.call_args
+        assert kwargs.get("is_schema_inferred") is True
+
+    def test_inferred_schema_conflict_returns_400(self, extract_test_client):
+        """Type conflict across examples during inference must surface as 400."""
+        body = {
+            "name": "conflict-schema",
+            "examples": [
+                {"text": "t1", "output": {"amount": 100}},
+                {"text": "t2", "output": {"amount": "one hundred"}},
+            ],
+        }
+        with patch("extract.api.v1.schema.db_repo.schema_name_exists", return_value=False), \
+             patch(
+                 "extract.api.v1.schema.infer_schema_from_examples",
+                 side_effect=SchemaValidationError(
+                     "SCHEMA_INFERENCE_CONFLICT",
+                     "Cannot infer schema: field 'amount' has conflicting types",
+                     400,
+                 ),
+             ):
+            resp = extract_test_client.post("/v1/schemas", json=body)
+
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "SCHEMA_INFERENCE_CONFLICT"
+
+    def test_inferred_schema_no_examples_returns_400(self, extract_test_client):
+        """Sending an explicit empty examples list with no json_schema must return 400."""
+        with patch("extract.api.v1.schema.db_repo.schema_name_exists", return_value=False), \
+             patch(
+                 "extract.api.v1.schema.infer_schema_from_examples",
+                 side_effect=SchemaValidationError(
+                     "INFERENCE_NO_EXAMPLES",
+                     "Cannot infer schema: no examples provided.",
+                     400,
+                 ),
+             ):
+            resp = extract_test_client.post(
+                "/v1/schemas",
+                json={"name": "no-examples", "examples": []},
+            )
+        # FastAPI strips empty list to None via Optional, so the MISSING_SCHEMA guard fires first.
+        assert resp.status_code == 400
 
 
 

--- a/services/extract/tests/unit/test_schema_registry.py
+++ b/services/extract/tests/unit/test_schema_registry.py
@@ -19,6 +19,7 @@ def _mock_schema_row(
     schema_id="schema-001",
     name="invoice-extraction",
     description="Test schema",
+    is_schema_inferred=False,
     json_schema=None,
     examples=None,
     custom_prompt=None,
@@ -31,6 +32,7 @@ def _mock_schema_row(
     row.schema_id = schema_id
     row.name = name
     row.description = description
+    row.is_schema_inferred = is_schema_inferred
     row.json_schema = json_schema or {
         "type": "object",
         "properties": {"name": {"type": "string"}},

--- a/services/extract/tests/unit/test_schema_utils.py
+++ b/services/extract/tests/unit/test_schema_utils.py
@@ -12,6 +12,7 @@ from extract.utils.schema import (
     check_extraction_budget,
     check_schema_share_in_context,
     compute_reserved_output,
+    infer_schema_from_examples,
     normalize_schema,
     validate_examples,
     validate_json_schema_structure,
@@ -241,6 +242,192 @@ class TestValidateExamples:
             )
         assert exc_info.value.details["example_index"] == 1
 
+
+
+# ---------------------------------------------------------------------------
+# infer_schema_from_examples
+# ---------------------------------------------------------------------------
+
+class TestInferSchemaFromExamples:
+    """Tests for the schema-inference path (no explicit json_schema supplied)."""
+
+    # ------------------------------------------------------------------
+    # Basic happy paths
+    # ------------------------------------------------------------------
+
+    def test_single_example_flat_types(self):
+        examples = [{"text": "t", "output": {"name": "Alice", "age": 30, "score": 9.5, "active": True}}]
+        schema = infer_schema_from_examples(examples)
+
+        assert schema["type"] == "object"
+        props = schema["properties"]
+        assert props["name"] == {"type": "string"}
+        assert props["age"] == {"type": "integer"}
+        assert props["score"] == {"type": "number"}
+        assert props["active"] == {"type": "boolean"}
+
+    def test_single_example_all_fields_required(self):
+        """Every field from a single example must appear in required."""
+        examples = [{"text": "t", "output": {"a": "x", "b": 1}}]
+        schema = infer_schema_from_examples(examples)
+        assert set(schema["required"]) == {"a", "b"}
+
+    def test_field_present_in_all_examples_is_required(self):
+        examples = [
+            {"text": "t1", "output": {"name": "Alice", "opt": "x"}},
+            {"text": "t2", "output": {"name": "Bob"}},
+        ]
+        schema = infer_schema_from_examples(examples)
+        assert "name" in schema["required"]
+        assert "opt" not in schema["required"]
+
+    def test_field_absent_from_all_examples_has_no_required(self):
+        """If every example omits a field entirely, it never appears at all."""
+        examples = [
+            {"text": "t1", "output": {"a": 1}},
+            {"text": "t2", "output": {"b": 2}},
+        ]
+        schema = infer_schema_from_examples(examples)
+        # Neither field is present in all examples.
+        assert "required" not in schema or set(schema.get("required", [])) == set()
+
+    def test_null_value_infers_null_type(self):
+        examples = [{"text": "t", "output": {"field": None}}]
+        schema = infer_schema_from_examples(examples)
+        assert schema["properties"]["field"] == {"type": "null"}
+
+    def test_list_value_infers_array_type(self):
+        examples = [{"text": "t", "output": {"tags": ["a", "b"]}}]
+        schema = infer_schema_from_examples(examples)
+        assert schema["properties"]["tags"] == {"type": "array"}
+
+    # ------------------------------------------------------------------
+    # Nested dict (recursive)
+    # ------------------------------------------------------------------
+
+    def test_nested_dict_becomes_object_sub_schema(self):
+        examples = [
+            {"text": "t", "output": {"address": {"street": "Main St", "zip": "12345"}}}
+        ]
+        schema = infer_schema_from_examples(examples)
+        addr = schema["properties"]["address"]
+        assert addr["type"] == "object"
+        assert addr["properties"]["street"] == {"type": "string"}
+        assert addr["properties"]["zip"] == {"type": "string"}
+
+    def test_nested_dict_merged_across_examples(self):
+        """Same nested field seen in two examples with the same types merges cleanly."""
+        examples = [
+            {"text": "t1", "output": {"meta": {"a": "x"}}},
+            {"text": "t2", "output": {"meta": {"b": 1}}},
+        ]
+        schema = infer_schema_from_examples(examples)
+        meta = schema["properties"]["meta"]
+        assert meta["type"] == "object"
+        assert meta["properties"]["a"] == {"type": "string"}
+        assert meta["properties"]["b"] == {"type": "integer"}
+
+    def test_deeply_nested_dict(self):
+        examples = [{"text": "t", "output": {"a": {"b": {"c": 42}}}}]
+        schema = infer_schema_from_examples(examples)
+        assert schema["properties"]["a"]["properties"]["b"]["properties"]["c"] == {"type": "integer"}
+
+    # ------------------------------------------------------------------
+    # bool vs int disambiguation
+    # ------------------------------------------------------------------
+
+    def test_bool_not_confused_with_integer(self):
+        """Python bool is a subclass of int; must be typed as boolean, not integer."""
+        examples = [{"text": "t", "output": {"flag": True}}]
+        schema = infer_schema_from_examples(examples)
+        assert schema["properties"]["flag"] == {"type": "boolean"}
+
+    # ------------------------------------------------------------------
+    # Type-conflict detection
+    # ------------------------------------------------------------------
+
+    def test_conflicting_types_raises(self):
+        examples = [
+            {"text": "t1", "output": {"amount": 100}},
+            {"text": "t2", "output": {"amount": "one hundred"}},
+        ]
+        with pytest.raises(SchemaValidationError) as exc_info:
+            infer_schema_from_examples(examples)
+        err = exc_info.value
+        assert err.code == "SCHEMA_INFERENCE_CONFLICT"
+        assert err.status == 400
+        assert "amount" in err.message
+
+    def test_conflicting_nested_types_raises(self):
+        examples = [
+            {"text": "t1", "output": {"meta": {"val": 1}}},
+            {"text": "t2", "output": {"meta": {"val": "one"}}},
+        ]
+        with pytest.raises(SchemaValidationError) as exc_info:
+            infer_schema_from_examples(examples)
+        assert exc_info.value.code == "SCHEMA_INFERENCE_CONFLICT"
+        assert "meta.val" in exc_info.value.message
+
+    def test_conflicting_top_level_vs_nested_type_raises(self):
+        """A string in one example and an object in another must raise a conflict."""
+        examples = [
+            {"text": "t1", "output": {"field": "plain"}},
+            {"text": "t2", "output": {"field": {"nested": 1}}},
+        ]
+        with pytest.raises(SchemaValidationError) as exc_info:
+            infer_schema_from_examples(examples)
+        assert exc_info.value.code == "SCHEMA_INFERENCE_CONFLICT"
+
+    # ------------------------------------------------------------------
+    # Error cases
+    # ------------------------------------------------------------------
+
+    def test_no_examples_raises(self):
+        with pytest.raises(SchemaValidationError) as exc_info:
+            infer_schema_from_examples([])
+        assert exc_info.value.code == "INFERENCE_NO_EXAMPLES"
+        assert exc_info.value.status == 400
+
+    def test_non_dict_output_raises(self):
+        with pytest.raises(SchemaValidationError) as exc_info:
+            infer_schema_from_examples([{"text": "t", "output": ["not", "a", "dict"]}])
+        assert exc_info.value.code == "INFERENCE_INVALID_EXAMPLE"
+        assert exc_info.value.status == 400
+
+    def test_non_dict_output_reports_correct_index(self):
+        examples = [
+            {"text": "t1", "output": {"ok": 1}},
+            {"text": "t2", "output": "not an object"},
+        ]
+        with pytest.raises(SchemaValidationError) as exc_info:
+            infer_schema_from_examples(examples)
+        assert "examples[1]" in exc_info.value.message
+
+    # ------------------------------------------------------------------
+    # Empty output dict
+    # ------------------------------------------------------------------
+
+    def test_empty_output_dict_produces_empty_schema(self):
+        examples = [{"text": "t", "output": {}}]
+        schema = infer_schema_from_examples(examples)
+        assert schema["type"] == "object"
+        assert schema["properties"] == {}
+        assert "required" not in schema
+
+    # ------------------------------------------------------------------
+    # Schema structure is valid draft 2020-12
+    # ------------------------------------------------------------------
+
+    def test_inferred_schema_passes_structural_validation(self):
+        """The schema produced by inference must itself pass validate_json_schema_structure."""
+        examples = [
+            {"text": "t1", "output": {"name": "Alice", "age": 30}},
+            {"text": "t2", "output": {"name": "Bob", "age": 25, "city": "Berlin"}},
+        ]
+        schema = infer_schema_from_examples(examples)
+        # Should not raise.
+        validate_json_schema_structure(schema)
+        assert schema["required"] == ["name", "age"]
 
 
 # ---------------------------------------------------------------------------

--- a/services/extract/tests/unit/test_schema_utils.py
+++ b/services/extract/tests/unit/test_schema_utils.py
@@ -299,7 +299,7 @@ class TestInferSchemaFromExamples:
     def test_list_value_infers_array_type(self):
         examples = [{"text": "t", "output": {"tags": ["a", "b"]}}]
         schema = infer_schema_from_examples(examples)
-        assert schema["properties"]["tags"] == {"type": "array"}
+        assert schema["properties"]["tags"] == {'type': 'array', 'items': {'type': 'string'}}
 
     # ------------------------------------------------------------------
     # Nested dict (recursive)
@@ -407,12 +407,11 @@ class TestInferSchemaFromExamples:
     # Empty output dict
     # ------------------------------------------------------------------
 
-    def test_empty_output_dict_produces_empty_schema(self):
+    def test_empty_output_dict_raises_error(self):
         examples = [{"text": "t", "output": {}}]
-        schema = infer_schema_from_examples(examples)
-        assert schema["type"] == "object"
-        assert schema["properties"] == {}
-        assert "required" not in schema
+        with pytest.raises(SchemaValidationError) as exc_info:
+            infer_schema_from_examples(examples)
+        assert exc_info.value.code == "INFERENCE_EMPTY_EXAMPLE"
 
     # ------------------------------------------------------------------
     # Schema structure is valid draft 2020-12

--- a/services/extract/utils/schema.py
+++ b/services/extract/utils/schema.py
@@ -15,7 +15,7 @@ Responsibilities:
 import json
 import re
 import copy
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import jsonschema
 from jsonschema import Draft202012Validator
@@ -191,6 +191,234 @@ def validate_json_schema_structure(json_schema: Dict[str, Any]) -> None:
             f"The root of json_schema must be 'type: object'; got {root_type!r}.",
             status=400,
         )
+
+
+# ---------------------------------------------------------------------------
+# Schema inference from examples
+# ---------------------------------------------------------------------------
+
+def _infer_object_schema(value: dict) -> Dict[str, Any]:
+    """
+    Infer a ``type: object`` sub-schema from a single dict value.
+
+    Every key present in *value* is added to ``required`` (the all-present
+    default). When multiple examples are merged, ``_merge_type_nodes``
+    intersects the ``required`` arrays so only universally-present keys
+    remain required.
+    """
+    properties = {k: _python_type_to_json_schema(v) for k, v in value.items()}
+    schema: Dict[str, Any] = {"type": "object", "properties": properties}
+    if properties:
+        schema["required"] = list(value.keys())
+    return schema
+
+
+def _infer_array_schema(value: list) -> Dict[str, Any]:
+    """
+    Infer a ``type: array`` schema from a list value.
+
+    If the list is non-empty, ``items`` is derived by inferring a schema from
+    each element and merging them (so ``[1, 2.5]`` yields
+    ``items: {type: number}``).  Empty lists produce an unconstrained array.
+    """
+    if not value:
+        return {"type": "array"}
+
+    items_schema = _python_type_to_json_schema(value[0])
+    for element in value[1:]:
+        items_schema = _merge_type_nodes(
+            items_schema, _python_type_to_json_schema(element), "[]"
+        )
+    return {"type": "array", "items": items_schema}
+
+
+def _python_type_to_json_schema(value: Any) -> Dict[str, Any]:
+    """Return the JSON Schema type node for a single Python *value*."""
+    # bool must be checked before int because bool is a subclass of int.
+    if isinstance(value, bool):
+        return {"type": "boolean"}
+    if isinstance(value, int):
+        return {"type": "integer"}
+    if isinstance(value, float):
+        return {"type": "number"}
+    if isinstance(value, str):
+        return {"type": "string"}
+    if isinstance(value, list):
+        return _infer_array_schema(value)
+    if isinstance(value, dict):
+        return _infer_object_schema(value)
+    if value is None:
+        return {"type": "null"}
+    # Fallback for unexpected types.
+    return {}
+
+
+def _merge_type_nodes(
+    existing: Dict[str, Any],
+    incoming: Dict[str, Any],
+    field_path: str,
+) -> Dict[str, Any]:
+    """
+    Merge two JSON Schema type nodes for the same field seen in two
+    different examples.
+
+    - Identical nodes are returned as-is.
+    - Two ``type: object`` nodes have their ``properties`` merged recursively.
+    - Differing ``type`` values raise SchemaValidationError.
+    """
+    if existing == incoming:
+        return existing
+
+    existing_type = existing.get("type")
+    incoming_type = incoming.get("type")
+
+    # --- null + any concrete type → nullable ---
+    if existing_type == "null" or incoming_type == "null":
+        non_null = incoming if existing_type == "null" else existing
+        non_null_type = non_null.get("type")
+        if non_null_type is None:
+            return non_null
+        result = dict(non_null)
+        if isinstance(non_null_type, list):
+            if "null" not in non_null_type:
+                result["type"] = non_null_type + ["null"]
+        else:
+            result["type"] = [non_null_type, "null"]
+        return result
+
+    # --- integer + number → number ---
+    if {existing_type, incoming_type} == {"integer", "number"}:
+        return {"type": "number"}
+
+    # --- object + object → union properties, intersect required ---
+    if existing_type == "object" and incoming_type == "object":
+        merged_props: Dict[str, Any] = dict(existing.get("properties", {}))
+        for key, inc_prop in incoming.get("properties", {}).items():
+            if key in merged_props:
+                merged_props[key] = _merge_type_nodes(
+                    merged_props[key], inc_prop, f"{field_path}.{key}"
+                )
+            else:
+                merged_props[key] = inc_prop
+
+        existing_req = set(existing.get("required", []))
+        incoming_req = set(incoming.get("required", []))
+        merged_required = sorted(existing_req & incoming_req)
+
+        result = {"type": "object", "properties": merged_props}
+        if merged_required:
+            result["required"] = merged_required
+        return result
+
+    # --- array + array → merge items ---
+    if existing_type == "array" and incoming_type == "array":
+        existing_items = existing.get("items")
+        incoming_items = incoming.get("items")
+        if existing_items and incoming_items:
+            merged_items = _merge_type_nodes(
+                existing_items, incoming_items, f"{field_path}[]"
+            )
+            return {"type": "array", "items": merged_items}
+        # One or both sides have no items (inferred from empty list);
+        # keep whichever has type information.
+        return {"type": "array", "items": existing_items or incoming_items}
+
+    # --- irreconcilable conflict ---
+    if existing_type != incoming_type:
+        raise SchemaValidationError(
+            "SCHEMA_INFERENCE_CONFLICT",
+            (
+                f"Cannot infer schema: field {field_path!r} has conflicting types "
+                f"across examples ({existing_type!r} vs {incoming_type!r})."
+            ),
+            status=400,
+        )
+
+    return existing
+
+
+def infer_schema_from_examples(examples: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Infer a JSON Schema draft 2020-12 ``type: object`` from example outputs.
+
+    *examples* is a list of raw example dicts (each having an ``output`` key).
+
+    Algorithm:
+    1. For each example's ``output`` dict, derive a type node per field
+       recursively (nested dicts become nested ``type: object`` sub-schemas).
+    2. Merge type nodes across examples; raise SchemaValidationError if the
+       same field has conflicting types.
+    3. Fields present in **all** examples are added to ``required``.
+
+    Raises SchemaValidationError if no examples are provided or a type
+    conflict is detected.
+    """
+    """
+        Infer a JSON Schema draft 2020-12 ``type: object`` from example outputs.
+
+        *examples* is a list of raw example dicts (each having an ``output`` key).
+
+        Algorithm:
+        1. For each example's ``output`` dict, derive a type node per field
+           recursively (nested dicts become nested ``type: object`` sub-schemas,
+           non-empty lists infer ``items`` from their elements).
+        2. Merge type nodes across examples: identical nodes pass through,
+           ``integer`` + ``number`` widens to ``number``, ``null`` + any type
+           produces a nullable type, and two ``object`` nodes have their
+           ``properties`` unioned and ``required`` arrays intersected.
+           Irreconcilable type conflicts raise SchemaValidationError.
+        3. Fields present in **all** examples are added to ``required``.
+
+        Raises SchemaValidationError if no examples are provided, an example
+        output is not a non-empty dict, or a type conflict is detected.
+        """
+    if not examples:
+        raise SchemaValidationError(
+            "INFERENCE_NO_EXAMPLES",
+            "Cannot infer schema: no examples provided. "
+            "Supply at least one example or provide json_schema explicitly.",
+            status=400,
+        )
+
+    field_schemas: Dict[str, Any] = {}
+    field_counts: Dict[str, int] = {}
+    total = len(examples)
+
+    for idx, example in enumerate(examples):
+        output = example.get("output", {})
+        if not isinstance(output, dict):
+            raise SchemaValidationError(
+                "INFERENCE_INVALID_EXAMPLE",
+                f"examples[{idx}].output must be an object for schema inference.",
+                status=400,
+            )
+        if not output:
+            raise SchemaValidationError(
+                "INFERENCE_EMPTY_EXAMPLE",
+                f"examples[{idx}].output must be a non-empty object for schema "
+                f"inference.",
+                status=400,
+            )
+        for key, value in output.items():
+            incoming_node = _python_type_to_json_schema(value)
+            if key in field_schemas:
+                field_schemas[key] = _merge_type_nodes(
+                    field_schemas[key], incoming_node, key
+                )
+            else:
+                field_schemas[key] = incoming_node
+            field_counts[key] = field_counts.get(key, 0) + 1
+
+    required = [k for k, count in field_counts.items() if count == total]
+
+    schema: Dict[str, Any] = {
+        "type": "object",
+        "properties": field_schemas,
+    }
+    if required:
+        schema["required"] = required
+
+    return schema
 
 
 # ---------------------------------------------------------------------------

--- a/services/extract/utils/schema.py
+++ b/services/extract/utils/schema.py
@@ -264,14 +264,59 @@ def _merge_type_nodes(
     different examples.
 
     - Identical nodes are returned as-is.
-    - Two ``type: object`` nodes have their ``properties`` merged recursively.
-    - Differing ``type`` values raise SchemaValidationError.
+    - Already-nullable list types (e.g. ``["integer", "null"]``) are
+      unwrapped to their base type, merged normally, then re-wrapped
+      with null if either side was nullable.
+    - ``null`` + any concrete type produces a nullable type
+      (e.g. ``{"type": ["string", "null"]}``).
+    - ``integer`` + ``number`` widens to ``number``.
+    - Two ``type: object`` nodes have their ``properties`` unioned and
+      their ``required`` arrays intersected.
+    - Two ``type: array`` nodes have their ``items`` merged recursively.
+    - All other type mismatches raise SchemaValidationError.
     """
     if existing == incoming:
         return existing
 
     existing_type = existing.get("type")
     incoming_type = incoming.get("type")
+
+    # --- already-nullable list type on either side → unwrap, merge base, re-wrap ---
+    existing_is_list = isinstance(existing_type, list)
+    incoming_is_list = isinstance(incoming_type, list)
+
+    if existing_is_list or incoming_is_list:
+        existing_has_null = existing_is_list and "null" in existing_type
+        incoming_has_null = incoming_is_list and "null" in incoming_type
+
+        if existing_is_list:
+            existing_base = [t for t in existing_type if t != "null"]
+            existing_base = existing_base[0] if len(existing_base) == 1 else existing_base
+        else:
+            existing_base = existing_type
+
+        if incoming_is_list:
+            incoming_base = [t for t in incoming_type if t != "null"]
+            incoming_base = incoming_base[0] if len(incoming_base) == 1 else incoming_base
+        else:
+            incoming_base = incoming_type
+
+        base_existing = dict(existing)
+        base_existing["type"] = existing_base
+        base_incoming = dict(incoming)
+        base_incoming["type"] = incoming_base
+
+        merged = _merge_type_nodes(base_existing, base_incoming, field_path)
+
+        if existing_has_null or incoming_has_null:
+            merged_type = merged.get("type")
+            if isinstance(merged_type, list):
+                if "null" not in merged_type:
+                    merged["type"] = merged_type + ["null"]
+            else:
+                merged["type"] = [merged_type, "null"]
+
+        return merged
 
     # --- null + any concrete type → nullable ---
     if existing_type == "null" or incoming_type == "null":
@@ -320,8 +365,6 @@ def _merge_type_nodes(
                 existing_items, incoming_items, f"{field_path}[]"
             )
             return {"type": "array", "items": merged_items}
-        # One or both sides have no items (inferred from empty list);
-        # keep whichever has type information.
         return {"type": "array", "items": existing_items or incoming_items}
 
     # --- irreconcilable conflict ---

--- a/services/extract/utils/schema.py
+++ b/services/extract/utils/schema.py
@@ -263,14 +263,59 @@ def _merge_type_nodes(
     different examples.
 
     - Identical nodes are returned as-is.
-    - Two ``type: object`` nodes have their ``properties`` merged recursively.
-    - Differing ``type`` values raise SchemaValidationError.
+    - Already-nullable list types (e.g. ``["integer", "null"]``) are
+      unwrapped to their base type, merged normally, then re-wrapped
+      with null if either side was nullable.
+    - ``null`` + any concrete type produces a nullable type
+      (e.g. ``{"type": ["string", "null"]}``).
+    - ``integer`` + ``number`` widens to ``number``.
+    - Two ``type: object`` nodes have their ``properties`` unioned and
+      their ``required`` arrays intersected.
+    - Two ``type: array`` nodes have their ``items`` merged recursively.
+    - All other type mismatches raise SchemaValidationError.
     """
     if existing == incoming:
         return existing
 
     existing_type = existing.get("type")
     incoming_type = incoming.get("type")
+
+    # --- already-nullable list type on either side → unwrap, merge base, re-wrap ---
+    existing_is_list = isinstance(existing_type, list)
+    incoming_is_list = isinstance(incoming_type, list)
+
+    if existing_is_list or incoming_is_list:
+        existing_has_null = existing_is_list and "null" in existing_type
+        incoming_has_null = incoming_is_list and "null" in incoming_type
+
+        if existing_is_list:
+            existing_base = [t for t in existing_type if t != "null"]
+            existing_base = existing_base[0] if len(existing_base) == 1 else existing_base
+        else:
+            existing_base = existing_type
+
+        if incoming_is_list:
+            incoming_base = [t for t in incoming_type if t != "null"]
+            incoming_base = incoming_base[0] if len(incoming_base) == 1 else incoming_base
+        else:
+            incoming_base = incoming_type
+
+        base_existing = dict(existing)
+        base_existing["type"] = existing_base
+        base_incoming = dict(incoming)
+        base_incoming["type"] = incoming_base
+
+        merged = _merge_type_nodes(base_existing, base_incoming, field_path)
+
+        if existing_has_null or incoming_has_null:
+            merged_type = merged.get("type")
+            if isinstance(merged_type, list):
+                if "null" not in merged_type:
+                    merged["type"] = merged_type + ["null"]
+            else:
+                merged["type"] = [merged_type, "null"]
+
+        return merged
 
     # --- null + any concrete type → nullable ---
     if existing_type == "null" or incoming_type == "null":
@@ -319,8 +364,6 @@ def _merge_type_nodes(
                 existing_items, incoming_items, f"{field_path}[]"
             )
             return {"type": "array", "items": merged_items}
-        # One or both sides have no items (inferred from empty list);
-        # keep whichever has type information.
         return {"type": "array", "items": existing_items or incoming_items}
 
     # --- irreconcilable conflict ---

--- a/services/extract/utils/schema.py
+++ b/services/extract/utils/schema.py
@@ -388,33 +388,18 @@ def infer_schema_from_examples(examples: List[Dict[str, Any]]) -> Dict[str, Any]
 
     Algorithm:
     1. For each example's ``output`` dict, derive a type node per field
-       recursively (nested dicts become nested ``type: object`` sub-schemas).
-    2. Merge type nodes across examples; raise SchemaValidationError if the
-       same field has conflicting types.
+       recursively (nested dicts become nested ``type: object`` sub-schemas,
+       non-empty lists infer ``items`` from their elements).
+    2. Merge type nodes across examples: identical nodes pass through,
+       ``integer`` + ``number`` widens to ``number``, ``null`` + any type
+       produces a nullable type, and two ``object`` nodes have their
+       ``properties`` unioned and ``required`` arrays intersected.
+       Irreconcilable type conflicts raise SchemaValidationError.
     3. Fields present in **all** examples are added to ``required``.
 
-    Raises SchemaValidationError if no examples are provided or a type
-    conflict is detected.
+    Raises SchemaValidationError if no examples are provided, an example
+    output is not a non-empty dict, or a type conflict is detected.
     """
-    """
-        Infer a JSON Schema draft 2020-12 ``type: object`` from example outputs.
-
-        *examples* is a list of raw example dicts (each having an ``output`` key).
-
-        Algorithm:
-        1. For each example's ``output`` dict, derive a type node per field
-           recursively (nested dicts become nested ``type: object`` sub-schemas,
-           non-empty lists infer ``items`` from their elements).
-        2. Merge type nodes across examples: identical nodes pass through,
-           ``integer`` + ``number`` widens to ``number``, ``null`` + any type
-           produces a nullable type, and two ``object`` nodes have their
-           ``properties`` unioned and ``required`` arrays intersected.
-           Irreconcilable type conflicts raise SchemaValidationError.
-        3. Fields present in **all** examples are added to ``required``.
-
-        Raises SchemaValidationError if no examples are provided, an example
-        output is not a non-empty dict, or a type conflict is detected.
-        """
     if not examples:
         raise SchemaValidationError(
             "INFERENCE_NO_EXAMPLES",

--- a/services/extract/utils/schema.py
+++ b/services/extract/utils/schema.py
@@ -389,33 +389,18 @@ def infer_schema_from_examples(examples: List[Dict[str, Any]]) -> Dict[str, Any]
 
     Algorithm:
     1. For each example's ``output`` dict, derive a type node per field
-       recursively (nested dicts become nested ``type: object`` sub-schemas).
-    2. Merge type nodes across examples; raise SchemaValidationError if the
-       same field has conflicting types.
+       recursively (nested dicts become nested ``type: object`` sub-schemas,
+       non-empty lists infer ``items`` from their elements).
+    2. Merge type nodes across examples: identical nodes pass through,
+       ``integer`` + ``number`` widens to ``number``, ``null`` + any type
+       produces a nullable type, and two ``object`` nodes have their
+       ``properties`` unioned and ``required`` arrays intersected.
+       Irreconcilable type conflicts raise SchemaValidationError.
     3. Fields present in **all** examples are added to ``required``.
 
-    Raises SchemaValidationError if no examples are provided or a type
-    conflict is detected.
+    Raises SchemaValidationError if no examples are provided, an example
+    output is not a non-empty dict, or a type conflict is detected.
     """
-    """
-        Infer a JSON Schema draft 2020-12 ``type: object`` from example outputs.
-
-        *examples* is a list of raw example dicts (each having an ``output`` key).
-
-        Algorithm:
-        1. For each example's ``output`` dict, derive a type node per field
-           recursively (nested dicts become nested ``type: object`` sub-schemas,
-           non-empty lists infer ``items`` from their elements).
-        2. Merge type nodes across examples: identical nodes pass through,
-           ``integer`` + ``number`` widens to ``number``, ``null`` + any type
-           produces a nullable type, and two ``object`` nodes have their
-           ``properties`` unioned and ``required`` arrays intersected.
-           Irreconcilable type conflicts raise SchemaValidationError.
-        3. Fields present in **all** examples are added to ``required``.
-
-        Raises SchemaValidationError if no examples are provided, an example
-        output is not a non-empty dict, or a type conflict is detected.
-        """
     if not examples:
         raise SchemaValidationError(
             "INFERENCE_NO_EXAMPLES",

--- a/services/extract/utils/schema.py
+++ b/services/extract/utils/schema.py
@@ -16,7 +16,7 @@ import json
 import re
 import copy
 from datetime import timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import jsonschema
 from jsonschema import Draft202012Validator
@@ -192,6 +192,234 @@ def validate_json_schema_structure(json_schema: Dict[str, Any]) -> None:
             f"The root of json_schema must be 'type: object'; got {root_type!r}.",
             status=400,
         )
+
+
+# ---------------------------------------------------------------------------
+# Schema inference from examples
+# ---------------------------------------------------------------------------
+
+def _infer_object_schema(value: dict) -> Dict[str, Any]:
+    """
+    Infer a ``type: object`` sub-schema from a single dict value.
+
+    Every key present in *value* is added to ``required`` (the all-present
+    default). When multiple examples are merged, ``_merge_type_nodes``
+    intersects the ``required`` arrays so only universally-present keys
+    remain required.
+    """
+    properties = {k: _python_type_to_json_schema(v) for k, v in value.items()}
+    schema: Dict[str, Any] = {"type": "object", "properties": properties}
+    if properties:
+        schema["required"] = list(value.keys())
+    return schema
+
+
+def _infer_array_schema(value: list) -> Dict[str, Any]:
+    """
+    Infer a ``type: array`` schema from a list value.
+
+    If the list is non-empty, ``items`` is derived by inferring a schema from
+    each element and merging them (so ``[1, 2.5]`` yields
+    ``items: {type: number}``).  Empty lists produce an unconstrained array.
+    """
+    if not value:
+        return {"type": "array"}
+
+    items_schema = _python_type_to_json_schema(value[0])
+    for element in value[1:]:
+        items_schema = _merge_type_nodes(
+            items_schema, _python_type_to_json_schema(element), "[]"
+        )
+    return {"type": "array", "items": items_schema}
+
+
+def _python_type_to_json_schema(value: Any) -> Dict[str, Any]:
+    """Return the JSON Schema type node for a single Python *value*."""
+    # bool must be checked before int because bool is a subclass of int.
+    if isinstance(value, bool):
+        return {"type": "boolean"}
+    if isinstance(value, int):
+        return {"type": "integer"}
+    if isinstance(value, float):
+        return {"type": "number"}
+    if isinstance(value, str):
+        return {"type": "string"}
+    if isinstance(value, list):
+        return _infer_array_schema(value)
+    if isinstance(value, dict):
+        return _infer_object_schema(value)
+    if value is None:
+        return {"type": "null"}
+    # Fallback for unexpected types.
+    return {}
+
+
+def _merge_type_nodes(
+    existing: Dict[str, Any],
+    incoming: Dict[str, Any],
+    field_path: str,
+) -> Dict[str, Any]:
+    """
+    Merge two JSON Schema type nodes for the same field seen in two
+    different examples.
+
+    - Identical nodes are returned as-is.
+    - Two ``type: object`` nodes have their ``properties`` merged recursively.
+    - Differing ``type`` values raise SchemaValidationError.
+    """
+    if existing == incoming:
+        return existing
+
+    existing_type = existing.get("type")
+    incoming_type = incoming.get("type")
+
+    # --- null + any concrete type → nullable ---
+    if existing_type == "null" or incoming_type == "null":
+        non_null = incoming if existing_type == "null" else existing
+        non_null_type = non_null.get("type")
+        if non_null_type is None:
+            return non_null
+        result = dict(non_null)
+        if isinstance(non_null_type, list):
+            if "null" not in non_null_type:
+                result["type"] = non_null_type + ["null"]
+        else:
+            result["type"] = [non_null_type, "null"]
+        return result
+
+    # --- integer + number → number ---
+    if {existing_type, incoming_type} == {"integer", "number"}:
+        return {"type": "number"}
+
+    # --- object + object → union properties, intersect required ---
+    if existing_type == "object" and incoming_type == "object":
+        merged_props: Dict[str, Any] = dict(existing.get("properties", {}))
+        for key, inc_prop in incoming.get("properties", {}).items():
+            if key in merged_props:
+                merged_props[key] = _merge_type_nodes(
+                    merged_props[key], inc_prop, f"{field_path}.{key}"
+                )
+            else:
+                merged_props[key] = inc_prop
+
+        existing_req = set(existing.get("required", []))
+        incoming_req = set(incoming.get("required", []))
+        merged_required = sorted(existing_req & incoming_req)
+
+        result = {"type": "object", "properties": merged_props}
+        if merged_required:
+            result["required"] = merged_required
+        return result
+
+    # --- array + array → merge items ---
+    if existing_type == "array" and incoming_type == "array":
+        existing_items = existing.get("items")
+        incoming_items = incoming.get("items")
+        if existing_items and incoming_items:
+            merged_items = _merge_type_nodes(
+                existing_items, incoming_items, f"{field_path}[]"
+            )
+            return {"type": "array", "items": merged_items}
+        # One or both sides have no items (inferred from empty list);
+        # keep whichever has type information.
+        return {"type": "array", "items": existing_items or incoming_items}
+
+    # --- irreconcilable conflict ---
+    if existing_type != incoming_type:
+        raise SchemaValidationError(
+            "SCHEMA_INFERENCE_CONFLICT",
+            (
+                f"Cannot infer schema: field {field_path!r} has conflicting types "
+                f"across examples ({existing_type!r} vs {incoming_type!r})."
+            ),
+            status=400,
+        )
+
+    return existing
+
+
+def infer_schema_from_examples(examples: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Infer a JSON Schema draft 2020-12 ``type: object`` from example outputs.
+
+    *examples* is a list of raw example dicts (each having an ``output`` key).
+
+    Algorithm:
+    1. For each example's ``output`` dict, derive a type node per field
+       recursively (nested dicts become nested ``type: object`` sub-schemas).
+    2. Merge type nodes across examples; raise SchemaValidationError if the
+       same field has conflicting types.
+    3. Fields present in **all** examples are added to ``required``.
+
+    Raises SchemaValidationError if no examples are provided or a type
+    conflict is detected.
+    """
+    """
+        Infer a JSON Schema draft 2020-12 ``type: object`` from example outputs.
+
+        *examples* is a list of raw example dicts (each having an ``output`` key).
+
+        Algorithm:
+        1. For each example's ``output`` dict, derive a type node per field
+           recursively (nested dicts become nested ``type: object`` sub-schemas,
+           non-empty lists infer ``items`` from their elements).
+        2. Merge type nodes across examples: identical nodes pass through,
+           ``integer`` + ``number`` widens to ``number``, ``null`` + any type
+           produces a nullable type, and two ``object`` nodes have their
+           ``properties`` unioned and ``required`` arrays intersected.
+           Irreconcilable type conflicts raise SchemaValidationError.
+        3. Fields present in **all** examples are added to ``required``.
+
+        Raises SchemaValidationError if no examples are provided, an example
+        output is not a non-empty dict, or a type conflict is detected.
+        """
+    if not examples:
+        raise SchemaValidationError(
+            "INFERENCE_NO_EXAMPLES",
+            "Cannot infer schema: no examples provided. "
+            "Supply at least one example or provide json_schema explicitly.",
+            status=400,
+        )
+
+    field_schemas: Dict[str, Any] = {}
+    field_counts: Dict[str, int] = {}
+    total = len(examples)
+
+    for idx, example in enumerate(examples):
+        output = example.get("output", {})
+        if not isinstance(output, dict):
+            raise SchemaValidationError(
+                "INFERENCE_INVALID_EXAMPLE",
+                f"examples[{idx}].output must be an object for schema inference.",
+                status=400,
+            )
+        if not output:
+            raise SchemaValidationError(
+                "INFERENCE_EMPTY_EXAMPLE",
+                f"examples[{idx}].output must be a non-empty object for schema "
+                f"inference.",
+                status=400,
+            )
+        for key, value in output.items():
+            incoming_node = _python_type_to_json_schema(value)
+            if key in field_schemas:
+                field_schemas[key] = _merge_type_nodes(
+                    field_schemas[key], incoming_node, key
+                )
+            else:
+                field_schemas[key] = incoming_node
+            field_counts[key] = field_counts.get(key, 0) + 1
+
+    required = [k for k, count in field_counts.items() if count == total]
+
+    schema: Dict[str, Any] = {
+        "type": "object",
+        "properties": field_schemas,
+    }
+    if required:
+        schema["required"] = required
+
+    return schema
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
In this PR:

- POST /v1/schemas. now accepts input without json schema also. In that case, the service infers schema from the given examples and saves the schema in json_schema.
- added a field called is_schema_inferred in ExtractSchema db model.
- unit tests

Other than the unit tests, tested the logic with the following testcases:
```
# ---------------------------------------------------------------------------
# Case 1: Single flat example — all scalar types, everything required
# ---------------------------------------------------------------------------
CASE_1_DESC = "Single flat example — all scalars, everything required"
 
CASE_1_EXAMPLES = [
    {
        "output": {
            "invoice_number": "INV-2041",
            "total_amount": 1204.50,
            "line_count": 3,
            "is_paid": True,
        }
    }
]
 
CASE_1_EXPECTED = {
    "type": "object",
    "properties": {
        "invoice_number": {"type": "string"},
        "total_amount": {"type": "number"},
        "line_count": {"type": "integer"},
        "is_paid": {"type": "boolean"},
    },
    "required": ["invoice_number", "total_amount", "line_count", "is_paid"],
}
 
 
# ---------------------------------------------------------------------------
# Case 2: Two examples — field present in only one becomes optional
# ---------------------------------------------------------------------------
CASE_2_DESC = "Two examples — missing field drops out of required"
 
CASE_2_EXAMPLES = [
    {
        "output": {
            "vendor_name": "Acme GmbH",
            "total_amount": 500.00,
            "currency": "EUR",
        }
    },
    {
        "output": {
            "vendor_name": "Northwind",
            "total_amount": 800.00,
        }
    },
]
 
CASE_2_EXPECTED = {
    "type": "object",
    "properties": {
        "vendor_name": {"type": "string"},
        "total_amount": {"type": "number"},
        "currency": {"type": "string"},
    },
    "required": ["vendor_name", "total_amount"],
}
 
 
# ---------------------------------------------------------------------------
# Case 3: integer in one example, float in another — widens to number
# ---------------------------------------------------------------------------
CASE_3_DESC = "integer + float across examples widens to number"
 
CASE_3_EXAMPLES = [
    {"output": {"quantity": 3}},
    {"output": {"quantity": 3.5}},
]
 
CASE_3_EXPECTED = {
    "type": "object",
    "properties": {
        "quantity": {"type": "number"},
    },
    "required": ["quantity"],
}
 
 
# ---------------------------------------------------------------------------
# Case 4: null in one example, concrete type in another — nullable type
# ---------------------------------------------------------------------------
CASE_4_DESC = "null + string across examples produces nullable type"
 
CASE_4_EXAMPLES = [
    {"output": {"fax": None, "name": "Acme"}},
    {"output": {"fax": "555-1234", "name": "Globex"}},
]
 
CASE_4_EXPECTED = {
    "type": "object",
    "properties": {
        "fax": {"type": ["string", "null"]},
        "name": {"type": "string"},
    },
    "required": ["fax", "name"],
}
 
 
# ---------------------------------------------------------------------------
# Case 5: Nested object — properties unioned, required intersected
# ---------------------------------------------------------------------------
CASE_5_DESC = "Nested objects — properties unioned, required intersected"
 
CASE_5_EXAMPLES = [
    {
        "output": {
            "address": {
                "street": "123 Main St",
                "city": "Springfield",
                "zip": "62704",
            }
        }
    },
    {
        "output": {
            "address": {
                "street": "456 Oak Ave",
                "city": "Shelbyville",
                "state": "IL",
            }
        }
    },
]
 
CASE_5_EXPECTED = {
    "type": "object",
    "properties": {
        "address": {
            "type": "object",
            "properties": {
                "street": {"type": "string"},
                "city": {"type": "string"},
                "zip": {"type": "string"},
                "state": {"type": "string"},
            },
            "required": ["city", "street"],
        }
    },
    "required": ["address"],
}
 
 
# ---------------------------------------------------------------------------
# Case 6: Array with object items — items schema inferred across elements
# ---------------------------------------------------------------------------
CASE_6_DESC = "Array of objects — items schema inferred from all elements"
 
CASE_6_EXAMPLES = [
    {
        "output": {
            "line_items": [
                {"description": "Widget A", "quantity": 2, "unit_price": 10.0},
                {"description": "Widget B", "quantity": 1, "unit_price": 25.0},
            ],
        }
    }
]
 
CASE_6_EXPECTED = {
    "type": "object",
    "properties": {
        "line_items": {
            "type": "array",
            "items": {
                "type": "object",
                "properties": {
                    "description": {"type": "string"},
                    "quantity": {"type": "integer"},
                    "unit_price": {"type": "number"},
                },
                "required": ["description", "quantity", "unit_price"],
            },
        },
    },
    "required": ["line_items"],
}
 
 
# ---------------------------------------------------------------------------
# Case 7: Empty list in one example, typed list in another — keeps items
# ---------------------------------------------------------------------------
CASE_7_DESC = "Empty array merged with typed array — items schema preserved"
 
CASE_7_EXAMPLES = [
    {"output": {"items": []}},
    {"output": {"items": [1, 2, 3]}},
]
 
CASE_7_EXPECTED = {
    "type": "object",
    "properties": {
        "items": {"type": "array", "items": {"type": "integer"}},
    },
    "required": ["items"],
}
 
 
# ---------------------------------------------------------------------------
# Case 8: Three examples — required needs all three to agree
# ---------------------------------------------------------------------------
CASE_8_DESC = "Three examples — field must appear in all three to be required"
 
CASE_8_EXAMPLES = [
    {"output": {"a": "x", "b": "y", "c": "z"}},
    {"output": {"a": "x", "b": "y"}},
    {"output": {"a": "x", "c": "z"}},
]
 
CASE_8_EXPECTED = {
    "type": "object",
    "properties": {
        "a": {"type": "string"},
        "b": {"type": "string"},
        "c": {"type": "string"},
    },
    "required": ["a"],  # only "a" appears in all three
}
 
 
# ---------------------------------------------------------------------------
# Case 9: Deeply nested objects (3 levels) — recursive inference
# ---------------------------------------------------------------------------
CASE_9_DESC = "Three-level nesting — recursive object inference"
 
CASE_9_EXAMPLES = [
    {
        "output": {
            "company": {
                "name": "Acme",
                "headquarters": {
                    "country": "DE",
                    "office": {
                        "floor": 3,
                        "room": "A-12",
                    },
                },
            }
        }
    }
]
 
CASE_9_EXPECTED = {
    "type": "object",
    "properties": {
        "company": {
            "type": "object",
            "properties": {
                "name": {"type": "string"},
                "headquarters": {
                    "type": "object",
                    "properties": {
                        "country": {"type": "string"},
                        "office": {
                            "type": "object",
                            "properties": {
                                "floor": {"type": "integer"},
                                "room": {"type": "string"},
                            },
                            "required": ["floor", "room"],
                        },
                    },
                    "required": ["country", "office"],
                },
            },
            "required": ["headquarters", "name"],
        }
    },
    "required": ["company"],
}
 
 
# ---------------------------------------------------------------------------
# Case 10: Array of objects across examples — item schemas merged,
#           item-level required intersected
# ---------------------------------------------------------------------------
CASE_10_DESC = "Array items merged across examples — item properties unioned, item required intersected"
 
CASE_10_EXAMPLES = [
    {
        "output": {
            "entries": [
                {"date": "2026-01-01", "amount": 100, "note": "payment"},
            ]
        }
    },
    {
        "output": {
            "entries": [
                {"date": "2026-02-01", "amount": 200, "category": "utilities"},
            ]
        }
    },
]
 
CASE_10_EXPECTED = {
    "type": "object",
    "properties": {
        "entries": {
            "type": "array",
            "items": {
                "type": "object",
                "properties": {
                    "date": {"type": "string"},
                    "amount": {"type": "integer"},
                    "note": {"type": "string"},
                    "category": {"type": "string"},
                },
                # note only in ex1, category only in ex2 — only date+amount in both
                "required": ["amount", "date"],
            },
        }
    },
    "required": ["entries"],
}
 
 
# ---------------------------------------------------------------------------
# Case 11: Mixed array elements — int + float in same list widens items to
#           number; null element in another example makes items nullable
# ---------------------------------------------------------------------------
CASE_11_DESC = "Array element type widening (int+float) and null element across examples"
 
CASE_11_EXAMPLES = [
    {"output": {"scores": [95, 87.5, 100]}},       # int + float → number
    {"output": {"scores": [None, 72]}},             # null + int → nullable
]
 
CASE_11_EXPECTED = {
    "type": "object",
    "properties": {
        "scores": {
            "type": "array",
            "items": {"type": ["number", "null"]},
        },
    },
    "required": ["scores"],
}
 
 
# ---------------------------------------------------------------------------
# Case 12: Combination — nullable nested object field, optional top-level,
#           integer widening, all in one realistic invoice scenario
# ---------------------------------------------------------------------------
CASE_12_DESC = "Realistic invoice — nullable field, optional field, int/float widening, nested object"
 
CASE_12_EXAMPLES = [
    {
        "output": {
            "invoice_number": "INV-001",
            "total": 1500,
            "tax": 150.0,
            "po_number": None,
            "vendor": {"name": "Acme", "tax_id": "DE123456"},
            "notes": "Net 30",
        }
    },
    {
        "output": {
            "invoice_number": "INV-002",
            "total": 2400.50,
            "tax": 240,
            "po_number": "PO-8877",
            "vendor": {"name": "Globex"},
            # notes absent
        }
    },
]
 
CASE_12_EXPECTED = {
    "type": "object",
    "properties": {
        "invoice_number": {"type": "string"},
        "total": {"type": "number"},          # int + float → number
        "tax": {"type": "number"},            # float + int → number
        "po_number": {"type": ["string", "null"]},  # null + string → nullable
        "vendor": {
            "type": "object",
            "properties": {
                "name": {"type": "string"},
                "tax_id": {"type": "string"},
            },
            "required": ["name"],             # tax_id only in ex1
        },
        "notes": {"type": "string"},
    },
    # notes absent from ex2 → not required
    "required": ["invoice_number", "po_number", "tax", "total", "vendor"],
}
 
 
# ---------------------------------------------------------------------------
# Case 13: Nested object present in one example, null in another
# ---------------------------------------------------------------------------
CASE_13_DESC = "Nested object in one example, null in another — nullable object"
 
CASE_13_EXAMPLES = [
    {
        "output": {
            "id": "DOC-1",
            "metadata": {"author": "Alice", "version": 2},
        }
    },
    {
        "output": {
            "id": "DOC-2",
            "metadata": None,
        }
    },
]
 
CASE_13_EXPECTED = {
    "type": "object",
    "properties": {
        "id": {"type": "string"},
        "metadata": {
            "type": ["object", "null"],
            "properties": {
                "author": {"type": "string"},
                "version": {"type": "integer"},
            },
            "required": ["author", "version"],
        },
    },
    "required": ["id", "metadata"],
}
 
 
# ---------------------------------------------------------------------------
# Case 14: Irreconcilable type conflict — string vs boolean
# ---------------------------------------------------------------------------
CASE_14_DESC = "ERROR — irreconcilable type conflict (string vs boolean)"
 
CASE_14_EXAMPLES = [
    {"output": {"value": "some string"}},
    {"output": {"value": True}},
]
 
CASE_14_EXPECTED_ERROR = "SCHEMA_INFERENCE_CONFLICT"
 
 
# ---------------------------------------------------------------------------
# Case 15: No examples provided
# ---------------------------------------------------------------------------
CASE_15_DESC = "ERROR — empty examples list"
 
CASE_15_EXAMPLES = []
 
CASE_15_EXPECTED_ERROR = "INFERENCE_NO_EXAMPLES"
```