### PR TITLE
add application ps api for openshift

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.222
+TAG?=v0.0.223
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.222
+  image: icr.io/ai-services-cicd/ai-services:v0.0.223
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.222
+  image: icr.io/ai-services-cicd/ai-services:v0.0.223
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
@@ -16,8 +17,12 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/validators"
+	consts "github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/common"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // ValidationError represents a validation error with HTTP status code.
@@ -670,6 +675,156 @@ func (s *ApplicationServiceBase) executeDeploymentAsync(parentCtx context.Contex
 	}
 
 	logger.InfolnCtx(ctx, fmt.Sprintf("Deployment completed successfully for application %s", plan.ApplicationName))
+}
+
+// ApplicationsPs returns runtime pod/container status for an application by querying the configured runtime.
+func (s *ApplicationServiceBase) ApplicationsPs(ctx context.Context, appID uuid.UUID, namespace string) (*types.ApplicationPSResponse, error) {
+	app, err := s.AppRepo.GetByID(ctx, appID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get application: %w", err)
+	}
+	if app == nil {
+		return nil, &ValidationError{
+			Code:    http.StatusNotFound,
+			Message: ErrMsgApplicationNotFound,
+		}
+	}
+
+	rt, err := vars.RuntimeFactory.Create(namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init runtime client: %w", err)
+	}
+
+	servicePods, err := s.collectServicePods(ctx, rt, app.Services)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect service pods: %w", err)
+	}
+
+	componentPods, err := s.collectComponentPods(ctx, rt, app.Services)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect component pods: %w", err)
+	}
+
+	return &types.ApplicationPSResponse{
+		ID:         app.ID.String(),
+		Name:       app.Name,
+		Services:   servicePods,
+		Components: componentPods,
+	}, nil
+}
+
+func (s *ApplicationServiceBase) collectServicePods(
+	ctx context.Context,
+	rt runtime.Runtime,
+	services []models.Service,
+) ([]types.Pod, error) {
+	servicePods := make([]types.Pod, 0, len(services))
+
+	for _, service := range services {
+		pod, err := loadApplicationPods(rt, service.ID.String())
+		if err != nil {
+			logger.ErrorfCtx(ctx, "Failed to load service pod: %v", err)
+
+			continue
+		}
+		servicePods = append(servicePods, pod...)
+	}
+
+	logger.InfofCtx(ctx, "Successfully collected %d service pods", len(servicePods))
+
+	return servicePods, nil
+}
+
+func (s *ApplicationServiceBase) collectComponentPods(
+	ctx context.Context,
+	rt runtime.Runtime,
+	services []models.Service,
+) ([]types.Pod, error) {
+	componentMap := make(map[string][]types.Pod)
+
+	for _, service := range services {
+		serviceDependencies, err := s.ServiceDependencyRepo.GetDependenciesByServiceID(ctx, service.ID)
+		if err != nil {
+			logger.ErrorfCtx(ctx, "Failed to get dependencies for service %s: %v", service.ID, err)
+
+			continue
+		}
+
+		for _, dependency := range serviceDependencies {
+			if dependency.DependencyType != models.DependencyTypeComponent {
+				continue
+			}
+
+			componentID := dependency.DependencyID.String()
+
+			if _, exists := componentMap[componentID]; exists {
+				continue
+			}
+
+			componentPod, err := loadApplicationPods(rt, componentID)
+			if err != nil {
+				logger.ErrorfCtx(ctx, "Failed to load component pod: %v", err)
+
+				continue
+			}
+
+			componentMap[componentID] = componentPod
+		}
+	}
+
+	componentPods := make([]types.Pod, 0, len(componentMap))
+	for _, podDetails := range componentMap {
+		componentPods = append(componentPods, podDetails...)
+	}
+
+	logger.InfofCtx(ctx, "Successfully collected %d unique component pods", len(componentPods))
+
+	return componentPods, nil
+}
+
+func loadApplicationPods(rt runtime.Runtime, appID string) ([]types.Pod, error) {
+	filteredPod, err := common.FetchFilteredPods(rt, appID)
+	if err != nil {
+		return nil, err
+	}
+	if len(filteredPod) == 0 {
+		return nil, fmt.Errorf("no pod found with given id")
+	}
+
+	appPodList := make([]types.Pod, 0, len(filteredPod))
+
+	for _, pod := range filteredPod {
+		processedPod, err := common.ProcessPod(rt, pod)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process pod: %w", err)
+		}
+		// ProcessPod returns (nil, nil) when InspectPod fails, so we should skip that pod
+		if processedPod == nil {
+			continue
+		}
+
+		containers := make([]types.PodContainer, 0, len(pod.Containers))
+		for _, container := range processedPod.Containers {
+			containers = append(containers, types.PodContainer{
+				Name:    container.Name,
+				Status:  types.Status(strings.ToLower(processedPod.Status)),
+				Healthy: strings.ToLower(container.Health) == string(consts.Ready),
+			})
+		}
+
+		appPod := types.Pod{
+			PodID:      processedPod.ID,
+			PodName:    processedPod.Name,
+			Status:     types.Status(strings.ToLower(processedPod.Status)),
+			Healthy:    processedPod.Health == string(consts.Ready),
+			Created:    pod.Created.Format(constants.RFC3339WithTimezone),
+			Containers: containers,
+		}
+
+		appPodList = append(appPodList, appPod)
+	}
+
+	return appPodList, nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -723,9 +723,7 @@ func (s *ApplicationServiceBase) collectServicePods(
 	for _, service := range services {
 		pod, err := loadApplicationPods(rt, service.ID.String())
 		if err != nil {
-			logger.ErrorfCtx(ctx, "Failed to load service pod: %v", err)
-
-			continue
+			return nil, fmt.Errorf("failed to load service pod for service %s: %w", service.ID, err)
 		}
 		servicePods = append(servicePods, pod...)
 	}
@@ -745,9 +743,7 @@ func (s *ApplicationServiceBase) collectComponentPods(
 	for _, service := range services {
 		serviceDependencies, err := s.ServiceDependencyRepo.GetDependenciesByServiceID(ctx, service.ID)
 		if err != nil {
-			logger.ErrorfCtx(ctx, "Failed to get dependencies for service %s: %v", service.ID, err)
-
-			continue
+			return nil, fmt.Errorf("failed to get dependencies for service %s: %w", service.ID, err)
 		}
 
 		for _, dependency := range serviceDependencies {
@@ -763,9 +759,7 @@ func (s *ApplicationServiceBase) collectComponentPods(
 
 			componentPod, err := loadApplicationPods(rt, componentID)
 			if err != nil {
-				logger.ErrorfCtx(ctx, "Failed to load component pod: %v", err)
-
-				continue
+				return nil, fmt.Errorf("failed to load component pod %s: %w", componentID, err)
 			}
 
 			componentMap[componentID] = componentPod

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/openshift.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/openshift.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	apimodels "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 )
 
@@ -32,8 +33,9 @@ func (s *OpenShiftApplicationService) GetApplicationResources(_ context.Context,
 	return nil, errOpenShiftNotSupported
 }
 
-func (s *OpenShiftApplicationService) ApplicationsPs(_ context.Context, _ uuid.UUID) (*types.ApplicationPSResponse, error) {
-	return nil, errOpenShiftNotSupported
+// ApplicationsPs retrieves pod/container status by querying the application's OpenShift namespace.
+func (s *OpenShiftApplicationService) ApplicationsPs(ctx context.Context, appID uuid.UUID) (*types.ApplicationPSResponse, error) {
+	return s.ApplicationServiceBase.ApplicationsPs(ctx, appID, catalogutils.AppNamespace(appID))
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/podman.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/podman.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	apimodels "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
@@ -18,7 +16,6 @@ import (
 	consts "github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime/common"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
@@ -86,6 +83,11 @@ func (s *PodmanApplicationService) CreateApplication(ctx context.Context, req ap
 	return s.ApplicationServiceBase.CreateApplication(ctx, req, runtimeTypes.RuntimeTypePodman)
 }
 
+// ApplicationsPs retrieves pod/container status by querying Podman.
+func (s *PodmanApplicationService) ApplicationsPs(ctx context.Context, appID uuid.UUID) (*types.ApplicationPSResponse, error) {
+	return s.ApplicationServiceBase.ApplicationsPs(ctx, appID, "")
+}
+
 // GetApplicationResources retrieves CPU, memory, and Spyre-card usage by querying Podman pods.
 func (s *PodmanApplicationService) GetApplicationResources(ctx context.Context, id uuid.UUID) (*types.ApplicationResourcesResponse, error) {
 	app, err := s.AppRepo.GetByID(ctx, id)
@@ -115,42 +117,6 @@ func (s *PodmanApplicationService) GetApplicationResources(ctx context.Context, 
 	}
 
 	return buildResourcesResponse(resourceTotals), nil
-}
-
-// ApplicationsPs returns runtime pod/container status for an application by querying Podman.
-func (s *PodmanApplicationService) ApplicationsPs(ctx context.Context, appID uuid.UUID) (*types.ApplicationPSResponse, error) {
-	app, err := s.AppRepo.GetByID(ctx, appID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get application: %w", err)
-	}
-	if app == nil {
-		return nil, &ValidationError{
-			Code:    http.StatusNotFound,
-			Message: ErrMsgApplicationNotFound,
-		}
-	}
-
-	rt, err := vars.RuntimeFactory.Create("")
-	if err != nil {
-		return nil, fmt.Errorf("failed to init %s client: %w", rt.Type(), err)
-	}
-
-	servicePods, err := s.collectServicePods(ctx, rt, app.Services)
-	if err != nil {
-		return nil, fmt.Errorf("failed to collect service pods: %w", err)
-	}
-
-	componentPods, err := s.collectComponentPods(ctx, rt, app.Services)
-	if err != nil {
-		return nil, fmt.Errorf("failed to collect component pods: %w", err)
-	}
-
-	return &types.ApplicationPSResponse{
-		ID:         app.ID.String(),
-		Name:       app.Name,
-		Services:   servicePods,
-		Components: componentPods,
-	}, nil
 }
 
 // --- resource helpers (Podman-only) ---
@@ -340,118 +306,6 @@ func buildResourcesResponse(totals *resourceTotals) *types.ApplicationResourcesR
 		},
 		Accelerators: accelerators,
 	}
-}
-
-// --- pod-status helpers (Podman-only) ---
-
-func (s *PodmanApplicationService) collectServicePods(
-	ctx context.Context,
-	rt runtime.Runtime,
-	services []models.Service,
-) ([]types.Pod, error) {
-	servicePods := make([]types.Pod, 0, len(services))
-
-	for _, service := range services {
-		pod, err := loadApplicationPods(rt, service.ID.String())
-		if err != nil {
-			logger.ErrorfCtx(ctx, "Failed to load service pod: %v", err)
-
-			continue
-		}
-		servicePods = append(servicePods, pod...)
-	}
-
-	logger.InfofCtx(ctx, "Successfully collected %d service pods", len(servicePods))
-
-	return servicePods, nil
-}
-
-func (s *PodmanApplicationService) collectComponentPods(
-	ctx context.Context,
-	rt runtime.Runtime,
-	services []models.Service,
-) ([]types.Pod, error) {
-	componentMap := make(map[string][]types.Pod)
-
-	for _, service := range services {
-		serviceDependencies, err := s.ServiceDependencyRepo.GetDependenciesByServiceID(ctx, service.ID)
-		if err != nil {
-			logger.ErrorfCtx(ctx, "Failed to get dependencies for service %s: %v", service.ID, err)
-
-			continue
-		}
-
-		for _, dependency := range serviceDependencies {
-			if dependency.DependencyType != models.DependencyTypeComponent {
-				continue
-			}
-
-			componentID := dependency.DependencyID.String()
-
-			if _, exists := componentMap[componentID]; exists {
-				continue
-			}
-
-			componentPod, err := loadApplicationPods(rt, componentID)
-			if err != nil {
-				logger.ErrorfCtx(ctx, "Failed to load component pod: %v", err)
-
-				continue
-			}
-
-			componentMap[componentID] = componentPod
-		}
-	}
-
-	componentPods := make([]types.Pod, 0, len(componentMap))
-	for _, podDetails := range componentMap {
-		componentPods = append(componentPods, podDetails...)
-	}
-
-	logger.InfofCtx(ctx, "Successfully collected %d unique component pods", len(componentPods))
-
-	return componentPods, nil
-}
-
-func loadApplicationPods(rt runtime.Runtime, appID string) ([]types.Pod, error) {
-	filteredPod, err := common.FetchFilteredPods(rt, appID)
-	if err != nil {
-		return nil, err
-	}
-	if len(filteredPod) == 0 {
-		return nil, fmt.Errorf("no pod found with given id")
-	}
-
-	appPodList := make([]types.Pod, 0, len(filteredPod))
-
-	for _, pod := range filteredPod {
-		processedPod, err := common.ProcessPod(rt, pod)
-		if err != nil {
-			return nil, fmt.Errorf("failed to process pod: %w", err)
-		}
-
-		containers := make([]types.PodContainer, 0, len(pod.Containers))
-		for _, container := range processedPod.Containers {
-			containers = append(containers, types.PodContainer{
-				Name:    container.Name,
-				Status:  types.Status(strings.ToLower(processedPod.Status)),
-				Healthy: strings.ToLower(container.Health) == string(consts.Ready),
-			})
-		}
-
-		appPod := types.Pod{
-			PodID:      processedPod.ID,
-			PodName:    processedPod.Name,
-			Status:     types.Status(strings.ToLower(processedPod.Status)),
-			Healthy:    processedPod.Health == string(consts.Ready),
-			Created:    pod.Created.Format(constants.RFC3339WithTimezone),
-			Containers: containers,
-		}
-
-		appPodList = append(appPodList, appPod)
-	}
-
-	return appPodList, nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/executor.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/executor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/openshift"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
+	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	openshiftRuntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/openshift"
 	podmanRuntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
@@ -106,8 +107,10 @@ func (e *DeploymentExecutor) executeOpenShiftDeployment(
 	plan *DeploymentPlan,
 	req apimodels.CreateApplicationRequest,
 ) error {
-	// Initialize OpenShift runtime client
-	rt, err := openshiftRuntime.NewOpenshiftClient()
+	// Initialize OpenShift runtime client scoped to the application's namespace
+	// so that ListRoutes, ListPods etc. query the correct namespace.
+	ns := catalogutils.AppNamespace(plan.ApplicationID)
+	rt, err := openshiftRuntime.NewOpenshiftClientWithNamespace(ns)
 	if err != nil {
 		return fmt.Errorf("failed to initialize OpenShift runtime: %w", err)
 	}


### PR DESCRIPTION
Extends the GET /applications/{id}/ps endpoint to support the OpenShift runtime.

Previously ApplicationsPs was implemented only on PodmanApplicationService. This PR refactors the implementation into ApplicationServiceBase so both runtimes share the pod/container status logic, and adds runtime-specific overrides that pass the correct namespace to the runtime client: