### PR TITLE
chore: spyre provider logic in selecting default and refactor the code

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.228
+TAG?=v0.0.229
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.228
+  image: icr.io/ai-services-cicd/ai-services:v0.0.229
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.228
+  image: icr.io/ai-services-cicd/ai-services:v0.0.229
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -928,88 +928,66 @@ func extractProviderParams(prefix string, allParams map[string]string, providerP
 
 // selectProviderFromDeployOptions determines the provider ID for a component using deploy options.
 // Priority:
-// 1. If user provided provider-specific params (e.g., llm.vllm-cpu.model), use that provider.
-// 2. For LLM and reranker components: Use vllm-spyre by default.
-// 3. Default provider marked in deploy options.
+// 1. User-specified provider (matched against deploy options).
+// 2. Default-marked provider.
+// 3. Provider containing "spyre" in its ID.
 // 4. First available provider.
-// Returns an error if multiple providers are specified for the same component type.
+// Returns an error if multiple providers are explicitly selected for the same component type.
 func selectProviderFromDeployOptions(compDeployOpt catalogTypes.DeployOptionsComponent, providerParams map[string]map[string]string) (string, map[string]string, error) {
-	// Check if user specified params for a specific provider.
-	providerID, params, err := findUserSpecifiedProvider(compDeployOpt, providerParams)
+	matchedProvider, defaultProvider, spyreProvider, firstProvider, err := collectProviderSelection(compDeployOpt, providerParams)
 	if err != nil {
 		return "", nil, err
 	}
 
-	if providerID != "" {
-		return providerID, params, nil
+	if matchedProvider != "" {
+		return matchedProvider, providerParams[matchedProvider], nil
 	}
 
-	// Special logic for LLM and reranker component types - prefer Spyre acceleration.
-	if spyreID := findSpyreProvider(compDeployOpt); spyreID != "" {
-		return spyreID, make(map[string]string), nil
+	if defaultProvider != "" {
+		return defaultProvider, make(map[string]string), nil
 	}
 
-	// Use default provider if marked.
-	if defaultID := findDefaultProvider(compDeployOpt); defaultID != "" {
-		return defaultID, make(map[string]string), nil
+	if spyreProvider != "" {
+		return spyreProvider, make(map[string]string), nil
 	}
 
-	// Fall back to first available provider.
-	if len(compDeployOpt.Providers) > 0 {
-		return compDeployOpt.Providers[0].ID, make(map[string]string), nil
-	}
-
-	return "", make(map[string]string), nil
+	return firstProvider, make(map[string]string), nil
 }
 
-// findUserSpecifiedProvider checks if user specified params for a specific provider.
-// Returns an error if multiple valid providers are specified for the same component type.
-func findUserSpecifiedProvider(compDeployOpt catalogTypes.DeployOptionsComponent, providerParams map[string]map[string]string) (string, map[string]string, error) {
+func collectProviderSelection(compDeployOpt catalogTypes.DeployOptionsComponent, providerParams map[string]map[string]string) (string, string, string, string, error) {
 	var matchedProvider string
-	var matchedParams map[string]string
+	var defaultProvider string
+	var spyreProvider string
+	var firstProvider string
 
-	for providerID := range providerParams {
-		// Verify this provider exists in deploy options.
-		for _, p := range compDeployOpt.Providers {
-			if p.ID == providerID {
-				if matchedProvider != "" {
-					return "", nil, fmt.Errorf(
-						"multiple providers specified for component type '%s': '%s' and '%s'. "+
-							"Only one provider can be selected per component type",
-						compDeployOpt.Type, matchedProvider, providerID)
-				}
-
-				matchedProvider = providerID
-				matchedParams = providerParams[providerID]
-
-				break
-			}
-		}
-	}
-
-	return matchedProvider, matchedParams, nil
-}
-
-// findSpyreProvider finds vllm-spyre provider if available for the component.
-func findSpyreProvider(compDeployOpt catalogTypes.DeployOptionsComponent) string {
 	for _, p := range compDeployOpt.Providers {
-		if p.ID == "vllm-spyre" {
-			return p.ID
+		if firstProvider == "" {
+			firstProvider = p.ID
 		}
-	}
 
-	return ""
-}
+		if spyreProvider == "" && p.ID == "vllm-spyre" {
+			spyreProvider = p.ID
+		}
 
-// findDefaultProvider finds the default provider marked in deploy options.
-func findDefaultProvider(compDeployOpt catalogTypes.DeployOptionsComponent) string {
-	for _, p := range compDeployOpt.Providers {
 		if p.Default {
-			return p.ID
+			defaultProvider = p.ID
 		}
+
+		if _, selected := providerParams[p.ID]; !selected {
+			continue
+		}
+
+		if matchedProvider != "" {
+			return "", "", "", "", fmt.Errorf(
+				"multiple providers specified for component type '%s': '%s' and '%s'. "+
+					"Only one provider can be selected per component type",
+				compDeployOpt.Type, matchedProvider, p.ID)
+		}
+
+		matchedProvider = p.ID
 	}
 
-	return ""
+	return matchedProvider, defaultProvider, spyreProvider, firstProvider, nil
 }
 
 // applySchemaDefaults fetches the component provider schema and applies default values.

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -930,7 +930,7 @@ func extractProviderParams(prefix string, allParams map[string]string, providerP
 // Priority:
 // 1. User-specified provider (matched against deploy options).
 // 2. Default-marked provider.
-// 3. Provider containing "spyre" in its ID.
+// 3. Provider is "vllm-spyre".
 // 4. First available provider.
 // Returns an error if multiple providers are explicitly selected for the same component type.
 func selectProviderFromDeployOptions(compDeployOpt catalogTypes.DeployOptionsComponent, providerParams map[string]map[string]string) (string, map[string]string, error) {

--- a/ai-services/cmd/ai-services/cmd/application/create_provider_test.go
+++ b/ai-services/cmd/ai-services/cmd/application/create_provider_test.go
@@ -148,7 +148,7 @@ func TestExtractComponentParamsForService_OnlyFalse_DefaultApplies(t *testing.T)
 	}
 }
 
-func TestFindUserSpecifiedProvider_SingleProvider(t *testing.T) {
+func TestSelectProviderFromDeployOptions_UserSelection(t *testing.T) {
 	compDeployOpt := catalogTypes.DeployOptionsComponent{
 		Type: "llm",
 		Providers: []catalogTypes.DeployOptionsProvider{
@@ -160,7 +160,7 @@ func TestFindUserSpecifiedProvider_SingleProvider(t *testing.T) {
 		"vllm-cpu": {},
 	}
 
-	providerID, params, err := findUserSpecifiedProvider(compDeployOpt, providerParams)
+	providerID, params, err := selectProviderFromDeployOptions(compDeployOpt, providerParams)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestFindUserSpecifiedProvider_SingleProvider(t *testing.T) {
 	}
 }
 
-func TestFindUserSpecifiedProvider_MultipleProviders_ReturnsError(t *testing.T) {
+func TestSelectProviderFromDeployOptions_MultipleSelections_ReturnsError(t *testing.T) {
 	compDeployOpt := catalogTypes.DeployOptionsComponent{
 		Type: "llm",
 		Providers: []catalogTypes.DeployOptionsProvider{
@@ -187,35 +187,34 @@ func TestFindUserSpecifiedProvider_MultipleProviders_ReturnsError(t *testing.T) 
 		"vllm-spyre": {},
 	}
 
-	_, _, err := findUserSpecifiedProvider(compDeployOpt, providerParams)
+	_, _, err := selectProviderFromDeployOptions(compDeployOpt, providerParams)
 	if err == nil {
-		t.Fatal("expected error when multiple providers specified, got nil")
+		t.Fatal("expected error when multiple providers selected, got nil")
 	}
 }
 
-func TestFindUserSpecifiedProvider_NoMatchingProvider(t *testing.T) {
+func TestSelectProviderFromDeployOptions_NoUserSelection_FallsBackToDefault(t *testing.T) {
 	compDeployOpt := catalogTypes.DeployOptionsComponent{
-		Type: "llm",
+		Type: "embedding",
 		Providers: []catalogTypes.DeployOptionsProvider{
 			{ID: "vllm-cpu"},
-			{ID: "vllm-spyre"},
+			{ID: "tei", Default: true},
 		},
 	}
-	providerParams := map[string]map[string]string{
-		"watsonx": {"model": "ibm/granite"},
-	}
+	// No user selection — should pick the default-marked provider.
+	providerParams := map[string]map[string]string{}
 
-	providerID, _, err := findUserSpecifiedProvider(compDeployOpt, providerParams)
+	providerID, _, err := selectProviderFromDeployOptions(compDeployOpt, providerParams)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if providerID != "" {
-		t.Errorf("expected empty provider ID for non-matching provider, got '%s'", providerID)
+	if providerID != "tei" {
+		t.Errorf("expected 'tei' as default provider, got '%s'", providerID)
 	}
 }
 
-func TestSelectProviderFromDeployOptions_FallsBackToSpyre(t *testing.T) {
+func TestSelectProviderFromDeployOptions_NoUserSelectionNoDefault_PrefersSpyre(t *testing.T) {
 	compDeployOpt := catalogTypes.DeployOptionsComponent{
 		Type: "llm",
 		Providers: []catalogTypes.DeployOptionsProvider{
@@ -223,7 +222,6 @@ func TestSelectProviderFromDeployOptions_FallsBackToSpyre(t *testing.T) {
 			{ID: "vllm-spyre"},
 		},
 	}
-	// Empty providerParams — no user selection.
 	providerParams := map[string]map[string]string{}
 
 	providerID, _, err := selectProviderFromDeployOptions(compDeployOpt, providerParams)
@@ -232,16 +230,16 @@ func TestSelectProviderFromDeployOptions_FallsBackToSpyre(t *testing.T) {
 	}
 
 	if providerID != "vllm-spyre" {
-		t.Errorf("expected 'vllm-spyre' as default, got '%s'", providerID)
+		t.Errorf("expected 'vllm-spyre' to be preferred, got '%s'", providerID)
 	}
 }
 
-func TestSelectProviderFromDeployOptions_FallsBackToDefault(t *testing.T) {
+func TestSelectProviderFromDeployOptions_NoUserSelectionNoDefaultNoSpyre_FallsBackToFirst(t *testing.T) {
 	compDeployOpt := catalogTypes.DeployOptionsComponent{
 		Type: "embedding",
 		Providers: []catalogTypes.DeployOptionsProvider{
-			{ID: "vllm-cpu"},
-			{ID: "tei", Default: true},
+			{ID: "tei"},
+			{ID: "bge"},
 		},
 	}
 	providerParams := map[string]map[string]string{}
@@ -252,6 +250,29 @@ func TestSelectProviderFromDeployOptions_FallsBackToDefault(t *testing.T) {
 	}
 
 	if providerID != "tei" {
-		t.Errorf("expected 'tei' as default provider, got '%s'", providerID)
+		t.Errorf("expected 'tei' as first provider, got '%s'", providerID)
+	}
+}
+
+func TestSelectProviderFromDeployOptions_UnknownProviderFallsBackToDefault(t *testing.T) {
+	compDeployOpt := catalogTypes.DeployOptionsComponent{
+		Type: "llm",
+		Providers: []catalogTypes.DeployOptionsProvider{
+			{ID: "vllm-cpu"},
+			{ID: "tei", Default: true},
+		},
+	}
+	// User specified a provider not in deploy options — should fall back to default.
+	providerParams := map[string]map[string]string{
+		"watsonx": {"model": "ibm/granite"},
+	}
+
+	providerID, _, err := selectProviderFromDeployOptions(compDeployOpt, providerParams)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if providerID != "tei" {
+		t.Errorf("expected 'tei' as default provider for unknown selection, got '%s'", providerID)
 	}
 }


### PR DESCRIPTION
Refactoring in the `selectProviderFromDeployOptions` code by reducing the number of for loops.