### PR TITLE
DSC (PR3) - Rest API Endpoints

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.212
+TAG?=v0.0.213
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.38
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.39
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.38
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.39
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.38
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.39
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.38
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.39
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.38
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.39
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.212
+  image: icr.io/ai-services-cicd/ai-services:v0.0.213
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.38
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.39
   log_level: "INFO"
   database: "digitize_metadata"
 

--- a/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
+++ b/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
@@ -261,7 +261,7 @@ DELETE /v1/connectors/{connector_id}
        if remaining_owner_count == 0:
          DELETE /v1/documents/{doc_id}
   → delete connector row
-  → cleanup staging dirs
+  → cleanup staging dirs: glob staging/connectors/<connector_id>-* and remove each match
 ```
 
 Document deletion is best-effort: `200`, `204`, `404` from `DELETE /v1/documents/{doc_id}` are treated as success; `5xx` or network failures are logged and cleanup continues.
@@ -997,9 +997,14 @@ _run_tick()
 │                                   (DB write happens inline, no separate list)
 │
 ├─ [Phase 4a] _process_new_files(ingest_list)
-│             download → create_job(connector_id, checksum) → doc_id (session creation)
-│             add_connector_checksum_entry(connector_id, checksum, doc_id)
-│             UPDATE documents.metadata
+│             for each (batch_number, remote_path, checksum):
+│               batch_dir_name = f"{connector_id}-{job_id}-{batch_number}"
+│               download file → staging/connectors/<batch_dir_name>/<filename>
+│               create_job(connector_id, checksum) → ingest → doc_id (session creation)
+│               add_connector_checksum_entry(connector_id, checksum, doc_id)
+│               UPDATE documents.metadata
+│               cleanup_staging_directory(batch_dir_name,
+│                 staging_dir/"connectors", ignore_errors=True)  ← per-file, after ingest
 │            ── RELEASE ingest_lock (after all Phase 4a membership rows committed) ─
 │
 ├─ [Phase 4b] _delete_orphans(orphan_checksums)
@@ -1015,13 +1020,16 @@ _run_tick()
 
 - Overlapping ticks are skipped by a tick guard.
 - `new_files` is updated live during staging and download.
-- Staging uses per-tick temporary directories.
+- Each file in a tick gets its own uniquely-named staging directory: `staging/connectors/<connector_id>-<job_id>-<batch_number>/`. The `job_id` is the UUID returned by `create_job()`, and `batch_number` is the zero-based index of the file within the tick's `ingest_list`. This naming makes every staging directory traceable to a specific connector, job, and position in the batch.
+- The staging directory is created immediately before `scanner.download()` and removed in the `finally` block after ingest, regardless of success or failure — before the next file is downloaded. No two batch directories exist simultaneously.
 - Download and ingest are blocking operations.
 - Fatal errors mark the tick as failed.
-- Per-file failures are counted and summarized instead of failing the whole connector.
+- Per-file failures are counted and summarized instead of failing the whole connector. Staging cleanup still runs for each file even when ingest fails.
 - Cross-connector duplicates are registered inline during Phase 3 classification — no deferred list.
 - **Phase 4b (orphan removal) always runs after Phase 4a (all new-file ingest jobs) completes.**
 - **A process-wide `ingest_lock` must be held from the Phase 2 DB read (`list_all_checksums`) through the end of Phase 4a (last `add_connector_checksum_entry` call, i.e. session creation complete).** This prevents two concurrent workers from both classifying the same brand-new checksum as absent and independently spawning duplicate ingest jobs.
+- Staging cleanup uses `cleanup_staging_directory(batch_dir_name, staging_dir / "connectors", ignore_errors=True)` from `common.misc_utils` — the same helper used by the job API, with `ignore_errors=True` for best-effort semantics.
+- On `DELETE /v1/connectors/{connector_id}`, any residual staging directories (e.g. left by a crash mid-tick) are swept by globbing `staging/connectors/<connector_id>-*` and removing each match.
 
 ### 8.3 Worker stub
 
@@ -1052,6 +1060,34 @@ def _run_tick(self) -> None:
         self._fail_tick(sync_seq, exc)
     finally:
         scanner.close()
+
+def _process_new_files(
+    self,
+    sync_seq: int,
+    scanner: BaseScanner,
+    ingest_list: list[tuple[str, str]],
+) -> None:
+    staging_base = settings.digitize.staging_dir / "connectors"
+    for batch_number, (remote_path, checksum) in enumerate(ingest_list):
+        job_id = generate_job_id()  # UUID generated before download so the dir name is known upfront
+        batch_dir_name = f"{self.connector_id}-{job_id}-{batch_number}"
+        batch_dir = staging_base / batch_dir_name
+        batch_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            scanner.download(remote_path, batch_dir)
+            doc_id = create_job(self.connector_id, checksum, staging_dir=batch_dir)
+            add_connector_checksum_entry(self.connector_id, checksum, doc_id)
+        except Exception as exc:
+            logger.warning(f"Failed to ingest {remote_path!r}: {exc}")
+            self._increment_failed(sync_seq)
+        finally:
+            # Remove this batch's staging directory immediately — before the
+            # next file is downloaded — regardless of success or failure.
+            cleanup_staging_directory(
+                batch_dir_name,
+                staging_base,
+                ignore_errors=True,
+            )
 ```
 
 ### 8.4 Classify
@@ -1341,6 +1377,7 @@ All connector DB functions from §5.1:
 - `ConnectorSyncWorker` with full `_run_tick()`: config refresh, scan, classify, ingest new files, register cross-connector dups, orphan deletion, tick finalize
 - `_classify()`: see §8.4 — `skip_list` is implicit (not returned)
 - Pass `connector_id` and `checksum` (pre-computed by scanner) to each create-job call; `add_connector_checksum_entry` called on job completion — `upsert_file_checksum` must NOT be called for connector jobs
+- `_process_new_files()`: for each file, generate a `job_id` upfront, create `staging/connectors/<connector_id>-<job_id>-<batch_number>/`, download into it, ingest, then `cleanup_staging_directory(batch_dir_name, ..., ignore_errors=True)` in a `finally` block — staging is cleared after each individual file, not at the end of the batch
 - Tick guard to prevent overlapping ticks
 - Crash guard (outer `try/except` in `run()`) — writes `crashed:` status to DB
 - `_cancel_if_requested()` check points at each phase boundary
@@ -1355,6 +1392,9 @@ All connector DB functions from §5.1:
 - `_classify` — assert intra-tick dedup (two paths with same checksum → first path wins)
 - `_classify` — assert absent checksums appear in `orphan_checksums`
 - Assert `_delete_orphans()` is called only after `_process_new_files()` returns
+- `_process_new_files` — assert staging dir is named `<connector_id>-<job_id>-<batch_number>` and is created before `scanner.download()`
+- `_process_new_files` — assert `cleanup_staging_directory` is called with `batch_dir_name` in the `finally` block, including when ingest raises
+- `_process_new_files` — assert staging directory is absent between two consecutive file downloads (i.e. cleanup happens before the next `scanner.download` call)
 
 ---
 

--- a/services/common/misc_utils.py
+++ b/services/common/misc_utils.py
@@ -390,7 +390,12 @@ logger = get_logger("cleanup")
 
 is_debug = logger.isEnabledFor(logging.DEBUG)
 
-def cleanup_staging_directory(job_id: str, staging_base_dir: Path) -> bool:
+def cleanup_staging_directory(
+    job_id: str,
+    staging_base_dir: Path,
+    *,
+    ignore_errors: bool = False,
+) -> bool:
     """
     Clean up the staging directory for a specific job.
 
@@ -400,6 +405,10 @@ def cleanup_staging_directory(job_id: str, staging_base_dir: Path) -> bool:
     Args:
         job_id: Unique identifier of the job
         staging_base_dir: Base directory where staging directories are created
+        ignore_errors: When True, per-file errors inside the tree are silently
+            swallowed (passed directly to ``shutil.rmtree``). Useful for
+            best-effort cleanup where leaving partial remnants is acceptable
+            (e.g. connector staging directories on DELETE).
 
     Returns:
         True if cleanup was successful or directory didn't exist, False if cleanup failed
@@ -412,7 +421,7 @@ def cleanup_staging_directory(job_id: str, staging_base_dir: Path) -> bool:
         return True
 
     try:
-        shutil.rmtree(staging_dir)
+        shutil.rmtree(staging_dir, ignore_errors=ignore_errors)
         logger.info(f"🗑️  Cleaned up staging directory: {staging_dir}")
         return True
     except Exception as e:

--- a/services/common/misc_utils.py
+++ b/services/common/misc_utils.py
@@ -4,6 +4,7 @@ import os
 import sys
 import shutil
 from pathlib import Path
+from typing import Optional
 
 import requests
 from contextvars import ContextVar
@@ -375,15 +376,28 @@ def validate_document_file(filename: str, content) -> None:
 def get_unprocessed_files(original_files, processed_pdfs):
     return set(original_files).difference(set(processed_pdfs))
 
-def get_utc_timestamp() -> str:
+_UNSET = object()
+
+def get_utc_timestamp(dt=_UNSET) -> Optional[str]:
     """
-    Generate UTC timestamp in ISO format with 'Z' suffix.
+    Serialize a datetime to ISO 8601 string with 'Z' suffix, or generate the
+    current UTC timestamp if no argument is provided.
+
+    Args:
+        dt: An existing datetime object to serialize.  Pass no argument (or
+            omit) to generate the current UTC time.  Pass None to get None
+            back (e.g. for optional nullable fields).
 
     Returns:
-        ISO 8601 formatted timestamp string with 'Z' suffix
+        ISO 8601 formatted timestamp string with 'Z' suffix, or None if dt
+        is explicitly passed as None.
     """
     from datetime import datetime, timezone
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    if dt is _UNSET:
+        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    if dt is None:
+        return None
+    return dt.isoformat().replace("+00:00", "Z")
 
 
 logger = get_logger("cleanup")

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.38
+TAG?=v0.0.39
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -26,6 +26,7 @@ from digitize.connectors.models import (
     ConnectorUpdateRequest,
     SyncLogItem,
     SyncLogResponse,
+    SyncStatus,
 )
 from digitize.connectors.encryption import (
     encrypt_secrets,
@@ -227,7 +228,7 @@ async def delete_connector(connector_id: str):
             )
 
         # Guard: reject if a tick is currently running
-        if connector.sync_status == "syncing":
+        if connector.sync_status == SyncStatus.SYNCING:
             APIError.raise_error(
                 ErrorCode.RESOURCE_LOCKED,
                 "A sync tick is currently running for this connector. "

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -277,12 +277,15 @@ async def delete_connector(connector_id: str):
 
 def _best_effort_delete_document(doc_id: str) -> None:
     """
-    Delete a document via the db_manager.  200 / 204 / 404 are all treated
-    as success — 5xx and unexpected exceptions are logged and swallowed.
+    Delete a document via the full teardown path (VDB → files → DB record).
+
+    Calls delete_document_data() so that indexed chunks and output files are
+    cleaned up — not just the DB row.
+    All failures are logged and swallowed (best-effort semantics).
     """
     try:
-        from digitize.db.manager import db_manager
-        db_manager.delete_document(doc_id)
+        from digitize.api.v1.documents import delete_document_data
+        delete_document_data(doc_id)
         logger.debug(f"Deleted document {doc_id!r} (connector cleanup)")
     except Exception as exc:
         logger.error(

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -17,7 +17,7 @@ from typing import List, Optional
 from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy.exc import IntegrityError
 
-from common.misc_utils import cleanup_staging_directory, get_logger
+from common.misc_utils import cleanup_staging_directory, get_logger, get_utc_timestamp
 from common.error_utils import APIError, ErrorCode, http_error_responses
 from digitize.connectors.models import (
     ConnectorCreateRequest,
@@ -48,13 +48,6 @@ _KEY_PATH = None  # resolved lazily via _get_key_path()
 def _get_key_path() -> str:
     """Return the encryption key path from settings."""
     return settings.digitize.connector.encryption_key_path
-
-
-def _serialize_dt(dt) -> Optional[str]:
-    """Convert a datetime to ISO-8601 string with Z suffix, or None."""
-    if dt is None:
-        return None
-    return dt.isoformat().replace("+00:00", "Z")
 
 
 # ---------------------------------------------------------------------------
@@ -340,8 +333,8 @@ async def list_connectors():
                 connector_id=c.id,
                 connector_name=c.name,
                 type=c.type,
-                attached_at=_serialize_dt(c.attached_at),
-                last_sync_at=_serialize_dt(c.last_sync_at),
+                attached_at=get_utc_timestamp(c.attached_at),
+                last_sync_at=get_utc_timestamp(c.last_sync_at),
                 sync_status=c.sync_status,
                 last_sync_error=c.last_sync_error,
                 total_files=c.total_files,
@@ -392,8 +385,8 @@ async def get_connector(connector_id: str):
             type=connector.type,
             allowed_extensions=list(connector.allowed_extensions or []),
             sync_interval_seconds=connector.sync_interval_seconds,
-            attached_at=_serialize_dt(connector.attached_at),
-            last_sync_at=_serialize_dt(connector.last_sync_at),
+            attached_at=get_utc_timestamp(connector.attached_at),
+            last_sync_at=get_utc_timestamp(connector.last_sync_at),
             sync_status=connector.sync_status,
             last_sync_error=connector.last_sync_error,
             connection_details=strip_secrets(connector.type, connector.connection_details or {}),
@@ -442,8 +435,8 @@ async def get_sync_history(
         items = [
             SyncLogItem(
                 id=log.id,
-                started_at=_serialize_dt(log.started_at) or "",
-                finished_at=_serialize_dt(log.finished_at),
+                started_at=get_utc_timestamp(log.started_at) or "",
+                finished_at=get_utc_timestamp(log.finished_at),
                 total_files=log.total_files,
                 new_files=log.new_files,
                 removed_files=log.removed_files,

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -376,10 +376,6 @@ async def get_connector(connector_id: str):
                 f"Connector {connector_id!r} not found",
             )
 
-        # Fetch latest sync stats from the most recent log row (if any)
-        logs, _ = db_ops.list_sync_logs(connector_id, limit=1, offset=0)
-        latest_log = logs[0] if logs else None
-
         return ConnectorDetailResponse(
             connector_id=connector.id,
             connector_name=connector.name,
@@ -392,9 +388,6 @@ async def get_connector(connector_id: str):
             last_sync_error=connector.last_sync_error,
             connection_details=strip_secrets(connector.type, connector.connection_details or {}),
             total_files=connector.total_files,
-            new_files=latest_log.new_files if latest_log else 0,
-            removed_files=latest_log.removed_files if latest_log else 0,
-            failed_files=latest_log.failed_files if latest_log else 0,
         )
     except HTTPException:
         raise

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -93,7 +93,7 @@ async def create_connector(body: ConnectorCreateRequest):
         )
         # Worker start is a no-op stub in PR3 — the worker manager (PR7) will hook
         # in here once implemented.
-        return Response(status_code=200)
+        return Response(status_code=201)
 
     except IntegrityError:
         # id or name already exists
@@ -266,7 +266,7 @@ async def delete_connector(connector_id: str):
         _sweep_connector_staging(connector_id, settings.digitize.staging_dir / "connectors")
 
         logger.info(f"Connector {connector_id!r} detached and deleted")
-        return None
+        return Response(status_code=204)
 
     except HTTPException:
         raise

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -17,7 +17,7 @@ from typing import List, Optional
 from fastapi import APIRouter, HTTPException, Query, status
 from sqlalchemy.exc import IntegrityError
 
-from common.misc_utils import get_logger
+from common.misc_utils import cleanup_staging_directory, get_logger
 from common.error_utils import APIError, ErrorCode, http_error_responses
 from digitize.connectors.models import (
     ConnectorCreateRequest,
@@ -225,8 +225,6 @@ async def delete_connector(connector_id: str):
     5. Delete the connector row
     6. Best-effort staging dir cleanup
     """
-    import shutil
-
     try:
         connector = db_ops.get_active_connector(connector_id)
         if connector is None:
@@ -267,8 +265,11 @@ async def delete_connector(connector_id: str):
                 "— row may have already been removed"
             )
 
-        # Best-effort staging directory cleanup
-        _cleanup_staging(connector_id)
+        # Best-effort sweep of any residual batch staging directories.
+        # Normal teardown: per-batch dirs are already gone (cleaned up in
+        # _process_new_files finally blocks). This glob catches anything left
+        # behind by a mid-tick crash: staging/connectors/<connector_id>-*
+        _sweep_connector_staging(connector_id, settings.digitize.staging_dir / "connectors")
 
         logger.info(f"Connector {connector_id!r} detached and deleted")
         return None
@@ -296,19 +297,24 @@ def _best_effort_delete_document(doc_id: str) -> None:
         )
 
 
-def _cleanup_staging(connector_id: str) -> None:
-    """Remove the per-connector staging directory, best-effort."""
-    import shutil
+def _sweep_connector_staging(connector_id: str, staging_connectors_dir) -> None:
+    """
+    Remove any residual batch staging directories for *connector_id*.
 
-    try:
-        staging_path = settings.digitize.staging_dir / "connectors" / connector_id
-        if staging_path.exists():
-            shutil.rmtree(staging_path, ignore_errors=True)
-            logger.debug(f"Cleaned up staging dir for connector {connector_id!r}")
-    except Exception as exc:
-        logger.warning(
-            f"Staging dir cleanup failed for connector {connector_id!r}: {exc}"
-        )
+    Per-batch dirs are named ``<connector_id>-<job_id>-<batch_number>`` and are
+    cleaned up inline after each ingest.  This sweep only has work to do when a
+    worker crashed mid-tick and left a directory behind.
+    """
+    from pathlib import Path
+
+    base = Path(staging_connectors_dir)
+    if not base.exists():
+        return
+    prefix = f"{connector_id}-"
+    for entry in base.iterdir():
+        if entry.is_dir() and entry.name.startswith(prefix):
+            cleanup_staging_directory(entry.name, base, ignore_errors=True)
+            logger.debug(f"Swept residual staging dir {entry.name!r} for connector {connector_id!r}")
 
 
 # ---------------------------------------------------------------------------

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -14,7 +14,7 @@ Endpoints:
 
 from typing import List, Optional
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, HTTPException, Query, Response, status
 from sqlalchemy.exc import IntegrityError
 
 from common.misc_utils import cleanup_staging_directory, get_logger, get_utc_timestamp
@@ -92,7 +92,7 @@ async def create_connector(body: ConnectorCreateRequest):
         )
         # Worker start is a no-op stub in PR3 — the worker manager (PR7) will hook
         # in here once implemented.
-        return {"connector_id": body.connector_id, "status": "accepted"}
+        return Response(status_code=200)
 
     except IntegrityError:
         # id or name already exists
@@ -136,7 +136,7 @@ async def update_connector(connector_id: str, body: ConnectorUpdateRequest):
     try:
         # Nothing to update — treat as success
         if body.connector_name is None and body.allowed_extensions is None and body.connection_details is None:
-            return {"connector_id": connector_id, "status": "updated"}
+            return Response(status_code=200)
 
         key_path = _get_key_path()
 
@@ -165,7 +165,7 @@ async def update_connector(connector_id: str, body: ConnectorUpdateRequest):
         )
 
         logger.info(f"Connector {connector_id!r} updated")
-        return {"connector_id": connector_id, "status": "updated"}
+        return Response(status_code=200)
 
     except FileNotFoundError:
         APIError.raise_error(

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -1,0 +1,462 @@
+"""
+Connector REST API endpoints.
+
+Mounted at /v1/connectors by app.py.
+
+Endpoints:
+  POST   /v1/connectors
+  PUT    /v1/connectors/{connector_id}
+  DELETE /v1/connectors/{connector_id}
+  GET    /v1/connectors
+  GET    /v1/connectors/{connector_id}
+  GET    /v1/connectors/{connector_id}/syncs
+"""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, HTTPException, Query, status
+from sqlalchemy.exc import IntegrityError
+
+from common.misc_utils import get_logger
+from common.error_utils import APIError, ErrorCode, http_error_responses
+from digitize.connectors.models import (
+    ConnectorCreateRequest,
+    ConnectorDetailResponse,
+    ConnectorListItem,
+    ConnectorUpdateRequest,
+    SyncLogItem,
+    SyncLogResponse,
+)
+from digitize.connectors.encryption import (
+    encrypt_secrets,
+    merge_and_encrypt_partial,
+    strip_secrets,
+)
+import digitize.utils.db as db_ops
+from digitize.settings import settings
+
+router = APIRouter()
+logger = get_logger("connectors_router")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_KEY_PATH = None  # resolved lazily via _get_key_path()
+
+
+def _get_key_path() -> str:
+    """Return the encryption key path from settings."""
+    return settings.digitize.connector.encryption_key_path
+
+
+def _serialize_dt(dt) -> Optional[str]:
+    """Convert a datetime to ISO-8601 string with Z suffix, or None."""
+    if dt is None:
+        return None
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/connectors
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "",
+    status_code=status.HTTP_202_ACCEPTED,
+    responses={
+        409: http_error_responses[409],
+        500: http_error_responses[500],
+    },
+    summary="Attach a data-source connector",
+    description=(
+        "Creates a connector, stores encrypted credentials, and schedules the "
+        "worker to start asynchronously. The worker runs its first tick immediately "
+        "after the thread starts. sync_interval_seconds is taken from the "
+        "CONNECTOR_SYNC_INTERVAL_SECONDS env variable and cannot be set per-request."
+    ),
+    response_description="Connector created; worker start scheduled",
+)
+async def create_connector(body: ConnectorCreateRequest):
+    try:
+        key_path = _get_key_path()
+        encrypted_details = encrypt_secrets(body.type, body.connection_details, key_path)
+
+        sync_interval = settings.digitize.connector.sync_interval_seconds
+
+        db_ops.insert_connector(
+            connector_id=body.connector_id,
+            name=body.connector_name,
+            connector_type=body.type,
+            connection_details=encrypted_details,
+            allowed_extensions=body.allowed_extensions,
+            sync_interval_seconds=sync_interval,
+        )
+
+        logger.info(
+            f"Connector {body.connector_id!r} ({body.connector_name!r}) attached "
+            f"(type={body.type}, interval={sync_interval}s)"
+        )
+        # Worker start is a no-op stub in PR3 — the worker manager (PR7) will hook
+        # in here once implemented.
+        return {"connector_id": body.connector_id, "status": "accepted"}
+
+    except IntegrityError:
+        # id or name already exists
+        APIError.raise_error(
+            ErrorCode.RESOURCE_LOCKED,
+            f"Connector {body.connector_id!r} or name {body.connector_name!r} already exists",
+        )
+    except RuntimeError as exc:
+        # encryption key not found
+        logger.error(f"Encryption key error: {exc}")
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Unexpected error creating connector: {exc}", exc_info=True)
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+
+
+# ---------------------------------------------------------------------------
+# PUT /v1/connectors/{connector_id}
+# ---------------------------------------------------------------------------
+
+@router.put(
+    "/{connector_id}",
+    status_code=status.HTTP_200_OK,
+    responses={
+        404: http_error_responses[404],
+        409: http_error_responses[409],
+        500: http_error_responses[500],
+    },
+    summary="Update a connector's configuration",
+    description=(
+        "Partial update — only supplied fields are written. "
+        "connection_details is merged at the key level (untouched keys survive). "
+        "If credentials are included they are re-encrypted before storage. "
+        "type and sync_interval_seconds cannot be changed."
+    ),
+    response_description="Connector updated; running worker picks up changes on next tick",
+)
+async def update_connector(connector_id: str, body: ConnectorUpdateRequest):
+    try:
+        # Nothing to update — treat as success
+        if body.connector_name is None and body.allowed_extensions is None and body.connection_details is None:
+            return {"connector_id": connector_id, "status": "updated"}
+
+        key_path = _get_key_path()
+
+        # If connection_details is being updated, we need to merge with existing
+        # encrypted details so untouched keys stay encrypted and intact.
+        merged_details: Optional[dict] = None
+        if body.connection_details is not None:
+            existing = db_ops.get_active_connector(connector_id)
+            if existing is None:
+                APIError.raise_error(
+                    ErrorCode.RESOURCE_NOT_FOUND,
+                    f"Connector {connector_id!r} not found",
+                )
+            merged_details = merge_and_encrypt_partial(
+                existing.type,
+                existing.connection_details,
+                body.connection_details,
+                key_path,
+            )
+
+        db_ops.upsert_connector(
+            connector_id=connector_id,
+            name=body.connector_name,
+            connection_details=merged_details,
+            allowed_extensions=body.allowed_extensions,
+        )
+
+        logger.info(f"Connector {connector_id!r} updated")
+        return {"connector_id": connector_id, "status": "updated"}
+
+    except FileNotFoundError:
+        APIError.raise_error(
+            ErrorCode.RESOURCE_NOT_FOUND,
+            f"Connector {connector_id!r} not found",
+        )
+    except IntegrityError:
+        APIError.raise_error(
+            ErrorCode.RESOURCE_LOCKED,
+            f"Connector name {body.connector_name!r} is already in use",
+        )
+    except RuntimeError as exc:
+        logger.error(f"Encryption key error: {exc}")
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Unexpected error updating connector {connector_id}: {exc}", exc_info=True)
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+
+
+# ---------------------------------------------------------------------------
+# DELETE /v1/connectors/{connector_id}
+# ---------------------------------------------------------------------------
+
+@router.delete(
+    "/{connector_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        404: http_error_responses[404],
+        409: http_error_responses[409],
+        500: http_error_responses[500],
+    },
+    summary="Detach and delete a connector",
+    description=(
+        "Removes a connector and all its associated state. "
+        "Rejected with 409 if a sync tick is currently in progress. "
+        "Documents owned exclusively by this connector are deleted. "
+        "Staging directories are cleaned up best-effort."
+    ),
+    response_description="No content on successful deletion",
+)
+async def delete_connector(connector_id: str):
+    """
+    DELETE stub for PR3 (no worker yet):
+    1. Check connector exists → 404 if not
+    2. Guard: check if sync is in progress (sync_status == 'syncing') → 409
+    3. Snapshot checksums owned by this connector
+    4. Remove ownership rows and delete documents when last owner
+    5. Delete the connector row
+    6. Best-effort staging dir cleanup
+    """
+    import shutil
+
+    try:
+        connector = db_ops.get_active_connector(connector_id)
+        if connector is None:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                f"Connector {connector_id!r} not found",
+            )
+
+        # Guard: reject if a tick is currently running
+        if connector.sync_status == "syncing":
+            APIError.raise_error(
+                ErrorCode.RESOURCE_LOCKED,
+                "A sync tick is currently running for this connector. "
+                "Retry after the tick completes.",
+            )
+
+        # Snapshot checksums owned by this connector
+        owned_checksums = db_ops.list_connector_checksums(connector_id)
+
+        # Remove ownership rows; delete documents when last owner
+        for checksum in owned_checksums:
+            try:
+                remaining, doc_id = db_ops.remove_connector_checksum_entry(connector_id, checksum)
+                if remaining == 0 and doc_id:
+                    _best_effort_delete_document(doc_id)
+            except Exception as exc:
+                logger.error(
+                    f"Error removing checksum {checksum!r} for connector "
+                    f"{connector_id!r}: {exc}",
+                    exc_info=True,
+                )
+
+        # Delete the connector row (cascades to connector_sync_logs)
+        deleted = db_ops.delete_active_connector(connector_id)
+        if not deleted:
+            logger.warning(
+                f"delete_active_connector returned False for {connector_id!r} "
+                "— row may have already been removed"
+            )
+
+        # Best-effort staging directory cleanup
+        _cleanup_staging(connector_id)
+
+        logger.info(f"Connector {connector_id!r} detached and deleted")
+        return None
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Unexpected error deleting connector {connector_id}: {exc}", exc_info=True)
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+
+
+def _best_effort_delete_document(doc_id: str) -> None:
+    """
+    Delete a document via the db_manager.  200 / 204 / 404 are all treated
+    as success — 5xx and unexpected exceptions are logged and swallowed.
+    """
+    try:
+        from digitize.db.manager import db_manager
+        db_manager.delete_document(doc_id)
+        logger.debug(f"Deleted document {doc_id!r} (connector cleanup)")
+    except Exception as exc:
+        logger.error(
+            f"Best-effort document deletion failed for {doc_id!r}: {exc}",
+            exc_info=True,
+        )
+
+
+def _cleanup_staging(connector_id: str) -> None:
+    """Remove the per-connector staging directory, best-effort."""
+    import shutil
+
+    try:
+        staging_path = settings.digitize.staging_dir / "connectors" / connector_id
+        if staging_path.exists():
+            shutil.rmtree(staging_path, ignore_errors=True)
+            logger.debug(f"Cleaned up staging dir for connector {connector_id!r}")
+    except Exception as exc:
+        logger.warning(
+            f"Staging dir cleanup failed for connector {connector_id!r}: {exc}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/connectors
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "",
+    response_model=List[ConnectorListItem],
+    responses={500: http_error_responses[500]},
+    summary="List all connectors",
+    description=(
+        "Returns all attached connectors with their sync state. "
+        "Secret connection fields (private_key, secret_access_key) are never included."
+    ),
+    response_description="List of connectors",
+)
+async def list_connectors():
+    try:
+        connectors = db_ops.list_connectors()
+        return [
+            ConnectorListItem(
+                connector_id=c.id,
+                connector_name=c.name,
+                type=c.type,
+                attached_at=_serialize_dt(c.attached_at),
+                last_sync_at=_serialize_dt(c.last_sync_at),
+                sync_status=c.sync_status,
+                last_sync_error=c.last_sync_error,
+                total_files=c.total_files,
+            )
+            for c in connectors
+        ]
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Unexpected error listing connectors: {exc}", exc_info=True)
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/connectors/{connector_id}
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/{connector_id}",
+    response_model=ConnectorDetailResponse,
+    responses={
+        404: http_error_responses[404],
+        500: http_error_responses[500],
+    },
+    summary="Get a single connector",
+    description=(
+        "Returns one connector with its latest file-processing counters. "
+        "Secret connection fields are stripped from the response."
+    ),
+    response_description="Connector detail",
+)
+async def get_connector(connector_id: str):
+    try:
+        connector = db_ops.get_active_connector(connector_id)
+        if connector is None:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                f"Connector {connector_id!r} not found",
+            )
+
+        # Fetch latest sync stats from the most recent log row (if any)
+        logs, _ = db_ops.list_sync_logs(connector_id, limit=1, offset=0)
+        latest_log = logs[0] if logs else None
+
+        return ConnectorDetailResponse(
+            connector_id=connector.id,
+            connector_name=connector.name,
+            type=connector.type,
+            allowed_extensions=list(connector.allowed_extensions or []),
+            sync_interval_seconds=connector.sync_interval_seconds,
+            attached_at=_serialize_dt(connector.attached_at),
+            last_sync_at=_serialize_dt(connector.last_sync_at),
+            sync_status=connector.sync_status,
+            last_sync_error=connector.last_sync_error,
+            connection_details=strip_secrets(connector.type, connector.connection_details or {}),
+            total_files=connector.total_files,
+            new_files=latest_log.new_files if latest_log else 0,
+            removed_files=latest_log.removed_files if latest_log else 0,
+            failed_files=latest_log.failed_files if latest_log else 0,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Unexpected error fetching connector {connector_id}: {exc}", exc_info=True)
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/connectors/{connector_id}/syncs
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/{connector_id}/syncs",
+    response_model=SyncLogResponse,
+    responses={
+        404: http_error_responses[404],
+        500: http_error_responses[500],
+    },
+    summary="Get sync log for a connector",
+    description="Returns paginated sync log for a connector, newest first.",
+    response_description="Paginated sync log",
+)
+async def get_sync_history(
+    connector_id: str,
+    limit: int = Query(50, ge=1, le=200, description="Max records to return (capped at 200)"),
+    offset: int = Query(0, ge=0, description="Zero-based offset"),
+):
+    try:
+        connector = db_ops.get_active_connector(connector_id)
+        if connector is None:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                f"Connector {connector_id!r} not found",
+            )
+
+        logs, total = db_ops.list_sync_logs(connector_id, limit=limit, offset=offset)
+
+        items = [
+            SyncLogItem(
+                id=log.id,
+                started_at=_serialize_dt(log.started_at) or "",
+                finished_at=_serialize_dt(log.finished_at),
+                total_files=log.total_files,
+                new_files=log.new_files,
+                removed_files=log.removed_files,
+                failed_files=log.failed_files,
+                status=log.status,
+                error=log.error or "",
+            )
+            for log in logs
+        ]
+
+        return SyncLogResponse(total=total, limit=limit, offset=offset, items=items)
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(
+            f"Unexpected error fetching sync log for {connector_id}: {exc}",
+            exc_info=True,
+        )
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+
+# Made with Bob

--- a/services/digitize/api/v1/documents.py
+++ b/services/digitize/api/v1/documents.py
@@ -26,6 +26,43 @@ router = APIRouter()
 logger = get_logger("documents_router")
 
 
+def delete_document_data(doc_id: str) -> None:
+    """
+    Steps 4-6 of the delete_document flow: VDB cleanup, file cleanup, DB record removal.
+    Extracted so connector cleanup can call the same teardown path.
+    Raises on failure; callers decide how to handle errors.
+    """
+    # 4. VDB cleanup.
+    import common.db_utils as db
+
+    vector_store = db.get_vector_store()
+    deleted_chunks = vector_store.delete_document_by_id(doc_id)
+    logger.info(f"VDB cleanup for {doc_id}: {deleted_chunks} chunks removed.")
+
+    # 5. File cleanup.
+    doc_metadata = None
+    try:
+        doc_metadata = dg_util.get_document(doc_id, include_details=False)
+    except FileNotFoundError:
+        logger.error(f"Metadata for {doc_id} not found. Proceeding with VDB cleanup.")
+    if doc_metadata:
+        storage_manager.delete_document_content(
+            doc_id, output_format=doc_metadata.output_format
+        )
+        logger.info(f"Files for {doc_id} deleted successfully.")
+
+    # 6. Database record removal.
+    from digitize.db.manager import db_manager
+
+    success = db_manager.delete_document(doc_id)
+    if success:
+        logger.info(f"Database record for {doc_id} deleted successfully.")
+    else:
+        logger.warning(
+            f"Database record for {doc_id} not found (may have been deleted already)."
+        )
+
+
 @router.get(
     "",
     response_model=models.DocumentsListResponse,
@@ -207,51 +244,12 @@ async def delete_document(doc_id: str):
                     f"Document part of active job '{doc_metadata.job_id}' and cannot be deleted",
                 )
 
-        # 4. VDB cleanup.
+        # 4-6. VDB cleanup, file cleanup, DB record removal.
         try:
-            import common.db_utils as db
-
-            vector_store = db.get_vector_store()
-            deleted_chunks = vector_store.delete_document_by_id(doc_id)
-            logger.info(f"VDB cleanup for {doc_id}: {deleted_chunks} chunks removed.")
+            delete_document_data(doc_id)
         except Exception as exc:
-            logger.error(f"VDB cleanup failed for {doc_id}: {exc}")
-            APIError.raise_error(
-                ErrorCode.INTERNAL_SERVER_ERROR,
-                f"Document metadata deleted but VDB cleanup failed: {exc}",
-            )
-
-        # 5. File cleanup.
-        if doc_metadata:
-            try:
-                storage_manager.delete_document_content(
-                    doc_id, output_format=doc_metadata.output_format
-                )
-                logger.info(f"Files for {doc_id} deleted successfully.")
-            except Exception as exc:
-                logger.error(f"VDB cleaned but file deletion failed for {doc_id}")
-                APIError.raise_error(
-                    ErrorCode.INTERNAL_SERVER_ERROR,
-                    f"Search data removed but files remain: {exc}",
-                )
-
-        # 6. Database record removal.
-        try:
-            from digitize.db.manager import db_manager
-
-            success = db_manager.delete_document(doc_id)
-            if success:
-                logger.info(f"Database record for {doc_id} deleted successfully.")
-            else:
-                logger.warning(
-                    f"Database record for {doc_id} not found (may have been deleted already)."
-                )
-        except Exception as exc:
-            logger.error(f"Failed to delete database record for {doc_id}: {exc}")
-            APIError.raise_error(
-                ErrorCode.INTERNAL_SERVER_ERROR,
-                f"Search data and files removed but database cleanup failed: {exc}",
-            )
+            logger.error(f"Document teardown failed for {doc_id}: {exc}")
+            APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
 
         return None
 

--- a/services/digitize/api/v1/documents.py
+++ b/services/digitize/api/v1/documents.py
@@ -3,6 +3,11 @@ Document-related API endpoints.
 
 Handles document listing, retrieval, content access, and deletion.
 Extracted from the monolithic app.py following the digitize-api-sample pattern.
+
+Connector visibility rules:
+  - GET  /v1/documents        — user-submitted only (connector-sourced excluded)
+  - GET  /v1/documents/{id}   — 404 for connector-sourced docs
+  - DELETE /v1/documents/{id} — 404 for connector-sourced docs
 """
 
 import json
@@ -65,6 +70,7 @@ async def list_documents(
             name=name,
             limit=limit,
             offset=offset,
+            exclude_connector_sourced=True,
         )
 
         logger.debug(
@@ -103,7 +109,13 @@ async def get_document_metadata(
     details: bool = Query(False, description="Include detailed metadata (pages, tables, timing)"),
 ):
     try:
-        from digitize.utils.db import get_document
+        from digitize.utils.db import get_document, is_connector_sourced_document
+
+        if is_connector_sourced_document(doc_id):
+            APIError.raise_error(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                f"Document with ID '{doc_id}' not found",
+            )
 
         return get_document(doc_id, include_details=details)
     except FileNotFoundError as exc:
@@ -163,21 +175,31 @@ async def get_document_content(doc_id: str):
 async def delete_document(doc_id: str):
     """
     Delete a single document — follows the 'Always-Clean-VDB' strategy:
-    1. Fetch metadata
-    2. Active-job guard
-    3. VDB cleanup (high priority)
-    4. File & metadata cleanup
-    5. Database record removal
+    1. Connector guard  — 404 for connector-sourced docs
+    2. Fetch metadata
+    3. Active-job guard
+    4. VDB cleanup (high priority)
+    5. File & metadata cleanup
+    6. Database record removal
     """
     try:
-        # 1. Fetch metadata (best-effort).
+        # 1. Connector guard — connector-sourced docs cannot be deleted via this API.
+        from digitize.utils.db import is_connector_sourced_document
+
+        if is_connector_sourced_document(doc_id):
+            APIError.raise_error(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                f"Document with ID '{doc_id}' not found",
+            )
+
+        # 2. Fetch metadata (best-effort).
         doc_metadata = None
         try:
             doc_metadata = dg_util.get_document(doc_id, include_details=False)
         except FileNotFoundError:
             logger.error(f"Metadata for {doc_id} not found. Proceeding with VDB cleanup.")
 
-        # 2. Active-job guard.
+        # 3. Active-job guard.
         if doc_metadata:
             if dg_util.is_document_in_active_job(doc_id, job_id=doc_metadata.job_id):
                 APIError.raise_error(
@@ -185,7 +207,7 @@ async def delete_document(doc_id: str):
                     f"Document part of active job '{doc_metadata.job_id}' and cannot be deleted",
                 )
 
-        # 3. VDB cleanup.
+        # 4. VDB cleanup.
         try:
             import common.db_utils as db
 
@@ -199,7 +221,7 @@ async def delete_document(doc_id: str):
                 f"Document metadata deleted but VDB cleanup failed: {exc}",
             )
 
-        # 4. File cleanup.
+        # 5. File cleanup.
         if doc_metadata:
             try:
                 storage_manager.delete_document_content(
@@ -213,7 +235,7 @@ async def delete_document(doc_id: str):
                     f"Search data removed but files remain: {exc}",
                 )
 
-        # 5. Database record removal.
+        # 6. Database record removal.
         try:
             from digitize.db.manager import db_manager
 

--- a/services/digitize/app.py
+++ b/services/digitize/app.py
@@ -138,6 +138,10 @@ tags_metadata = [
         "name": "documents",
         "description": "Document management operations including retrieval and deletion",
     },
+    {
+        "name": "connectors",
+        "description": "Data-source connector lifecycle management (SFTP, S3)",
+    },
 ]
 
 app = FastAPI(
@@ -210,10 +214,12 @@ async def health_check():
 from digitize.api.v1.jobs import router as jobs_router
 from digitize.api.v1.admin import router as admin_router
 from digitize.api.v1.documents import router as documents_router
+from digitize.api.v1.connectors import router as connectors_router
 
 app.include_router(jobs_router, prefix="/v1/jobs", tags=["jobs"])
 app.include_router(admin_router, prefix="/v1", tags=["jobs"])
 app.include_router(documents_router, prefix="/v1/documents", tags=["documents"])
+app.include_router(connectors_router, prefix="/v1/connectors", tags=["connectors"])
 
 
 if __name__ == "__main__":

--- a/services/digitize/connectors/__init__.py
+++ b/services/digitize/connectors/__init__.py
@@ -1,0 +1,1 @@
+# Made with Bob

--- a/services/digitize/connectors/encryption.py
+++ b/services/digitize/connectors/encryption.py
@@ -1,0 +1,150 @@
+"""
+Connector credential encryption/decryption.
+
+Secret fields are encrypted at rest using AES-256-GCM with a key loaded from
+the path configured in settings (default: /run/secrets/connector_encryption_key).
+
+The key file must contain exactly 32 raw bytes (256 bits).
+When the key file is absent (e.g. in tests), operations raise RuntimeError.
+
+Ciphertext wire format (stored as base64):
+    base64( nonce[12] || tag[16] || ciphertext )
+"""
+
+import base64
+import os
+from functools import lru_cache
+from pathlib import Path
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from common.misc_utils import get_logger
+
+logger = get_logger("connector_encryption")
+
+# Secret fields per connector type that must be encrypted before storage
+# and stripped before API responses.
+_SECRET_FIELDS: dict[str, set[str]] = {
+    "ssh": {"private_key"},
+    "s3": {"secret_access_key"},
+}
+
+_NONCE_SIZE = 12  # 96-bit nonce recommended for GCM
+
+
+@lru_cache(maxsize=1)
+def _load_key(key_path: str) -> AESGCM:
+    """Load and cache the AES-256-GCM cipher from the key file."""
+    path = Path(key_path)
+    if not path.exists():
+        raise RuntimeError(
+            f"Connector encryption key not found at {key_path}. "
+            "Ensure the secret is mounted before starting the service."
+        )
+    raw = path.read_bytes().strip()
+    if len(raw) != 32:
+        raise RuntimeError(
+            f"Connector encryption key at {key_path} must be exactly 32 bytes "
+            f"(AES-256); got {len(raw)} bytes."
+        )
+    return AESGCM(raw)
+
+
+def _get_cipher(key_path: str) -> AESGCM:
+    return _load_key(key_path)
+
+
+def _encrypt_value(cipher: AESGCM, plaintext: str) -> str:
+    """Encrypt a plaintext string; return base64(nonce || tag || ciphertext)."""
+    nonce = os.urandom(_NONCE_SIZE)
+    # AESGCM.encrypt returns ciphertext + tag (tag appended)
+    ct_and_tag = cipher.encrypt(nonce, plaintext.encode(), None)
+    return base64.b64encode(nonce + ct_and_tag).decode()
+
+
+def _decrypt_value(cipher: AESGCM, token: str) -> str:
+    """Decrypt a base64(nonce || tag || ciphertext) token; return plaintext string."""
+    raw = base64.b64decode(token.encode())
+    nonce = raw[:_NONCE_SIZE]
+    ct_and_tag = raw[_NONCE_SIZE:]
+    return cipher.decrypt(nonce, ct_and_tag, None).decode()
+
+
+def encrypt_secrets(
+    connector_type: str,
+    connection_details: dict,
+    key_path: str,
+) -> dict:
+    """
+    Return a copy of *connection_details* with secret fields encrypted.
+
+    Only the fields listed in _SECRET_FIELDS for the given connector type
+    are touched; all other fields are passed through unchanged.
+    """
+    cipher = _get_cipher(key_path)
+    secret_fields = _SECRET_FIELDS.get(connector_type, set())
+    result = dict(connection_details)
+    for field in secret_fields:
+        if field in result and result[field] is not None:
+            result[field] = _encrypt_value(cipher, str(result[field]))
+    return result
+
+
+def decrypt_secrets(
+    connector_type: str,
+    connection_details: dict,
+    key_path: str,
+) -> dict:
+    """
+    Return a copy of *connection_details* with secret fields decrypted.
+    """
+    cipher = _get_cipher(key_path)
+    secret_fields = _SECRET_FIELDS.get(connector_type, set())
+    result = dict(connection_details)
+    for field in secret_fields:
+        if field in result and result[field] is not None:
+            try:
+                result[field] = _decrypt_value(cipher, result[field])
+            except Exception as exc:
+                logger.error(f"Failed to decrypt field {field!r}: {exc}")
+                raise
+    return result
+
+
+def strip_secrets(connector_type: str, connection_details: dict) -> dict:
+    """
+    Return a copy of *connection_details* with all secret fields removed.
+
+    Used for safe API responses — ensures private keys / secrets are never
+    returned to callers.
+    """
+    secret_fields = _SECRET_FIELDS.get(connector_type, set())
+    return {k: v for k, v in connection_details.items() if k not in secret_fields}
+
+
+def merge_and_encrypt_partial(
+    connector_type: str,
+    existing_encrypted: dict,
+    partial_update: dict,
+    key_path: str,
+) -> dict:
+    """
+    Merge *partial_update* into *existing_encrypted* at the key level,
+    re-encrypting any secret fields found in *partial_update*.
+
+    Keys absent from *partial_update* are preserved from *existing_encrypted*
+    as-is (already encrypted). Only the supplied keys are overwritten.
+
+    Returns the merged dict (all secret fields encrypted).
+    """
+    cipher = _get_cipher(key_path)
+    secret_fields = _SECRET_FIELDS.get(connector_type, set())
+    result = dict(existing_encrypted)
+    for key, value in partial_update.items():
+        if key in secret_fields and value is not None:
+            result[key] = _encrypt_value(cipher, str(value))
+        else:
+            result[key] = value
+    return result
+
+# Made with Bob

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -101,9 +101,6 @@ class ConnectorDetailResponse(BaseModel):
     last_sync_error: Optional[str]
     connection_details: Dict[str, Any]
     total_files: int
-    new_files: int
-    removed_files: int
-    failed_files: int
 
 
 class SyncLogItem(BaseModel):

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -1,0 +1,104 @@
+"""
+Pydantic request/response models for the connector REST API.
+
+Covers:
+  POST /v1/connectors
+  PUT  /v1/connectors/{connector_id}
+  GET  /v1/connectors
+  GET  /v1/connectors/{connector_id}
+  GET  /v1/connectors/{connector_id}/syncs
+"""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+class ConnectorCreateRequest(BaseModel):
+    """Body accepted by POST /v1/connectors."""
+
+    connector_id: str = Field(..., description="Stable catalog UUID for this connector")
+    connector_name: str = Field(..., description="Human-readable unique name, e.g. 'prod-sftp-reports'")
+    type: str = Field(..., description="Connector transport type: 'ssh' or 's3'")
+    allowed_extensions: List[str] = Field(..., description="File extensions to accept, e.g. ['.pdf', '.docx']")
+    connection_details: Dict[str, Any] = Field(..., description="Transport-specific connection parameters")
+
+
+class ConnectorUpdateRequest(BaseModel):
+    """Body accepted by PUT /v1/connectors/{connector_id}.
+
+    All fields are optional — only supplied fields are written.
+    connection_details is merged at the key level, not replaced wholesale.
+    type and sync_interval_seconds cannot be changed via this endpoint.
+    """
+
+    connector_name: Optional[str] = Field(None, description="New human-readable name (must be unique)")
+    allowed_extensions: Optional[List[str]] = Field(None, description="Replacement allowed-extensions list")
+    connection_details: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Partial connection details — only supplied keys are overwritten",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+class ConnectorListItem(BaseModel):
+    """One connector in GET /v1/connectors list."""
+
+    connector_id: str
+    connector_name: str
+    type: str
+    attached_at: Optional[str]
+    last_sync_at: Optional[str]
+    sync_status: str
+    last_sync_error: Optional[str]
+    total_files: int
+
+
+class ConnectorDetailResponse(BaseModel):
+    """Single connector returned by GET /v1/connectors/{connector_id}."""
+
+    connector_id: str
+    connector_name: str
+    type: str
+    allowed_extensions: List[str]
+    sync_interval_seconds: int
+    attached_at: Optional[str]
+    last_sync_at: Optional[str]
+    sync_status: str
+    last_sync_error: Optional[str]
+    connection_details: Dict[str, Any]
+    total_files: int
+    new_files: int
+    removed_files: int
+    failed_files: int
+
+
+class SyncLogItem(BaseModel):
+    """One tick entry in GET /v1/connectors/{connector_id}/syncs."""
+
+    id: int
+    started_at: str
+    finished_at: Optional[str]
+    total_files: int
+    new_files: int
+    removed_files: int
+    failed_files: int
+    status: str
+    error: str
+
+
+class SyncLogResponse(BaseModel):
+    """Paginated response for GET /v1/connectors/{connector_id}/syncs."""
+
+    total: int
+    limit: int
+    offset: int
+    items: List[SyncLogItem]
+
+# Made with Bob

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -14,6 +14,33 @@ from pydantic import BaseModel, Field
 
 
 # ---------------------------------------------------------------------------
+# Connector / sync-log status constants
+# ---------------------------------------------------------------------------
+
+class SyncStatus:
+    """String constants for connector sync_status and sync-log status columns.
+
+    Connector.sync_status lifecycle:
+        IDLE  ──► SYNCING  ──► IDLE        (tick completed cleanly)
+                          └──► OUT_OF_SYNC (tick finished with errors)
+
+    ConnectorSyncLog.status lifecycle:
+        STARTED ──► COMPLETED  (all files processed successfully)
+                └──► FAILED    (fatal tick error or partial failure)
+    """
+
+    # Connector.sync_status values
+    IDLE = "up to date"
+    SYNCING = "syncing"
+    OUT_OF_SYNC = "out of sync"
+
+    # ConnectorSyncLog.status values
+    STARTED = "started"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+# ---------------------------------------------------------------------------
 # Request models
 # ---------------------------------------------------------------------------
 

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -21,7 +21,7 @@ class SyncStatus:
     """String constants for connector sync_status and sync-log status columns.
 
     Connector.sync_status lifecycle:
-        IDLE  ──► SYNCING  ──► IDLE        (tick completed cleanly)
+        UP_TO_DATE  ──► SYNCING  ──► UP_TO_DATE  (tick completed cleanly)
                           └──► OUT_OF_SYNC (tick finished with errors)
 
     ConnectorSyncLog.status lifecycle:
@@ -30,7 +30,7 @@ class SyncStatus:
     """
 
     # Connector.sync_status values
-    IDLE = "up to date"
+    UP_TO_DATE = "up to date"
     SYNCING = "syncing"
     OUT_OF_SYNC = "out of sync"
 

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -432,7 +432,8 @@ class DatabaseManager:
         status: Optional[str] = None,
         name: Optional[str] = None,
         limit: int = 20,
-        offset: int = 0
+        offset: int = 0,
+        exclude_connector_sourced: bool = False,
     ) -> tuple[List[Document], int]:
         """
         Retrieve all documents with optional filtering and pagination.
@@ -442,6 +443,8 @@ class DatabaseManager:
             name: Filter by document name (partial match)
             limit: Maximum number of documents to return
             offset: Number of documents to skip
+            exclude_connector_sourced: When True, omit docs that appear in
+                connector_document_checksum (connector-sourced documents).
 
         Returns:
             Tuple of (list of Document objects, total count)
@@ -460,7 +463,14 @@ class DatabaseManager:
                     filters.append(Document.status != DocStatus.ALREADY_EXISTS.value)
                 if name:
                     filters.append(Document.name.ilike(f"%{name}%"))
-                
+                if exclude_connector_sourced:
+                    # Exclude connector-sourced documents via NOT EXISTS subquery.
+                    filters.append(
+                        ~select(ConnectorDocumentChecksum.doc_id)
+                        .where(ConnectorDocumentChecksum.doc_id == Document.doc_id)
+                        .exists()
+                    )
+
                 if filters:
                     stmt = stmt.where(and_(*filters))
                 

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -775,7 +775,7 @@ class DatabaseManager:
                         allowed_extensions=allowed_extensions,
                         sync_interval_seconds=sync_interval_seconds,
                         attached_at=datetime.now(timezone.utc),
-                        sync_status=SyncStatus.IDLE,
+                        sync_status=SyncStatus.UP_TO_DATE,
                         total_files=0,
                     )
                     .on_conflict_do_nothing(index_elements=["id"])

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -15,6 +15,7 @@ from common.misc_utils import get_logger
 from digitize.db.models import Job, Document, DocumentChecksum, Connector, ConnectorDocumentChecksum, ConnectorSyncLog
 from digitize.db.connection import get_db_session
 from digitize.models import JobStatus, DocStatus
+from digitize.connectors.models import SyncStatus
 
 logger = get_logger("db_repository")
 
@@ -774,7 +775,7 @@ class DatabaseManager:
                         allowed_extensions=allowed_extensions,
                         sync_interval_seconds=sync_interval_seconds,
                         attached_at=datetime.now(timezone.utc),
-                        sync_status="up to date",
+                        sync_status=SyncStatus.IDLE,
                         total_files=0,
                     )
                     .on_conflict_do_nothing(index_elements=["id"])
@@ -1057,7 +1058,7 @@ class DatabaseManager:
                         connector_id=connector_id,
                         seq=seq_subquery,
                         started_at=started_at or datetime.now(timezone.utc),
-                        status="started",
+                        status=SyncStatus.STARTED,
                         error="",
                     )
                     .returning(ConnectorSyncLog.seq)
@@ -1066,7 +1067,7 @@ class DatabaseManager:
                 session.execute(
                     update(Connector)
                     .where(Connector.id == connector_id)
-                    .values(sync_status="syncing")
+                    .values(sync_status=SyncStatus.SYNCING)
                 )
                 logger.debug(f"open_sync_log: connector={connector_id!r} seq={seq}")
                 return seq

--- a/services/digitize/db/models.py
+++ b/services/digitize/db/models.py
@@ -202,7 +202,7 @@ class Connector(Base):
         default=lambda: datetime.now(timezone.utc),
     )
     last_sync_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
-    sync_status: Mapped[str] = mapped_column(Text, nullable=False, default=SyncStatus.IDLE)
+    sync_status: Mapped[str] = mapped_column(Text, nullable=False, default=SyncStatus.UP_TO_DATE)
     last_sync_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     total_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 

--- a/services/digitize/db/models.py
+++ b/services/digitize/db/models.py
@@ -21,6 +21,8 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
+from digitize.connectors.models import SyncStatus
+
 
 class Base(DeclarativeBase):
     """Base class for all ORM models."""
@@ -200,7 +202,7 @@ class Connector(Base):
         default=lambda: datetime.now(timezone.utc),
     )
     last_sync_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
-    sync_status: Mapped[str] = mapped_column(Text, nullable=False, default="up to date")
+    sync_status: Mapped[str] = mapped_column(Text, nullable=False, default=SyncStatus.IDLE)
     last_sync_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     total_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
@@ -266,7 +268,7 @@ class ConnectorSyncLog(Base):
     new_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     removed_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     failed_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    status: Mapped[str] = mapped_column(Text, nullable=False, default="started")
+    status: Mapped[str] = mapped_column(Text, nullable=False, default=SyncStatus.STARTED)
     error: Mapped[str] = mapped_column(Text, nullable=False, default="")
 
     # Relationships

--- a/services/digitize/settings.py
+++ b/services/digitize/settings.py
@@ -11,11 +11,30 @@ from common.settings import Settings as CommonSettings
 class DigitizeConfig(BaseSettings):
     """Digitize service configuration."""
 
+    class ConnectorConfig(BaseSettings):
+        """Connector-specific configuration."""
+
+        sync_interval_seconds: int = Field(
+            default=300,
+            ge=1,
+            description="Sync interval in seconds applied to all connectors at attach time",
+        )
+
+        encryption_key_path: str = Field(
+            default="/run/secrets/connector_encryption_key",
+            description="Path to the AES-256-GCM key file (32 raw bytes) used to encrypt connector secrets at rest",
+        )
+
+        model_config = SettingsConfigDict(env_prefix="CONNECTOR_")
+
     # Directory paths
     cache_dir: Path = Field(
         default=Path("/var/cache"),
         description="Base cache directory for all operations",
     )
+
+    # Connector settings
+    connector: ConnectorConfig = Field(default_factory=ConnectorConfig)
 
     # Worker pool sizes
     doc_worker_size: int = Field(

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -189,11 +189,11 @@ def connector_test_client(monkeypatch, tmp_path, mock_db_operations):
 # ===========================================================================
 
 class TestPostConnector:
-    def test_returns_202_on_success(self, connector_test_client, monkeypatch):
+    def test_returns_200_on_success(self, connector_test_client, monkeypatch):
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())
         response = connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
-        assert response.status_code == 202
-        assert response.json()["connector_id"] == CONNECTOR_ID
+        assert response.status_code == 200
+        assert response.text == ""
 
     def test_encrypts_private_key_before_insert(self, connector_test_client, monkeypatch):
         captured = {}
@@ -214,18 +214,15 @@ class TestPostConnector:
         response = connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
         assert response.status_code == 409
 
-    def test_s3_connector_returns_202(self, connector_test_client, monkeypatch):
+    def test_s3_connector_returns_200(self, connector_test_client, monkeypatch):
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())
         response = connector_test_client.post("/v1/connectors", json=S3_PAYLOAD)
-        assert response.status_code == 202
+        assert response.status_code == 200
 
     def test_secret_not_returned_in_response(self, connector_test_client, monkeypatch):
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())
         response = connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
-        body = response.json()
-        # The 202 response body only has connector_id and status
-        assert "private_key" not in str(body)
-        assert "secret_access_key" not in str(body)
+        assert response.text == ""
 
 
 # ===========================================================================
@@ -418,16 +415,16 @@ class TestGetConnector:
             "digitize.api.v1.connectors.db_ops.get_active_connector",
             Mock(return_value=_make_connector()),
         )
-        monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.list_sync_logs",
-            Mock(return_value=([_make_sync_log()], 1)),
-        )
         response = connector_test_client.get(f"/v1/connectors/{CONNECTOR_ID}")
         assert response.status_code == 200
         data = response.json()
         assert data["connector_id"] == CONNECTOR_ID
         assert data["total_files"] == 42
-        assert data["new_files"] == 2
+        assert data["connection_details"] == {
+            "host": "sftp.example.com",
+            "username": "sync_user",
+            "remote_path": "/exports",
+        }
 
     def test_returns_404_when_not_found(self, connector_test_client, monkeypatch):
         monkeypatch.setattr(

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -189,10 +189,10 @@ def connector_test_client(monkeypatch, tmp_path, mock_db_operations):
 # ===========================================================================
 
 class TestPostConnector:
-    def test_returns_200_on_success(self, connector_test_client, monkeypatch):
+    def test_returns_201_on_success(self, connector_test_client, monkeypatch):
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())
         response = connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
-        assert response.status_code == 200
+        assert response.status_code == 201
         assert response.text == ""
 
     def test_encrypts_private_key_before_insert(self, connector_test_client, monkeypatch):
@@ -214,10 +214,10 @@ class TestPostConnector:
         response = connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
         assert response.status_code == 409
 
-    def test_s3_connector_returns_200(self, connector_test_client, monkeypatch):
+    def test_s3_connector_returns_201(self, connector_test_client, monkeypatch):
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())
         response = connector_test_client.post("/v1/connectors", json=S3_PAYLOAD)
-        assert response.status_code == 200
+        assert response.status_code == 201
 
     def test_secret_not_returned_in_response(self, connector_test_client, monkeypatch):
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -1,0 +1,577 @@
+"""
+Integration tests for PR3 — REST API endpoints for connectors.
+
+All tests use httpx.AsyncClient + FastAPI TestClient (via the sync TestClient
+wrapper) and mock out DB operations, encryption key access, and the worker
+manager stub so no real database or secret file is needed.
+
+Coverage:
+  - POST   /v1/connectors                                 (202, 409)
+  - PUT    /v1/connectors/{id}                            (200, 404, 409)
+  - DELETE /v1/connectors/{id}                            (204, 404, 409)
+  - GET    /v1/connectors                                 (200)
+  - GET    /v1/connectors/{id}                            (200, 404)
+  - GET    /v1/connectors/{id}/syncs                      (200, 404)
+  - GET    /v1/documents — excludes connector-sourced docs
+  - GET    /v1/documents/{doc_id} — 404 for connector-sourced
+  - DELETE /v1/documents/{doc_id} — 404 for connector-sourced
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
+
+import digitize.app as digitize_app
+import digitize.api.v1.documents as documents_router_module
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+_NOW_STR = "2025-01-15T12:00:00Z"
+
+CONNECTOR_ID = "c7f3a2d1-0000-0000-0000-000000000001"
+CONNECTOR_NAME = "prod-sftp-reports"
+CONNECTOR_TYPE = "ssh"
+
+SSH_PAYLOAD = {
+    "connector_id": CONNECTOR_ID,
+    "connector_name": CONNECTOR_NAME,
+    "type": "ssh",
+    "allowed_extensions": [".pdf", ".docx"],
+    "connection_details": {
+        "host": "sftp.example.com",
+        "username": "sync_user",
+        "remote_path": "/exports/reports",
+        "private_key": "-----BEGIN OPENSSH PRIVATE KEY-----\nfake-key\n",
+    },
+}
+
+S3_PAYLOAD = {
+    "connector_id": "a1b2c3d4-0000-0000-0000-000000000002",
+    "connector_name": "prod-s3-rag-docs",
+    "type": "s3",
+    "allowed_extensions": [".pdf"],
+    "connection_details": {
+        "endpoint_url": "https://s3.us-east-1.amazonaws.com",
+        "bucket_name": "my-bucket",
+        "access_key_id": "AKIAIOSFODNN7EXAMPLE",
+        "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfi",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Mock Connector / SyncLog factories
+# ---------------------------------------------------------------------------
+
+def _make_connector(
+    connector_id: str = CONNECTOR_ID,
+    name: str = CONNECTOR_NAME,
+    connector_type: str = CONNECTOR_TYPE,
+    sync_status: str = "up to date",
+) -> MagicMock:
+    c = MagicMock()
+    c.id = connector_id
+    c.name = name
+    c.type = connector_type
+    c.connection_details = {"host": "sftp.example.com", "username": "sync_user", "remote_path": "/exports"}
+    c.allowed_extensions = [".pdf", ".docx"]
+    c.sync_interval_seconds = 300
+    c.attached_at = _NOW
+    c.last_sync_at = _NOW
+    c.sync_status = sync_status
+    c.last_sync_error = None
+    c.total_files = 42
+    return c
+
+
+def _make_sync_log(log_id: int = 1, seq: int = 1) -> MagicMock:
+    log = MagicMock()
+    log.id = log_id
+    log.connector_id = CONNECTOR_ID
+    log.seq = seq
+    log.started_at = _NOW
+    log.finished_at = _NOW
+    log.total_files = 42
+    log.new_files = 2
+    log.removed_files = 0
+    log.failed_files = 1
+    log.status = "completed"
+    log.error = ""
+    return log
+
+
+# ---------------------------------------------------------------------------
+# Shared test fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def connector_test_client(monkeypatch, tmp_path, mock_db_operations):
+    """
+    TestClient wired with all external dependencies mocked out.
+
+    Patches:
+      - settings → fake dirs and fast-path values
+      - encrypt_secrets / merge_and_encrypt_partial → return input unchanged
+      - _get_key_path → /dev/null (never touched because encryption is mocked)
+      - db_ops.insert_connector, upsert_connector, etc.
+    """
+    from digitize.workers.concurrency import concurrency_manager
+
+    digitized_dir = tmp_path / "digitized"
+    staging_dir = tmp_path / "staging"
+    for path in (digitized_dir, staging_dir):
+        path.mkdir(parents=True, exist_ok=True)
+
+    fake_settings = SimpleNamespace(
+        common=SimpleNamespace(app=SimpleNamespace(log_level="INFO")),
+        digitize=SimpleNamespace(
+            digitized_docs_dir=digitized_dir,
+            staging_dir=staging_dir,
+            digitization_concurrency_limit=2,
+            ingestion_concurrency_limit=1,
+            connector=SimpleNamespace(
+                sync_interval_seconds=300,
+                encryption_key_path="/dev/null",
+            ),
+        ),
+    )
+
+    monkeypatch.setattr(digitize_app, "settings", fake_settings, raising=False)
+    monkeypatch.setattr(digitize_app.dg_util, "settings", fake_settings, raising=False)
+
+    import digitize.api.v1.connectors as connectors_module
+
+    monkeypatch.setattr(connectors_module, "settings", fake_settings, raising=False)
+
+    # Concurrency stubs
+    from unittest.mock import AsyncMock
+    monkeypatch.setattr(concurrency_manager, "is_locked", Mock(return_value=False))
+    monkeypatch.setattr(concurrency_manager, "acquire", AsyncMock())
+    monkeypatch.setattr(concurrency_manager, "release", Mock())
+
+    # Misc stubs
+    monkeypatch.setattr(digitize_app.dg_util, "has_active_jobs", Mock(return_value=(False, [])))
+    monkeypatch.setattr(digitize_app, "configure_uvicorn_logging", Mock())
+    monkeypatch.setattr(documents_router_module, "reset_db", Mock())
+
+    # Encryption: pass-through (no real key needed)
+    monkeypatch.setattr(
+        "digitize.api.v1.connectors.encrypt_secrets",
+        lambda connector_type, details, key_path: dict(details),
+    )
+    monkeypatch.setattr(
+        "digitize.api.v1.connectors.merge_and_encrypt_partial",
+        lambda connector_type, existing, partial, key_path: {**existing, **partial},
+    )
+    monkeypatch.setattr(
+        "digitize.api.v1.connectors.strip_secrets",
+        lambda connector_type, details: {
+            k: v for k, v in details.items()
+            if k not in {"private_key", "secret_access_key"}
+        },
+    )
+
+    import digitize.api.v1.jobs as jobs_router_module
+    mock_hash_db_manager = Mock()
+    mock_hash_db_manager.find_completed_document_by_hash = Mock(return_value=None)
+    monkeypatch.setattr(jobs_router_module, "db_manager", mock_hash_db_manager)
+
+    return TestClient(digitize_app.app)
+
+
+# ===========================================================================
+# POST /v1/connectors
+# ===========================================================================
+
+class TestPostConnector:
+    def test_returns_202_on_success(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())
+        response = connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
+        assert response.status_code == 202
+        assert response.json()["connector_id"] == CONNECTOR_ID
+
+    def test_encrypts_private_key_before_insert(self, connector_test_client, monkeypatch):
+        captured = {}
+
+        def capture_insert(**kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", capture_insert)
+        connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
+        # private_key passes through our no-op mock — just confirm it was passed in
+        assert "connection_details" in captured
+
+    def test_returns_409_on_duplicate(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.insert_connector",
+            Mock(side_effect=IntegrityError(None, None, Exception("dup"))),
+        )
+        response = connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
+        assert response.status_code == 409
+
+    def test_s3_connector_returns_202(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())
+        response = connector_test_client.post("/v1/connectors", json=S3_PAYLOAD)
+        assert response.status_code == 202
+
+    def test_secret_not_returned_in_response(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())
+        response = connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
+        body = response.json()
+        # The 202 response body only has connector_id and status
+        assert "private_key" not in str(body)
+        assert "secret_access_key" not in str(body)
+
+
+# ===========================================================================
+# PUT /v1/connectors/{connector_id}
+# ===========================================================================
+
+class TestPutConnector:
+    def test_returns_200_on_success(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.upsert_connector", Mock())
+        response = connector_test_client.put(
+            f"/v1/connectors/{CONNECTOR_ID}",
+            json={"connection_details": {"remote_path": "/v2"}},
+        )
+        assert response.status_code == 200
+
+    def test_returns_404_when_not_found(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.upsert_connector",
+            Mock(side_effect=FileNotFoundError("not found")),
+        )
+        response = connector_test_client.put(
+            f"/v1/connectors/{CONNECTOR_ID}",
+            json={"connector_name": "new-name"},
+        )
+        assert response.status_code == 404
+
+    def test_partial_update_only_overwrites_supplied_keys(self, connector_test_client, monkeypatch):
+        """PUT with only connector_name must not touch connection_details."""
+        upsert_mock = Mock()
+        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.upsert_connector", upsert_mock)
+        connector_test_client.put(
+            f"/v1/connectors/{CONNECTOR_ID}",
+            json={"connector_name": "renamed"},
+        )
+        # connection_details kwarg should be None (not supplied)
+        call_kwargs = upsert_mock.call_args.kwargs if upsert_mock.called else {}
+        assert call_kwargs.get("connection_details") is None
+
+    def test_returns_409_on_name_conflict(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.upsert_connector",
+            Mock(side_effect=IntegrityError(None, None, Exception("dup"))),
+        )
+        response = connector_test_client.put(
+            f"/v1/connectors/{CONNECTOR_ID}",
+            json={"connector_name": "taken-name"},
+        )
+        assert response.status_code == 409
+
+
+# ===========================================================================
+# DELETE /v1/connectors/{connector_id}
+# ===========================================================================
+
+class TestDeleteConnector:
+    def test_returns_204_on_success(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.list_connector_checksums",
+            Mock(return_value=[]),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.delete_active_connector",
+            Mock(return_value=True),
+        )
+        response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}")
+        assert response.status_code == 204
+
+    def test_returns_404_when_not_found(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=None),
+        )
+        response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}")
+        assert response.status_code == 404
+
+    def test_returns_409_when_sync_in_progress(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector(sync_status="syncing")),
+        )
+        response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}")
+        assert response.status_code == 409
+
+    def test_deletes_document_when_last_owner(self, connector_test_client, monkeypatch):
+        """When remaining_owner_count == 0 after removing a checksum, the doc is deleted."""
+        doc_delete_mock = Mock()
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.list_connector_checksums",
+            Mock(return_value=["abc123"]),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.remove_connector_checksum_entry",
+            Mock(return_value=(0, "doc-0001")),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.delete_active_connector",
+            Mock(return_value=True),
+        )
+        with patch("digitize.api.v1.connectors._best_effort_delete_document", doc_delete_mock):
+            connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}")
+        doc_delete_mock.assert_called_once_with("doc-0001")
+
+    def test_does_not_delete_doc_when_other_owners_remain(self, connector_test_client, monkeypatch):
+        """remaining_owner_count > 0 → doc must NOT be deleted."""
+        doc_delete_mock = Mock()
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.list_connector_checksums",
+            Mock(return_value=["abc123"]),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.remove_connector_checksum_entry",
+            Mock(return_value=(2, "doc-0001")),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.delete_active_connector",
+            Mock(return_value=True),
+        )
+        with patch("digitize.api.v1.connectors._best_effort_delete_document", doc_delete_mock):
+            connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}")
+        doc_delete_mock.assert_not_called()
+
+
+# ===========================================================================
+# GET /v1/connectors
+# ===========================================================================
+
+class TestListConnectors:
+    def test_returns_200_with_list(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.list_connectors",
+            Mock(return_value=[_make_connector()]),
+        )
+        response = connector_test_client.get("/v1/connectors")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["connector_id"] == CONNECTOR_ID
+
+    def test_never_returns_secret_fields(self, connector_test_client, monkeypatch):
+        c = _make_connector()
+        c.connection_details = {
+            "host": "sftp.example.com",
+            "username": "sync_user",
+            "private_key": "ENCRYPTED_PRIVATE_KEY",
+        }
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.list_connectors",
+            Mock(return_value=[c]),
+        )
+        response = connector_test_client.get("/v1/connectors")
+        assert "private_key" not in str(response.json())
+
+    def test_returns_empty_list(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.list_connectors",
+            Mock(return_value=[]),
+        )
+        response = connector_test_client.get("/v1/connectors")
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+# ===========================================================================
+# GET /v1/connectors/{connector_id}
+# ===========================================================================
+
+class TestGetConnector:
+    def test_returns_200_with_detail(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.list_sync_logs",
+            Mock(return_value=([_make_sync_log()], 1)),
+        )
+        response = connector_test_client.get(f"/v1/connectors/{CONNECTOR_ID}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["connector_id"] == CONNECTOR_ID
+        assert data["total_files"] == 42
+        assert data["new_files"] == 2
+
+    def test_returns_404_when_not_found(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=None),
+        )
+        response = connector_test_client.get(f"/v1/connectors/{CONNECTOR_ID}")
+        assert response.status_code == 404
+
+    def test_secrets_stripped_from_connection_details(self, connector_test_client, monkeypatch):
+        c = _make_connector()
+        c.connection_details = {
+            "host": "sftp.example.com",
+            "username": "sync_user",
+            "private_key": "ENCRYPTED_PRIVATE_KEY",
+        }
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=c),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.list_sync_logs",
+            Mock(return_value=([], 0)),
+        )
+        response = connector_test_client.get(f"/v1/connectors/{CONNECTOR_ID}")
+        assert response.status_code == 200
+        conn_details = response.json()["connection_details"]
+        assert "private_key" not in conn_details
+        assert conn_details["host"] == "sftp.example.com"
+
+
+# ===========================================================================
+# GET /v1/connectors/{connector_id}/syncs
+# ===========================================================================
+
+class TestSyncLog:
+    def test_returns_paginated_history(self, connector_test_client, monkeypatch):
+        logs = [_make_sync_log(log_id=3, seq=3), _make_sync_log(log_id=2, seq=2)]
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.list_sync_logs",
+            Mock(return_value=(logs, 3)),
+        )
+        response = connector_test_client.get(
+            f"/v1/connectors/{CONNECTOR_ID}/syncs?limit=2&offset=0"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 3
+        assert data["limit"] == 2
+        assert data["offset"] == 0
+        assert len(data["items"]) == 2
+
+    def test_returns_404_when_connector_not_found(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=None),
+        )
+        response = connector_test_client.get(
+            f"/v1/connectors/{CONNECTOR_ID}/syncs"
+        )
+        assert response.status_code == 404
+
+    def test_limit_capped_at_200(self, connector_test_client, monkeypatch):
+        """limit > 200 must be rejected by FastAPI's Query validation."""
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.list_sync_logs",
+            Mock(return_value=([], 0)),
+        )
+        response = connector_test_client.get(
+            f"/v1/connectors/{CONNECTOR_ID}/syncs?limit=999"
+        )
+        assert response.status_code == 422  # FastAPI validation error
+
+
+# ===========================================================================
+# GET /v1/documents — connector visibility
+# ===========================================================================
+
+class TestDocumentListConnectorFilter:
+    def test_list_docs_excludes_connector_sourced(self, connector_test_client, monkeypatch):
+        """get_all_documents_paginated must be called with exclude_connector_sourced=True.
+
+        The function is imported lazily inside the handler via
+        `from digitize.utils.db import get_all_documents_paginated`, so we
+        patch the *source* module attribute that the handler looks up at call time.
+        """
+        captured = {}
+
+        def mock_paginated(**kwargs):
+            captured.update(kwargs)
+            return [], 0
+
+        monkeypatch.setattr(
+            "digitize.utils.db.get_all_documents_paginated",
+            mock_paginated,
+        )
+        connector_test_client.get("/v1/documents")
+        assert captured.get("exclude_connector_sourced") is True
+
+    def test_get_doc_returns_404_for_connector_sourced(self, connector_test_client, monkeypatch):
+        """is_connector_sourced_document is imported inside the handler — patch the source."""
+        monkeypatch.setattr(
+            "digitize.utils.db.is_connector_sourced_document",
+            Mock(return_value=True),
+        )
+        response = connector_test_client.get("/v1/documents/some-connector-doc-id")
+        assert response.status_code == 404
+
+    def test_get_doc_returns_data_for_user_submitted(self, connector_test_client, monkeypatch):
+        from digitize.models import DocumentDetailResponse
+
+        monkeypatch.setattr(
+            "digitize.utils.db.is_connector_sourced_document",
+            Mock(return_value=False),
+        )
+        fake_doc = DocumentDetailResponse(
+            id="doc-001",
+            name="test.pdf",
+            type="ingestion",
+            status="completed",
+            output_format="json",
+        )
+        monkeypatch.setattr(
+            "digitize.utils.db.get_document",
+            Mock(return_value=fake_doc),
+        )
+        response = connector_test_client.get("/v1/documents/doc-001")
+        assert response.status_code == 200
+
+    def test_delete_doc_returns_404_for_connector_sourced(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.utils.db.is_connector_sourced_document",
+            Mock(return_value=True),
+        )
+        response = connector_test_client.delete("/v1/documents/connector-owned-doc")
+        assert response.status_code == 404
+
+# Made with Bob

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -32,8 +32,7 @@ import digitize.api.v1.documents as documents_router_module
 # Constants
 # ---------------------------------------------------------------------------
 
-_NOW = datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
-_NOW_STR = "2025-01-15T12:00:00Z"
+_NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
 
 CONNECTOR_ID = "c7f3a2d1-0000-0000-0000-000000000001"
 CONNECTOR_NAME = "prod-sftp-reports"

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -470,11 +470,34 @@ def get_document(doc_id: str, include_details: bool = True) -> DocumentDetailRes
         raise
 
 
+def is_connector_sourced_document(doc_id: str) -> bool:
+    """
+    Return True if *doc_id* appears in connector_document_checksum (i.e. is
+    connector-sourced and must not be exposed via user-facing document APIs).
+    """
+    try:
+        with get_db_session() as session:
+            from sqlalchemy import exists
+
+            stmt = select(
+                exists().where(ConnectorDocumentChecksum.doc_id == doc_id)
+            )
+            return bool(session.scalar(stmt))
+    except Exception as exc:
+        logger.error(
+            f"DB error in is_connector_sourced_document({doc_id!r}): {exc}",
+            exc_info=True,
+        )
+        # Safe default: do not block on error — treat as user-submitted.
+        return False
+
+
 def get_all_documents_paginated(
     status: Optional[str] = None,
     name: Optional[str] = None,
     limit: int = 20,
-    offset: int = 0
+    offset: int = 0,
+    exclude_connector_sourced: bool = False,
 ) -> tuple[List[dict], int]:
     """
     Get all documents from database.
@@ -484,6 +507,8 @@ def get_all_documents_paginated(
         name: Filter by document name (partial match)
         limit: Maximum number of documents to return
         offset: Number of documents to skip
+        exclude_connector_sourced: When True, omit docs whose doc_id appears
+            in connector_document_checksum (connector-sourced documents)
 
     Returns:
         Tuple of (list of document dictionaries, total count)
@@ -497,7 +522,8 @@ def get_all_documents_paginated(
             status=status,
             name=name,
             limit=limit,
-            offset=offset
+            offset=offset,
+            exclude_connector_sourced=exclude_connector_sourced,
         )
 
         # Convert SQLAlchemy models to dictionaries


### PR DESCRIPTION
- Add POST/PUT/DELETE/GET /v1/connectors and GET /v1/connectors/{id}/sync-history
- Encrypt connector secrets at rest via AES-256-GCM before DB insert; strip on read
- DELETE /v1/connectors stubs worker stop, cleans up checksums and docs
- GET /v1/documents excludes connector-sourced docs (NOT EXISTS filter)
- GET/DELETE /v1/documents/{id} return 404 for connector-sourced docs
- Add connector_sync_interval_seconds and connector_encryption_key_path to settings
- 27 new endpoint tests; all 288 tests pass