### PR TITLE
Data Source Connectors: Sync Tick Logic 

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.242
+TAG?=v0.0.243
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.43
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.44
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.43
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.44
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.43
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.44
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.43
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.44
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.43
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.44
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.242
+  image: icr.io/ai-services-cicd/ai-services:v0.0.243
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.242
+  image: icr.io/ai-services-cicd/ai-services:v0.0.243
   runtime: ""
   adminPasswordHash: ""
   # workerGatewayPort: port for the gRPC worker gateway. Always active; default is 9090.

--- a/ai-services/assets/services/digitize/openshift/values.yaml
+++ b/ai-services/assets/services/digitize/openshift/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.43
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.44
   log_level: "INFO"
   database: "digitize_metadata"
   numShards: 1

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.43
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.44
   log_level: "INFO"
   database: "digitize_metadata"
 

--- a/docs/proposals/data-source-connectors/architecture-diagram.svg
+++ b/docs/proposals/data-source-connectors/architecture-diagram.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 680" width="800" height="680" font-family="-apple-system, Segoe UI, system-ui, sans-serif" font-size="12">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 700" width="800" height="700" font-family="-apple-system, Segoe UI, system-ui, sans-serif" font-size="12">
   <defs>
     <marker id="a-arr" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#3b82d4"/></marker>
     <marker id="a-arrg" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#2d9a5f"/></marker>
@@ -14,20 +14,20 @@
   <text x="408" y="68" font-size="11" fill="#57606a">POST / PUT / DELETE / GET</text>
 
   <!-- digitize outer box -->
-  <rect x="20" y="82" width="760" height="580" rx="6" fill="#f7f8fa" stroke="#e5e7eb" stroke-width="1.5"/>
+  <rect x="20" y="82" width="760" height="600" rx="6" fill="#f7f8fa" stroke="#e5e7eb" stroke-width="1.5"/>
   <text x="40" y="102" font-weight="700" font-size="13" fill="#1f2328">digitize</text>
 
   <!-- ── Connector API sub-box ── -->
-  <rect x="40" y="114" width="720" height="96" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1"/>
+  <rect x="40" y="114" width="720" height="108" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1"/>
   <text x="56" y="132" font-weight="600" fill="#1e40af">Connector API  (FastAPI router)</text>
 
   <!-- POST /v1/connectors -->
   <rect x="56" y="142" width="160" height="26" rx="3" fill="white" stroke="#3b82d4" stroke-width="1"/>
   <text x="136" y="159" text-anchor="middle" font-size="11" fill="#1e40af">POST /v1/connectors</text>
 
-  <!-- POST /v1/connectors/{id}/sync -->
+  <!-- POST /v1/connectors/{id}/syncs -->
   <rect x="226" y="142" width="200" height="26" rx="3" fill="white" stroke="#3b82d4" stroke-width="1"/>
-  <text x="326" y="159" text-anchor="middle" font-size="11" fill="#1e40af">POST /v1/connectors/{id}/sync</text>
+  <text x="326" y="159" text-anchor="middle" font-size="11" fill="#1e40af">POST /v1/connectors/{id}/syncs</text>
 
   <!-- DELETE /v1/connectors/{id} -->
   <rect x="436" y="142" width="170" height="26" rx="3" fill="white" stroke="#c0392b" stroke-width="1.5"/>
@@ -37,58 +37,67 @@
   <rect x="616" y="142" width="140" height="26" rx="3" fill="white" stroke="#3b82d4" stroke-width="1"/>
   <text x="686" y="159" text-anchor="middle" font-size="11" fill="#1e40af">PUT /v1/connectors/{id}</text>
 
-  <text x="56" y="194" fill="#1f2328" font-size="11">&#x25B8;  validates payload · encrypts secret fields before DB write</text>
-  <text x="56" y="210" fill="#1f2328" font-size="11">&#x25B8;  DELETE: marks sync_status=&#x27;delete_pending&#x27; in DB; dispatches async teardown (non-blocking)</text>
+  <text x="56" y="194" fill="#1f2328" font-size="11">&#x25B8;  validates payload · encrypts secret fields (AES-256-GCM) before DB write via encrypt_secrets()</text>
+  <text x="56" y="210" fill="#1f2328" font-size="11">&#x25B8;  DELETE: mark_connector_delete_pending() (unconditional) · if not syncing: asyncio.create_task(_run_teardown())</text>
 
-  <!-- Arrow from Connector API down to ConnectorScheduler -->
-  <line x1="400" y1="210" x2="400" y2="234" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#a-arr)"/>
+  <!-- Arrow from Connector API down to Sync Engine note -->
+  <line x1="400" y1="222" x2="400" y2="246" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#a-arr)"/>
 
-  <!-- ── ConnectorScheduler sub-box ── -->
-  <rect x="40" y="234" width="720" height="144" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="1"/>
-  <text x="56" y="254" font-weight="600" fill="#166534">ConnectorScheduler  (APScheduler AsyncScheduler singleton)</text>
-  <text x="72" y="274" fill="#1f2328" font-size="11">&#x25B8;  one IntervalTrigger job per active connector · max_instances=1 prevents overlapping ticks</text>
-  <text x="72" y="290" fill="#1f2328" font-size="11">&#x25B8;  register_connector_job() on POST · remove_connector_job() on DELETE · DB sync_status used as distributed lock</text>
-  <text x="72" y="306" fill="#1f2328" font-size="11">&#x25B8;  lifespan recovery: re-registers all persisted connector jobs on startup with fire_immediately=False</text>
-  <text x="72" y="322" fill="#1f2328" font-size="11">&#x25B8;  APScheduler dispatches _run_tick_wrapped(), which calls _check_delete_pending() then acquires sync lock, then awaits _run_tick()</text>
+  <!-- ── Sync Engine sub-box (replaces ConnectorScheduler — not yet implemented) ── -->
+  <rect x="40" y="246" width="720" height="130" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="1"/>
+  <text x="56" y="266" font-weight="600" fill="#166534">Sync Execution Engine  (sync_tick.py)</text>
+  <text x="72" y="286" fill="#1f2328" font-size="11">&#x25B8;  run_tick(connector_id) called by: POST /syncs handler (lock acquired before call) or APScheduler (PR7 — not yet implemented)</text>
+  <text x="72" y="302" fill="#1f2328" font-size="11">&#x25B8;  Phases: open log → interrupt check → connect → scan → classify → update counts → ingest batches → delete orphans → finalize</text>
+  <text x="72" y="318" fill="#1f2328" font-size="11">&#x25B8;  _check_interrupt_call(connector_id, sync_seq): reads connectors.sync_status (DELETE_PENDING) AND connector_sync_logs.status (CANCEL_PENDING)</text>
+  <text x="72" y="334" fill="#1f2328" font-size="11">&#x25B8;  Raises CancelledError at 4 checkpoints; _handle_interrupt(async) dispatches _cancel_tick + _run_teardown or _sweep_staging_dir</text>
 
-  <!-- _run_tick inner box -->
-  <rect x="72" y="334" width="656" height="32" rx="4" fill="#bbf7d0" stroke="#2d9a5f" stroke-width="1"/>
-  <text x="400" y="350" text-anchor="middle" font-weight="600" fill="#166534">_run_tick(connector_id)  — async coroutine (Phase 0–5)</text>
-  <text x="400" y="362" text-anchor="middle" font-size="11" fill="#1f2328">Phases: acquire lock → open log → connect → scan → classify → ingest files → delete orphans → finalize</text>
+  <!-- PR7 stub note -->
+  <rect x="72" y="346" width="678" height="22" rx="3" fill="#fef9c3" stroke="#ca8a04" stroke-width="1"/>
+  <text x="411" y="361" text-anchor="middle" font-size="10" fill="#854d0e" font-weight="600">&#x26A0;  APScheduler (scheduler.py) and recover_connector_sync_state() are NOT YET IMPLEMENTED — planned for PR7</text>
 
-  <!-- Arrow from ConnectorScheduler down to Threading + Persistence -->
-  <line x1="400" y1="378" x2="400" y2="398" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#a-arr)"/>
+  <!-- Arrow from Sync Engine down to Thread Executor -->
+  <line x1="400" y1="376" x2="400" y2="396" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#a-arr)"/>
 
   <!-- ── Thread Executor sub-box ── -->
-  <rect x="40" y="398" width="720" height="96" rx="4" fill="#e0e7ff" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="2,2"/>
-  <text x="56" y="416" font-weight="600" fill="#ca8a04">Thread Executor  (asyncio.run_in_executor &#x2192; ThreadPoolExecutor)</text>
-  <text x="72" y="432" fill="#1f2328" font-size="11">&#x25B8;  All blocking I/O offloaded: scanner.connect(), scanner.scan(), scanner.download_to()</text>
-  <text x="72" y="448" fill="#1f2328" font-size="11">&#x25B8;  Sized in lifespan(): pool_size = max(connector_count + 4, 8) · each tick uses &#x2264; 1 thread at a time</text>
-  <text x="72" y="464" fill="#1f2328" font-size="11">&#x25B8;  Event loop remains responsive during executor calls; CancelledError injected at each await boundary</text>
-  <text x="72" y="480" fill="#1f2328" font-size="11">&#x25B8;  Phase boundaries: _check_delete_pending() does live DB SELECT; raises CancelledError if status = &#x27;delete_pending&#x27;</text>
+  <rect x="40" y="396" width="720" height="96" rx="4" fill="#e0e7ff" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="2,2"/>
+  <text x="56" y="414" font-weight="600" fill="#ca8a04">Thread Executor  (asyncio.to_thread &#x2192; ThreadPoolExecutor)</text>
+  <text x="72" y="430" fill="#1f2328" font-size="11">&#x25B8;  All blocking I/O offloaded: scanner.connect(), scanner.scan(), scanner.download_to(), _best_effort_delete_document()</text>
+  <text x="72" y="446" fill="#1f2328" font-size="11">&#x25B8;  Pool sized in lifespan (PR7): pool_size = max(connector_count + 4, 8) · each connector tick uses &#x2264; 1 thread at a time</text>
+  <text x="72" y="462" fill="#1f2328" font-size="11">&#x25B8;  Event loop remains responsive during executor calls; CancelledError injected only at coroutine await boundaries</text>
+  <text x="72" y="478" fill="#1f2328" font-size="11">&#x25B8;  A thread already in flight runs to natural completion; interrupt is caught at the next checkpoint after the await</text>
 
   <!-- Arrow from Threading down to Persistence -->
-  <line x1="400" y1="494" x2="400" y2="514" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#a-arr)"/>
+  <line x1="400" y1="492" x2="400" y2="512" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#a-arr)"/>
 
   <!-- ── Persistence sub-box ── -->
-  <rect x="40" y="514" width="720" height="120" rx="4" fill="#fef9c3" stroke="#ca8a04" stroke-width="1"/>
-  <text x="56" y="532" font-weight="600" fill="#854d0e">Persistence  (PostgreSQL + Job State)</text>
+  <rect x="40" y="512" width="720" height="132" rx="4" fill="#fef9c3" stroke="#ca8a04" stroke-width="1"/>
+  <text x="56" y="530" font-weight="600" fill="#854d0e">Persistence  (PostgreSQL)</text>
 
   <!-- Row 1 -->
-  <rect x="72" y="546" width="220" height="26" rx="3" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="182" y="564" text-anchor="middle" fill="#854d0e" font-size="11">connectors</text>
-  <rect x="302" y="546" width="220" height="26" rx="3" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="412" y="564" text-anchor="middle" fill="#854d0e" font-size="11">connector_document_checksum</text>
-  <rect x="532" y="546" width="220" height="26" rx="3" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="642" y="564" text-anchor="middle" fill="#854d0e" font-size="11">connector_sync_logs</text>
+  <rect x="72" y="544" width="220" height="28" rx="3" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
+  <text x="182" y="562" text-anchor="middle" fill="#854d0e" font-size="11">connectors</text>
+  <text x="182" y="574" text-anchor="middle" fill="#854d0e" font-size="9">id, sync_status, error, total_files …</text>
+
+  <rect x="302" y="544" width="220" height="28" rx="3" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
+  <text x="412" y="562" text-anchor="middle" fill="#854d0e" font-size="11">connector_document_checksum</text>
+  <text x="412" y="574" text-anchor="middle" fill="#854d0e" font-size="9">PK(checksum, connector_id) · doc_id</text>
+
+  <rect x="532" y="544" width="220" height="28" rx="3" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
+  <text x="642" y="562" text-anchor="middle" fill="#854d0e" font-size="11">connector_sync_logs</text>
+  <text x="642" y="574" text-anchor="middle" fill="#854d0e" font-size="9">PK(connector_id, seq) · status · counts</text>
 
   <!-- Row 2 -->
-  <rect x="72" y="580" width="220" height="26" rx="3" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="182" y="598" text-anchor="middle" fill="#854d0e" font-size="11">APScheduler job state (Postgres)</text>
-  <rect x="302" y="580" width="450" height="26" rx="3" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="527" y="598" text-anchor="middle" fill="#854d0e" font-size="11">document_checksum (user docs; read-only to connectors)</text>
+  <rect x="72" y="580" width="340" height="28" rx="3" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
+  <text x="242" y="598" text-anchor="middle" fill="#854d0e" font-size="11">document_checksum  (user docs — connectors never write)</text>
+
+  <rect x="422" y="580" width="330" height="28" rx="3" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
+  <text x="587" y="598" text-anchor="middle" fill="#854d0e" font-size="11">jobs  /  documents  (all ops visible in GET /v1/jobs)</text>
+
+  <!-- Interrupt model note -->
+  <rect x="72" y="616" width="678" height="20" rx="3" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1" stroke-dasharray="1,1"/>
+  <text x="411" y="630" text-anchor="middle" fill="#166534" font-size="10" font-weight="600">Interrupt model: connectors.sync_status='delete pending' · connector_sync_logs.status='cancel pending' — no in-process _pending_deletions or _live_tasks</text>
 
   <!-- Cancellation model note -->
-  <rect x="40" y="642" width="720" height="20" rx="3" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1" stroke-dasharray="1,1"/>
-  <text x="400" y="655" text-anchor="middle" fill="#166534" font-size="10" font-weight="600">Cancellation model: sync_status=&#x27;delete_pending&#x27; stored in DB only · no in-process _pending_deletions or _live_tasks</text>
+  <rect x="40" y="654" width="720" height="20" rx="3" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1" stroke-dasharray="1,1"/>
+  <text x="400" y="668" text-anchor="middle" fill="#166534" font-size="10" font-weight="600">Teardown: single _run_teardown() in connectors.py used for both DELETE mid-sync (Case A, awaited by _handle_interrupt) and DELETE idle (Case B, asyncio.create_task)</text>
 </svg>

--- a/docs/proposals/data-source-connectors/delete-flow.svg
+++ b/docs/proposals/data-source-connectors/delete-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 1200" width="900" height="1200" font-family="-apple-system, Segoe UI, system-ui, sans-serif" font-size="12">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 1280" width="900" height="1280" font-family="-apple-system, Segoe UI, system-ui, sans-serif" font-size="12">
   <defs>
     <marker id="del-arr" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#c0392b"/></marker>
     <marker id="del-arrg" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#2d9a5f"/></marker>
@@ -7,126 +7,107 @@
 
   <!-- Title -->
   <rect x="100" y="10" width="700" height="36" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="2"/>
-  <text x="450" y="32" text-anchor="middle" font-weight="700" font-size="14" fill="#991b1b">DELETE /v1/connectors/{id} &#x2014; Handler &amp; Teardown Flow</text>
+  <text x="450" y="32" text-anchor="middle" font-weight="700" font-size="14" fill="#991b1b">DELETE /v1/connectors/{id} — Handler &amp; Teardown Flow</text>
   <line x1="450" y1="46" x2="450" y2="66" stroke="#c0392b" stroke-width="2" marker-end="url(#del-arr)"/>
 
   <!-- HTTP HANDLER — FAST PATH -->
   <rect x="80" y="66" width="740" height="22" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1.5"/>
-  <text x="450" y="81" text-anchor="middle" font-weight="700" fill="#854d0e">HTTP Handler (fast synchronous path &#x2014; returns 204 immediately)</text>
+  <text x="450" y="81" text-anchor="middle" font-weight="700" fill="#854d0e">HTTP Handler (fast synchronous path — returns 204 immediately)</text>
 
   <line x1="450" y1="88" x2="450" y2="108" stroke="#c0392b" stroke-width="1.5" marker-end="url(#del-arr)"/>
 
   <!-- Step 1: Check existence -->
   <rect x="100" y="108" width="700" height="48" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1"/>
-  <text x="450" y="124" text-anchor="middle" font-weight="600" fill="#991b1b">Step 1 &#x2014; Check existence</text>
-  <text x="450" y="140" text-anchor="middle" fill="#57606a" font-size="11">SELECT * FROM connectors WHERE id = :connector_id</text>
-  <text x="450" y="152" text-anchor="middle" fill="#57606a" font-size="11">&#x2192; None &#x2192; return 404 Not Found (exit)</text>
+  <text x="450" y="124" text-anchor="middle" font-weight="600" fill="#991b1b">Step 1 — Check existence</text>
+  <text x="450" y="140" text-anchor="middle" fill="#57606a" font-size="11">get_active_connector(connector_id)</text>
+  <text x="450" y="152" text-anchor="middle" fill="#57606a" font-size="11">→ None → return 404 Not Found (exit)</text>
 
   <line x1="450" y1="156" x2="450" y2="176" stroke="#c0392b" stroke-width="1.5" marker-end="url(#del-arr)"/>
 
-  <!-- Step 2: Read sync_status -->
-  <rect x="100" y="176" width="700" height="48" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1"/>
-  <text x="450" y="192" text-anchor="middle" font-weight="600" fill="#991b1b">Step 2 &#x2014; Read current sync_status</text>
-  <text x="450" y="208" text-anchor="middle" fill="#57606a" font-size="11">SELECT sync_status FROM connectors WHERE id = :connector_id</text>
-  <text x="450" y="220" text-anchor="middle" fill="#57606a" font-size="11">Branch on result: Case A (&#x27;syncing&#x27;) or Case B (everything else)</text>
+  <!-- Step 2: mark_sync_delete_pending -->
+  <rect x="100" y="176" width="700" height="60" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1"/>
+  <text x="450" y="194" text-anchor="middle" font-weight="600" fill="#991b1b">Step 2 — mark_sync_delete_pending(connector_id)</text>
+  <text x="450" y="210" text-anchor="middle" fill="#57606a" font-size="11">Atomic UPDATE connectors SET sync_status='delete pending'</text>
+  <text x="450" y="222" text-anchor="middle" fill="#57606a" font-size="11">WHERE sync_status='syncing'  →  returns True (Case A) or False (Case B)</text>
 
   <!-- Case A / Case B split -->
-  <line x1="450" y1="224" x2="450" y2="244" stroke="#c0392b" stroke-width="1.5" marker-end="url(#del-arr)"/>
+  <line x1="450" y1="236" x2="450" y2="256" stroke="#c0392b" stroke-width="1.5" marker-end="url(#del-arr)"/>
 
   <!-- Case A box (left) -->
-  <rect x="100" y="244" width="320" height="88" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1.5"/>
-  <text x="260" y="262" text-anchor="middle" font-weight="700" fill="#991b1b">Case A &#x2014; sync_status = &#x27;syncing&#x27;</text>
-  <text x="260" y="278" text-anchor="middle" fill="#57606a" font-size="11">(a tick is actively running)</text>
-  <text x="260" y="296" text-anchor="middle" fill="#57606a" font-size="11">UPDATE connectors</text>
-  <text x="260" y="310" text-anchor="middle" fill="#57606a" font-size="11">SET sync_status = &#x27;delete_pending&#x27;</text>
-  <text x="260" y="324" text-anchor="middle" fill="#57606a" font-size="11">Return 204. Running tick detects flag at next checkpoint.</text>
+  <rect x="100" y="256" width="320" height="88" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1.5"/>
+  <text x="260" y="274" text-anchor="middle" font-weight="700" fill="#991b1b">Case A — returned True</text>
+  <text x="260" y="290" text-anchor="middle" fill="#57606a" font-size="11">(tick was actively running)</text>
+  <text x="260" y="308" text-anchor="middle" fill="#57606a" font-size="11">connector now marked 'delete pending'</text>
+  <text x="260" y="322" text-anchor="middle" fill="#57606a" font-size="11">Tick detects it at next _check_interrupt_call</text>
+  <text x="260" y="336" text-anchor="middle" fill="#57606a" font-size="11">→ _handle_interrupt → _run_delete_teardown</text>
 
   <!-- Case B box (right) -->
-  <rect x="480" y="244" width="320" height="88" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1.5"/>
-  <text x="640" y="262" text-anchor="middle" font-weight="700" fill="#991b1b">Case B &#x2014; other status</text>
-  <text x="640" y="278" text-anchor="middle" fill="#57606a" font-size="11">(&#x27;up to date&#x27; / &#x27;out of sync&#x27; / etc.)</text>
-  <text x="640" y="296" text-anchor="middle" fill="#57606a" font-size="11">UPDATE connectors</text>
-  <text x="640" y="310" text-anchor="middle" fill="#57606a" font-size="11">SET sync_status = &#x27;delete_pending&#x27;</text>
-  <text x="640" y="324" text-anchor="middle" fill="#57606a" font-size="11">asyncio.create_task(_run_teardown(id))</text>
+  <rect x="480" y="256" width="320" height="88" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1.5"/>
+  <text x="640" y="274" text-anchor="middle" font-weight="700" fill="#991b1b">Case B — returned False</text>
+  <text x="640" y="290" text-anchor="middle" fill="#57606a" font-size="11">(no tick running)</text>
+  <text x="640" y="308" text-anchor="middle" fill="#57606a" font-size="11">asyncio.create_task(_run_teardown(id))</text>
+  <text x="640" y="322" text-anchor="middle" fill="#57606a" font-size="11">Background task runs teardown</text>
 
   <!-- arrows from both cases down to Return 204 -->
-  <line x1="260" y1="332" x2="260" y2="362" stroke="#c0392b" stroke-width="1.5"/>
-  <line x1="260" y1="362" x2="416" y2="362" stroke="#c0392b" stroke-width="1.5"/>
-  <line x1="640" y1="332" x2="640" y2="362" stroke="#c0392b" stroke-width="1.5"/>
-  <line x1="640" y1="362" x2="484" y2="362" stroke="#c0392b" stroke-width="1.5"/>
-  <line x1="450" y1="362" x2="450" y2="384" stroke="#c0392b" stroke-width="1.5" marker-end="url(#del-arr)"/>
+  <line x1="260" y1="344" x2="260" y2="374" stroke="#c0392b" stroke-width="1.5"/>
+  <line x1="260" y1="374" x2="416" y2="374" stroke="#c0392b" stroke-width="1.5"/>
+  <line x1="640" y1="344" x2="640" y2="374" stroke="#c0392b" stroke-width="1.5"/>
+  <line x1="640" y1="374" x2="484" y2="374" stroke="#c0392b" stroke-width="1.5"/>
+  <line x1="450" y1="374" x2="450" y2="396" stroke="#c0392b" stroke-width="1.5" marker-end="url(#del-arr)"/>
 
   <!-- Return 204 -->
-  <rect x="100" y="384" width="700" height="40" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="2"/>
-  <text x="450" y="400" text-anchor="middle" font-weight="700" fill="#166534">Return 204 No Content immediately</text>
-  <text x="450" y="416" text-anchor="middle" fill="#57606a" font-size="11">Case A: tick calls _cancel_tick then dispatches _run_teardown on its own</text>
+  <rect x="100" y="396" width="700" height="30" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="2"/>
+  <text x="450" y="416" text-anchor="middle" font-weight="700" fill="#166534">Return 204 No Content immediately</text>
 
-  <line x1="450" y1="424" x2="450" y2="450" stroke="#ca8a04" stroke-width="2" marker-end="url(#del-arry)"/>
+  <line x1="450" y1="426" x2="450" y2="452" stroke="#ca8a04" stroke-width="2" marker-end="url(#del-arry)"/>
 
-  <!-- BACKGROUND TEARDOWN -->
-  <rect x="80" y="450" width="740" height="22" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1.5"/>
-  <text x="450" y="465" text-anchor="middle" font-weight="700" fill="#854d0e">_run_teardown(connector_id) &#x2014; background asyncio.Task (runs AFTER 204)</text>
+  <!-- Case A inline teardown note -->
+  <rect x="80" y="452" width="740" height="40" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="450" y="470" text-anchor="middle" font-weight="700" fill="#991b1b">Case A — _run_delete_teardown (inline in sync_tick.py, called from _handle_interrupt)</text>
+  <text x="450" y="486" text-anchor="middle" fill="#57606a" font-size="11">Running tick: _check_interrupt_call → DELETE_PENDING → CancelledError → _cancel_tick → _run_delete_teardown</text>
 
-  <line x1="450" y1="472" x2="450" y2="492" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
+  <line x1="450" y1="492" x2="450" y2="512" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
 
-  <!-- Step A: Finalize open sync log -->
-  <rect x="100" y="492" width="700" height="60" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="450" y="510" text-anchor="middle" font-weight="600" fill="#854d0e">Step A &#x2014; Finalize open sync log</text>
-  <text x="450" y="526" text-anchor="middle" fill="#57606a" font-size="11">_finalize_open_sync_log(connector_id)</text>
-  <text x="450" y="542" text-anchor="middle" fill="#57606a" font-size="11">&#x2192; if last log not in {completed, failed, cancelled} &#x2192; close_sync_log(status=&#x27;cancelled&#x27;, update_connector_status=False)</text>
+  <!-- BACKGROUND TEARDOWN — shared steps C/D/E/F -->
+  <rect x="80" y="512" width="740" height="22" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1.5"/>
+  <text x="450" y="527" text-anchor="middle" font-weight="700" fill="#854d0e">Shared Teardown Steps (both Case A _run_delete_teardown and Case B _run_teardown)</text>
 
-  <line x1="450" y1="552" x2="450" y2="572" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
+  <line x1="450" y1="534" x2="450" y2="554" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
 
-  <!-- Step B: Remove APScheduler job -->
-  <rect x="100" y="572" width="700" height="60" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="450" y="590" text-anchor="middle" font-weight="600" fill="#854d0e">Step B &#x2014; Remove APScheduler job</text>
-  <text x="450" y="606" text-anchor="middle" fill="#57606a" font-size="11">await remove_connector_job(connector_id)</text>
-  <text x="450" y="622" text-anchor="middle" fill="#57606a" font-size="11">&#x2192; No new tick can fire during or after teardown</text>
+  <!-- Step C+D: Remove ownership rows -->
+  <rect x="100" y="554" width="700" height="72" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
+  <text x="450" y="572" text-anchor="middle" font-weight="600" fill="#854d0e">Step C+D — Remove checksum ownership &amp; delete orphaned documents</text>
+  <text x="450" y="588" text-anchor="middle" fill="#57606a" font-size="11">list_connector_checksums(connector_id) → owned_checksums</text>
+  <text x="450" y="604" text-anchor="middle" fill="#57606a" font-size="11">For each checksum: remove_connector_checksum_entry(connector_id, checksum)</text>
+  <text x="450" y="616" text-anchor="middle" fill="#57606a" font-size="11">  → if remaining_owner_count == 0 → best-effort _best_effort_delete_document(doc_id)</text>
 
-  <line x1="450" y1="632" x2="450" y2="652" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
-
-  <!-- Step C: Snapshot owned checksums -->
-  <rect x="100" y="652" width="700" height="60" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="450" y="670" text-anchor="middle" font-weight="600" fill="#854d0e">Step C &#x2014; Snapshot owned checksums</text>
-  <text x="450" y="686" text-anchor="middle" fill="#57606a" font-size="11">SELECT checksum, doc_id FROM connector_document_checksum WHERE connector_id = :id</text>
-  <text x="450" y="702" text-anchor="middle" fill="#57606a" font-size="11">&#x2192; owned_rows list captured before any deletions begin</text>
-
-  <line x1="450" y1="712" x2="450" y2="732" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
-
-  <!-- Step D: Remove ownership row by row -->
-  <rect x="100" y="732" width="700" height="72" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="450" y="750" text-anchor="middle" font-weight="600" fill="#854d0e">Step D &#x2014; Remove ownership row by row</text>
-  <text x="450" y="766" text-anchor="middle" fill="#57606a" font-size="11">For each (checksum, doc_id) in owned_rows:</text>
-  <text x="450" y="780" text-anchor="middle" fill="#57606a" font-size="11">  remove_connector_checksum_entry(connector_id, checksum)</text>
-  <text x="450" y="794" text-anchor="middle" fill="#57606a" font-size="11">  if remaining_owner_count == 0 &#x2192; best-effort delete_document_internal(doc_id)</text>
-
-  <line x1="450" y1="804" x2="450" y2="824" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
+  <line x1="450" y1="626" x2="450" y2="646" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
 
   <!-- Step E: Delete connector row -->
-  <rect x="100" y="824" width="700" height="60" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="450" y="842" text-anchor="middle" font-weight="600" fill="#854d0e">Step E &#x2014; Delete connector row</text>
-  <text x="450" y="858" text-anchor="middle" fill="#57606a" font-size="11">DELETE FROM connectors WHERE id = :connector_id</text>
-  <text x="450" y="874" text-anchor="middle" fill="#57606a" font-size="11">&#x2192; ON DELETE CASCADE removes all connector_sync_logs rows</text>
+  <rect x="100" y="646" width="700" height="60" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
+  <text x="450" y="664" text-anchor="middle" font-weight="600" fill="#854d0e">Step E — Delete connector row</text>
+  <text x="450" y="680" text-anchor="middle" fill="#57606a" font-size="11">delete_active_connector(connector_id)</text>
+  <text x="450" y="696" text-anchor="middle" fill="#57606a" font-size="11">→ ON DELETE CASCADE removes all connector_sync_logs rows</text>
 
-  <line x1="450" y1="884" x2="450" y2="904" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
+  <line x1="450" y1="706" x2="450" y2="726" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
 
   <!-- Step F: Cleanup staging dirs -->
-  <rect x="100" y="904" width="700" height="60" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="450" y="922" text-anchor="middle" font-weight="600" fill="#854d0e">Step F &#x2014; Cleanup staging directories</text>
-  <text x="450" y="938" text-anchor="middle" fill="#57606a" font-size="11">cleanup_connector_staging_dirs(connector_id)</text>
-  <text x="450" y="954" text-anchor="middle" fill="#57606a" font-size="11">glob staging/connectors/{connector_id}-* &#x2192; rm -rf</text>
+  <rect x="100" y="726" width="700" height="60" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
+  <text x="450" y="744" text-anchor="middle" font-weight="600" fill="#854d0e">Step F — Cleanup staging directories</text>
+  <text x="450" y="760" text-anchor="middle" fill="#57606a" font-size="11">_sweep_staging_dir(connector_id, staging/connectors)</text>
+  <text x="450" y="776" text-anchor="middle" fill="#57606a" font-size="11">glob staging/connectors/{connector_id}-* → rm -rf</text>
 
   <!-- Final invariant -->
-  <rect x="100" y="980" width="700" height="18" rx="4" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1"/>
-  <text x="450" y="993" text-anchor="middle" font-size="11" fill="#166534" font-weight="600">INVARIANT: No connector_document_checksum rows remain &#x2022; APScheduler job removed &#x2022; DB row deleted &#x2022; staging dirs clean</text>
+  <rect x="100" y="806" width="700" height="18" rx="4" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1"/>
+  <text x="450" y="819" text-anchor="middle" font-size="11" fill="#166534" font-weight="600">INVARIANT: No connector_document_checksum rows remain • DB row deleted • staging dirs clean</text>
 
-  <!-- Case A side note: tick cancellation path -->
-  <rect x="100" y="1016" width="700" height="60" rx="4" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1" stroke-dasharray="3,2"/>
-  <text x="450" y="1034" text-anchor="middle" font-weight="600" fill="#166534">Case A &#x2014; Tick cancellation path (concurrent with teardown)</text>
-  <text x="450" y="1050" text-anchor="middle" fill="#57606a" font-size="11">Running tick hits _check_delete_pending() &#x2192; raises CancelledError &#x2192; _cancel_tick() (log status=&#x27;cancelled&#x27;)</text>
-  <text x="450" y="1066" text-anchor="middle" fill="#57606a" font-size="11">&#x2192; asyncio.create_task(_run_teardown(connector_id)) dispatched &#x2022; no timeout &#x2022; no _live_tasks await</text>
+  <!-- Cancel path note -->
+  <rect x="80" y="844" width="740" height="60" rx="4" fill="#ede9fe" stroke="#7c5cd8" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="450" y="862" text-anchor="middle" font-weight="600" fill="#4c1d95">Cancel-sync (SYNC_CANCEL) — different path, connector is NOT deleted</text>
+  <text x="450" y="878" text-anchor="middle" fill="#57606a" font-size="11">POST /syncs/{seq}/stop → mark_sync_cancel_pending → writes connector_sync_logs.status='cancel pending'</text>
+  <text x="450" y="894" text-anchor="middle" fill="#57606a" font-size="11">Tick: _check_interrupt_call detects CANCEL_PENDING → _cancel_tick (log→'cancelled', connector→'out of sync') + sweep staging</text>
 
   <!-- No in-process state note -->
-  <rect x="100" y="1092" width="700" height="20" rx="3" fill="#ede9fe" stroke="#7c5cd8" stroke-width="1"/>
-  <text x="450" y="1106" text-anchor="middle" font-size="10" fill="#4c1d95" font-weight="600">No in-process state: delete logic uses only DB sync_status=&#x27;delete_pending&#x27; &#x2014; no _pending_deletions set, no _live_tasks dict</text>
+  <rect x="100" y="922" width="700" height="20" rx="3" fill="#ede9fe" stroke="#7c5cd8" stroke-width="1"/>
+  <text x="450" y="936" text-anchor="middle" font-size="10" fill="#4c1d95" font-weight="600">No in-process state: interrupt detection uses DB only — connectors.sync_status and connector_sync_logs.status</text>
 </svg>

--- a/docs/proposals/data-source-connectors/delete-flow.svg
+++ b/docs/proposals/data-source-connectors/delete-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 1280" width="900" height="1280" font-family="-apple-system, Segoe UI, system-ui, sans-serif" font-size="12">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 1180" width="900" height="1180" font-family="-apple-system, Segoe UI, system-ui, sans-serif" font-size="12">
   <defs>
     <marker id="del-arr" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#c0392b"/></marker>
     <marker id="del-arrg" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#2d9a5f"/></marker>
@@ -24,90 +24,98 @@
 
   <line x1="450" y1="156" x2="450" y2="176" stroke="#c0392b" stroke-width="1.5" marker-end="url(#del-arr)"/>
 
-  <!-- Step 2: mark_sync_delete_pending -->
-  <rect x="100" y="176" width="700" height="60" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1"/>
-  <text x="450" y="194" text-anchor="middle" font-weight="600" fill="#991b1b">Step 2 — mark_sync_delete_pending(connector_id)</text>
-  <text x="450" y="210" text-anchor="middle" fill="#57606a" font-size="11">Atomic UPDATE connectors SET sync_status='delete pending'</text>
-  <text x="450" y="222" text-anchor="middle" fill="#57606a" font-size="11">WHERE sync_status='syncing'  →  returns True (Case A) or False (Case B)</text>
+  <!-- Step 2: mark_connector_delete_pending (unconditional) -->
+  <rect x="100" y="176" width="700" height="70" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1"/>
+  <text x="450" y="194" text-anchor="middle" font-weight="600" fill="#991b1b">Step 2 — mark_connector_delete_pending(connector_id)</text>
+  <text x="450" y="210" text-anchor="middle" fill="#57606a" font-size="11">Unconditional UPDATE connectors SET sync_status='delete pending'</text>
+  <text x="450" y="224" text-anchor="middle" fill="#57606a" font-size="11">(no WHERE sync_status guard — always sets delete pending)</text>
+  <text x="450" y="238" text-anchor="middle" fill="#57606a" font-size="11">Read connector.sync_status (fetched in Step 1) to decide Case A vs Case B</text>
 
   <!-- Case A / Case B split -->
-  <line x1="450" y1="236" x2="450" y2="256" stroke="#c0392b" stroke-width="1.5" marker-end="url(#del-arr)"/>
+  <line x1="450" y1="246" x2="450" y2="266" stroke="#c0392b" stroke-width="1.5" marker-end="url(#del-arr)"/>
 
   <!-- Case A box (left) -->
-  <rect x="100" y="256" width="320" height="88" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1.5"/>
-  <text x="260" y="274" text-anchor="middle" font-weight="700" fill="#991b1b">Case A — returned True</text>
-  <text x="260" y="290" text-anchor="middle" fill="#57606a" font-size="11">(tick was actively running)</text>
-  <text x="260" y="308" text-anchor="middle" fill="#57606a" font-size="11">connector now marked 'delete pending'</text>
-  <text x="260" y="322" text-anchor="middle" fill="#57606a" font-size="11">Tick detects it at next _check_interrupt_call</text>
-  <text x="260" y="336" text-anchor="middle" fill="#57606a" font-size="11">→ _handle_interrupt → _run_delete_teardown</text>
+  <rect x="100" y="266" width="320" height="96" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1.5"/>
+  <text x="260" y="284" text-anchor="middle" font-weight="700" fill="#991b1b">Case A — was 'syncing'</text>
+  <text x="260" y="300" text-anchor="middle" fill="#57606a" font-size="11">(tick actively running)</text>
+  <text x="260" y="316" text-anchor="middle" fill="#57606a" font-size="11">connector now 'delete pending'</text>
+  <text x="260" y="332" text-anchor="middle" fill="#57606a" font-size="11">Tick detects at next _check_interrupt_call</text>
+  <text x="260" y="348" text-anchor="middle" fill="#57606a" font-size="11">→ _handle_interrupt → await _run_teardown()</text>
 
   <!-- Case B box (right) -->
-  <rect x="480" y="256" width="320" height="88" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1.5"/>
-  <text x="640" y="274" text-anchor="middle" font-weight="700" fill="#991b1b">Case B — returned False</text>
-  <text x="640" y="290" text-anchor="middle" fill="#57606a" font-size="11">(no tick running)</text>
-  <text x="640" y="308" text-anchor="middle" fill="#57606a" font-size="11">asyncio.create_task(_run_teardown(id))</text>
-  <text x="640" y="322" text-anchor="middle" fill="#57606a" font-size="11">Background task runs teardown</text>
+  <rect x="480" y="266" width="320" height="96" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1.5"/>
+  <text x="640" y="284" text-anchor="middle" font-weight="700" fill="#991b1b">Case B — not 'syncing'</text>
+  <text x="640" y="300" text-anchor="middle" fill="#57606a" font-size="11">(no tick running)</text>
+  <text x="640" y="316" text-anchor="middle" fill="#57606a" font-size="11">asyncio.create_task(_run_teardown(id))</text>
+  <text x="640" y="332" text-anchor="middle" fill="#57606a" font-size="11">Background asyncio task runs teardown</text>
 
   <!-- arrows from both cases down to Return 204 -->
-  <line x1="260" y1="344" x2="260" y2="374" stroke="#c0392b" stroke-width="1.5"/>
-  <line x1="260" y1="374" x2="416" y2="374" stroke="#c0392b" stroke-width="1.5"/>
-  <line x1="640" y1="344" x2="640" y2="374" stroke="#c0392b" stroke-width="1.5"/>
-  <line x1="640" y1="374" x2="484" y2="374" stroke="#c0392b" stroke-width="1.5"/>
-  <line x1="450" y1="374" x2="450" y2="396" stroke="#c0392b" stroke-width="1.5" marker-end="url(#del-arr)"/>
+  <line x1="260" y1="362" x2="260" y2="392" stroke="#c0392b" stroke-width="1.5"/>
+  <line x1="260" y1="392" x2="416" y2="392" stroke="#c0392b" stroke-width="1.5"/>
+  <line x1="640" y1="362" x2="640" y2="392" stroke="#c0392b" stroke-width="1.5"/>
+  <line x1="640" y1="392" x2="484" y2="392" stroke="#c0392b" stroke-width="1.5"/>
+  <line x1="450" y1="392" x2="450" y2="414" stroke="#c0392b" stroke-width="1.5" marker-end="url(#del-arr)"/>
 
   <!-- Return 204 -->
-  <rect x="100" y="396" width="700" height="30" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="2"/>
-  <text x="450" y="416" text-anchor="middle" font-weight="700" fill="#166534">Return 204 No Content immediately</text>
+  <rect x="100" y="414" width="700" height="30" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="2"/>
+  <text x="450" y="434" text-anchor="middle" font-weight="700" fill="#166534">Return 204 No Content immediately</text>
 
-  <line x1="450" y1="426" x2="450" y2="452" stroke="#ca8a04" stroke-width="2" marker-end="url(#del-arry)"/>
+  <line x1="450" y1="444" x2="450" y2="470" stroke="#ca8a04" stroke-width="2" marker-end="url(#del-arry)"/>
 
-  <!-- Case A inline teardown note -->
-  <rect x="80" y="452" width="740" height="40" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1" stroke-dasharray="3,2"/>
-  <text x="450" y="470" text-anchor="middle" font-weight="700" fill="#991b1b">Case A — _run_delete_teardown (inline in sync_tick.py, called from _handle_interrupt)</text>
-  <text x="450" y="486" text-anchor="middle" fill="#57606a" font-size="11">Running tick: _check_interrupt_call → DELETE_PENDING → CancelledError → _cancel_tick → _run_delete_teardown</text>
+  <!-- Shared _run_teardown note -->
+  <rect x="80" y="470" width="740" height="48" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="450" y="488" text-anchor="middle" font-weight="700" fill="#991b1b">_run_teardown(connector_id)  — single shared function in connectors.py</text>
+  <text x="450" y="504" text-anchor="middle" fill="#57606a" font-size="11">Case A: awaited directly by async _handle_interrupt() inside the running tick's CancelledError handler</text>
+  <text x="450" y="516" text-anchor="middle" fill="#57606a" font-size="11">Case B: dispatched as asyncio.create_task() by the DELETE handler before returning 204</text>
 
-  <line x1="450" y1="492" x2="450" y2="512" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
+  <line x1="450" y1="518" x2="450" y2="538" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
 
-  <!-- BACKGROUND TEARDOWN — shared steps C/D/E/F -->
-  <rect x="80" y="512" width="740" height="22" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1.5"/>
-  <text x="450" y="527" text-anchor="middle" font-weight="700" fill="#854d0e">Shared Teardown Steps (both Case A _run_delete_teardown and Case B _run_teardown)</text>
+  <!-- SHARED TEARDOWN STEPS header -->
+  <rect x="80" y="538" width="740" height="22" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1.5"/>
+  <text x="450" y="553" text-anchor="middle" font-weight="700" fill="#854d0e">Teardown Steps (Case A and Case B — same _run_teardown code path)</text>
 
-  <line x1="450" y1="534" x2="450" y2="554" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
+  <line x1="450" y1="560" x2="450" y2="580" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
 
-  <!-- Step C+D: Remove ownership rows -->
-  <rect x="100" y="554" width="700" height="72" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="450" y="572" text-anchor="middle" font-weight="600" fill="#854d0e">Step C+D — Remove checksum ownership &amp; delete orphaned documents</text>
-  <text x="450" y="588" text-anchor="middle" fill="#57606a" font-size="11">list_connector_checksums(connector_id) → owned_checksums</text>
-  <text x="450" y="604" text-anchor="middle" fill="#57606a" font-size="11">For each checksum: remove_connector_checksum_entry(connector_id, checksum)</text>
-  <text x="450" y="616" text-anchor="middle" fill="#57606a" font-size="11">  → if remaining_owner_count == 0 → best-effort _best_effort_delete_document(doc_id)</text>
+  <!-- Step 1+2: Remove ownership rows -->
+  <rect x="100" y="580" width="700" height="80" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
+  <text x="450" y="598" text-anchor="middle" font-weight="600" fill="#854d0e">Steps 1+2 — Remove checksum ownership &amp; delete orphaned documents</text>
+  <text x="450" y="614" text-anchor="middle" fill="#57606a" font-size="11">list_connector_checksums(connector_id) → owned_checksums</text>
+  <text x="450" y="628" text-anchor="middle" fill="#57606a" font-size="11">For each checksum: remove_connector_checksum_entry(connector_id, checksum) → (remaining, doc_id)</text>
+  <text x="450" y="642" text-anchor="middle" fill="#57606a" font-size="11">  → if remaining == 0 and doc_id → _best_effort_delete_document(doc_id)  [returns True/False, best-effort]</text>
+  <text x="450" y="654" text-anchor="middle" fill="#57606a" font-size="10">  → on any failure: set_connector_error(connector_id, "Documents deletion failed") → return early (connector row kept)</text>
 
-  <line x1="450" y1="626" x2="450" y2="646" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
+  <line x1="450" y1="660" x2="450" y2="680" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
 
-  <!-- Step E: Delete connector row -->
-  <rect x="100" y="646" width="700" height="60" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="450" y="664" text-anchor="middle" font-weight="600" fill="#854d0e">Step E — Delete connector row</text>
-  <text x="450" y="680" text-anchor="middle" fill="#57606a" font-size="11">delete_active_connector(connector_id)</text>
-  <text x="450" y="696" text-anchor="middle" fill="#57606a" font-size="11">→ ON DELETE CASCADE removes all connector_sync_logs rows</text>
+  <!-- Step 3: Delete connector row -->
+  <rect x="100" y="680" width="700" height="60" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
+  <text x="450" y="698" text-anchor="middle" font-weight="600" fill="#854d0e">Step 3 — Delete connector row</text>
+  <text x="450" y="714" text-anchor="middle" fill="#57606a" font-size="11">delete_active_connector(connector_id)</text>
+  <text x="450" y="728" text-anchor="middle" fill="#57606a" font-size="11">→ ON DELETE CASCADE removes all connector_sync_logs rows</text>
 
-  <line x1="450" y1="706" x2="450" y2="726" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
+  <line x1="450" y1="740" x2="450" y2="760" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#del-arry)"/>
 
-  <!-- Step F: Cleanup staging dirs -->
-  <rect x="100" y="726" width="700" height="60" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="450" y="744" text-anchor="middle" font-weight="600" fill="#854d0e">Step F — Cleanup staging directories</text>
-  <text x="450" y="760" text-anchor="middle" fill="#57606a" font-size="11">_sweep_staging_dir(connector_id, staging/connectors)</text>
-  <text x="450" y="776" text-anchor="middle" fill="#57606a" font-size="11">glob staging/connectors/{connector_id}-* → rm -rf</text>
+  <!-- Step 4: Cleanup staging dirs -->
+  <rect x="100" y="760" width="700" height="60" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
+  <text x="450" y="778" text-anchor="middle" font-weight="600" fill="#854d0e">Step 4 — Cleanup staging directories</text>
+  <text x="450" y="794" text-anchor="middle" fill="#57606a" font-size="11">_sweep_staging_dir(connector_id, staging/connectors)</text>
+  <text x="450" y="808" text-anchor="middle" fill="#57606a" font-size="11">glob staging/connectors/{connector_id}-* → rm -rf each matching dir</text>
 
   <!-- Final invariant -->
-  <rect x="100" y="806" width="700" height="18" rx="4" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1"/>
-  <text x="450" y="819" text-anchor="middle" font-size="11" fill="#166534" font-weight="600">INVARIANT: No connector_document_checksum rows remain • DB row deleted • staging dirs clean</text>
+  <rect x="100" y="838" width="700" height="18" rx="4" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1"/>
+  <text x="450" y="851" text-anchor="middle" font-size="11" fill="#166534" font-weight="600">INVARIANT: No connector_document_checksum rows remain · DB row deleted · staging dirs clean</text>
 
   <!-- Cancel path note -->
-  <rect x="80" y="844" width="740" height="60" rx="4" fill="#ede9fe" stroke="#7c5cd8" stroke-width="1" stroke-dasharray="3,2"/>
-  <text x="450" y="862" text-anchor="middle" font-weight="600" fill="#4c1d95">Cancel-sync (SYNC_CANCEL) — different path, connector is NOT deleted</text>
-  <text x="450" y="878" text-anchor="middle" fill="#57606a" font-size="11">POST /syncs/{seq}/stop → mark_sync_cancel_pending → writes connector_sync_logs.status='cancel pending'</text>
-  <text x="450" y="894" text-anchor="middle" fill="#57606a" font-size="11">Tick: _check_interrupt_call detects CANCEL_PENDING → _cancel_tick (log→'cancelled', connector→'out of sync') + sweep staging</text>
+  <rect x="80" y="874" width="740" height="60" rx="4" fill="#ede9fe" stroke="#7c5cd8" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="450" y="892" text-anchor="middle" font-weight="600" fill="#4c1d95">Cancel-sync (SYNC_CANCEL) — different path, connector is NOT deleted</text>
+  <text x="450" y="908" text-anchor="middle" fill="#57606a" font-size="11">POST /syncs/{seq}/stop → check sync_status=='syncing' → get_active_sync_seq() → mark_sync_cancel_pending()</text>
+  <text x="450" y="924" text-anchor="middle" fill="#57606a" font-size="11">Tick: _check_interrupt_call detects CANCEL_PENDING → _cancel_tick (log→'cancelled', connector→'out of sync') + _sweep_staging_dir(sync_seq=seq)</text>
 
   <!-- No in-process state note -->
-  <rect x="100" y="922" width="700" height="20" rx="3" fill="#ede9fe" stroke="#7c5cd8" stroke-width="1"/>
-  <text x="450" y="936" text-anchor="middle" font-size="10" fill="#4c1d95" font-weight="600">No in-process state: interrupt detection uses DB only — connectors.sync_status and connector_sync_logs.status</text>
+  <rect x="100" y="952" width="700" height="20" rx="3" fill="#ede9fe" stroke="#7c5cd8" stroke-width="1"/>
+  <text x="450" y="966" text-anchor="middle" font-size="10" fill="#4c1d95" font-weight="600">No in-process state: interrupt detection uses DB only — connectors.sync_status and connector_sync_logs.status</text>
+
+  <!-- Function name correction note -->
+  <rect x="100" y="988" width="700" height="32" rx="3" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1"/>
+  <text x="450" y="1004" text-anchor="middle" font-size="10" fill="#166534">mark_connector_delete_pending() — unconditional, no WHERE sync_status guard</text>
+  <text x="450" y="1018" text-anchor="middle" font-size="10" fill="#166534">mark_sync_cancel_pending() — writes to connector_sync_logs.status only; connector row stays 'syncing'</text>
 </svg>

--- a/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
+++ b/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
@@ -27,9 +27,8 @@ Before any `digitize` connector endpoint is called:
 **Main Components:**
 - `connectors`: Stores connector configuration, encrypted credentials, and top-level sync status.
 - `connector_document_checksum`: Dedup registry for connector-sourced content. Composite PK `(checksum, connector_id)` tracks connector ownership and maps to `doc_id`.
-- `connector_sync_logs`: Per-tick execution log and counters backing history queries.
-- `ConnectorScheduler`: APScheduler `AsyncScheduler` singleton backed by `PostgresDataStore`.
-- `BaseScanner` / Scanners: Transport-specific remote I/O abstraction (`S3Scanner`, `SFTPScanner`).
+- `connector_sync_logs`: Per-tick execution log and counters backing history queries. Composite PK `(connector_id, seq)`.
+- `BaseScanner` / Scanners: Transport-specific remote I/O abstraction (`S3Scanner`, `SSHScanner`).
 - `Sync Execution Engine`: `run_tick()` async coroutine executing the multi-phase sync cycle; blocking I/O offloaded to thread pool via `asyncio.to_thread`.
 
 ---
@@ -49,9 +48,9 @@ CREATE TABLE IF NOT EXISTS connectors (
     sync_interval_seconds   INTEGER     NOT NULL DEFAULT 300,
     attached_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     last_sync_at            TIMESTAMPTZ,
-    sync_status             TEXT        NOT NULL DEFAULT 'up to date'
-                                        CHECK (sync_status IN ('up to date', 'syncing', 'out of sync', 'delete pending')),
+    sync_status             TEXT        NOT NULL DEFAULT 'up to date',
     last_sync_error         TEXT,
+    error                   TEXT,
     total_files             INTEGER     NOT NULL DEFAULT 0,
     CONSTRAINT chk_connector_type CHECK (type IN ('ssh', 's3'))
 );
@@ -59,6 +58,7 @@ CREATE TABLE IF NOT EXISTS connectors (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_connectors_name ON connectors (name);
 
 -- Connector document checksum registry (Connector-sourced documents ONLY)
+-- No FK constraints, no ON DELETE CASCADE — deletion is managed by application code.
 CREATE TABLE IF NOT EXISTS connector_document_checksum (
     checksum     TEXT NOT NULL,
     connector_id TEXT NOT NULL,
@@ -70,7 +70,6 @@ CREATE INDEX IF NOT EXISTS idx_cdc_connector_id ON connector_document_checksum (
 
 -- Connector sync logs table
 CREATE TABLE IF NOT EXISTS connector_sync_logs (
-    id               SERIAL      PRIMARY KEY,
     connector_id     TEXT        NOT NULL,
     seq              INTEGER     NOT NULL,
     started_at       TIMESTAMPTZ NOT NULL,
@@ -80,7 +79,7 @@ CREATE TABLE IF NOT EXISTS connector_sync_logs (
     removed_files    INTEGER     NOT NULL DEFAULT 0,
     status           TEXT        NOT NULL DEFAULT 'started',
     error            TEXT        NOT NULL DEFAULT '',
-    UNIQUE (connector_id, seq),
+    CONSTRAINT pk_csl PRIMARY KEY (connector_id, seq),
     CONSTRAINT fk_csh_connector
         FOREIGN KEY (connector_id)
         REFERENCES connectors(id) ON DELETE CASCADE
@@ -88,6 +87,8 @@ CREATE TABLE IF NOT EXISTS connector_sync_logs (
 
 CREATE INDEX IF NOT EXISTS idx_csl_connector_started ON connector_sync_logs (connector_id, started_at DESC);
 ```
+
+> **Note:** `init_schema.sql` still contains a `failed_files INTEGER` column that is not reflected in the ORM and should be removed in a schema cleanup pass.
 
 ---
 
@@ -99,45 +100,48 @@ CREATE INDEX IF NOT EXISTS idx_csl_connector_started ON connector_sync_logs (con
 class Connector(Base):
     __tablename__ = "connectors"
 
-    id = Column(String, primary_key=True)
-    name = Column(String, nullable=False, unique=True)
-    type = Column(String, nullable=False)
-    connection_details = Column(JSONB, nullable=False, default={})
-    allowed_extensions = Column(JSONB, nullable=False, default=[])
-    sync_interval_seconds = Column(Integer, nullable=False, default=300)
-    attached_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    last_sync_at = Column(DateTime(timezone=True), nullable=True)
-    sync_status = Column(String, nullable=False, default="up to date")
-    last_sync_error = Column(String, nullable=True)
-    total_files = Column(Integer, nullable=False, default=0)
+    id = mapped_column(Text, primary_key=True)
+    name = mapped_column(Text, nullable=False, unique=True)
+    type = mapped_column(Text, nullable=False)
+    connection_details = mapped_column(JSONB, nullable=False, default={})
+    allowed_extensions = mapped_column(JSONB, nullable=False, default=[])
+    sync_interval_seconds = mapped_column(Integer, nullable=False, default=300)
+    attached_at = mapped_column(DateTime(timezone=True), nullable=False,
+                                default=lambda: datetime.now(timezone.utc))
+    last_sync_at = mapped_column(DateTime(timezone=True), nullable=True)
+    sync_status = mapped_column(Text, nullable=False, default=ConnectorStatus.UP_TO_DATE)
+    last_sync_error = mapped_column(Text, nullable=True)
+    error = mapped_column(Text, nullable=True)   # ← teardown error field (no schema equivalent in proposal)
+    total_files = mapped_column(Integer, nullable=False, default=0)
 
-    sync_logs = relationship("ConnectorSyncLog", back_populates="connector", cascade="all, delete-orphan")
+    sync_logs = relationship("ConnectorSyncLog", back_populates="connector",
+                             cascade="all, delete-orphan")
 
 
 class ConnectorDocumentChecksum(Base):
     __tablename__ = "connector_document_checksum"
 
-    checksum = Column(String, primary_key=True, nullable=False)
-    connector_id = Column(String, primary_key=True, nullable=False)
-    doc_id = Column(String, nullable=False)
+    checksum = mapped_column(Text, nullable=False, primary_key=True)
+    connector_id = mapped_column(Text, nullable=False, primary_key=True)
+    doc_id = mapped_column(Text, nullable=False)
 
 
 class ConnectorSyncLog(Base):
     __tablename__ = "connector_sync_logs"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    connector_id = Column(String, ForeignKey("connectors.id", ondelete="CASCADE"), nullable=False)
-    seq = Column(Integer, nullable=False)
-    started_at = Column(DateTime(timezone=True), nullable=False)
-    finished_at = Column(DateTime(timezone=True), nullable=True)
-    total_files = Column(Integer, nullable=False, default=0)
-    new_files = Column(Integer, nullable=False, default=0)
-    removed_files = Column(Integer, nullable=False, default=0)
-    status = Column(String, nullable=False, default="started")
-    error = Column(String, nullable=False, default="")
+    connector_id = mapped_column(Text, ForeignKey("connectors.id", ondelete="CASCADE"),
+                                 nullable=False, primary_key=True)
+    seq = mapped_column(Integer, nullable=False, primary_key=True)
+    started_at = mapped_column(DateTime(timezone=True), nullable=False)
+    finished_at = mapped_column(DateTime(timezone=True), nullable=True)
+    total_files = mapped_column(Integer, nullable=False, default=0)
+    new_files = mapped_column(Integer, nullable=False, default=0)
+    removed_files = mapped_column(Integer, nullable=False, default=0)
+    status = mapped_column(Text, nullable=False, default=SyncLogStatus.STARTED)
+    error = mapped_column(Text, nullable=False, default="")
 
     connector = relationship("Connector", back_populates="sync_logs")
-    # UNIQUE (connector_id, seq) — enforced by uq_csh_connector_seq constraint
+    # PRIMARY KEY (connector_id, seq) — composite, no auto-increment id column
 ```
 
 ---
@@ -160,13 +164,13 @@ class ConnectorSyncLog(Base):
 
 ### 3.1 `POST /v1/connectors`
 
-Creates a connector, encrypts secrets at rest, persists configuration, and registers an APScheduler job. The first tick fires immediately (`next_run_time = NOW()`).
+Creates a connector, encrypts secrets at rest, persists configuration. Returns `201 Created` immediately. The first scheduled tick fires when the scheduler is registered (PR7).
 
 #### Request Parameters
-- Common: `connector_id` (UUID), `connector_name` (string, unique), `type` (`"ssh"` | `"s3"`), `allowed_extensions` (`array[string]`), `connection_details` (object).
-- `sync_interval_seconds`: Read from `CONNECTOR_SYNC_INTERVAL_SECONDS` env var (default `300`).
-- SSH `connection_details`: `host`, `username`, `remote_path`, `private_key`.
-- S3 `connection_details`: `endpoint_url` (full URL), `bucket_name`, `access_key_id`, `secret_access_key`, `prefix` (optional), `delimiter` (optional).
+- Common: `connector_id` (UUID, optional — auto-generated if omitted), `connector_name` (string, unique), `type` (`"ssh"` | `"s3"`), `allowed_extensions` (`array[string]`), `connection_details` (object).
+- `sync_interval_seconds`: Read from `CONNECTOR_SYNC_INTERVAL_SECONDS` env var (default `300`). Not settable per-request.
+- SSH `connection_details`: `host`, `username`, `remote_path`, `private_key`. Optional: `port` (default `22`).
+- S3 `connection_details`: `endpoint_url` (full URL with scheme), `bucket_name`, `access_key_id`, `secret_access_key`. Optional: `prefix`, `delimiter`, `download_concurrency`, `verify_ssl`.
 
 #### Example Payloads
 ```json
@@ -202,7 +206,7 @@ Creates a connector, encrypts secrets at rest, persists configuration, and regis
 ```
 
 #### Responses
-- `201 Created` / `202 Accepted`: Connector created and periodic tick scheduled.
+- `201 Created`: Connector created. Scheduler registration happens in `lifespan()` (PR7 — not yet implemented).
 - `409 Conflict`: `connector_id` or `connector_name` already exists.
 
 ---
@@ -211,8 +215,8 @@ Creates a connector, encrypts secrets at rest, persists configuration, and regis
 
 Updates connector configuration in place.
 - Secrets are re-encrypted if provided.
-- `connection_details` is merged key-by-key (omitted fields remain unchanged).
-- `type` cannot be modified.
+- `connection_details` is merged key-by-key using the PostgreSQL `||` JSONB operator (omitted fields remain unchanged).
+- `type` and `sync_interval_seconds` cannot be modified.
 - Does not restart the scheduler — the next scheduled tick reads updated config directly from DB.
 
 #### Responses
@@ -224,7 +228,7 @@ Updates connector configuration in place.
 
 ### 3.3 `DELETE /v1/connectors/{connector_id}`
 
-Fast, non-blocking detachment. Returns `204 No Content` immediately; teardown runs asynchronously in a background task. No `409 Conflict` guard for running ticks.
+Fast, non-blocking detachment. Returns `204 No Content` immediately; teardown runs asynchronously in a background task.
 
 #### Handler Flow
 
@@ -232,17 +236,16 @@ Fast, non-blocking detachment. Returns `204 No Content` immediately; teardown ru
 DELETE /v1/connectors/{connector_id} (API Handler)
   │
   ├─ 1. SELECT connector → 404 if not found
-  ├─ 2. mark_sync_delete_pending(connector_id)
-  │      (atomic UPDATE connectors SET sync_status='delete pending'
-  │       WHERE sync_status='syncing')
+  ├─ 2. mark_connector_delete_pending(connector_id)
+  │      (unconditional UPDATE connectors SET sync_status='delete pending')
   │
-  ├─ [Case A] sync_status was 'syncing'  (mark_sync_delete_pending returned True)
+  ├─ [Case A] connector.sync_status was 'syncing' (read before step 2)
   │     └─ Return 204 No Content immediately
   │          └─ Running tick hits _check_interrupt_call at its next checkpoint,
   │             detects DELETE_PENDING → raises CancelledError →
-  │             _handle_interrupt calls _cancel_tick then _run_delete_teardown
+  │             _handle_interrupt calls _cancel_tick then _run_teardown (from connectors.py)
   │
-  └─ [Case B] sync_status != 'syncing'  (mark_sync_delete_pending returned False)
+  └─ [Case B] connector.sync_status != 'syncing'
         ├─ asyncio.create_task(_run_teardown(connector_id))
         └─ Return 204 No Content immediately
 ```
@@ -250,20 +253,17 @@ DELETE /v1/connectors/{connector_id} (API Handler)
 #### Teardown Flow
 
 ```text
-_run_teardown(connector_id) (Background asyncio.Task — Case B only)
+_run_teardown(connector_id)  (connectors.py — used for BOTH Case A and Case B)
   │
-  ├─ Step C+D: list_connector_checksums → for each checksum:
+  ├─ Step 1+2: list_connector_checksums → for each checksum:
   │              remove_connector_checksum_entry(connector_id, checksum)
   │              if remaining == 0 and doc_id → _best_effort_delete_document(doc_id)
-  ├─ Step E: delete_active_connector(connector_id) (cascades to sync_logs)
-  └─ Step F: _sweep_staging_dir(connector_id, staging/connectors)
-
-_run_delete_teardown(connector_id) (Inline in sync_tick.py — Case A only)
-  │  Called after _cancel_tick inside CancelledError handler when DELETE_PENDING
-  ├─ Step 1: list_connector_checksums → remove ownership rows + delete orphaned docs
-  ├─ Step 2: delete_active_connector(connector_id) (cascades to sync_logs)
-  └─ Step 3: _sweep_staging_dir(connector_id, staging/connectors)
+  │              on any failure → set_connector_error + return early (connector row kept)
+  ├─ Step 3: delete_active_connector(connector_id) (cascades to sync_logs)
+  └─ Step 4: _sweep_staging_dir(connector_id, staging/connectors)
 ```
+
+> **Note:** There is no separate `_run_delete_teardown` function in `sync_tick.py`. `_handle_interrupt` for `DELETE_CONNECTOR` directly `await`s `_run_teardown` imported from `connectors.py`. The same teardown function is used for both Case A (via the interrupt handler) and Case B (via `asyncio.create_task`).
 
 ![Delete Flow](delete-flow.svg)
 
@@ -271,18 +271,24 @@ _run_delete_teardown(connector_id) (Inline in sync_tick.py — Case A only)
 
 ### 3.4 `GET /v1/connectors` & `GET /v1/connectors/{connector_id}`
 
-- `GET /v1/connectors`: Returns active connectors list without secrets.
-- `GET /v1/connectors/{id}`: Returns connector details + latest file processing counters (`total_files`, `new_files`, `removed_files`).
+- `GET /v1/connectors`: Returns all connectors ordered by `attached_at` descending. Excludes secret fields. Includes `error` field (teardown error state).
+- `GET /v1/connectors/{id}`: Returns full connector detail including `connection_details` (secrets stripped), `allowed_extensions`, `sync_interval_seconds`, and file processing counters (`total_files`).
 
 ---
 
-### 3.5 `GET`, `POST` & `POST /syncs/{sync_seq}/stop` — `/v1/connectors/{connector_id}/syncs`
+### 3.5 Sync Endpoints — `/v1/connectors/{connector_id}/syncs`
 
-- `GET /v1/connectors/{connector_id}/syncs`: Returns paginated execution history items from `connector_sync_logs` (`limit` default 50, max 200).
-- `POST /v1/connectors/{connector_id}/syncs`: Triggers an immediate manual sync tick.
-  - Safe & idempotent: acquires DB lock via atomic `UPDATE connectors SET sync_status='syncing' WHERE id=:id AND sync_status!='syncing' RETURNING id`.
-  - If lock acquired, dispatches `asyncio.create_task(run_tick(connector_id))` (open log happens *inside* `run_tick`); polls `get_active_sync_seq()` in a loop until the row appears, then returns `202 Accepted` with the `sync_seq`.
-  - If locked (already syncing), fetches the current active `sync_seq` via `get_active_sync_seq()` and returns `202 Accepted` with it (no duplicate tick started).
+#### `GET /v1/connectors/{connector_id}/syncs`
+Returns paginated execution history from `connector_sync_logs` (`limit` default 50, max 200, `offset` 0). Results ordered newest first.
+
+#### `GET /v1/connectors/{connector_id}/syncs/{sync_seq}`
+Returns a single sync log entry identified by its sequence number. Returns `404` if the connector or the specific `sync_seq` does not exist.
+
+#### `POST /v1/connectors/{connector_id}/syncs`
+Triggers an immediate manual sync tick.
+- Safe & idempotent: acquires DB lock via atomic `UPDATE connectors SET sync_status='syncing' WHERE id=:id AND sync_status!='syncing' RETURNING id`.
+- If lock acquired: dispatches `asyncio.create_task(run_tick(connector_id))`; polls `get_active_sync_seq()` via `_wait_for_sync_seq()` (10 attempts × 100ms) until the log row appears, then returns `202 Accepted` with `{"sync_seq": <n>}`.
+- If lock unavailable (already syncing): fetches current active `sync_seq` via `get_active_sync_seq()` and returns `202 Accepted` with it (no duplicate tick started).
 
 ```text
 POST /v1/connectors/{connector_id}/syncs
@@ -290,26 +296,28 @@ POST /v1/connectors/{connector_id}/syncs
   ├─ 1. Check existence → 404 if not found
   ├─ 2. try_acquire_sync_lock(connector_id) (atomic UPDATE ... RETURNING)
   │      ├─ Lock acquired → asyncio.create_task(run_tick(connector_id))
-  │      │    └─ _wait_for_sync_seq() polls until open_new_sync_log row appears
+  │      │    └─ _wait_for_sync_seq() polls until init_sync_log_and_update_connector row appears
   │      └─ Lock unavailable (already syncing) → get_active_sync_seq()
   └─ 3. Return 202 Accepted { "sync_seq": <seq> }
 ```
-- `POST /v1/connectors/{connector_id}/syncs/{sync_seq}/stop`: Stops the currently running sync tick without deleting the connector. The connector remains and resumes its normal schedule on the next interval.
-  - `sync_seq` must match the currently-active sync row; returns `409 Conflict` on a stale or absent seq.
-  - If the seq matches: writes `connector_sync_logs.status = 'cancel pending'` via `mark_sync_cancel_pending()` (connector row stays `'syncing'`); returns `204 No Content` immediately.
-  - The tick's `_check_interrupt_call(connector_id, sync_seq)` detects `CANCEL_PENDING` on the log row at its next checkpoint, raises `CancelledError`, and `_cancel_tick` closes the sync log with `status = 'cancelled'`.
-  - `close_sync_log` transitions `connectors.sync_status` to `'out of sync'` so the scheduler can acquire the lock on the next interval.
+
+#### `POST /v1/connectors/{connector_id}/syncs/{sync_seq}/stop`
+Stops the currently running sync tick without deleting the connector.
+- `sync_seq` must match the currently-active sync row; returns `409 Conflict` on a stale or absent seq, or if no sync is running.
+- If the seq matches: writes `connector_sync_logs.status = 'cancel pending'` via `mark_sync_cancel_pending()` (connector row stays `'syncing'`); returns `204 No Content` immediately.
+- The tick's `_check_interrupt_call(connector_id, sync_seq)` detects `CANCEL_PENDING` on the log row at its next checkpoint, raises `CancelledError`, and `_cancel_tick` closes the sync log with `status = 'cancelled'`.
+- `finalize_sync_log_and_update_connector` transitions `connectors.sync_status` to `'out of sync'` so the scheduler can acquire the lock on the next interval.
 
 ```text
 POST /v1/connectors/{connector_id}/syncs/{sync_seq}/stop
   │
   ├─ 1. Check existence → 404 if not found
-  ├─ 2. get_active_sync_seq() → 409 if None or != sync_seq
-  ├─ 3. mark_sync_cancel_pending(connector_id)
+  ├─ 2. Check connector.sync_status == 'syncing' → 409 if not syncing
+  ├─ 3. get_active_sync_seq() → 409 if None or != sync_seq
+  ├─ 4. mark_sync_cancel_pending(connector_id)
   │      → writes connector_sync_logs.status='cancel pending' (connector stays 'syncing')
-  │      ├─ Returns False (not syncing) → 409 Conflict
-  │      └─ Returns True → proceed
-  └─ 4. Return 204 No Content immediately
+  │      └─ Returns False (no started row) → 409 Conflict
+  └─ 5. Return 204 No Content immediately
            └─ Running tick hits _check_interrupt_call checkpoint →
               CANCEL_PENDING detected on sync-log row →
               raises CancelledError → _cancel_tick writes sync log
@@ -322,17 +330,11 @@ POST /v1/connectors/{connector_id}/syncs/{sync_seq}/stop
 
 #### Document APIs (`/v1/documents`)
 - Connector-sourced documents are **excluded** from `GET /v1/documents`, `GET /v1/documents/{doc_id}`, and `DELETE /v1/documents/{doc_id}` (returns `404`).
-- **Implementation:** SQL queries for user document endpoints include:
-  ```sql
-  WHERE NOT EXISTS (
-      SELECT 1 FROM connector_document_checksum 
-      WHERE doc_id = documents.doc_id
-  )
-  ```
+- **Implementation:** `is_connector_sourced_document(doc_id)` checks for presence in `connector_document_checksum`. `get_all_documents_paginated()` accepts `exclude_connector_sourced=True` which filters via `NOT EXISTS (SELECT 1 FROM connector_document_checksum WHERE doc_id = documents.doc_id)`.
 
 #### Job APIs (`/v1/jobs`)
 - All jobs (user-submitted and connector-initiated) are visible in `GET /v1/jobs` and `GET /v1/jobs/{job_id}`.
-- Connector jobs store `connector_id` in `jobs.metadata` and use job naming convention: `{connector_id} - {sync_seq} - {batch_number}`.
+- Connector jobs use the naming convention: `Connector-{connector_name}-{sync_seq}-{batch_number}`.
 
 ---
 
@@ -342,74 +344,112 @@ POST /v1/connectors/{connector_id}/syncs/{sync_seq}/stop
 
 ### 4.1 Functions Reference
 
-| Function | Purpose / Behavior |
+| Function (`utils/db.py` wrapper → `manager.py` method) | Purpose / Behavior |
 | --- | --- |
-| `insert_connector()` | Create new connector row. |
-| `update_connector()` / `upsert_connector()` | Merge configuration fields & re-encrypt secrets. |
-| `get_connector_by_id()` / `get_all_connectors()` | Fetch single or all connectors. |
-| `delete_connector()` / `delete_active_connector()` | Delete connector row (cascades to sync_logs). Returns `bool`. |
-| `mark_sync_delete_pending(connector_id)` | Atomic `UPDATE connectors SET sync_status='delete pending' WHERE sync_status='syncing'`. Returns `True` if a running tick was signalled. |
-| `mark_sync_cancel_pending(connector_id)` | Verifies `connectors.sync_status='syncing'`, then sets `connector_sync_logs.status='cancel pending'` on the active log row. Connector row stays `'syncing'`. Returns `bool`. |
-| `find_connector_doc_by_checksum(checksum)` | Lookup existing `doc_id` in `connector_document_checksum`. |
-| `get_connector_checksums(connector_id)` / `list_connector_checksums()` | Return list of checksums owned by `connector_id`. |
-| `get_all_connector_checksums()` / `list_all_checksums()` | Return list of all distinct checksums in `connector_document_checksum`. |
-| `insert_connector_checksum(connector_id, checksum, doc_id)` | Insert `(checksum, connector_id, doc_id)` with `ON CONFLICT DO NOTHING`. |
-| `delete_connector_checksum(connector_id, checksum)` | Remove `(checksum, connector_id)`; returns `(remaining_owner_count, doc_id)`. |
-| `get_connector_sync_status(connector_id)` | `SELECT sync_status FROM connectors WHERE id = :id`. Returns the current status string or `None`. Used by `_check_interrupt_call`. |
-| `get_active_sync_seq(connector_id)` | Returns `seq` of the active sync-log row (status in `{started, cancel pending}`), or `None` if no tick is running. Used by `POST /syncs` and `POST /syncs/{seq}/stop`. |
-| `try_acquire_sync_lock(connector_id)` | Atomic `UPDATE connectors SET sync_status='syncing' WHERE id=:id AND sync_status!='syncing' RETURNING id`. Returns `bool`. |
-| `open_sync_log(connector_id)` | Create tick log row with `seq = COALESCE(MAX(seq), 0) + 1` and status `'started'`. Also sets connector `sync_status='syncing'`. Returns `seq`. |
-| `update_sync_log_progress(log_id, total_files, new_files, removed_files)` | Write all three file counts in a single DB update immediately after `_classify()` returns. All counts are derived from classify output and known before any I/O begins. (Exposed via `update_sync_log` in `utils/db.py` which takes `seq`.) |
-| `close_sync_log(connector_id, seq, status, error)` | Finalize log row with terminal status and `finished_at`. Updates connector `last_sync_at` and `sync_status` (`CANCELLED`/`FAILED` both map to `OUT_OF_SYNC`). Does **not** carry file counts — those are already persisted by `update_sync_log`. |
-| `get_sync_log_status(connector_id, seq)` | Returns `status` of a specific `(connector_id, seq)` row or `None`. Used by `_check_interrupt_call` to detect `CANCEL_PENDING`. |
-| `get_sync_logs(connector_id, limit, offset)` | Paginated log history query. Returns `(items, total_count)`. |
-| `reset_stale_syncing_connectors()` | On startup: `UPDATE connectors SET sync_status='out of sync' WHERE sync_status='syncing'`. Returns the list of affected `connector_id` values. Used by `recover_connector_sync_state()`. |
+| `insert_connector()` → `insert_connector()` | Create new connector row. Raises `IntegrityError` on duplicate id. |
+| `upsert_connector()` → `update_connector()` | Partial update: only non-None kwargs written. `connection_details` merged via JSONB `\|\|` operator. Raises `FileNotFoundError` if not found. |
+| `get_active_connector()` → `get_connector_by_id()` | Fetch single connector (eagerly loaded + expunged). Returns `None` if not found. |
+| `list_connectors()` → `get_all_connectors()` | All connectors ordered by `attached_at` desc. |
+| `delete_active_connector()` → `delete_connector()` | Delete connector row (cascades to `connector_sync_logs`). Returns `bool`. |
+| `get_connector_sync_status()` → `get_connector_sync_status()` | Minimal `SELECT sync_status` query. Returns `None` if not found. |
+| `mark_connector_delete_pending()` → `mark_connector_delete_pending()` | Unconditional `UPDATE connectors SET sync_status='delete pending'`. Returns `True` if row found. |
+| `mark_sync_cancel_pending()` → `mark_sync_cancel_pending()` | Sets `connector_sync_logs.status='cancel pending'` on the active `STARTED` log row. Connector row stays `'syncing'`. Returns `bool`. |
+| `try_acquire_sync_lock()` → `try_acquire_sync_lock()` | Atomic `UPDATE ... WHERE sync_status != 'syncing' RETURNING id`. Returns `bool`. |
+| `get_active_sync_seq()` → `get_active_sync_seq()` | Returns `seq` of active (`started` \| `cancel pending`) log row, or `None`. |
+| `lookup_connector_content_by_checksum()` → `find_connector_doc_by_checksum()` | Lookup existing `doc_id` for a checksum across all connectors. |
+| `list_connector_checksums()` → `get_connector_checksums()` | All checksums owned by a given connector. |
+| `list_all_checksums()` → `get_all_connector_checksums()` | All distinct checksums across all connectors. |
+| `add_connector_checksum_entry()` → `insert_connector_checksum()` | Insert `(checksum, connector_id, doc_id)` with `ON CONFLICT DO NOTHING`. |
+| `remove_connector_checksum_entry()` → `delete_connector_checksum()` + `count_checksum_owners()` | Delete `(checksum, connector_id)` row; return `(remaining_owner_count, doc_id)`. Two separate DB calls: delete returns `doc_id`; count is a separate query. |
+| `set_connector_error()` → `update_connector()` | Persist error string on connector row (best-effort; logs on failure). |
+| `update_connector_total_files()` → `update_connector()` | Update `total_files` count on connector row. Called after `update_sync_log` in Phase 3b. |
+| `init_sync_log_and_update_connector()` → `insert_sync_log()` + `set_connector_sync_status_syncing()` | Insert new log row (seq = `COALESCE(MAX(seq),0)+1`) with `status='started'`; then set connector `sync_status='syncing'`. Returns `seq`. Two separate DB calls. |
+| `update_sync_log()` → `update_sync_log_progress()` | Write `total_files`, `new_files`, `removed_files` before I/O phase. Takes `connector_id` + `seq`. Returns `bool`. |
+| `finalize_sync_log_and_update_connector()` → `finalize_sync_log()` + `update_connector_after_sync()` | Finalize log row (status, finished_at, optional counts/error); then update connector `last_sync_at` and `sync_status`. `CANCELLED`/`FAILED` both map to `OUT_OF_SYNC`. Two separate DB calls. |
+| `get_sync_log()` → `get_sync_log()` | Single sync-log row by `(connector_id, seq)`. |
+| `get_sync_log_status()` → `get_sync_log_status()` | Minimal `SELECT status` for `(connector_id, seq)`. Used by `_check_interrupt_call`. |
+| `list_sync_logs()` → `get_sync_logs()` + `count_sync_logs()` | Paginated log history. Returns `(items, total_count)`. |
 
 ---
 
 ### 4.2 DB Methods Implementation Code
 
 ```python
+# utils/db.py — thin wrappers that delegate to db_manager
+
+def init_sync_log_and_update_connector(connector_id: str, started_at=None) -> int:
+    """Two DB calls: insert log row + set connector sync_status=SYNCING. Returns seq."""
+    seq = db_manager.insert_sync_log(connector_id, started_at=started_at)
+    db_manager.set_connector_sync_status_syncing(connector_id)
+    return seq
+
+
+def finalize_sync_log_and_update_connector(
+    connector_id, seq, status, finished_at=None, total_files=None,
+    new_files=None, removed_files=None, error=None,
+) -> bool:
+    """
+    Two DB calls: finalize log row + update connector.
+    CANCELLED/FAILED both map to OUT_OF_SYNC on the connector row.
+    Returns True on success, False if the sync-log row was not found.
+    """
+    now = finished_at or datetime.now(timezone.utc)
+    found = db_manager.finalize_sync_log(connector_id, seq, status, now,
+                                         total_files, new_files, removed_files, error)
+    if not found:
+        return False
+    db_manager.update_connector_after_sync(connector_id, status=status, last_sync_at=now)
+    return True
+
+
+def remove_connector_checksum_entry(connector_id: str, checksum: str) -> tuple[int, str | None]:
+    """
+    Two DB calls: delete_connector_checksum (returns doc_id) +
+    count_checksum_owners (counts remaining rows for that checksum).
+    Returns (remaining_owner_count, doc_id) or (0, None) if not found.
+    """
+    doc_id = db_manager.delete_connector_checksum(connector_id, checksum)
+    if doc_id is None:
+        return 0, None
+    remaining = db_manager.count_checksum_owners(checksum)
+    return remaining, doc_id
+
+
+# manager.py — key implementations
+
 class DatabaseManager:
     @staticmethod
-    def find_connector_doc_by_checksum(checksum: str) -> str | None:
+    def mark_connector_delete_pending(connector_id: str) -> bool:
+        """
+        Unconditional UPDATE connectors SET sync_status='delete pending'.
+        Returns True if the connector row was found and updated, False otherwise.
+        """
         with get_db_session() as session:
-            row = session.execute(
-                select(ConnectorDocumentChecksum.doc_id)
-                .where(ConnectorDocumentChecksum.checksum == checksum)
-                .limit(1)
+            result = session.execute(
+                update(Connector)
+                .where(Connector.id == connector_id)
+                .values(sync_status=ConnectorStatus.DELETE_PENDING)
+                .returning(Connector.id)
             ).one_or_none()
-        return row[0] if row else None
+            return result is not None
 
     @staticmethod
-    def insert_connector_checksum(connector_id: str, checksum: str, doc_id: str) -> None:
+    def mark_sync_cancel_pending(connector_id: str) -> bool:
+        """
+        Writes 'cancel pending' to connector_sync_logs.status on the STARTED row.
+        Connector row stays 'syncing'. Returns True if a started log row was found.
+        """
         with get_db_session() as session:
-            stmt = (
-                pg_insert(ConnectorDocumentChecksum)
-                .values(checksum=checksum, connector_id=connector_id, doc_id=doc_id)
-                .on_conflict_do_nothing(index_elements=["checksum", "connector_id"])
-            )
-            session.execute(stmt)
-
-    @staticmethod
-    def delete_connector_checksum(connector_id: str, checksum: str) -> tuple[int, str | None]:
-        with get_db_session() as session:
-            deleted = session.execute(
-                delete(ConnectorDocumentChecksum)
+            result = session.execute(
+                update(ConnectorSyncLog)
                 .where(
-                    ConnectorDocumentChecksum.checksum == checksum,
-                    ConnectorDocumentChecksum.connector_id == connector_id,
+                    ConnectorSyncLog.connector_id == connector_id,
+                    ConnectorSyncLog.status == SyncLogStatus.STARTED,
                 )
-                .returning(ConnectorDocumentChecksum.doc_id)
+                .values(status=SyncLogStatus.CANCEL_PENDING)
+                .returning(ConnectorSyncLog.seq)
             ).one_or_none()
-            if deleted is None:
-                return 0, None
-            doc_id = deleted[0]
-            remaining = session.scalar(
-                select(func.count())
-                .where(ConnectorDocumentChecksum.checksum == checksum)
-            ) or 0
-        return remaining, doc_id
+            return result is not None
 
     @staticmethod
     def try_acquire_sync_lock(connector_id: str) -> bool:
@@ -418,62 +458,22 @@ class DatabaseManager:
                 update(Connector)
                 .where(
                     Connector.id == connector_id,
-                    Connector.sync_status != SyncStatus.SYNCING,
+                    Connector.sync_status != ConnectorStatus.SYNCING,
                 )
-                .values(sync_status=SyncStatus.SYNCING)
+                .values(sync_status=ConnectorStatus.SYNCING)
                 .returning(Connector.id)
             ).one_or_none()
             return result is not None
 
     @staticmethod
-    def mark_sync_cancel_pending(connector_id: str) -> bool:
-        """
-        Writes 'cancel pending' to connector_sync_logs.status — NOT connectors.
-        Connector row stays 'syncing' until the tick's close_sync_log() call.
-        Returns True only when connectors.sync_status='syncing' (a tick is running).
-        """
-        with get_db_session() as session:
-            connector_row = session.execute(
-                select(Connector.id)
-                .where(Connector.id == connector_id, Connector.sync_status == SyncStatus.SYNCING)
-            ).one_or_none()
-            if connector_row is None:
-                return False
-            result = session.execute(
-                update(ConnectorSyncLog)
-                .where(
-                    ConnectorSyncLog.connector_id == connector_id,
-                    ConnectorSyncLog.status == SyncStatus.STARTED,
-                )
-                .values(status=SyncStatus.CANCEL_PENDING)
-                .returning(ConnectorSyncLog.seq)
-            ).one_or_none()
-            return result is not None
-
-    @staticmethod
-    def mark_sync_delete_pending(connector_id: str) -> bool:
-        """
-        Sets connectors.sync_status='delete pending' only when currently 'syncing'.
-        Returns True if a running tick was signalled, False otherwise.
-        """
-        with get_db_session() as session:
-            result = session.execute(
-                update(Connector)
-                .where(Connector.id == connector_id, Connector.sync_status == SyncStatus.SYNCING)
-                .values(sync_status=SyncStatus.DELETE_PENDING)
-                .returning(Connector.id)
-            ).one_or_none()
-            return result is not None
-
-    @staticmethod
-    def get_active_sync_seq(connector_id: str) -> int | None:
-        """Return seq of the active (started | cancel pending) sync-log row, or None."""
+    def get_active_sync_seq(connector_id: str) -> Optional[int]:
+        """Return seq of active (started | cancel pending) sync-log row, or None."""
         with get_db_session() as session:
             row = session.execute(
                 select(ConnectorSyncLog.seq)
                 .where(
                     ConnectorSyncLog.connector_id == connector_id,
-                    ConnectorSyncLog.status.in_([SyncStatus.STARTED, SyncStatus.CANCEL_PENDING]),
+                    ConnectorSyncLog.status.in_([SyncLogStatus.STARTED, SyncLogStatus.CANCEL_PENDING]),
                 )
                 .order_by(ConnectorSyncLog.seq.desc())
                 .limit(1)
@@ -481,49 +481,25 @@ class DatabaseManager:
             return row[0] if row else None
 
     @staticmethod
-    def close_sync_log(connector_id, seq, status, error=None, finished_at=None, ...) -> bool:
-        """
-        CANCELLED and FAILED both transition connector to OUT_OF_SYNC.
-        Only COMPLETED writes the status value through verbatim.
-        """
-        ...
+    def update_connector_after_sync(connector_id, status, last_sync_at=None) -> None:
+        """CANCELLED/FAILED both map to OUT_OF_SYNC; COMPLETED written verbatim."""
         connector_sync_status = (
-            SyncStatus.OUT_OF_SYNC
-            if status in (SyncStatus.CANCELLED, SyncStatus.FAILED)
-            else status  # COMPLETED → "completed"
+            ConnectorStatus.OUT_OF_SYNC
+            if status in (SyncLogStatus.CANCELLED, SyncLogStatus.FAILED)
+            else status
         )
         session.execute(
             update(Connector)
             .where(Connector.id == connector_id)
-            .values(last_sync_at=now, sync_status=connector_sync_status)
+            .values(last_sync_at=last_sync_at, sync_status=connector_sync_status)
         )
-
-    @staticmethod
-    def reset_stale_syncing_connectors() -> list[str]:
-        """
-        Called once on startup. Any connector still marked 'syncing' was
-        interrupted by a crash — the tick will never self-recover because
-        try_acquire_sync_lock guards with sync_status != 'syncing'.
-
-        Resets them to 'out of sync' so the scheduler can acquire the lock
-        on the next tick. Returns the list of affected connector_id values
-        so the caller can close their open sync logs.
-        """
-        with get_db_session() as session:
-            result = session.execute(
-                update(Connector)
-                .where(Connector.sync_status == SyncStatus.SYNCING)
-                .values(sync_status=SyncStatus.OUT_OF_SYNC)
-                .returning(Connector.id)
-            )
-            return [row[0] for row in result]
 ```
 
 ---
 
 ## 5. Scanner Abstraction Layer
 
-**Files:** `services/digitize/connectors/scanners/` (`base_scanner.py`, `s3_scanner.py`, `sftp_scanner.py`, `scanner_factory.py`)
+**Files:** `services/digitize/connectors/scanners/` (`base_scanner.py`, `s3_scanner.py`, `ssh_scanner.py`, `scanner_factory.py`, `config.py`, `hashing.py`)
 
 ### 5.1 Base Contract (`base_scanner.py`)
 
@@ -537,12 +513,12 @@ class BaseScanner(ABC):
 
     @abstractmethod
     def scan(self) -> list[tuple[str, str]]:
-        """Return (remote_path, checksum) for ALL remote files. No dedup filtering here."""
+        """Return (remote_path, checksum) for ALL remote files with within-walk dedup."""
         ...
 
     @abstractmethod
     def download_to(self, remote_path: str, local_path: Path) -> str:
-        """Download remote file to local_path and return computed local hex digest."""
+        """Download remote file to local_path; return hex digest computed inline."""
         ...
 
     @abstractmethod
@@ -557,9 +533,12 @@ class BaseScanner(ABC):
 ### 5.2 Concrete Implementations
 
 #### 1. `S3Scanner` (`s3_scanner.py`)
-- Auto-detects provider (AWS S3 vs IBM COS) from `endpoint_url` hostname and configures boto3 `addressing_style` (`"virtual"` for AWS, `"path"` for IBM COS).
-- `scan()` uses `list_objects_v2` paginator; uses S3 ETag as checksum.
-- `download_to()` streams payload through `_HashingWriter` to compute local MD5 in a single pass.
+- Auto-detects provider (AWS S3 vs IBM COS) from `endpoint_url` hostname. `is_aws` is `True` when the URL contains `amazonaws.com` or when no URL is set.
+- For AWS: `endpoint_url` is **not** forwarded to boto3 (prevents double-domain URL issue); `region_name` is derived from the endpoint URL. Addressing style = `"auto"`.
+- For IBM COS: `endpoint_url` is forwarded; path-style addressing (`"path"`) is used. IBM COS cross-region alias segments (`us`, `eu`, `ap`) are resolved to canonical SigV4 regions (`us-south`, `eu-de`, `jp-tok`).
+- `connect()` calls `head_bucket` as a pre-flight connectivity check; raises `ConnectionError` on failure.
+- `scan()` uses `list_objects_v2` paginator; uses S3 ETag (quotes stripped) as checksum. Within-walk dedup: first occurrence of each ETag wins.
+- `download_to()` streams payload through `HashingWriter` to compute local MD5 inline (no second read).
 - Overrides `verify_integrity()` to bypass check for multi-part ETags (`"-" in remote_checksum`).
 
 ```python
@@ -569,19 +548,36 @@ def verify_integrity(self, local_checksum: str, remote_checksum: str) -> bool:
     return super().verify_integrity(local_checksum, remote_checksum)
 ```
 
-#### 2. `SFTPScanner` (`sftp_scanner.py`)
+#### 2. `SSHScanner` (`ssh_scanner.py`)
 - Paramiko-based directory walk and file transfer.
-- Computes remote MD5 via SSH `md5sum "{remote_path}"` command (hashing executes on remote host; no file bytes transferred during scan).
+- `connect()`: loads PEM key (tries RSA → ECDSA → Ed25519 in order); opens SSH + SFTP sessions. Raises `ConnectionError` on auth/network failure.
+- `scan()`: recursively walks `remote_path` via `sftp.listdir_attr`; computes remote MD5 via SSH `md5sum "{remote_path}"` command. Within-walk dedup on MD5.
+- `download_to()`: uses `sftp.getfo()` streaming into `HashingWriter`.
 
 #### 3. Scanner Factory (`scanner_factory.py`)
 ```python
-def build_scanner(config: ConnectorConfig) -> BaseScanner:
-    if config.type == "s3":
-        return S3Scanner(config)
-    elif config.type == "ssh":
-        return SFTPScanner(config)
-    raise ValueError(f"Unsupported connector type: {config.type}")
+_REGISTRY: dict[str, tuple[type[BaseScanner], type]] = {
+    "s3": (S3Scanner, S3ConnectorConfig),
+    "ssh": (SSHScanner, SSHConnectorConfig),
+}
+
+def build_scanner(connector_row: Any) -> BaseScanner:
+    """Decrypt secrets, build config dataclass, return scanner instance."""
+    # 1. Decrypt secrets from stored connection_details
+    key_path = settings.digitize.connector.encryption_key_path
+    connection_details = decrypt_secrets(connector_type, connection_details, key_path)
+    # 2. Build typed config
+    config = S3ConnectorConfig.from_connection_details(connection_details, allowed_extensions)
+    # or SSHConnectorConfig.from_connection_details(...)
+    # 3. Return scanner instance
+    return S3Scanner(config)  # or SSHScanner(config)
 ```
+
+#### 4. Config Models (`config.py`)
+
+`S3ConnectorConfig` — fields: `bucket_name`, `access_key_id`, `secret_access_key`, `endpoint_url`, `prefix`, `delimiter`, `download_concurrency`, `verify_ssl`, `allowed_extensions`. Computed properties: `provider`, `is_aws`, `effective_region`. Validators: require scheme on `endpoint_url`; require non-empty credentials for IBM COS.
+
+`SSHConnectorConfig` — fields: `host`, `port`, `username`, `private_key`, `remote_path`, `allowed_extensions`. Validators: non-empty host/username/private_key; `"PRIVATE KEY"` substring check on PEM.
 
 ---
 
@@ -589,89 +585,106 @@ def build_scanner(config: ConnectorConfig) -> BaseScanner:
 
 **File:** `services/digitize/connectors/sync_tick.py`
 
-### 6.1 Execution Flow
+### 6.1 Status Enums
 
-![Sync Tick Flow](sync-worker-tick-flow.svg)
+**File:** `services/digitize/connectors/models.py`
 
-- **Phase 0 (Lock):** Acquire lock via `try_acquire_sync_lock(connector_id)`. Called externally (by scheduler or `POST /syncs`); `run_tick` assumes the lock is already held.
-- **Phase 1 (Log):** `open_new_sync_log(connector_id)` is called **inside** `run_tick`, not the caller. Returns `sync_seq` used for all subsequent interrupt checks.
-- **Phase 1b (Interrupt Check):** `_check_interrupt_call(connector_id, sync_seq)` is called immediately before any remote I/O. If `DELETE_PENDING` or `CANCEL_PENDING`, raises `asyncio.CancelledError`.
-- **Phase 2 (Scan & State):** Query owned `known_checksums` and `all_checksums`. Offload blocking network calls (`connect`, `scan`) to thread pool via `asyncio.to_thread(...)`.
-- **Phase 3 (Classify):** `_classify()` separates `scanned_files` into `ingest_list` and cross-connector duplicates. Cross-connector duplicates execute `add_connector_checksum_entry` inline using existing `doc_id`.
-- **Phase 3b (Count Commit):** All three counters (`total_files`, `new_files`, `removed_files`) are fully determined from classify output. A single `update_sync_log()` call persists them before any I/O-heavy work begins. No further counter writes happen during batch processing.
-- **Phase 4a (Ingest New Files):** Download and ingest `ingest_list` in batches of `_BATCH_SIZE = 10`:
-  - Dedicated per-batch staging directory: `staging/connectors/{connector_id}-{sync_seq}-{batch_number}`.
-  - Interrupt checkpoint **before** each batch starts.
-  - Offload download to executor thread (`asyncio.to_thread(scanner.download_to, ...)`).
-  - Files failing `verify_integrity` are **skipped** (logged as warnings), not fatal.
-  - Interrupt checkpoint **after** batch downloads complete.
-  - Call `initialize_job_state()` → obtain `doc_id` map, insert checksum rows, call `ingest()`, then `_wait_for_job()`.
-  - `_wait_for_job()` polls every `_JOB_POLL_INTERVAL=10s` and calls `_check_interrupt_call` on each wake-up.
-  - Cleanup staging directory in `finally` per batch; batch failure sets `batch_failed=True` flag.
-  - After all batches: if `batch_failed`, raises `RuntimeError` → tick closes as `FAILED` → connector set to `OUT_OF_SYNC`.
-- **Phase 4b (Orphan Removal):** Runs **strictly after Phase 4a completes**. Delete checksum rows for `orphan_checksums = known_checksums − scanned_checksums`. If remaining count is `0`, call `_best_effort_delete_document(doc_id)`.
-- **Phase 5 (Finalize):** Write terminal status (`'completed'`/`'failed'`/`'cancelled'`) and update `sync_status` on the connector row. `scanner.close()` is called in top-level `finally` regardless of outcome.
+```python
+class ConnectorStatus(str, Enum):
+    """Values for connectors.sync_status column."""
+    UP_TO_DATE = "up to date"
+    SYNCING = "syncing"
+    OUT_OF_SYNC = "out of sync"
+    DELETE_PENDING = "delete pending"
 
-#### Interrupt Handling
 
-The tick uses `_check_interrupt_call(connector_id, sync_seq)` which checks **two independent DB sources** and returns an `InterruptType` enum value or `None`:
-
-1. **`connectors.sync_status == DELETE_PENDING`** → `InterruptType.DELETE_CONNECTOR`
-   - Triggered when `DELETE /v1/connectors/{id}` arrives while a sync is running (`mark_sync_delete_pending` succeeds).
-   - When the tick detects this, `CancelledError` is raised; `_handle_interrupt` calls `_cancel_tick` then `_run_delete_teardown`:
-     - Remove all checksum ownership rows; delete documents when they lose their last owner
-     - `delete_active_connector` (cascades to all sync_logs)
-     - Sweep all residual batch staging directories
-
-2. **`connector_sync_logs.status == CANCEL_PENDING`** → `InterruptType.SYNC_CANCEL`
-   - Triggered when `POST /syncs/{seq}/stop` arrives (`mark_sync_cancel_pending` writes to the log row; connector stays `'syncing'`).
-   - When detected, `_handle_interrupt` calls `_cancel_tick` (log → `'cancelled'`, connector → `'out of sync'`), then sweeps staging directories for this sync's batches only.
-   - The connector remains and re-syncs on the next scheduler interval.
-
-`_check_interrupt_call()` is invoked at **four checkpoints**: (1) after `open_new_sync_log`, (2) before each batch starts, (3) after batch downloads complete, and (4) inside `_wait_for_job` on every poll cycle.
+class SyncLogStatus(str, Enum):
+    """Values for connector_sync_logs.status column."""
+    STARTED = "started"
+    CANCEL_PENDING = "cancel pending"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+```
 
 ---
 
-### 6.2 Implementation Code
+### 6.2 Execution Flow
+
+![Sync Tick Flow](sync-worker-tick-flow.svg)
+
+- **Phase 0 (Lock):** Lock acquired externally before `run_tick` is called — either by `_run_tick_wrapped` in `scheduler.py` (PR7) or by `trigger_sync` in `connectors.py`. `run_tick` assumes the lock is already held when it is called.
+- **Phase 1 (Log):** `init_sync_log_and_update_connector(connector_id)` is called **inside** `run_tick`. Two DB calls: insert sync-log row (seq = `COALESCE(MAX(seq),0)+1`) + set connector `sync_status='syncing'`. Returns `sync_seq`.
+- **Phase 1b (Interrupt Check):** `_check_interrupt_call(connector_id, sync_seq)` immediately before any remote I/O. If any interrupt detected, raises `asyncio.CancelledError`.
+- **Phase 2 (Scan & State):** Query `known_checksums` and `all_checksums`. Offload blocking calls (`connect`, `scan`) to thread pool via `asyncio.to_thread(...)`.
+- **Phase 3 (Classify):** `_classify()` separates `scanned_files` into `ingest_list` and cross-connector duplicates. Cross-connector duplicates execute `add_connector_checksum_entry` inline.
+- **Phase 3b (Count Commit):** `update_sync_log(connector_id, sync_seq, total_files=..., new_files=..., removed_files=...)` + `update_connector_total_files(connector_id, len(scanned_files))`. Both called before any I/O-heavy work.
+- **Phase 4a (Ingest New Files):** Download and ingest `ingest_list` in batches of `_BATCH_SIZE = 10`:
+  - Staging directory: `staging/connectors/{connector_id}-{sync_seq}-{batch_number}` (1-based).
+  - Interrupt checkpoint **before** each batch starts.
+  - Offload download to executor (`asyncio.to_thread(scanner.download_to, ...)`).
+  - Files failing `verify_integrity` are **skipped** (warned), not fatal.
+  - Interrupt checkpoint **after** batch downloads complete.
+  - Call `initialize_job_state()` with `job_name = f"Connector-{connector_name}-{sync_seq}-{batch_number}"`.
+  - Insert checksum rows (`add_connector_checksum_entry`), call `ingest()`, then `_wait_for_job()`.
+  - `_wait_for_job()` polls every `_JOB_POLL_INTERVAL=10s` and calls `_check_interrupt_call` on each wake-up.
+  - Cleanup staging directory in `finally`; batch failure sets `batch_failed=True`.
+  - After all batches: if `batch_failed`, raises `RuntimeError` → tick closes as `FAILED` → connector set to `OUT_OF_SYNC`.
+- **Phase 4b (Orphan Removal):** After Phase 4a completes. For each checksum in `orphan_checksums = known_checksums − scanned_checksums`: call `remove_connector_checksum_entry`; if `remaining == 0` call `_best_effort_delete_document(doc_id)` via `asyncio.to_thread`.
+- **Phase 5 (Finalize):** Call `finalize_sync_log_and_update_connector` with terminal status. `scanner.close()` in top-level `finally` regardless of outcome.
+
+#### Interrupt Handling
+
+`_check_interrupt_call(connector_id, sync_seq)` checks **two independent DB sources** and returns an `InterruptType` enum value or `None`:
+
+1. **`connectors.sync_status == DELETE_PENDING`** → `InterruptType.DELETE_CONNECTOR`
+   - Triggered when `DELETE /v1/connectors/{id}` arrives (via `mark_connector_delete_pending`).
+   - `_handle_interrupt` calls `_cancel_tick` then `await _run_teardown(connector_id)` (imported from `connectors.py`). Full teardown: remove all checksum ownership rows, delete orphaned docs, delete connector row, sweep staging dirs.
+
+2. **`connector_sync_logs.status == CANCEL_PENDING`** → `InterruptType.SYNC_CANCEL`
+   - Triggered when `POST /syncs/{seq}/stop` arrives (`mark_sync_cancel_pending`).
+   - `_handle_interrupt` calls `_cancel_tick` (log → `'cancelled'`, connector → `'out of sync'`) + `_sweep_staging_dir(connector_id, ..., sync_seq=sync_seq)` (only this sync's batch dirs).
+   - Connector remains and re-syncs on the next interval.
+
+`_check_interrupt_call()` is invoked at **four checkpoints**: (1) after `init_sync_log_and_update_connector` (Phase 1b), (2) before each batch starts, (3) after batch downloads complete, (4) inside `_wait_for_job` on every poll cycle.
+
+---
+
+### 6.3 Implementation Code
 
 ```python
 class InterruptType(str, Enum):
     SYNC_CANCEL = "sync_cancel"           # CANCEL_PENDING on connector_sync_logs row
     DELETE_CONNECTOR = "delete_connector" # DELETE_PENDING on connectors row
 
+
 def _check_interrupt_call(connector_id: str, sync_seq: int) -> Optional[InterruptType]:
     """Check both sources; return the appropriate InterruptType or None."""
-    # Priority 1: check connectors table for DELETE_PENDING
     connector_status = get_connector_sync_status(connector_id)
-    if connector_status == SyncStatus.DELETE_PENDING:
+    if connector_status == ConnectorStatus.DELETE_PENDING:
         return InterruptType.DELETE_CONNECTOR
-    # Priority 2: check sync-log row for CANCEL_PENDING
     sync_log_status = get_sync_log_status(connector_id, sync_seq)
-    if sync_log_status == SyncStatus.CANCEL_PENDING:
+    if sync_log_status == SyncLogStatus.CANCEL_PENDING:
         return InterruptType.SYNC_CANCEL
     return None
 
 
 async def run_tick(connector_id: str) -> None:
     """
-    Execute one full sync tick. Caller must have acquired the sync lock
-    (try_acquire_sync_lock) before calling this coroutine.
+    Execute one full sync tick. Caller must have acquired the sync lock before calling.
     """
     config = get_active_connector(connector_id)
     if config is None:
         logger.error(f"Connector {connector_id!r} not found; tick aborted")
         return
 
-    sync_seq: int = open_new_sync_log(connector_id)   # Phase 1
+    sync_seq: int = init_sync_log_and_update_connector(connector_id)
     scanner = build_scanner(config)
 
     try:
-        # Phase 1b: interrupt checkpoint before any remote I/O
         interrupt = _check_interrupt_call(connector_id, sync_seq)
-        if interrupt == InterruptType.DELETE_CONNECTOR:
-            raise asyncio.CancelledError(f"Connector {connector_id!r} marked for deletion")
-        elif interrupt == InterruptType.SYNC_CANCEL:
-            raise asyncio.CancelledError(f"Sync cancel requested for connector {connector_id!r}")
+        if interrupt:
+            raise asyncio.CancelledError(f"Connector {connector_id!r} interrupted")
 
         await asyncio.to_thread(scanner.connect)
         scanned_files = await asyncio.to_thread(scanner.scan)
@@ -679,104 +692,106 @@ async def run_tick(connector_id: str) -> None:
         known_checksums = set(list_connector_checksums(connector_id))
         all_checksums = set(list_all_checksums())
 
-        ingest_list, orphan_checksums = _classify(           # Phase 3
+        ingest_list, orphan_checksums = _classify(
             connector_id, scanned_files, known_checksums, all_checksums
         )
 
-        update_sync_log(                                     # Phase 3b
-            sync_seq,
+        update_sync_log(
+            connector_id, sync_seq,
             total_files=len(scanned_files),
             new_files=len(ingest_list),
             removed_files=len(orphan_checksums),
         )
+        update_connector_total_files(connector_id, len(scanned_files))
 
-        await _process_new_files(sync_seq, connector_id, scanner, ingest_list)  # Phase 4a
-        await _delete_orphans(connector_id, orphan_checksums)                    # Phase 4b
-        _complete_tick(sync_seq, connector_id)                                   # Phase 5
+        await _process_new_files(sync_seq, connector_id, config.name, scanner, ingest_list)
+        await _delete_orphans(connector_id, orphan_checksums)
+        _complete_tick(sync_seq, connector_id)
 
     except asyncio.CancelledError as ce:
-        logger.info(f"Tick cancelled for connector {connector_id!r}: {ce}")
         interrupt = _check_interrupt_call(connector_id, sync_seq)
-        _handle_interrupt(sync_seq, connector_id, interrupt)
+        await _handle_interrupt(sync_seq, connector_id, interrupt)
         raise
 
     except Exception as exc:
-        logger.error(f"Tick failed for connector {connector_id!r}: {exc}", exc_info=True)
-        _fail_tick(sync_seq, connector_id, exc)   # → close_sync_log(FAILED) → OUT_OF_SYNC
+        _fail_tick(sync_seq, connector_id, exc)
 
     finally:
         await asyncio.to_thread(scanner.close)
 
 
-def _classify(...) -> tuple[list[tuple[str, str]], set[str]]:
-    # Same logic as before — no changes to classification algorithm.
-    ...
-    orphan_checksums = known_checksums - scanned_checksums
-    return ingest_list, orphan_checksums
-
-
 _BATCH_SIZE = 10
 _JOB_POLL_INTERVAL = 10  # seconds
 
-async def _process_new_files(sync_seq, connector_id, scanner, ingest_list) -> None:
-    """
-    Download and ingest ingest_list in batches of up to BATCH_SIZE=10.
-
-    Integrity failures skip the file (logged warning).
-    Batch-level exceptions set batch_failed=True but processing continues.
-    After all batches: raises RuntimeError if batch_failed → _fail_tick → OUT_OF_SYNC.
-    """
+async def _process_new_files(sync_seq, connector_id, connector_name, scanner, ingest_list) -> None:
     staging_base = settings.digitize.staging_dir / "connectors"
     batch_failed = False
 
-    for batch_number in range(0, len(ingest_list), _BATCH_SIZE):
-        batch = ingest_list[batch_number : batch_number + _BATCH_SIZE]
+    for batch_number, batch_offset in enumerate(range(0, len(ingest_list), _BATCH_SIZE), start=1):
+        batch = ingest_list[batch_offset : batch_offset + _BATCH_SIZE]
 
-        # Checkpoint 2: interrupt check before each batch
         interrupt = _check_interrupt_call(connector_id, sync_seq)
         if interrupt:
             raise asyncio.CancelledError(...)
 
+        job_id = generate_uuid()
         batch_dir_name = f"{connector_id}-{sync_seq}-{batch_number}"
-        ...
+        batch_dir = staging_base / batch_dir_name
+        batch_dir.mkdir(parents=True, exist_ok=True)
+        checksum_to_filename: dict[str, str] = {}
+
         try:
             for remote_path, checksum in batch:
-                local_checksum = await asyncio.to_thread(scanner.download_to, ...)
+                filename = Path(remote_path).name
+                local_checksum = await asyncio.to_thread(
+                    scanner.download_to, remote_path, batch_dir / filename
+                )
                 if not scanner.verify_integrity(local_checksum, checksum):
                     logger.warning(f"Integrity check failed for {remote_path!r}; skipping")
-                    continue                 # ← skip, not fatal
+                    continue
                 checksum_to_filename[checksum] = filename
 
-            # Checkpoint 3: interrupt check after downloads
             interrupt = _check_interrupt_call(connector_id, sync_seq)
             if interrupt:
                 raise asyncio.CancelledError(...)
 
-            doc_id_dict = initialize_job_state(...)
+            job_name = f"Connector-{connector_name}-{sync_seq}-{batch_number}"
+            doc_id_dict = initialize_job_state(
+                job_id=job_id, operation=OperationType.INGESTION,
+                output_format=OutputFormat.JSON,
+                documents_info=list(checksum_to_filename.values()),
+                job_name=job_name,
+            )
             for checksum, filename in checksum_to_filename.items():
                 add_connector_checksum_entry(connector_id, checksum, doc_id_dict[filename])
+
             await asyncio.to_thread(ingest, batch_dir, job_id, doc_id_dict)
-            await _wait_for_job(job_id, connector_id, sync_seq)  # Checkpoint 4: polls + interrupt
+            await _wait_for_job(job_id, connector_id, sync_seq)
 
         except asyncio.CancelledError:
-            raise  # propagate upward to run_tick's CancelledError handler
+            raise
         except Exception as exc:
-            logger.warning(f"Batch {batch_number!r} failed: {exc}")
             batch_failed = True
         finally:
             cleanup_staging_directory(batch_dir_name, staging_base, ignore_errors=True)
 
     if batch_failed:
-        raise RuntimeError("One or more batches failed; connector marked as out of sync")
+        raise RuntimeError("One or more batches failed")
 
 
-def _handle_interrupt(sync_seq, connector_id, interrupt_type) -> None:
+async def _handle_interrupt(sync_seq, connector_id, interrupt_type) -> None:
+    """Note: _handle_interrupt is async — it awaits _run_teardown for DELETE_CONNECTOR."""
     if interrupt_type == InterruptType.SYNC_CANCEL:
-        _cancel_tick(sync_seq, connector_id)   # log → 'cancelled', connector → 'out of sync'
-        _sweep_staging_dir(connector_id, ..., sync_seq=sync_seq)  # sweep only this sync's dirs
+        _cancel_tick(sync_seq, connector_id)
+        from digitize.api.v1.connectors import _sweep_staging_dir
+        _sweep_staging_dir(connector_id, settings.digitize.staging_dir / "connectors",
+                           sync_seq=sync_seq)
+
     elif interrupt_type == InterruptType.DELETE_CONNECTOR:
         _cancel_tick(sync_seq, connector_id)
-        _run_delete_teardown(connector_id)     # full teardown inline in sync_tick.py
+        from digitize.api.v1.connectors import _run_teardown
+        await _run_teardown(connector_id)  # same function as Case B
+
     else:  # None (unexpected CancelledError)
         _cancel_tick(sync_seq, connector_id)
 ```
@@ -785,24 +800,24 @@ def _handle_interrupt(sync_seq, connector_id, interrupt_type) -> None:
 
 ## 7. Scheduler & Task Coordination
 
-**File:** `services/digitize/connectors/scheduler.py`
+**File:** `services/digitize/connectors/scheduler.py` — ⚠️ **NOT YET IMPLEMENTED (PR7)**
 
 ### 7.1 Architecture & State Tracking
 
-`ConnectorScheduler` uses an APScheduler `AsyncScheduler` singleton backed by `AsyncSQLAlchemyDataStore` in Postgres.
+`ConnectorScheduler` will use an APScheduler `AsyncScheduler` singleton backed by `AsyncSQLAlchemyDataStore` in Postgres.
 
-**No in-process registries.** Delete state is stored exclusively in the `connectors` table (`sync_status = 'delete_pending'`). There is no `_pending_deletions` set and no `_live_tasks` dict. All cancellation and teardown decisions are driven by live DB reads.
+**No in-process registries.** Delete state is stored exclusively in the `connectors` table (`sync_status = 'delete pending'`). All cancellation and teardown decisions are driven by live DB reads.
 
 ---
 
-### 7.2 Scheduler Implementation
+### 7.2 Scheduler Implementation _(planned)_
 
 ```python
-# No module-level _pending_deletions or _live_tasks.
-# All interrupt state is read from DB: connectors.sync_status and
-# connector_sync_logs.status polled by _check_interrupt_call.
+# Planned implementation in scheduler.py
 
-async def register_connector_job(connector_id: str, interval_seconds: int, fire_immediately: bool = False) -> None:
+async def register_connector_job(
+    connector_id: str, interval_seconds: int, fire_immediately: bool = False
+) -> None:
     kwargs = dict(
         func=_run_tick_wrapped,
         trigger=IntervalTrigger(seconds=interval_seconds),
@@ -817,94 +832,57 @@ async def register_connector_job(connector_id: str, interval_seconds: int, fire_
 
 
 async def _run_tick_wrapped(connector_id: str) -> None:
-    """APScheduler entry point for each scheduled tick.
-
-    Guards:
-    1. Check for DELETE_PENDING — skip tick entirely if connector is being deleted.
-    2. try_acquire_sync_lock — skip tick if one is already running.
+    """APScheduler entry point.
+    1. Skip if DELETE_PENDING.
+    2. try_acquire_sync_lock — skip if already syncing.
+    3. Call run_tick(connector_id).
     """
     status = get_connector_sync_status(connector_id)
-    if status == SyncStatus.DELETE_PENDING:
-        return  # connector is being torn down; skip tick
+    if status == ConnectorStatus.DELETE_PENDING:
+        return
     if not try_acquire_sync_lock(connector_id):
-        return  # another tick is already running
-    await run_tick(connector_id)  # run_tick opens the log row internally
+        return
+    await run_tick(connector_id)
 ```
 
 ---
 
-### 7.3 Crash Recovery (`utils/recovery.py`)
+### 7.3 Crash Recovery for Connector Sync State _(planned)_
 
-**File:** `services/digitize/utils/recovery.py`
+`recover_connector_sync_state()` in `services/digitize/utils/recovery.py` — **NOT YET IMPLEMENTED**.
 
-`recover_connector_sync_state()` is called once at startup, before the scheduler
-begins firing ticks. It addresses two invariants broken by a mid-tick crash:
+Planned behavior on startup:
+1. Bulk `UPDATE connectors SET sync_status='out of sync' WHERE sync_status='syncing'` — unlocks connectors stuck in `'syncing'` from a mid-tick crash.
+2. For each affected connector: find the open `connector_sync_logs` row and close it to `status='failed'` with `error='Service restarted during sync tick'`.
 
-1. **Stuck `sync_status`** — a connector left as `'syncing'` will never tick again
-   because `try_acquire_sync_lock` guards with `sync_status != 'syncing'`. Reset to
-   `'out of sync'` so the next scheduled tick can acquire the lock.
-2. **Open sync log** — a log row left as `'started'` has no terminal state. Close it
-   to `'failed'` with a crash error message, mirroring how `recover_zombie_jobs()`
-   handles regular jobs. The connector `sync_status` is left as `'out of sync'` —
-   already set correctly by `reset_stale_syncing_connectors()`.
-
-```python
-def recover_connector_sync_state() -> int:
-    """
-    Startup crash recovery for connector sync state.
-
-    For every connector that was left in 'syncing' by a previous crash:
-      1. Reset connectors.sync_status → 'out of sync'  (single bulk UPDATE)
-      2. Close the open sync log row → status='failed', error='...'
-
-    Returns the number of connectors recovered.
-    """
-    stale_ids = reset_stale_syncing_connectors()   # bulk UPDATE, returns affected ids
-    if not stale_ids:
-        logger.debug("✅ No stale syncing connectors found on startup")
-        return 0
-
-    for connector_id in stale_ids:
-        logger.warning(f"Recovering stale sync state for connector {connector_id!r}")
-        last_log = get_last_sync_log(connector_id)
-        if last_log is not None and last_log.status not in _TERMINAL_SYNC_LOG_STATUSES:
-            close_sync_log(
-                connector_id,
-                seq=last_log.seq,
-                status=SyncStatus.FAILED,
-                error="Service restarted during sync tick",
-                # connector sync_status already set to 'out of sync' by reset_stale_syncing_connectors
-            )
-
-    logger.info(f"🔄 Recovered {len(stale_ids)} stale connector(s) on startup")
-    return len(stale_ids)
-```
+Note: `recover_zombie_jobs()` for regular (non-connector) jobs **is** implemented in `recovery.py` and called from `lifespan()`.
 
 ---
 
-### 7.4 Lifespan Integration (`app.py`)
+### 7.4 Lifespan Integration _(planned)_
+
+`app.py` currently implements `lifespan()` with DB connection, schema creation, and `recover_zombie_jobs()` only. Planned additions (PR7):
 
 ```python
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    async_engine = create_async_engine(_make_async_db_url())
-    data_store = AsyncSQLAlchemyDataStore(async_engine)
+# Planned additions to lifespan() in app.py
 
-    async with AsyncScheduler(data_store=data_store) as sched:
-        scheduler_module._scheduler = sched
+async with AsyncScheduler(data_store=data_store) as sched:
+    scheduler_module._scheduler = sched
 
-        # Crash recovery: close any open sync logs and unblock stale 'syncing' connectors.
-        recover_connector_sync_state()
+    # Connector crash recovery
+    recover_connector_sync_state()
 
-        # Recover existing connectors without resetting schedules (fire_immediately=False)
-        for connector in get_all_connectors():
-            await register_connector_job(connector.id, connector.sync_interval_seconds, fire_immediately=False)
+    # Re-register existing connectors (fire_immediately=False — don't double-fire)
+    for connector in get_all_connectors():
+        await register_connector_job(
+            connector.id, connector.sync_interval_seconds, fire_immediately=False
+        )
 
-        pool_size = max(len(get_all_connectors()) + 4, 8)
-        asyncio.get_running_loop().set_default_executor(ThreadPoolExecutor(max_workers=pool_size))
+    # Size thread pool based on connector count
+    pool_size = max(len(get_all_connectors()) + 4, 8)
+    asyncio.get_running_loop().set_default_executor(ThreadPoolExecutor(max_workers=pool_size))
 
-        yield
-    scheduler_module._scheduler = None
+    yield
 ```
 
 ---
@@ -918,22 +896,21 @@ Scanners perform synchronous blocking I/O (`boto3` calls, Paramiko SFTP operatio
 - All blocking scanner methods (`connect`, `scan`, `download_to`) are called via `await asyncio.to_thread(scanner.<method>, *args)`.
 - Event loop remains fully responsive.
 - Interrupt state is stored exclusively in the DB — no in-memory sets or task registries:
-  - **`connectors.sync_status = 'delete pending'`** — set by `mark_sync_delete_pending` when DELETE arrives mid-sync.
+  - **`connectors.sync_status = 'delete pending'`** — set by `mark_connector_delete_pending` when DELETE arrives (unconditionally).
   - **`connector_sync_logs.status = 'cancel pending'`** — set by `mark_sync_cancel_pending` when stop-sync is requested.
-- `_check_interrupt_call(connector_id, sync_seq)` reads both sources on every call. It is invoked at **four checkpoints**:
-  - In `run_tick` — immediately after `open_new_sync_log` (Phase 1b).
+- `_check_interrupt_call(connector_id, sync_seq)` reads both sources on every call. Invoked at **four checkpoints**:
+  - In `run_tick` — immediately after `init_sync_log_and_update_connector` (Phase 1b).
   - In `_process_new_files` — before each batch starts (Checkpoint 2).
   - In `_process_new_files` — after each batch of downloads completes (Checkpoint 3).
   - In `_wait_for_job` — on every poll cycle (Checkpoint 4).
 - `CancelledError` is raised in the coroutine at those checkpoints, never inside the thread.
-- A download already in flight runs to natural completion. Interrupts arriving between files are caught at the next checkpoint.
-- `run_tick`'s `except asyncio.CancelledError` block calls `_handle_interrupt` which dispatches:
+- A download already in flight runs to natural completion. Interrupts are caught at the next checkpoint.
+- `run_tick`'s `except asyncio.CancelledError` block calls `await _handle_interrupt` which dispatches:
   - `_cancel_tick` + `_sweep_staging_dir(sync_seq=sync_seq)` for `SYNC_CANCEL`.
-  - `_cancel_tick` + `_run_delete_teardown(connector_id)` (synchronous, runs inline) for `DELETE_CONNECTOR`.
-- `_run_teardown` in `connectors.py` handles the background-task path (Case B: no tick running at delete time).
+  - `_cancel_tick` + `await _run_teardown(connector_id)` for `DELETE_CONNECTOR` (same `_run_teardown` used for Case B).
 - No safety-net timeout. No waiting for the tick to exit before teardown begins.
 
-### 8.3 Thread Pool Sizing
+### 8.3 Thread Pool Sizing _(planned — PR7)_
 Each ticking connector holds at most **1 thread at a time**.
 $$\text{pool\_size} = \max(N + 4, 8) \quad \text{(where } N = \text{total configured connectors)}$$
 
@@ -943,24 +920,31 @@ $$\text{pool\_size} = \max(N + 4, 8) \quad \text{(where } N = \text{total config
 
 ### Implemented PRs
 
-- **PR 1 — DB Schema + ORM Models + Settings ✅:** `connectors`, `connector_document_checksum`, `connector_sync_logs` tables & ORM models created (`db/scripts/init_schema.sql`, `db/models.py`). `connector_sync_logs` now has auto-increment `id` PK with `UNIQUE (connector_id, seq)`.
-- **PR 2 — DB Operations Layer ✅:** `manager.py` & `utils/db.py` fully implemented. All checksum helpers (`insert_connector_checksum`, `delete_connector_checksum`, `find_connector_doc_by_checksum`, `get_connector_checksums`, `get_all_connector_checksums`), sync-lock/signal helpers (`try_acquire_sync_lock`, `mark_sync_cancel_pending`, `mark_sync_delete_pending`), sync-log helpers (`open_sync_log`, `close_sync_log`, `update_sync_log_progress`, `get_sync_logs`, `get_sync_log_status`, `get_active_sync_seq`), and startup helper (`reset_stale_syncing_connectors`) are all present and tested in `test_connector_db.py`.
-- **PR 3 — REST API Endpoints ✅:** Full CRUD in `connectors.py` (`POST`, `PUT`, `DELETE`, `GET`, `GET /{id}`, `GET /{id}/syncs`, `POST /{id}/syncs`, `POST /{id}/syncs/{seq}/stop`). Connector-sourced document visibility filtering in `documents.py`.
-- **PR 4a — Scanner Abstraction ✅:** `BaseScanner` interface (`base_scanner.py`) & `scanner_factory.py` with `_REGISTRY` for `"s3"` and `"ssh"` types.
-- **PR 4b — SSH/SFTP Scanner ✅:** `SSHScanner` implemented in `connectors/scanners/ssh_scanner.py`. *(Named `ssh_scanner.py` rather than `sftp_scanner.py` — accepted naming.)*
-- **PR 5 — S3 Scanner ✅:** `S3Scanner` implementation & tests.
-- **PR 6 — Core Sync Engine ✅:** `sync_tick.py` fully implemented. `run_tick`, `_classify`, `_process_new_files` (batch download, integrity skip, `batch_failed` flag, `_wait_for_job`), `_delete_orphans`, `_handle_interrupt`, `_run_delete_teardown`. `_check_interrupt_call(connector_id, sync_seq)` replaces the old `_check_delete_pending` — now reads from both tables. Tests in `test_sync_tick.py`.
-- **PR 7 — Scheduler + Lifespan + `POST /syncs` Dispatch ✅:** `scheduler.py` created. `lifespan()` in `app.py` starts `AsyncScheduler`, calls `recover_connector_sync_state()`, and registers all connector jobs. `POST /syncs` in `connectors.py` dispatches `run_tick` and returns `sync_seq`. `SyncStatus` enum extended with `CANCEL_PENDING`, `DELETE_PENDING`, `CANCELLED`. `recover_connector_sync_state()` added to `utils/recovery.py`.
-- **PR 9 — Non-Blocking DELETE ✅:** `DELETE /v1/connectors/{id}` uses `mark_sync_delete_pending` + `_run_teardown` (background task). Tick handles teardown via `_check_interrupt_call` → `_run_delete_teardown` in `sync_tick.py`. Teardown paths are split: `_run_teardown` in `connectors.py` (Case B) and `_run_delete_teardown` in `sync_tick.py` (Case A).
-- **PR 8 — Cancel Sync Endpoint ✅:** `POST /syncs/{seq}/stop` implemented. `mark_sync_cancel_pending` writes to `connector_sync_logs.status`. `SyncStatus.CANCEL_PENDING` and `InterruptType.SYNC_CANCEL` handle the cancel path in `_check_interrupt_call`. `close_sync_log` maps `CANCELLED` → `OUT_OF_SYNC` so the connector resumes on the next interval. `failed_files` counter removed from schema, models, and API.
+- **PR 1 — DB Schema + ORM Models + Settings ✅:** `connectors`, `connector_document_checksum`, `connector_sync_logs` tables & ORM models (`db/scripts/init_schema.sql`, `db/models.py`). `connector_sync_logs` uses composite PK `(connector_id, seq)`. `Connector` ORM has an `error` field for teardown errors (in model, not shown in SQL schema). `ConnectorStatus` and `SyncLogStatus` string enums in `connectors/models.py`. Scanner config models (`S3ConnectorConfig`, `SSHConnectorConfig`) in `connectors/scanners/config.py`.
+
+- **PR 2 — DB Operations Layer ✅:** `manager.py` & `utils/db.py` fully implemented. All checksum helpers (`insert_connector_checksum`, `delete_connector_checksum` returning `doc_id`, `count_checksum_owners`, `find_connector_doc_by_checksum`, `get_connector_checksums`, `get_all_connector_checksums`), sync-lock/signal helpers (`try_acquire_sync_lock`, `mark_sync_cancel_pending`, `mark_connector_delete_pending`), sync-log helpers (`init_sync_log_and_update_connector`, `finalize_sync_log_and_update_connector`, `update_sync_log`, `update_connector_total_files`, `set_connector_error`, `list_sync_logs`, `get_sync_log`, `get_sync_log_status`, `get_active_sync_seq`). All tested in `test_connector_db.py`.
+
+- **PR 3 — REST API Endpoints ✅:** Full CRUD in `connectors.py` (`POST`, `PUT`, `DELETE`, `GET`, `GET /{id}`, `GET /{id}/syncs`, `GET /{id}/syncs/{seq}`, `POST /{id}/syncs`, `POST /{id}/syncs/{seq}/stop`). Connector visibility filtering in `documents.py` (`is_connector_sourced_document`, `exclude_connector_sourced` in `get_all_documents_paginated`).
+
+- **PR 4a — Scanner Abstraction ✅:** `BaseScanner` interface (`base_scanner.py`) & `scanner_factory.py` with `_REGISTRY` for `"s3"` and `"ssh"` types. Factory decrypts secrets before building the typed config.
+
+- **PR 4b — SSH/SFTP Scanner ✅:** `SSHScanner` implemented in `connectors/scanners/ssh_scanner.py`. Supports RSA, ECDSA, Ed25519 key types. *(Named `ssh_scanner.py` — accepted naming.)*
+
+- **PR 5 — S3 Scanner ✅:** `S3Scanner` implementation with AWS/IBM COS provider auto-detection, cross-region alias resolution, `head_bucket` pre-flight check, `HashingWriter` inline MD5, multi-part ETag integrity bypass.
+
+- **PR 6 — Core Sync Engine ✅:** `sync_tick.py` fully implemented. `run_tick`, `_classify`, `_process_new_files` (batch download, integrity skip, `batch_failed` flag, 1-based `batch_number`, job named `Connector-{connector_name}-{sync_seq}-{batch_number}`), `_delete_orphans` (uses `asyncio.to_thread` for `_best_effort_delete_document`), `async _handle_interrupt` (awaits `_run_teardown` for DELETE path), `_cancel_tick`, `_fail_tick`, `_complete_tick`. `_check_interrupt_call(connector_id, sync_seq)` reads from both tables using `ConnectorStatus`/`SyncLogStatus`. Tests in `test_sync_tick.py`.
+
+- **PR 8 — Cancel Sync Endpoint ✅:** `POST /syncs/{seq}/stop` implemented with `sync_status` pre-check + seq validation + `mark_sync_cancel_pending`. `SyncLogStatus.CANCEL_PENDING` and `InterruptType.SYNC_CANCEL` handle the cancel path. `finalize_sync_log_and_update_connector` maps `CANCELLED` → `OUT_OF_SYNC`.
+
+- **PR 9 — Non-Blocking DELETE ✅:** `DELETE /v1/connectors/{id}` uses `mark_connector_delete_pending` (unconditional) + checks `sync_status` to decide Case A vs B. Case B dispatches `asyncio.create_task(_run_teardown(...))`. Case A tick detects `DELETE_PENDING` via `_check_interrupt_call` → `await _run_teardown` in `_handle_interrupt`. Single `_run_teardown` function in `connectors.py` handles both paths.
 
 ---
 
-### Notes on Divergences from Original Proposal
+### Pending PRs
 
-- `connector_sync_logs` PK changed from composite `(connector_id, seq)` to auto-increment `id`; uniqueness enforced by `UNIQUE (connector_id, seq)`. `seq` remains the logical identifier for API purposes.
-- `POST /v1/connectors/{id}/syncs` returns `{"sync_seq": <int>}` — both new and already-running syncs return the active seq, making the response useful for callers regardless of idempotency path.
-- Cancel-sync endpoint is `POST /{id}/syncs/{seq}/stop` (not `DELETE /{id}/sync`). Requires `sync_seq` to prevent stale cancels.
-- `mark_sync_cancel_pending` writes to `connector_sync_logs.status`, not `connectors.sync_status`. The connector row stays `'syncing'` until `close_sync_log` transitions it.
-- `_check_interrupt_call` (not `_check_delete_pending`) is the single interrupt-check entry point; it combines both DELETE and CANCEL detection.
-- `_run_delete_teardown` (inline in `sync_tick.py`) handles teardown for the Case A path instead of dispatching `_run_teardown` as a new task.
+- **PR 7 — Scheduler + Lifespan + Crash Recovery ❌ NOT IMPLEMENTED:**
+  - `scheduler.py` does not exist. No `ConnectorScheduler`, no `register_connector_job`, no `_run_tick_wrapped`, no `AsyncScheduler`, no `AsyncSQLAlchemyDataStore`.
+  - `recover_connector_sync_state()` does not exist in `utils/recovery.py` (only `recover_zombie_jobs()` is present, which handles regular jobs only).
+  - `app.py` `lifespan()` does not start an APScheduler, does not call `recover_connector_sync_state()`, does not re-register connector jobs on startup, and does not set a custom thread pool executor.
+  - `POST /v1/connectors` currently has a code comment reading "Worker start is a no-op stub in PR3 — the worker manager (PR7) will hook in here once implemented." Scheduler registration on connector creation is pending.
+

--- a/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
+++ b/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
@@ -274,7 +274,7 @@ _run_teardown(connector_id) (Background asyncio.Task)
 
 ---
 
-### 3.5 `GET` & `POST /v1/connectors/{connector_id}/sync`
+### 3.5 `GET`, `POST` & `DELETE /v1/connectors/{connector_id}/sync`
 
 - `GET`: Returns paginated execution history items from `connector_sync_logs` (`limit` default 50, max 200).
 - `POST`: Triggers an immediate manual sync tick.
@@ -292,6 +292,25 @@ POST /v1/connectors/{connector_id}/sync
   ├─ 3. open_new_sync_log(connector_id) → sync_seq
   ├─ 4. asyncio.create_task(_run_tick(connector_id))
   └─ 5. Return 202 Accepted
+```
+- `DELETE`: Stops the currently running sync tick without deleting the connector. The connector remains and resumes its normal schedule on the next interval.
+  - Returns `409 Conflict` if no tick is currently running (`sync_status != 'syncing'`).
+  - If running: atomically sets `sync_status = 'cancel pending'` via `mark_sync_cancel_pending()`, returns `204 No Content` immediately.
+  - The tick hits `_check_delete_pending` at its next checkpoint, raises `CancelledError`, and `_cancel_tick` closes the sync log with `status = 'cancelled'`.
+  - `close_sync_log` resets `connectors.sync_status` to `'out of sync'` (not `'cancelled'`) so the scheduler can acquire the lock on the next interval.
+
+```text
+DELETE /v1/connectors/{connector_id}/sync
+  │
+  ├─ 1. Check existence → 404 if not found
+  ├─ 2. mark_sync_cancel_pending(connector_id)
+  │      (atomic UPDATE WHERE sync_status='syncing' SET sync_status='cancel pending')
+  │      ├─ No rows updated (not syncing) → return 409 Conflict
+  │      └─ Updated → proceed
+  └─ 3. Return 204 No Content immediately
+           └─ Running tick hits _check_delete_pending checkpoint →
+              raises CancelledError → _cancel_tick writes sync log
+              status='cancelled', connector sync_status resets to 'out of sync'
 ```
 
 ---

--- a/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
+++ b/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
@@ -30,7 +30,7 @@ Before any `digitize` connector endpoint is called:
 - `connector_sync_logs`: Per-tick execution log and counters backing history queries.
 - `ConnectorScheduler`: APScheduler `AsyncScheduler` singleton backed by `PostgresDataStore`.
 - `BaseScanner` / Scanners: Transport-specific remote I/O abstraction (`S3Scanner`, `SFTPScanner`).
-- `Sync Execution Engine`: `_run_tick()` async coroutine executing the multi-phase sync cycle offloaded to thread pool for blocking I/O.
+- `Sync Execution Engine`: `run_tick()` async coroutine executing the multi-phase sync cycle; blocking I/O offloaded to thread pool via `asyncio.to_thread`.
 
 ---
 
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS connectors (
     sync_interval_seconds   INTEGER     NOT NULL DEFAULT 300,
     attached_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     last_sync_at            TIMESTAMPTZ,
-    sync_status             TEXT        NOT NULL DEFAULT 'up to date' 
+    sync_status             TEXT        NOT NULL DEFAULT 'up to date'
                                         CHECK (sync_status IN ('up to date', 'syncing', 'out of sync', 'delete pending')),
     last_sync_error         TEXT,
     total_files             INTEGER     NOT NULL DEFAULT 0,
@@ -70,6 +70,7 @@ CREATE INDEX IF NOT EXISTS idx_cdc_connector_id ON connector_document_checksum (
 
 -- Connector sync logs table
 CREATE TABLE IF NOT EXISTS connector_sync_logs (
+    id               SERIAL      PRIMARY KEY,
     connector_id     TEXT        NOT NULL,
     seq              INTEGER     NOT NULL,
     started_at       TIMESTAMPTZ NOT NULL,
@@ -79,7 +80,7 @@ CREATE TABLE IF NOT EXISTS connector_sync_logs (
     removed_files    INTEGER     NOT NULL DEFAULT 0,
     status           TEXT        NOT NULL DEFAULT 'started',
     error            TEXT        NOT NULL DEFAULT '',
-    PRIMARY KEY (connector_id, seq),
+    UNIQUE (connector_id, seq),
     CONSTRAINT fk_csh_connector
         FOREIGN KEY (connector_id)
         REFERENCES connectors(id) ON DELETE CASCADE
@@ -124,8 +125,9 @@ class ConnectorDocumentChecksum(Base):
 class ConnectorSyncLog(Base):
     __tablename__ = "connector_sync_logs"
 
-    connector_id = Column(String, ForeignKey("connectors.id", ondelete="CASCADE"), primary_key=True)
-    seq = Column(Integer, primary_key=True)
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    connector_id = Column(String, ForeignKey("connectors.id", ondelete="CASCADE"), nullable=False)
+    seq = Column(Integer, nullable=False)
     started_at = Column(DateTime(timezone=True), nullable=False)
     finished_at = Column(DateTime(timezone=True), nullable=True)
     total_files = Column(Integer, nullable=False, default=0)
@@ -135,6 +137,7 @@ class ConnectorSyncLog(Base):
     error = Column(String, nullable=False, default="")
 
     connector = relationship("Connector", back_populates="sync_logs")
+    # UNIQUE (connector_id, seq) — enforced by uq_csh_connector_seq constraint
 ```
 
 ---
@@ -229,17 +232,17 @@ Fast, non-blocking detachment. Returns `204 No Content` immediately; teardown ru
 DELETE /v1/connectors/{connector_id} (API Handler)
   │
   ├─ 1. SELECT connector → 404 if not found
-  ├─ 2. Read current sync_status
+  ├─ 2. mark_sync_delete_pending(connector_id)
+  │      (atomic UPDATE connectors SET sync_status='delete pending'
+  │       WHERE sync_status='syncing')
   │
-  ├─ [Case A] sync_status == 'syncing'  (a tick is actively running)
-  │     ├─ UPDATE connectors SET sync_status = 'delete_pending'  (committed)
+  ├─ [Case A] sync_status was 'syncing'  (mark_sync_delete_pending returned True)
   │     └─ Return 204 No Content immediately
-  │          └─ The running tick will hit _check_delete_pending at its next
-  │             checkpoint, raise CancelledError, call _cancel_tick (sync log
-  │             status = 'cancelled'), then dispatch asyncio.create_task(_run_teardown)
+  │          └─ Running tick hits _check_interrupt_call at its next checkpoint,
+  │             detects DELETE_PENDING → raises CancelledError →
+  │             _handle_interrupt calls _cancel_tick then _run_delete_teardown
   │
-  └─ [Case B] sync_status != 'syncing'  ('up to date' | 'out of sync')
-        ├─ UPDATE connectors SET sync_status = 'delete_pending'  (committed)
+  └─ [Case B] sync_status != 'syncing'  (mark_sync_delete_pending returned False)
         ├─ asyncio.create_task(_run_teardown(connector_id))
         └─ Return 204 No Content immediately
 ```
@@ -247,18 +250,19 @@ DELETE /v1/connectors/{connector_id} (API Handler)
 #### Teardown Flow
 
 ```text
-_run_teardown(connector_id) (Background asyncio.Task)
+_run_teardown(connector_id) (Background asyncio.Task — Case B only)
   │
-  ├─ Step A: _finalize_open_sync_log(connector_id)
-  │            └─ get_last_sync_log → if status not in {completed, failed, cancelled}
-  │               → close_sync_log(status='cancelled', update_connector_status=False)
-  │               (no-op if last log is already terminal, or if no log exists)
-  ├─ Step B: remove_connector_job(connector_id) → unregisters APScheduler job
-  ├─ Step C: snapshot owned checksums for connector
-  ├─ Step D: remove_connector_checksum_entry row by row
-  │            └─ if remaining_owner_count == 0 → best-effort delete_document_internal(doc_id)
-  ├─ Step E: DELETE FROM connectors WHERE id = :connector_id (cascades to sync_logs)
-  └─ Step F: cleanup_connector_staging_dirs(connector_id)
+  ├─ Step C+D: list_connector_checksums → for each checksum:
+  │              remove_connector_checksum_entry(connector_id, checksum)
+  │              if remaining == 0 and doc_id → _best_effort_delete_document(doc_id)
+  ├─ Step E: delete_active_connector(connector_id) (cascades to sync_logs)
+  └─ Step F: _sweep_staging_dir(connector_id, staging/connectors)
+
+_run_delete_teardown(connector_id) (Inline in sync_tick.py — Case A only)
+  │  Called after _cancel_tick inside CancelledError handler when DELETE_PENDING
+  ├─ Step 1: list_connector_checksums → remove ownership rows + delete orphaned docs
+  ├─ Step 2: delete_active_connector(connector_id) (cascades to sync_logs)
+  └─ Step 3: _sweep_staging_dir(connector_id, staging/connectors)
 ```
 
 ![Delete Flow](delete-flow.svg)
@@ -268,45 +272,46 @@ _run_teardown(connector_id) (Background asyncio.Task)
 ### 3.4 `GET /v1/connectors` & `GET /v1/connectors/{connector_id}`
 
 - `GET /v1/connectors`: Returns active connectors list without secrets.
-- `GET /v1/connectors/{id}`: Returns connector details + latest file processing counters (`total_files`, `new_files`, `removed_files`, `failed_files`).
+- `GET /v1/connectors/{id}`: Returns connector details + latest file processing counters (`total_files`, `new_files`, `removed_files`).
 
 ---
 
-### 3.5 `GET`, `POST` & `DELETE /v1/connectors/{connector_id}/sync`
+### 3.5 `GET`, `POST` & `POST /syncs/{sync_seq}/stop` — `/v1/connectors/{connector_id}/syncs`
 
-- `GET`: Returns paginated execution history items from `connector_sync_logs` (`limit` default 50, max 200).
-- `POST`: Triggers an immediate manual sync tick.
+- `GET /v1/connectors/{connector_id}/syncs`: Returns paginated execution history items from `connector_sync_logs` (`limit` default 50, max 200).
+- `POST /v1/connectors/{connector_id}/syncs`: Triggers an immediate manual sync tick.
   - Safe & idempotent: acquires DB lock via atomic `UPDATE connectors SET sync_status='syncing' WHERE id=:id AND sync_status!='syncing' RETURNING id`.
-  - If locked, returns `202 Accepted` immediately (no-op).
-  - If lock acquired, opens log row (`open_sync_log`), dispatches `asyncio.create_task(_run_tick(connector_id))`, and returns `202 Accepted`.
+  - If lock acquired, dispatches `asyncio.create_task(run_tick(connector_id))` (open log happens *inside* `run_tick`); polls `get_active_sync_seq()` in a loop until the row appears, then returns `202 Accepted` with the `sync_seq`.
+  - If locked (already syncing), fetches the current active `sync_seq` via `get_active_sync_seq()` and returns `202 Accepted` with it (no duplicate tick started).
 
 ```text
-POST /v1/connectors/{connector_id}/sync
+POST /v1/connectors/{connector_id}/syncs
   │
   ├─ 1. Check existence → 404 if not found
   ├─ 2. try_acquire_sync_lock(connector_id) (atomic UPDATE ... RETURNING)
-  │      ├─ Lock unavailable (already syncing) → return 202 Accepted (no-op)
-  │      └─ Lock acquired → proceed
-  ├─ 3. open_new_sync_log(connector_id) → sync_seq
-  ├─ 4. asyncio.create_task(_run_tick(connector_id))
-  └─ 5. Return 202 Accepted
+  │      ├─ Lock acquired → asyncio.create_task(run_tick(connector_id))
+  │      │    └─ _wait_for_sync_seq() polls until open_new_sync_log row appears
+  │      └─ Lock unavailable (already syncing) → get_active_sync_seq()
+  └─ 3. Return 202 Accepted { "sync_seq": <seq> }
 ```
-- `DELETE`: Stops the currently running sync tick without deleting the connector. The connector remains and resumes its normal schedule on the next interval.
-  - Returns `409 Conflict` if no tick is currently running (`sync_status != 'syncing'`).
-  - If running: atomically sets `sync_status = 'cancel pending'` via `mark_sync_cancel_pending()`, returns `204 No Content` immediately.
-  - The tick hits `_check_delete_pending` at its next checkpoint, raises `CancelledError`, and `_cancel_tick` closes the sync log with `status = 'cancelled'`.
-  - `close_sync_log` resets `connectors.sync_status` to `'out of sync'` (not `'cancelled'`) so the scheduler can acquire the lock on the next interval.
+- `POST /v1/connectors/{connector_id}/syncs/{sync_seq}/stop`: Stops the currently running sync tick without deleting the connector. The connector remains and resumes its normal schedule on the next interval.
+  - `sync_seq` must match the currently-active sync row; returns `409 Conflict` on a stale or absent seq.
+  - If the seq matches: writes `connector_sync_logs.status = 'cancel pending'` via `mark_sync_cancel_pending()` (connector row stays `'syncing'`); returns `204 No Content` immediately.
+  - The tick's `_check_interrupt_call(connector_id, sync_seq)` detects `CANCEL_PENDING` on the log row at its next checkpoint, raises `CancelledError`, and `_cancel_tick` closes the sync log with `status = 'cancelled'`.
+  - `close_sync_log` transitions `connectors.sync_status` to `'out of sync'` so the scheduler can acquire the lock on the next interval.
 
 ```text
-DELETE /v1/connectors/{connector_id}/sync
+POST /v1/connectors/{connector_id}/syncs/{sync_seq}/stop
   │
   ├─ 1. Check existence → 404 if not found
-  ├─ 2. mark_sync_cancel_pending(connector_id)
-  │      (atomic UPDATE WHERE sync_status='syncing' SET sync_status='cancel pending')
-  │      ├─ No rows updated (not syncing) → return 409 Conflict
-  │      └─ Updated → proceed
-  └─ 3. Return 204 No Content immediately
-           └─ Running tick hits _check_delete_pending checkpoint →
+  ├─ 2. get_active_sync_seq() → 409 if None or != sync_seq
+  ├─ 3. mark_sync_cancel_pending(connector_id)
+  │      → writes connector_sync_logs.status='cancel pending' (connector stays 'syncing')
+  │      ├─ Returns False (not syncing) → 409 Conflict
+  │      └─ Returns True → proceed
+  └─ 4. Return 204 No Content immediately
+           └─ Running tick hits _check_interrupt_call checkpoint →
+              CANCEL_PENDING detected on sync-log row →
               raises CancelledError → _cancel_tick writes sync log
               status='cancelled', connector sync_status resets to 'out of sync'
 ```
@@ -342,20 +347,23 @@ DELETE /v1/connectors/{connector_id}/sync
 | `insert_connector()` | Create new connector row. |
 | `update_connector()` / `upsert_connector()` | Merge configuration fields & re-encrypt secrets. |
 | `get_connector_by_id()` / `get_all_connectors()` | Fetch single or all connectors. |
-| `delete_connector()` / `mark_connector_delete_pending()` | Set `sync_status = 'delete pending'` or delete row. |
+| `delete_connector()` / `delete_active_connector()` | Delete connector row (cascades to sync_logs). Returns `bool`. |
+| `mark_sync_delete_pending(connector_id)` | Atomic `UPDATE connectors SET sync_status='delete pending' WHERE sync_status='syncing'`. Returns `True` if a running tick was signalled. |
+| `mark_sync_cancel_pending(connector_id)` | Verifies `connectors.sync_status='syncing'`, then sets `connector_sync_logs.status='cancel pending'` on the active log row. Connector row stays `'syncing'`. Returns `bool`. |
 | `find_connector_doc_by_checksum(checksum)` | Lookup existing `doc_id` in `connector_document_checksum`. |
-| `get_connector_checksums(connector_id)` | Return set of checksums owned by `connector_id`. |
-| `get_all_connector_checksums()` | Return set of all distinct checksums in `connector_document_checksum`. |
+| `get_connector_checksums(connector_id)` / `list_connector_checksums()` | Return list of checksums owned by `connector_id`. |
+| `get_all_connector_checksums()` / `list_all_checksums()` | Return list of all distinct checksums in `connector_document_checksum`. |
 | `insert_connector_checksum(connector_id, checksum, doc_id)` | Insert `(checksum, connector_id, doc_id)` with `ON CONFLICT DO NOTHING`. |
 | `delete_connector_checksum(connector_id, checksum)` | Remove `(checksum, connector_id)`; returns `(remaining_owner_count, doc_id)`. |
-| `get_connector_sync_status(connector_id)` | `SELECT sync_status FROM connectors WHERE id = :id`. Returns the current status string or `None` if not found. Used by `_check_delete_pending`. |
-| `try_acquire_sync_lock(connector_id)` | Atomic `UPDATE connectors SET sync_status='syncing' WHERE id=:id AND sync_status!='syncing' RETURNING id`. |
-| `open_sync_log(connector_id)` | Create tick log row with `seq = COALESCE(MAX(seq), 0) + 1` and status `'started'`. |
-| `update_sync_log(seq, total_files, new_files, removed_files)` | Write all three file counts in a single DB update immediately after `_classify()` returns. All counts are derived from classify output and known before any I/O begins. |
-| `close_sync_log(connector_id, seq, status, error)` | Finalize log row with terminal status and `finished_at`. Also updates connector `last_sync_at` / `sync_status`. Does **not** carry file counts — those are already persisted by `update_sync_log`. |
-| `get_last_sync_log(connector_id)` | `SELECT ... FROM connector_sync_logs WHERE connector_id = :id ORDER BY seq DESC LIMIT 1`. Returns the most-recent log row or `None`. Used by `_run_teardown` to detect open logs. |
+| `get_connector_sync_status(connector_id)` | `SELECT sync_status FROM connectors WHERE id = :id`. Returns the current status string or `None`. Used by `_check_interrupt_call`. |
+| `get_active_sync_seq(connector_id)` | Returns `seq` of the active sync-log row (status in `{started, cancel pending}`), or `None` if no tick is running. Used by `POST /syncs` and `POST /syncs/{seq}/stop`. |
+| `try_acquire_sync_lock(connector_id)` | Atomic `UPDATE connectors SET sync_status='syncing' WHERE id=:id AND sync_status!='syncing' RETURNING id`. Returns `bool`. |
+| `open_sync_log(connector_id)` | Create tick log row with `seq = COALESCE(MAX(seq), 0) + 1` and status `'started'`. Also sets connector `sync_status='syncing'`. Returns `seq`. |
+| `update_sync_log_progress(log_id, total_files, new_files, removed_files)` | Write all three file counts in a single DB update immediately after `_classify()` returns. All counts are derived from classify output and known before any I/O begins. (Exposed via `update_sync_log` in `utils/db.py` which takes `seq`.) |
+| `close_sync_log(connector_id, seq, status, error)` | Finalize log row with terminal status and `finished_at`. Updates connector `last_sync_at` and `sync_status` (`CANCELLED`/`FAILED` both map to `OUT_OF_SYNC`). Does **not** carry file counts — those are already persisted by `update_sync_log`. |
+| `get_sync_log_status(connector_id, seq)` | Returns `status` of a specific `(connector_id, seq)` row or `None`. Used by `_check_interrupt_call` to detect `CANCEL_PENDING`. |
+| `get_sync_logs(connector_id, limit, offset)` | Paginated log history query. Returns `(items, total_count)`. |
 | `reset_stale_syncing_connectors()` | On startup: `UPDATE connectors SET sync_status='out of sync' WHERE sync_status='syncing'`. Returns the list of affected `connector_id` values. Used by `recover_connector_sync_state()`. |
-| `get_sync_logs(connector_id, limit, offset)` | Paginated log history query. |
 
 ---
 
@@ -364,7 +372,7 @@ DELETE /v1/connectors/{connector_id}/sync
 ```python
 class DatabaseManager:
     @staticmethod
-    def lookup_connector_content_by_checksum(checksum: str) -> str | None:
+    def find_connector_doc_by_checksum(checksum: str) -> str | None:
         with get_db_session() as session:
             row = session.execute(
                 select(ConnectorDocumentChecksum.doc_id)
@@ -374,17 +382,17 @@ class DatabaseManager:
         return row[0] if row else None
 
     @staticmethod
-    def add_connector_checksum_entry(connector_id: str, checksum: str, doc_id: str) -> None:
+    def insert_connector_checksum(connector_id: str, checksum: str, doc_id: str) -> None:
         with get_db_session() as session:
             stmt = (
-                insert(ConnectorDocumentChecksum)
+                pg_insert(ConnectorDocumentChecksum)
                 .values(checksum=checksum, connector_id=connector_id, doc_id=doc_id)
                 .on_conflict_do_nothing(index_elements=["checksum", "connector_id"])
             )
             session.execute(stmt)
 
     @staticmethod
-    def remove_connector_checksum_entry(connector_id: str, checksum: str) -> tuple[int, str | None]:
+    def delete_connector_checksum(connector_id: str, checksum: str) -> tuple[int, str | None]:
         with get_db_session() as session:
             deleted = session.execute(
                 delete(ConnectorDocumentChecksum)
@@ -407,15 +415,88 @@ class DatabaseManager:
     def try_acquire_sync_lock(connector_id: str) -> bool:
         with get_db_session() as session:
             result = session.execute(
-                text("""
-                    UPDATE connectors
-                    SET sync_status = 'syncing'
-                    WHERE id = :id AND sync_status != 'syncing'
-                    RETURNING id
-                """),
-                {"id": connector_id},
+                update(Connector)
+                .where(
+                    Connector.id == connector_id,
+                    Connector.sync_status != SyncStatus.SYNCING,
+                )
+                .values(sync_status=SyncStatus.SYNCING)
+                .returning(Connector.id)
             ).one_or_none()
             return result is not None
+
+    @staticmethod
+    def mark_sync_cancel_pending(connector_id: str) -> bool:
+        """
+        Writes 'cancel pending' to connector_sync_logs.status — NOT connectors.
+        Connector row stays 'syncing' until the tick's close_sync_log() call.
+        Returns True only when connectors.sync_status='syncing' (a tick is running).
+        """
+        with get_db_session() as session:
+            connector_row = session.execute(
+                select(Connector.id)
+                .where(Connector.id == connector_id, Connector.sync_status == SyncStatus.SYNCING)
+            ).one_or_none()
+            if connector_row is None:
+                return False
+            result = session.execute(
+                update(ConnectorSyncLog)
+                .where(
+                    ConnectorSyncLog.connector_id == connector_id,
+                    ConnectorSyncLog.status == SyncStatus.STARTED,
+                )
+                .values(status=SyncStatus.CANCEL_PENDING)
+                .returning(ConnectorSyncLog.seq)
+            ).one_or_none()
+            return result is not None
+
+    @staticmethod
+    def mark_sync_delete_pending(connector_id: str) -> bool:
+        """
+        Sets connectors.sync_status='delete pending' only when currently 'syncing'.
+        Returns True if a running tick was signalled, False otherwise.
+        """
+        with get_db_session() as session:
+            result = session.execute(
+                update(Connector)
+                .where(Connector.id == connector_id, Connector.sync_status == SyncStatus.SYNCING)
+                .values(sync_status=SyncStatus.DELETE_PENDING)
+                .returning(Connector.id)
+            ).one_or_none()
+            return result is not None
+
+    @staticmethod
+    def get_active_sync_seq(connector_id: str) -> int | None:
+        """Return seq of the active (started | cancel pending) sync-log row, or None."""
+        with get_db_session() as session:
+            row = session.execute(
+                select(ConnectorSyncLog.seq)
+                .where(
+                    ConnectorSyncLog.connector_id == connector_id,
+                    ConnectorSyncLog.status.in_([SyncStatus.STARTED, SyncStatus.CANCEL_PENDING]),
+                )
+                .order_by(ConnectorSyncLog.seq.desc())
+                .limit(1)
+            ).one_or_none()
+            return row[0] if row else None
+
+    @staticmethod
+    def close_sync_log(connector_id, seq, status, error=None, finished_at=None, ...) -> bool:
+        """
+        CANCELLED and FAILED both transition connector to OUT_OF_SYNC.
+        Only COMPLETED writes the status value through verbatim.
+        """
+        ...
+        connector_sync_status = (
+            SyncStatus.OUT_OF_SYNC
+            if status in (SyncStatus.CANCELLED, SyncStatus.FAILED)
+            else status  # COMPLETED → "completed"
+        )
+        session.execute(
+            update(Connector)
+            .where(Connector.id == connector_id)
+            .values(last_sync_at=now, sync_status=connector_sync_status)
+        )
 
     @staticmethod
     def reset_stale_syncing_connectors() -> list[str]:
@@ -512,56 +593,81 @@ def build_scanner(config: ConnectorConfig) -> BaseScanner:
 
 ![Sync Tick Flow](sync-worker-tick-flow.svg)
 
-- **Phase 0 (Lock):** Acquire lock via `try_acquire_sync_lock(connector_id)`.
-- **Phase 1 (Log):** Open tick row (`open_sync_log`).
-- **Phase 2 (Scan & State):** Query owned `known_checksums` and `all_checksums`. Offload blocking network calls (`connect`, `scan`) to thread pool via `run_in_executor(None, ...)`.
-- **Phase 3 (Classify):** `_classify()` separates `scanned_files` into `skip_list`, `ingest_list`, and cross-connector duplicates. Cross-connector duplicates execute `insert_connector_checksum` inline using existing `doc_id`.
+- **Phase 0 (Lock):** Acquire lock via `try_acquire_sync_lock(connector_id)`. Called externally (by scheduler or `POST /syncs`); `run_tick` assumes the lock is already held.
+- **Phase 1 (Log):** `open_new_sync_log(connector_id)` is called **inside** `run_tick`, not the caller. Returns `sync_seq` used for all subsequent interrupt checks.
+- **Phase 1b (Interrupt Check):** `_check_interrupt_call(connector_id, sync_seq)` is called immediately before any remote I/O. If `DELETE_PENDING` or `CANCEL_PENDING`, raises `asyncio.CancelledError`.
+- **Phase 2 (Scan & State):** Query owned `known_checksums` and `all_checksums`. Offload blocking network calls (`connect`, `scan`) to thread pool via `asyncio.to_thread(...)`.
+- **Phase 3 (Classify):** `_classify()` separates `scanned_files` into `ingest_list` and cross-connector duplicates. Cross-connector duplicates execute `add_connector_checksum_entry` inline using existing `doc_id`.
 - **Phase 3b (Count Commit):** All three counters (`total_files`, `new_files`, `removed_files`) are fully determined from classify output. A single `update_sync_log()` call persists them before any I/O-heavy work begins. No further counter writes happen during batch processing.
-- **Phase 4a (Ingest New Files):** Sequentially download files in `ingest_list`:
-  - Dedicated per-batch staging directory: `staging/connectors/{connector_id}-{seq}-{batch_number}`.
+- **Phase 4a (Ingest New Files):** Download and ingest `ingest_list` in batches of `_BATCH_SIZE = 10`:
+  - Dedicated per-batch staging directory: `staging/connectors/{connector_id}-{sync_seq}-{batch_number}`.
+  - Interrupt checkpoint **before** each batch starts.
   - Offload download to executor thread (`asyncio.to_thread(scanner.download_to, ...)`).
-  - Call `initialize_job_state()` → obtain `doc_id` map, insert checksum rows, call `ingest()`.
-  - Cleanup staging directory immediately in `finally` block.
+  - Files failing `verify_integrity` are **skipped** (logged as warnings), not fatal.
+  - Interrupt checkpoint **after** batch downloads complete.
+  - Call `initialize_job_state()` → obtain `doc_id` map, insert checksum rows, call `ingest()`, then `_wait_for_job()`.
+  - `_wait_for_job()` polls every `_JOB_POLL_INTERVAL=10s` and calls `_check_interrupt_call` on each wake-up.
+  - Cleanup staging directory in `finally` per batch; batch failure sets `batch_failed=True` flag.
+  - After all batches: if `batch_failed`, raises `RuntimeError` → tick closes as `FAILED` → connector set to `OUT_OF_SYNC`.
 - **Phase 4b (Orphan Removal):** Runs **strictly after Phase 4a completes**. Delete checksum rows for `orphan_checksums = known_checksums − scanned_checksums`. If remaining count is `0`, call `_best_effort_delete_document(doc_id)`.
-- **Phase 5 (Finalize):** Write terminal status (`'completed'`/`'failed'`/`'cancelled'`) and update `sync_status` on the connector row. Call `scanner.close()` in top-level `finally`.
+- **Phase 5 (Finalize):** Write terminal status (`'completed'`/`'failed'`/`'cancelled'`) and update `sync_status` on the connector row. `scanner.close()` is called in top-level `finally` regardless of outcome.
 
 #### Interrupt Handling
 
-The tick implementation uses a generic `_check_interrupt_call()` function that checks for interrupt signals from **two distinct sources** and returns an `InterruptType` enum:
+The tick uses `_check_interrupt_call(connector_id, sync_seq)` which checks **two independent DB sources** and returns an `InterruptType` enum value or `None`:
 
-1. **`connectors.sync_status = DELETE_PENDING`** → `InterruptType.DELETE_CONNECTOR`
-   - When a DELETE request is issued while a sync is running, the connector is marked for deletion.
-   - When the running tick detects this, it stops the sync, closes the sync log as cancelled, and proceeds to **full teardown**:
+1. **`connectors.sync_status == DELETE_PENDING`** → `InterruptType.DELETE_CONNECTOR`
+   - Triggered when `DELETE /v1/connectors/{id}` arrives while a sync is running (`mark_sync_delete_pending` succeeds).
+   - When the tick detects this, `CancelledError` is raised; `_handle_interrupt` calls `_cancel_tick` then `_run_delete_teardown`:
      - Remove all checksum ownership rows; delete documents when they lose their last owner
-     - Delete the connector row (cascades to all sync_logs)
-     - Sweep residual batch staging directories
+     - `delete_active_connector` (cascades to all sync_logs)
+     - Sweep all residual batch staging directories
 
-2. **`connectors.sync_status = CANCEL_PENDING`** → `InterruptType.SYNC_CANCEL`
-   - When a DELETE /sync request is issued, only the current sync should be stopped.
-   - When detected, the tick stops, closes the sync log as cancelled, and:
-     - Sets connector to `OUT_OF_SYNC` status (automatic via `close_sync_log` when status='cancelled')
-     - Cleans up staging directories for this specific sync
-     - The connector remains in the database and will be re-synced on the next scheduler interval
+2. **`connector_sync_logs.status == CANCEL_PENDING`** → `InterruptType.SYNC_CANCEL`
+   - Triggered when `POST /syncs/{seq}/stop` arrives (`mark_sync_cancel_pending` writes to the log row; connector stays `'syncing'`).
+   - When detected, `_handle_interrupt` calls `_cancel_tick` (log → `'cancelled'`, connector → `'out of sync'`), then sweeps staging directories for this sync's batches only.
+   - The connector remains and re-syncs on the next scheduler interval.
 
-The `_check_interrupt_call()` is invoked at **three phase boundaries** (before scan, after download, after each batch) to catch interrupts promptly without leaving partial work behind.
+`_check_interrupt_call()` is invoked at **four checkpoints**: (1) after `open_new_sync_log`, (2) before each batch starts, (3) after batch downloads complete, and (4) inside `_wait_for_job` on every poll cycle.
 
 ---
 
 ### 6.2 Implementation Code
 
 ```python
+class InterruptType(str, Enum):
+    SYNC_CANCEL = "sync_cancel"           # CANCEL_PENDING on connector_sync_logs row
+    DELETE_CONNECTOR = "delete_connector" # DELETE_PENDING on connectors row
+
+def _check_interrupt_call(connector_id: str, sync_seq: int) -> Optional[InterruptType]:
+    """Check both sources; return the appropriate InterruptType or None."""
+    # Priority 1: check connectors table for DELETE_PENDING
+    connector_status = get_connector_sync_status(connector_id)
+    if connector_status == SyncStatus.DELETE_PENDING:
+        return InterruptType.DELETE_CONNECTOR
+    # Priority 2: check sync-log row for CANCEL_PENDING
+    sync_log_status = get_sync_log_status(connector_id, sync_seq)
+    if sync_log_status == SyncStatus.CANCEL_PENDING:
+        return InterruptType.SYNC_CANCEL
+    return None
+
+
 async def run_tick(connector_id: str) -> None:
+    """
+    Execute one full sync tick. Caller must have acquired the sync lock
+    (try_acquire_sync_lock) before calling this coroutine.
+    """
     config = get_active_connector(connector_id)
     if config is None:
         logger.error(f"Connector {connector_id!r} not found; tick aborted")
         return
 
-    sync_seq = open_new_sync_log(connector_id)
+    sync_seq: int = open_new_sync_log(connector_id)   # Phase 1
     scanner = build_scanner(config)
 
     try:
-        # Phase boundary: check for interrupt signals before any remote I/O starts
-        interrupt = _check_interrupt_call(connector_id)
+        # Phase 1b: interrupt checkpoint before any remote I/O
+        interrupt = _check_interrupt_call(connector_id, sync_seq)
         if interrupt == InterruptType.DELETE_CONNECTOR:
             raise asyncio.CancelledError(f"Connector {connector_id!r} marked for deletion")
         elif interrupt == InterruptType.SYNC_CANCEL:
@@ -573,128 +679,106 @@ async def run_tick(connector_id: str) -> None:
         known_checksums = set(list_connector_checksums(connector_id))
         all_checksums = set(list_all_checksums())
 
-        ingest_list, orphan_checksums = _classify(
+        ingest_list, orphan_checksums = _classify(           # Phase 3
             connector_id, scanned_files, known_checksums, all_checksums
         )
 
-        # Phase 3b: all counts known — single DB write before any I/O begins.
-        update_sync_log(
+        update_sync_log(                                     # Phase 3b
             sync_seq,
             total_files=len(scanned_files),
             new_files=len(ingest_list),
             removed_files=len(orphan_checksums),
         )
 
-        await _process_new_files(sync_seq, connector_id, scanner, ingest_list)
-        await _delete_orphans(connector_id, orphan_checksums)
-        _complete_tick(sync_seq, connector_id)
+        await _process_new_files(sync_seq, connector_id, scanner, ingest_list)  # Phase 4a
+        await _delete_orphans(connector_id, orphan_checksums)                    # Phase 4b
+        _complete_tick(sync_seq, connector_id)                                   # Phase 5
 
     except asyncio.CancelledError as ce:
         logger.info(f"Tick cancelled for connector {connector_id!r}: {ce}")
-        interrupt = _check_interrupt_call(connector_id)
+        interrupt = _check_interrupt_call(connector_id, sync_seq)
         _handle_interrupt(sync_seq, connector_id, interrupt)
         raise
+
     except Exception as exc:
         logger.error(f"Tick failed for connector {connector_id!r}: {exc}", exc_info=True)
-        _fail_tick(sync_seq, connector_id, exc)
+        _fail_tick(sync_seq, connector_id, exc)   # → close_sync_log(FAILED) → OUT_OF_SYNC
+
     finally:
         await asyncio.to_thread(scanner.close)
 
 
-def _classify(
-    connector_id: str,
-    scanned_files: list[tuple[str, str]],
-    known_checksums: set[str],
-    all_checksums: set[str],
-) -> tuple[list[tuple[str, str]], set[str]]:
-    scanned_checksums: set[str] = set()
-    seen_this_tick: set[str] = set()
-    ingest_list: list[tuple[str, str]] = []
-
-    for remote_path, checksum in scanned_files:
-        scanned_checksums.add(checksum)
-        if checksum in known_checksums:
-            pass  # Already owned by this connector
-        elif checksum in all_checksums:
-            if checksum not in seen_this_tick:
-                seen_this_tick.add(checksum)
-                existing_doc_id = lookup_connector_content_by_checksum(checksum)
-                if existing_doc_id:
-                    add_connector_checksum_entry(connector_id, checksum, existing_doc_id)
-        else:
-            if checksum not in seen_this_tick:
-                seen_this_tick.add(checksum)
-                ingest_list.append((remote_path, checksum))
-
+def _classify(...) -> tuple[list[tuple[str, str]], set[str]]:
+    # Same logic as before — no changes to classification algorithm.
+    ...
     orphan_checksums = known_checksums - scanned_checksums
     return ingest_list, orphan_checksums
 
 
-async def _process_new_files(
-    sync_seq: int,
-    connector_id: str,
-    scanner,
-    ingest_list: list[tuple[str, str]],
-) -> None:
-    """Download and ingest ingest_list in batches of up to 10 files.
+_BATCH_SIZE = 10
+_JOB_POLL_INTERVAL = 10  # seconds
 
-    Counts are not tracked here; they were already written by update_sync_log
-    immediately after _classify().
+async def _process_new_files(sync_seq, connector_id, scanner, ingest_list) -> None:
+    """
+    Download and ingest ingest_list in batches of up to BATCH_SIZE=10.
+
+    Integrity failures skip the file (logged warning).
+    Batch-level exceptions set batch_failed=True but processing continues.
+    After all batches: raises RuntimeError if batch_failed → _fail_tick → OUT_OF_SYNC.
     """
     staging_base = settings.digitize.staging_dir / "connectors"
+    batch_failed = False
 
     for batch_number in range(0, len(ingest_list), _BATCH_SIZE):
         batch = ingest_list[batch_number : batch_number + _BATCH_SIZE]
-        # Checkpoint: check for interrupts before each batch
-        interrupt = _check_interrupt_call(connector_id)
+
+        # Checkpoint 2: interrupt check before each batch
+        interrupt = _check_interrupt_call(connector_id, sync_seq)
         if interrupt:
-            raise asyncio.CancelledError(
-                f"Connector {connector_id!r} interrupted (type={interrupt.value})"
-            )
+            raise asyncio.CancelledError(...)
 
-        job_id = generate_uuid()
         batch_dir_name = f"{connector_id}-{sync_seq}-{batch_number}"
-        batch_dir = staging_base / batch_dir_name
-        batch_dir.mkdir(parents=True, exist_ok=True)
-        checksum_to_filename: dict[str, str] = {}
-
+        ...
         try:
             for remote_path, checksum in batch:
-                filename = Path(remote_path).name
-                local_checksum = await asyncio.to_thread(
-                    scanner.download_to, remote_path, batch_dir / filename
-                )
-                scanner.verify_integrity(local_checksum, checksum)
+                local_checksum = await asyncio.to_thread(scanner.download_to, ...)
+                if not scanner.verify_integrity(local_checksum, checksum):
+                    logger.warning(f"Integrity check failed for {remote_path!r}; skipping")
+                    continue                 # ← skip, not fatal
                 checksum_to_filename[checksum] = filename
 
-            # Checkpoint: check for interrupts after downloads
-            interrupt = _check_interrupt_call(connector_id)
+            # Checkpoint 3: interrupt check after downloads
+            interrupt = _check_interrupt_call(connector_id, sync_seq)
             if interrupt:
-                raise asyncio.CancelledError(
-                    f"Connector {connector_id!r} interrupted (type={interrupt.value})"
-                )
+                raise asyncio.CancelledError(...)
 
-            filenames = list(checksum_to_filename.values())
-            doc_id_dict = initialize_job_state(
-                job_id=job_id,
-                operation=OperationType.INGESTION,
-                output_format=OutputFormat.JSON,
-                documents_info=filenames,
-                job_name=f"{connector_id} - {sync_seq} - {batch_number}",
-            )
+            doc_id_dict = initialize_job_state(...)
             for checksum, filename in checksum_to_filename.items():
                 add_connector_checksum_entry(connector_id, checksum, doc_id_dict[filename])
-
             await asyncio.to_thread(ingest, batch_dir, job_id, doc_id_dict)
-            await _wait_for_job(job_id, connector_id)
+            await _wait_for_job(job_id, connector_id, sync_seq)  # Checkpoint 4: polls + interrupt
 
+        except asyncio.CancelledError:
+            raise  # propagate upward to run_tick's CancelledError handler
         except Exception as exc:
-            logger.warning(
-                f"Failed to ingest batch {batch_number!r} for connector {connector_id!r}: {exc}",
-                exc_info=True,
-            )
+            logger.warning(f"Batch {batch_number!r} failed: {exc}")
+            batch_failed = True
         finally:
             cleanup_staging_directory(batch_dir_name, staging_base, ignore_errors=True)
+
+    if batch_failed:
+        raise RuntimeError("One or more batches failed; connector marked as out of sync")
+
+
+def _handle_interrupt(sync_seq, connector_id, interrupt_type) -> None:
+    if interrupt_type == InterruptType.SYNC_CANCEL:
+        _cancel_tick(sync_seq, connector_id)   # log → 'cancelled', connector → 'out of sync'
+        _sweep_staging_dir(connector_id, ..., sync_seq=sync_seq)  # sweep only this sync's dirs
+    elif interrupt_type == InterruptType.DELETE_CONNECTOR:
+        _cancel_tick(sync_seq, connector_id)
+        _run_delete_teardown(connector_id)     # full teardown inline in sync_tick.py
+    else:  # None (unexpected CancelledError)
+        _cancel_tick(sync_seq, connector_id)
 ```
 
 ---
@@ -715,7 +799,8 @@ async def _process_new_files(
 
 ```python
 # No module-level _pending_deletions or _live_tasks.
-# All delete state is read from the connectors table.
+# All interrupt state is read from DB: connectors.sync_status and
+# connector_sync_logs.status polled by _check_interrupt_call.
 
 async def register_connector_job(connector_id: str, interval_seconds: int, fire_immediately: bool = False) -> None:
     kwargs = dict(
@@ -735,71 +820,15 @@ async def _run_tick_wrapped(connector_id: str) -> None:
     """APScheduler entry point for each scheduled tick.
 
     Guards:
-    1. _check_delete_pending — skips tick entirely if connector is being deleted.
-    2. try_acquire_sync_lock — skips tick if one is already running.
+    1. Check for DELETE_PENDING — skip tick entirely if connector is being deleted.
+    2. try_acquire_sync_lock — skip tick if one is already running.
     """
-    _check_delete_pending(connector_id)   # raises CancelledError → APScheduler suppresses, tick skipped
+    status = get_connector_sync_status(connector_id)
+    if status == SyncStatus.DELETE_PENDING:
+        return  # connector is being torn down; skip tick
     if not try_acquire_sync_lock(connector_id):
-        return
-    await _run_tick(connector_id)
-
-
-def _check_delete_pending(connector_id: str) -> None:
-    """Query the DB and raise CancelledError if the connector is marked for deletion.
-
-    Called at every phase boundary inside _run_tick and _process_new_files.
-    Raises asyncio.CancelledError — caught by _run_tick's except block which
-    calls _cancel_tick and dispatches _run_teardown.
-    """
-    status = get_connector_sync_status(connector_id)   # SELECT sync_status FROM connectors WHERE id = :id
-    if status == "delete_pending":
-        raise asyncio.CancelledError(f"Connector {connector_id!r} is pending deletion")
-
-
-async def _run_teardown(connector_id: str) -> None:
-    """Performs full connector teardown. Dispatched either:
-    - By the DELETE handler directly (when no tick was running at delete time).
-    - By _run_tick's except CancelledError block (when a tick was interrupted).
-    """
-    # Guard: ensure the last sync log (if any) is in a terminal state before
-    # delete_connector cascades the connector_sync_logs rows away.
-    # Case A (tick was running): _cancel_tick already closed the log as
-    #   'cancelled' before dispatching this task — the check is a no-op.
-    # Case B (no tick was running): the last log may be stuck in 'started'
-    #   from a previous crash. Close it to 'cancelled' now.
-    _finalize_open_sync_log(connector_id)
-
-    await remove_connector_job(connector_id)
-
-    owned_rows = get_connector_checksums_with_docs(connector_id)
-    for checksum, doc_id in owned_rows:
-        remaining, _ = remove_connector_checksum_entry(connector_id, checksum)
-        if remaining == 0:
-            delete_document_internal(doc_id)
-
-    delete_connector(connector_id)          # cascades to connector_sync_logs
-    cleanup_connector_staging_dirs(connector_id)
-
-
-_TERMINAL_SYNC_LOG_STATUSES = {SyncStatus.COMPLETED, SyncStatus.FAILED, SyncStatus.CANCELLED}
-
-
-def _finalize_open_sync_log(connector_id: str) -> None:
-    """Close the most-recent sync log to 'cancelled' if it is not already in a
-    terminal state (completed | failed | cancelled).
-
-    Uses update_connector_status=False so that connectors.sync_status remains
-    'delete_pending' — _run_teardown will remove the connector row entirely
-    moments later, so no further status update is needed.
-    """
-    last_log = get_last_sync_log(connector_id)
-    if last_log is not None and last_log.status not in _TERMINAL_SYNC_LOG_STATUSES:
-        close_sync_log(
-            connector_id,
-            seq=last_log.seq,
-            status=SyncStatus.CANCELLED,
-            update_connector_status=False,
-        )
+        return  # another tick is already running
+    await run_tick(connector_id)  # run_tick opens the log row internally
 ```
 
 ---
@@ -816,8 +845,8 @@ begins firing ticks. It addresses two invariants broken by a mid-tick crash:
    `'out of sync'` so the next scheduled tick can acquire the lock.
 2. **Open sync log** — a log row left as `'started'` has no terminal state. Close it
    to `'failed'` with a crash error message, mirroring how `recover_zombie_jobs()`
-   handles regular jobs. `update_connector_status=False` is passed because
-   `reset_stale_syncing_connectors()` already set the connector status correctly.
+   handles regular jobs. The connector `sync_status` is left as `'out of sync'` —
+   already set correctly by `reset_stale_syncing_connectors()`.
 
 ```python
 def recover_connector_sync_state() -> int:
@@ -844,7 +873,7 @@ def recover_connector_sync_state() -> int:
                 seq=last_log.seq,
                 status=SyncStatus.FAILED,
                 error="Service restarted during sync tick",
-                update_connector_status=False,  # reset_stale_syncing_connectors already set it
+                # connector sync_status already set to 'out of sync' by reset_stale_syncing_connectors
             )
 
     logger.info(f"🔄 Recovered {len(stale_ids)} stale connector(s) on startup")
@@ -886,16 +915,22 @@ async def lifespan(app: FastAPI):
 Scanners perform synchronous blocking I/O (`boto3` calls, Paramiko SFTP operations). Running these on the main event loop thread would freeze Uvicorn request handling and prevent cancellation signals from being processed.
 
 ### 8.2 Execution & Cancellation Model
-- All blocking scanner methods (`connect`, `scan`, `download_to`) are called via `await loop.run_in_executor(None, scanner.<method>, *args)`.
+- All blocking scanner methods (`connect`, `scan`, `download_to`) are called via `await asyncio.to_thread(scanner.<method>, *args)`.
 - Event loop remains fully responsive.
-- Delete state is stored in the DB (`sync_status = 'delete_pending'`). There are no in-memory sets or task registries.
-- `_check_delete_pending(connector_id)` does a live `SELECT sync_status FROM connectors WHERE id = :id` and raises `asyncio.CancelledError` if the result is `'delete_pending'`. It is called:
-  - In `_run_tick_wrapped` — skips the tick entirely if delete is already set when the scheduler fires.
-  - In `_run_tick` — at the phase boundary before scan, and after scan before classify.
-  - In `_process_new_files` — before each download starts, and after each download returns.
+- Interrupt state is stored exclusively in the DB — no in-memory sets or task registries:
+  - **`connectors.sync_status = 'delete pending'`** — set by `mark_sync_delete_pending` when DELETE arrives mid-sync.
+  - **`connector_sync_logs.status = 'cancel pending'`** — set by `mark_sync_cancel_pending` when stop-sync is requested.
+- `_check_interrupt_call(connector_id, sync_seq)` reads both sources on every call. It is invoked at **four checkpoints**:
+  - In `run_tick` — immediately after `open_new_sync_log` (Phase 1b).
+  - In `_process_new_files` — before each batch starts (Checkpoint 2).
+  - In `_process_new_files` — after each batch of downloads completes (Checkpoint 3).
+  - In `_wait_for_job` — on every poll cycle (Checkpoint 4).
 - `CancelledError` is raised in the coroutine at those checkpoints, never inside the thread.
-- A download already in flight runs to natural completion. Deletes that arrive between files are caught at the next checkpoint.
-- `_run_tick`'s `except asyncio.CancelledError` block calls `_cancel_tick` (sets sync log `status = 'cancelled'`) then dispatches `asyncio.create_task(_run_teardown(connector_id))`.
+- A download already in flight runs to natural completion. Interrupts arriving between files are caught at the next checkpoint.
+- `run_tick`'s `except asyncio.CancelledError` block calls `_handle_interrupt` which dispatches:
+  - `_cancel_tick` + `_sweep_staging_dir(sync_seq=sync_seq)` for `SYNC_CANCEL`.
+  - `_cancel_tick` + `_run_delete_teardown(connector_id)` (synchronous, runs inline) for `DELETE_CONNECTOR`.
+- `_run_teardown` in `connectors.py` handles the background-task path (Case B: no tick running at delete time).
 - No safety-net timeout. No waiting for the tick to exit before teardown begins.
 
 ### 8.3 Thread Pool Sizing
@@ -907,49 +942,25 @@ $$\text{pool\_size} = \max(N + 4, 8) \quad \text{(where } N = \text{total config
 ## 9. Implementation Plan & PR Breakdown
 
 ### Implemented PRs
-- **PR 1 — DB Schema + ORM Models + Settings ✅:** `connectors`, `connector_document_checksum`, `connector_sync_logs` tables & ORM models created (`db/scripts/init_schema.sql`, `db/models.py`).
-- **PR 2 — DB Operations Layer ✅:** `manager.py` & `utils/db.py` methods fully implemented with tests in `test_connector_db.py`. All checksum helpers (`insert_connector_checksum`, `delete_connector_checksum`, `find_connector_doc_by_checksum`, `get_connector_checksums`, `get_all_connector_checksums`) and sync-log helpers (`open_sync_log`, `close_sync_log`, `update_sync_log_progress`, `get_sync_logs`) are present. (*Pending minor addition: `get_connector_sync_status(connector_id)` — `SELECT sync_status FROM connectors WHERE id = :id` — not yet in `manager.py` or `utils/db.py`*).
-- **PR 3 — REST API Endpoints ✅:** Full CRUD in `connectors.py` (`POST`, `PUT`, `DELETE`, `GET`, `GET /{id}`, `GET /{id}/syncs`). Connector-sourced document visibility filtering in `documents.py` (`exclude_connector_sourced=True` on list, `is_connector_sourced_document` guard on GET/DELETE).
+
+- **PR 1 — DB Schema + ORM Models + Settings ✅:** `connectors`, `connector_document_checksum`, `connector_sync_logs` tables & ORM models created (`db/scripts/init_schema.sql`, `db/models.py`). `connector_sync_logs` now has auto-increment `id` PK with `UNIQUE (connector_id, seq)`.
+- **PR 2 — DB Operations Layer ✅:** `manager.py` & `utils/db.py` fully implemented. All checksum helpers (`insert_connector_checksum`, `delete_connector_checksum`, `find_connector_doc_by_checksum`, `get_connector_checksums`, `get_all_connector_checksums`), sync-lock/signal helpers (`try_acquire_sync_lock`, `mark_sync_cancel_pending`, `mark_sync_delete_pending`), sync-log helpers (`open_sync_log`, `close_sync_log`, `update_sync_log_progress`, `get_sync_logs`, `get_sync_log_status`, `get_active_sync_seq`), and startup helper (`reset_stale_syncing_connectors`) are all present and tested in `test_connector_db.py`.
+- **PR 3 — REST API Endpoints ✅:** Full CRUD in `connectors.py` (`POST`, `PUT`, `DELETE`, `GET`, `GET /{id}`, `GET /{id}/syncs`, `POST /{id}/syncs`, `POST /{id}/syncs/{seq}/stop`). Connector-sourced document visibility filtering in `documents.py`.
 - **PR 4a — Scanner Abstraction ✅:** `BaseScanner` interface (`base_scanner.py`) & `scanner_factory.py` with `_REGISTRY` for `"s3"` and `"ssh"` types.
-- **PR 4b — SSH/SFTP Scanner ✅:** `SSHScanner` implemented in `connectors/scanners/ssh_scanner.py` (subclasses `BaseScanner`, uses Paramiko for SFTP walk + SSH `md5sum` hashing, registered in `scanner_factory.py` under `"ssh"`). Full unit-test coverage in `test_connector_scanners.py` (connect/close, scan, download, `_load_private_key`, factory registration). *(Note: file is named `ssh_scanner.py` rather than `sftp_scanner.py` as originally proposed — this is the accepted name.)*
-- **PR 5 — S3 Scanner ✅:** `S3Scanner` implementation & tests in `test_connector_scanners.py`.
+- **PR 4b — SSH/SFTP Scanner ✅:** `SSHScanner` implemented in `connectors/scanners/ssh_scanner.py`. *(Named `ssh_scanner.py` rather than `sftp_scanner.py` — accepted naming.)*
+- **PR 5 — S3 Scanner ✅:** `S3Scanner` implementation & tests.
+- **PR 6 — Core Sync Engine ✅:** `sync_tick.py` fully implemented. `run_tick`, `_classify`, `_process_new_files` (batch download, integrity skip, `batch_failed` flag, `_wait_for_job`), `_delete_orphans`, `_handle_interrupt`, `_run_delete_teardown`. `_check_interrupt_call(connector_id, sync_seq)` replaces the old `_check_delete_pending` — now reads from both tables. Tests in `test_sync_tick.py`.
+- **PR 7 — Scheduler + Lifespan + `POST /syncs` Dispatch ✅:** `scheduler.py` created. `lifespan()` in `app.py` starts `AsyncScheduler`, calls `recover_connector_sync_state()`, and registers all connector jobs. `POST /syncs` in `connectors.py` dispatches `run_tick` and returns `sync_seq`. `SyncStatus` enum extended with `CANCEL_PENDING`, `DELETE_PENDING`, `CANCELLED`. `recover_connector_sync_state()` added to `utils/recovery.py`.
+- **PR 9 — Non-Blocking DELETE ✅:** `DELETE /v1/connectors/{id}` uses `mark_sync_delete_pending` + `_run_teardown` (background task). Tick handles teardown via `_check_interrupt_call` → `_run_delete_teardown` in `sync_tick.py`. Teardown paths are split: `_run_teardown` in `connectors.py` (Case B) and `_run_delete_teardown` in `sync_tick.py` (Case A).
+- **PR 8 — Cancel Sync Endpoint ✅:** `POST /syncs/{seq}/stop` implemented. `mark_sync_cancel_pending` writes to `connector_sync_logs.status`. `SyncStatus.CANCEL_PENDING` and `InterruptType.SYNC_CANCEL` handle the cancel path in `_check_interrupt_call`. `close_sync_log` maps `CANCELLED` → `OUT_OF_SYNC` so the connector resumes on the next interval. `failed_files` counter removed from schema, models, and API.
 
 ---
 
-### Pending PRs
+### Notes on Divergences from Original Proposal
 
-#### PR 6 — Core Sync Engine (`_classify` + `_run_tick`) ❌
-- **Target File:** `services/digitize/connectors/sync_tick.py`
-- **Deliverables:** Implement `_classify()`, `_process_new_files()`, `_delete_orphans()`, and `_run_tick()`. Wire DB helper functions and staging cleanup. Unit & integration tests in `tests/test_sync_tick.py` (test file exists but module is absent).
-- **Cancellation helper:** Add `_check_delete_pending(connector_id: str) -> None` (imported from `scheduler.py`) that does a live DB query — raises `asyncio.CancelledError()` if `connectors.sync_status == 'delete_pending'` for the given `connector_id`. No in-memory set. Call it:
-  - At the start of `_run_tick` after acquiring the lock (phase boundary before scan).
-  - At the top of the `_process_new_files` loop (before each download starts).
-  - Once after `run_in_executor` returns (after each download completes).
-
-#### PR 7 — Scheduler + Lifespan + `POST /sync` Dispatch ❌
-- **Target Files:** `services/digitize/connectors/scheduler.py`, `app.py`, `connectors.py`
-- **Deliverables:**
-  - Create `scheduler.py` (job registration, `_run_tick_wrapped`, `_check_delete_pending`, `_run_teardown`, `_finalize_open_sync_log`). No `_live_tasks` or `_pending_deletions` dicts.
-  - Wire `lifespan()` in `app.py` to start `AsyncScheduler` and recover connector sync state (`fire_immediately=False`). Currently `app.py` only calls `recover_zombie_jobs()` — connector scheduler startup is absent.
-  - Wire `POST /v1/connectors/{id}/sync` in `connectors.py`: DB lock check → open log → `asyncio.create_task(_run_tick)`. Currently the endpoint does not exist.
-  - Add `get_last_sync_log(connector_id)` to `manager.py` / `utils/db.py` (not yet present).
-  - Add `reset_stale_syncing_connectors()` to `manager.py` / `utils/db.py` (not yet present).
-  - Add `update_connector_status: bool = True` parameter to `close_sync_log` in `manager.py`; skip the `UPDATE connectors SET sync_status` statement when `False` (parameter absent from current signature).
-  - Add `SyncStatus.CANCELLED = "cancelled"` and `SyncStatus.DELETE_PENDING = "delete pending"` to `connectors/models.py` (only `UP_TO_DATE`, `SYNCING`, `OUT_OF_SYNC`, `STARTED`, `COMPLETED`, `FAILED` exist today).
-  - Add `recover_connector_sync_state()` to `utils/recovery.py`; call it in `lifespan()` in `app.py` before scheduler job registration (currently only `recover_zombie_jobs()` is called).
-
-#### PR 9 — Non-Blocking DELETE Wiring ❌
-- **Target Files:** `services/digitize/api/v1/connectors.py`, `scheduler.py`
-- **Deliverables:**
-  - Replace the current blocking DELETE implementation (synchronous teardown in `connectors.py`) with the non-blocking flow:
-    - Read `sync_status` before marking delete.
-    - If `'syncing'`: `UPDATE sync_status = 'delete_pending'` → return `204`. Tick handles teardown via `_check_delete_pending`.
-    - If not `'syncing'`: `UPDATE sync_status = 'delete_pending'` → `asyncio.create_task(_run_teardown(id))` → return `204`.
-  - Implement `_run_teardown()` in `scheduler.py`: `_finalize_open_sync_log` → `remove_connector_job` → checksum snapshot → per-checksum delete + doc cleanup → `delete_connector` → staging sweep.
-
-#### PR 8 — Cancelled Job Status (Enhancement) ❌
-- **Target Files:** `db/scripts/init_schema.sql`, `models.py`, `db/manager.py`, `connectors.py`
-- **Deliverables:**
-  - Update `jobs.status` check constraint in `init_schema.sql` to include `'cancelled'` (currently: `'accepted', 'in_progress', 'completed', 'failed'`).
-  - Add `JobStatus.CANCELLED = "cancelled"` to `models.py` (enum currently has only `ACCEPTED`, `IN_PROGRESS`, `COMPLETED`, `FAILED`).
-  - Add DB helper `cancel_connector_jobs(connector_id)` to `manager.py` / `utils/db.py` — sets `accepted`/`in_progress` jobs for a connector to `cancelled`. Call during teardown.
+- `connector_sync_logs` PK changed from composite `(connector_id, seq)` to auto-increment `id`; uniqueness enforced by `UNIQUE (connector_id, seq)`. `seq` remains the logical identifier for API purposes.
+- `POST /v1/connectors/{id}/syncs` returns `{"sync_seq": <int>}` — both new and already-running syncs return the active seq, making the response useful for callers regardless of idempotency path.
+- Cancel-sync endpoint is `POST /{id}/syncs/{seq}/stop` (not `DELETE /{id}/sync`). Requires `sync_seq` to prevent stale cancels.
+- `mark_sync_cancel_pending` writes to `connector_sync_logs.status`, not `connectors.sync_status`. The connector row stays `'syncing'` until `close_sync_log` transitions it.
+- `_check_interrupt_call` (not `_check_delete_pending`) is the single interrupt-check entry point; it combines both DELETE and CANCEL detection.
+- `_run_delete_teardown` (inline in `sync_tick.py`) handles teardown for the Case A path instead of dispatching `_run_teardown` as a new task.

--- a/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
+++ b/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
@@ -77,7 +77,6 @@ CREATE TABLE IF NOT EXISTS connector_sync_logs (
     total_files      INTEGER     NOT NULL DEFAULT 0,
     new_files        INTEGER     NOT NULL DEFAULT 0,
     removed_files    INTEGER     NOT NULL DEFAULT 0,
-    failed_files     INTEGER     NOT NULL DEFAULT 0,
     status           TEXT        NOT NULL DEFAULT 'started',
     error            TEXT        NOT NULL DEFAULT '',
     PRIMARY KEY (connector_id, seq),
@@ -132,7 +131,6 @@ class ConnectorSyncLog(Base):
     total_files = Column(Integer, nullable=False, default=0)
     new_files = Column(Integer, nullable=False, default=0)
     removed_files = Column(Integer, nullable=False, default=0)
-    failed_files = Column(Integer, nullable=False, default=default=0)
     status = Column(String, nullable=False, default="started")
     error = Column(String, nullable=False, default="")
 
@@ -353,10 +351,10 @@ DELETE /v1/connectors/{connector_id}/sync
 | `get_connector_sync_status(connector_id)` | `SELECT sync_status FROM connectors WHERE id = :id`. Returns the current status string or `None` if not found. Used by `_check_delete_pending`. |
 | `try_acquire_sync_lock(connector_id)` | Atomic `UPDATE connectors SET sync_status='syncing' WHERE id=:id AND sync_status!='syncing' RETURNING id`. |
 | `open_sync_log(connector_id)` | Create tick log row with `seq = COALESCE(MAX(seq), 0) + 1` and status `'started'`. |
-| `close_sync_log(connector_id, seq, status, error, counters, update_connector_status)` | Finalize log row. When `update_connector_status=True` (default), also updates connector `last_sync_at` / `sync_status`. Pass `update_connector_status=False` when closing a log with `'cancelled'` so that `connectors.sync_status` stays `'delete_pending'`. |
+| `update_sync_log(seq, total_files, new_files, removed_files)` | Write all three file counts in a single DB update immediately after `_classify()` returns. All counts are derived from classify output and known before any I/O begins. |
+| `close_sync_log(connector_id, seq, status, error)` | Finalize log row with terminal status and `finished_at`. Also updates connector `last_sync_at` / `sync_status`. Does **not** carry file counts — those are already persisted by `update_sync_log`. |
 | `get_last_sync_log(connector_id)` | `SELECT ... FROM connector_sync_logs WHERE connector_id = :id ORDER BY seq DESC LIMIT 1`. Returns the most-recent log row or `None`. Used by `_run_teardown` to detect open logs. |
 | `reset_stale_syncing_connectors()` | On startup: `UPDATE connectors SET sync_status='out of sync' WHERE sync_status='syncing'`. Returns the list of affected `connector_id` values. Used by `recover_connector_sync_state()`. |
-| `update_sync_log_progress()` | Increment progress counters during execution. |
 | `get_sync_logs(connector_id, limit, offset)` | Paginated log history query. |
 
 ---
@@ -518,47 +516,63 @@ def build_scanner(config: ConnectorConfig) -> BaseScanner:
 - **Phase 1 (Log):** Open tick row (`open_sync_log`).
 - **Phase 2 (Scan & State):** Query owned `known_checksums` and `all_checksums`. Offload blocking network calls (`connect`, `scan`) to thread pool via `run_in_executor(None, ...)`.
 - **Phase 3 (Classify):** `_classify()` separates `scanned_files` into `skip_list`, `ingest_list`, and cross-connector duplicates. Cross-connector duplicates execute `insert_connector_checksum` inline using existing `doc_id`.
+- **Phase 3b (Count Commit):** All three counters (`total_files`, `new_files`, `removed_files`) are fully determined from classify output. A single `update_sync_log()` call persists them before any I/O-heavy work begins. No further counter writes happen during batch processing.
 - **Phase 4a (Ingest New Files):** Sequentially download files in `ingest_list`:
-  - Dedicated per-file staging directory: `staging/connectors/{connector_id}-{job_id}-{batch_number}`.
-  - Offload download to executor thread (`run_in_executor(None, scanner.download_to, ...)`).
-  - Call `create_job()` → obtain `doc_id`, insert checksum row, write `documents.metadata`.
-  - Cleanup staging directory immediately in `finally` block before downloading next file.
-- **Phase 4b (Orphan Removal):** Runs **strictly after Phase 4a completes**. Delete checksum rows for `orphan_checksums = known_checksums − scanned_checksums`. If remaining count is `0`, call `DELETE /v1/documents/{doc_id}`.
-- **Phase 5 (Finalize):** Finalize logs and update `sync_status` to `'completed'` or `'out of sync'`. Call `scanner.close()` in top-level `finally`.
+  - Dedicated per-batch staging directory: `staging/connectors/{connector_id}-{seq}-{batch_number}`.
+  - Offload download to executor thread (`asyncio.to_thread(scanner.download_to, ...)`).
+  - Call `initialize_job_state()` → obtain `doc_id` map, insert checksum rows, call `ingest()`.
+  - Cleanup staging directory immediately in `finally` block.
+- **Phase 4b (Orphan Removal):** Runs **strictly after Phase 4a completes**. Delete checksum rows for `orphan_checksums = known_checksums − scanned_checksums`. If remaining count is `0`, call `_best_effort_delete_document(doc_id)`.
+- **Phase 5 (Finalize):** Write terminal status (`'completed'`/`'failed'`/`'cancelled'`) and update `sync_status` on the connector row. Call `scanner.close()` in top-level `finally`.
 
 ---
 
 ### 6.2 Implementation Code
 
 ```python
-async def _run_tick(connector_id: str) -> None:
-    loop = asyncio.get_running_loop()
-    config = get_connector_by_id(connector_id)
-    sync_seq = open_sync_log(connector_id)
+async def run_tick(connector_id: str) -> None:
+    config = get_active_connector(connector_id)
+    if config is None:
+        logger.error(f"Connector {connector_id!r} not found; tick aborted")
+        return
+
+    sync_seq = open_new_sync_log(connector_id)
     scanner = build_scanner(config)
+
     try:
         _check_delete_pending(connector_id)  # Phase boundary: before scan
-        await loop.run_in_executor(None, scanner.connect)
-        scanned_files: list[tuple[str, str]] = await loop.run_in_executor(None, scanner.scan)
 
-        _check_delete_pending(connector_id)  # Phase boundary: after scan, before classify
-        known_checksums = set(get_connector_checksums(connector_id))
-        all_checksums = set(get_all_connector_checksums())
+        await asyncio.to_thread(scanner.connect)
+        scanned_files = await asyncio.to_thread(scanner.scan)
 
-        ingest_list, orphan_checksums = _classify(connector_id, scanned_files, known_checksums, all_checksums)
+        known_checksums = set(list_connector_checksums(connector_id))
+        all_checksums = set(list_all_checksums())
+
+        ingest_list, orphan_checksums = _classify(
+            connector_id, scanned_files, known_checksums, all_checksums
+        )
+
+        # Phase 3b: all counts known — single DB write before any I/O begins.
+        update_sync_log(
+            sync_seq,
+            total_files=len(scanned_files),
+            new_files=len(ingest_list),
+            removed_files=len(orphan_checksums),
+        )
 
         await _process_new_files(sync_seq, connector_id, scanner, ingest_list)
         await _delete_orphans(connector_id, orphan_checksums)
         _complete_tick(sync_seq, connector_id)
+
     except asyncio.CancelledError:
-        _cancel_tick(sync_seq, connector_id)  # status='cancelled', sync_status='delete_pending'
-        asyncio.create_task(_run_teardown(connector_id))  # hand off to teardown
+        logger.info(f"Tick cancelled for connector {connector_id!r} (delete_pending)")
+        _cancel_tick(sync_seq, connector_id)
         raise
     except Exception as exc:
         logger.error(f"Tick failed for connector {connector_id!r}: {exc}", exc_info=True)
-        _fail_tick(sync_seq, connector_id, exc)  # status='failed', sync_status='out of sync'
+        _fail_tick(sync_seq, connector_id, exc)
     finally:
-        scanner.close()
+        await asyncio.to_thread(scanner.close)
 
 
 def _classify(
@@ -578,8 +592,9 @@ def _classify(
         elif checksum in all_checksums:
             if checksum not in seen_this_tick:
                 seen_this_tick.add(checksum)
-                doc_id = find_connector_doc_by_checksum(checksum)
-                insert_connector_checksum(connector_id, checksum, doc_id)
+                existing_doc_id = lookup_connector_content_by_checksum(checksum)
+                if existing_doc_id:
+                    add_connector_checksum_entry(connector_id, checksum, existing_doc_id)
         else:
             if checksum not in seen_this_tick:
                 seen_this_tick.add(checksum)
@@ -589,27 +604,61 @@ def _classify(
     return ingest_list, orphan_checksums
 
 
-async def _process_new_files(sync_seq: int, connector_id: str, scanner: BaseScanner, ingest_list: list[tuple[str, str]]) -> None:
-    loop = asyncio.get_running_loop()
+async def _process_new_files(
+    sync_seq: int,
+    connector_id: str,
+    scanner,
+    ingest_list: list[tuple[str, str]],
+) -> None:
+    """Download and ingest ingest_list in batches of up to 10 files.
+
+    Counts are not tracked here; they were already written by update_sync_log
+    immediately after _classify().
+    """
     staging_base = settings.digitize.staging_dir / "connectors"
-    for batch_number, (remote_path, checksum) in enumerate(ingest_list):
-        _check_delete_pending(connector_id)  # checkpoint: before starting each download
-        job_id = generate_job_id()
-        batch_dir = staging_base / f"{connector_id}-{job_id}-{batch_number}"
+
+    for batch_number in range(0, len(ingest_list), _BATCH_SIZE):
+        batch = ingest_list[batch_number : batch_number + _BATCH_SIZE]
+        _check_delete_pending(connector_id)  # checkpoint: before each batch
+
+        job_id = generate_uuid()
+        batch_dir_name = f"{connector_id}-{sync_seq}-{batch_number}"
+        batch_dir = staging_base / batch_dir_name
         batch_dir.mkdir(parents=True, exist_ok=True)
+        checksum_to_filename: dict[str, str] = {}
+
         try:
-            local_path = batch_dir / Path(remote_path).name
-            await loop.run_in_executor(None, scanner.download_to, remote_path, local_path)
-            _check_delete_pending(connector_id)  # checkpoint: after download returns, before job creation
-            doc_id = await create_job(connector_id, checksum, staging_dir=batch_dir)
-            insert_connector_checksum(connector_id, checksum, doc_id)
-        except asyncio.CancelledError:
-            raise  # propagates to _run_tick's except block → _cancel_tick + _run_teardown
+            for remote_path, checksum in batch:
+                filename = Path(remote_path).name
+                local_checksum = await asyncio.to_thread(
+                    scanner.download_to, remote_path, batch_dir / filename
+                )
+                scanner.verify_integrity(local_checksum, checksum)
+                checksum_to_filename[checksum] = filename
+
+            _check_delete_pending(connector_id)  # checkpoint: after downloads
+
+            filenames = list(checksum_to_filename.values())
+            doc_id_dict = initialize_job_state(
+                job_id=job_id,
+                operation=OperationType.INGESTION,
+                output_format=OutputFormat.JSON,
+                documents_info=filenames,
+                job_name=f"{connector_id} - {sync_seq} - {batch_number}",
+            )
+            for checksum, filename in checksum_to_filename.items():
+                add_connector_checksum_entry(connector_id, checksum, doc_id_dict[filename])
+
+            await asyncio.to_thread(ingest, batch_dir, job_id, doc_id_dict)
+            await _wait_for_job(job_id, connector_id)
+
         except Exception as exc:
-            logger.warning(f"Failed to ingest {remote_path!r}: {exc}")
-            increment_failed_files(sync_seq)
+            logger.warning(
+                f"Failed to ingest batch {batch_number!r} for connector {connector_id!r}: {exc}",
+                exc_info=True,
+            )
         finally:
-            cleanup_staging_directory(batch_dir.name, staging_base, ignore_errors=True)
+            cleanup_staging_directory(batch_dir_name, staging_base, ignore_errors=True)
 ```
 
 ---

--- a/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
+++ b/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
@@ -525,6 +525,26 @@ def build_scanner(config: ConnectorConfig) -> BaseScanner:
 - **Phase 4b (Orphan Removal):** Runs **strictly after Phase 4a completes**. Delete checksum rows for `orphan_checksums = known_checksums − scanned_checksums`. If remaining count is `0`, call `_best_effort_delete_document(doc_id)`.
 - **Phase 5 (Finalize):** Write terminal status (`'completed'`/`'failed'`/`'cancelled'`) and update `sync_status` on the connector row. Call `scanner.close()` in top-level `finally`.
 
+#### Interrupt Handling
+
+The tick implementation uses a generic `_check_interrupt_call()` function that checks for interrupt signals from **two distinct sources** and returns an `InterruptType` enum:
+
+1. **`connectors.sync_status = DELETE_PENDING`** → `InterruptType.DELETE_CONNECTOR`
+   - When a DELETE request is issued while a sync is running, the connector is marked for deletion.
+   - When the running tick detects this, it stops the sync, closes the sync log as cancelled, and proceeds to **full teardown**:
+     - Remove all checksum ownership rows; delete documents when they lose their last owner
+     - Delete the connector row (cascades to all sync_logs)
+     - Sweep residual batch staging directories
+
+2. **`connectors.sync_status = CANCEL_PENDING`** → `InterruptType.SYNC_CANCEL`
+   - When a DELETE /sync request is issued, only the current sync should be stopped.
+   - When detected, the tick stops, closes the sync log as cancelled, and:
+     - Sets connector to `OUT_OF_SYNC` status (automatic via `close_sync_log` when status='cancelled')
+     - Cleans up staging directories for this specific sync
+     - The connector remains in the database and will be re-synced on the next scheduler interval
+
+The `_check_interrupt_call()` is invoked at **three phase boundaries** (before scan, after download, after each batch) to catch interrupts promptly without leaving partial work behind.
+
 ---
 
 ### 6.2 Implementation Code
@@ -540,7 +560,12 @@ async def run_tick(connector_id: str) -> None:
     scanner = build_scanner(config)
 
     try:
-        _check_delete_pending(connector_id)  # Phase boundary: before scan
+        # Phase boundary: check for interrupt signals before any remote I/O starts
+        interrupt = _check_interrupt_call(connector_id)
+        if interrupt == InterruptType.DELETE_CONNECTOR:
+            raise asyncio.CancelledError(f"Connector {connector_id!r} marked for deletion")
+        elif interrupt == InterruptType.SYNC_CANCEL:
+            raise asyncio.CancelledError(f"Sync cancel requested for connector {connector_id!r}")
 
         await asyncio.to_thread(scanner.connect)
         scanned_files = await asyncio.to_thread(scanner.scan)
@@ -564,9 +589,10 @@ async def run_tick(connector_id: str) -> None:
         await _delete_orphans(connector_id, orphan_checksums)
         _complete_tick(sync_seq, connector_id)
 
-    except asyncio.CancelledError:
-        logger.info(f"Tick cancelled for connector {connector_id!r} (delete_pending)")
-        _cancel_tick(sync_seq, connector_id)
+    except asyncio.CancelledError as ce:
+        logger.info(f"Tick cancelled for connector {connector_id!r}: {ce}")
+        interrupt = _check_interrupt_call(connector_id)
+        _handle_interrupt(sync_seq, connector_id, interrupt)
         raise
     except Exception as exc:
         logger.error(f"Tick failed for connector {connector_id!r}: {exc}", exc_info=True)
@@ -619,7 +645,12 @@ async def _process_new_files(
 
     for batch_number in range(0, len(ingest_list), _BATCH_SIZE):
         batch = ingest_list[batch_number : batch_number + _BATCH_SIZE]
-        _check_delete_pending(connector_id)  # checkpoint: before each batch
+        # Checkpoint: check for interrupts before each batch
+        interrupt = _check_interrupt_call(connector_id)
+        if interrupt:
+            raise asyncio.CancelledError(
+                f"Connector {connector_id!r} interrupted (type={interrupt.value})"
+            )
 
         job_id = generate_uuid()
         batch_dir_name = f"{connector_id}-{sync_seq}-{batch_number}"
@@ -636,7 +667,12 @@ async def _process_new_files(
                 scanner.verify_integrity(local_checksum, checksum)
                 checksum_to_filename[checksum] = filename
 
-            _check_delete_pending(connector_id)  # checkpoint: after downloads
+            # Checkpoint: check for interrupts after downloads
+            interrupt = _check_interrupt_call(connector_id)
+            if interrupt:
+                raise asyncio.CancelledError(
+                    f"Connector {connector_id!r} interrupted (type={interrupt.value})"
+                )
 
             filenames = list(checksum_to_filename.values())
             doc_id_dict = initialize_job_state(

--- a/docs/proposals/data-source-connectors/scheduler-lifecycle.svg
+++ b/docs/proposals/data-source-connectors/scheduler-lifecycle.svg
@@ -30,7 +30,7 @@
   <!-- Note row -->
   <rect x="26" y="110" width="814" height="46" rx="4" fill="white" stroke="#e5e7eb" stroke-width="1"/>
   <text x="433" y="129" text-anchor="middle" font-weight="700" fill="#1f2328">ConnectorScheduler  (module-level singleton &#x2014; no _pending_deletions / no _live_tasks)</text>
-  <text x="433" y="148" text-anchor="middle" font-size="11" fill="#57606a">register_connector_job(id, interval)  ·  remove_connector_job(id)  ·  _check_delete_pending(id) reads DB  ·  lifespan: async with AsyncScheduler()</text>
+  <text x="433" y="148" text-anchor="middle" font-size="11" fill="#57606a">register_connector_job(id, interval)  ·  remove_connector_job(id)  ·  _check_interrupt_call(id, seq) reads DB  ·  lifespan: async with AsyncScheduler()</text>
 
   <!-- ═══════════════════════════════════════════════════════
        LEGEND
@@ -102,24 +102,24 @@
   <text x="410" y="497" text-anchor="middle" font-size="10" fill="#57606a">job de-registered · DB row deleted</text>
 
   <!-- ═══════════════════════════════════════════════════════
-       RIGHT COLUMN — POST /sync manual trigger path
+       RIGHT COLUMN — POST /syncs manual trigger path
        ═══════════════════════════════════════════════════════ -->
 
-  <!-- POST /sync trigger box -->
+  <!-- POST /syncs trigger box -->
   <rect x="600" y="256" width="220" height="36" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1.5"/>
-  <text x="710" y="273" text-anchor="middle" font-weight="700" fill="#1e40af">POST /sync request</text>
-  <text x="710" y="285" text-anchor="middle" font-size="10" fill="#57606a">try_acquire_sync_lock()</text>
+  <text x="710" y="273" text-anchor="middle" font-weight="700" fill="#1e40af">POST /syncs request</text>
+  <text x="710" y="285" text-anchor="middle" font-size="10" fill="#57606a">try_acquire_sync_lock() → dispatch run_tick</text>
 
-  <!-- arrow from POST /sync to Tick Running (wins lock) -->
+  <!-- arrow from POST /syncs to Tick Running (wins lock) -->
   <line x1="600" y1="274" x2="512" y2="342" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#s-arr)"/>
-  <text x="538" y="296" font-size="11" fill="#3b82d4">lock acquired &#x2192;</text>
-  <text x="538" y="309" font-size="11" fill="#3b82d4">dispatch _run_tick</text>
+  <text x="538" y="296" font-size="11" fill="#3b82d4">lock acquired →</text>
+  <text x="538" y="309" font-size="11" fill="#3b82d4">dispatch run_tick</text>
 
-  <!-- no-op path: already syncing -->
+  <!-- no-op path: already syncing — returns active sync_seq -->
   <line x1="710" y1="292" x2="710" y2="350" stroke="#ca8a04" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#s-arro)"/>
   <rect x="634" y="350" width="150" height="36" rx="4" fill="#fef9c3" stroke="#ca8a04" stroke-width="1"/>
-  <text x="709" y="367" text-anchor="middle" font-size="11" font-weight="600" fill="#854d0e">202 no-op</text>
-  <text x="709" y="380" text-anchor="middle" font-size="10" fill="#854d0e">already syncing &#x2014; skip</text>
+  <text x="709" y="367" text-anchor="middle" font-size="11" font-weight="600" fill="#854d0e">202 + sync_seq</text>
+  <text x="709" y="380" text-anchor="middle" font-size="10" fill="#854d0e">already syncing — active seq</text>
 
   <!-- ═══════════════════════════════════════════════════════
        BOTTOM — Startup recovery
@@ -134,5 +134,5 @@
 
   <!-- Cancellation model note -->
   <rect x="190" y="614" width="460" height="20" rx="3" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1" stroke-dasharray="1,1"/>
-  <text x="420" y="628" text-anchor="middle" font-size="10" fill="#166534" font-weight="600">Cancellation: _check_delete_pending() reads sync_status from DB &#x2014; no in-process _pending_deletions or _live_tasks</text>
+  <text x="420" y="628" text-anchor="middle" font-size="10" fill="#166534" font-weight="600">Cancellation: _check_interrupt_call(id, seq) reads both connectors.sync_status and connector_sync_logs.status — no in-process state</text>
 </svg>

--- a/docs/proposals/data-source-connectors/scheduler-lifecycle.svg
+++ b/docs/proposals/data-source-connectors/scheduler-lifecycle.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 680" width="860" height="680" font-family="-apple-system, Segoe UI, system-ui, sans-serif" font-size="12">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 700" width="860" height="700" font-family="-apple-system, Segoe UI, system-ui, sans-serif" font-size="12">
   <defs>
     <marker id="s-arr"  markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#3b82d4"/></marker>
     <marker id="s-arrg" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#2d9a5f"/></marker>
@@ -7,132 +7,145 @@
     <marker id="s-arro" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#ca8a04"/></marker>
   </defs>
 
-  <!-- ═══════════════════════════════════════════════════════
-       TOP SECTION — Process / concurrency model
-       ═══════════════════════════════════════════════════════ -->
+  <!-- ══════════════════════════════════════════════════════════════
+       NOT-YET-IMPLEMENTED BANNER
+       ══════════════════════════════════════════════════════════════ -->
+  <rect x="10" y="10" width="840" height="36" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="2"/>
+  <text x="430" y="26" text-anchor="middle" font-weight="700" font-size="13" fill="#854d0e">&#x26A0;  PR7 — Scheduler + Lifespan + Crash Recovery  (NOT YET IMPLEMENTED)</text>
+  <text x="430" y="40" text-anchor="middle" font-size="10" fill="#854d0e">scheduler.py does not exist · recover_connector_sync_state() does not exist · app.py lifespan has no APScheduler</text>
+
+  <!-- ══════════════════════════════════════════════════════════════
+       TOP SECTION — planned Process / concurrency model
+       ══════════════════════════════════════════════════════════════ -->
 
   <!-- OS Process outer box -->
-  <rect x="10" y="10" width="840" height="160" rx="6" fill="#f7f8fa" stroke="#e5e7eb" stroke-width="1.5"/>
-  <text x="26" y="30" font-size="11" font-weight="600" fill="#57606a">OS Process (uvicorn &#x2014; single worker)</text>
+  <rect x="10" y="58" width="840" height="160" rx="6" fill="#f7f8fa" stroke="#e5e7eb" stroke-width="1.5" stroke-dasharray="6,3"/>
+  <text x="26" y="78" font-size="11" font-weight="600" fill="#57606a">OS Process (uvicorn &#x2014; single worker)  [planned]</text>
 
   <!-- Main asyncio event loop box -->
-  <rect x="26" y="40" width="460" height="54" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1.5"/>
-  <text x="256" y="58" text-anchor="middle" font-weight="700" fill="#1e40af">asyncio event loop  (FastAPI / Uvicorn)</text>
-  <text x="256" y="74" text-anchor="middle" font-size="11" fill="#1e40af">handles HTTP · runs lifespan hooks</text>
-  <text x="256" y="88" text-anchor="middle" font-size="11" fill="#1e40af">PUT updates DB only &#x2014; _run_tick re-reads config each tick</text>
+  <rect x="26" y="88" width="460" height="54" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1.5"/>
+  <text x="256" y="106" text-anchor="middle" font-weight="700" fill="#1e40af">asyncio event loop  (FastAPI / Uvicorn)</text>
+  <text x="256" y="122" text-anchor="middle" font-size="11" fill="#1e40af">handles HTTP · runs lifespan hooks</text>
+  <text x="256" y="136" text-anchor="middle" font-size="11" fill="#1e40af">PUT updates DB only &#x2014; run_tick re-reads config each tick</text>
 
-  <!-- APScheduler box — same event loop -->
-  <rect x="500" y="40" width="334" height="54" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="1.5"/>
-  <text x="667" y="58" text-anchor="middle" font-weight="700" fill="#166534">APScheduler  AsyncScheduler</text>
-  <text x="667" y="74" text-anchor="middle" font-size="11" fill="#166534">one IntervalTrigger job per connector</text>
-  <text x="667" y="88" text-anchor="middle" font-size="11" fill="#166534">max_instances=1  ·  backed by PostgresDataStore</text>
+  <!-- APScheduler box — same event loop (planned) -->
+  <rect x="500" y="88" width="334" height="54" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <text x="667" y="106" text-anchor="middle" font-weight="700" fill="#166534">APScheduler  AsyncScheduler  [planned]</text>
+  <text x="667" y="122" text-anchor="middle" font-size="11" fill="#166534">one IntervalTrigger job per connector</text>
+  <text x="667" y="136" text-anchor="middle" font-size="11" fill="#166534">max_instances=1  ·  backed by AsyncSQLAlchemyDataStore</text>
 
-  <!-- Note row -->
-  <rect x="26" y="110" width="814" height="46" rx="4" fill="white" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="433" y="129" text-anchor="middle" font-weight="700" fill="#1f2328">ConnectorScheduler  (module-level singleton &#x2014; no _pending_deletions / no _live_tasks)</text>
-  <text x="433" y="148" text-anchor="middle" font-size="11" fill="#57606a">register_connector_job(id, interval)  ·  remove_connector_job(id)  ·  _check_interrupt_call(id, seq) reads DB  ·  lifespan: async with AsyncScheduler()</text>
+  <!-- Planned singleton note -->
+  <rect x="26" y="158" width="814" height="50" rx="4" fill="white" stroke="#e5e7eb" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="433" y="177" text-anchor="middle" font-weight="700" fill="#1f2328">ConnectorScheduler  (planned module-level singleton &#x2014; no _pending_deletions / no _live_tasks)</text>
+  <text x="433" y="196" text-anchor="middle" font-size="11" fill="#57606a">register_connector_job(id, interval, fire_immediately)  ·  _run_tick_wrapped(id): check DELETE_PENDING → try_acquire_sync_lock → run_tick</text>
 
-  <!-- ═══════════════════════════════════════════════════════
+  <!-- ══════════════════════════════════════════════════════════════
        LEGEND
-       ═══════════════════════════════════════════════════════ -->
-  <rect x="10" y="188" width="152" height="112" rx="4" fill="white" stroke="#e5e7eb" stroke-width="1"/>
-  <text x="20" y="206" font-weight="600" fill="#1f2328">Legend</text>
-  <line x1="20" y1="220" x2="52" y2="220" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#s-arr)"/>
-  <text x="58" y="224" fill="#1f2328">API-triggered</text>
-  <line x1="20" y1="236" x2="52" y2="236" stroke="#2d9a5f" stroke-width="1.5" marker-end="url(#s-arrg)"/>
-  <text x="58" y="240" fill="#1f2328">Scheduler-driven</text>
-  <line x1="20" y1="252" x2="52" y2="252" stroke="#c0392b" stroke-width="1.5" marker-end="url(#s-arrr)"/>
-  <text x="58" y="256" fill="#1f2328">Error / remove</text>
-  <line x1="20" y1="268" x2="52" y2="268" stroke="#7c5cd8" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#s-arrm)"/>
-  <text x="58" y="272" fill="#1f2328">Startup recovery</text>
-  <line x1="20" y1="284" x2="52" y2="284" stroke="#ca8a04" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#s-arro)"/>
-  <text x="58" y="288" fill="#1f2328">No-op guard</text>
+       ══════════════════════════════════════════════════════════════ -->
+  <rect x="10" y="232" width="152" height="122" rx="4" fill="white" stroke="#e5e7eb" stroke-width="1"/>
+  <text x="20" y="250" font-weight="600" fill="#1f2328">Legend</text>
+  <line x1="20" y1="264" x2="52" y2="264" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#s-arr)"/>
+  <text x="58" y="268" fill="#1f2328">API-triggered</text>
+  <line x1="20" y1="280" x2="52" y2="280" stroke="#2d9a5f" stroke-width="1.5" marker-end="url(#s-arrg)"/>
+  <text x="58" y="284" fill="#1f2328">Scheduler-driven</text>
+  <line x1="20" y1="296" x2="52" y2="296" stroke="#c0392b" stroke-width="1.5" marker-end="url(#s-arrr)"/>
+  <text x="58" y="300" fill="#1f2328">Error / remove</text>
+  <line x1="20" y1="312" x2="52" y2="312" stroke="#7c5cd8" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#s-arrm)"/>
+  <text x="58" y="316" fill="#1f2328">Startup recovery</text>
+  <line x1="20" y1="328" x2="52" y2="328" stroke="#ca8a04" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#s-arro)"/>
+  <text x="58" y="332" fill="#1f2328">No-op guard</text>
 
-  <!-- ═══════════════════════════════════════════════════════
+  <!-- ══════════════════════════════════════════════════════════════
        SCHEDULER JOB LIFECYCLE  (center column)
-       ═══════════════════════════════════════════════════════ -->
+       ══════════════════════════════════════════════════════════════ -->
 
   <!-- Not Registered -->
-  <rect x="310" y="188" width="200" height="36" rx="4" fill="#f7f8fa" stroke="#57606a" stroke-width="1.5"/>
-  <text x="410" y="211" text-anchor="middle" font-weight="700" fill="#57606a">Not Registered</text>
+  <rect x="310" y="232" width="200" height="36" rx="4" fill="#f7f8fa" stroke="#57606a" stroke-width="1.5"/>
+  <text x="410" y="255" text-anchor="middle" font-weight="700" fill="#57606a">Not Registered</text>
 
   <!-- arrow: POST /v1/connectors → Registered -->
-  <line x1="410" y1="224" x2="410" y2="256" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#s-arr)"/>
-  <text x="418" y="245" font-size="11" fill="#57606a">POST /v1/connectors</text>
+  <line x1="410" y1="268" x2="410" y2="300" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#s-arr)"/>
+  <text x="418" y="289" font-size="11" fill="#57606a">POST /v1/connectors</text>
+  <text x="418" y="302" font-size="10" fill="#ca8a04">(+ register_connector_job — PR7)</text>
 
   <!-- Registered (Idle) -->
-  <rect x="310" y="256" width="200" height="36" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="1.5"/>
-  <text x="410" y="276" text-anchor="middle" font-weight="700" fill="#166534">Registered  (Idle)</text>
-  <text x="410" y="288" text-anchor="middle" font-size="10" fill="#57606a">sync_status = &#x27;up to date&#x27;</text>
+  <rect x="310" y="308" width="200" height="38" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="1.5"/>
+  <text x="410" y="326" text-anchor="middle" font-weight="700" fill="#166534">Registered  (Idle)</text>
+  <text x="410" y="340" text-anchor="middle" font-size="10" fill="#57606a">sync_status = 'up to date'</text>
 
   <!-- arrow: IntervalTrigger fires → Tick Running -->
-  <line x1="410" y1="294" x2="410" y2="326" stroke="#2d9a5f" stroke-width="1.5" marker-end="url(#s-arrg)"/>
-  <text x="418" y="315" font-size="11" fill="#57606a">IntervalTrigger fires</text>
+  <line x1="410" y1="346" x2="410" y2="378" stroke="#2d9a5f" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#s-arrg)"/>
+  <text x="418" y="366" font-size="11" fill="#57606a">IntervalTrigger fires</text>
+  <text x="418" y="379" font-size="10" fill="#ca8a04">(PR7 — planned)</text>
 
   <!-- Tick Running -->
-  <rect x="310" y="326" width="200" height="36" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="1.5"/>
-  <text x="410" y="346" text-anchor="middle" font-weight="700" fill="#166534">Tick Running</text>
-  <text x="410" y="358" text-anchor="middle" font-size="10" fill="#57606a">sync_status = &#x27;syncing&#x27;</text>
+  <rect x="310" y="386" width="200" height="36" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="1.5"/>
+  <text x="410" y="406" text-anchor="middle" font-weight="700" fill="#166534">Tick Running</text>
+  <text x="410" y="418" text-anchor="middle" font-size="10" fill="#57606a">sync_status = 'syncing'</text>
 
   <!-- arrow: tick completes → Registered (Idle) -->
-  <path d="M510,344 C560,344 560,274 512,274" fill="none" stroke="#2d9a5f" stroke-width="1.5" marker-end="url(#s-arrg)"/>
-  <text x="530" y="315" font-size="11" fill="#57606a">completed</text>
+  <path d="M510,404 C560,404 560,326 512,326" fill="none" stroke="#2d9a5f" stroke-width="1.5" marker-end="url(#s-arrg)"/>
+  <text x="530" y="370" font-size="11" fill="#57606a">completed →</text>
+  <text x="530" y="382" font-size="11" fill="#57606a">sync_status=</text>
+  <text x="530" y="394" font-size="11" fill="#57606a">'up to date'</text>
 
   <!-- arrow: tick fails → Out of Sync -->
-  <line x1="410" y1="362" x2="410" y2="394" stroke="#c0392b" stroke-width="1.5" marker-end="url(#s-arrr)"/>
-  <text x="418" y="383" font-size="11" fill="#c0392b">exception</text>
+  <line x1="410" y1="422" x2="410" y2="454" stroke="#c0392b" stroke-width="1.5" marker-end="url(#s-arrr)"/>
+  <text x="418" y="443" font-size="11" fill="#c0392b">exception</text>
 
-  <!-- Out of Sync -->
-  <rect x="310" y="394" width="200" height="36" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1.5"/>
-  <text x="410" y="414" text-anchor="middle" font-weight="700" fill="#991b1b">Tick Failed</text>
-  <text x="410" y="426" text-anchor="middle" font-size="10" fill="#57606a">sync_status = &#x27;out of sync&#x27;  ·  log closed</text>
+  <!-- Out of Sync / Tick Failed -->
+  <rect x="310" y="454" width="200" height="38" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1.5"/>
+  <text x="410" y="472" text-anchor="middle" font-weight="700" fill="#991b1b">Tick Failed</text>
+  <text x="410" y="486" text-anchor="middle" font-size="10" fill="#57606a">sync_status = 'out of sync'  ·  log closed</text>
 
   <!-- arrow: next IntervalTrigger fires again from Out of Sync → Tick Running -->
-  <path d="M310,412 C260,412 260,344 308,344" fill="none" stroke="#2d9a5f" stroke-width="1.5" marker-end="url(#s-arrg)"/>
-  <text x="185" y="380" font-size="11" fill="#57606a">next interval</text>
-  <text x="185" y="393" font-size="11" fill="#57606a">fires anyway</text>
+  <path d="M310,472 C260,472 260,404 308,404" fill="none" stroke="#2d9a5f" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#s-arrg)"/>
+  <text x="180" y="438" font-size="11" fill="#57606a">next interval</text>
+  <text x="180" y="451" font-size="11" fill="#57606a">fires anyway</text>
+  <text x="180" y="464" font-size="10" fill="#ca8a04">(PR7)</text>
 
   <!-- arrow: DELETE /v1/connectors → Removed -->
-  <line x1="410" y1="430" x2="410" y2="462" stroke="#c0392b" stroke-width="1.5" marker-end="url(#s-arrr)"/>
-  <text x="418" y="451" font-size="11" fill="#c0392b">DELETE /v1/connectors</text>
+  <line x1="410" y1="492" x2="410" y2="524" stroke="#c0392b" stroke-width="1.5" marker-end="url(#s-arrr)"/>
+  <text x="418" y="513" font-size="11" fill="#c0392b">DELETE /v1/connectors</text>
 
   <!-- Removed -->
-  <rect x="310" y="462" width="200" height="36" rx="4" fill="#f7f8fa" stroke="#57606a" stroke-width="1.5"/>
-  <text x="410" y="485" text-anchor="middle" font-weight="700" fill="#57606a">Removed</text>
-  <text x="410" y="497" text-anchor="middle" font-size="10" fill="#57606a">job de-registered · DB row deleted</text>
+  <rect x="310" y="524" width="200" height="36" rx="4" fill="#f7f8fa" stroke="#57606a" stroke-width="1.5"/>
+  <text x="410" y="547" text-anchor="middle" font-weight="700" fill="#57606a">Removed</text>
+  <text x="410" y="559" text-anchor="middle" font-size="10" fill="#57606a">_run_teardown() · DB row deleted</text>
 
-  <!-- ═══════════════════════════════════════════════════════
-       RIGHT COLUMN — POST /syncs manual trigger path
-       ═══════════════════════════════════════════════════════ -->
+  <!-- ══════════════════════════════════════════════════════════════
+       RIGHT COLUMN — POST /syncs manual trigger path (implemented)
+       ══════════════════════════════════════════════════════════════ -->
 
   <!-- POST /syncs trigger box -->
-  <rect x="600" y="256" width="220" height="36" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1.5"/>
-  <text x="710" y="273" text-anchor="middle" font-weight="700" fill="#1e40af">POST /syncs request</text>
-  <text x="710" y="285" text-anchor="middle" font-size="10" fill="#57606a">try_acquire_sync_lock() → dispatch run_tick</text>
+  <rect x="600" y="308" width="230" height="48" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1.5"/>
+  <text x="715" y="326" text-anchor="middle" font-weight="700" fill="#1e40af">POST /syncs request  (&#x2705; implemented)</text>
+  <text x="715" y="340" text-anchor="middle" font-size="10" fill="#57606a">try_acquire_sync_lock() → create_task(run_tick)</text>
+  <text x="715" y="352" text-anchor="middle" font-size="10" fill="#57606a">poll _wait_for_sync_seq() → return sync_seq</text>
 
   <!-- arrow from POST /syncs to Tick Running (wins lock) -->
-  <line x1="600" y1="274" x2="512" y2="342" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#s-arr)"/>
-  <text x="538" y="296" font-size="11" fill="#3b82d4">lock acquired →</text>
-  <text x="538" y="309" font-size="11" fill="#3b82d4">dispatch run_tick</text>
+  <line x1="600" y1="330" x2="512" y2="402" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#s-arr)"/>
+  <text x="536" y="350" font-size="11" fill="#3b82d4">lock acquired →</text>
+  <text x="536" y="363" font-size="11" fill="#3b82d4">create_task(run_tick)</text>
 
   <!-- no-op path: already syncing — returns active sync_seq -->
-  <line x1="710" y1="292" x2="710" y2="350" stroke="#ca8a04" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#s-arro)"/>
-  <rect x="634" y="350" width="150" height="36" rx="4" fill="#fef9c3" stroke="#ca8a04" stroke-width="1"/>
-  <text x="709" y="367" text-anchor="middle" font-size="11" font-weight="600" fill="#854d0e">202 + sync_seq</text>
-  <text x="709" y="380" text-anchor="middle" font-size="10" fill="#854d0e">already syncing — active seq</text>
+  <line x1="715" y1="356" x2="715" y2="410" stroke="#ca8a04" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#s-arro)"/>
+  <rect x="636" y="410" width="160" height="38" rx="4" fill="#fef9c3" stroke="#ca8a04" stroke-width="1"/>
+  <text x="716" y="428" text-anchor="middle" font-size="11" font-weight="600" fill="#854d0e">202 + sync_seq</text>
+  <text x="716" y="442" text-anchor="middle" font-size="10" fill="#854d0e">already syncing — active seq</text>
 
-  <!-- ═══════════════════════════════════════════════════════
-       BOTTOM — Startup recovery
-       ═══════════════════════════════════════════════════════ -->
-  <rect x="190" y="550" width="460" height="48" rx="4" fill="#ede9fe" stroke="#7c5cd8" stroke-width="1"/>
-  <text x="420" y="568" text-anchor="middle" font-size="11" font-weight="600" fill="#4c1d95">FastAPI startup  (lifespan hook)</text>
-  <text x="420" y="582" text-anchor="middle" font-size="11" fill="#4c1d95">async with AsyncScheduler(data_store=AsyncSQLAlchemyDataStore(engine)) as sched:</text>
-  <text x="420" y="596" text-anchor="middle" font-size="11" fill="#4c1d95">iterate get_all_connectors() &#x2192; register_connector_job(id, interval, fire_immediately=False)</text>
+  <!-- ══════════════════════════════════════════════════════════════
+       BOTTOM — Planned startup lifespan
+       ══════════════════════════════════════════════════════════════ -->
+  <rect x="170" y="596" width="500" height="60" rx="4" fill="#ede9fe" stroke="#7c5cd8" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="420" y="614" text-anchor="middle" font-size="11" font-weight="600" fill="#4c1d95">FastAPI lifespan — planned additions (PR7)</text>
+  <text x="420" y="630" text-anchor="middle" font-size="11" fill="#4c1d95">recover_connector_sync_state() · async with AsyncScheduler() as sched:</text>
+  <text x="420" y="644" text-anchor="middle" font-size="11" fill="#4c1d95">for c in get_all_connectors(): register_connector_job(c.id, c.sync_interval_seconds, fire_immediately=False)</text>
 
   <!-- arrow from startup box to Registered (Idle) -->
-  <line x1="420" y1="550" x2="412" y2="494" stroke="#7c5cd8" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#s-arrm)"/>
+  <line x1="420" y1="596" x2="412" y2="562" stroke="#7c5cd8" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#s-arrm)"/>
 
-  <!-- Cancellation model note -->
-  <rect x="190" y="614" width="460" height="20" rx="3" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1" stroke-dasharray="1,1"/>
-  <text x="420" y="628" text-anchor="middle" font-size="10" fill="#166534" font-weight="600">Cancellation: _check_interrupt_call(id, seq) reads both connectors.sync_status and connector_sync_logs.status — no in-process state</text>
+  <!-- Crash recovery note -->
+  <rect x="170" y="666" width="500" height="20" rx="3" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1" stroke-dasharray="1,1"/>
+  <text x="420" y="680" text-anchor="middle" font-size="10" fill="#166534" font-weight="600">Planned: recover_connector_sync_state() — reset 'syncing' → 'out of sync' + close open log rows as 'failed' on crash restart</text>
 </svg>

--- a/docs/proposals/data-source-connectors/sync-worker-tick-flow.svg
+++ b/docs/proposals/data-source-connectors/sync-worker-tick-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 1060" width="800" height="1060" font-family="-apple-system, Segoe UI, system-ui, sans-serif" font-size="11">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 1180" width="800" height="1180" font-family="-apple-system, Segoe UI, system-ui, sans-serif" font-size="11">
   <defs>
     <marker id="sw-arr"  markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#3b82d4"/></marker>
     <marker id="sw-arrg" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#2d9a5f"/></marker>
@@ -6,112 +6,115 @@
     <marker id="sw-arry" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#f59e0b"/></marker>
   </defs>
 
-  <!-- Entry point — dispatched by APScheduler or POST /sync -->
+  <!-- Entry point -->
   <rect x="80" y="10" width="640" height="36" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1.5"/>
-  <text x="400" y="25" text-anchor="middle" font-weight="700" fill="#1e40af">_run_tick(connector_id)  &#x2014; async coroutine</text>
-  <text x="400" y="40" text-anchor="middle" font-size="10" fill="#57606a">dispatched by APScheduler IntervalTrigger  OR  POST /v1/connectors/{id}/sync</text>
+  <text x="400" y="25" text-anchor="middle" font-weight="700" fill="#1e40af">run_tick(connector_id)  — async coroutine</text>
+  <text x="400" y="40" text-anchor="middle" font-size="10" fill="#57606a">dispatched by APScheduler IntervalTrigger  OR  POST /v1/connectors/{id}/syncs</text>
   <line x1="400" y1="46" x2="400" y2="66" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
-  <!-- ① open tick -->
-  <rect x="80" y="66" width="640" height="48" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1"/>
-  <text x="400" y="82" text-anchor="middle" fill="#1e40af" font-weight="600">&#x2460; Phase 1 &#x2014; open tick record</text>
-  <text x="400" y="96" text-anchor="middle" fill="#57606a" font-size="10">INSERT connector_sync_logs  (seq, started_at, status=&#x27;started&#x27;)</text>
-  <text x="400" y="108" text-anchor="middle" fill="#57606a" font-size="10">sync_status already &#x27;syncing&#x27;  (set by lock-acquisition before dispatch)</text>
-  <line x1="400" y1="114" x2="400" y2="134" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+  <!-- Phase 0 note: lock acquired BEFORE calling run_tick -->
+  <rect x="100" y="66" width="600" height="20" rx="3" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1"/>
+  <text x="400" y="79" text-anchor="middle" fill="#166534" font-size="10">Phase 0 (lock): try_acquire_sync_lock() already called by caller (scheduler or POST /syncs handler)</text>
+  <line x1="400" y1="86" x2="400" y2="106" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
-  <!-- Phase boundary before scan -->
-  <rect x="100" y="134" width="600" height="24" rx="3" fill="#fff3e0" stroke="#f59e0b" stroke-width="1" stroke-dasharray="3,2"/>
-  <text x="400" y="147" text-anchor="middle" fill="#ca8a04" font-size="9" font-weight="600">PHASE BOUNDARY: _check_delete_pending() &#x2014; live DB SELECT; raises CancelledError if status=&#x27;delete_pending&#x27;</text>
-  <line x1="400" y1="158" x2="400" y2="178" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+  <!-- ① Phase 1: open tick record -->
+  <rect x="80" y="106" width="640" height="48" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1"/>
+  <text x="400" y="122" text-anchor="middle" fill="#1e40af" font-weight="600">① Phase 1 — open tick record</text>
+  <text x="400" y="136" text-anchor="middle" fill="#57606a" font-size="10">sync_seq = open_new_sync_log(connector_id)</text>
+  <text x="400" y="148" text-anchor="middle" fill="#57606a" font-size="10">INSERT connector_sync_logs (seq, started_at, status='started')</text>
+  <line x1="400" y1="154" x2="400" y2="174" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+
+  <!-- Phase boundary 1b: _check_interrupt_call -->
+  <rect x="100" y="174" width="600" height="24" rx="3" fill="#fff3e0" stroke="#f59e0b" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="400" y="188" text-anchor="middle" fill="#ca8a04" font-size="9" font-weight="600">CHECKPOINT 1: _check_interrupt_call(connector_id, sync_seq) — checks connectors.sync_status AND connector_sync_logs.status</text>
+  <line x1="400" y1="198" x2="400" y2="218" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
   <!-- ② Phase 2 — load known state -->
-  <rect x="80" y="178" width="640" height="36" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1"/>
-  <text x="400" y="194" text-anchor="middle" fill="#1e40af" font-weight="600">&#x2461; Phase 2 &#x2014; load known state</text>
-  <text x="400" y="208" text-anchor="middle" fill="#57606a" font-size="10">SELECT known_checksums; SELECT all_checksums (for cross-connector dedup)</text>
-  <line x1="400" y1="214" x2="400" y2="234" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+  <rect x="80" y="218" width="640" height="36" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1"/>
+  <text x="400" y="234" text-anchor="middle" fill="#1e40af" font-weight="600">② Phase 2 — load known state</text>
+  <text x="400" y="248" text-anchor="middle" fill="#57606a" font-size="10">list_connector_checksums(connector_id); list_all_checksums()</text>
+  <line x1="400" y1="254" x2="400" y2="274" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
-  <!-- ③ Phase 3a: scanner.connect (executor) -->
-  <rect x="80" y="234" width="640" height="60" rx="4" fill="#e0e7ff" stroke="#3b82d4" stroke-width="1" stroke-dasharray="2,2"/>
-  <text x="400" y="250" text-anchor="middle" fill="#1e40af" font-weight="600">&#x2462; Phase 3a &#x2014; scanner.connect()</text>
-  <text x="400" y="264" text-anchor="middle" fill="#57606a" font-size="10">await loop.run_in_executor(None, scanner.connect)  [BLOCKING &#x2192; ThreadPoolExecutor]</text>
-  <text x="400" y="276" text-anchor="middle" fill="#f59e0b" font-size="9" font-weight="500">Executor: SFTP handshake or boto3 head_bucket</text>
-  <text x="400" y="288" text-anchor="middle" fill="#57606a" font-size="9">Event loop responsive; CancelledError can land at this await</text>
-  <line x1="400" y1="294" x2="400" y2="314" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+  <!-- ③a Phase 3a: scanner.connect (asyncio.to_thread) -->
+  <rect x="80" y="274" width="640" height="48" rx="4" fill="#e0e7ff" stroke="#3b82d4" stroke-width="1" stroke-dasharray="2,2"/>
+  <text x="400" y="290" text-anchor="middle" fill="#1e40af" font-weight="600">③ Phase 3a — scanner.connect() + scanner.scan()</text>
+  <text x="400" y="304" text-anchor="middle" fill="#57606a" font-size="10">await asyncio.to_thread(scanner.connect)  [BLOCKING → ThreadPoolExecutor]</text>
+  <text x="400" y="316" text-anchor="middle" fill="#f59e0b" font-size="9" font-weight="500">await asyncio.to_thread(scanner.scan)  →  list[(remote_path, checksum)]</text>
+  <line x1="400" y1="322" x2="400" y2="342" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
-  <!-- ③b Phase 3b: scanner.scan (executor) -->
-  <rect x="80" y="314" width="640" height="72" rx="4" fill="#e0e7ff" stroke="#3b82d4" stroke-width="1" stroke-dasharray="2,2"/>
-  <text x="400" y="330" text-anchor="middle" fill="#1e40af" font-weight="600">&#x2462; Phase 3b &#x2014; scanned_files = await scanner.scan()</text>
-  <text x="400" y="344" text-anchor="middle" fill="#57606a" font-size="10">await loop.run_in_executor(None, scanner.scan)  [BLOCKING &#x2192; ThreadPoolExecutor]</text>
-  <text x="400" y="356" text-anchor="middle" fill="#f59e0b" font-size="9" font-weight="500">Executor: SFTP directory walk + md5sum  OR  S3 list_objects_v2 paginator</text>
-  <text x="400" y="368" text-anchor="middle" fill="#57606a" font-size="9">Can take minutes; event loop remains responsive; thread sleeps in kernel</text>
-  <text x="400" y="380" text-anchor="middle" fill="#57606a" font-size="9">Yields: (remote_path, checksum) for ALL files &#x2014; no dedup filtering here</text>
-  <line x1="400" y1="386" x2="400" y2="406" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+  <!-- ④ Phase 3c: _classify -->
+  <rect x="80" y="342" width="640" height="72" rx="4" fill="#e0f2fe" stroke="#3b82d4" stroke-width="1"/>
+  <text x="400" y="358" text-anchor="middle" fill="#0369a1" font-weight="600">④ Phase 3 — _classify(connector_id, scanned_files, known_checksums, all_checksums)</text>
+  <text x="400" y="372" text-anchor="middle" fill="#57606a" font-size="10">For each (path, checksum) in scanned_files:</text>
+  <text x="400" y="384" text-anchor="middle" fill="#57606a" font-size="10">  • in known_checksums → skip (already owned)  |  • in all_checksums → add_connector_checksum_entry inline (cross-connector dup)</text>
+  <text x="400" y="396" text-anchor="middle" fill="#57606a" font-size="10">  • neither → append to ingest_list  |  orphan_checksums = known_checksums − scanned_checksums</text>
+  <text x="400" y="408" text-anchor="middle" fill="#57606a" font-size="9">Phase 3b: update_sync_log(sync_seq, total_files, new_files, removed_files) — single write, all counts known</text>
+  <line x1="400" y1="414" x2="400" y2="434" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
-  <!-- Phase boundary after scan -->
-  <rect x="100" y="406" width="600" height="24" rx="3" fill="#fff3e0" stroke="#f59e0b" stroke-width="1" stroke-dasharray="3,2"/>
-  <text x="400" y="419" text-anchor="middle" fill="#ca8a04" font-size="9" font-weight="600">PHASE BOUNDARY: _check_delete_pending() &#x2014; live DB SELECT; raises CancelledError if status=&#x27;delete_pending&#x27;</text>
-  <line x1="400" y1="430" x2="400" y2="450" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+  <!-- ⑤ Phase 4a: _process_new_files batches -->
+  <rect x="80" y="434" width="640" height="120" rx="4" fill="#e0f2fe" stroke="#3b82d4" stroke-width="1"/>
+  <text x="400" y="450" text-anchor="middle" fill="#0369a1" font-weight="600">⑤ Phase 4a — _process_new_files(ingest_list)  [BATCH_SIZE=10]</text>
+  <text x="400" y="464" text-anchor="middle" fill="#57606a" font-size="10">For each batch (up to 10 files):</text>
+  <text x="400" y="478" text-anchor="middle" fill="#57606a" font-size="10">  CHECKPOINT 2: _check_interrupt_call before batch starts</text>
+  <text x="400" y="492" text-anchor="middle" fill="#57606a" font-size="10">  await asyncio.to_thread(scanner.download_to, ...)  per file</text>
+  <text x="400" y="506" text-anchor="middle" fill="#57606a" font-size="10">  verify_integrity() → if failed: skip file (warning log, not fatal)</text>
+  <text x="400" y="520" text-anchor="middle" fill="#57606a" font-size="10">  CHECKPOINT 3: _check_interrupt_call after downloads</text>
+  <text x="400" y="534" text-anchor="middle" fill="#57606a" font-size="10">  initialize_job_state → add_connector_checksum_entry → ingest() → _wait_for_job(sync_seq)  [CHECKPOINT 4: polls + interrupt]</text>
+  <text x="400" y="546" text-anchor="middle" fill="#57606a" font-size="9">  batch exception → batch_failed=True (continues); finally: cleanup staging dir per batch</text>
+  <text x="400" y="558" text-anchor="middle" fill="#57606a" font-size="9">  After all batches: if batch_failed → raise RuntimeError → _fail_tick → OUT_OF_SYNC</text>
+  <line x1="400" y1="554" x2="400" y2="574" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
-  <!-- ④ Phase 4a: classify + ingest -->
-  <rect x="80" y="450" width="640" height="108" rx="4" fill="#e0f2fe" stroke="#3b82d4" stroke-width="1"/>
-  <text x="400" y="466" text-anchor="middle" fill="#0369a1" font-weight="600">&#x2463; Phase 4a &#x2014; _classify() + _process_new_files(ingest_list)</text>
-  <text x="400" y="480" text-anchor="middle" fill="#57606a" font-size="10">_classify(): separates scanned_files into skip_list, ingest_list, cross-connector dups</text>
-  <text x="400" y="492" text-anchor="middle" fill="#57606a" font-size="10">Cross-connector dups: insert_connector_checksum(connector_id, checksum, existing_doc_id) inline</text>
-  <text x="400" y="506" text-anchor="middle" fill="#57606a" font-size="10">For each in ingest_list (sequentially, one at a time):</text>
-  <text x="400" y="518" text-anchor="middle" fill="#57606a" font-size="10">  CHECKPOINT: _check_delete_pending() before download starts</text>
-  <text x="400" y="530" text-anchor="middle" fill="#57606a" font-size="10">  await loop.run_in_executor(None, scanner.download_to, ...)  [BLOCKING]</text>
-  <text x="400" y="542" text-anchor="middle" fill="#57606a" font-size="9">  CHECKPOINT: _check_delete_pending() after download · create_job() &#x2192; doc_id · finally: cleanup staging dir</text>
-  <line x1="400" y1="558" x2="400" y2="578" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+  <!-- ⑥ Phase 4b: delete orphans -->
+  <rect x="80" y="574" width="640" height="72" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
+  <text x="400" y="590" text-anchor="middle" fill="#854d0e" font-weight="600">⑥ Phase 4b — _delete_orphans(orphan_checksums)</text>
+  <text x="400" y="604" text-anchor="middle" fill="#57606a" font-size="10">Runs AFTER all Phase 4a batches complete</text>
+  <text x="400" y="616" text-anchor="middle" fill="#57606a" font-size="10">orphan_checksums = known_checksums − {scanned checksums}</text>
+  <text x="400" y="628" text-anchor="middle" fill="#57606a" font-size="10">For each: remove_connector_checksum_entry() → if remaining == 0: _best_effort_delete_document(doc_id)</text>
+  <text x="400" y="640" text-anchor="middle" fill="#57606a" font-size="9">Errors re-raised (not swallowed)</text>
+  <line x1="400" y1="646" x2="400" y2="666" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
-  <!-- ⑤ Phase 4b: delete orphans -->
-  <rect x="80" y="578" width="640" height="72" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="400" y="594" text-anchor="middle" fill="#854d0e" font-weight="600">&#x2464; Phase 4b &#x2014; await _delete_orphans(orphan_checksums)</text>
-  <text x="400" y="608" text-anchor="middle" fill="#57606a" font-size="10">Runs AFTER all Phase 4a writes complete</text>
-  <text x="400" y="620" text-anchor="middle" fill="#57606a" font-size="10">orphan_checksums = known_checksums &#x2212; {scanned checksums}</text>
-  <text x="400" y="632" text-anchor="middle" fill="#57606a" font-size="10">For each: remove_connector_checksum_entry() &#x2192; if remaining == 0: delete_document_internal(doc_id)</text>
-  <text x="400" y="644" text-anchor="middle" fill="#57606a" font-size="9">Best-effort deletion; errors logged and skipped</text>
-  <line x1="400" y1="650" x2="400" y2="670" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+  <!-- ⑦ Phase 5: finalize tick -->
+  <rect x="80" y="666" width="640" height="60" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="1"/>
+  <text x="400" y="682" text-anchor="middle" fill="#166534" font-weight="600">⑦ Phase 5 — _complete_tick()</text>
+  <text x="400" y="696" text-anchor="middle" fill="#57606a" font-size="10">close_sync_log(seq, status=COMPLETED) → connector sync_status='completed' → 'up to date'</text>
+  <text x="400" y="708" text-anchor="middle" fill="#57606a" font-size="10">UPDATE connectors SET last_sync_at=now, sync_status='completed'  [single transaction]</text>
+  <text x="400" y="720" text-anchor="middle" fill="#57606a" font-size="9">APScheduler will fire next tick at next interval</text>
+  <line x1="400" y1="726" x2="400" y2="746" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
-  <!-- ⑥ Phase 5: finalize tick -->
-  <rect x="80" y="670" width="640" height="60" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="1"/>
-  <text x="400" y="686" text-anchor="middle" fill="#166534" font-weight="600">&#x2465; Phase 5 &#x2014; _complete_tick()</text>
-  <text x="400" y="700" text-anchor="middle" fill="#57606a" font-size="10">UPDATE connector_sync_logs (finished_at, counters, status=&#x27;completed&#x27;)</text>
-  <text x="400" y="712" text-anchor="middle" fill="#57606a" font-size="10">UPDATE connectors (last_sync_at, sync_status=&#x27;up to date&#x27;)  [single transaction]</text>
-  <text x="400" y="724" text-anchor="middle" fill="#57606a" font-size="9">APScheduler will fire next tick at next interval</text>
-  <line x1="400" y1="730" x2="400" y2="750" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
-
-  <!-- ⑦ finally: scanner.close() -->
-  <rect x="80" y="750" width="640" height="36" rx="4" fill="#f7f8fa" stroke="#57606a" stroke-width="1"/>
-  <text x="400" y="766" text-anchor="middle" fill="#57606a" font-weight="600">&#x2466; finally:  scanner.close()</text>
-  <text x="400" y="780" text-anchor="middle" fill="#57606a" font-size="9">Always runs &#x2014; SFTP close, boto3 cleanup, etc.; coroutine exits</text>
+  <!-- ⑧ finally: scanner.close() -->
+  <rect x="80" y="746" width="640" height="36" rx="4" fill="#f7f8fa" stroke="#57606a" stroke-width="1"/>
+  <text x="400" y="762" text-anchor="middle" fill="#57606a" font-weight="600">⑧ finally:  scanner.close()</text>
+  <text x="400" y="778" text-anchor="middle" fill="#57606a" font-size="9">Always runs — SFTP close, boto3 cleanup, etc.; coroutine exits</text>
 
   <!-- exception side-rail: CancelledError path -->
-  <line x1="718" y1="540" x2="748" y2="540" stroke="#c0392b" stroke-width="1.5"/>
-  <line x1="748" y1="540" x2="748" y2="826" stroke="#c0392b" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <line x1="748" y1="826" x2="722" y2="826" stroke="#c0392b" stroke-width="1.5" marker-end="url(#sw-arrr)"/>
-  <text x="758" y="700" font-size="10" fill="#c0392b" font-weight="500" transform="rotate(-90,758,700)">CancelledError &#x2192; _cancel_tick() + _run_teardown</text>
+  <line x1="718" y1="550" x2="748" y2="550" stroke="#c0392b" stroke-width="1.5"/>
+  <line x1="748" y1="550" x2="748" y2="836" stroke="#c0392b" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <line x1="748" y1="836" x2="722" y2="836" stroke="#c0392b" stroke-width="1.5" marker-end="url(#sw-arrr)"/>
+  <text x="758" y="720" font-size="10" fill="#c0392b" font-weight="500" transform="rotate(-90,758,720)">CancelledError → _handle_interrupt</text>
 
   <!-- exception side-rail: other Exception path -->
-  <line x1="718" y1="614" x2="736" y2="614" stroke="#c0392b" stroke-width="1.5" stroke-dasharray="3,2"/>
-  <line x1="736" y1="614" x2="736" y2="846" stroke="#c0392b" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <line x1="736" y1="846" x2="722" y2="846" stroke="#c0392b" stroke-width="1.5" marker-end="url(#sw-arrr)"/>
-  <text x="742" y="740" font-size="10" fill="#c0392b" font-weight="500" transform="rotate(-90,742,740)">Exception &#x2192; _fail_tick()</text>
+  <line x1="718" y1="630" x2="736" y2="630" stroke="#c0392b" stroke-width="1.5" stroke-dasharray="3,2"/>
+  <line x1="736" y1="630" x2="736" y2="856" stroke="#c0392b" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <line x1="736" y1="856" x2="722" y2="856" stroke="#c0392b" stroke-width="1.5" marker-end="url(#sw-arrr)"/>
+  <text x="742" y="760" font-size="10" fill="#c0392b" font-weight="500" transform="rotate(-90,742,760)">Exception → _fail_tick</text>
 
   <!-- exception box -->
-  <rect x="80" y="810" width="640" height="72" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1"/>
-  <text x="400" y="826" text-anchor="middle" fill="#991b1b" font-weight="600">Exception handling</text>
-  <text x="400" y="840" text-anchor="middle" fill="#57606a" font-size="10">CancelledError: _cancel_tick() (log status=&#x27;cancelled&#x27;, sync_status=&#x27;delete_pending&#x27;)</text>
-  <text x="400" y="852" text-anchor="middle" fill="#57606a" font-size="10">&#x2192; asyncio.create_task(_run_teardown(connector_id))  &#x2022;  CancelledError is re-raised</text>
-  <text x="400" y="864" text-anchor="middle" fill="#57606a" font-size="9">Other Exception: _fail_tick() (log status=&#x27;failed&#x27;, sync_status=&#x27;out of sync&#x27;)  &#x2022;  error logged</text>
-  <text x="400" y="876" text-anchor="middle" fill="#57606a" font-size="9">finally: scanner.close() always runs; APScheduler fires next tick regardless</text>
+  <rect x="80" y="820" width="640" height="90" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1"/>
+  <text x="400" y="836" text-anchor="middle" fill="#991b1b" font-weight="600">Exception handling</text>
+  <text x="400" y="850" text-anchor="middle" fill="#57606a" font-size="10">CancelledError: _check_interrupt_call(connector_id, sync_seq) → identify type</text>
+  <text x="400" y="864" text-anchor="middle" fill="#57606a" font-size="10">  SYNC_CANCEL → _cancel_tick (log→'cancelled', connector→'out of sync') + sweep staging (sync_seq only)</text>
+  <text x="400" y="878" text-anchor="middle" fill="#57606a" font-size="10">  DELETE_CONNECTOR → _cancel_tick + _run_delete_teardown (inline) • CancelledError re-raised</text>
+  <text x="400" y="892" text-anchor="middle" fill="#57606a" font-size="9">Other Exception: _fail_tick (log→'failed', connector→'out of sync') • error logged • no re-raise</text>
+  <text x="400" y="904" text-anchor="middle" fill="#57606a" font-size="9">finally: scanner.close() always runs; APScheduler fires next tick regardless</text>
 
   <!-- Legend -->
-  <rect x="80" y="900" width="640" height="80" rx="4" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1" stroke-dasharray="2,2"/>
-  <text x="90" y="917" font-weight="600" fill="#166534">Legend:</text>
-  <rect x="100" y="923" width="8" height="8" fill="#e0e7ff" stroke="#3b82d4"/>
-  <text x="115" y="931" font-size="10" fill="#1f2328">Executor (async &#x2192; executor thread): blocking I/O offloaded to ThreadPoolExecutor</text>
-  <text x="115" y="944" font-size="10" fill="#1f2328">Event loop remains responsive; CancelledError can be injected at each await</text>
-  <text x="115" y="957" font-size="10" fill="#1f2328">Thread continues its blocking call naturally if cancelled (cannot be forcibly stopped)</text>
+  <rect x="80" y="928" width="640" height="100" rx="4" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1" stroke-dasharray="2,2"/>
+  <text x="90" y="945" font-weight="600" fill="#166534">Legend:</text>
+  <rect x="100" y="951" width="8" height="8" fill="#e0e7ff" stroke="#3b82d4"/>
+  <text x="115" y="959" font-size="10" fill="#1f2328">Executor (asyncio.to_thread): blocking I/O offloaded to ThreadPoolExecutor — event loop stays responsive</text>
   <rect x="100" y="969" width="8" height="8" fill="#fff3e0" stroke="#f59e0b"/>
-  <text x="115" y="977" font-size="10" fill="#1f2328">Phase boundary: _check_delete_pending() does live DB SELECT; raises CancelledError if &#x27;delete_pending&#x27;</text>
+  <text x="115" y="977" font-size="10" fill="#1f2328">Checkpoint: _check_interrupt_call(connector_id, sync_seq) — reads connectors.sync_status AND connector_sync_logs.status</text>
+  <text x="115" y="990" font-size="10" fill="#1f2328">  → DELETE_PENDING → InterruptType.DELETE_CONNECTOR  |  CANCEL_PENDING → InterruptType.SYNC_CANCEL</text>
+  <text x="115" y="1003" font-size="10" fill="#1f2328">  Called at 4 points: after open_log, before batch, after downloads, inside _wait_for_job poll loop</text>
+  <text x="115" y="1016" font-size="10" fill="#1f2328">  CancelledError is raised in the coroutine; a thread already in flight runs to natural completion</text>
 </svg>

--- a/docs/proposals/data-source-connectors/sync-worker-tick-flow.svg
+++ b/docs/proposals/data-source-connectors/sync-worker-tick-flow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 1180" width="800" height="1180" font-family="-apple-system, Segoe UI, system-ui, sans-serif" font-size="11">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 1220" width="800" height="1220" font-family="-apple-system, Segoe UI, system-ui, sans-serif" font-size="11">
   <defs>
     <marker id="sw-arr"  markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#3b82d4"/></marker>
     <marker id="sw-arrg" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#2d9a5f"/></marker>
@@ -9,112 +9,109 @@
   <!-- Entry point -->
   <rect x="80" y="10" width="640" height="36" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1.5"/>
   <text x="400" y="25" text-anchor="middle" font-weight="700" fill="#1e40af">run_tick(connector_id)  — async coroutine</text>
-  <text x="400" y="40" text-anchor="middle" font-size="10" fill="#57606a">dispatched by APScheduler IntervalTrigger  OR  POST /v1/connectors/{id}/syncs</text>
+  <text x="400" y="40" text-anchor="middle" font-size="10" fill="#57606a">dispatched by APScheduler IntervalTrigger (PR7 — not yet implemented)  OR  POST /v1/connectors/{id}/syncs</text>
   <line x1="400" y1="46" x2="400" y2="66" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
   <!-- Phase 0 note: lock acquired BEFORE calling run_tick -->
   <rect x="100" y="66" width="600" height="20" rx="3" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1"/>
-  <text x="400" y="79" text-anchor="middle" fill="#166534" font-size="10">Phase 0 (lock): try_acquire_sync_lock() already called by caller (scheduler or POST /syncs handler)</text>
+  <text x="400" y="79" text-anchor="middle" fill="#166534" font-size="10">Phase 0 (lock): try_acquire_sync_lock() already called by caller (scheduler or POST /syncs handler); run_tick assumes lock held</text>
   <line x1="400" y1="86" x2="400" y2="106" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
   <!-- ① Phase 1: open tick record -->
-  <rect x="80" y="106" width="640" height="48" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1"/>
+  <rect x="80" y="106" width="640" height="52" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1"/>
   <text x="400" y="122" text-anchor="middle" fill="#1e40af" font-weight="600">① Phase 1 — open tick record</text>
-  <text x="400" y="136" text-anchor="middle" fill="#57606a" font-size="10">sync_seq = open_new_sync_log(connector_id)</text>
-  <text x="400" y="148" text-anchor="middle" fill="#57606a" font-size="10">INSERT connector_sync_logs (seq, started_at, status='started')</text>
-  <line x1="400" y1="154" x2="400" y2="174" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+  <text x="400" y="136" text-anchor="middle" fill="#57606a" font-size="10">sync_seq = init_sync_log_and_update_connector(connector_id)</text>
+  <text x="400" y="148" text-anchor="middle" fill="#57606a" font-size="10">Two DB calls: INSERT connector_sync_logs (seq, started_at, status='started') + SET connector sync_status='syncing'</text>
+  <line x1="400" y1="158" x2="400" y2="178" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
   <!-- Phase boundary 1b: _check_interrupt_call -->
-  <rect x="100" y="174" width="600" height="24" rx="3" fill="#fff3e0" stroke="#f59e0b" stroke-width="1" stroke-dasharray="3,2"/>
-  <text x="400" y="188" text-anchor="middle" fill="#ca8a04" font-size="9" font-weight="600">CHECKPOINT 1: _check_interrupt_call(connector_id, sync_seq) — checks connectors.sync_status AND connector_sync_logs.status</text>
-  <line x1="400" y1="198" x2="400" y2="218" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+  <rect x="100" y="178" width="600" height="24" rx="3" fill="#fff3e0" stroke="#f59e0b" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="400" y="192" text-anchor="middle" fill="#ca8a04" font-size="9" font-weight="600">CHECKPOINT 1: _check_interrupt_call(connector_id, sync_seq) — reads connectors.sync_status AND connector_sync_logs.status</text>
+  <line x1="400" y1="202" x2="400" y2="222" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
-  <!-- ② Phase 2 — load known state -->
-  <rect x="80" y="218" width="640" height="36" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1"/>
-  <text x="400" y="234" text-anchor="middle" fill="#1e40af" font-weight="600">② Phase 2 — load known state</text>
-  <text x="400" y="248" text-anchor="middle" fill="#57606a" font-size="10">list_connector_checksums(connector_id); list_all_checksums()</text>
-  <line x1="400" y1="254" x2="400" y2="274" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+  <!-- ② Phase 2 — load known state + scan -->
+  <rect x="80" y="222" width="640" height="50" rx="4" fill="#dbeafe" stroke="#3b82d4" stroke-width="1"/>
+  <text x="400" y="238" text-anchor="middle" fill="#1e40af" font-weight="600">② Phase 2 — load known state + scan</text>
+  <text x="400" y="252" text-anchor="middle" fill="#57606a" font-size="10">list_connector_checksums(connector_id); list_all_checksums()</text>
+  <text x="400" y="264" text-anchor="middle" fill="#57606a" font-size="10">await asyncio.to_thread(scanner.connect)  →  await asyncio.to_thread(scanner.scan)  →  list[(remote_path, checksum)]</text>
+  <line x1="400" y1="272" x2="400" y2="292" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
-  <!-- ③a Phase 3a: scanner.connect (asyncio.to_thread) -->
-  <rect x="80" y="274" width="640" height="48" rx="4" fill="#e0e7ff" stroke="#3b82d4" stroke-width="1" stroke-dasharray="2,2"/>
-  <text x="400" y="290" text-anchor="middle" fill="#1e40af" font-weight="600">③ Phase 3a — scanner.connect() + scanner.scan()</text>
-  <text x="400" y="304" text-anchor="middle" fill="#57606a" font-size="10">await asyncio.to_thread(scanner.connect)  [BLOCKING → ThreadPoolExecutor]</text>
-  <text x="400" y="316" text-anchor="middle" fill="#f59e0b" font-size="9" font-weight="500">await asyncio.to_thread(scanner.scan)  →  list[(remote_path, checksum)]</text>
-  <line x1="400" y1="322" x2="400" y2="342" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+  <!-- ③ Phase 3: _classify -->
+  <rect x="80" y="292" width="640" height="80" rx="4" fill="#e0f2fe" stroke="#3b82d4" stroke-width="1"/>
+  <text x="400" y="308" text-anchor="middle" fill="#0369a1" font-weight="600">③ Phase 3 — _classify(connector_id, scanned_files, known_checksums, all_checksums)</text>
+  <text x="400" y="322" text-anchor="middle" fill="#57606a" font-size="10">For each (path, checksum) in scanned_files:</text>
+  <text x="400" y="334" text-anchor="middle" fill="#57606a" font-size="10">  • in known_checksums → skip (already owned)  |  • in all_checksums → add_connector_checksum_entry inline (cross-connector dup)</text>
+  <text x="400" y="346" text-anchor="middle" fill="#57606a" font-size="10">  • neither → append to ingest_list  |  orphan_checksums = known_checksums − scanned_checksums</text>
+  <text x="400" y="360" text-anchor="middle" fill="#57606a" font-size="9">Phase 3b: update_sync_log(connector_id, sync_seq, total_files, new_files, removed_files) + update_connector_total_files(connector_id, total)</text>
+  <text x="400" y="372" text-anchor="middle" fill="#57606a" font-size="9">All counts known post-classify — single write each before any I/O-heavy work begins</text>
+  <line x1="400" y1="372" x2="400" y2="392" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
-  <!-- ④ Phase 3c: _classify -->
-  <rect x="80" y="342" width="640" height="72" rx="4" fill="#e0f2fe" stroke="#3b82d4" stroke-width="1"/>
-  <text x="400" y="358" text-anchor="middle" fill="#0369a1" font-weight="600">④ Phase 3 — _classify(connector_id, scanned_files, known_checksums, all_checksums)</text>
-  <text x="400" y="372" text-anchor="middle" fill="#57606a" font-size="10">For each (path, checksum) in scanned_files:</text>
-  <text x="400" y="384" text-anchor="middle" fill="#57606a" font-size="10">  • in known_checksums → skip (already owned)  |  • in all_checksums → add_connector_checksum_entry inline (cross-connector dup)</text>
-  <text x="400" y="396" text-anchor="middle" fill="#57606a" font-size="10">  • neither → append to ingest_list  |  orphan_checksums = known_checksums − scanned_checksums</text>
-  <text x="400" y="408" text-anchor="middle" fill="#57606a" font-size="9">Phase 3b: update_sync_log(sync_seq, total_files, new_files, removed_files) — single write, all counts known</text>
-  <line x1="400" y1="414" x2="400" y2="434" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+  <!-- ④ Phase 4a: _process_new_files batches -->
+  <rect x="80" y="392" width="640" height="138" rx="4" fill="#e0f2fe" stroke="#3b82d4" stroke-width="1"/>
+  <text x="400" y="408" text-anchor="middle" fill="#0369a1" font-weight="600">④ Phase 4a — _process_new_files(sync_seq, connector_id, connector_name, scanner, ingest_list)  [BATCH_SIZE=10]</text>
+  <text x="400" y="422" text-anchor="middle" fill="#57606a" font-size="10">For each batch (batch_number 1-based, up to 10 files):</text>
+  <text x="400" y="436" text-anchor="middle" fill="#57606a" font-size="10">  CHECKPOINT 2: _check_interrupt_call before batch starts</text>
+  <text x="400" y="450" text-anchor="middle" fill="#57606a" font-size="10">  staging dir: staging/connectors/{connector_id}-{sync_seq}-{batch_number}</text>
+  <text x="400" y="464" text-anchor="middle" fill="#57606a" font-size="10">  await asyncio.to_thread(scanner.download_to, remote_path, local_path)  per file</text>
+  <text x="400" y="478" text-anchor="middle" fill="#57606a" font-size="10">  verify_integrity() → if failed: skip file (warning log, not fatal)  |  CHECKPOINT 3: after downloads</text>
+  <text x="400" y="492" text-anchor="middle" fill="#57606a" font-size="10">  initialize_job_state(job_name="Connector-{connector_name}-{sync_seq}-{batch_number}") → add_connector_checksum_entry</text>
+  <text x="400" y="506" text-anchor="middle" fill="#57606a" font-size="10">  await asyncio.to_thread(ingest, batch_dir, job_id, doc_id_dict) → await _wait_for_job(job_id, connector_id, sync_seq)  [CHECKPOINT 4]</text>
+  <text x="400" y="520" text-anchor="middle" fill="#57606a" font-size="9">  batch exception → batch_failed=True (continues); finally: cleanup_staging_directory per batch</text>
+  <text x="400" y="530" text-anchor="middle" fill="#57606a" font-size="9">  After all batches: if batch_failed → raise RuntimeError → _fail_tick → OUT_OF_SYNC</text>
+  <line x1="400" y1="530" x2="400" y2="550" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
-  <!-- ⑤ Phase 4a: _process_new_files batches -->
-  <rect x="80" y="434" width="640" height="120" rx="4" fill="#e0f2fe" stroke="#3b82d4" stroke-width="1"/>
-  <text x="400" y="450" text-anchor="middle" fill="#0369a1" font-weight="600">⑤ Phase 4a — _process_new_files(ingest_list)  [BATCH_SIZE=10]</text>
-  <text x="400" y="464" text-anchor="middle" fill="#57606a" font-size="10">For each batch (up to 10 files):</text>
-  <text x="400" y="478" text-anchor="middle" fill="#57606a" font-size="10">  CHECKPOINT 2: _check_interrupt_call before batch starts</text>
-  <text x="400" y="492" text-anchor="middle" fill="#57606a" font-size="10">  await asyncio.to_thread(scanner.download_to, ...)  per file</text>
-  <text x="400" y="506" text-anchor="middle" fill="#57606a" font-size="10">  verify_integrity() → if failed: skip file (warning log, not fatal)</text>
-  <text x="400" y="520" text-anchor="middle" fill="#57606a" font-size="10">  CHECKPOINT 3: _check_interrupt_call after downloads</text>
-  <text x="400" y="534" text-anchor="middle" fill="#57606a" font-size="10">  initialize_job_state → add_connector_checksum_entry → ingest() → _wait_for_job(sync_seq)  [CHECKPOINT 4: polls + interrupt]</text>
-  <text x="400" y="546" text-anchor="middle" fill="#57606a" font-size="9">  batch exception → batch_failed=True (continues); finally: cleanup staging dir per batch</text>
-  <text x="400" y="558" text-anchor="middle" fill="#57606a" font-size="9">  After all batches: if batch_failed → raise RuntimeError → _fail_tick → OUT_OF_SYNC</text>
-  <line x1="400" y1="554" x2="400" y2="574" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+  <!-- ⑤ Phase 4b: delete orphans -->
+  <rect x="80" y="550" width="640" height="80" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
+  <text x="400" y="566" text-anchor="middle" fill="#854d0e" font-weight="600">⑤ Phase 4b — _delete_orphans(connector_id, orphan_checksums)</text>
+  <text x="400" y="580" text-anchor="middle" fill="#57606a" font-size="10">Runs AFTER all Phase 4a batches complete</text>
+  <text x="400" y="594" text-anchor="middle" fill="#57606a" font-size="10">orphan_checksums = known_checksums − {scanned checksums}</text>
+  <text x="400" y="608" text-anchor="middle" fill="#57606a" font-size="10">For each: remove_connector_checksum_entry(connector_id, checksum) → if remaining == 0:</text>
+  <text x="400" y="620" text-anchor="middle" fill="#57606a" font-size="10">  await asyncio.to_thread(_best_effort_delete_document, doc_id)  |  Errors re-raised (not swallowed)</text>
+  <line x1="400" y1="630" x2="400" y2="650" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
-  <!-- ⑥ Phase 4b: delete orphans -->
-  <rect x="80" y="574" width="640" height="72" rx="4" fill="#fef3c7" stroke="#ca8a04" stroke-width="1"/>
-  <text x="400" y="590" text-anchor="middle" fill="#854d0e" font-weight="600">⑥ Phase 4b — _delete_orphans(orphan_checksums)</text>
-  <text x="400" y="604" text-anchor="middle" fill="#57606a" font-size="10">Runs AFTER all Phase 4a batches complete</text>
-  <text x="400" y="616" text-anchor="middle" fill="#57606a" font-size="10">orphan_checksums = known_checksums − {scanned checksums}</text>
-  <text x="400" y="628" text-anchor="middle" fill="#57606a" font-size="10">For each: remove_connector_checksum_entry() → if remaining == 0: _best_effort_delete_document(doc_id)</text>
-  <text x="400" y="640" text-anchor="middle" fill="#57606a" font-size="9">Errors re-raised (not swallowed)</text>
-  <line x1="400" y1="646" x2="400" y2="666" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
+  <!-- ⑥ Phase 5: finalize tick -->
+  <rect x="80" y="650" width="640" height="66" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="1"/>
+  <text x="400" y="666" text-anchor="middle" fill="#166534" font-weight="600">⑥ Phase 5 — _complete_tick(sync_seq, connector_id)</text>
+  <text x="400" y="680" text-anchor="middle" fill="#57606a" font-size="10">finalize_sync_log_and_update_connector(connector_id, seq, status=COMPLETED)</text>
+  <text x="400" y="694" text-anchor="middle" fill="#57606a" font-size="10">Two DB calls: finalize log row (finished_at, status='completed') + UPDATE connectors SET last_sync_at, sync_status='completed'</text>
+  <text x="400" y="708" text-anchor="middle" fill="#57606a" font-size="9">APScheduler (PR7) will fire next tick at next interval</text>
+  <line x1="400" y1="716" x2="400" y2="736" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
 
-  <!-- ⑦ Phase 5: finalize tick -->
-  <rect x="80" y="666" width="640" height="60" rx="4" fill="#dcfce7" stroke="#2d9a5f" stroke-width="1"/>
-  <text x="400" y="682" text-anchor="middle" fill="#166534" font-weight="600">⑦ Phase 5 — _complete_tick()</text>
-  <text x="400" y="696" text-anchor="middle" fill="#57606a" font-size="10">close_sync_log(seq, status=COMPLETED) → connector sync_status='completed' → 'up to date'</text>
-  <text x="400" y="708" text-anchor="middle" fill="#57606a" font-size="10">UPDATE connectors SET last_sync_at=now, sync_status='completed'  [single transaction]</text>
-  <text x="400" y="720" text-anchor="middle" fill="#57606a" font-size="9">APScheduler will fire next tick at next interval</text>
-  <line x1="400" y1="726" x2="400" y2="746" stroke="#3b82d4" stroke-width="1.5" marker-end="url(#sw-arr)"/>
-
-  <!-- ⑧ finally: scanner.close() -->
-  <rect x="80" y="746" width="640" height="36" rx="4" fill="#f7f8fa" stroke="#57606a" stroke-width="1"/>
-  <text x="400" y="762" text-anchor="middle" fill="#57606a" font-weight="600">⑧ finally:  scanner.close()</text>
-  <text x="400" y="778" text-anchor="middle" fill="#57606a" font-size="9">Always runs — SFTP close, boto3 cleanup, etc.; coroutine exits</text>
+  <!-- ⑦ finally: scanner.close() -->
+  <rect x="80" y="736" width="640" height="36" rx="4" fill="#f7f8fa" stroke="#57606a" stroke-width="1"/>
+  <text x="400" y="752" text-anchor="middle" fill="#57606a" font-weight="600">⑦ finally:  await asyncio.to_thread(scanner.close)</text>
+  <text x="400" y="768" text-anchor="middle" fill="#57606a" font-size="9">Always runs — SFTP close, boto3 client release, etc.; coroutine exits</text>
 
   <!-- exception side-rail: CancelledError path -->
-  <line x1="718" y1="550" x2="748" y2="550" stroke="#c0392b" stroke-width="1.5"/>
-  <line x1="748" y1="550" x2="748" y2="836" stroke="#c0392b" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <line x1="748" y1="836" x2="722" y2="836" stroke="#c0392b" stroke-width="1.5" marker-end="url(#sw-arrr)"/>
-  <text x="758" y="720" font-size="10" fill="#c0392b" font-weight="500" transform="rotate(-90,758,720)">CancelledError → _handle_interrupt</text>
+  <line x1="718" y1="520" x2="748" y2="520" stroke="#c0392b" stroke-width="1.5"/>
+  <line x1="748" y1="520" x2="748" y2="826" stroke="#c0392b" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <line x1="748" y1="826" x2="722" y2="826" stroke="#c0392b" stroke-width="1.5" marker-end="url(#sw-arrr)"/>
+  <text x="758" y="700" font-size="10" fill="#c0392b" font-weight="500" transform="rotate(-90,758,700)">CancelledError → await _handle_interrupt</text>
 
   <!-- exception side-rail: other Exception path -->
-  <line x1="718" y1="630" x2="736" y2="630" stroke="#c0392b" stroke-width="1.5" stroke-dasharray="3,2"/>
-  <line x1="736" y1="630" x2="736" y2="856" stroke="#c0392b" stroke-width="1.5" stroke-dasharray="4,3"/>
-  <line x1="736" y1="856" x2="722" y2="856" stroke="#c0392b" stroke-width="1.5" marker-end="url(#sw-arrr)"/>
-  <text x="742" y="760" font-size="10" fill="#c0392b" font-weight="500" transform="rotate(-90,742,760)">Exception → _fail_tick</text>
+  <line x1="718" y1="610" x2="736" y2="610" stroke="#c0392b" stroke-width="1.5" stroke-dasharray="3,2"/>
+  <line x1="736" y1="610" x2="736" y2="846" stroke="#c0392b" stroke-width="1.5" stroke-dasharray="4,3"/>
+  <line x1="736" y1="846" x2="722" y2="846" stroke="#c0392b" stroke-width="1.5" marker-end="url(#sw-arrr)"/>
+  <text x="742" y="740" font-size="10" fill="#c0392b" font-weight="500" transform="rotate(-90,742,740)">Exception → _fail_tick</text>
 
   <!-- exception box -->
-  <rect x="80" y="820" width="640" height="90" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1"/>
-  <text x="400" y="836" text-anchor="middle" fill="#991b1b" font-weight="600">Exception handling</text>
-  <text x="400" y="850" text-anchor="middle" fill="#57606a" font-size="10">CancelledError: _check_interrupt_call(connector_id, sync_seq) → identify type</text>
-  <text x="400" y="864" text-anchor="middle" fill="#57606a" font-size="10">  SYNC_CANCEL → _cancel_tick (log→'cancelled', connector→'out of sync') + sweep staging (sync_seq only)</text>
-  <text x="400" y="878" text-anchor="middle" fill="#57606a" font-size="10">  DELETE_CONNECTOR → _cancel_tick + _run_delete_teardown (inline) • CancelledError re-raised</text>
-  <text x="400" y="892" text-anchor="middle" fill="#57606a" font-size="9">Other Exception: _fail_tick (log→'failed', connector→'out of sync') • error logged • no re-raise</text>
-  <text x="400" y="904" text-anchor="middle" fill="#57606a" font-size="9">finally: scanner.close() always runs; APScheduler fires next tick regardless</text>
+  <rect x="80" y="810" width="640" height="100" rx="4" fill="#fee2e2" stroke="#c0392b" stroke-width="1"/>
+  <text x="400" y="826" text-anchor="middle" fill="#991b1b" font-weight="600">Exception handling</text>
+  <text x="400" y="840" text-anchor="middle" fill="#57606a" font-size="10">CancelledError: _check_interrupt_call(connector_id, sync_seq) → identify type</text>
+  <text x="400" y="854" text-anchor="middle" fill="#57606a" font-size="10">  SYNC_CANCEL → _cancel_tick (log→'cancelled', connector→'out of sync') + _sweep_staging_dir(sync_seq=sync_seq only)</text>
+  <text x="400" y="868" text-anchor="middle" fill="#57606a" font-size="10">  DELETE_CONNECTOR → _cancel_tick + await _run_teardown(connector_id)  [imported from connectors.py — same as Case B]</text>
+  <text x="400" y="882" text-anchor="middle" fill="#57606a" font-size="9">Other Exception: _fail_tick (log→'failed', connector→'out of sync') • error logged • no re-raise</text>
+  <text x="400" y="896" text-anchor="middle" fill="#57606a" font-size="9">finally: scanner.close() always runs; CancelledError is re-raised after _handle_interrupt completes</text>
 
   <!-- Legend -->
-  <rect x="80" y="928" width="640" height="100" rx="4" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1" stroke-dasharray="2,2"/>
+  <rect x="80" y="928" width="640" height="116" rx="4" fill="#f0fdf4" stroke="#2d9a5f" stroke-width="1" stroke-dasharray="2,2"/>
   <text x="90" y="945" font-weight="600" fill="#166534">Legend:</text>
   <rect x="100" y="951" width="8" height="8" fill="#e0e7ff" stroke="#3b82d4"/>
-  <text x="115" y="959" font-size="10" fill="#1f2328">Executor (asyncio.to_thread): blocking I/O offloaded to ThreadPoolExecutor — event loop stays responsive</text>
+  <text x="115" y="959" font-size="10" fill="#1f2328">asyncio.to_thread: blocking I/O offloaded to ThreadPoolExecutor — event loop stays responsive</text>
   <rect x="100" y="969" width="8" height="8" fill="#fff3e0" stroke="#f59e0b"/>
-  <text x="115" y="977" font-size="10" fill="#1f2328">Checkpoint: _check_interrupt_call(connector_id, sync_seq) — reads connectors.sync_status AND connector_sync_logs.status</text>
+  <text x="115" y="977" font-size="10" fill="#1f2328">Checkpoint: _check_interrupt_call(connector_id, sync_seq) — live DB reads of connectors.sync_status AND connector_sync_logs.status</text>
   <text x="115" y="990" font-size="10" fill="#1f2328">  → DELETE_PENDING → InterruptType.DELETE_CONNECTOR  |  CANCEL_PENDING → InterruptType.SYNC_CANCEL</text>
-  <text x="115" y="1003" font-size="10" fill="#1f2328">  Called at 4 points: after open_log, before batch, after downloads, inside _wait_for_job poll loop</text>
-  <text x="115" y="1016" font-size="10" fill="#1f2328">  CancelledError is raised in the coroutine; a thread already in flight runs to natural completion</text>
+  <text x="115" y="1003" font-size="10" fill="#1f2328">  Called at 4 points: after init_sync_log_and_update_connector, before batch, after downloads, inside _wait_for_job poll loop</text>
+  <text x="115" y="1016" font-size="10" fill="#1f2328">  CancelledError raised in coroutine; a thread already in flight runs to natural completion</text>
+  <text x="115" y="1029" font-size="10" fill="#1f2328">  _handle_interrupt is async def — awaits _run_teardown for DELETE_CONNECTOR path</text>
 </svg>

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.43
+TAG?=v0.0.44
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -10,6 +10,7 @@ Endpoints:
   GET    /v1/connectors
   GET    /v1/connectors/{connector_id}
   GET    /v1/connectors/{connector_id}/syncs
+  GET    /v1/connectors/{connector_id}/syncs/{sync_seq}
   POST   /v1/connectors/{connector_id}/syncs
   POST   /v1/connectors/{connector_id}/syncs/{sync_seq}/stop
 """
@@ -27,6 +28,7 @@ from digitize.connectors.models import (
     ConnectorDetailResponse,
     ConnectorListItem,
     ConnectorUpdateRequest,
+    SyncLogDetailResponse,
     SyncLogItem,
     SyncLogResponse,
     SyncStatus,
@@ -640,6 +642,58 @@ async def get_sync_history(
     except Exception as exc:
         logger.error(
             f"Unexpected error fetching sync log for {connector_id}: {exc}",
+            exc_info=True,
+        )
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/connectors/{connector_id}/syncs/{sync_seq}
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/{connector_id}/syncs/{sync_seq}",
+    response_model=SyncLogDetailResponse,
+    responses={
+        404: http_error_responses[404],
+        500: http_error_responses[500],
+    },
+    summary="Get a specific sync log entry",
+    description="Returns one sync log entry identified by its sequence number.",
+    response_description="Sync log entry",
+)
+async def get_sync(connector_id: str, sync_seq: int):
+    try:
+        connector = db_ops.get_active_connector(connector_id)
+        if connector is None:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                f"Connector {connector_id!r} not found",
+            )
+
+        log = db_ops.get_sync_log(connector_id, sync_seq)
+        if log is None:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                f"Sync {sync_seq} not found for connector {connector_id!r}",
+            )
+
+        return SyncLogDetailResponse(
+            seq=log.seq,
+            started_at=get_utc_timestamp(log.started_at) or "",
+            finished_at=get_utc_timestamp(log.finished_at),
+            total_files=log.total_files,
+            new_files=log.new_files,
+            removed_files=log.removed_files,
+            status=log.status,
+            error=log.error or "",
+        )
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(
+            f"Unexpected error fetching sync {sync_seq} for {connector_id}: {exc}",
             exc_info=True,
         )
         APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -30,6 +30,7 @@ from digitize.connectors.models import (
     SyncLogItem,
     SyncLogResponse,
     SyncStatus,
+    SyncTriggerResponse,
 )
 from digitize.connectors.encryption import (
     encrypt_secrets,
@@ -429,6 +430,7 @@ async def get_connector(connector_id: str):
 @router.post(
     "/{connector_id}/sync",
     status_code=status.HTTP_202_ACCEPTED,
+    response_model=SyncTriggerResponse,
     responses={
         404: http_error_responses[404],
         500: http_error_responses[500],
@@ -439,7 +441,9 @@ async def get_connector(connector_id: str):
         "Safe and idempotent: if a tick is already running the request is "
         "accepted without starting a duplicate (no-op 202). "
         "The tick runs asynchronously; this endpoint returns as soon as the "
-        "task has been dispatched."
+        "task has been dispatched. "
+        "Always returns the sync_seq of the active sync — either the newly "
+        "dispatched one or the already-running one."
     ),
     response_description="Sync dispatched (or already in progress)",
 )
@@ -459,14 +463,44 @@ async def trigger_sync(connector_id: str):
         if acquired:
             asyncio.create_task(run_tick(connector_id))
             logger.info(f"Manual sync dispatched for connector {connector_id!r}")
-        
-        return Response(status_code=202)
+            # open_new_sync_log hasn't been called yet (that happens inside run_tick),
+            # so fetch the seq of the row that the background task will open shortly.
+            # Since we hold the lock we query for the highest existing seq + 1 via
+            # the active row that run_tick will create. Instead, we read it after a
+            # brief yield so the task can open the log first.
+            # Simpler and race-free: open_new_sync_log is the very first thing
+            # run_tick does — schedule a wait-for-seq helper.
+            sync_seq = await _wait_for_sync_seq(connector_id)
+        else:
+            sync_seq = db_ops.get_active_sync_seq(connector_id)
+            if sync_seq is None:
+                raise RuntimeError(
+                    f"Sync lock held but no active sync-log row found for connector {connector_id!r}"
+                )
+            logger.info(f"Sync already in progress for connector {connector_id!r}, seq={sync_seq}")
+
+        return SyncTriggerResponse(sync_seq=sync_seq)
 
     except HTTPException:
         raise
     except Exception as exc:
         logger.error(f"Unexpected error triggering sync for {connector_id}: {exc}", exc_info=True)
         APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+
+
+async def _wait_for_sync_seq(connector_id: str, attempts: int = 10, interval: float = 0.1) -> int:
+    """Poll until run_tick's open_new_sync_log creates the active sync-log row.
+
+    Returns the seq as soon as it appears, or raises RuntimeError if it never does.
+    """
+    for _ in range(attempts):
+        await asyncio.sleep(interval)
+        seq = db_ops.get_active_sync_seq(connector_id)
+        if seq is not None:
+            return seq
+    raise RuntimeError(
+        f"Timed out waiting for sync-log row to appear for connector {connector_id!r}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -32,7 +32,8 @@ from digitize.connectors.models import (
     SyncLogDetailResponse,
     SyncLogItem,
     SyncLogResponse,
-    SyncStatus,
+    ConnectorStatus,
+    SyncLogStatus,
     SyncTriggerResponse,
 )
 from digitize.connectors.encryption import (
@@ -242,7 +243,7 @@ async def delete_connector(connector_id: str):
 
         db_ops.mark_sync_delete_pending(connector_id)
 
-        if connector.sync_status != SyncStatus.SYNCING:
+        if connector.sync_status != ConnectorStatus.SYNCING:
             # No tick running — kick off teardown ourselves.
             asyncio.create_task(_run_teardown(connector_id))
 
@@ -274,7 +275,7 @@ async def _run_teardown(connector_id: str) -> None:
     try:
         # Step 1: guard — verify the latest sync-log is terminal before
         # proceeding.  If it is still 'started' (stuck), cancel it now.
-        _TERMINAL_STATUSES = {SyncStatus.CANCELLED, SyncStatus.FAILED, SyncStatus.COMPLETED}
+        _TERMINAL_STATUSES = {SyncLogStatus.CANCELLED, SyncLogStatus.FAILED, SyncLogStatus.COMPLETED}
         logs, _ = db_ops.list_sync_logs(connector_id, limit=1)
         if logs:
             latest_log = logs[0]
@@ -287,7 +288,7 @@ async def _run_teardown(connector_id: str) -> None:
                 db_ops.close_sync_log(
                     connector_id=connector_id,
                     seq=latest_log.seq,
-                    status=SyncStatus.CANCELLED,
+                    status=SyncLogStatus.CANCELLED,
                     error="Cancelled by connector deletion",
                 )
 
@@ -567,7 +568,7 @@ async def cancel_sync(connector_id: str, sync_seq: int):
                 ErrorCode.RESOURCE_NOT_FOUND,
                 f"Connector {connector_id!r} not found",
             )
-        if connector.sync_status != SyncStatus.SYNCING:
+        if connector.sync_status != ConnectorStatus.SYNCING:
             APIError.raise_error(
                 ErrorCode.RESOURCE_LOCKED,
                 "No sync is currently running for this connector.",

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -152,18 +152,24 @@ async def update_connector(connector_id: str, body: ConnectorUpdateRequest):
         if body.connector_name is None and body.allowed_extensions is None and body.connection_details is None:
             return Response(status_code=200)
 
+        existing = db_ops.get_active_connector(connector_id)
+        if existing is None:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                f"Connector {connector_id!r} not found",
+            )
+        if existing.sync_status == ConnectorStatus.DELETE_PENDING:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_LOCKED,
+                f"Connector {connector_id!r} is pending deletion and cannot be updated",
+            )
+
         key_path = _get_key_path()
 
         # If connection_details is being updated, we need to merge with existing
         # encrypted details so untouched keys stay encrypted and intact.
         merged_details: Optional[dict] = None
         if body.connection_details is not None:
-            existing = db_ops.get_active_connector(connector_id)
-            if existing is None:
-                APIError.raise_error(
-                    ErrorCode.RESOURCE_NOT_FOUND,
-                    f"Connector {connector_id!r} not found",
-                )
             merged_details = merge_and_encrypt_partial(
                 existing.type,
                 existing.connection_details,

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -376,6 +376,7 @@ async def list_connectors():
                 last_sync_at=get_utc_timestamp(c.last_sync_at),
                 sync_status=c.sync_status,
                 last_sync_error=c.last_sync_error,
+                error=c.error,
                 total_files=c.total_files,
             )
             for c in connectors
@@ -424,6 +425,7 @@ async def get_connector(connector_id: str):
             last_sync_at=get_utc_timestamp(connector.last_sync_at),
             sync_status=connector.sync_status,
             last_sync_error=connector.last_sync_error,
+            error=connector.error,
             connection_details=strip_secrets(connector.type, connector.connection_details or {}),
             total_files=connector.total_files,
         )

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -559,6 +559,11 @@ async def cancel_sync(connector_id: str, sync_seq: int):
                 ErrorCode.RESOURCE_NOT_FOUND,
                 f"Connector {connector_id!r} not found",
             )
+        if connector.sync_status != SyncStatus.SYNCING:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_LOCKED,
+                "No sync is currently running for this connector.",
+            )
 
         active_seq = db_ops.get_active_sync_seq(connector_id)
         if active_seq is None or active_seq != sync_seq:

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -621,7 +621,7 @@ async def get_sync_history(
 
         items = [
             SyncLogItem(
-                id=log.id,
+                seq=log.seq,
                 started_at=get_utc_timestamp(log.started_at) or "",
                 finished_at=get_utc_timestamp(log.finished_at),
                 total_files=log.total_files,

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -11,6 +11,7 @@ Endpoints:
   GET    /v1/connectors/{connector_id}
   GET    /v1/connectors/{connector_id}/syncs
   POST   /v1/connectors/{connector_id}/sync
+  DELETE /v1/connectors/{connector_id}/sync
 """
 
 from typing import List, Optional
@@ -444,6 +445,54 @@ async def trigger_sync(connector_id: str):
         raise
     except Exception as exc:
         logger.error(f"Unexpected error triggering sync for {connector_id}: {exc}", exc_info=True)
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+
+
+# ---------------------------------------------------------------------------
+# DELETE /v1/connectors/{connector_id}/sync
+# ---------------------------------------------------------------------------
+
+@router.delete(
+    "/{connector_id}/sync",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        404: http_error_responses[404],
+        409: http_error_responses[409],
+        500: http_error_responses[500],
+    },
+    summary="Stop a running sync",
+    description=(
+        "Signals the active sync tick to stop at its next cancellation checkpoint. "
+        "Returns 204 immediately; the tick exits asynchronously and the sync log "
+        "is marked 'cancelled'. The connector remains and resumes its normal "
+        "schedule on the next interval. "
+        "Returns 409 if no sync is currently running."
+    ),
+    response_description="Stop signal sent",
+)
+async def cancel_sync(connector_id: str):
+    try:
+        connector = db_ops.get_active_connector(connector_id)
+        if connector is None:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                f"Connector {connector_id!r} not found",
+            )
+
+        signalled = db_ops.mark_sync_cancel_pending(connector_id)
+        if not signalled:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_LOCKED,
+                "No sync is currently running for this connector.",
+            )
+
+        logger.info(f"Cancel-sync signal sent for connector {connector_id!r}")
+        return Response(status_code=204)
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Unexpected error cancelling sync for {connector_id}: {exc}", exc_info=True)
         APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
 
 

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -14,6 +14,7 @@ Endpoints:
   DELETE /v1/connectors/{connector_id}/sync
 """
 
+import asyncio
 from typing import List, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Response, status
@@ -199,27 +200,28 @@ async def update_connector(connector_id: str, body: ConnectorUpdateRequest):
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
         404: http_error_responses[404],
-        409: http_error_responses[409],
         500: http_error_responses[500],
     },
     summary="Detach and delete a connector",
     description=(
-        "Removes a connector and all its associated state. "
-        "Rejected with 409 if a sync tick is currently in progress. "
-        "Documents owned exclusively by this connector are deleted. "
-        "Staging directories are cleaned up best-effort."
+        "Non-blocking detachment. Always returns 204 immediately. "
+        "If a sync tick is running the connector is marked delete_pending and "
+        "the tick handles teardown; otherwise teardown runs as a background task."
     ),
-    response_description="No content on successful deletion",
+    response_description="No content — teardown proceeds in the background",
 )
 async def delete_connector(connector_id: str):
     """
-    DELETE stub for PR3 (no worker yet):
-    1. Check connector exists → 404 if not
-    2. Guard: check if sync is in progress (sync_status == 'syncing') → 409
-    3. Snapshot checksums owned by this connector
-    4. Remove ownership rows and delete documents when last owner
-    5. Delete the connector row
-    6. Best-effort staging dir cleanup
+    Fast, non-blocking DELETE:
+
+    Case A — sync_status == 'syncing':
+        Mark DELETE_PENDING. The running tick will hit _check_delete_pending at
+        its next checkpoint, cancel itself, and dispatch teardown.
+        Return 204 immediately.
+
+    Case B — sync_status != 'syncing':
+        Mark DELETE_PENDING, dispatch asyncio.create_task(_run_teardown(...)),
+        return 204 immediately.
     """
     try:
         connector = db_ops.get_active_connector(connector_id)
@@ -229,18 +231,35 @@ async def delete_connector(connector_id: str):
                 f"Connector {connector_id!r} not found",
             )
 
-        # Guard: reject if a tick is currently running
-        if connector.sync_status == SyncStatus.SYNCING:
-            APIError.raise_error(
-                ErrorCode.RESOURCE_LOCKED,
-                "A sync tick is currently running for this connector. "
-                "Retry after the tick completes.",
-            )
+        db_ops.mark_sync_delete_pending(connector_id)
 
-        # Snapshot checksums owned by this connector
+        if connector.sync_status != SyncStatus.SYNCING:
+            # No tick running — kick off teardown ourselves.
+            asyncio.create_task(_run_teardown(connector_id))
+
+        return Response(status_code=204)
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Unexpected error deleting connector {connector_id}: {exc}", exc_info=True)
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+
+
+async def _run_teardown(connector_id: str) -> None:
+    """
+    Background teardown task for connector deletion (Case B: no tick running).
+
+    Steps mirror the spec teardown flow:
+      C. Snapshot checksums owned by this connector
+      D. Remove ownership rows; delete documents when last owner
+      E. Delete the connector row (cascades to sync_logs)
+      F. Sweep residual batch staging directories
+    """
+    logger.info(f"Starting teardown for connector {connector_id!r}")
+    try:
+        # Step C+D: remove checksum ownership; delete orphaned documents
         owned_checksums = db_ops.list_connector_checksums(connector_id)
-
-        # Remove ownership rows; delete documents when last owner
         for checksum in owned_checksums:
             try:
                 remaining, doc_id = db_ops.remove_connector_checksum_entry(connector_id, checksum)
@@ -253,7 +272,7 @@ async def delete_connector(connector_id: str):
                     exc_info=True,
                 )
 
-        # Delete the connector row (cascades to connector_sync_logs)
+        # Step E: delete the connector row (cascades to connector_sync_logs)
         deleted = db_ops.delete_active_connector(connector_id)
         if not deleted:
             logger.warning(
@@ -261,20 +280,15 @@ async def delete_connector(connector_id: str):
                 "— row may have already been removed"
             )
 
-        # Best-effort sweep of any residual batch staging directories.
-        # Normal teardown: per-batch dirs are already gone (cleaned up in
-        # _process_new_files finally blocks). This glob catches anything left
-        # behind by a mid-tick crash: staging/connectors/<connector_id>-*
+        # Step F: sweep any residual batch staging directories
         _sweep_connector_staging(connector_id, settings.digitize.staging_dir / "connectors")
 
-        logger.info(f"Connector {connector_id!r} detached and deleted")
-        return Response(status_code=204)
-
-    except HTTPException:
-        raise
+        logger.info(f"Connector {connector_id!r} teardown complete")
     except Exception as exc:
-        logger.error(f"Unexpected error deleting connector {connector_id}: {exc}", exc_info=True)
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+        logger.error(
+            f"Unexpected error during teardown for connector {connector_id!r}: {exc}",
+            exc_info=True,
+        )
 
 
 def _best_effort_delete_document(doc_id: str) -> None:

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -465,6 +465,93 @@ async def get_connector(connector_id: str):
 # POST /v1/connectors/{connector_id}/syncs
 # ---------------------------------------------------------------------------
 
+
+class SyncNotFound(Exception):
+    """Raised by dispatch_sync when the connector does not exist."""
+
+
+class SyncLocked(Exception):
+    """Raised by dispatch_sync when the connector cannot accept a new sync
+    (DELETE_PENDING or a cancellation already in progress)."""
+
+
+async def dispatch_sync(connector_id: str) -> int:
+    """Dispatch a sync tick for *connector_id* and return the active sync_seq.
+
+    This is the shared core used by both the HTTP handler (``trigger_sync``)
+    and the APScheduler job (``_run_tick_wrapped``).  It contains no FastAPI or
+    HTTP concerns — callers map the exceptions it raises to their own error
+    handling:
+
+    Raises
+    ------
+    SyncNotFound
+        The connector does not exist.
+    SyncLocked
+        The connector is pending deletion, or a cancellation is already in
+        progress and a new sync cannot be accepted yet.
+    RuntimeError
+        The sync lock is held but no active sync-log row exists (should not
+        happen under normal operation).
+
+    Returns
+    -------
+    int
+        The ``sync_seq`` of the active sync — either the newly dispatched one
+        or the already-running one (idempotent: safe to call when a tick is
+        already in progress).
+
+    APScheduler usage
+    -----------------
+    The scheduler can call this directly without any HTTP machinery::
+
+        from digitize.api.v1.connectors import dispatch_sync, SyncNotFound, SyncLocked
+
+        async def _run_tick_wrapped(connector_id: str) -> None:
+            try:
+                await dispatch_sync(connector_id)
+            except SyncNotFound:
+                logger.warning(f"Connector {connector_id!r} not found; skipping")
+            except SyncLocked as exc:
+                logger.info(f"Connector {connector_id!r} skipped: {exc}")
+    """
+    from digitize.connectors.sync_tick import run_tick
+
+    connector = db_ops.get_active_connector(connector_id)
+    if connector is None:
+        raise SyncNotFound(f"Connector {connector_id!r} not found")
+    if connector.sync_status == ConnectorStatus.DELETE_PENDING:
+        raise SyncLocked(
+            f"Connector {connector_id!r} is pending deletion and cannot accept new syncs."
+        )
+
+    active_seq = db_ops.get_active_sync_seq(connector_id)
+    if active_seq is not None:
+        sync_log_status = db_ops.get_sync_log_status(connector_id, active_seq)
+        if sync_log_status == SyncLogStatus.CANCEL_PENDING:
+            raise SyncLocked(
+                f"Connector {connector_id!r} has a sync cancellation in progress "
+                f"(seq={active_seq}) and cannot accept a new sync until it completes."
+            )
+
+    acquired = db_ops.try_acquire_sync_lock(connector_id)
+    if acquired:
+        # Open the sync-log row synchronously before dispatching the background
+        # task so the seq is known immediately — no polling required.
+        sync_seq = db_ops.init_sync_log_and_update_connector(connector_id)
+        asyncio.create_task(run_tick(connector_id, sync_seq))
+        logger.info(f"Sync dispatched for connector {connector_id!r}, seq={sync_seq}")
+    else:
+        sync_seq = db_ops.get_active_sync_seq(connector_id)
+        if sync_seq is None:
+            raise RuntimeError(
+                f"Sync lock held but no active sync-log row found for connector {connector_id!r}"
+            )
+        logger.info(f"Sync already in progress for connector {connector_id!r}, seq={sync_seq}")
+
+    return sync_seq
+
+
 @router.post(
     "/{connector_id}/syncs",
     status_code=status.HTTP_202_ACCEPTED,
@@ -486,49 +573,13 @@ async def get_connector(connector_id: str):
     response_description="Sync dispatched (or already in progress)",
 )
 async def trigger_sync(connector_id: str):
-    import asyncio
-    from digitize.connectors.sync_tick import run_tick
-
     try:
-        connector = db_ops.get_active_connector(connector_id)
-        if connector is None:
-            APIError.raise_error(
-                ErrorCode.RESOURCE_NOT_FOUND,
-                f"Connector {connector_id!r} not found",
-            )
-        if connector.sync_status == ConnectorStatus.DELETE_PENDING:
-            APIError.raise_error(
-                ErrorCode.RESOURCE_LOCKED,
-                f"Connector {connector_id!r} is pending deletion and cannot accept new syncs.",
-            )
-
-        active_seq = db_ops.get_active_sync_seq(connector_id)
-        if active_seq is not None:
-            sync_log_status = db_ops.get_sync_log_status(connector_id, active_seq)
-            if sync_log_status == SyncLogStatus.CANCEL_PENDING:
-                APIError.raise_error(
-                    ErrorCode.RESOURCE_LOCKED,
-                    f"Connector {connector_id!r} has a sync cancellation in progress (seq={active_seq}) "
-                    "and cannot accept a new sync until it completes.",
-                )
-
-        acquired = db_ops.try_acquire_sync_lock(connector_id)
-        if acquired:
-            # Open the sync-log row here, before dispatching the background task,
-            # so the seq is known synchronously.  run_tick() receives it directly
-            sync_seq = db_ops.init_sync_log_and_update_connector(connector_id)
-            asyncio.create_task(run_tick(connector_id, sync_seq))
-            logger.info(f"Manual sync dispatched for connector {connector_id!r}, seq={sync_seq}")
-        else:
-            sync_seq = db_ops.get_active_sync_seq(connector_id)
-            if sync_seq is None:
-                raise RuntimeError(
-                    f"Sync lock held but no active sync-log row found for connector {connector_id!r}"
-                )
-            logger.info(f"Sync already in progress for connector {connector_id!r}, seq={sync_seq}")
-
+        sync_seq = await dispatch_sync(connector_id)
         return SyncTriggerResponse(sync_seq=sync_seq)
-
+    except SyncNotFound as exc:
+        APIError.raise_error(ErrorCode.RESOURCE_NOT_FOUND, str(exc))
+    except SyncLocked as exc:
+        APIError.raise_error(ErrorCode.RESOURCE_LOCKED, str(exc))
     except HTTPException:
         raise
     except Exception as exc:

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -10,6 +10,7 @@ Endpoints:
   GET    /v1/connectors
   GET    /v1/connectors/{connector_id}
   GET    /v1/connectors/{connector_id}/syncs
+  POST   /v1/connectors/{connector_id}/sync
 """
 
 from typing import List, Optional
@@ -396,6 +397,53 @@ async def get_connector(connector_id: str):
         raise
     except Exception as exc:
         logger.error(f"Unexpected error fetching connector {connector_id}: {exc}", exc_info=True)
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/connectors/{connector_id}/sync
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "/{connector_id}/sync",
+    status_code=status.HTTP_202_ACCEPTED,
+    responses={
+        404: http_error_responses[404],
+        500: http_error_responses[500],
+    },
+    summary="Trigger an immediate manual sync",
+    description=(
+        "Dispatches a sync tick for the connector immediately. "
+        "Safe and idempotent: if a tick is already running the request is "
+        "accepted without starting a duplicate (no-op 202). "
+        "The tick runs asynchronously; this endpoint returns as soon as the "
+        "task has been dispatched."
+    ),
+    response_description="Sync dispatched (or already in progress)",
+)
+async def trigger_sync(connector_id: str):
+    import asyncio
+    from digitize.connectors.sync_tick import run_tick
+
+    try:
+        connector = db_ops.get_active_connector(connector_id)
+        if connector is None:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                f"Connector {connector_id!r} not found",
+            )
+
+        acquired = db_ops.try_acquire_sync_lock(connector_id)
+        if acquired:
+            asyncio.create_task(run_tick(connector_id))
+            logger.info(f"Manual sync dispatched for connector {connector_id!r}")
+        
+        return Response(status_code=202)
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Unexpected error triggering sync for {connector_id}: {exc}", exc_info=True)
         APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
 
 

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -265,8 +265,8 @@ async def _run_teardown(connector_id: str) -> None:
     Steps:
       1. Snapshot checksums owned by this connector
       2. Remove ownership rows; delete documents when last owner
-      3. Delete the connector row (cascades to sync_logs)
-      4. Sweep residual batch staging directories
+      3. Sweep residual batch staging directories
+      4. Delete the connector row (cascades to connector_sync_logs)
     """
     logger.info(f"Starting teardown for connector {connector_id!r}")
     deletion_failed = False
@@ -287,24 +287,22 @@ async def _run_teardown(connector_id: str) -> None:
                     exc_info=True,
                 )
 
+        # Step 3: sweep any residual batch staging directories
+        if not _sweep_staging_dir(connector_id, settings.digitize.staging_dir / "connectors"):
+            deletion_failed = True
+
         if deletion_failed:
-            db_ops.set_connector_error(connector_id, "Documents deletion failed")
-            logger.warning(
-                f"Skipping connector row deletion for {connector_id!r} "
-                "due to document deletion failures"
-            )
+            db_ops.set_connector_error(connector_id, "Teardown failed — skipping connector row deletion")
+            logger.warning(f"Skipping connector row deletion for {connector_id!r} due to teardown failures")
             return
 
-        # Step 3: delete the connector row (cascades to connector_sync_logs)
+        # Step 4: delete the connector row (cascades to connector_sync_logs)
         deleted = db_ops.delete_active_connector(connector_id)
         if not deleted:
             logger.warning(
                 f"delete_active_connector returned False for {connector_id!r} "
                 "— row may have already been removed"
             )
-
-        # Step 4: sweep any residual batch staging directories
-        _sweep_staging_dir(connector_id, settings.digitize.staging_dir / "connectors")
 
         logger.info(f"Connector {connector_id!r} teardown complete")
     except Exception as exc:
@@ -342,7 +340,7 @@ def _sweep_staging_dir(
     connector_id: str,
     staging_connectors_dir,
     sync_seq: int | None = None,
-) -> None:
+) -> bool:
     """
     Remove any residual batch staging directories for *connector_id*.
 
@@ -352,17 +350,27 @@ def _sweep_staging_dir(
 
     When *sync_seq* is given the sweep is narrowed to dirs matching
     ``<connector_id>-<sync_seq>-*`` (i.e. only the batches of that sync).
+
+    Returns True on success, False if an error occurred.
     """
     from pathlib import Path
 
     base = Path(staging_connectors_dir)
     if not base.exists():
-        return
+        return True
     prefix = f"{connector_id}-{sync_seq}-" if sync_seq is not None else f"{connector_id}-"
-    for entry in base.iterdir():
-        if entry.is_dir() and entry.name.startswith(prefix):
-            cleanup_staging_directory(entry.name, base, ignore_errors=True)
-            logger.debug(f"Swept residual staging dir {entry.name!r} for connector {connector_id!r}")
+    try:
+        for entry in base.iterdir():
+            if entry.is_dir() and entry.name.startswith(prefix):
+                cleanup_staging_directory(entry.name, base, ignore_errors=True)
+                logger.debug(f"Swept residual staging dir {entry.name!r} for connector {connector_id!r}")
+        return True
+    except Exception as exc:
+        logger.error(
+            f"Error sweeping staging dir for connector {connector_id!r}: {exc}",
+            exc_info=True,
+        )
+        return False
 
 
 # ---------------------------------------------------------------------------

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -33,6 +33,7 @@ from digitize.connectors.models import (
     SyncLogItem,
     SyncLogResponse,
     ConnectorStatus,
+    SyncLogStatus,
     SyncTriggerResponse,
 )
 from digitize.connectors.encryption import (
@@ -495,6 +496,21 @@ async def trigger_sync(connector_id: str):
                 ErrorCode.RESOURCE_NOT_FOUND,
                 f"Connector {connector_id!r} not found",
             )
+        if connector.sync_status == ConnectorStatus.DELETE_PENDING:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_LOCKED,
+                f"Connector {connector_id!r} is pending deletion and cannot accept new syncs.",
+            )
+
+        active_seq = db_ops.get_active_sync_seq(connector_id)
+        if active_seq is not None:
+            sync_log_status = db_ops.get_sync_log_status(connector_id, active_seq)
+            if sync_log_status == SyncLogStatus.CANCEL_PENDING:
+                APIError.raise_error(
+                    ErrorCode.RESOURCE_LOCKED,
+                    f"Connector {connector_id!r} has a sync cancellation in progress (seq={active_seq}) "
+                    "and cannot accept a new sync until it completes.",
+                )
 
         acquired = db_ops.try_acquire_sync_lock(connector_id)
         if acquired:

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -16,6 +16,7 @@ Endpoints:
 """
 
 import asyncio
+import uuid
 from typing import List, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Response, status
@@ -78,6 +79,7 @@ def _get_key_path() -> str:
     response_description="Connector created; worker start scheduled",
 )
 async def create_connector(body: ConnectorCreateRequest):
+    connector_id = body.connector_id or str(uuid.uuid4())
     try:
         key_path = _get_key_path()
         encrypted_details = encrypt_secrets(body.type, body.connection_details, key_path)
@@ -85,7 +87,7 @@ async def create_connector(body: ConnectorCreateRequest):
         sync_interval = settings.digitize.connector.sync_interval_seconds
 
         db_ops.insert_connector(
-            connector_id=body.connector_id,
+            connector_id=connector_id,
             name=body.connector_name,
             connector_type=body.type,
             connection_details=encrypted_details,
@@ -94,18 +96,22 @@ async def create_connector(body: ConnectorCreateRequest):
         )
 
         logger.info(
-            f"Connector {body.connector_id!r} ({body.connector_name!r}) attached "
+            f"Connector {connector_id!r} ({body.connector_name!r}) attached "
             f"(type={body.type}, interval={sync_interval}s)"
         )
         # Worker start is a no-op stub in PR3 — the worker manager (PR7) will hook
         # in here once implemented.
-        return Response(status_code=201)
+        return Response(
+            content=f'{{"connector_id": "{connector_id}"}}',
+            status_code=201,
+            media_type="application/json",
+        )
 
     except IntegrityError:
         # id or name already exists
         APIError.raise_error(
             ErrorCode.RESOURCE_LOCKED,
-            f"Connector {body.connector_id!r} or name {body.connector_name!r} already exists",
+            f"Connector {connector_id!r} or name {body.connector_name!r} already exists",
         )
     except RuntimeError as exc:
         # encryption key not found

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -514,16 +514,11 @@ async def trigger_sync(connector_id: str):
 
         acquired = db_ops.try_acquire_sync_lock(connector_id)
         if acquired:
-            asyncio.create_task(run_tick(connector_id))
-            logger.info(f"Manual sync dispatched for connector {connector_id!r}")
-            # init_sync_log_and_update_connector hasn't been called yet (that happens inside run_tick),
-            # so fetch the seq of the row that the background task will open shortly.
-            # Since we hold the lock we query for the highest existing seq + 1 via
-            # the active row that run_tick will create. Instead, we read it after a
-            # brief yield so the task can open the log first.
-            # Simpler and race-free: init_sync_log_and_update_connector is the very first thing
-            # run_tick does — schedule a wait-for-seq helper.
-            sync_seq = await _wait_for_sync_seq(connector_id)
+            # Open the sync-log row here, before dispatching the background task,
+            # so the seq is known synchronously.  run_tick() receives it directly
+            sync_seq = db_ops.init_sync_log_and_update_connector(connector_id)
+            asyncio.create_task(run_tick(connector_id, sync_seq))
+            logger.info(f"Manual sync dispatched for connector {connector_id!r}, seq={sync_seq}")
         else:
             sync_seq = db_ops.get_active_sync_seq(connector_id)
             if sync_seq is None:
@@ -539,21 +534,6 @@ async def trigger_sync(connector_id: str):
     except Exception as exc:
         logger.error(f"Unexpected error triggering sync for {connector_id}: {exc}", exc_info=True)
         APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
-
-
-async def _wait_for_sync_seq(connector_id: str, attempts: int = 10, interval: float = 0.1) -> int:
-    """Poll until run_tick's init_sync_log_and_update_connector creates the active sync-log row.
-
-    Returns the seq as soon as it appears, or raises RuntimeError if it never does.
-    """
-    for _ in range(attempts):
-        await asyncio.sleep(interval)
-        seq = db_ops.get_active_sync_seq(connector_id)
-        if seq is not None:
-            return seq
-    raise RuntimeError(
-        f"Timed out waiting for sync-log row to appear for connector {connector_id!r}"
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -269,6 +269,7 @@ async def _run_teardown(connector_id: str) -> None:
       4. Sweep residual batch staging directories
     """
     logger.info(f"Starting teardown for connector {connector_id!r}")
+    deletion_failed = False
     try:
         # Steps 1+2: remove checksum ownership; delete orphaned documents
         owned_checksums = db_ops.list_connector_checksums(connector_id)
@@ -276,13 +277,23 @@ async def _run_teardown(connector_id: str) -> None:
             try:
                 remaining, doc_id = db_ops.remove_connector_checksum_entry(connector_id, checksum)
                 if remaining == 0 and doc_id:
-                    _best_effort_delete_document(doc_id)
+                    if not _best_effort_delete_document(doc_id):
+                        deletion_failed = True
             except Exception as exc:
+                deletion_failed = True
                 logger.error(
                     f"Error removing checksum {checksum!r} for connector "
                     f"{connector_id!r}: {exc}",
                     exc_info=True,
                 )
+
+        if deletion_failed:
+            db_ops.set_connector_error(connector_id, "Documents deletion failed")
+            logger.warning(
+                f"Skipping connector row deletion for {connector_id!r} "
+                "due to document deletion failures"
+            )
+            return
 
         # Step 3: delete the connector row (cascades to connector_sync_logs)
         deleted = db_ops.delete_active_connector(connector_id)
@@ -301,25 +312,30 @@ async def _run_teardown(connector_id: str) -> None:
             f"Unexpected error during teardown for connector {connector_id!r}: {exc}",
             exc_info=True,
         )
+        db_ops.set_connector_error(connector_id, "Documents deletion failed")
 
 
-def _best_effort_delete_document(doc_id: str) -> None:
+def _best_effort_delete_document(doc_id: str) -> bool:
     """
     Delete a document via the full teardown path (VDB → files → DB record).
 
     Calls delete_document_data() so that indexed chunks and output files are
     cleaned up — not just the DB row.
     All failures are logged and swallowed (best-effort semantics).
+
+    Returns True on success, False if an error occurred.
     """
     try:
         from digitize.api.v1.documents import delete_document_data
         delete_document_data(doc_id)
         logger.debug(f"Deleted document {doc_id!r} (connector cleanup)")
+        return True
     except Exception as exc:
         logger.error(
             f"Best-effort document deletion failed for {doc_id!r}: {exc}",
             exc_info=True,
         )
+        return False
 
 
 def _sweep_staging_dir(

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -240,7 +240,7 @@ async def delete_connector(connector_id: str):
                 f"Connector {connector_id!r} not found",
             )
 
-        db_ops.mark_sync_delete_pending(connector_id)
+        db_ops.mark_connector_delete_pending(connector_id)
 
         if connector.sync_status != ConnectorStatus.SYNCING:
             # No tick running — kick off teardown ourselves.

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -255,14 +255,35 @@ async def _run_teardown(connector_id: str) -> None:
     and awaited directly from _handle_interrupt in sync_tick (Case A).
 
     Steps:
-      C. Snapshot checksums owned by this connector
-      D. Remove ownership rows; delete documents when last owner
-      E. Delete the connector row (cascades to sync_logs)
-      F. Sweep residual batch staging directories
+      1. Guard: ensure the latest sync-log is in a terminal state; if it is
+         stuck in 'started' mark it 'cancelled' before proceeding.
+      2. Snapshot checksums owned by this connector
+      3. Remove ownership rows; delete documents when last owner
+      4. Delete the connector row (cascades to sync_logs)
+      5. Sweep residual batch staging directories
     """
     logger.info(f"Starting teardown for connector {connector_id!r}")
     try:
-        # Step C+D: remove checksum ownership; delete orphaned documents
+        # Step 1: guard — verify the latest sync-log is terminal before
+        # proceeding.  If it is still 'started' (stuck), cancel it now.
+        _TERMINAL_STATUSES = {SyncStatus.CANCELLED, SyncStatus.FAILED, SyncStatus.COMPLETED}
+        logs, _ = db_ops.list_sync_logs(connector_id, limit=1)
+        if logs:
+            latest_log = logs[0]
+            if latest_log.status not in _TERMINAL_STATUSES:
+                logger.warning(
+                    f"Connector {connector_id!r} latest sync-log (seq={latest_log.seq}) "
+                    f"has non-terminal status {latest_log.status!r}; "
+                    "marking it cancelled before teardown"
+                )
+                db_ops.close_sync_log(
+                    connector_id=connector_id,
+                    seq=latest_log.seq,
+                    status=SyncStatus.CANCELLED,
+                    error="Cancelled by connector deletion",
+                )
+
+        # Steps 2+3: remove checksum ownership; delete orphaned documents
         owned_checksums = db_ops.list_connector_checksums(connector_id)
         for checksum in owned_checksums:
             try:
@@ -276,7 +297,7 @@ async def _run_teardown(connector_id: str) -> None:
                     exc_info=True,
                 )
 
-        # Step E: delete the connector row (cascades to connector_sync_logs)
+        # Step 4: delete the connector row (cascades to connector_sync_logs)
         deleted = db_ops.delete_active_connector(connector_id)
         if not deleted:
             logger.warning(
@@ -284,7 +305,7 @@ async def _run_teardown(connector_id: str) -> None:
                 "— row may have already been removed"
             )
 
-        # Step F: sweep any residual batch staging directories
+        # Step 5: sweep any residual batch staging directories
         _sweep_staging_dir(connector_id, settings.digitize.staging_dir / "connectors")
 
         logger.info(f"Connector {connector_id!r} teardown complete")

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -10,8 +10,8 @@ Endpoints:
   GET    /v1/connectors
   GET    /v1/connectors/{connector_id}
   GET    /v1/connectors/{connector_id}/syncs
-  POST   /v1/connectors/{connector_id}/sync
-  DELETE /v1/connectors/{connector_id}/sync
+  POST   /v1/connectors/{connector_id}/syncs
+  DELETE /v1/connectors/{connector_id}/syncs
 """
 
 import asyncio
@@ -424,11 +424,11 @@ async def get_connector(connector_id: str):
 
 
 # ---------------------------------------------------------------------------
-# POST /v1/connectors/{connector_id}/sync
+# POST /v1/connectors/{connector_id}/syncs
 # ---------------------------------------------------------------------------
 
 @router.post(
-    "/{connector_id}/sync",
+    "/{connector_id}/syncs",
     status_code=status.HTTP_202_ACCEPTED,
     response_model=SyncTriggerResponse,
     responses={
@@ -504,11 +504,11 @@ async def _wait_for_sync_seq(connector_id: str, attempts: int = 10, interval: fl
 
 
 # ---------------------------------------------------------------------------
-# DELETE /v1/connectors/{connector_id}/sync
+# DELETE /v1/connectors/{connector_id}/syncs
 # ---------------------------------------------------------------------------
 
 @router.delete(
-    "/{connector_id}/sync",
+    "/{connector_id}/syncs",
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
         404: http_error_responses[404],

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -285,7 +285,7 @@ async def _run_teardown(connector_id: str) -> None:
                     f"has non-terminal status {latest_log.status!r}; "
                     "marking it cancelled before teardown"
                 )
-                db_ops.close_sync_log(
+                db_ops.finalize_sync_log_and_update_connector(
                     connector_id=connector_id,
                     seq=latest_log.seq,
                     status=SyncLogStatus.CANCELLED,
@@ -496,12 +496,12 @@ async def trigger_sync(connector_id: str):
         if acquired:
             asyncio.create_task(run_tick(connector_id))
             logger.info(f"Manual sync dispatched for connector {connector_id!r}")
-            # open_new_sync_log hasn't been called yet (that happens inside run_tick),
+            # init_sync_log_and_set_syncing hasn't been called yet (that happens inside run_tick),
             # so fetch the seq of the row that the background task will open shortly.
             # Since we hold the lock we query for the highest existing seq + 1 via
             # the active row that run_tick will create. Instead, we read it after a
             # brief yield so the task can open the log first.
-            # Simpler and race-free: open_new_sync_log is the very first thing
+            # Simpler and race-free: init_sync_log_and_set_syncing is the very first thing
             # run_tick does — schedule a wait-for-seq helper.
             sync_seq = await _wait_for_sync_seq(connector_id)
         else:
@@ -522,7 +522,7 @@ async def trigger_sync(connector_id: str):
 
 
 async def _wait_for_sync_seq(connector_id: str, attempts: int = 10, interval: float = 0.1) -> int:
-    """Poll until run_tick's open_new_sync_log creates the active sync-log row.
+    """Poll until run_tick's init_sync_log_and_set_syncing creates the active sync-log row.
 
     Returns the seq as soon as it appears, or raises RuntimeError if it never does.
     """

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -33,7 +33,6 @@ from digitize.connectors.models import (
     SyncLogItem,
     SyncLogResponse,
     ConnectorStatus,
-    SyncLogStatus,
     SyncTriggerResponse,
 )
 from digitize.connectors.encryption import (
@@ -264,35 +263,14 @@ async def _run_teardown(connector_id: str) -> None:
     and awaited directly from _handle_interrupt in sync_tick (Case A).
 
     Steps:
-      1. Guard: ensure the latest sync-log is in a terminal state; if it is
-         stuck in 'started' mark it 'cancelled' before proceeding.
-      2. Snapshot checksums owned by this connector
-      3. Remove ownership rows; delete documents when last owner
-      4. Delete the connector row (cascades to sync_logs)
-      5. Sweep residual batch staging directories
+      1. Snapshot checksums owned by this connector
+      2. Remove ownership rows; delete documents when last owner
+      3. Delete the connector row (cascades to sync_logs)
+      4. Sweep residual batch staging directories
     """
     logger.info(f"Starting teardown for connector {connector_id!r}")
     try:
-        # Step 1: guard — verify the latest sync-log is terminal before
-        # proceeding.  If it is still 'started' (stuck), cancel it now.
-        _TERMINAL_STATUSES = {SyncLogStatus.CANCELLED, SyncLogStatus.FAILED, SyncLogStatus.COMPLETED}
-        logs, _ = db_ops.list_sync_logs(connector_id, limit=1)
-        if logs:
-            latest_log = logs[0]
-            if latest_log.status not in _TERMINAL_STATUSES:
-                logger.warning(
-                    f"Connector {connector_id!r} latest sync-log (seq={latest_log.seq}) "
-                    f"has non-terminal status {latest_log.status!r}; "
-                    "marking it cancelled before teardown"
-                )
-                db_ops.finalize_sync_log_and_update_connector(
-                    connector_id=connector_id,
-                    seq=latest_log.seq,
-                    status=SyncLogStatus.CANCELLED,
-                    error="Cancelled by connector deletion",
-                )
-
-        # Steps 2+3: remove checksum ownership; delete orphaned documents
+        # Steps 1+2: remove checksum ownership; delete orphaned documents
         owned_checksums = db_ops.list_connector_checksums(connector_id)
         for checksum in owned_checksums:
             try:
@@ -306,7 +284,7 @@ async def _run_teardown(connector_id: str) -> None:
                     exc_info=True,
                 )
 
-        # Step 4: delete the connector row (cascades to connector_sync_logs)
+        # Step 3: delete the connector row (cascades to connector_sync_logs)
         deleted = db_ops.delete_active_connector(connector_id)
         if not deleted:
             logger.warning(
@@ -314,7 +292,7 @@ async def _run_teardown(connector_id: str) -> None:
                 "— row may have already been removed"
             )
 
-        # Step 5: sweep any residual batch staging directories
+        # Step 4: sweep any residual batch staging directories
         _sweep_staging_dir(connector_id, settings.digitize.staging_dir / "connectors")
 
         logger.info(f"Connector {connector_id!r} teardown complete")

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -474,12 +474,12 @@ async def trigger_sync(connector_id: str):
         if acquired:
             asyncio.create_task(run_tick(connector_id))
             logger.info(f"Manual sync dispatched for connector {connector_id!r}")
-            # init_sync_log_and_set_syncing hasn't been called yet (that happens inside run_tick),
+            # init_sync_log_and_update_connector hasn't been called yet (that happens inside run_tick),
             # so fetch the seq of the row that the background task will open shortly.
             # Since we hold the lock we query for the highest existing seq + 1 via
             # the active row that run_tick will create. Instead, we read it after a
             # brief yield so the task can open the log first.
-            # Simpler and race-free: init_sync_log_and_set_syncing is the very first thing
+            # Simpler and race-free: init_sync_log_and_update_connector is the very first thing
             # run_tick does — schedule a wait-for-seq helper.
             sync_seq = await _wait_for_sync_seq(connector_id)
         else:
@@ -500,7 +500,7 @@ async def trigger_sync(connector_id: str):
 
 
 async def _wait_for_sync_seq(connector_id: str, attempts: int = 10, interval: float = 0.1) -> int:
-    """Poll until run_tick's init_sync_log_and_set_syncing creates the active sync-log row.
+    """Poll until run_tick's init_sync_log_and_update_connector creates the active sync-log row.
 
     Returns the seq as soon as it appears, or raises RuntimeError if it never does.
     """

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -534,7 +534,6 @@ async def get_sync_history(
                 total_files=log.total_files,
                 new_files=log.new_files,
                 removed_files=log.removed_files,
-                failed_files=log.failed_files,
                 status=log.status,
                 error=log.error or "",
             )

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -281,7 +281,7 @@ async def _run_teardown(connector_id: str) -> None:
             )
 
         # Step F: sweep any residual batch staging directories
-        _sweep_connector_staging(connector_id, settings.digitize.staging_dir / "connectors")
+        _sweep_staging_dir(connector_id, settings.digitize.staging_dir / "connectors")
 
         logger.info(f"Connector {connector_id!r} teardown complete")
     except Exception as exc:
@@ -310,20 +310,27 @@ def _best_effort_delete_document(doc_id: str) -> None:
         )
 
 
-def _sweep_connector_staging(connector_id: str, staging_connectors_dir) -> None:
+def _sweep_staging_dir(
+    connector_id: str,
+    staging_connectors_dir,
+    sync_seq: int | None = None,
+) -> None:
     """
     Remove any residual batch staging directories for *connector_id*.
 
     Per-batch dirs are named ``<connector_id>-<job_id>-<batch_number>`` and are
     cleaned up inline after each ingest.  This sweep only has work to do when a
     worker crashed mid-tick and left a directory behind.
+
+    When *sync_seq* is given the sweep is narrowed to dirs matching
+    ``<connector_id>-<sync_seq>-*`` (i.e. only the batches of that sync).
     """
     from pathlib import Path
 
     base = Path(staging_connectors_dir)
     if not base.exists():
         return
-    prefix = f"{connector_id}-"
+    prefix = f"{connector_id}-{sync_seq}-" if sync_seq is not None else f"{connector_id}-"
     for entry in base.iterdir():
         if entry.is_dir() and entry.name.startswith(prefix):
             cleanup_staging_directory(entry.name, base, ignore_errors=True)

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -249,9 +249,12 @@ async def delete_connector(connector_id: str):
 
 async def _run_teardown(connector_id: str) -> None:
     """
-    Background teardown task for connector deletion (Case B: no tick running).
+    Teardown for connector deletion.
 
-    Steps mirror the spec teardown flow:
+    Scheduled via asyncio.create_task from the delete endpoint (Case B),
+    and awaited directly from _handle_interrupt in sync_tick (Case A).
+
+    Steps:
       C. Snapshot checksums owned by this connector
       D. Remove ownership rows; delete documents when last owner
       E. Delete the connector row (cascades to sync_logs)

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -11,7 +11,7 @@ Endpoints:
   GET    /v1/connectors/{connector_id}
   GET    /v1/connectors/{connector_id}/syncs
   POST   /v1/connectors/{connector_id}/syncs
-  DELETE /v1/connectors/{connector_id}/syncs
+  POST   /v1/connectors/{connector_id}/syncs/{sync_seq}/stop
 """
 
 import asyncio
@@ -504,11 +504,11 @@ async def _wait_for_sync_seq(connector_id: str, attempts: int = 10, interval: fl
 
 
 # ---------------------------------------------------------------------------
-# DELETE /v1/connectors/{connector_id}/syncs
+# POST /v1/connectors/{connector_id}/syncs/{sync_seq}/stop
 # ---------------------------------------------------------------------------
 
-@router.delete(
-    "/{connector_id}/syncs",
+@router.post(
+    "/{connector_id}/syncs/{sync_seq}/stop",
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
         404: http_error_responses[404],
@@ -518,20 +518,29 @@ async def _wait_for_sync_seq(connector_id: str, attempts: int = 10, interval: fl
     summary="Stop a running sync",
     description=(
         "Signals the active sync tick to stop at its next cancellation checkpoint. "
+        "The caller must supply the sync_seq of the sync they intend to cancel. "
+        "Returns 409 if sync_seq does not match the currently-running sync "
+        "(stale seq) or if no sync is running at all. "
         "Returns 204 immediately; the tick exits asynchronously and the sync log "
         "is marked 'cancelled'. The connector remains and resumes its normal "
-        "schedule on the next interval. "
-        "Returns 409 if no sync is currently running."
+        "schedule on the next interval."
     ),
     response_description="Stop signal sent",
 )
-async def cancel_sync(connector_id: str):
+async def cancel_sync(connector_id: str, sync_seq: int):
     try:
         connector = db_ops.get_active_connector(connector_id)
         if connector is None:
             APIError.raise_error(
                 ErrorCode.RESOURCE_NOT_FOUND,
                 f"Connector {connector_id!r} not found",
+            )
+
+        active_seq = db_ops.get_active_sync_seq(connector_id)
+        if active_seq is None or active_seq != sync_seq:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_LOCKED,
+                f"sync_seq {sync_seq} is not the active sync for this connector.",
             )
 
         signalled = db_ops.mark_sync_cancel_pending(connector_id)
@@ -541,7 +550,7 @@ async def cancel_sync(connector_id: str):
                 "No sync is currently running for this connector.",
             )
 
-        logger.info(f"Cancel-sync signal sent for connector {connector_id!r}")
+        logger.info(f"Cancel-sync signal sent for connector {connector_id!r} (seq={sync_seq})")
         return Response(status_code=204)
 
     except HTTPException:

--- a/services/digitize/api/v1/jobs.py
+++ b/services/digitize/api/v1/jobs.py
@@ -12,7 +12,7 @@ import asyncio
 from pathlib import Path
 from typing import List, Optional
 
-from fastapi import APIRouter, BackgroundTasks, File, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, File, HTTPException, Query, UploadFile, status
 
 from common.misc_utils import get_logger, validate_document_file, cleanup_staging_directory, generate_file_checksum
 from common.error_utils import APIError, ErrorCode, http_error_responses
@@ -146,7 +146,6 @@ async def _validate_files(
     response_description="Job accepted. `job_id` can be used to poll status.",
 )
 async def create_job(
-    background_tasks: BackgroundTasks,
     files: List[UploadFile] = File(
         ...,
         description="Document files (PDF or DOCX) to process",
@@ -287,7 +286,7 @@ async def create_job(
         # 6. Acquire semaphore slot.
         await concurrency_manager.acquire(op_key)
 
-        # 7. Stage files and schedule background task.
+        # 7. Stage files and dispatch async task.
         try:
             await dg_util.stage_upload_files(
                 job_id,
@@ -300,15 +299,13 @@ async def create_job(
                 already_exists_files=already_exists_files,
             )
             if operation == models.OperationType.INGESTION:
-                background_tasks.add_task(
-                    _run_ingest, job_id, filenames, doc_id_dict, file_checksum_dict
-                )
+                asyncio.create_task(_run_ingest(job_id, filenames, doc_id_dict, file_checksum_dict))
             else:
-                background_tasks.add_task(_run_digitize, job_id, doc_id_dict, output_format, file_checksum_dict)
+                asyncio.create_task(_run_digitize(job_id, doc_id_dict, output_format, file_checksum_dict))
         except Exception as exc:
             concurrency_manager.release(op_key)
             logger.error(
-                f"Failed to schedule background task for job {job_id}, "
+                f"Failed to dispatch task for job {job_id}, "
                 f"semaphore released: {exc}"
             )
             APIError.raise_error("INTERNAL_SERVER_ERROR", str(exc))

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -127,6 +127,7 @@ class ConnectorListItem(BaseModel):
     last_sync_at: Optional[str]
     sync_status: str
     last_sync_error: Optional[str]
+    error: Optional[str]
     total_files: int
 
 
@@ -142,6 +143,7 @@ class ConnectorDetailResponse(BaseModel):
     last_sync_at: Optional[str]
     sync_status: str
     last_sync_error: Optional[str]
+    error: Optional[str]
     connection_details: Dict[str, Any]
     total_files: int
 

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -25,15 +25,23 @@ class SyncStatus(str, Enum):
     compared with raw DB strings without calling .value.
 
     Connector.sync_status lifecycle:
-        UP_TO_DATE    ──► SYNCING       ──► UP_TO_DATE    (tick completed cleanly)
-                            └──► OUT_OF_SYNC              (tick finished with errors)
-        UP_TO_DATE    ──► DELETE_PENDING                  (DELETE, no active sync)
-        SYNCING       ──► DELETE_PENDING                  (DELETE arrived mid-sync)
+        UP_TO_DATE ──► SYNCING       ──► UP_TO_DATE   (tick completed cleanly)
+                           └──► OUT_OF_SYNC            (tick finished with errors)
+        UP_TO_DATE ──► DELETE_PENDING                  (DELETE, no active sync)
+        SYNCING    ──► DELETE_PENDING                  (DELETE arrived mid-sync)
+        SYNCING    ──► OUT_OF_SYNC                     (cancel honoured; close_sync_log
+                                                        reverts connector after CANCELLED)
 
     ConnectorSyncLog.status lifecycle:
-        STARTED ──► COMPLETED  (all files processed successfully)
-                ├──► FAILED    (fatal tick error or partial failure)
-                └──► CANCELLED (tick was cancelled via DELETE_PENDING)
+        STARTED ──► CANCEL_PENDING ──► CANCELLED  (cancel-sync request received mid-tick;
+                │                                   close_sync_log sets connector OUT_OF_SYNC)
+                ├──► COMPLETED                    (all files processed successfully)
+                ├──► FAILED                       (fatal tick error or partial failure)
+                └──► CANCELLED                    (tick interrupted by DELETE_PENDING)
+
+    Note: CANCEL_PENDING is written to connector_sync_logs.status (not to connectors).
+    The connector stays SYNCING while the tick winds down; close_sync_log() transitions
+    it to OUT_OF_SYNC when it writes the terminal CANCELLED status.
     """
 
     # Connector.sync_status values
@@ -41,10 +49,10 @@ class SyncStatus(str, Enum):
     SYNCING = "syncing"
     OUT_OF_SYNC = "out of sync"
     DELETE_PENDING = "delete pending"
-    CANCEL_PENDING = "cancel pending"
 
     # ConnectorSyncLog.status values
     STARTED = "started"
+    CANCEL_PENDING = "cancel pending"
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELLED = "cancelled"

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -31,7 +31,7 @@ class ConnectorStatus(str, Enum):
                            └──► OUT_OF_SYNC            (tick finished with errors)
         UP_TO_DATE ──► DELETE_PENDING                  (DELETE, no active sync)
         SYNCING    ──► DELETE_PENDING                  (DELETE arrived mid-sync)
-        SYNCING    ──► OUT_OF_SYNC                     (cancel honoured; close_sync_log
+        SYNCING    ──► OUT_OF_SYNC                     (cancel honoured; finalize_sync_log_and_update_connector
                                                         reverts connector after CANCELLED)
     """
 
@@ -49,13 +49,13 @@ class SyncLogStatus(str, Enum):
 
     Lifecycle:
         STARTED ──► CANCEL_PENDING ──► CANCELLED  (cancel-sync request received mid-tick;
-                │                                   close_sync_log sets connector OUT_OF_SYNC)
+                │                                   finalize_sync_log_and_update_connector sets connector OUT_OF_SYNC)
                 ├──► COMPLETED                    (all files processed successfully)
                 ├──► FAILED                       (fatal tick error or partial failure)
                 └──► CANCELLED                    (tick interrupted by DELETE_PENDING)
 
     Note: CANCEL_PENDING is written to connector_sync_logs.status (not to connectors).
-    The connector stays SYNCING while the tick winds down; close_sync_log() transitions
+    The connector stays SYNCING while the tick winds down; finalize_sync_log_and_update_connector() transitions
     it to OUT_OF_SYNC when it writes the terminal CANCELLED status.
     """
 

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -7,6 +7,7 @@ Covers:
   GET  /v1/connectors
   GET  /v1/connectors/{connector_id}
   GET  /v1/connectors/{connector_id}/syncs
+  GET  /v1/connectors/{connector_id}/syncs/{sync_seq}
 """
 
 from enum import Enum
@@ -141,6 +142,19 @@ class SyncLogResponse(BaseModel):
     limit: int
     offset: int
     items: List[SyncLogItem]
+
+
+class SyncLogDetailResponse(BaseModel):
+    """Single sync-log item returned by GET /v1/connectors/{connector_id}/syncs/{sync_seq}."""
+
+    seq: int
+    started_at: str
+    finished_at: Optional[str]
+    total_files: int
+    new_files: int
+    removed_files: int
+    status: str
+    error: str
 
 
 class SyncTriggerResponse(BaseModel):

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -21,23 +21,28 @@ class SyncStatus:
     """String constants for connector sync_status and sync-log status columns.
 
     Connector.sync_status lifecycle:
-        UP_TO_DATE  ──► SYNCING  ──► UP_TO_DATE  (tick completed cleanly)
-                          └──► OUT_OF_SYNC (tick finished with errors)
+        UP_TO_DATE    ──► SYNCING       ──► UP_TO_DATE    (tick completed cleanly)
+                            └──► OUT_OF_SYNC              (tick finished with errors)
+        UP_TO_DATE    ──► DELETE_PENDING                  (DELETE, no active sync)
+        SYNCING       ──► DELETE_PENDING                  (DELETE arrived mid-sync)
 
     ConnectorSyncLog.status lifecycle:
         STARTED ──► COMPLETED  (all files processed successfully)
-                └──► FAILED    (fatal tick error or partial failure)
+                ├──► FAILED    (fatal tick error or partial failure)
+                └──► CANCELLED (tick was cancelled via DELETE_PENDING)
     """
 
     # Connector.sync_status values
     UP_TO_DATE = "up to date"
     SYNCING = "syncing"
     OUT_OF_SYNC = "out of sync"
+    DELETE_PENDING = "delete pending"
 
     # ConnectorSyncLog.status values
     STARTED = "started"
     COMPLETED = "completed"
     FAILED = "failed"
+    CANCELLED = "cancelled"
 
 
 # ---------------------------------------------------------------------------

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -118,7 +118,6 @@ class SyncLogItem(BaseModel):
     total_files: int
     new_files: int
     removed_files: int
-    failed_files: int
     status: str
     error: str
 

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -9,6 +9,7 @@ Covers:
   GET  /v1/connectors/{connector_id}/syncs
 """
 
+from enum import Enum
 from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
@@ -17,8 +18,11 @@ from pydantic import BaseModel, Field
 # Connector / sync-log status constants
 # ---------------------------------------------------------------------------
 
-class SyncStatus:
-    """String constants for connector sync_status and sync-log status columns.
+class SyncStatus(str, Enum):
+    """String enum for connector sync_status and sync-log status columns.
+
+    Inherits from str so values can be passed directly to SQLAlchemy and
+    compared with raw DB strings without calling .value.
 
     Connector.sync_status lifecycle:
         UP_TO_DATE    ──► SYNCING       ──► UP_TO_DATE    (tick completed cleanly)

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -124,7 +124,7 @@ class ConnectorDetailResponse(BaseModel):
 class SyncLogItem(BaseModel):
     """One tick entry in GET /v1/connectors/{connector_id}/syncs."""
 
-    id: int
+    seq: int
     started_at: str
     finished_at: Optional[str]
     total_files: int

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -20,21 +20,34 @@ from pydantic import BaseModel, Field, field_validator
 # Connector / sync-log status constants
 # ---------------------------------------------------------------------------
 
-class SyncStatus(str, Enum):
-    """String enum for connector sync_status and sync-log status columns.
+class ConnectorStatus(str, Enum):
+    """String enum for the Connector.sync_status column.
 
     Inherits from str so values can be passed directly to SQLAlchemy and
     compared with raw DB strings without calling .value.
 
-    Connector.sync_status lifecycle:
+    Lifecycle:
         UP_TO_DATE ──► SYNCING       ──► UP_TO_DATE   (tick completed cleanly)
                            └──► OUT_OF_SYNC            (tick finished with errors)
         UP_TO_DATE ──► DELETE_PENDING                  (DELETE, no active sync)
         SYNCING    ──► DELETE_PENDING                  (DELETE arrived mid-sync)
         SYNCING    ──► OUT_OF_SYNC                     (cancel honoured; close_sync_log
                                                         reverts connector after CANCELLED)
+    """
 
-    ConnectorSyncLog.status lifecycle:
+    UP_TO_DATE = "up to date"
+    SYNCING = "syncing"
+    OUT_OF_SYNC = "out of sync"
+    DELETE_PENDING = "delete pending"
+
+
+class SyncLogStatus(str, Enum):
+    """String enum for the ConnectorSyncLog.status column.
+
+    Inherits from str so values can be passed directly to SQLAlchemy and
+    compared with raw DB strings without calling .value.
+
+    Lifecycle:
         STARTED ──► CANCEL_PENDING ──► CANCELLED  (cancel-sync request received mid-tick;
                 │                                   close_sync_log sets connector OUT_OF_SYNC)
                 ├──► COMPLETED                    (all files processed successfully)
@@ -46,13 +59,6 @@ class SyncStatus(str, Enum):
     it to OUT_OF_SYNC when it writes the terminal CANCELLED status.
     """
 
-    # Connector.sync_status values
-    UP_TO_DATE = "up to date"
-    SYNCING = "syncing"
-    OUT_OF_SYNC = "out of sync"
-    DELETE_PENDING = "delete pending"
-
-    # ConnectorSyncLog.status values
     STARTED = "started"
     CANCEL_PENDING = "cancel pending"
     COMPLETED = "completed"

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -37,6 +37,7 @@ class SyncStatus:
     SYNCING = "syncing"
     OUT_OF_SYNC = "out of sync"
     DELETE_PENDING = "delete pending"
+    CANCEL_PENDING = "cancel pending"
 
     # ConnectorSyncLog.status values
     STARTED = "started"

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -10,9 +10,10 @@ Covers:
   GET  /v1/connectors/{connector_id}/syncs/{sync_seq}
 """
 
+import uuid
 from enum import Enum
 from typing import Any, Dict, List, Optional
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 # ---------------------------------------------------------------------------
@@ -66,11 +67,28 @@ class SyncStatus(str, Enum):
 class ConnectorCreateRequest(BaseModel):
     """Body accepted by POST /v1/connectors."""
 
-    connector_id: str = Field(..., description="Stable catalog UUID for this connector")
+    connector_id: Optional[str] = Field(
+        None,
+        description=(
+            "Stable catalog UUID for this connector. "
+            "If omitted, a UUID v4 is generated automatically."
+        ),
+    )
     connector_name: str = Field(..., description="Human-readable unique name, e.g. 'prod-sftp-reports'")
     type: str = Field(..., description="Connector transport type: 'ssh' or 's3'")
     allowed_extensions: List[str] = Field(..., description="File extensions to accept, e.g. ['.pdf', '.docx']")
     connection_details: Dict[str, Any] = Field(..., description="Transport-specific connection parameters")
+
+    @field_validator("connector_id", mode="before")
+    @classmethod
+    def validate_connector_id(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        try:
+            uuid.UUID(str(v))
+        except ValueError:
+            raise ValueError(f"connector_id must be a valid UUID, got {v!r}")
+        return str(v)
 
 
 class ConnectorUpdateRequest(BaseModel):

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -142,4 +142,10 @@ class SyncLogResponse(BaseModel):
     offset: int
     items: List[SyncLogItem]
 
+
+class SyncTriggerResponse(BaseModel):
+    """Response body for POST /v1/connectors/{connector_id}/sync."""
+
+    sync_seq: int = Field(..., description="Sequence number of the active or newly-started sync")
+
 # Made with Bob

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -370,33 +370,19 @@ def _handle_interrupt(
         _cancel_tick(sync_seq, connector_id)
         # Note: close_sync_log() automatically sets connector to OUT_OF_SYNC when
         # sync log status is CANCELLED. Cleanup staging directory for this sync.
-        _sweep_sync_staging(connector_id, sync_seq)
+        from digitize.api.v1.connectors import _sweep_staging_dir
+        from digitize.settings import settings
+        _sweep_staging_dir(
+            connector_id,
+            settings.digitize.staging_dir / "connectors",
+            sync_seq=sync_seq,
+        )
 
     elif interrupt_type == InterruptType.DELETE_CONNECTOR:
         logger.info(f"Handling delete connector for {connector_id!r}")
         _cancel_tick(sync_seq, connector_id)
         # Run full teardown: remove checksums, delete orphaned docs, delete connector row
         _run_delete_teardown(connector_id)
-
-
-def _sweep_sync_staging(connector_id: str, sync_seq: int) -> None:
-    """Remove staging directories for a specific sync (pattern: {connector_id}-{sync_seq}-*)."""
-    from digitize.settings import settings
-    staging_base = settings.digitize.staging_dir / "connectors"
-    try:
-        if not staging_base.exists():
-            return
-        # Pattern: {connector_id}-{sync_seq}-* (matches all batch directories for this sync)
-        prefix = f"{connector_id}-{sync_seq}-"
-        for entry in staging_base.iterdir():
-            if entry.is_dir() and entry.name.startswith(prefix):
-                cleanup_staging_directory(entry.name, staging_base, ignore_errors=True)
-        logger.debug(f"Swept staging directories for sync {connector_id!r}:{sync_seq}")
-    except Exception as exc:
-        logger.warning(
-            f"Error sweeping staging directories for {connector_id!r}:{sync_seq}: {exc}",
-            exc_info=True,
-        )
 
 
 def _run_delete_teardown(connector_id: str) -> None:
@@ -414,7 +400,7 @@ def _run_delete_teardown(connector_id: str) -> None:
         delete_active_connector,
     )
     from digitize.settings import settings
-    from digitize.api.v1.connectors import _sweep_connector_staging
+    from digitize.api.v1.connectors import _sweep_staging_dir
 
     logger.info(f"Running full teardown for connector {connector_id!r}")
     try:
@@ -441,7 +427,7 @@ def _run_delete_teardown(connector_id: str) -> None:
             )
 
         # Step 3: sweep all residual batch staging directories for this connector
-        _sweep_connector_staging(connector_id, settings.digitize.staging_dir / "connectors")
+        _sweep_staging_dir(connector_id, settings.digitize.staging_dir / "connectors")
 
         logger.info(f"Connector {connector_id!r} full teardown complete")
     except Exception as exc:

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -1,0 +1,281 @@
+"""
+connectors/sync_tick.py — end-to-end sync-tick logic for one connector.
+
+Phases
+------
+1.  open_new_sync_log        → INSERT connector_sync_logs row (status='started')
+2.  load known/all checksums + scanner.scan()
+3.  _classify()              → ingest_list, orphan_checksums
+                               cross-connector dups registered inline
+4a. _process_new_files()     → download → create job/doc → add checksum row
+4b. _delete_orphans()        → remove checksum rows; delete docs with no owners
+5.  close_sync_log()         → finalize tick row + reset sync_status
+
+Called by the APScheduler job (_run_tick_wrapped in scheduler.py, PR7) and
+directly by POST /v1/connectors/{id}/sync after the caller has already
+acquired the sync lock via try_acquire_sync_lock().
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from common.misc_utils import cleanup_staging_directory, get_logger
+from digitize.connectors.scanners.scanner_factory import build_scanner
+from digitize.models import OutputFormat, OperationType
+from digitize.pipeline.ingest import ingest
+from digitize.settings import settings
+from digitize.utils.db import (
+    add_connector_checksum_entry,
+    close_sync_log,
+    get_active_connector,
+    list_all_checksums,
+    list_connector_checksums,
+    lookup_connector_content_by_checksum,
+    open_new_sync_log,
+    remove_connector_checksum_entry,
+    update_sync_log,
+)
+from digitize.utils.jobs import generate_uuid, initialize_job_state
+
+logger = get_logger("sync_tick")
+
+
+# ---------------------------------------------------------------------------
+# Public entry-point
+# ---------------------------------------------------------------------------
+
+async def run_tick(connector_id: str) -> None:
+    """
+    Execute one full sync tick for *connector_id*.
+
+    The caller is responsible for acquiring the sync lock (sync_status='syncing')
+    before calling this coroutine.  open_new_sync_log() is called here to open
+    the sync-log row.
+    """
+    config = get_active_connector(connector_id)
+    if config is None:
+        logger.error(f"Connector {connector_id!r} not found; tick aborted")
+        return
+
+    sync_seq: int = open_new_sync_log(connector_id)
+    scanner = build_scanner(config)
+
+    failed: int = 0
+    new: int = 0
+    removed: int = 0
+
+    try:
+        await asyncio.to_thread(scanner.connect)
+        scanned_files: list[tuple[str, str]] = await asyncio.to_thread(scanner.scan)
+
+        known_checksums: set[str] = set(list_connector_checksums(connector_id))
+        all_checksums: set[str] = set(list_all_checksums())
+
+        ingest_list, orphan_checksums = _classify(
+            connector_id, scanned_files, known_checksums, all_checksums
+        )
+
+        update_sync_log(sync_seq, total_files=len(scanned_files))
+
+        new, failed = await _process_new_files(
+            sync_seq, connector_id, scanner, ingest_list
+        )
+
+        removed = await _delete_orphans(connector_id, orphan_checksums)
+
+        _complete_tick(
+            sync_seq, connector_id,
+            total_files=len(scanned_files),
+            new_files=new,
+            removed_files=removed,
+            failed_files=failed,
+        )
+
+    except Exception as exc:
+        logger.error(
+            f"Tick failed for connector {connector_id!r}: {exc}", exc_info=True
+        )
+        _fail_tick(sync_seq, connector_id, exc)
+
+    finally:
+        await asyncio.to_thread(scanner.close)
+
+
+# ---------------------------------------------------------------------------
+# Classification (pure — no I/O beyond inline DB writes for cross-connector dups)
+# ---------------------------------------------------------------------------
+
+def _classify(
+    connector_id: str,
+    scanned_files: list[tuple[str, str]],
+    known_checksums: set[str],
+    all_checksums: set[str],
+) -> tuple[list[tuple[str, str]], set[str]]:
+    """
+    Partition *scanned_files* into files to ingest and orphan checksums to remove.
+
+    Cross-connector duplicates (checksum already owned by another connector) are
+    registered inline via add_connector_checksum_entry — no deferred list.
+
+    Returns
+    -------
+    ingest_list:
+        (remote_path, checksum) pairs that are brand-new to all connectors.
+    orphan_checksums:
+        Checksums previously owned by *connector_id* that no longer appear on
+        the remote source.
+    """
+    scanned_checksums: set[str] = set()
+    seen_this_tick: set[str] = set()
+    ingest_list: list[tuple[str, str]] = []
+
+    for remote_path, checksum in scanned_files:
+        scanned_checksums.add(checksum)
+        if checksum in known_checksums:
+            pass  # already owned by this connector → skip
+        elif checksum in all_checksums:
+            if checksum not in seen_this_tick:
+                seen_this_tick.add(checksum)
+                existing_doc_id = lookup_connector_content_by_checksum(checksum)
+                if existing_doc_id:
+                    add_connector_checksum_entry(connector_id, checksum, existing_doc_id)
+        else:
+            if checksum not in seen_this_tick:
+                seen_this_tick.add(checksum)
+                ingest_list.append((remote_path, checksum))
+
+    orphan_checksums = known_checksums - scanned_checksums
+    return ingest_list, orphan_checksums
+
+
+# ---------------------------------------------------------------------------
+# Phase 4a — download + ingest new files
+# ---------------------------------------------------------------------------
+
+async def _process_new_files(
+    sync_seq: int,
+    connector_id: str,
+    scanner,
+    ingest_list: list[tuple[str, str]],
+) -> tuple[int, int]:
+    """Download and ingest each file in *ingest_list*.
+
+    Returns (new_count, failed_count).  Staging directories are removed after
+    each file regardless of success.
+    """
+    staging_base = settings.digitize.staging_dir / "connectors"
+    new_count = 0
+    failed_count = 0
+
+    for batch_number, (remote_path, checksum) in enumerate(ingest_list):
+        job_id = generate_uuid()
+        batch_dir_name = f"{connector_id}-{job_id}-{batch_number}"
+        batch_dir = staging_base / batch_dir_name
+        batch_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            local_checksum = await asyncio.to_thread(
+                scanner.download_to, remote_path, batch_dir / Path(remote_path).name
+            )
+            scanner.verify_integrity(local_checksum, checksum)
+
+            filename = Path(remote_path).name
+            job_name = f"{connector_id} - {sync_seq} - {batch_number}"
+            doc_id_dict = initialize_job_state(
+                job_id=job_id,
+                operation=OperationType.INGESTION,
+                output_format=OutputFormat.JSON,
+                documents_info=[filename],
+                job_name=job_name,
+            )
+            doc_id = doc_id_dict[filename]
+            add_connector_checksum_entry(connector_id, checksum, doc_id)
+
+            await asyncio.to_thread(ingest, batch_dir, job_id, doc_id_dict)
+
+            new_count += 1
+            update_sync_log(sync_seq, new_files=new_count)
+
+        except Exception as exc:
+            logger.warning(
+                f"Failed to ingest {remote_path!r} for connector {connector_id!r}: {exc}",
+                exc_info=True,
+            )
+            failed_count += 1
+            update_sync_log(sync_seq, failed_files=failed_count)
+
+        finally:
+            cleanup_staging_directory(batch_dir_name, staging_base, ignore_errors=True)
+
+    return new_count, failed_count
+
+
+# ---------------------------------------------------------------------------
+# Phase 4b — orphan removal
+# ---------------------------------------------------------------------------
+
+async def _delete_orphans(connector_id: str, orphan_checksums: set[str]) -> int:
+    """Remove orphaned checksum rows and delete documents that lose their last owner.
+
+    Returns the number of ownership rows removed.
+    """
+    from digitize.api.v1.connectors import _best_effort_delete_document
+
+    removed = 0
+    for checksum in orphan_checksums:
+        try:
+            remaining, doc_id = remove_connector_checksum_entry(connector_id, checksum)
+            removed += 1
+            if remaining == 0 and doc_id:
+                await asyncio.to_thread(_best_effort_delete_document, doc_id)
+        except Exception as exc:
+            logger.error(
+                f"Error removing orphan checksum {checksum!r} "
+                f"for connector {connector_id!r}: {exc}",
+                exc_info=True,
+            )
+    return removed
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 helpers
+# ---------------------------------------------------------------------------
+
+def _complete_tick(
+    sync_seq: int,
+    connector_id: str,
+    total_files: int,
+    new_files: int,
+    removed_files: int,
+    failed_files: int,
+) -> None:
+    close_sync_log(
+        connector_id=connector_id,
+        seq=sync_seq,
+        status="completed",
+        total_files=total_files,
+        new_files=new_files,
+        removed_files=removed_files,
+        failed_files=failed_files,
+    )
+    logger.info(
+        f"Tick completed for {connector_id!r} — "
+        f"total={total_files} new={new_files} removed={removed_files} failed={failed_files}"
+    )
+
+
+def _fail_tick(sync_seq: int, connector_id: str, exc: Exception) -> None:
+    try:
+        close_sync_log(
+            connector_id=connector_id,
+            seq=sync_seq,
+            status="failed",
+            error=str(exc),
+        )
+    except Exception as close_exc:
+        logger.error(
+            f"Failed to close sync log for {connector_id!r} after tick failure: {close_exc}",
+            exc_info=True,
+        )

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -239,7 +239,12 @@ async def _process_new_files(
                 local_checksum = await asyncio.to_thread(
                     scanner.download_to, remote_path, batch_dir / filename
                 )
-                scanner.verify_integrity(local_checksum, checksum)
+                if not scanner.verify_integrity(local_checksum, checksum):
+                    logger.warning(
+                        f"Integrity check failed for {remote_path!r} in connector "
+                        f"{connector_id!r}; skipping file"
+                    )
+                    continue
                 checksum_to_filename[checksum] = filename
 
             # Cancellation checkpoint: bail after each batch of downloads.

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -26,6 +26,7 @@ from common.misc_utils import cleanup_staging_directory, get_logger
 from digitize.connectors.scanners.scanner_factory import build_scanner
 from digitize.pipeline.ingest import ingest
 from digitize.settings import settings
+from digitize.connectors.models import SyncStatus
 from digitize.models import JobStatus, OutputFormat, OperationType
 from digitize.utils.db import (
     add_connector_checksum_entry,
@@ -60,7 +61,7 @@ def _check_delete_pending(connector_id: str) -> None:
     running to completion.
     """
     status = get_connector_sync_status(connector_id)
-    if status in ("delete pending", "cancel pending"):
+    if status in (SyncStatus.DELETE_PENDING, SyncStatus.CANCEL_PENDING):
         raise asyncio.CancelledError(
             f"Connector {connector_id!r} sync cancelled (status={status!r})"
         )
@@ -307,7 +308,7 @@ def _complete_tick(sync_seq: int, connector_id: str) -> None:
     close_sync_log(
         connector_id=connector_id,
         seq=sync_seq,
-        status="completed",
+        status=SyncStatus.COMPLETED,
     )
     logger.info(f"Tick completed for {connector_id!r}")
 
@@ -318,7 +319,7 @@ def _cancel_tick(sync_seq: int, connector_id: str) -> None:
         close_sync_log(
             connector_id=connector_id,
             seq=sync_seq,
-            status="cancelled",
+            status=SyncStatus.CANCELLED,
         )
     except Exception as close_exc:
         logger.error(
@@ -332,7 +333,7 @@ def _fail_tick(sync_seq: int, connector_id: str, exc: Exception) -> None:
         close_sync_log(
             connector_id=connector_id,
             seq=sync_seq,
-            status="failed",
+            status=SyncStatus.FAILED,
             error=str(exc),
         )
     except Exception as close_exc:

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -182,23 +182,31 @@ def _classify(
 # Phase 4a — download + ingest new files
 # ---------------------------------------------------------------------------
 
+_BATCH_SIZE = 10
+
+
 async def _process_new_files(
     sync_seq: int,
     connector_id: str,
     scanner,
     ingest_list: list[tuple[str, str]],
 ) -> tuple[int, int]:
-    """Download and ingest each file in *ingest_list*.
+    """Download and ingest *ingest_list* in batches of up to 10 files.
+
+    Each batch of up to 10 files is downloaded into a single staging directory,
+    registered as a single job, and passed to ``ingest()`` together.
 
     Returns (new_count, failed_count).  Staging directories are removed after
-    each file regardless of success.
+    each batch regardless of success.
     """
     staging_base = settings.digitize.staging_dir / "connectors"
     new_count = 0
     failed_count = 0
 
-    for batch_number, (remote_path, checksum) in enumerate(ingest_list):
-        # Cancellation checkpoint: bail before each download starts.
+    for batch_number in range(0, len(ingest_list), _BATCH_SIZE):
+        batch = ingest_list[batch_number : batch_number + _BATCH_SIZE]
+
+        # Cancellation checkpoint: bail before each batch download starts.
         _check_delete_pending(connector_id)
 
         job_id = generate_uuid()
@@ -206,37 +214,44 @@ async def _process_new_files(
         batch_dir = staging_base / batch_dir_name
         batch_dir.mkdir(parents=True, exist_ok=True)
 
-        try:
-            local_checksum = await asyncio.to_thread(
-                scanner.download_to, remote_path, batch_dir / Path(remote_path).name
-            )
-            # Cancellation checkpoint: bail after the blocking download returns.
-            _check_delete_pending(connector_id)
-            scanner.verify_integrity(local_checksum, checksum)
+        # checksum → filename for post-ingest checksum registration
+        checksum_to_filename: dict[str, str] = {}
 
-            filename = Path(remote_path).name
+        try:
+            for remote_path, checksum in batch:
+                filename = Path(remote_path).name
+                local_checksum = await asyncio.to_thread(
+                    scanner.download_to, remote_path, batch_dir / filename
+                )
+                # Cancellation checkpoint: bail after each blocking download.
+                _check_delete_pending(connector_id)
+                scanner.verify_integrity(local_checksum, checksum)
+                checksum_to_filename[checksum] = filename
+
+            filenames = list(checksum_to_filename.values())
             job_name = f"{connector_id} - {sync_seq} - {batch_number}"
             doc_id_dict = initialize_job_state(
                 job_id=job_id,
                 operation=OperationType.INGESTION,
                 output_format=OutputFormat.JSON,
-                documents_info=[filename],
+                documents_info=filenames,
                 job_name=job_name,
             )
-            doc_id = doc_id_dict[filename]
-            add_connector_checksum_entry(connector_id, checksum, doc_id)
+
+            for checksum, filename in checksum_to_filename.items():
+                add_connector_checksum_entry(connector_id, checksum, doc_id_dict[filename])
 
             await asyncio.to_thread(ingest, batch_dir, job_id, doc_id_dict)
 
-            new_count += 1
+            new_count += len(batch)
             update_sync_log(sync_seq, new_files=new_count)
 
         except Exception as exc:
             logger.warning(
-                f"Failed to ingest {remote_path!r} for connector {connector_id!r}: {exc}",
+                f"Failed to ingest batch {batch_number!r} for connector {connector_id!r}: {exc}",
                 exc_info=True,
             )
-            failed_count += 1
+            failed_count += len(batch)
             update_sync_log(sync_seq, failed_files=failed_count)
 
         finally:

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -3,14 +3,14 @@ connectors/sync_tick.py — end-to-end sync-tick logic for one connector.
 
 Phases
 ------
-1.  open_new_sync_log        → INSERT connector_sync_logs row (status='started')
+1.  init_sync_log_and_set_syncing        → INSERT connector_sync_logs row (status='started')
 2.  load known/all checksums + scanner.scan()
 3.  _classify()              → ingest_list, orphan_checksums
                                cross-connector dups registered inline
 3b. update_sync_log()        → single DB write of total/new/removed counts (all known post-classify)
 4a. _process_new_files()     → download → create job/doc → add checksum row
 4b. _delete_orphans()        → remove checksum rows; delete docs with no owners
-5.  close_sync_log()         → finalize tick row with terminal status + reset sync_status
+5.  finalize_sync_log_and_update_connector()         → finalize tick row with terminal status + reset sync_status
 
 Called by the APScheduler job (_run_tick_wrapped in scheduler.py, PR7) and
 directly by POST /v1/connectors/{id}/sync after the caller has already
@@ -32,7 +32,7 @@ from digitize.connectors.models import ConnectorStatus, SyncLogStatus
 from digitize.models import JobStatus, OutputFormat, OperationType
 from digitize.utils.db import (
     add_connector_checksum_entry,
-    close_sync_log,
+    finalize_sync_log_and_update_connector,
     get_active_connector,
     get_connector_sync_status,
     get_sync_log_status,
@@ -40,7 +40,7 @@ from digitize.utils.db import (
     list_all_checksums,
     list_connector_checksums,
     lookup_connector_content_by_checksum,
-    open_new_sync_log,
+    init_sync_log_and_set_syncing,
     remove_connector_checksum_entry,
     update_sync_log,
 )
@@ -99,7 +99,7 @@ async def run_tick(connector_id: str) -> None:
     Execute one full sync tick for *connector_id*.
 
     The caller is responsible for acquiring the sync lock (sync_status='syncing')
-    before calling this coroutine.  open_new_sync_log() is called here to open
+    before calling this coroutine.  init_sync_log_and_set_syncing() is called here to open
     the sync-log row.
     """
     config = get_active_connector(connector_id)
@@ -107,7 +107,7 @@ async def run_tick(connector_id: str) -> None:
         logger.error(f"Connector {connector_id!r} not found; tick aborted")
         return
 
-    sync_seq: int = open_new_sync_log(connector_id)
+    sync_seq: int = init_sync_log_and_set_syncing(connector_id)
     scanner = build_scanner(config)
 
     try:
@@ -378,7 +378,7 @@ async def _handle_interrupt(
     if interrupt_type == InterruptType.SYNC_CANCEL:
         logger.info(f"Handling sync cancel for connector {connector_id!r}")
         _cancel_tick(sync_seq, connector_id)
-        # Note: close_sync_log() automatically sets connector to OUT_OF_SYNC when
+        # Note: finalize_sync_log_and_update_connector() automatically sets connector to OUT_OF_SYNC when
         # sync log status is CANCELLED. Cleanup staging directory for this sync.
         from digitize.api.v1.connectors import _sweep_staging_dir
         from digitize.settings import settings
@@ -401,7 +401,7 @@ async def _handle_interrupt(
 # ---------------------------------------------------------------------------
 
 def _complete_tick(sync_seq: int, connector_id: str) -> None:
-    close_sync_log(
+    finalize_sync_log_and_update_connector(
         connector_id=connector_id,
         seq=sync_seq,
         status=SyncLogStatus.COMPLETED,
@@ -412,7 +412,7 @@ def _complete_tick(sync_seq: int, connector_id: str) -> None:
 def _cancel_tick(sync_seq: int, connector_id: str) -> None:
     """Close the sync log with status='cancelled' after a CancelledError."""
     try:
-        close_sync_log(
+        finalize_sync_log_and_update_connector(
             connector_id=connector_id,
             seq=sync_seq,
             status=SyncLogStatus.CANCELLED,
@@ -426,7 +426,7 @@ def _cancel_tick(sync_seq: int, connector_id: str) -> None:
 
 def _fail_tick(sync_seq: int, connector_id: str, exc: Exception) -> None:
     try:
-        close_sync_log(
+        finalize_sync_log_and_update_connector(
             connector_id=connector_id,
             seq=sync_seq,
             status=SyncLogStatus.FAILED,

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -28,7 +28,7 @@ from common.misc_utils import cleanup_staging_directory, get_logger
 from digitize.connectors.scanners.scanner_factory import build_scanner
 from digitize.pipeline.ingest import ingest
 from digitize.settings import settings
-from digitize.connectors.models import SyncStatus
+from digitize.connectors.models import ConnectorStatus, SyncLogStatus
 from digitize.models import JobStatus, OutputFormat, OperationType
 from digitize.utils.db import (
     add_connector_checksum_entry,
@@ -79,12 +79,12 @@ def _check_interrupt_call(connector_id: str, sync_seq: int) -> Optional[Interrup
     """
     # Check connectors table for DELETE_PENDING
     connector_status = get_connector_sync_status(connector_id)
-    if connector_status == SyncStatus.DELETE_PENDING:
+    if connector_status == ConnectorStatus.DELETE_PENDING:
         return InterruptType.DELETE_CONNECTOR
 
     # Check the specific sync-log row for CANCEL_PENDING (not the connector row)
     sync_log_status = get_sync_log_status(connector_id, sync_seq)
-    if sync_log_status == SyncStatus.CANCEL_PENDING:
+    if sync_log_status == SyncLogStatus.CANCEL_PENDING:
         return InterruptType.SYNC_CANCEL
 
     return None
@@ -404,7 +404,7 @@ def _complete_tick(sync_seq: int, connector_id: str) -> None:
     close_sync_log(
         connector_id=connector_id,
         seq=sync_seq,
-        status=SyncStatus.COMPLETED,
+        status=SyncLogStatus.COMPLETED,
     )
     logger.info(f"Tick completed for {connector_id!r}")
 
@@ -415,7 +415,7 @@ def _cancel_tick(sync_seq: int, connector_id: str) -> None:
         close_sync_log(
             connector_id=connector_id,
             seq=sync_seq,
-            status=SyncStatus.CANCELLED,
+            status=SyncLogStatus.CANCELLED,
         )
     except Exception as close_exc:
         logger.error(
@@ -429,7 +429,7 @@ def _fail_tick(sync_seq: int, connector_id: str, exc: Exception) -> None:
         close_sync_log(
             connector_id=connector_id,
             seq=sync_seq,
-            status=SyncStatus.FAILED,
+            status=SyncLogStatus.FAILED,
             error=str(exc),
         )
     except Exception as close_exc:

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -129,6 +129,7 @@ async def run_tick(connector_id: str) -> None:
         )
 
         update_sync_log(
+            connector_id,
             sync_seq,
             total_files=len(scanned_files),
             new_files=len(ingest_list),

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -70,13 +70,12 @@ def _check_interrupt_call(connector_id: str, sync_seq: int) -> Optional[Interrup
     Checks two sources:
     1. connectors.sync_status for DELETE_PENDING (delete entire connector)
     2. connector_sync_logs.status for CANCEL_PENDING on the active seq row
-       (cancel only current sync)
+       (cancel only the current sync; written by mark_sync_cancel_pending)
 
     Returns the appropriate InterruptType if a signal is detected, None otherwise.
-    Performs a live DB query — no in-memory state. Called at the three phase
-    boundaries inside run_tick / _process_new_files so that a DELETE or
-    CANCEL request is honoured promptly without leaving the tick running to
-    completion.
+    Performs a live DB query — no in-memory state. Called at phase boundaries
+    inside run_tick / _process_new_files so that a DELETE or CANCEL request is
+    honoured promptly without leaving the tick running to completion.
     """
     # Check connectors table for DELETE_PENDING
     connector_status = get_connector_sync_status(connector_id)

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -20,7 +20,9 @@ acquired the sync lock via try_acquire_sync_lock().
 from __future__ import annotations
 
 import asyncio
+from enum import Enum
 from pathlib import Path
+from typing import Optional
 
 from common.misc_utils import cleanup_staging_directory, get_logger
 from digitize.connectors.scanners.scanner_factory import build_scanner
@@ -33,6 +35,7 @@ from digitize.utils.db import (
     close_sync_log,
     get_active_connector,
     get_connector_sync_status,
+    get_sync_log_status,
     get_job,
     list_all_checksums,
     list_connector_checksums,
@@ -47,24 +50,45 @@ logger = get_logger("sync_tick")
 
 
 # ---------------------------------------------------------------------------
+# Interrupt handling enum
+# ---------------------------------------------------------------------------
+
+class InterruptType(Enum):
+    """Indicates the type of interrupt signal detected during sync execution."""
+    SYNC_CANCEL = "sync_cancel"      # CANCEL_PENDING in ConnectorSyncLog
+    DELETE_CONNECTOR = "delete_connector"  # DELETE_PENDING in Connectors table
+
+
+# ---------------------------------------------------------------------------
 # Cancellation helper
 # ---------------------------------------------------------------------------
 
-def _check_delete_pending(connector_id: str) -> None:
+def _check_interrupt_call(connector_id: str, sync_seq: int) -> Optional[InterruptType]:
     """
-    Raise asyncio.CancelledError if the connector is marked for deletion or
-    a stop-sync request has been issued.
+    Check for interrupt signals from both connectors and connector_sync_logs tables.
 
-    Performs a live DB query — no in-memory state.  Called at the three
-    phase boundaries inside run_tick / _process_new_files so that a DELETE
-    or DELETE /sync request is honoured promptly without leaving the tick
-    running to completion.
+    Checks two sources:
+    1. connectors.sync_status for DELETE_PENDING (delete entire connector)
+    2. connector_sync_logs.status for CANCEL_PENDING on the active seq row
+       (cancel only current sync)
+
+    Returns the appropriate InterruptType if a signal is detected, None otherwise.
+    Performs a live DB query — no in-memory state. Called at the three phase
+    boundaries inside run_tick / _process_new_files so that a DELETE or
+    CANCEL request is honoured promptly without leaving the tick running to
+    completion.
     """
-    status = get_connector_sync_status(connector_id)
-    if status in (SyncStatus.DELETE_PENDING, SyncStatus.CANCEL_PENDING):
-        raise asyncio.CancelledError(
-            f"Connector {connector_id!r} sync cancelled (status={status!r})"
-        )
+    # Check connectors table for DELETE_PENDING
+    connector_status = get_connector_sync_status(connector_id)
+    if connector_status == SyncStatus.DELETE_PENDING:
+        return InterruptType.DELETE_CONNECTOR
+
+    # Check the specific sync-log row for CANCEL_PENDING (not the connector row)
+    sync_log_status = get_sync_log_status(connector_id, sync_seq)
+    if sync_log_status == SyncStatus.CANCEL_PENDING:
+        return InterruptType.SYNC_CANCEL
+
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -88,8 +112,16 @@ async def run_tick(connector_id: str) -> None:
     scanner = build_scanner(config)
 
     try:
-        # Phase boundary: check for DELETE_PENDING before any remote I/O starts.
-        _check_delete_pending(connector_id)
+        # Phase boundary: check for interrupt signals before any remote I/O starts.
+        interrupt = _check_interrupt_call(connector_id, sync_seq)
+        if interrupt == InterruptType.DELETE_CONNECTOR:
+            raise asyncio.CancelledError(
+                f"Connector {connector_id!r} marked for deletion"
+            )
+        elif interrupt == InterruptType.SYNC_CANCEL:
+            raise asyncio.CancelledError(
+                f"Sync cancel requested for connector {connector_id!r}"
+            )
 
         await asyncio.to_thread(scanner.connect)
         scanned_files: list[tuple[str, str]] = await asyncio.to_thread(scanner.scan)
@@ -114,9 +146,10 @@ async def run_tick(connector_id: str) -> None:
 
         _complete_tick(sync_seq, connector_id)
 
-    except asyncio.CancelledError:
-        logger.info(f"Tick cancelled for connector {connector_id!r} (delete_pending)")
-        _cancel_tick(sync_seq, connector_id)
+    except asyncio.CancelledError as ce:
+        logger.info(f"Tick cancelled for connector {connector_id!r}: {ce}")
+        interrupt = _check_interrupt_call(connector_id, sync_seq)
+        _handle_interrupt(sync_seq, connector_id, interrupt)
         raise
 
     except Exception as exc:
@@ -184,11 +217,11 @@ _BATCH_SIZE = 10
 _JOB_POLL_INTERVAL = 10  # seconds between job-status polls while waiting for a batch
 
 
-async def _wait_for_job(job_id: str, connector_id: str) -> None:
+async def _wait_for_job(job_id: str, connector_id: str, sync_seq: int) -> None:
     """Poll *job_id* until it reaches a terminal state.
 
     Sleeps *_JOB_POLL_INTERVAL* seconds between polls.  On every wake-up it
-    also calls ``_check_delete_pending`` so that a deletion/cancel request is
+    also calls ``_check_interrupt_call`` so that a deletion/cancel request is
     honoured promptly even while the batch is running.
 
     Raises ``asyncio.CancelledError`` if the connector is marked for deletion
@@ -197,7 +230,11 @@ async def _wait_for_job(job_id: str, connector_id: str) -> None:
     _TERMINAL = {JobStatus.COMPLETED.value, JobStatus.FAILED.value}
     while True:
         await asyncio.sleep(_JOB_POLL_INTERVAL)
-        _check_delete_pending(connector_id)
+        interrupt = _check_interrupt_call(connector_id, sync_seq)
+        if interrupt:
+            raise asyncio.CancelledError(
+                f"Connector {connector_id!r} interrupted (type={interrupt.value})"
+            )
         job_data = get_job(job_id)
         status = (job_data or {}).get("status", "")
         logger.debug(f"Polling job {job_id!r} for connector {connector_id!r}: status={status!r}")
@@ -224,7 +261,11 @@ async def _process_new_files(
         batch = ingest_list[batch_number : batch_number + _BATCH_SIZE]
 
         # Cancellation checkpoint: bail before each batch starts.
-        _check_delete_pending(connector_id)
+        interrupt = _check_interrupt_call(connector_id, sync_seq)
+        if interrupt:
+            raise asyncio.CancelledError(
+                f"Connector {connector_id!r} interrupted (type={interrupt.value})"
+            )
 
         job_id = generate_uuid()
         batch_dir_name = f"{connector_id}-{sync_seq}-{batch_number}"
@@ -249,7 +290,11 @@ async def _process_new_files(
                 checksum_to_filename[checksum] = filename
 
             # Cancellation checkpoint: bail after each batch of downloads.
-            _check_delete_pending(connector_id)
+            interrupt = _check_interrupt_call(connector_id, sync_seq)
+            if interrupt:
+                raise asyncio.CancelledError(
+                    f"Connector {connector_id!r} interrupted (type={interrupt.value})"
+                )
 
             filenames = list(checksum_to_filename.values())
             job_name = f"{connector_id} - {sync_seq} - {batch_number}"
@@ -266,7 +311,7 @@ async def _process_new_files(
 
             await asyncio.to_thread(ingest, batch_dir, job_id, doc_id_dict)
 
-            await _wait_for_job(job_id, connector_id)
+            await _wait_for_job(job_id, connector_id, sync_seq)
 
         except Exception as exc:
             logger.warning(
@@ -298,6 +343,118 @@ async def _delete_orphans(connector_id: str, orphan_checksums: set[str]) -> None
                 exc_info=True,
             )
             raise
+
+
+# ---------------------------------------------------------------------------
+# Interrupt handler — differentiated handling for cancel vs delete
+# ---------------------------------------------------------------------------
+
+def _handle_interrupt(
+    sync_seq: int,
+    connector_id: str,
+    interrupt_type: Optional[InterruptType],
+) -> None:
+    """
+    Handle cancellation based on interrupt type.
+
+    SYNC_CANCEL: Stop the current sync, set connector to OUT_OF_SYNC, cleanup staging.
+    DELETE_CONNECTOR: Stop sync + full teardown (remove checksums, docs, connector row).
+    """
+    if interrupt_type is None:
+        # Default cancel behavior — treat as sync cancel
+        _cancel_tick(sync_seq, connector_id)
+        return
+
+    if interrupt_type == InterruptType.SYNC_CANCEL:
+        logger.info(f"Handling sync cancel for connector {connector_id!r}")
+        _cancel_tick(sync_seq, connector_id)
+        # Note: close_sync_log() automatically sets connector to OUT_OF_SYNC when
+        # sync log status is CANCELLED. Cleanup staging directory for this sync.
+        _sweep_sync_staging(connector_id, sync_seq)
+
+    elif interrupt_type == InterruptType.DELETE_CONNECTOR:
+        logger.info(f"Handling delete connector for {connector_id!r}")
+        _cancel_tick(sync_seq, connector_id)
+        # Run full teardown: remove checksums, delete orphaned docs, delete connector row
+        _run_delete_teardown(connector_id)
+
+
+def _sweep_sync_staging(connector_id: str, sync_seq: int) -> None:
+    """Remove staging directories for a specific sync (pattern: {connector_id}-{sync_seq}-*)."""
+    from digitize.settings import settings
+    staging_base = settings.digitize.staging_dir / "connectors"
+    try:
+        if not staging_base.exists():
+            return
+        # Pattern: {connector_id}-{sync_seq}-* (matches all batch directories for this sync)
+        prefix = f"{connector_id}-{sync_seq}-"
+        for entry in staging_base.iterdir():
+            if entry.is_dir() and entry.name.startswith(prefix):
+                cleanup_staging_directory(entry.name, staging_base, ignore_errors=True)
+        logger.debug(f"Swept staging directories for sync {connector_id!r}:{sync_seq}")
+    except Exception as exc:
+        logger.warning(
+            f"Error sweeping staging directories for {connector_id!r}:{sync_seq}: {exc}",
+            exc_info=True,
+        )
+
+
+def _run_delete_teardown(connector_id: str) -> None:
+    """
+    Full teardown for connector deletion.
+
+    Steps:
+      1. Remove all checksum ownership rows; delete documents when last owner
+      2. Delete the connector row (cascades to sync_logs)
+      3. Sweep all residual batch staging directories
+    """
+    from digitize.utils.db import (
+        list_connector_checksums,
+        remove_connector_checksum_entry,
+        delete_active_connector,
+    )
+    from digitize.settings import settings
+    from digitize.api.v1.connectors import _sweep_connector_staging
+
+    logger.info(f"Running full teardown for connector {connector_id!r}")
+    try:
+        # Step 1: remove checksum ownership; delete orphaned documents
+        owned_checksums = list_connector_checksums(connector_id)
+        for checksum in owned_checksums:
+            try:
+                remaining, doc_id = remove_connector_checksum_entry(connector_id, checksum)
+                if remaining == 0 and doc_id:
+                    _best_effort_delete_document(doc_id)
+            except Exception as exc:
+                logger.error(
+                    f"Error removing checksum {checksum!r} for connector "
+                    f"{connector_id!r}: {exc}",
+                    exc_info=True,
+                )
+
+        # Step 2: delete the connector row (cascades to connector_sync_logs)
+        deleted = delete_active_connector(connector_id)
+        if not deleted:
+            logger.warning(
+                f"delete_active_connector returned False for {connector_id!r} "
+                "— row may have already been removed"
+            )
+
+        # Step 3: sweep all residual batch staging directories for this connector
+        _sweep_connector_staging(connector_id, settings.digitize.staging_dir / "connectors")
+
+        logger.info(f"Connector {connector_id!r} full teardown complete")
+    except Exception as exc:
+        logger.error(
+            f"Unexpected error during full teardown for connector {connector_id!r}: {exc}",
+            exc_info=True,
+        )
+
+
+def _best_effort_delete_document(doc_id: str) -> None:
+    """Best-effort document deletion — log but don't raise on failure."""
+    from digitize.api.v1.connectors import _best_effort_delete_document as delete_doc
+    delete_doc(doc_id)
 
 
 # ---------------------------------------------------------------------------

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -3,7 +3,7 @@ connectors/sync_tick.py — end-to-end sync-tick logic for one connector.
 
 Phases
 ------
-1.  init_sync_log_and_set_syncing        → INSERT connector_sync_logs row (status='started')
+1.  init_sync_log_and_update_connector        → INSERT connector_sync_logs row (status='started')
 2.  load known/all checksums + scanner.scan()
 3.  _classify()              → ingest_list, orphan_checksums
                                cross-connector dups registered inline
@@ -40,7 +40,7 @@ from digitize.utils.db import (
     list_all_checksums,
     list_connector_checksums,
     lookup_connector_content_by_checksum,
-    init_sync_log_and_set_syncing,
+    init_sync_log_and_update_connector,
     remove_connector_checksum_entry,
     update_sync_log,
 )
@@ -99,7 +99,7 @@ async def run_tick(connector_id: str) -> None:
     Execute one full sync tick for *connector_id*.
 
     The caller is responsible for acquiring the sync lock (sync_status='syncing')
-    before calling this coroutine.  init_sync_log_and_set_syncing() is called here to open
+    before calling this coroutine.  init_sync_log_and_update_connector() is called here to open
     the sync-log row.
     """
     config = get_active_connector(connector_id)
@@ -107,7 +107,7 @@ async def run_tick(connector_id: str) -> None:
         logger.error(f"Connector {connector_id!r} not found; tick aborted")
         return
 
-    sync_seq: int = init_sync_log_and_set_syncing(connector_id)
+    sync_seq: int = init_sync_log_and_update_connector(connector_id)
     scanner = build_scanner(config)
 
     try:

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -231,7 +231,7 @@ async def _process_new_files(
     for batch_number in range(0, len(ingest_list), _BATCH_SIZE):
         batch = ingest_list[batch_number : batch_number + _BATCH_SIZE]
 
-        # Cancellation checkpoint: bail before each batch download starts.
+        # Cancellation checkpoint: bail before each batch starts.
         _check_delete_pending(connector_id)
 
         job_id = generate_uuid()
@@ -248,10 +248,11 @@ async def _process_new_files(
                 local_checksum = await asyncio.to_thread(
                     scanner.download_to, remote_path, batch_dir / filename
                 )
-                # Cancellation checkpoint: bail after each blocking download.
-                _check_delete_pending(connector_id)
                 scanner.verify_integrity(local_checksum, checksum)
                 checksum_to_filename[checksum] = filename
+
+            # Cancellation checkpoint: bail after each batch of downloads.
+            _check_delete_pending(connector_id)
 
             filenames = list(checksum_to_filename.values())
             job_name = f"{connector_id} - {sync_seq} - {batch_number}"

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -148,7 +148,7 @@ async def run_tick(connector_id: str) -> None:
     except asyncio.CancelledError as ce:
         logger.info(f"Tick cancelled for connector {connector_id!r}: {ce}")
         interrupt = _check_interrupt_call(connector_id, sync_seq)
-        _handle_interrupt(sync_seq, connector_id, interrupt)
+        await _handle_interrupt(sync_seq, connector_id, interrupt)
         raise
 
     except Exception as exc:
@@ -362,7 +362,7 @@ async def _delete_orphans(connector_id: str, orphan_checksums: set[str]) -> None
 # Interrupt handler — differentiated handling for cancel vs delete
 # ---------------------------------------------------------------------------
 
-def _handle_interrupt(
+async def _handle_interrupt(
     sync_seq: int,
     connector_id: str,
     interrupt_type: Optional[InterruptType],
@@ -395,65 +395,8 @@ def _handle_interrupt(
         logger.info(f"Handling delete connector for {connector_id!r}")
         _cancel_tick(sync_seq, connector_id)
         # Run full teardown: remove checksums, delete orphaned docs, delete connector row
-        _run_delete_teardown(connector_id)
-
-
-def _run_delete_teardown(connector_id: str) -> None:
-    """
-    Full teardown for connector deletion.
-
-    Steps:
-      1. Remove all checksum ownership rows; delete documents when last owner
-      2. Delete the connector row (cascades to sync_logs)
-      3. Sweep all residual batch staging directories
-    """
-    from digitize.utils.db import (
-        list_connector_checksums,
-        remove_connector_checksum_entry,
-        delete_active_connector,
-    )
-    from digitize.settings import settings
-    from digitize.api.v1.connectors import _sweep_staging_dir
-
-    logger.info(f"Running full teardown for connector {connector_id!r}")
-    try:
-        # Step 1: remove checksum ownership; delete orphaned documents
-        owned_checksums = list_connector_checksums(connector_id)
-        for checksum in owned_checksums:
-            try:
-                remaining, doc_id = remove_connector_checksum_entry(connector_id, checksum)
-                if remaining == 0 and doc_id:
-                    _best_effort_delete_document(doc_id)
-            except Exception as exc:
-                logger.error(
-                    f"Error removing checksum {checksum!r} for connector "
-                    f"{connector_id!r}: {exc}",
-                    exc_info=True,
-                )
-
-        # Step 2: delete the connector row (cascades to connector_sync_logs)
-        deleted = delete_active_connector(connector_id)
-        if not deleted:
-            logger.warning(
-                f"delete_active_connector returned False for {connector_id!r} "
-                "— row may have already been removed"
-            )
-
-        # Step 3: sweep all residual batch staging directories for this connector
-        _sweep_staging_dir(connector_id, settings.digitize.staging_dir / "connectors")
-
-        logger.info(f"Connector {connector_id!r} full teardown complete")
-    except Exception as exc:
-        logger.error(
-            f"Unexpected error during full teardown for connector {connector_id!r}: {exc}",
-            exc_info=True,
-        )
-
-
-def _best_effort_delete_document(doc_id: str) -> None:
-    """Best-effort document deletion — log but don't raise on failure."""
-    from digitize.api.v1.connectors import _best_effort_delete_document as delete_doc
-    delete_doc(doc_id)
+        from digitize.api.v1.connectors import _run_teardown
+        await _run_teardown(connector_id)
 
 
 # ---------------------------------------------------------------------------

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -30,6 +30,7 @@ from digitize.utils.db import (
     add_connector_checksum_entry,
     close_sync_log,
     get_active_connector,
+    get_connector_sync_status,
     list_all_checksums,
     list_connector_checksums,
     lookup_connector_content_by_checksum,
@@ -40,6 +41,25 @@ from digitize.utils.db import (
 from digitize.utils.jobs import generate_uuid, initialize_job_state
 
 logger = get_logger("sync_tick")
+
+
+# ---------------------------------------------------------------------------
+# Cancellation helper
+# ---------------------------------------------------------------------------
+
+def _check_delete_pending(connector_id: str) -> None:
+    """
+    Raise asyncio.CancelledError if the connector is marked for deletion.
+
+    Performs a live DB query — no in-memory state.  Called at the three
+    phase boundaries inside run_tick / _process_new_files so that a DELETE
+    request is honoured promptly without leaving the tick running to completion.
+    """
+    status = get_connector_sync_status(connector_id)
+    if status == "delete pending":
+        raise asyncio.CancelledError(
+            f"Connector {connector_id!r} marked delete_pending — tick cancelled"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -67,6 +87,9 @@ async def run_tick(connector_id: str) -> None:
     removed: int = 0
 
     try:
+        # Phase boundary: check for DELETE_PENDING before any remote I/O starts.
+        _check_delete_pending(connector_id)
+
         await asyncio.to_thread(scanner.connect)
         scanned_files: list[tuple[str, str]] = await asyncio.to_thread(scanner.scan)
 
@@ -92,6 +115,11 @@ async def run_tick(connector_id: str) -> None:
             removed_files=removed,
             failed_files=failed,
         )
+
+    except asyncio.CancelledError:
+        logger.info(f"Tick cancelled for connector {connector_id!r} (delete_pending)")
+        _cancel_tick(sync_seq, connector_id)
+        raise
 
     except Exception as exc:
         logger.error(
@@ -170,6 +198,9 @@ async def _process_new_files(
     failed_count = 0
 
     for batch_number, (remote_path, checksum) in enumerate(ingest_list):
+        # Cancellation checkpoint: bail before each download starts.
+        _check_delete_pending(connector_id)
+
         job_id = generate_uuid()
         batch_dir_name = f"{connector_id}-{job_id}-{batch_number}"
         batch_dir = staging_base / batch_dir_name
@@ -179,6 +210,8 @@ async def _process_new_files(
             local_checksum = await asyncio.to_thread(
                 scanner.download_to, remote_path, batch_dir / Path(remote_path).name
             )
+            # Cancellation checkpoint: bail after the blocking download returns.
+            _check_delete_pending(connector_id)
             scanner.verify_integrity(local_checksum, checksum)
 
             filename = Path(remote_path).name
@@ -264,6 +297,21 @@ def _complete_tick(
         f"Tick completed for {connector_id!r} — "
         f"total={total_files} new={new_files} removed={removed_files} failed={failed_files}"
     )
+
+
+def _cancel_tick(sync_seq: int, connector_id: str) -> None:
+    """Close the sync log with status='cancelled' after a CancelledError."""
+    try:
+        close_sync_log(
+            connector_id=connector_id,
+            seq=sync_seq,
+            status="cancelled",
+        )
+    except Exception as close_exc:
+        logger.error(
+            f"Failed to close sync log for {connector_id!r} after cancellation: {close_exc}",
+            exc_info=True,
+        )
 
 
 def _fail_tick(sync_seq: int, connector_id: str, exc: Exception) -> None:

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -113,13 +113,9 @@ async def run_tick(connector_id: str) -> None:
     try:
         # Phase boundary: check for interrupt signals before any remote I/O starts.
         interrupt = _check_interrupt_call(connector_id, sync_seq)
-        if interrupt == InterruptType.DELETE_CONNECTOR:
+        if interrupt:
             raise asyncio.CancelledError(
-                f"Connector {connector_id!r} marked for deletion"
-            )
-        elif interrupt == InterruptType.SYNC_CANCEL:
-            raise asyncio.CancelledError(
-                f"Sync cancel requested for connector {connector_id!r}"
+                f"Connector {connector_id!r} interrupted (type={interrupt.value})"
             )
 
         await asyncio.to_thread(scanner.connect)

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -42,6 +42,7 @@ from digitize.utils.db import (
     lookup_connector_content_by_checksum,
     init_sync_log_and_update_connector,
     remove_connector_checksum_entry,
+    update_connector_total_files,
     update_sync_log,
 )
 from digitize.utils.jobs import generate_uuid, initialize_job_state
@@ -135,6 +136,7 @@ async def run_tick(connector_id: str) -> None:
             new_files=len(ingest_list),
             removed_files=len(orphan_checksums),
         )
+        update_connector_total_files(connector_id, len(scanned_files))
 
         await _process_new_files(sync_seq, connector_id, config.name, scanner, ingest_list)
 

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -136,7 +136,7 @@ async def run_tick(connector_id: str) -> None:
             removed_files=len(orphan_checksums),
         )
 
-        await _process_new_files(sync_seq, connector_id, scanner, ingest_list)
+        await _process_new_files(sync_seq, connector_id, config.name, scanner, ingest_list)
 
         await _delete_orphans(connector_id, orphan_checksums)
 
@@ -241,6 +241,7 @@ async def _wait_for_job(job_id: str, connector_id: str, sync_seq: int) -> None:
 async def _process_new_files(
     sync_seq: int,
     connector_id: str,
+    connector_name: str,
     scanner,
     ingest_list: list[tuple[str, str]],
 ) -> None:
@@ -297,7 +298,7 @@ async def _process_new_files(
                 )
 
             filenames = list(checksum_to_filename.values())
-            job_name = f"{connector_id} - {sync_seq} - {batch_number}"
+            job_name = f"Connector-{connector_name}-{sync_seq}-{batch_number}"
             doc_id_dict = initialize_job_state(
                 job_id=job_id,
                 operation=OperationType.INGESTION,

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -276,18 +276,13 @@ async def _process_new_files(
 # Phase 4b — orphan removal
 # ---------------------------------------------------------------------------
 
-async def _delete_orphans(connector_id: str, orphan_checksums: set[str]) -> int:
-    """Remove orphaned checksum rows and delete documents that lose their last owner.
-
-    Returns the number of ownership rows removed.
-    """
+async def _delete_orphans(connector_id: str, orphan_checksums: set[str]) -> None:
+    """Remove orphaned checksum rows and delete documents that lose their last owner."""
     from digitize.api.v1.connectors import _best_effort_delete_document
 
-    removed = 0
     for checksum in orphan_checksums:
         try:
             remaining, doc_id = remove_connector_checksum_entry(connector_id, checksum)
-            removed += 1
             if remaining == 0 and doc_id:
                 await asyncio.to_thread(_best_effort_delete_document, doc_id)
         except Exception as exc:
@@ -296,7 +291,7 @@ async def _delete_orphans(connector_id: str, orphan_checksums: set[str]) -> int:
                 f"for connector {connector_id!r}: {exc}",
                 exc_info=True,
             )
-    return removed
+            raise
 
 
 # ---------------------------------------------------------------------------

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -253,8 +253,12 @@ async def _process_new_files(
     registered as a single job, and passed to ``ingest()`` together.
 
     Staging directories are removed after each batch regardless of success.
+
+    Raises ``RuntimeError`` after processing all batches if any batch failed,
+    so the caller can mark the connector as OUT_OF_SYNC.
     """
     staging_base = settings.digitize.staging_dir / "connectors"
+    batch_failed = False
 
     for batch_number in range(0, len(ingest_list), _BATCH_SIZE):
         batch = ingest_list[batch_number : batch_number + _BATCH_SIZE]
@@ -312,14 +316,24 @@ async def _process_new_files(
 
             await _wait_for_job(job_id, connector_id, sync_seq)
 
+        except asyncio.CancelledError:
+            raise
+
         except Exception as exc:
             logger.warning(
                 f"Failed to ingest batch {batch_number!r} for connector {connector_id!r}: {exc}",
                 exc_info=True,
             )
+            batch_failed = True
 
         finally:
             cleanup_staging_directory(batch_dir_name, staging_base, ignore_errors=True)
+
+    if batch_failed:
+        raise RuntimeError(
+            f"One or more batches failed to ingest for connector {connector_id!r}; "
+            "connector marked as out of sync"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -3,18 +3,31 @@ connectors/sync_tick.py — end-to-end sync-tick logic for one connector.
 
 Phases
 ------
-1.  init_sync_log_and_update_connector        → INSERT connector_sync_logs row (status='started')
-2.  load known/all checksums + scanner.scan()
-3.  _classify()              → ingest_list, orphan_checksums
+1.  [caller] try_acquire_sync_lock()              → atomically set connector.sync_status=SYNCING
+2.  [caller] init_sync_log_and_update_connector() → INSERT connector_sync_logs row (status='started'),
+             returns sync_seq which is passed directly into run_tick()
+3.  load known/all checksums + scanner.scan()
+4.  _classify()              → ingest_list, orphan_checksums
                                cross-connector dups registered inline
-3b. update_sync_log()        → single DB write of total/new/removed counts (all known post-classify)
-4a. _process_new_files()     → download → create job/doc → add checksum row
-4b. _delete_orphans()        → remove checksum rows; delete docs with no owners
-5.  finalize_sync_log_and_update_connector()         → finalize tick row with terminal status + reset sync_status
+4b. update_sync_log()        → single DB write of total/new/removed counts (all known post-classify)
+5a. _process_new_files()     → download → create job/doc → add checksum row
+5b. _delete_orphans()        → remove checksum rows; delete docs with no owners
+6.  finalize_sync_log_and_update_connector()      → finalize tick row with terminal status + reset sync_status
 
-Called by the APScheduler job (_run_tick_wrapped in scheduler.py, PR7) and
-directly by POST /v1/connectors/{id}/sync after the caller has already
-acquired the sync lock via try_acquire_sync_lock().
+Caller contract
+---------------
+Any caller — the HTTP handler (POST /v1/connectors/{id}/syncs) or the future
+APScheduler job (_run_tick_wrapped in scheduler.py) — must follow the same
+three-step preamble before calling run_tick():
+
+    acquired = db_ops.try_acquire_sync_lock(connector_id)
+    if not acquired:
+        return  # another tick is already running
+    sync_seq = db_ops.init_sync_log_and_update_connector(connector_id)
+    asyncio.create_task(run_tick(connector_id, sync_seq))
+
+This keeps seq generation synchronous and in the caller's control, eliminating
+any need for polling after task dispatch.
 """
 
 from __future__ import annotations
@@ -40,7 +53,6 @@ from digitize.utils.db import (
     list_all_checksums,
     list_connector_checksums,
     lookup_connector_content_by_checksum,
-    init_sync_log_and_update_connector,
     remove_connector_checksum_entry,
     update_connector_total_files,
     update_sync_log,
@@ -95,20 +107,25 @@ def _check_interrupt_call(connector_id: str, sync_seq: int) -> Optional[Interrup
 # Public entry-point
 # ---------------------------------------------------------------------------
 
-async def run_tick(connector_id: str) -> None:
+async def run_tick(connector_id: str, sync_seq: int) -> None:
     """
     Execute one full sync tick for *connector_id*.
 
-    The caller is responsible for acquiring the sync lock (sync_status='syncing')
-    before calling this coroutine.  init_sync_log_and_update_connector() is called here to open
-    the sync-log row.
+    Parameters
+    ----------
+    connector_id:
+        The connector to sync.
+    sync_seq:
+        The seq of the sync-log row that the caller already opened via
+        ``init_sync_log_and_update_connector()``.  The caller is also
+        responsible for acquiring the sync lock beforehand via
+        ``try_acquire_sync_lock()``.
     """
     config = get_active_connector(connector_id)
     if config is None:
         logger.error(f"Connector {connector_id!r} not found; tick aborted")
         return
 
-    sync_seq: int = init_sync_log_and_update_connector(connector_id)
     scanner = build_scanner(config)
 
     try:

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -7,9 +7,10 @@ Phases
 2.  load known/all checksums + scanner.scan()
 3.  _classify()              → ingest_list, orphan_checksums
                                cross-connector dups registered inline
+3b. update_sync_log()        → single DB write of total/new/removed counts (all known post-classify)
 4a. _process_new_files()     → download → create job/doc → add checksum row
 4b. _delete_orphans()        → remove checksum rows; delete docs with no owners
-5.  close_sync_log()         → finalize tick row + reset sync_status
+5.  close_sync_log()         → finalize tick row with terminal status + reset sync_status
 
 Called by the APScheduler job (_run_tick_wrapped in scheduler.py, PR7) and
 directly by POST /v1/connectors/{id}/sync after the caller has already
@@ -85,10 +86,6 @@ async def run_tick(connector_id: str) -> None:
     sync_seq: int = open_new_sync_log(connector_id)
     scanner = build_scanner(config)
 
-    failed: int = 0
-    new: int = 0
-    removed: int = 0
-
     try:
         # Phase boundary: check for DELETE_PENDING before any remote I/O starts.
         _check_delete_pending(connector_id)
@@ -103,21 +100,18 @@ async def run_tick(connector_id: str) -> None:
             connector_id, scanned_files, known_checksums, all_checksums
         )
 
-        update_sync_log(sync_seq, total_files=len(scanned_files))
-
-        new, failed = await _process_new_files(
-            sync_seq, connector_id, scanner, ingest_list
-        )
-
-        removed = await _delete_orphans(connector_id, orphan_checksums)
-
-        _complete_tick(
-            sync_seq, connector_id,
+        update_sync_log(
+            sync_seq,
             total_files=len(scanned_files),
-            new_files=new,
-            removed_files=removed,
-            failed_files=failed,
+            new_files=len(ingest_list),
+            removed_files=len(orphan_checksums),
         )
+
+        await _process_new_files(sync_seq, connector_id, scanner, ingest_list)
+
+        await _delete_orphans(connector_id, orphan_checksums)
+
+        _complete_tick(sync_seq, connector_id)
 
     except asyncio.CancelledError:
         logger.info(f"Tick cancelled for connector {connector_id!r} (delete_pending)")
@@ -215,18 +209,15 @@ async def _process_new_files(
     connector_id: str,
     scanner,
     ingest_list: list[tuple[str, str]],
-) -> tuple[int, int]:
+) -> None:
     """Download and ingest *ingest_list* in batches of up to 10 files.
 
     Each batch of up to 10 files is downloaded into a single staging directory,
     registered as a single job, and passed to ``ingest()`` together.
 
-    Returns (new_count, failed_count).  Staging directories are removed after
-    each batch regardless of success.
+    Staging directories are removed after each batch regardless of success.
     """
     staging_base = settings.digitize.staging_dir / "connectors"
-    new_count = 0
-    failed_count = 0
 
     for batch_number in range(0, len(ingest_list), _BATCH_SIZE):
         batch = ingest_list[batch_number : batch_number + _BATCH_SIZE]
@@ -271,21 +262,14 @@ async def _process_new_files(
 
             await _wait_for_job(job_id, connector_id)
 
-            new_count += len(batch)
-            update_sync_log(sync_seq, new_files=new_count)
-
         except Exception as exc:
             logger.warning(
                 f"Failed to ingest batch {batch_number!r} for connector {connector_id!r}: {exc}",
                 exc_info=True,
             )
-            failed_count += len(batch)
-            update_sync_log(sync_seq, failed_files=failed_count)
 
         finally:
             cleanup_staging_directory(batch_dir_name, staging_base, ignore_errors=True)
-
-    return new_count, failed_count
 
 
 # ---------------------------------------------------------------------------
@@ -319,27 +303,13 @@ async def _delete_orphans(connector_id: str, orphan_checksums: set[str]) -> int:
 # Phase 5 helpers
 # ---------------------------------------------------------------------------
 
-def _complete_tick(
-    sync_seq: int,
-    connector_id: str,
-    total_files: int,
-    new_files: int,
-    removed_files: int,
-    failed_files: int,
-) -> None:
+def _complete_tick(sync_seq: int, connector_id: str) -> None:
     close_sync_log(
         connector_id=connector_id,
         seq=sync_seq,
         status="completed",
-        total_files=total_files,
-        new_files=new_files,
-        removed_files=removed_files,
-        failed_files=failed_files,
     )
-    logger.info(
-        f"Tick completed for {connector_id!r} — "
-        f"total={total_files} new={new_files} removed={removed_files} failed={failed_files}"
-    )
+    logger.info(f"Tick completed for {connector_id!r}")
 
 
 def _cancel_tick(sync_seq: int, connector_id: str) -> None:

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -49,16 +49,18 @@ logger = get_logger("sync_tick")
 
 def _check_delete_pending(connector_id: str) -> None:
     """
-    Raise asyncio.CancelledError if the connector is marked for deletion.
+    Raise asyncio.CancelledError if the connector is marked for deletion or
+    a stop-sync request has been issued.
 
     Performs a live DB query — no in-memory state.  Called at the three
     phase boundaries inside run_tick / _process_new_files so that a DELETE
-    request is honoured promptly without leaving the tick running to completion.
+    or DELETE /sync request is honoured promptly without leaving the tick
+    running to completion.
     """
     status = get_connector_sync_status(connector_id)
-    if status == "delete pending":
+    if status in ("delete pending", "cancel pending"):
         raise asyncio.CancelledError(
-            f"Connector {connector_id!r} marked delete_pending — tick cancelled"
+            f"Connector {connector_id!r} sync cancelled (status={status!r})"
         )
 
 

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -257,8 +257,8 @@ async def _process_new_files(
     staging_base = settings.digitize.staging_dir / "connectors"
     batch_failed = False
 
-    for batch_number in range(0, len(ingest_list), _BATCH_SIZE):
-        batch = ingest_list[batch_number : batch_number + _BATCH_SIZE]
+    for batch_number, batch_offset in enumerate(range(0, len(ingest_list), _BATCH_SIZE), start=1):
+        batch = ingest_list[batch_offset : batch_offset + _BATCH_SIZE]
 
         # Cancellation checkpoint: bail before each batch starts.
         interrupt = _check_interrupt_call(connector_id, sync_seq)
@@ -318,7 +318,7 @@ async def _process_new_files(
 
         except Exception as exc:
             logger.warning(
-                f"Failed to ingest batch {batch_number!r} for connector {connector_id!r}: {exc}",
+                f"Failed to ingest batch {batch_number} for connector {connector_id!r}: {exc}",
                 exc_info=True,
             )
             batch_failed = True

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -202,7 +202,7 @@ async def _process_new_files(
         _check_delete_pending(connector_id)
 
         job_id = generate_uuid()
-        batch_dir_name = f"{connector_id}-{job_id}-{batch_number}"
+        batch_dir_name = f"{connector_id}-{sync_seq}-{batch_number}"
         batch_dir = staging_base / batch_dir_name
         batch_dir.mkdir(parents=True, exist_ok=True)
 

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -23,14 +23,15 @@ from pathlib import Path
 
 from common.misc_utils import cleanup_staging_directory, get_logger
 from digitize.connectors.scanners.scanner_factory import build_scanner
-from digitize.models import OutputFormat, OperationType
 from digitize.pipeline.ingest import ingest
 from digitize.settings import settings
+from digitize.models import JobStatus, OutputFormat, OperationType
 from digitize.utils.db import (
     add_connector_checksum_entry,
     close_sync_log,
     get_active_connector,
     get_connector_sync_status,
+    get_job,
     list_all_checksums,
     list_connector_checksums,
     lookup_connector_content_by_checksum,
@@ -185,6 +186,28 @@ def _classify(
 # ---------------------------------------------------------------------------
 
 _BATCH_SIZE = 10
+_JOB_POLL_INTERVAL = 10  # seconds between job-status polls while waiting for a batch
+
+
+async def _wait_for_job(job_id: str, connector_id: str) -> None:
+    """Poll *job_id* until it reaches a terminal state.
+
+    Sleeps *_JOB_POLL_INTERVAL* seconds between polls.  On every wake-up it
+    also calls ``_check_delete_pending`` so that a deletion/cancel request is
+    honoured promptly even while the batch is running.
+
+    Raises ``asyncio.CancelledError`` if the connector is marked for deletion
+    or a stop-sync request is issued during the wait.
+    """
+    _TERMINAL = {JobStatus.COMPLETED.value, JobStatus.FAILED.value}
+    while True:
+        await asyncio.sleep(_JOB_POLL_INTERVAL)
+        _check_delete_pending(connector_id)
+        job_data = get_job(job_id)
+        status = (job_data or {}).get("status", "")
+        logger.debug(f"Polling job {job_id!r} for connector {connector_id!r}: status={status!r}")
+        if status in _TERMINAL:
+            break
 
 
 async def _process_new_files(
@@ -244,6 +267,8 @@ async def _process_new_files(
                 add_connector_checksum_entry(connector_id, checksum, doc_id_dict[filename])
 
             await asyncio.to_thread(ingest, batch_dir, job_id, doc_id_dict)
+
+            await _wait_for_job(job_id, connector_id)
 
             new_count += len(batch)
             update_sync_log(sync_seq, new_files=new_count)

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -53,7 +53,7 @@ logger = get_logger("sync_tick")
 # Interrupt handling enum
 # ---------------------------------------------------------------------------
 
-class InterruptType(Enum):
+class InterruptType(str, Enum):
     """Indicates the type of interrupt signal detected during sync execution."""
     SYNC_CANCEL = "sync_cancel"      # CANCEL_PENDING in ConnectorSyncLog
     DELETE_CONNECTOR = "delete_connector"  # DELETE_PENDING in Connectors table

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1112,26 +1112,10 @@ class DatabaseManager:
         """
         Signal a running tick to cancel by setting connector_sync_logs.status='cancel pending'.
 
-        Only writes the signal when connectors.sync_status='syncing', which guarantees
-        an active tick exists.  The connectors row is left untouched — it stays 'syncing'
-        until the tick's close_sync_log() call transitions it to 'out of sync'.
-
-        Returns True if the signal was written (a tick was running), False if no tick
-        was running or the connector does not exist.
+        Returns True if the signal was written, False if no started sync-log row exists.
         """
         try:
             with get_db_session() as session:
-                # Verify a tick is currently running
-                connector_row = session.execute(
-                    select(Connector.id)
-                    .where(
-                        Connector.id == connector_id,
-                        Connector.sync_status == SyncStatus.SYNCING,
-                    )
-                ).one_or_none()
-                if connector_row is None:
-                    return False
-                # Write the cancel signal onto the active sync-log row
                 result = session.execute(
                     update(ConnectorSyncLog)
                     .where(

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1134,7 +1134,7 @@ class DatabaseManager:
             raise
 
     @staticmethod
-    def mark_sync_delete_pending(connector_id: str) -> bool:
+    def mark_connector_delete_pending(connector_id: str) -> bool:
         """
         Atomically set sync_status='delete pending' when sync_status='syncing'.
 
@@ -1159,7 +1159,7 @@ class DatabaseManager:
                 ).one_or_none()
                 return result is not None
         except SQLAlchemyError as e:
-            logger.error(f"DB error in mark_sync_delete_pending({connector_id!r}): {e}", exc_info=True)
+            logger.error(f"DB error in mark_connector_delete_pending({connector_id!r}): {e}", exc_info=True)
             raise
 
     @staticmethod

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1084,21 +1084,36 @@ class DatabaseManager:
     @staticmethod
     def mark_sync_cancel_pending(connector_id: str) -> bool:
         """
-        Atomically set sync_status='cancel pending' when sync_status='syncing'.
+        Signal a running tick to cancel by setting connector_sync_logs.status='cancel pending'.
 
-        Returns True if the update landed (a tick was running and is now
-        signalled to cancel), False if no tick was running or connector not found.
+        Only writes the signal when connectors.sync_status='syncing', which guarantees
+        an active tick exists.  The connectors row is left untouched — it stays 'syncing'
+        until the tick's close_sync_log() call transitions it to 'out of sync'.
+
+        Returns True if the signal was written (a tick was running), False if no tick
+        was running or the connector does not exist.
         """
         try:
             with get_db_session() as session:
-                result = session.execute(
-                    update(Connector)
+                # Verify a tick is currently running
+                connector_row = session.execute(
+                    select(Connector.id)
                     .where(
                         Connector.id == connector_id,
                         Connector.sync_status == SyncStatus.SYNCING,
                     )
-                    .values(sync_status=SyncStatus.CANCEL_PENDING)
-                    .returning(Connector.id)
+                ).one_or_none()
+                if connector_row is None:
+                    return False
+                # Write the cancel signal onto the active sync-log row
+                result = session.execute(
+                    update(ConnectorSyncLog)
+                    .where(
+                        ConnectorSyncLog.connector_id == connector_id,
+                        ConnectorSyncLog.status == SyncStatus.STARTED,
+                    )
+                    .values(status=SyncStatus.CANCEL_PENDING)
+                    .returning(ConnectorSyncLog.seq)
                 ).one_or_none()
                 return result is not None
         except SQLAlchemyError as e:

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -870,6 +870,29 @@ class DatabaseManager:
             return None
 
     @staticmethod
+    def get_connector_sync_status(connector_id: str) -> Optional[str]:
+        """
+        Return the current sync_status string for a connector.
+
+        Does a minimal SELECT sync_status query — does not load the full row.
+        Returns None if the connector does not exist.
+        """
+        try:
+            with get_db_session() as session:
+                stmt = (
+                    select(Connector.sync_status)
+                    .where(Connector.id == connector_id)
+                )
+                row = session.execute(stmt).one_or_none()
+                return row[0] if row else None
+        except SQLAlchemyError as e:
+            logger.error(
+                f"DB error in get_connector_sync_status({connector_id!r}): {e}",
+                exc_info=True,
+            )
+            return None
+
+    @staticmethod
     def get_all_connectors() -> List[Connector]:
         """
         Return all connectors ordered by attached_at descending.

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -15,7 +15,7 @@ from common.misc_utils import get_logger
 from digitize.db.models import Job, Document, DocumentChecksum, Connector, ConnectorDocumentChecksum, ConnectorSyncLog
 from digitize.db.connection import get_db_session
 from digitize.models import JobStatus, DocStatus
-from digitize.connectors.models import SyncStatus
+from digitize.connectors.models import ConnectorStatus, SyncLogStatus
 
 logger = get_logger("db_repository")
 
@@ -775,7 +775,7 @@ class DatabaseManager:
                         allowed_extensions=allowed_extensions,
                         sync_interval_seconds=sync_interval_seconds,
                         attached_at=datetime.now(timezone.utc),
-                        sync_status=SyncStatus.UP_TO_DATE,
+                        sync_status=ConnectorStatus.UP_TO_DATE,
                         total_files=0,
                     )
                     .on_conflict_do_nothing(index_elements=["id"])
@@ -1072,7 +1072,7 @@ class DatabaseManager:
                     .where(
                         ConnectorSyncLog.connector_id == connector_id,
                         ConnectorSyncLog.status.in_(
-                            [SyncStatus.STARTED, SyncStatus.CANCEL_PENDING]
+                            [SyncLogStatus.STARTED, SyncLogStatus.CANCEL_PENDING]
                         ),
                     )
                     .order_by(ConnectorSyncLog.seq.desc())
@@ -1097,9 +1097,9 @@ class DatabaseManager:
                     update(Connector)
                     .where(
                         Connector.id == connector_id,
-                        Connector.sync_status != SyncStatus.SYNCING,
+                        Connector.sync_status != ConnectorStatus.SYNCING,
                     )
-                    .values(sync_status=SyncStatus.SYNCING)
+                    .values(sync_status=ConnectorStatus.SYNCING)
                     .returning(Connector.id)
                 ).one_or_none()
                 return result is not None
@@ -1120,9 +1120,9 @@ class DatabaseManager:
                     update(ConnectorSyncLog)
                     .where(
                         ConnectorSyncLog.connector_id == connector_id,
-                        ConnectorSyncLog.status == SyncStatus.STARTED,
+                        ConnectorSyncLog.status == SyncLogStatus.STARTED,
                     )
-                    .values(status=SyncStatus.CANCEL_PENDING)
+                    .values(status=SyncLogStatus.CANCEL_PENDING)
                     .returning(ConnectorSyncLog.seq)
                 ).one_or_none()
                 return result is not None
@@ -1149,9 +1149,9 @@ class DatabaseManager:
                     update(Connector)
                     .where(
                         Connector.id == connector_id,
-                        Connector.sync_status == SyncStatus.SYNCING,
+                        Connector.sync_status == ConnectorStatus.SYNCING,
                     )
-                    .values(sync_status=SyncStatus.DELETE_PENDING)
+                    .values(sync_status=ConnectorStatus.DELETE_PENDING)
                     .returning(Connector.id)
                 ).one_or_none()
                 return result is not None
@@ -1183,7 +1183,7 @@ class DatabaseManager:
                         connector_id=connector_id,
                         seq=seq_subquery,
                         started_at=started_at or datetime.now(timezone.utc),
-                        status=SyncStatus.STARTED,
+                        status=SyncLogStatus.STARTED,
                         error="",
                     )
                     .returning(ConnectorSyncLog.seq)
@@ -1192,7 +1192,7 @@ class DatabaseManager:
                 session.execute(
                     update(Connector)
                     .where(Connector.id == connector_id)
-                    .values(sync_status=SyncStatus.SYNCING)
+                    .values(sync_status=ConnectorStatus.SYNCING)
                 )
                 logger.debug(f"open_sync_log: connector={connector_id!r} seq={seq}")
                 return seq
@@ -1248,8 +1248,8 @@ class DatabaseManager:
                 # Cancelled and failed ticks both leave the connector OUT_OF_SYNC
                 # so the scheduler can retry.  Only COMPLETED writes through verbatim.
                 connector_sync_status = (
-                    SyncStatus.OUT_OF_SYNC
-                    if status in (SyncStatus.CANCELLED, SyncStatus.FAILED)
+                    ConnectorStatus.OUT_OF_SYNC
+                    if status in (SyncLogStatus.CANCELLED, SyncLogStatus.FAILED)
                     else status
                 )
                 session.execute(

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1283,6 +1283,31 @@ class DatabaseManager:
             return False
 
     @staticmethod
+    def get_sync_log_status(connector_id: str, seq: int) -> Optional[str]:
+        """
+        Return the status of a specific sync-log row identified by (connector_id, seq).
+
+        Returns None if the row does not exist.
+        """
+        try:
+            with get_db_session() as session:
+                stmt = (
+                    select(ConnectorSyncLog.status)
+                    .where(
+                        ConnectorSyncLog.connector_id == connector_id,
+                        ConnectorSyncLog.seq == seq,
+                    )
+                )
+                row = session.execute(stmt).one_or_none()
+                return row[0] if row else None
+        except SQLAlchemyError as e:
+            logger.error(
+                f"DB error in get_sync_log_status(connector={connector_id!r}, seq={seq}): {e}",
+                exc_info=True,
+            )
+            return None
+
+    @staticmethod
     def get_sync_logs(
         connector_id: str,
         limit: int = 50,

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1058,6 +1058,32 @@ class DatabaseManager:
     # ========================================================================
 
     @staticmethod
+    def get_active_sync_seq(connector_id: str) -> Optional[int]:
+        """
+        Return the seq of the currently-running sync-log row for connector_id.
+
+        A row is considered active when its status is 'started' or 'cancel pending'.
+        Returns None if no active row exists.
+        """
+        try:
+            with get_db_session() as session:
+                row = session.execute(
+                    select(ConnectorSyncLog.seq)
+                    .where(
+                        ConnectorSyncLog.connector_id == connector_id,
+                        ConnectorSyncLog.status.in_(
+                            [SyncStatus.STARTED, SyncStatus.CANCEL_PENDING]
+                        ),
+                    )
+                    .order_by(ConnectorSyncLog.seq.desc())
+                    .limit(1)
+                ).one_or_none()
+                return row[0] if row else None
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in get_active_sync_seq({connector_id!r}): {e}", exc_info=True)
+            raise
+
+    @staticmethod
     def try_acquire_sync_lock(connector_id: str) -> bool:
         """
         Atomically set sync_status='syncing' if it is not already 'syncing'.

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1082,6 +1082,30 @@ class DatabaseManager:
             raise
 
     @staticmethod
+    def mark_sync_cancel_pending(connector_id: str) -> bool:
+        """
+        Atomically set sync_status='cancel pending' when sync_status='syncing'.
+
+        Returns True if the update landed (a tick was running and is now
+        signalled to cancel), False if no tick was running or connector not found.
+        """
+        try:
+            with get_db_session() as session:
+                result = session.execute(
+                    update(Connector)
+                    .where(
+                        Connector.id == connector_id,
+                        Connector.sync_status == SyncStatus.SYNCING,
+                    )
+                    .values(sync_status=SyncStatus.CANCEL_PENDING)
+                    .returning(Connector.id)
+                ).one_or_none()
+                return result is not None
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in mark_sync_cancel_pending({connector_id!r}): {e}", exc_info=True)
+            raise
+
+    @staticmethod
     def open_sync_log(
         connector_id: str,
         started_at: Optional[datetime] = None,
@@ -1170,10 +1194,19 @@ class DatabaseManager:
                         f"Sync log connector={connector_id!r} seq={seq} not found for update"
                     )
                     return False
+                # When a tick is cancelled (stop-sync request) the connector
+                # should revert to 'out of sync' so the scheduler can run the
+                # next tick normally.  All other terminal statuses are written
+                # through verbatim (completed → 'completed', failed → 'failed').
+                connector_sync_status = (
+                    SyncStatus.OUT_OF_SYNC
+                    if status == SyncStatus.CANCELLED
+                    else status
+                )
                 session.execute(
                     update(Connector)
                     .where(Connector.id == connector_id)
-                    .values(last_sync_at=now, sync_status=status)
+                    .values(last_sync_at=now, sync_status=connector_sync_status)
                 )
                 return True
         except SQLAlchemyError as e:

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1338,6 +1338,38 @@ class DatabaseManager:
             return None
 
     @staticmethod
+    def get_sync_log(connector_id: str, seq: int) -> Optional[ConnectorSyncLog]:
+        """Return a specific sync-log row identified by (connector_id, seq)."""
+        try:
+            with get_db_session() as session:
+                stmt = select(ConnectorSyncLog).where(
+                    ConnectorSyncLog.connector_id == connector_id,
+                    ConnectorSyncLog.seq == seq,
+                )
+                row = session.scalars(stmt).one_or_none()
+                if row is None:
+                    return None
+                _ = (
+                    row.connector_id,
+                    row.seq,
+                    row.started_at,
+                    row.finished_at,
+                    row.total_files,
+                    row.new_files,
+                    row.removed_files,
+                    row.status,
+                    row.error,
+                )
+                session.expunge(row)
+                return row
+        except SQLAlchemyError as e:
+            logger.error(
+                f"DB error in get_sync_log(connector={connector_id!r}, seq={seq}): {e}",
+                exc_info=True,
+            )
+            return None
+
+    @staticmethod
     def get_sync_logs(
         connector_id: str,
         limit: int = 50,
@@ -1353,7 +1385,7 @@ class DatabaseManager:
                 base = select(ConnectorSyncLog).where(
                     ConnectorSyncLog.connector_id == connector_id
                 )
-                total: int = session.execute(
+                total = session.execute(
                     select(func.count()).select_from(base.subquery())
                 ).scalar() or 0
 

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1106,6 +1106,35 @@ class DatabaseManager:
             raise
 
     @staticmethod
+    def mark_sync_delete_pending(connector_id: str) -> bool:
+        """
+        Atomically set sync_status='delete pending' when sync_status='syncing'.
+
+        Used when a DELETE request arrives while a tick is in progress: the
+        running tick will notice the status at its next _check_delete_pending
+        checkpoint and cancel itself, after which the caller must finish the
+        deletion (remove checksums / docs / row).
+
+        Returns True if the signal was set (a tick was running), False if no
+        tick was running or the connector does not exist.
+        """
+        try:
+            with get_db_session() as session:
+                result = session.execute(
+                    update(Connector)
+                    .where(
+                        Connector.id == connector_id,
+                        Connector.sync_status == SyncStatus.SYNCING,
+                    )
+                    .values(sync_status=SyncStatus.DELETE_PENDING)
+                    .returning(Connector.id)
+                ).one_or_none()
+                return result is not None
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in mark_sync_delete_pending({connector_id!r}): {e}", exc_info=True)
+            raise
+
+    @staticmethod
     def open_sync_log(
         connector_id: str,
         started_at: Optional[datetime] = None,

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1058,6 +1058,30 @@ class DatabaseManager:
     # ========================================================================
 
     @staticmethod
+    def try_acquire_sync_lock(connector_id: str) -> bool:
+        """
+        Atomically set sync_status='syncing' if it is not already 'syncing'.
+
+        Returns True if the lock was acquired, False if another tick already
+        holds it (or the connector row does not exist).
+        """
+        try:
+            with get_db_session() as session:
+                result = session.execute(
+                    update(Connector)
+                    .where(
+                        Connector.id == connector_id,
+                        Connector.sync_status != SyncStatus.SYNCING,
+                    )
+                    .values(sync_status=SyncStatus.SYNCING)
+                    .returning(Connector.id)
+                ).one_or_none()
+                return result is not None
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in try_acquire_sync_lock({connector_id}): {e}", exc_info=True)
+            raise
+
+    @staticmethod
     def open_sync_log(
         connector_id: str,
         started_at: Optional[datetime] = None,

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1155,7 +1155,6 @@ class DatabaseManager:
         total_files: Optional[int] = None,
         new_files: Optional[int] = None,
         removed_files: Optional[int] = None,
-        failed_files: Optional[int] = None,
         error: Optional[str] = None,
     ) -> bool:
         """
@@ -1176,8 +1175,6 @@ class DatabaseManager:
                     log_values["new_files"] = new_files
                 if removed_files is not None:
                     log_values["removed_files"] = removed_files
-                if failed_files is not None:
-                    log_values["failed_files"] = failed_files
                 if error is not None:
                     log_values["error"] = error
                 log_stmt = (
@@ -1222,7 +1219,6 @@ class DatabaseManager:
         total_files: Optional[int] = None,
         new_files: Optional[int] = None,
         removed_files: Optional[int] = None,
-        failed_files: Optional[int] = None,
     ) -> bool:
         """
         Write live progress counters into an in-progress sync-log row.
@@ -1239,8 +1235,6 @@ class DatabaseManager:
                     values["new_files"] = new_files
                 if removed_files is not None:
                     values["removed_files"] = removed_files
-                if failed_files is not None:
-                    values["failed_files"] = failed_files
                 if not values:
                     return True
                 stmt = (
@@ -1290,7 +1284,7 @@ class DatabaseManager:
                         row.id, row.connector_id, row.seq,
                         row.started_at, row.finished_at,
                         row.total_files, row.new_files, row.removed_files,
-                        row.failed_files, row.status, row.error,
+                        row.status, row.error,
                     )
                     session.expunge(row)
                 logger.debug(

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1021,12 +1021,11 @@ class DatabaseManager:
     @staticmethod
     def delete_connector_checksum(
         connector_id: str, checksum: str
-    ) -> tuple[int, Optional[str]]:
+    ) -> Optional[str]:
         """
         Delete the (checksum, connector_id) row.
 
-        Returns (remaining_owner_count, doc_id).
-        If the row did not exist, returns (0, None).
+        Returns the doc_id of the deleted row, or None if the row did not exist.
         """
         try:
             with get_db_session() as session:
@@ -1040,23 +1039,33 @@ class DatabaseManager:
                 )
                 deleted_row = session.execute(del_stmt).one_or_none()
                 if deleted_row is None:
-                    return 0, None
+                    return None
                 doc_id: str = deleted_row[0]
-
-                count_stmt = select(func.count()).where(
-                    ConnectorDocumentChecksum.checksum == checksum
-                )
-                remaining: int = session.execute(count_stmt).scalar() or 0
                 logger.debug(
                     f"delete_connector_checksum: connector={connector_id!r} "
-                    f"checksum={checksum[:20]}... remaining={remaining}"
+                    f"checksum={checksum[:20]}... doc_id={doc_id!r}"
                 )
-                return remaining, doc_id
+                return doc_id
         except SQLAlchemyError as e:
             logger.error(
                 f"DB error in delete_connector_checksum({connector_id}, {checksum[:20]}...): {e}",
                 exc_info=True,
             )
+            raise
+
+    @staticmethod
+    def count_checksum_owners(checksum: str) -> int:
+        """
+        Return the number of connector rows that still reference *checksum*.
+        """
+        try:
+            with get_db_session() as session:
+                count_stmt = select(func.count()).where(
+                    ConnectorDocumentChecksum.checksum == checksum
+                )
+                return session.execute(count_stmt).scalar() or 0
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in count_checksum_owners({checksum[:20]}...): {e}", exc_info=True)
             raise
 
     # ========================================================================
@@ -1161,15 +1170,13 @@ class DatabaseManager:
             raise
 
     @staticmethod
-    def init_sync_log_and_update_connector(
+    def insert_sync_log(
         connector_id: str,
         started_at: Optional[datetime] = None,
     ) -> int:
         """
-        Initialise a new sync run across two tables:
-          - connector_sync_log: inserts a new row with status=STARTED and an
-            auto-incremented seq (COALESCE(MAX(seq), 0) + 1) scoped to this connector.
-          - connector: sets sync_status=SYNCING on the matching row.
+        Insert a new sync-log row with status=STARTED and an auto-incremented seq
+        (COALESCE(MAX(seq), 0) + 1) scoped to this connector.
 
         Returns the generated seq value.
         """
@@ -1192,19 +1199,28 @@ class DatabaseManager:
                     .returning(ConnectorSyncLog.seq)
                 )
                 seq: int = session.execute(stmt).scalar_one()
+                logger.debug(f"insert_sync_log: connector={connector_id!r} seq={seq}")
+                return seq
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in insert_sync_log({connector_id}): {e}", exc_info=True)
+            raise
+
+    @staticmethod
+    def set_connector_sync_status_syncing(connector_id: str) -> None:
+        """Set sync_status=SYNCING on the connector row."""
+        try:
+            with get_db_session() as session:
                 session.execute(
                     update(Connector)
                     .where(Connector.id == connector_id)
                     .values(sync_status=ConnectorStatus.SYNCING)
                 )
-                logger.debug(f"init_sync_log_and_update_connector: connector={connector_id!r} seq={seq}")
-                return seq
         except SQLAlchemyError as e:
-            logger.error(f"DB error in init_sync_log_and_update_connector({connector_id}): {e}", exc_info=True)
+            logger.error(f"DB error in set_connector_sync_status_syncing({connector_id}): {e}", exc_info=True)
             raise
 
     @staticmethod
-    def finalize_sync_log_and_update_connector(
+    def finalize_sync_log(
         connector_id: str,
         seq: int,
         status: str,
@@ -1215,14 +1231,10 @@ class DatabaseManager:
         error: Optional[str] = None,
     ) -> bool:
         """
-        Finalize a sync run across two tables:
-          - connector_sync_log: UPDATEs the matching row with status, finished_at,
-            and optional file counts / error message.
-          - connector: UPDATEs last_sync_at to now, and sync_status to the terminal
-            state — CANCELLED/FAILED both map to OUT_OF_SYNC so the scheduler can
-            retry; any other status (e.g. COMPLETED) is written through verbatim.
+        Update the sync-log row identified by (connector_id, seq) with the terminal
+        status, finished_at, and optional file counts / error message.
 
-        Returns True on success, False if the sync-log row was not found.
+        Returns True on success, False if the row was not found.
         """
         try:
             with get_db_session() as session:
@@ -1253,8 +1265,28 @@ class DatabaseManager:
                         f"Sync log connector={connector_id!r} seq={seq} not found for update"
                     )
                     return False
-                # Cancelled and failed ticks both leave the connector OUT_OF_SYNC
-                # so the scheduler can retry.  Only COMPLETED writes through verbatim.
+                return True
+        except SQLAlchemyError as e:
+            logger.error(
+                f"DB error in finalize_sync_log(connector={connector_id!r}, seq={seq}): {e}",
+                exc_info=True,
+            )
+            return False
+
+    @staticmethod
+    def update_connector_after_sync(
+        connector_id: str,
+        status: str,
+        last_sync_at: Optional[datetime] = None,
+    ) -> None:
+        """
+        Update last_sync_at and sync_status on the connector row after a sync run.
+
+        CANCELLED/FAILED both map to OUT_OF_SYNC so the scheduler can retry;
+        any other status (e.g. COMPLETED) is written through verbatim.
+        """
+        try:
+            with get_db_session() as session:
                 connector_sync_status = (
                     ConnectorStatus.OUT_OF_SYNC
                     if status in (SyncLogStatus.CANCELLED, SyncLogStatus.FAILED)
@@ -1263,15 +1295,17 @@ class DatabaseManager:
                 session.execute(
                     update(Connector)
                     .where(Connector.id == connector_id)
-                    .values(last_sync_at=now, sync_status=connector_sync_status)
+                    .values(
+                        last_sync_at=last_sync_at or datetime.now(timezone.utc),
+                        sync_status=connector_sync_status,
+                    )
                 )
-                return True
         except SQLAlchemyError as e:
             logger.error(
-                f"DB error in finalize_sync_log_and_update_connector(connector={connector_id!r}, seq={seq}): {e}",
+                f"DB error in update_connector_after_sync({connector_id!r}): {e}",
                 exc_info=True,
             )
-            return False
+            raise
 
     @staticmethod
     def update_sync_log_progress(
@@ -1378,27 +1412,35 @@ class DatabaseManager:
             return None
 
     @staticmethod
-    def get_sync_logs(
-        connector_id: str,
-        limit: int = 50,
-        offset: int = 0,
-    ) -> tuple[List[ConnectorSyncLog], int]:
-        """
-        Return paginated sync-log rows for a connector, newest first.
-
-        Returns (items, total_count).
-        """
+    def count_sync_logs(connector_id: str) -> int:
+        """Return the total number of sync-log rows for the given connector."""
         try:
             with get_db_session() as session:
                 base = select(ConnectorSyncLog).where(
                     ConnectorSyncLog.connector_id == connector_id
                 )
-                total = session.execute(
+                return session.execute(
                     select(func.count()).select_from(base.subquery())
                 ).scalar() or 0
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in count_sync_logs({connector_id}): {e}", exc_info=True)
+            return 0
 
+    @staticmethod
+    def get_sync_logs(
+        connector_id: str,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[ConnectorSyncLog]:
+        """
+        Return paginated sync-log rows for a connector, newest first.
+        """
+        try:
+            with get_db_session() as session:
                 stmt = (
-                    base.order_by(ConnectorSyncLog.started_at.desc())
+                    select(ConnectorSyncLog)
+                    .where(ConnectorSyncLog.connector_id == connector_id)
+                    .order_by(ConnectorSyncLog.started_at.desc())
                     .limit(limit)
                     .offset(offset)
                 )
@@ -1412,13 +1454,12 @@ class DatabaseManager:
                     )
                     session.expunge(row)
                 logger.debug(
-                    f"get_sync_logs: connector={connector_id!r} "
-                    f"returned {len(rows)} of {total}"
+                    f"get_sync_logs: connector={connector_id!r} returned {len(rows)}"
                 )
-                return rows, total
+                return rows
         except SQLAlchemyError as e:
             logger.error(f"DB error in get_sync_logs({connector_id}): {e}", exc_info=True)
-            return [], 0
+            return []
 
     # ========================================================================
     # Document metadata helper

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1404,7 +1404,7 @@ class DatabaseManager:
                 rows = list(session.scalars(stmt).all())
                 for row in rows:
                     _ = (
-                        row.id, row.connector_id, row.seq,
+                        row.connector_id, row.seq,
                         row.started_at, row.finished_at,
                         row.total_files, row.new_files, row.removed_files,
                         row.status, row.error,

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -800,6 +800,7 @@ class DatabaseManager:
         name: Optional[str] = None,
         connection_details: Optional[dict] = None,
         allowed_extensions: Optional[list] = None,
+        total_files: Optional[int] = None,
     ) -> None:
         """
         Partial update of an existing connector.
@@ -816,6 +817,8 @@ class DatabaseManager:
                     values["name"] = name
                 if allowed_extensions is not None:
                     values["allowed_extensions"] = allowed_extensions
+                if total_files is not None:
+                    values["total_files"] = total_files
                 if connection_details is not None:
                     stmt = (
                         update(Connector)

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -801,6 +801,7 @@ class DatabaseManager:
         connection_details: Optional[dict] = None,
         allowed_extensions: Optional[list] = None,
         total_files: Optional[int] = None,
+        error: Optional[str] = None,
     ) -> None:
         """
         Partial update of an existing connector.
@@ -819,6 +820,8 @@ class DatabaseManager:
                     values["allowed_extensions"] = allowed_extensions
                 if total_files is not None:
                     values["total_files"] = total_files
+                if error is not None:
+                    values["error"] = error
                 if connection_details is not None:
                     stmt = (
                         update(Connector)

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1160,7 +1160,7 @@ class DatabaseManager:
             raise
 
     @staticmethod
-    def init_sync_log_and_set_syncing(
+    def init_sync_log_and_update_connector(
         connector_id: str,
         started_at: Optional[datetime] = None,
     ) -> int:
@@ -1196,10 +1196,10 @@ class DatabaseManager:
                     .where(Connector.id == connector_id)
                     .values(sync_status=ConnectorStatus.SYNCING)
                 )
-                logger.debug(f"init_sync_log_and_set_syncing: connector={connector_id!r} seq={seq}")
+                logger.debug(f"init_sync_log_and_update_connector: connector={connector_id!r} seq={seq}")
                 return seq
         except SQLAlchemyError as e:
-            logger.error(f"DB error in init_sync_log_and_set_syncing({connector_id}): {e}", exc_info=True)
+            logger.error(f"DB error in init_sync_log_and_update_connector({connector_id}): {e}", exc_info=True)
             raise
 
     @staticmethod

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1160,14 +1160,16 @@ class DatabaseManager:
             raise
 
     @staticmethod
-    def open_sync_log(
+    def init_sync_log_and_set_syncing(
         connector_id: str,
         started_at: Optional[datetime] = None,
     ) -> int:
         """
-        Create a new sync-log row and set connector sync_status to 'syncing'.
+        Initialise a new sync run across two tables:
+          - connector_sync_log: inserts a new row with status=STARTED and an
+            auto-incremented seq (COALESCE(MAX(seq), 0) + 1) scoped to this connector.
+          - connector: sets sync_status=SYNCING on the matching row.
 
-        seq is auto-generated as COALESCE(MAX(seq), 0) + 1 scoped to this connector.
         Returns the generated seq value.
         """
         try:
@@ -1194,14 +1196,14 @@ class DatabaseManager:
                     .where(Connector.id == connector_id)
                     .values(sync_status=ConnectorStatus.SYNCING)
                 )
-                logger.debug(f"open_sync_log: connector={connector_id!r} seq={seq}")
+                logger.debug(f"init_sync_log_and_set_syncing: connector={connector_id!r} seq={seq}")
                 return seq
         except SQLAlchemyError as e:
-            logger.error(f"DB error in open_sync_log({connector_id}): {e}", exc_info=True)
+            logger.error(f"DB error in init_sync_log_and_set_syncing({connector_id}): {e}", exc_info=True)
             raise
 
     @staticmethod
-    def close_sync_log(
+    def finalize_sync_log_and_update_connector(
         connector_id: str,
         seq: int,
         status: str,
@@ -1212,7 +1214,12 @@ class DatabaseManager:
         error: Optional[str] = None,
     ) -> bool:
         """
-        Finalize a sync-log row and update connector last_sync_at / sync_status.
+        Finalize a sync run across two tables:
+          - connector_sync_log: UPDATEs the matching row with status, finished_at,
+            and optional file counts / error message.
+          - connector: UPDATEs last_sync_at to now, and sync_status to the terminal
+            state — CANCELLED/FAILED both map to OUT_OF_SYNC so the scheduler can
+            retry; any other status (e.g. COMPLETED) is written through verbatim.
 
         Returns True on success, False if the sync-log row was not found.
         """
@@ -1260,7 +1267,7 @@ class DatabaseManager:
                 return True
         except SQLAlchemyError as e:
             logger.error(
-                f"DB error in close_sync_log(connector={connector_id!r}, seq={seq}): {e}",
+                f"DB error in finalize_sync_log_and_update_connector(connector={connector_id!r}, seq={seq}): {e}",
                 exc_info=True,
             )
             return False

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1261,13 +1261,11 @@ class DatabaseManager:
                         f"Sync log connector={connector_id!r} seq={seq} not found for update"
                     )
                     return False
-                # When a tick is cancelled (stop-sync request) the connector
-                # should revert to 'out of sync' so the scheduler can run the
-                # next tick normally.  All other terminal statuses are written
-                # through verbatim (completed → 'completed', failed → 'failed').
+                # Cancelled and failed ticks both leave the connector OUT_OF_SYNC
+                # so the scheduler can retry.  Only COMPLETED writes through verbatim.
                 connector_sync_status = (
                     SyncStatus.OUT_OF_SYNC
-                    if status == SyncStatus.CANCELLED
+                    if status in (SyncStatus.CANCELLED, SyncStatus.FAILED)
                     else status
                 )
                 session.execute(

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1267,7 +1267,8 @@ class DatabaseManager:
 
     @staticmethod
     def update_sync_log_progress(
-        log_id: int,
+        connector_id: str,
+        seq: int,
         total_files: Optional[int] = None,
         new_files: Optional[int] = None,
         removed_files: Optional[int] = None,
@@ -1291,17 +1292,23 @@ class DatabaseManager:
                     return True
                 stmt = (
                     update(ConnectorSyncLog)
-                    .where(ConnectorSyncLog.id == log_id)
+                    .where(
+                        ConnectorSyncLog.connector_id == connector_id,
+                        ConnectorSyncLog.seq == seq,
+                    )
                     .values(**values)
                 )
                 result = session.execute(stmt)
                 updated = result.rowcount > 0
                 if not updated:
-                    logger.warning(f"Sync log id={log_id} not found for progress update")
+                    logger.warning(
+                        f"Sync log connector={connector_id!r} seq={seq} not found for progress update"
+                    )
                 return updated
         except SQLAlchemyError as e:
             logger.error(
-                f"DB error in update_sync_log_progress(id={log_id}): {e}", exc_info=True
+                f"DB error in update_sync_log_progress(connector={connector_id!r}, seq={seq}): {e}",
+                exc_info=True,
             )
             return False
 

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1136,23 +1136,18 @@ class DatabaseManager:
     @staticmethod
     def mark_connector_delete_pending(connector_id: str) -> bool:
         """
-        Atomically set sync_status='delete pending' when sync_status='syncing'.
+        Set sync_status='delete pending' for the given connector regardless of
+        current status.
 
-        Used when a DELETE request arrives while a tick is in progress: the
-        running tick will notice the status at its next _check_delete_pending
-        checkpoint and cancel itself, after which the caller must finish the
-        deletion (remove checksums / docs / row).
-
-        Returns True if the signal was set (a tick was running), False if no
-        tick was running or the connector does not exist.
+        Returns True if the connector was found and updated, False if it does
+        not exist.
         """
         try:
             with get_db_session() as session:
                 result = session.execute(
                     update(Connector)
                     .where(
-                        Connector.id == connector_id,
-                        Connector.sync_status == ConnectorStatus.SYNCING,
+                        Connector.id == connector_id
                     )
                     .values(sync_status=ConnectorStatus.DELETE_PENDING)
                     .returning(Connector.id)

--- a/services/digitize/db/models.py
+++ b/services/digitize/db/models.py
@@ -204,6 +204,7 @@ class Connector(Base):
     last_sync_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     sync_status: Mapped[str] = mapped_column(Text, nullable=False, default=ConnectorStatus.UP_TO_DATE)
     last_sync_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     total_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
     # Relationships

--- a/services/digitize/db/models.py
+++ b/services/digitize/db/models.py
@@ -21,7 +21,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
-from digitize.connectors.models import SyncStatus
+from digitize.connectors.models import ConnectorStatus, SyncLogStatus
 
 
 class Base(DeclarativeBase):
@@ -202,7 +202,7 @@ class Connector(Base):
         default=lambda: datetime.now(timezone.utc),
     )
     last_sync_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
-    sync_status: Mapped[str] = mapped_column(Text, nullable=False, default=SyncStatus.UP_TO_DATE)
+    sync_status: Mapped[str] = mapped_column(Text, nullable=False, default=ConnectorStatus.UP_TO_DATE)
     last_sync_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     total_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
@@ -267,7 +267,7 @@ class ConnectorSyncLog(Base):
     total_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     new_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     removed_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    status: Mapped[str] = mapped_column(Text, nullable=False, default=SyncStatus.STARTED)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default=SyncLogStatus.STARTED)
     error: Mapped[str] = mapped_column(Text, nullable=False, default="")
 
     # Relationships

--- a/services/digitize/db/models.py
+++ b/services/digitize/db/models.py
@@ -267,7 +267,6 @@ class ConnectorSyncLog(Base):
     total_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     new_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     removed_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    failed_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     status: Mapped[str] = mapped_column(Text, nullable=False, default=SyncStatus.STARTED)
     error: Mapped[str] = mapped_column(Text, nullable=False, default="")
 

--- a/services/digitize/db/models.py
+++ b/services/digitize/db/models.py
@@ -255,13 +255,13 @@ class ConnectorSyncLog(Base):
     """
     __tablename__ = "connector_sync_logs"
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     connector_id: Mapped[str] = mapped_column(
         Text,
         ForeignKey("connectors.id", ondelete="CASCADE"),
         nullable=False,
+        primary_key=True,
     )
-    seq: Mapped[int] = mapped_column(Integer, nullable=False)
+    seq: Mapped[int] = mapped_column(Integer, nullable=False, primary_key=True)
     started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     finished_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     total_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
@@ -277,10 +277,9 @@ class ConnectorSyncLog(Base):
 
     __table_args__ = (
         Index("idx_csl_connector_started", "connector_id", desc("started_at")),
-        UniqueConstraint("connector_id", "seq", name="uq_csh_connector_seq"),
     )
 
     def __repr__(self) -> str:
-        return f"<ConnectorSyncLog(id={self.id}, connector_id='{self.connector_id}', seq={self.seq})>"
+        return f"<ConnectorSyncLog(connector_id='{self.connector_id}', seq={self.seq})>"
 
 # Made with Bob

--- a/services/digitize/db/scripts/init_schema.sql
+++ b/services/digitize/db/scripts/init_schema.sql
@@ -74,7 +74,6 @@ CREATE INDEX IF NOT EXISTS idx_cdc_connector_id
     ON connector_document_checksum (connector_id);
 
 CREATE TABLE IF NOT EXISTS connector_sync_logs (
-    id               BIGSERIAL   PRIMARY KEY,
     connector_id     TEXT        NOT NULL,
     seq              INTEGER     NOT NULL,
     started_at       TIMESTAMPTZ NOT NULL,
@@ -85,11 +84,10 @@ CREATE TABLE IF NOT EXISTS connector_sync_logs (
     failed_files     INTEGER     NOT NULL DEFAULT 0,
     status           TEXT        NOT NULL DEFAULT 'started',
     error            TEXT        NOT NULL DEFAULT '',
+    CONSTRAINT pk_csl PRIMARY KEY (connector_id, seq),
     CONSTRAINT fk_csh_connector
         FOREIGN KEY (connector_id)
-        REFERENCES connectors(id) ON DELETE CASCADE,
-    CONSTRAINT uq_csh_connector_seq
-        UNIQUE (connector_id, seq)
+        REFERENCES connectors(id) ON DELETE CASCADE
 );
 
 -- Create indexes with IF NOT EXISTS

--- a/services/digitize/db/scripts/init_schema.sql
+++ b/services/digitize/db/scripts/init_schema.sql
@@ -54,6 +54,7 @@ CREATE TABLE IF NOT EXISTS connectors (
     last_sync_at            TIMESTAMPTZ,
     sync_status             TEXT        NOT NULL DEFAULT 'up to date',
     last_sync_error         TEXT,
+    error                   TEXT,
     total_files             INTEGER     NOT NULL DEFAULT 0,
     CONSTRAINT chk_connector_type CHECK (type IN ('ssh', 's3'))
 );

--- a/services/digitize/tests/test_connector_db.py
+++ b/services/digitize/tests/test_connector_db.py
@@ -608,7 +608,6 @@ class TestListSyncLogs:
         log.total_files = 0
         log.new_files = 0
         log.removed_files = 0
-        log.failed_files = 0
         log.status = "started"
         log.error = ""
         return log

--- a/services/digitize/tests/test_connector_db.py
+++ b/services/digitize/tests/test_connector_db.py
@@ -456,12 +456,12 @@ class TestRemoveConnectorFromMembership:
 
 
 # ===========================================================================
-# open_new_sync_log
+# init_sync_log_and_set_syncing
 # ===========================================================================
 
 class TestInsertSyncLog:
     def test_returns_generated_seq(self):
-        """open_new_sync_log must return the auto-generated seq value."""
+        """init_sync_log_and_set_syncing must return the auto-generated seq value."""
         session = MagicMock()
         # First execute: INSERT … RETURNING seq → scalar_one() returns 3
         insert_result = MagicMock()
@@ -470,9 +470,9 @@ class TestInsertSyncLog:
         update_result = MagicMock()
         session.execute.side_effect = [insert_result, update_result]
 
-        from digitize.utils.db import open_new_sync_log
+        from digitize.utils.db import init_sync_log_and_set_syncing
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            seq = open_new_sync_log(CONNECTOR_ID)
+            seq = init_sync_log_and_set_syncing(CONNECTOR_ID)
         assert seq == 3
         assert session.execute.call_count == 2
 
@@ -483,30 +483,30 @@ class TestInsertSyncLog:
         insert_result.scalar_one.return_value = 1
         session.execute.side_effect = [insert_result, MagicMock()]
 
-        from digitize.utils.db import open_new_sync_log
+        from digitize.utils.db import init_sync_log_and_set_syncing
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            open_new_sync_log(CONNECTOR_ID)
+            init_sync_log_and_set_syncing(CONNECTOR_ID)
         # Two DB calls: INSERT log row + UPDATE connector status
         assert session.execute.call_count == 2
 
     def test_does_not_accept_seq_parameter(self):
         """seq must not be an accepted parameter — it is auto-generated."""
-        from digitize.utils.db import open_new_sync_log
+        from digitize.utils.db import init_sync_log_and_set_syncing
         import inspect
-        sig = inspect.signature(open_new_sync_log)
+        sig = inspect.signature(init_sync_log_and_set_syncing)
         assert "seq" not in sig.parameters
 
     def test_raises_on_db_error(self):
         session = MagicMock()
         session.execute.side_effect = SQLAlchemyError("constraint violation")
-        from digitize.utils.db import open_new_sync_log
+        from digitize.utils.db import init_sync_log_and_set_syncing
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
             with pytest.raises(SQLAlchemyError):
-                open_new_sync_log(CONNECTOR_ID)
+                init_sync_log_and_set_syncing(CONNECTOR_ID)
 
 
 # ===========================================================================
-# close_sync_log
+# finalize_sync_log_and_update_connector
 # ===========================================================================
 
 class TestUpdateSyncLog:
@@ -518,9 +518,9 @@ class TestUpdateSyncLog:
         # Second execute: UPDATE connectors
         conn_result = _execute_result(rowcount=1)
         session.execute.side_effect = [log_result, conn_result]
-        from digitize.utils.db import close_sync_log
+        from digitize.utils.db import finalize_sync_log_and_update_connector
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            result = close_sync_log(
+            result = finalize_sync_log_and_update_connector(
                 CONNECTOR_ID, seq=1, status=SyncLogStatus.COMPLETED, total_files=10, new_files=2
             )
         assert result is True
@@ -530,9 +530,9 @@ class TestUpdateSyncLog:
         """When the log row is not found, return False without updating connectors."""
         session = MagicMock()
         session.execute.return_value = _execute_result(rowcount=0)
-        from digitize.utils.db import close_sync_log
+        from digitize.utils.db import finalize_sync_log_and_update_connector
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            result = close_sync_log(CONNECTOR_ID, seq=999, status=SyncLogStatus.FAILED)
+            result = finalize_sync_log_and_update_connector(CONNECTOR_ID, seq=999, status=SyncLogStatus.FAILED)
         assert result is False
         # Only one execute call: the failed log-row lookup; connectors must NOT be updated
         assert session.execute.call_count == 1
@@ -543,9 +543,9 @@ class TestUpdateSyncLog:
         log_result = _execute_result(rowcount=1)
         conn_result = _execute_result(rowcount=1)
         session.execute.side_effect = [log_result, conn_result]
-        from digitize.utils.db import close_sync_log
+        from digitize.utils.db import finalize_sync_log_and_update_connector
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            close_sync_log(CONNECTOR_ID, seq=2, status=ConnectorStatus.UP_TO_DATE)
+            finalize_sync_log_and_update_connector(CONNECTOR_ID, seq=2, status=ConnectorStatus.UP_TO_DATE)
         assert session.execute.call_count == 2
 
     def test_optional_fields_omitted_when_none(self):
@@ -554,9 +554,9 @@ class TestUpdateSyncLog:
         log_result = _execute_result(rowcount=1)
         conn_result = _execute_result(rowcount=1)
         session.execute.side_effect = [log_result, conn_result]
-        from digitize.utils.db import close_sync_log
+        from digitize.utils.db import finalize_sync_log_and_update_connector
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            close_sync_log(CONNECTOR_ID, seq=1, status=SyncLogStatus.COMPLETED)
+            finalize_sync_log_and_update_connector(CONNECTOR_ID, seq=1, status=SyncLogStatus.COMPLETED)
         assert session.execute.called
 
 

--- a/services/digitize/tests/test_connector_db.py
+++ b/services/digitize/tests/test_connector_db.py
@@ -669,4 +669,39 @@ class TestSetDocumentMetadata:
             result = set_document_metadata(DOC_ID_A, {"source_type": "sftp"})
         assert result is False
 
+
+# ===========================================================================
+# get_connector_sync_status
+# ===========================================================================
+
+class TestGetConnectorSyncStatus:
+    def _call(self, session_mock, connector_id=CONNECTOR_ID):
+        from digitize.utils.db import get_connector_sync_status
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session_mock)):
+            return get_connector_sync_status(connector_id)
+
+    def test_returns_status_string(self):
+        session = MagicMock()
+        session.execute.return_value.one_or_none.return_value = ("syncing",)
+        result = self._call(session)
+        assert result == "syncing"
+
+    def test_returns_none_when_not_found(self):
+        session = MagicMock()
+        session.execute.return_value.one_or_none.return_value = None
+        result = self._call(session)
+        assert result is None
+
+    def test_returns_delete_pending(self):
+        session = MagicMock()
+        session.execute.return_value.one_or_none.return_value = ("delete pending",)
+        result = self._call(session)
+        assert result == "delete pending"
+
+    def test_returns_none_on_db_error(self):
+        session = MagicMock()
+        session.execute.side_effect = SQLAlchemyError("timeout")
+        result = self._call(session)
+        assert result is None
+
 # Made with Bob

--- a/services/digitize/tests/test_connector_db.py
+++ b/services/digitize/tests/test_connector_db.py
@@ -13,6 +13,8 @@ from unittest.mock import MagicMock, Mock, call, patch
 import pytest
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
+from digitize.connectors.models import SyncStatus
+
 
 # ---------------------------------------------------------------------------
 # Helpers shared across test cases
@@ -158,7 +160,7 @@ class TestGetConnector:
         c.sync_interval_seconds = SYNC_INTERVAL
         c.attached_at = _NOW
         c.last_sync_at = None
-        c.sync_status = "up to date"
+        c.sync_status = SyncStatus.UP_TO_DATE
         c.last_sync_error = None
         c.total_files = 0
         return c
@@ -205,7 +207,7 @@ class TestListConnectors:
         c1.sync_interval_seconds = 300
         c1.attached_at = _NOW
         c1.last_sync_at = None
-        c1.sync_status = "up to date"
+        c1.sync_status = SyncStatus.UP_TO_DATE
         c1.last_sync_error = None
         c1.total_files = 0
 
@@ -519,7 +521,7 @@ class TestUpdateSyncLog:
         from digitize.utils.db import close_sync_log
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
             result = close_sync_log(
-                CONNECTOR_ID, seq=1, status="completed", total_files=10, new_files=2
+                CONNECTOR_ID, seq=1, status=SyncStatus.COMPLETED, total_files=10, new_files=2
             )
         assert result is True
         assert session.execute.call_count == 2
@@ -530,7 +532,7 @@ class TestUpdateSyncLog:
         session.execute.return_value = _execute_result(rowcount=0)
         from digitize.utils.db import close_sync_log
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            result = close_sync_log(CONNECTOR_ID, seq=999, status="failed")
+            result = close_sync_log(CONNECTOR_ID, seq=999, status=SyncStatus.FAILED)
         assert result is False
         # Only one execute call: the failed log-row lookup; connectors must NOT be updated
         assert session.execute.call_count == 1
@@ -543,7 +545,7 @@ class TestUpdateSyncLog:
         session.execute.side_effect = [log_result, conn_result]
         from digitize.utils.db import close_sync_log
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            close_sync_log(CONNECTOR_ID, seq=2, status="up to date")
+            close_sync_log(CONNECTOR_ID, seq=2, status=SyncStatus.UP_TO_DATE)
         assert session.execute.call_count == 2
 
     def test_optional_fields_omitted_when_none(self):
@@ -554,7 +556,7 @@ class TestUpdateSyncLog:
         session.execute.side_effect = [log_result, conn_result]
         from digitize.utils.db import close_sync_log
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            close_sync_log(CONNECTOR_ID, seq=1, status="completed")
+            close_sync_log(CONNECTOR_ID, seq=1, status=SyncStatus.COMPLETED)
         assert session.execute.called
 
 
@@ -608,7 +610,7 @@ class TestListSyncLogs:
         log.total_files = 0
         log.new_files = 0
         log.removed_files = 0
-        log.status = "started"
+        log.status = SyncStatus.STARTED
         log.error = ""
         return log
 
@@ -681,9 +683,9 @@ class TestGetConnectorSyncStatus:
 
     def test_returns_status_string(self):
         session = MagicMock()
-        session.execute.return_value.one_or_none.return_value = ("syncing",)
+        session.execute.return_value.one_or_none.return_value = (SyncStatus.SYNCING,)
         result = self._call(session)
-        assert result == "syncing"
+        assert result == SyncStatus.SYNCING
 
     def test_returns_none_when_not_found(self):
         session = MagicMock()
@@ -693,9 +695,9 @@ class TestGetConnectorSyncStatus:
 
     def test_returns_delete_pending(self):
         session = MagicMock()
-        session.execute.return_value.one_or_none.return_value = ("delete pending",)
+        session.execute.return_value.one_or_none.return_value = (SyncStatus.DELETE_PENDING,)
         result = self._call(session)
-        assert result == "delete pending"
+        assert result == SyncStatus.DELETE_PENDING
 
     def test_returns_none_on_db_error(self):
         session = MagicMock()

--- a/services/digitize/tests/test_connector_db.py
+++ b/services/digitize/tests/test_connector_db.py
@@ -456,12 +456,12 @@ class TestRemoveConnectorFromMembership:
 
 
 # ===========================================================================
-# init_sync_log_and_set_syncing
+# init_sync_log_and_update_connector
 # ===========================================================================
 
 class TestInsertSyncLog:
     def test_returns_generated_seq(self):
-        """init_sync_log_and_set_syncing must return the auto-generated seq value."""
+        """init_sync_log_and_update_connector must return the auto-generated seq value."""
         session = MagicMock()
         # First execute: INSERT … RETURNING seq → scalar_one() returns 3
         insert_result = MagicMock()
@@ -470,9 +470,9 @@ class TestInsertSyncLog:
         update_result = MagicMock()
         session.execute.side_effect = [insert_result, update_result]
 
-        from digitize.utils.db import init_sync_log_and_set_syncing
+        from digitize.utils.db import init_sync_log_and_update_connector
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            seq = init_sync_log_and_set_syncing(CONNECTOR_ID)
+            seq = init_sync_log_and_update_connector(CONNECTOR_ID)
         assert seq == 3
         assert session.execute.call_count == 2
 
@@ -483,26 +483,26 @@ class TestInsertSyncLog:
         insert_result.scalar_one.return_value = 1
         session.execute.side_effect = [insert_result, MagicMock()]
 
-        from digitize.utils.db import init_sync_log_and_set_syncing
+        from digitize.utils.db import init_sync_log_and_update_connector
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            init_sync_log_and_set_syncing(CONNECTOR_ID)
+            init_sync_log_and_update_connector(CONNECTOR_ID)
         # Two DB calls: INSERT log row + UPDATE connector status
         assert session.execute.call_count == 2
 
     def test_does_not_accept_seq_parameter(self):
         """seq must not be an accepted parameter — it is auto-generated."""
-        from digitize.utils.db import init_sync_log_and_set_syncing
+        from digitize.utils.db import init_sync_log_and_update_connector
         import inspect
-        sig = inspect.signature(init_sync_log_and_set_syncing)
+        sig = inspect.signature(init_sync_log_and_update_connector)
         assert "seq" not in sig.parameters
 
     def test_raises_on_db_error(self):
         session = MagicMock()
         session.execute.side_effect = SQLAlchemyError("constraint violation")
-        from digitize.utils.db import init_sync_log_and_set_syncing
+        from digitize.utils.db import init_sync_log_and_update_connector
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
             with pytest.raises(SQLAlchemyError):
-                init_sync_log_and_set_syncing(CONNECTOR_ID)
+                init_sync_log_and_update_connector(CONNECTOR_ID)
 
 
 # ===========================================================================

--- a/services/digitize/tests/test_connector_db.py
+++ b/services/digitize/tests/test_connector_db.py
@@ -570,7 +570,7 @@ class TestUpdateSyncLogFilesSyncing:
         session.execute.return_value = _execute_result(rowcount=1)
         from digitize.utils.db import update_sync_log
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            result = update_sync_log(42, total_files=5, new_files=3)
+            result = update_sync_log(CONNECTOR_ID, 1, total_files=5, new_files=3)
         assert result is True
 
     def test_returns_true_when_nothing_to_update(self):
@@ -578,7 +578,7 @@ class TestUpdateSyncLogFilesSyncing:
         session = MagicMock()
         from digitize.utils.db import update_sync_log
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            result = update_sync_log(42)
+            result = update_sync_log(CONNECTOR_ID, 1)
         assert result is True
         session.execute.assert_not_called()
 
@@ -600,9 +600,8 @@ class TestUpdateSyncLogFilesSyncing:
 # ===========================================================================
 
 class TestListSyncLogs:
-    def _make_log(self, log_id: int, seq: int) -> MagicMock:
+    def _make_log(self, seq: int) -> MagicMock:
         log = MagicMock()
-        log.id = log_id
         log.connector_id = CONNECTOR_ID
         log.seq = seq
         log.started_at = _NOW
@@ -615,7 +614,7 @@ class TestListSyncLogs:
         return log
 
     def test_returns_items_and_total(self):
-        log = self._make_log(1, 1)
+        log = self._make_log(1)
         session = MagicMock()
         # First execute: COUNT query → total=1
         count_result = MagicMock()

--- a/services/digitize/tests/test_connector_db.py
+++ b/services/digitize/tests/test_connector_db.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, Mock, call, patch
 import pytest
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
-from digitize.connectors.models import SyncStatus
+from digitize.connectors.models import ConnectorStatus, SyncLogStatus
 
 
 # ---------------------------------------------------------------------------
@@ -160,7 +160,7 @@ class TestGetConnector:
         c.sync_interval_seconds = SYNC_INTERVAL
         c.attached_at = _NOW
         c.last_sync_at = None
-        c.sync_status = SyncStatus.UP_TO_DATE
+        c.sync_status = ConnectorStatus.UP_TO_DATE
         c.last_sync_error = None
         c.total_files = 0
         return c
@@ -207,7 +207,7 @@ class TestListConnectors:
         c1.sync_interval_seconds = 300
         c1.attached_at = _NOW
         c1.last_sync_at = None
-        c1.sync_status = SyncStatus.UP_TO_DATE
+        c1.sync_status = ConnectorStatus.UP_TO_DATE
         c1.last_sync_error = None
         c1.total_files = 0
 
@@ -521,7 +521,7 @@ class TestUpdateSyncLog:
         from digitize.utils.db import close_sync_log
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
             result = close_sync_log(
-                CONNECTOR_ID, seq=1, status=SyncStatus.COMPLETED, total_files=10, new_files=2
+                CONNECTOR_ID, seq=1, status=SyncLogStatus.COMPLETED, total_files=10, new_files=2
             )
         assert result is True
         assert session.execute.call_count == 2
@@ -532,7 +532,7 @@ class TestUpdateSyncLog:
         session.execute.return_value = _execute_result(rowcount=0)
         from digitize.utils.db import close_sync_log
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            result = close_sync_log(CONNECTOR_ID, seq=999, status=SyncStatus.FAILED)
+            result = close_sync_log(CONNECTOR_ID, seq=999, status=SyncLogStatus.FAILED)
         assert result is False
         # Only one execute call: the failed log-row lookup; connectors must NOT be updated
         assert session.execute.call_count == 1
@@ -545,7 +545,7 @@ class TestUpdateSyncLog:
         session.execute.side_effect = [log_result, conn_result]
         from digitize.utils.db import close_sync_log
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            close_sync_log(CONNECTOR_ID, seq=2, status=SyncStatus.UP_TO_DATE)
+            close_sync_log(CONNECTOR_ID, seq=2, status=ConnectorStatus.UP_TO_DATE)
         assert session.execute.call_count == 2
 
     def test_optional_fields_omitted_when_none(self):
@@ -556,7 +556,7 @@ class TestUpdateSyncLog:
         session.execute.side_effect = [log_result, conn_result]
         from digitize.utils.db import close_sync_log
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            close_sync_log(CONNECTOR_ID, seq=1, status=SyncStatus.COMPLETED)
+            close_sync_log(CONNECTOR_ID, seq=1, status=SyncLogStatus.COMPLETED)
         assert session.execute.called
 
 
@@ -609,7 +609,7 @@ class TestListSyncLogs:
         log.total_files = 0
         log.new_files = 0
         log.removed_files = 0
-        log.status = SyncStatus.STARTED
+        log.status = SyncLogStatus.STARTED
         log.error = ""
         return log
 
@@ -682,9 +682,9 @@ class TestGetConnectorSyncStatus:
 
     def test_returns_status_string(self):
         session = MagicMock()
-        session.execute.return_value.one_or_none.return_value = (SyncStatus.SYNCING,)
+        session.execute.return_value.one_or_none.return_value = (ConnectorStatus.SYNCING,)
         result = self._call(session)
-        assert result == SyncStatus.SYNCING
+        assert result == ConnectorStatus.SYNCING
 
     def test_returns_none_when_not_found(self):
         session = MagicMock()
@@ -694,9 +694,9 @@ class TestGetConnectorSyncStatus:
 
     def test_returns_delete_pending(self):
         session = MagicMock()
-        session.execute.return_value.one_or_none.return_value = (SyncStatus.DELETE_PENDING,)
+        session.execute.return_value.one_or_none.return_value = (ConnectorStatus.DELETE_PENDING,)
         result = self._call(session)
-        assert result == SyncStatus.DELETE_PENDING
+        assert result == ConnectorStatus.DELETE_PENDING
 
     def test_returns_none_on_db_error(self):
         session = MagicMock()

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -265,6 +265,10 @@ class TestPutConnector:
 
     def test_partial_update_only_overwrites_supplied_keys(self, connector_test_client, monkeypatch):
         """PUT with only connector_name must not touch connection_details."""
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
         upsert_mock = Mock()
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.upsert_connector", upsert_mock)
         connector_test_client.put(
@@ -277,12 +281,27 @@ class TestPutConnector:
 
     def test_returns_409_on_name_conflict(self, connector_test_client, monkeypatch):
         monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.upsert_connector",
             Mock(side_effect=IntegrityError(None, None, Exception("dup"))),
         )
         response = connector_test_client.put(
             f"/v1/connectors/{CONNECTOR_ID}",
             json={"connector_name": "taken-name"},
+        )
+        assert response.status_code == 409
+
+    def test_returns_409_when_delete_pending(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector(sync_status=ConnectorStatus.DELETE_PENDING)),
+        )
+        response = connector_test_client.put(
+            f"/v1/connectors/{CONNECTOR_ID}",
+            json={"connector_name": "new-name"},
         )
         assert response.status_code == 409
 

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -93,9 +93,8 @@ def _make_connector(
     return c
 
 
-def _make_sync_log(log_id: int = 1, seq: int = 1) -> MagicMock:
+def _make_sync_log(seq: int = 1) -> MagicMock:
     log = MagicMock()
-    log.id = log_id
     log.connector_id = CONNECTOR_ID
     log.seq = seq
     log.started_at = _NOW
@@ -495,7 +494,7 @@ class TestGetConnector:
 
 class TestSyncLog:
     def test_returns_paginated_history(self, connector_test_client, monkeypatch):
-        logs = [_make_sync_log(log_id=3, seq=3), _make_sync_log(log_id=2, seq=2)]
+        logs = [_make_sync_log(seq=3), _make_sync_log(seq=2)]
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.get_active_connector",
             Mock(return_value=_make_connector()),

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -600,10 +600,10 @@ class TestDocumentListConnectorFilter:
 # ===========================================================================
 
 class TestTriggerSync:
-    def test_returns_202_and_dispatches_task_when_lock_acquired(
+    def test_returns_202_with_sync_seq_when_lock_acquired(
         self, connector_test_client, monkeypatch
     ):
-        """Lock acquired → create_task called, 202 returned."""
+        """Lock acquired → create_task called, 202 returned with sync_seq."""
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.get_active_connector",
             Mock(return_value=_make_connector()),
@@ -612,16 +612,21 @@ class TestTriggerSync:
             "digitize.api.v1.connectors.db_ops.try_acquire_sync_lock",
             Mock(return_value=True),
         )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_sync_seq",
+            Mock(return_value=7),
+        )
         task_mock = Mock(side_effect=lambda coro: coro.close())
         with patch("asyncio.create_task", task_mock):
             response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/sync")
         assert response.status_code == 202
+        assert response.json()["sync_seq"] == 7
         task_mock.assert_called_once()
 
-    def test_returns_202_no_op_when_already_syncing(
+    def test_returns_202_no_op_with_existing_sync_seq_when_already_syncing(
         self, connector_test_client, monkeypatch
     ):
-        """Lock not acquired (already syncing) → 202, no task created."""
+        """Lock not acquired (already syncing) → 202, no task created, existing sync_seq returned."""
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.get_active_connector",
             Mock(return_value=_make_connector()),
@@ -630,10 +635,15 @@ class TestTriggerSync:
             "digitize.api.v1.connectors.db_ops.try_acquire_sync_lock",
             Mock(return_value=False),
         )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_sync_seq",
+            Mock(return_value=3),
+        )
         task_mock = Mock(side_effect=lambda coro: coro.close())
         with patch("asyncio.create_task", task_mock):
             response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/sync")
         assert response.status_code == 202
+        assert response.json()["sync_seq"] == 3
         task_mock.assert_not_called()
 
     def test_returns_404_when_connector_not_found(

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -13,6 +13,7 @@ Coverage:
   - GET    /v1/connectors/{id}                            (200, 404)
   - GET    /v1/connectors/{id}/syncs                      (200, 404)
   - POST   /v1/connectors/{id}/sync                       (202 dispatched, 202 no-op, 404)
+  - DELETE /v1/connectors/{id}/sync                       (204 signalled, 409 not running, 404)
   - GET    /v1/documents — excludes connector-sourced docs
   - GET    /v1/documents/{doc_id} — 404 for connector-sourced
   - DELETE /v1/documents/{doc_id} — 404 for connector-sourced
@@ -620,6 +621,51 @@ class TestTriggerSync:
             Mock(return_value=None),
         )
         response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/sync")
+        assert response.status_code == 404
+
+# ===========================================================================
+# DELETE /v1/connectors/{connector_id}/sync
+# ===========================================================================
+
+class TestStopSync:
+    def test_returns_204_when_sync_signalled(
+        self, connector_test_client, monkeypatch
+    ):
+        """mark_sync_stop_pending returns True → 204 returned."""
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.mark_sync_cancel_pending",
+            Mock(return_value=True),
+        )
+        response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}/sync")
+        assert response.status_code == 204
+
+    def test_returns_409_when_no_sync_running(
+        self, connector_test_client, monkeypatch
+    ):
+        """mark_sync_stop_pending returns False (not syncing) → 409."""
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.mark_sync_cancel_pending",
+            Mock(return_value=False),
+        )
+        response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}/sync")
+        assert response.status_code == 409
+
+    def test_returns_404_when_connector_not_found(
+        self, connector_test_client, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=None),
+        )
+        response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}/sync")
         assert response.status_code == 404
 
 # Made with Bob

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -303,7 +303,7 @@ class TestDeleteConnector:
     def _patch_mark(self, monkeypatch, return_value=True):
         mock = Mock(return_value=return_value)
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.mark_sync_delete_pending",
+            "digitize.api.v1.connectors.db_ops.mark_connector_delete_pending",
             mock,
         )
         return mock

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -351,6 +351,10 @@ class TestRunTeardown:
         """remaining_owner_count == 0 → document is deleted."""
         doc_delete_mock = Mock()
         monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.list_sync_logs",
+            Mock(return_value=([], 0)),
+        )
+        monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.list_connector_checksums",
             Mock(return_value=["abc123"]),
         )
@@ -371,6 +375,10 @@ class TestRunTeardown:
     async def test_does_not_delete_doc_when_other_owners_remain(self, monkeypatch):
         """remaining_owner_count > 0 → doc must NOT be deleted."""
         doc_delete_mock = Mock()
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.list_sync_logs",
+            Mock(return_value=([], 0)),
+        )
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.list_connector_checksums",
             Mock(return_value=["abc123"]),
@@ -669,7 +677,7 @@ class TestStopSync:
         """Correct sync_seq + mark_sync_cancel_pending True → 204."""
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.get_active_connector",
-            Mock(return_value=_make_connector()),
+            Mock(return_value=_make_connector(sync_status=SyncStatus.SYNCING)),
         )
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.get_active_sync_seq",

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -363,7 +363,7 @@ class TestRunTeardown:
             Mock(return_value=True),
         )
         with patch("digitize.api.v1.connectors._best_effort_delete_document", doc_delete_mock):
-            with patch("digitize.api.v1.connectors._sweep_connector_staging"):
+            with patch("digitize.api.v1.connectors._sweep_staging_dir"):
                 from digitize.api.v1.connectors import _run_teardown
                 await _run_teardown(CONNECTOR_ID)
         doc_delete_mock.assert_called_once_with("doc-0001")
@@ -384,7 +384,7 @@ class TestRunTeardown:
             Mock(return_value=True),
         )
         with patch("digitize.api.v1.connectors._best_effort_delete_document", doc_delete_mock):
-            with patch("digitize.api.v1.connectors._sweep_connector_staging"):
+            with patch("digitize.api.v1.connectors._sweep_staging_dir"):
                 from digitize.api.v1.connectors import _run_teardown
                 await _run_teardown(CONNECTOR_ID)
         doc_delete_mock.assert_not_called()

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -101,7 +101,6 @@ def _make_sync_log(log_id: int = 1, seq: int = 1) -> MagicMock:
     log.total_files = 42
     log.new_files = 2
     log.removed_files = 0
-    log.failed_files = 1
     log.status = "completed"
     log.error = ""
     return log

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -28,7 +28,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 
-from digitize.connectors.models import SyncStatus
+from digitize.connectors.models import ConnectorStatus, SyncLogStatus
 
 import digitize.app as digitize_app
 import digitize.api.v1.documents as documents_router_module
@@ -77,7 +77,7 @@ def _make_connector(
     connector_id: str = CONNECTOR_ID,
     name: str = CONNECTOR_NAME,
     connector_type: str = CONNECTOR_TYPE,
-    sync_status: str = SyncStatus.UP_TO_DATE,
+    sync_status: str = ConnectorStatus.UP_TO_DATE,
 ) -> MagicMock:
     c = MagicMock()
     c.id = connector_id
@@ -103,7 +103,7 @@ def _make_sync_log(seq: int = 1) -> MagicMock:
     log.total_files = 42
     log.new_files = 2
     log.removed_files = 0
-    log.status = SyncStatus.COMPLETED
+    log.status = SyncLogStatus.COMPLETED
     log.error = ""
     return log
 
@@ -326,7 +326,7 @@ class TestDeleteConnector:
         mark_mock = self._patch_mark(monkeypatch)
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.get_active_connector",
-            Mock(return_value=_make_connector(sync_status=SyncStatus.SYNCING)),
+            Mock(return_value=_make_connector(sync_status=ConnectorStatus.SYNCING)),
         )
         with patch("digitize.api.v1.connectors.asyncio.create_task") as task_mock:
             response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}")
@@ -557,7 +557,7 @@ class TestGetSync:
         assert response.status_code == 200
         data = response.json()
         assert data["seq"] == 3
-        assert data["status"] == SyncStatus.COMPLETED
+        assert data["status"] == SyncLogStatus.COMPLETED
         assert data["total_files"] == 42
 
     def test_returns_404_when_sync_not_found(self, connector_test_client, monkeypatch):
@@ -722,7 +722,7 @@ class TestStopSync:
         """Correct sync_seq + mark_sync_cancel_pending True → 204."""
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.get_active_connector",
-            Mock(return_value=_make_connector(sync_status=SyncStatus.SYNCING)),
+            Mock(return_value=_make_connector(sync_status=ConnectorStatus.SYNCING)),
         )
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.get_active_sync_seq",

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -27,6 +27,8 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 
+from digitize.connectors.models import SyncStatus
+
 import digitize.app as digitize_app
 import digitize.api.v1.documents as documents_router_module
 
@@ -74,7 +76,7 @@ def _make_connector(
     connector_id: str = CONNECTOR_ID,
     name: str = CONNECTOR_NAME,
     connector_type: str = CONNECTOR_TYPE,
-    sync_status: str = "up to date",
+    sync_status: str = SyncStatus.UP_TO_DATE,
 ) -> MagicMock:
     c = MagicMock()
     c.id = connector_id
@@ -101,7 +103,7 @@ def _make_sync_log(log_id: int = 1, seq: int = 1) -> MagicMock:
     log.total_files = 42
     log.new_files = 2
     log.removed_files = 0
-    log.status = "completed"
+    log.status = SyncStatus.COMPLETED
     log.error = ""
     return log
 
@@ -314,7 +316,7 @@ class TestDeleteConnector:
     def test_returns_409_when_sync_in_progress(self, connector_test_client, monkeypatch):
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.get_active_connector",
-            Mock(return_value=_make_connector(sync_status="syncing")),
+            Mock(return_value=_make_connector(sync_status=SyncStatus.SYNCING)),
         )
         response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}")
         assert response.status_code == 409

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -12,6 +12,7 @@ Coverage:
   - GET    /v1/connectors                                 (200)
   - GET    /v1/connectors/{id}                            (200, 404)
   - GET    /v1/connectors/{id}/syncs                      (200, 404)
+  - GET    /v1/connectors/{id}/syncs/{sync_seq}           (200, 404)
   - POST   /v1/connectors/{id}/sync                       (202 dispatched, 202 no-op, 404)
   - POST   /v1/connectors/{id}/syncs/{sync_seq}/stop      (204 signalled, 409 stale seq, 409 not running, 404)
   - GET    /v1/documents — excludes connector-sourced docs
@@ -537,6 +538,51 @@ class TestSyncLog:
             f"/v1/connectors/{CONNECTOR_ID}/syncs?limit=999"
         )
         assert response.status_code == 422  # FastAPI validation error
+
+
+class TestGetSync:
+    def test_returns_200_with_sync_detail(self, connector_test_client, monkeypatch):
+        log = _make_sync_log(seq=3)
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_sync_log",
+            Mock(return_value=log),
+        )
+        response = connector_test_client.get(
+            f"/v1/connectors/{CONNECTOR_ID}/syncs/3"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["seq"] == 3
+        assert data["status"] == SyncStatus.COMPLETED
+        assert data["total_files"] == 42
+
+    def test_returns_404_when_sync_not_found(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_sync_log",
+            Mock(return_value=None),
+        )
+        response = connector_test_client.get(
+            f"/v1/connectors/{CONNECTOR_ID}/syncs/999"
+        )
+        assert response.status_code == 404
+
+    def test_returns_404_when_connector_not_found(self, connector_test_client, monkeypatch):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=None),
+        )
+        response = connector_test_client.get(
+            f"/v1/connectors/{CONNECTOR_ID}/syncs/3"
+        )
+        assert response.status_code == 404
 
 
 # ===========================================================================

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -90,6 +90,7 @@ def _make_connector(
     c.last_sync_at = _NOW
     c.sync_status = sync_status
     c.last_sync_error = None
+    c.error = None
     c.total_files = 42
     return c
 

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -618,7 +618,7 @@ class TestTriggerSync:
         )
         task_mock = Mock(side_effect=lambda coro: coro.close())
         with patch("asyncio.create_task", task_mock):
-            response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/sync")
+            response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/syncs")
         assert response.status_code == 202
         assert response.json()["sync_seq"] == 7
         task_mock.assert_called_once()
@@ -641,7 +641,7 @@ class TestTriggerSync:
         )
         task_mock = Mock(side_effect=lambda coro: coro.close())
         with patch("asyncio.create_task", task_mock):
-            response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/sync")
+            response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/syncs")
         assert response.status_code == 202
         assert response.json()["sync_seq"] == 3
         task_mock.assert_not_called()

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -12,6 +12,7 @@ Coverage:
   - GET    /v1/connectors                                 (200)
   - GET    /v1/connectors/{id}                            (200, 404)
   - GET    /v1/connectors/{id}/syncs                      (200, 404)
+  - POST   /v1/connectors/{id}/sync                       (202 dispatched, 202 no-op, 404)
   - GET    /v1/documents — excludes connector-sourced docs
   - GET    /v1/documents/{doc_id} — 404 for connector-sourced
   - DELETE /v1/documents/{doc_id} — 404 for connector-sourced
@@ -568,6 +569,57 @@ class TestDocumentListConnectorFilter:
             Mock(return_value=True),
         )
         response = connector_test_client.delete("/v1/documents/connector-owned-doc")
+        assert response.status_code == 404
+
+# ===========================================================================
+# POST /v1/connectors/{connector_id}/sync
+# ===========================================================================
+
+class TestTriggerSync:
+    def test_returns_202_and_dispatches_task_when_lock_acquired(
+        self, connector_test_client, monkeypatch
+    ):
+        """Lock acquired → create_task called, 202 returned."""
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.try_acquire_sync_lock",
+            Mock(return_value=True),
+        )
+        task_mock = Mock(side_effect=lambda coro: coro.close())
+        with patch("asyncio.create_task", task_mock):
+            response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/sync")
+        assert response.status_code == 202
+        task_mock.assert_called_once()
+
+    def test_returns_202_no_op_when_already_syncing(
+        self, connector_test_client, monkeypatch
+    ):
+        """Lock not acquired (already syncing) → 202, no task created."""
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.try_acquire_sync_lock",
+            Mock(return_value=False),
+        )
+        task_mock = Mock(side_effect=lambda coro: coro.close())
+        with patch("asyncio.create_task", task_mock):
+            response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/sync")
+        assert response.status_code == 202
+        task_mock.assert_not_called()
+
+    def test_returns_404_when_connector_not_found(
+        self, connector_test_client, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=None),
+        )
+        response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/sync")
         assert response.status_code == 404
 
 # Made with Bob

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -196,7 +196,7 @@ class TestPostConnector:
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())
         response = connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
         assert response.status_code == 201
-        assert response.text == ""
+        assert response.json() == {"connector_id": CONNECTOR_ID}
 
     def test_encrypts_private_key_before_insert(self, connector_test_client, monkeypatch):
         captured = {}
@@ -225,7 +225,9 @@ class TestPostConnector:
     def test_secret_not_returned_in_response(self, connector_test_client, monkeypatch):
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())
         response = connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
-        assert response.text == ""
+        assert response.json() == {"connector_id": CONNECTOR_ID}
+        assert "private_key" not in response.text
+        assert "password" not in response.text
 
 
 # ===========================================================================

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -659,22 +659,22 @@ class TestTriggerSync:
     def test_returns_202_with_sync_seq_when_lock_acquired(
         self, connector_test_client, monkeypatch
     ):
-        """Lock acquired → create_task called, 202 returned with sync_seq."""
+        """Lock acquired → sync-log opened, create_task called, 202 returned with sync_seq."""
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.get_active_connector",
             Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_sync_seq",
+            Mock(return_value=None),  # no sync running — lock can be acquired
         )
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.try_acquire_sync_lock",
             Mock(return_value=True),
         )
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_sync_seq",
+            "digitize.api.v1.connectors.db_ops.init_sync_log_and_update_connector",
             Mock(return_value=7),
-        )
-        monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_sync_log_status",
-            Mock(return_value=SyncLogStatus.STARTED),
         )
         task_mock = Mock(side_effect=lambda coro: coro.close())
         with patch("asyncio.create_task", task_mock):

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -22,7 +22,7 @@ Coverage:
 
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -652,73 +652,143 @@ class TestDocumentListConnectorFilter:
         assert response.status_code == 404
 
 # ===========================================================================
-# POST /v1/connectors/{connector_id}/sync
+# dispatch_sync  (core logic — no HTTP)
+# ===========================================================================
+
+class TestDispatchSync:
+    """Unit tests for dispatch_sync — verifies the dispatch logic in isolation,
+    without going through the HTTP layer."""
+
+    def _run(self, coro):
+        import asyncio
+        return asyncio.run(coro)
+
+    def test_dispatches_task_and_returns_seq_when_lock_acquired(self):
+        """Lock acquired → sync-log opened, task created, seq returned."""
+        from digitize.api.v1.connectors import dispatch_sync
+
+        task_mock = Mock(side_effect=lambda coro: coro.close())
+        with patch("digitize.api.v1.connectors.db_ops.get_active_connector",
+                   return_value=_make_connector()), \
+             patch("digitize.api.v1.connectors.db_ops.get_active_sync_seq",
+                   return_value=None), \
+             patch("digitize.api.v1.connectors.db_ops.try_acquire_sync_lock",
+                   return_value=True), \
+             patch("digitize.api.v1.connectors.db_ops.init_sync_log_and_update_connector",
+                   return_value=7), \
+             patch("asyncio.create_task", task_mock):
+            seq = self._run(dispatch_sync(CONNECTOR_ID))
+
+        assert seq == 7
+        task_mock.assert_called_once()
+
+    def test_returns_existing_seq_when_already_syncing(self):
+        """Lock not acquired → existing seq returned, no new task."""
+        from digitize.api.v1.connectors import dispatch_sync
+
+        task_mock = Mock()
+        with patch("digitize.api.v1.connectors.db_ops.get_active_connector",
+                   return_value=_make_connector()), \
+             patch("digitize.api.v1.connectors.db_ops.get_active_sync_seq",
+                   return_value=3), \
+             patch("digitize.api.v1.connectors.db_ops.get_sync_log_status",
+                   return_value=SyncLogStatus.STARTED), \
+             patch("digitize.api.v1.connectors.db_ops.try_acquire_sync_lock",
+                   return_value=False), \
+             patch("asyncio.create_task", task_mock):
+            seq = self._run(dispatch_sync(CONNECTOR_ID))
+
+        assert seq == 3
+        task_mock.assert_not_called()
+
+    def test_raises_sync_not_found_when_connector_missing(self):
+        from digitize.api.v1.connectors import dispatch_sync, SyncNotFound
+
+        with patch("digitize.api.v1.connectors.db_ops.get_active_connector",
+                   return_value=None):
+            with pytest.raises(SyncNotFound):
+                self._run(dispatch_sync(CONNECTOR_ID))
+
+    def test_raises_sync_locked_when_delete_pending(self):
+        from digitize.api.v1.connectors import dispatch_sync, SyncLocked
+
+        with patch("digitize.api.v1.connectors.db_ops.get_active_connector",
+                   return_value=_make_connector(sync_status=ConnectorStatus.DELETE_PENDING)):
+            with pytest.raises(SyncLocked):
+                self._run(dispatch_sync(CONNECTOR_ID))
+
+    def test_raises_sync_locked_when_cancel_pending(self):
+        from digitize.api.v1.connectors import dispatch_sync, SyncLocked
+
+        with patch("digitize.api.v1.connectors.db_ops.get_active_connector",
+                   return_value=_make_connector()), \
+             patch("digitize.api.v1.connectors.db_ops.get_active_sync_seq",
+                   return_value=5), \
+             patch("digitize.api.v1.connectors.db_ops.get_sync_log_status",
+                   return_value=SyncLogStatus.CANCEL_PENDING):
+            with pytest.raises(SyncLocked):
+                self._run(dispatch_sync(CONNECTOR_ID))
+
+
+# ===========================================================================
+# POST /v1/connectors/{connector_id}/syncs  (HTTP mapping only)
 # ===========================================================================
 
 class TestTriggerSync:
-    def test_returns_202_with_sync_seq_when_lock_acquired(
+    """Tests for the trigger_sync route handler.
+
+    The dispatch logic is tested in TestDispatchSync; these tests only verify
+    that dispatch_sync results and exceptions are mapped to the correct HTTP
+    responses.
+    """
+
+    def test_returns_202_with_sync_seq_when_dispatched(
         self, connector_test_client, monkeypatch
     ):
-        """Lock acquired → sync-log opened, create_task called, 202 returned with sync_seq."""
+        """dispatch_sync succeeds → 202 with sync_seq."""
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
-            Mock(return_value=_make_connector()),
+            "digitize.api.v1.connectors.dispatch_sync",
+            AsyncMock(return_value=7),
         )
-        monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_sync_seq",
-            Mock(return_value=None),  # no sync running — lock can be acquired
-        )
-        monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.try_acquire_sync_lock",
-            Mock(return_value=True),
-        )
-        monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.init_sync_log_and_update_connector",
-            Mock(return_value=7),
-        )
-        task_mock = Mock(side_effect=lambda coro: coro.close())
-        with patch("asyncio.create_task", task_mock):
-            response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/syncs")
+        response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/syncs")
         assert response.status_code == 202
         assert response.json()["sync_seq"] == 7
-        task_mock.assert_called_once()
 
-    def test_returns_202_no_op_with_existing_sync_seq_when_already_syncing(
+    def test_returns_202_no_op_when_already_syncing(
         self, connector_test_client, monkeypatch
     ):
-        """Lock not acquired (already syncing) → 202, no task created, existing sync_seq returned."""
+        """dispatch_sync returns existing seq (no-op) → 202."""
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
-            Mock(return_value=_make_connector()),
+            "digitize.api.v1.connectors.dispatch_sync",
+            AsyncMock(return_value=3),
         )
-        monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.try_acquire_sync_lock",
-            Mock(return_value=False),
-        )
-        monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_sync_seq",
-            Mock(return_value=3),
-        )
-        monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_sync_log_status",
-            Mock(return_value=SyncLogStatus.STARTED),
-        )
-        task_mock = Mock(side_effect=lambda coro: coro.close())
-        with patch("asyncio.create_task", task_mock):
-            response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/syncs")
+        response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/syncs")
         assert response.status_code == 202
         assert response.json()["sync_seq"] == 3
-        task_mock.assert_not_called()
 
     def test_returns_404_when_connector_not_found(
         self, connector_test_client, monkeypatch
     ):
+        """dispatch_sync raises SyncNotFound → 404."""
+        from digitize.api.v1.connectors import SyncNotFound
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
-            Mock(return_value=None),
+            "digitize.api.v1.connectors.dispatch_sync",
+            AsyncMock(side_effect=SyncNotFound("not found")),
         )
-        response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/sync")
+        response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/syncs")
         assert response.status_code == 404
+
+    def test_returns_409_when_sync_locked(
+        self, connector_test_client, monkeypatch
+    ):
+        """dispatch_sync raises SyncLocked → 409."""
+        from digitize.api.v1.connectors import SyncLocked
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.dispatch_sync",
+            AsyncMock(side_effect=SyncLocked("locked")),
+        )
+        response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/syncs")
+        assert response.status_code == 409
 
 # ===========================================================================
 # POST /v1/connectors/{connector_id}/syncs/{sync_seq}/stop

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -13,7 +13,7 @@ Coverage:
   - GET    /v1/connectors/{id}                            (200, 404)
   - GET    /v1/connectors/{id}/syncs                      (200, 404)
   - POST   /v1/connectors/{id}/sync                       (202 dispatched, 202 no-op, 404)
-  - DELETE /v1/connectors/{id}/sync                       (204 signalled, 409 not running, 404)
+  - POST   /v1/connectors/{id}/syncs/{sync_seq}/stop      (204 signalled, 409 stale seq, 409 not running, 404)
   - GET    /v1/documents — excludes connector-sourced docs
   - GET    /v1/documents/{doc_id} — 404 for connector-sourced
   - DELETE /v1/documents/{doc_id} — 404 for connector-sourced
@@ -657,38 +657,71 @@ class TestTriggerSync:
         assert response.status_code == 404
 
 # ===========================================================================
-# DELETE /v1/connectors/{connector_id}/sync
+# POST /v1/connectors/{connector_id}/syncs/{sync_seq}/stop
 # ===========================================================================
+
+_ACTIVE_SEQ = 7
 
 class TestStopSync:
     def test_returns_204_when_sync_signalled(
         self, connector_test_client, monkeypatch
     ):
-        """mark_sync_stop_pending returns True → 204 returned."""
+        """Correct sync_seq + mark_sync_cancel_pending True → 204."""
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.get_active_connector",
             Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_sync_seq",
+            Mock(return_value=_ACTIVE_SEQ),
         )
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.mark_sync_cancel_pending",
             Mock(return_value=True),
         )
-        response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}/sync")
+        response = connector_test_client.post(
+            f"/v1/connectors/{CONNECTOR_ID}/syncs/{_ACTIVE_SEQ}/stop"
+        )
         assert response.status_code == 204
 
-    def test_returns_409_when_no_sync_running(
+    def test_returns_409_when_stale_sync_seq(
         self, connector_test_client, monkeypatch
     ):
-        """mark_sync_stop_pending returns False (not syncing) → 409."""
+        """sync_seq older than the active one → 409 without calling mark_sync_cancel_pending."""
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.get_active_connector",
             Mock(return_value=_make_connector()),
         )
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.mark_sync_cancel_pending",
-            Mock(return_value=False),
+            "digitize.api.v1.connectors.db_ops.get_active_sync_seq",
+            Mock(return_value=_ACTIVE_SEQ),
         )
-        response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}/sync")
+        cancel_mock = Mock()
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.mark_sync_cancel_pending",
+            cancel_mock,
+        )
+        response = connector_test_client.post(
+            f"/v1/connectors/{CONNECTOR_ID}/syncs/{_ACTIVE_SEQ - 1}/stop"
+        )
+        assert response.status_code == 409
+        cancel_mock.assert_not_called()
+
+    def test_returns_409_when_no_sync_running(
+        self, connector_test_client, monkeypatch
+    ):
+        """get_active_sync_seq returns None (not syncing) → 409."""
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_sync_seq",
+            Mock(return_value=None),
+        )
+        response = connector_test_client.post(
+            f"/v1/connectors/{CONNECTOR_ID}/syncs/{_ACTIVE_SEQ}/stop"
+        )
         assert response.status_code == 409
 
     def test_returns_404_when_connector_not_found(
@@ -698,7 +731,9 @@ class TestStopSync:
             "digitize.api.v1.connectors.db_ops.get_active_connector",
             Mock(return_value=None),
         )
-        response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}/sync")
+        response = connector_test_client.post(
+            f"/v1/connectors/{CONNECTOR_ID}/syncs/{_ACTIVE_SEQ}/stop"
+        )
         assert response.status_code == 404
 
 # Made with Bob

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -289,21 +289,50 @@ class TestPutConnector:
 # ===========================================================================
 
 class TestDeleteConnector:
-    def test_returns_204_on_success(self, connector_test_client, monkeypatch):
+    """
+    The DELETE endpoint is non-blocking: it always returns 204 immediately.
+
+    Case A (SYNCING)  — mark DELETE_PENDING, return 204; tick handles teardown.
+    Case B (not SYNCING) — mark DELETE_PENDING, schedule _run_teardown, return 204.
+
+    _run_teardown itself is exercised by TestRunTeardown below.
+    """
+
+    def _patch_mark(self, monkeypatch, return_value=True):
+        mock = Mock(return_value=return_value)
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.mark_sync_delete_pending",
+            mock,
+        )
+        return mock
+
+    def test_returns_204_case_b_not_syncing(self, connector_test_client, monkeypatch):
+        """Case B: not syncing → mark DELETE_PENDING, schedule teardown, return 204."""
+        mark_mock = self._patch_mark(monkeypatch)
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.get_active_connector",
             Mock(return_value=_make_connector()),
         )
-        monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.list_connector_checksums",
-            Mock(return_value=[]),
-        )
-        monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.delete_active_connector",
-            Mock(return_value=True),
-        )
-        response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}")
+        def _consume_coro(coro):
+            coro.close()  # prevent "coroutine never awaited" warning
+        with patch("digitize.api.v1.connectors.asyncio.create_task", side_effect=_consume_coro) as task_mock:
+            response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}")
         assert response.status_code == 204
+        mark_mock.assert_called_once_with(CONNECTOR_ID)
+        task_mock.assert_called_once()
+
+    def test_returns_204_case_a_syncing(self, connector_test_client, monkeypatch):
+        """Case A: syncing → mark DELETE_PENDING, return 204; no teardown task created."""
+        mark_mock = self._patch_mark(monkeypatch)
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector(sync_status=SyncStatus.SYNCING)),
+        )
+        with patch("digitize.api.v1.connectors.asyncio.create_task") as task_mock:
+            response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}")
+        assert response.status_code == 204
+        mark_mock.assert_called_once_with(CONNECTOR_ID)
+        task_mock.assert_not_called()
 
     def test_returns_404_when_not_found(self, connector_test_client, monkeypatch):
         monkeypatch.setattr(
@@ -313,21 +342,14 @@ class TestDeleteConnector:
         response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}")
         assert response.status_code == 404
 
-    def test_returns_409_when_sync_in_progress(self, connector_test_client, monkeypatch):
-        monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
-            Mock(return_value=_make_connector(sync_status=SyncStatus.SYNCING)),
-        )
-        response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}")
-        assert response.status_code == 409
 
-    def test_deletes_document_when_last_owner(self, connector_test_client, monkeypatch):
-        """When remaining_owner_count == 0 after removing a checksum, the doc is deleted."""
+@pytest.mark.asyncio
+class TestRunTeardown:
+    """Unit tests for the _run_teardown background coroutine."""
+
+    async def test_deletes_document_when_last_owner(self, monkeypatch):
+        """remaining_owner_count == 0 → document is deleted."""
         doc_delete_mock = Mock()
-        monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
-            Mock(return_value=_make_connector()),
-        )
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.list_connector_checksums",
             Mock(return_value=["abc123"]),
@@ -341,16 +363,14 @@ class TestDeleteConnector:
             Mock(return_value=True),
         )
         with patch("digitize.api.v1.connectors._best_effort_delete_document", doc_delete_mock):
-            connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}")
+            with patch("digitize.api.v1.connectors._sweep_connector_staging"):
+                from digitize.api.v1.connectors import _run_teardown
+                await _run_teardown(CONNECTOR_ID)
         doc_delete_mock.assert_called_once_with("doc-0001")
 
-    def test_does_not_delete_doc_when_other_owners_remain(self, connector_test_client, monkeypatch):
+    async def test_does_not_delete_doc_when_other_owners_remain(self, monkeypatch):
         """remaining_owner_count > 0 → doc must NOT be deleted."""
         doc_delete_mock = Mock()
-        monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
-            Mock(return_value=_make_connector()),
-        )
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.list_connector_checksums",
             Mock(return_value=["abc123"]),
@@ -364,7 +384,9 @@ class TestDeleteConnector:
             Mock(return_value=True),
         )
         with patch("digitize.api.v1.connectors._best_effort_delete_document", doc_delete_mock):
-            connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}")
+            with patch("digitize.api.v1.connectors._sweep_connector_staging"):
+                from digitize.api.v1.connectors import _run_teardown
+                await _run_teardown(CONNECTOR_ID)
         doc_delete_mock.assert_not_called()
 
 

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -672,6 +672,10 @@ class TestTriggerSync:
             "digitize.api.v1.connectors.db_ops.get_active_sync_seq",
             Mock(return_value=7),
         )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_sync_log_status",
+            Mock(return_value=SyncLogStatus.STARTED),
+        )
         task_mock = Mock(side_effect=lambda coro: coro.close())
         with patch("asyncio.create_task", task_mock):
             response = connector_test_client.post(f"/v1/connectors/{CONNECTOR_ID}/syncs")
@@ -694,6 +698,10 @@ class TestTriggerSync:
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.get_active_sync_seq",
             Mock(return_value=3),
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_sync_log_status",
+            Mock(return_value=SyncLogStatus.STARTED),
         )
         task_mock = Mock(side_effect=lambda coro: coro.close())
         with patch("asyncio.create_task", task_mock):

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -44,6 +44,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from digitize.connectors.models import SyncStatus
 from digitize.connectors.sync_tick import (
     _cancel_tick,
     _check_delete_pending,
@@ -187,7 +188,7 @@ class TestProcessNewFiles:
         stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
         # cancellation checkpoint must not fire in normal test runs
         stack.enter_context(
-            patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing")
+            patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING)
         )
         return stack
 
@@ -229,7 +230,7 @@ class TestProcessNewFiles:
             stack.enter_context(patch(f"{DB_MODULE}._wait_for_job", new_callable=AsyncMock))
             stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
             stack.enter_context(
-                patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing")
+                patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING)
             )
             # Force batch_size=1 so the two files land in separate batches
             stack.enter_context(patch.object(_st_mod, "_BATCH_SIZE", 1))
@@ -271,40 +272,39 @@ class TestDeleteOrphans:
     def test_deletes_doc_when_last_owner(self):
         with patch(f"{DB_MODULE}.remove_connector_checksum_entry", return_value=(0, "doc-1")) as mock_rm, \
              patch(_DELETE_DOC) as mock_del:
-            removed = asyncio.run(_delete_orphans("c1", {"ck_orphan"}))
+            asyncio.run(_delete_orphans("c1", {"ck_orphan"}))
 
-        assert removed == 1
         mock_rm.assert_called_once_with("c1", "ck_orphan")
         mock_del.assert_called_once_with("doc-1")
 
     def test_skips_doc_deletion_when_other_owners_remain(self):
         with patch(f"{DB_MODULE}.remove_connector_checksum_entry", return_value=(2, "doc-1")), \
              patch(_DELETE_DOC) as mock_del:
-            removed = asyncio.run(_delete_orphans("c1", {"ck_shared"}))
+            asyncio.run(_delete_orphans("c1", {"ck_shared"}))
 
-        assert removed == 1
         mock_del.assert_not_called()
 
-    def test_continues_after_remove_raises(self):
+    def test_raises_when_remove_raises(self):
         with patch(f"{DB_MODULE}.remove_connector_checksum_entry",
                    side_effect=RuntimeError("db gone")), \
              patch(_DELETE_DOC) as mock_del:
-            removed = asyncio.run(_delete_orphans("c1", {"ck_orphan"}))
+            with pytest.raises(RuntimeError, match="db gone"):
+                asyncio.run(_delete_orphans("c1", {"ck_orphan"}))
 
-        assert removed == 0
         mock_del.assert_not_called()
 
-    def test_returns_correct_removed_count_multiple(self):
+    def test_processes_multiple_checksums(self):
         side_effects = [(0, "doc-1"), (1, "doc-2")]
-        with patch(f"{DB_MODULE}.remove_connector_checksum_entry", side_effect=side_effects), \
+        with patch(f"{DB_MODULE}.remove_connector_checksum_entry", side_effect=side_effects) as mock_rm, \
              patch(_DELETE_DOC):
-            removed = asyncio.run(_delete_orphans("c1", {"ck1", "ck2"}))
+            asyncio.run(_delete_orphans("c1", {"ck1", "ck2"}))
 
-        assert removed == 2
+        assert mock_rm.call_count == 2
 
     def test_empty_orphan_set(self):
-        removed = asyncio.run(_delete_orphans("c1", set()))
-        assert removed == 0
+        with patch(f"{DB_MODULE}.remove_connector_checksum_entry") as mock_rm:
+            asyncio.run(_delete_orphans("c1", set()))
+        mock_rm.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -319,7 +319,7 @@ class TestTickFinalizers:
         mock_close.assert_called_once_with(
             connector_id="c1",
             seq=7,
-            status="completed",
+            status=SyncStatus.COMPLETED,
         )
 
     def test_fail_tick_calls_close_sync_log_with_error(self):
@@ -330,7 +330,7 @@ class TestTickFinalizers:
         mock_close.assert_called_once_with(
             connector_id="c1",
             seq=3,
-            status="failed",
+            status=SyncStatus.FAILED,
             error="disk full",
         )
 
@@ -370,7 +370,7 @@ class TestRunTick:
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
-             patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing"), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch("digitize.connectors.sync_tick._process_new_files",
@@ -381,7 +381,7 @@ class TestRunTick:
 
         mock_open.assert_called_once_with("conn-1")
         mock_close.assert_called_once()
-        assert mock_close.call_args.kwargs["status"] == "completed"
+        assert mock_close.call_args.kwargs["status"] == SyncStatus.COMPLETED
 
     def test_scanner_connect_failure_calls_fail_tick(self):
         connector = _connector()
@@ -389,13 +389,13 @@ class TestRunTick:
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
              patch(f"{DB_MODULE}.open_new_sync_log", return_value=2), \
-             patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing"), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close:
             asyncio.run(run_tick("conn-1"))
 
         args = mock_close.call_args.kwargs
-        assert args["status"] == "failed"
+        assert args["status"] == SyncStatus.FAILED
         assert "refused" in args["error"]
 
     def test_scanner_close_always_called(self):
@@ -406,7 +406,7 @@ class TestRunTick:
              patch(f"{DB_MODULE}.open_new_sync_log", return_value=3), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
-             patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing"), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.close_sync_log"):
             asyncio.run(run_tick("conn-1"))
@@ -421,13 +421,13 @@ class TestRunTick:
              patch(f"{DB_MODULE}.open_new_sync_log", return_value=4), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
-             patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing"), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close:
             asyncio.run(run_tick("conn-1"))
 
         args = mock_close.call_args.kwargs
-        assert args["status"] == "failed"
+        assert args["status"] == SyncStatus.FAILED
 
 
 # ---------------------------------------------------------------------------
@@ -436,12 +436,12 @@ class TestRunTick:
 
 class TestCheckDeletePending:
     def test_raises_cancelled_error_when_delete_pending(self):
-        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value="delete pending"):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.DELETE_PENDING):
             with pytest.raises(asyncio.CancelledError):
                 _check_delete_pending("conn-1")
 
     def test_does_not_raise_when_syncing(self):
-        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing"):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING):
             _check_delete_pending("conn-1")  # must not raise
 
     def test_does_not_raise_when_none(self):
@@ -449,12 +449,12 @@ class TestCheckDeletePending:
             _check_delete_pending("conn-1")  # must not raise
 
     def test_raises_cancelled_error_when_cancel_pending(self):
-        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value="cancel pending"):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.CANCEL_PENDING):
             with pytest.raises(asyncio.CancelledError):
                 _check_delete_pending("conn-1")
 
     def test_does_not_raise_when_up_to_date(self):
-        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value="up to date"):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.UP_TO_DATE):
             _check_delete_pending("conn-1")  # must not raise
 
 
@@ -469,7 +469,7 @@ class TestCancelTick:
         mock_close.assert_called_once_with(
             connector_id="conn-1",
             seq=5,
-            status="cancelled",
+            status=SyncStatus.CANCELLED,
         )
 
     def test_swallows_close_exception(self):
@@ -499,13 +499,13 @@ class TestRunTickCancellation:
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
              patch(f"{DB_MODULE}.open_new_sync_log", return_value=10), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
-             patch(f"{DB_MODULE}.get_connector_sync_status", return_value="delete pending"), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.DELETE_PENDING), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close:
             with pytest.raises(asyncio.CancelledError):
                 asyncio.run(run_tick("conn-1"))
 
         args = mock_close.call_args.kwargs
-        assert args["status"] == "cancelled"
+        assert args["status"] == SyncStatus.CANCELLED
         mock_scanner.close.assert_called_once()
 
     def test_not_cancelled_when_not_delete_pending(self):
@@ -518,7 +518,7 @@ class TestRunTickCancellation:
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
-             patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing"), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch("digitize.connectors.sync_tick._process_new_files",
@@ -527,7 +527,7 @@ class TestRunTickCancellation:
                    new_callable=AsyncMock, return_value=0):
             asyncio.run(run_tick("conn-1"))  # must not raise
 
-        assert mock_close.call_args.kwargs["status"] == "completed"
+        assert mock_close.call_args.kwargs["status"] == SyncStatus.COMPLETED
 
     def test_cancelled_mid_process_closes_log(self):
         """_check_delete_pending fires inside _process_new_files loop."""
@@ -554,5 +554,5 @@ class TestRunTickCancellation:
                 asyncio.run(run_tick("conn-1"))
 
         args = mock_close.call_args.kwargs
-        assert args["status"] == "cancelled"
+        assert args["status"] == SyncStatus.CANCELLED
         mock_scanner.close.assert_called_once()

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -44,7 +44,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from digitize.connectors.models import SyncStatus
+from digitize.connectors.models import ConnectorStatus, SyncLogStatus
 from digitize.connectors.sync_tick import (
     _cancel_tick,
     _check_interrupt_call,
@@ -189,10 +189,10 @@ class TestProcessNewFiles:
         stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
         # cancellation checkpoint must not fire in normal test runs
         stack.enter_context(
-            patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING)
+            patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING)
         )
         stack.enter_context(
-            patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED)
+            patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED)
         )
         return stack
 
@@ -234,10 +234,10 @@ class TestProcessNewFiles:
             stack.enter_context(patch(f"{DB_MODULE}._wait_for_job", new_callable=AsyncMock))
             stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
             stack.enter_context(
-                patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING)
+                patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING)
             )
             stack.enter_context(
-                patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED)
+                patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED)
             )
             # Force batch_size=1 so the two files land in separate batches
             stack.enter_context(patch.object(_st_mod, "_BATCH_SIZE", 1))
@@ -328,7 +328,7 @@ class TestTickFinalizers:
         mock_close.assert_called_once_with(
             connector_id="c1",
             seq=7,
-            status=SyncStatus.COMPLETED,
+            status=SyncLogStatus.COMPLETED,
         )
 
     def test_fail_tick_calls_close_sync_log_with_error(self):
@@ -339,7 +339,7 @@ class TestTickFinalizers:
         mock_close.assert_called_once_with(
             connector_id="c1",
             seq=3,
-            status=SyncStatus.FAILED,
+            status=SyncLogStatus.FAILED,
             error="disk full",
         )
 
@@ -379,8 +379,8 @@ class TestRunTick:
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
-             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
-             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch("digitize.connectors.sync_tick._process_new_files",
@@ -391,7 +391,7 @@ class TestRunTick:
 
         mock_open.assert_called_once_with("conn-1")
         mock_close.assert_called_once()
-        assert mock_close.call_args.kwargs["status"] == SyncStatus.COMPLETED
+        assert mock_close.call_args.kwargs["status"] == SyncLogStatus.COMPLETED
 
     def test_scanner_connect_failure_calls_fail_tick(self):
         connector = _connector()
@@ -399,14 +399,14 @@ class TestRunTick:
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
              patch(f"{DB_MODULE}.open_new_sync_log", return_value=2), \
-             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
-             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close:
             asyncio.run(run_tick("conn-1"))
 
         args = mock_close.call_args.kwargs
-        assert args["status"] == SyncStatus.FAILED
+        assert args["status"] == SyncLogStatus.FAILED
         assert "refused" in args["error"]
 
     def test_scanner_close_always_called(self):
@@ -417,8 +417,8 @@ class TestRunTick:
              patch(f"{DB_MODULE}.open_new_sync_log", return_value=3), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
-             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
-             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.close_sync_log"):
             asyncio.run(run_tick("conn-1"))
@@ -433,14 +433,14 @@ class TestRunTick:
              patch(f"{DB_MODULE}.open_new_sync_log", return_value=4), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
-             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
-             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close:
             asyncio.run(run_tick("conn-1"))
 
         args = mock_close.call_args.kwargs
-        assert args["status"] == SyncStatus.FAILED
+        assert args["status"] == SyncLogStatus.FAILED
 
 
 # ---------------------------------------------------------------------------
@@ -449,39 +449,39 @@ class TestRunTick:
 
 class TestCheckInterruptCall:
     def test_returns_delete_connector_when_delete_pending(self):
-        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.DELETE_PENDING), \
-             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.DELETE_PENDING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED):
             result = _check_interrupt_call("conn-1", sync_seq=1)
             assert result == InterruptType.DELETE_CONNECTOR
 
     def test_returns_sync_cancel_when_cancel_pending_on_log(self):
         """CANCEL_PENDING is read from connector_sync_logs, not from connectors.sync_status."""
-        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
-             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.CANCEL_PENDING):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.CANCEL_PENDING):
             result = _check_interrupt_call("conn-1", sync_seq=5)
             assert result == InterruptType.SYNC_CANCEL
 
     def test_returns_none_when_syncing_and_log_started(self):
-        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
-             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED):
             result = _check_interrupt_call("conn-1", sync_seq=1)
             assert result is None
 
     def test_returns_none_when_connector_status_is_none(self):
         with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=None), \
-             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED):
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED):
             result = _check_interrupt_call("conn-1", sync_seq=1)
             assert result is None
 
     def test_returns_none_when_up_to_date(self):
-        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.UP_TO_DATE), \
-             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.UP_TO_DATE), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED):
             result = _check_interrupt_call("conn-1", sync_seq=1)
             assert result is None
 
     def test_delete_pending_short_circuits_before_log_check(self):
         """DELETE_PENDING on the connector row is detected without querying the log."""
-        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.DELETE_PENDING) as mock_cs, \
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.DELETE_PENDING) as mock_cs, \
              patch(f"{DB_MODULE}.get_sync_log_status") as mock_ls:
             result = _check_interrupt_call("conn-1", sync_seq=7)
         assert result == InterruptType.DELETE_CONNECTOR
@@ -499,7 +499,7 @@ class TestCancelTick:
         mock_close.assert_called_once_with(
             connector_id="conn-1",
             seq=5,
-            status=SyncStatus.CANCELLED,
+            status=SyncLogStatus.CANCELLED,
         )
 
     def test_swallows_close_exception(self):
@@ -529,13 +529,13 @@ class TestRunTickCancellation:
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
              patch(f"{DB_MODULE}.open_new_sync_log", return_value=10), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
-             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.DELETE_PENDING), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.DELETE_PENDING), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close:
             with pytest.raises(asyncio.CancelledError):
                 asyncio.run(run_tick("conn-1"))
 
         args = mock_close.call_args.kwargs
-        assert args["status"] == SyncStatus.CANCELLED
+        assert args["status"] == SyncLogStatus.CANCELLED
         mock_scanner.close.assert_called_once()
 
     def test_not_cancelled_when_not_delete_pending(self):
@@ -548,8 +548,8 @@ class TestRunTickCancellation:
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
-             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
-             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch("digitize.connectors.sync_tick._process_new_files",
@@ -558,7 +558,7 @@ class TestRunTickCancellation:
                    new_callable=AsyncMock, return_value=0):
             asyncio.run(run_tick("conn-1"))  # must not raise
 
-        assert mock_close.call_args.kwargs["status"] == SyncStatus.COMPLETED
+        assert mock_close.call_args.kwargs["status"] == SyncLogStatus.COMPLETED
 
     def test_cancelled_mid_process_closes_log(self):
         """_check_interrupt_call fires inside _process_new_files loop."""
@@ -586,5 +586,5 @@ class TestRunTickCancellation:
                 asyncio.run(run_tick("conn-1"))
 
         args = mock_close.call_args.kwargs
-        assert args["status"] == SyncStatus.CANCELLED
+        assert args["status"] == SyncLogStatus.CANCELLED
         mock_scanner.close.assert_called_once()

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -25,13 +25,13 @@ _delete_orphans
   - returns count of ownership rows removed
 
 _complete_tick / _fail_tick
-  - _complete_tick calls close_sync_log with status='completed' and correct counters
-  - _fail_tick calls close_sync_log with status='failed' and error string
-  - _fail_tick swallows a secondary exception from close_sync_log
+  - _complete_tick calls finalize_sync_log_and_update_connector with status='completed' and correct counters
+  - _fail_tick calls finalize_sync_log_and_update_connector with status='failed' and error string
+  - _fail_tick swallows a secondary exception from finalize_sync_log_and_update_connector
 
 run_tick
   - aborts gracefully when connector not found
-  - calls open_new_sync_log, scan, classify, process, orphan, complete in order
+  - calls init_sync_log_and_set_syncing, scan, classify, process, orphan, complete in order
   - on scanner.connect failure: _fail_tick is called, scanner.close still runs
   - on scan failure: _fail_tick is called, scanner.close still runs
 """
@@ -321,8 +321,8 @@ class TestDeleteOrphans:
 # ---------------------------------------------------------------------------
 
 class TestTickFinalizers:
-    def test_complete_tick_calls_close_sync_log(self):
-        with patch(f"{DB_MODULE}.close_sync_log") as mock_close:
+    def test_complete_tick_calls_finalize_sync_log_and_update_connector(self):
+        with patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close:
             _complete_tick(7, "c1")
 
         mock_close.assert_called_once_with(
@@ -331,9 +331,9 @@ class TestTickFinalizers:
             status=SyncLogStatus.COMPLETED,
         )
 
-    def test_fail_tick_calls_close_sync_log_with_error(self):
+    def test_fail_tick_calls_finalize_sync_log_and_update_connector_with_error(self):
         exc = ValueError("disk full")
-        with patch(f"{DB_MODULE}.close_sync_log") as mock_close:
+        with patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close:
             _fail_tick(3, "c1", exc)
 
         mock_close.assert_called_once_with(
@@ -344,7 +344,7 @@ class TestTickFinalizers:
         )
 
     def test_fail_tick_swallows_close_exception(self):
-        with patch(f"{DB_MODULE}.close_sync_log", side_effect=RuntimeError("write failed")):
+        with patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector", side_effect=RuntimeError("write failed")):
             _fail_tick(3, "c1", ValueError("original"))  # must not raise
 
 
@@ -366,7 +366,7 @@ class TestRunTick:
 
     def test_aborts_when_connector_not_found(self):
         with patch(f"{DB_MODULE}.get_active_connector", return_value=None), \
-             patch(f"{DB_MODULE}.open_new_sync_log") as mock_open:
+             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing") as mock_open:
             asyncio.run(run_tick("missing"))
         mock_open.assert_not_called()
 
@@ -375,13 +375,13 @@ class TestRunTick:
         mock_scanner = self._make_scanner(scan_result=[])
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.open_new_sync_log", return_value=1) as mock_open, \
+             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing", return_value=1) as mock_open, \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
              patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
-             patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
+             patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch("digitize.connectors.sync_tick._process_new_files",
                    new_callable=AsyncMock, return_value=None), \
@@ -398,11 +398,11 @@ class TestRunTick:
         mock_scanner = self._make_scanner(connect_raises=ConnectionError("refused"))
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.open_new_sync_log", return_value=2), \
+             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing", return_value=2), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
              patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
-             patch(f"{DB_MODULE}.close_sync_log") as mock_close:
+             patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close:
             asyncio.run(run_tick("conn-1"))
 
         args = mock_close.call_args.kwargs
@@ -414,13 +414,13 @@ class TestRunTick:
         mock_scanner = self._make_scanner(scan_raises=RuntimeError("scan exploded"))
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.open_new_sync_log", return_value=3), \
+             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing", return_value=3), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
              patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
-             patch(f"{DB_MODULE}.close_sync_log"):
+             patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector"):
             asyncio.run(run_tick("conn-1"))
 
         mock_scanner.close.assert_called_once()
@@ -430,13 +430,13 @@ class TestRunTick:
         mock_scanner = self._make_scanner(scan_raises=IOError("timeout"))
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.open_new_sync_log", return_value=4), \
+             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing", return_value=4), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
              patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
-             patch(f"{DB_MODULE}.close_sync_log") as mock_close:
+             patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close:
             asyncio.run(run_tick("conn-1"))
 
         args = mock_close.call_args.kwargs
@@ -493,8 +493,8 @@ class TestCheckInterruptCall:
 # ---------------------------------------------------------------------------
 
 class TestCancelTick:
-    def test_calls_close_sync_log_with_cancelled(self):
-        with patch(f"{DB_MODULE}.close_sync_log") as mock_close:
+    def test_calls_finalize_sync_log_and_update_connector_with_cancelled(self):
+        with patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close:
             _cancel_tick(5, "conn-1")
         mock_close.assert_called_once_with(
             connector_id="conn-1",
@@ -503,7 +503,7 @@ class TestCancelTick:
         )
 
     def test_swallows_close_exception(self):
-        with patch(f"{DB_MODULE}.close_sync_log", side_effect=RuntimeError("write failed")):
+        with patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector", side_effect=RuntimeError("write failed")):
             _cancel_tick(5, "conn-1")  # must not raise
 
 
@@ -527,10 +527,10 @@ class TestRunTickCancellation:
         mock_scanner = self._make_scanner()
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.open_new_sync_log", return_value=10), \
+             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing", return_value=10), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.DELETE_PENDING), \
-             patch(f"{DB_MODULE}.close_sync_log") as mock_close:
+             patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close:
             with pytest.raises(asyncio.CancelledError):
                 asyncio.run(run_tick("conn-1"))
 
@@ -544,13 +544,13 @@ class TestRunTickCancellation:
         mock_scanner = self._make_scanner()
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.open_new_sync_log", return_value=11), \
+             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing", return_value=11), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
              patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
-             patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
+             patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch("digitize.connectors.sync_tick._process_new_files",
                    new_callable=AsyncMock, return_value=None), \
@@ -575,12 +575,12 @@ class TestRunTickCancellation:
             return None
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.open_new_sync_log", return_value=12), \
+             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing", return_value=12), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
              patch(f"{DB_MODULE}._check_interrupt_call", side_effect=_maybe_cancel), \
-             patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
+             patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner):
             with pytest.raises(asyncio.CancelledError):
                 asyncio.run(run_tick("conn-1"))

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -458,6 +458,11 @@ class TestCheckDeletePending:
         with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=None):
             _check_delete_pending("conn-1")  # must not raise
 
+    def test_raises_cancelled_error_when_cancel_pending(self):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value="cancel pending"):
+            with pytest.raises(asyncio.CancelledError):
+                _check_delete_pending("conn-1")
+
     def test_does_not_raise_when_up_to_date(self):
         with patch(f"{DB_MODULE}.get_connector_sync_status", return_value="up to date"):
             _check_delete_pending("conn-1")  # must not raise

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -180,6 +180,10 @@ class TestProcessNewFiles:
         stack.enter_context(
             patch(f"{DB_MODULE}.ingest", side_effect=ingest_raises)
         )
+        # _wait_for_job polls with asyncio.sleep(_JOB_POLL_INTERVAL=10s) until the
+        # job reaches a terminal state.  With get_job mocked to return None the
+        # status never becomes terminal → infinite sleep → test hangs.
+        stack.enter_context(patch(f"{DB_MODULE}._wait_for_job", new_callable=AsyncMock))
         stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
         # cancellation checkpoint must not fire in normal test runs
         stack.enter_context(
@@ -194,7 +198,9 @@ class TestProcessNewFiles:
             asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
 
     def test_failure_does_not_stop_loop(self):
-        """First file fails, second succeeds — both are processed."""
+        """First batch fails, second batch succeeds — both batches are attempted."""
+        # Force batch_size=1 so each file is its own batch; a failure in batch 0
+        # must not prevent batch 1 from running.
         call_count = {"n": 0}
 
         def _download(remote_path, local_path):
@@ -209,6 +215,7 @@ class TestProcessNewFiles:
 
         ingest_list = [("a.pdf", "ck1"), ("b.pdf", "ck2")]
 
+        import digitize.connectors.sync_tick as _st_mod
         from contextlib import ExitStack
         with ExitStack() as stack:
             mock_settings = stack.enter_context(patch(f"{DB_MODULE}.settings"))
@@ -219,10 +226,13 @@ class TestProcessNewFiles:
             )
             stack.enter_context(patch(f"{DB_MODULE}.generate_uuid", return_value="job-uuid"))
             stack.enter_context(patch(f"{DB_MODULE}.ingest"))
+            stack.enter_context(patch(f"{DB_MODULE}._wait_for_job", new_callable=AsyncMock))
             stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
             stack.enter_context(
                 patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing")
             )
+            # Force batch_size=1 so the two files land in separate batches
+            stack.enter_context(patch.object(_st_mod, "_BATCH_SIZE", 1))
 
             asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
 

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -68,9 +68,10 @@ def _classify(connector_id, scanned_files, known, all_cs):
     return _real_classify(connector_id, scanned_files, known, all_cs)
 
 
-def _connector(connector_id: str = "conn-1", **kwargs):
+def _connector(connector_id: str = "conn-1", name: str = "conn-name", **kwargs):
     return SimpleNamespace(
         id=connector_id,
+        name=name,
         type="s3",
         connection_details={"bucket_name": "b", "access_key_id": "a", "secret_access_key": "s"},
         allowed_extensions=[".pdf"],
@@ -200,7 +201,7 @@ class TestProcessNewFiles:
         scanner = self._make_scanner()
         ingest_list = [("docs/report.pdf", "ck1")]
         with self._patches():
-            asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
+            asyncio.run(_process_new_files(1, "conn-1", "conn-name", scanner, ingest_list))
 
     def test_failure_does_not_stop_loop(self):
         """First batch fails, second batch succeeds — both batches are attempted."""
@@ -243,7 +244,7 @@ class TestProcessNewFiles:
             stack.enter_context(patch.object(_st_mod, "_BATCH_SIZE", 1))
 
             with pytest.raises(RuntimeError, match="One or more batches failed"):
-                asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
+                asyncio.run(_process_new_files(1, "conn-1", "conn-name", scanner, ingest_list))
 
         assert call_count["n"] == 2
 
@@ -251,7 +252,7 @@ class TestProcessNewFiles:
         scanner = self._make_scanner()
         ingest_list = [("docs/report.pdf", "ck1")]
         with self._patches() as stack:
-            asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
+            asyncio.run(_process_new_files(1, "conn-1", "conn-name", scanner, ingest_list))
         # cleanup is patched — just verifying it was called (no exception means finally ran)
 
     def test_staging_dir_cleaned_on_failure(self):
@@ -259,14 +260,14 @@ class TestProcessNewFiles:
         ingest_list = [("docs/report.pdf", "ck1")]
         with self._patches():
             with pytest.raises(RuntimeError, match="One or more batches failed"):
-                asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
+                asyncio.run(_process_new_files(1, "conn-1", "conn-name", scanner, ingest_list))
 
     def test_add_checksum_entry_called_on_success(self):
         scanner = self._make_scanner()
         ingest_list = [("docs/report.pdf", "ck1")]
         with self._patches() as stack:
             with patch(f"{DB_MODULE}.add_connector_checksum_entry") as mock_add:
-                asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
+                asyncio.run(_process_new_files(1, "conn-1", "conn-name", scanner, ingest_list))
         mock_add.assert_called_once_with("conn-1", "ck1", "doc-1")
 
 

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -15,9 +15,8 @@ _classify
 
 _process_new_files
   - happy path: download → initialize_job_state → add_connector_checksum_entry → ingest called
-  - per-file failure: exception increments failed counter, staging cleaned up, loop continues
+  - per-file failure: exception logged, staging cleaned up, loop continues
   - staging directory is removed after each file (success and failure)
-  - returns (new_count, failed_count) correctly
 
 _delete_orphans
   - removes checksum row and deletes doc when remaining == 0
@@ -174,7 +173,6 @@ class TestProcessNewFiles:
         mock_settings.digitize.staging_dir.__truediv__ = MagicMock(return_value=MagicMock())
 
         stack.enter_context(patch(f"{DB_MODULE}.add_connector_checksum_entry"))
-        stack.enter_context(patch(f"{DB_MODULE}.update_sync_log"))
         stack.enter_context(
             patch(f"{DB_MODULE}.initialize_job_state", return_value={"report.pdf": "doc-1"})
         )
@@ -189,21 +187,11 @@ class TestProcessNewFiles:
         )
         return stack
 
-    def test_happy_path_returns_new_count(self):
+    def test_happy_path_completes_without_error(self):
         scanner = self._make_scanner()
         ingest_list = [("docs/report.pdf", "ck1")]
         with self._patches():
-            new, failed = asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
-        assert new == 1
-        assert failed == 0
-
-    def test_per_file_failure_increments_failed(self):
-        scanner = self._make_scanner(download_raises=RuntimeError("network down"))
-        ingest_list = [("docs/a.pdf", "ck1"), ("docs/b.pdf", "ck2")]
-        with self._patches():
-            new, failed = asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
-        assert new == 0
-        assert failed == 2
+            asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
 
     def test_failure_does_not_stop_loop(self):
         """First file fails, second succeeds — both are processed."""
@@ -226,7 +214,6 @@ class TestProcessNewFiles:
             mock_settings = stack.enter_context(patch(f"{DB_MODULE}.settings"))
             mock_settings.digitize.staging_dir.__truediv__ = MagicMock(return_value=MagicMock())
             stack.enter_context(patch(f"{DB_MODULE}.add_connector_checksum_entry"))
-            stack.enter_context(patch(f"{DB_MODULE}.update_sync_log"))
             stack.enter_context(
                 patch(f"{DB_MODULE}.initialize_job_state", return_value={"b.pdf": "doc-2"})
             )
@@ -237,11 +224,9 @@ class TestProcessNewFiles:
                 patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing")
             )
 
-            new, failed = asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
+            asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
 
         assert call_count["n"] == 2
-        assert new == 1
-        assert failed == 1
 
     def test_staging_dir_cleaned_on_success(self):
         scanner = self._make_scanner()
@@ -254,8 +239,7 @@ class TestProcessNewFiles:
         scanner = self._make_scanner(download_raises=RuntimeError("fail"))
         ingest_list = [("docs/report.pdf", "ck1")]
         with self._patches():
-            new, failed = asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
-        assert failed == 1
+            asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
 
     def test_add_checksum_entry_called_on_success(self):
         scanner = self._make_scanner()
@@ -320,16 +304,12 @@ class TestDeleteOrphans:
 class TestTickFinalizers:
     def test_complete_tick_calls_close_sync_log(self):
         with patch(f"{DB_MODULE}.close_sync_log") as mock_close:
-            _complete_tick(7, "c1", total_files=10, new_files=3, removed_files=1, failed_files=0)
+            _complete_tick(7, "c1")
 
         mock_close.assert_called_once_with(
             connector_id="c1",
             seq=7,
             status="completed",
-            total_files=10,
-            new_files=3,
-            removed_files=1,
-            failed_files=0,
         )
 
     def test_fail_tick_calls_close_sync_log_with_error(self):
@@ -384,7 +364,7 @@ class TestRunTick:
              patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch("digitize.connectors.sync_tick._process_new_files",
-                   new_callable=AsyncMock, return_value=(0, 0)), \
+                   new_callable=AsyncMock, return_value=None), \
              patch("digitize.connectors.sync_tick._delete_orphans",
                    new_callable=AsyncMock, return_value=0):
             asyncio.run(run_tick("conn-1"))
@@ -532,7 +512,7 @@ class TestRunTickCancellation:
              patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch("digitize.connectors.sync_tick._process_new_files",
-                   new_callable=AsyncMock, return_value=(0, 0)), \
+                   new_callable=AsyncMock, return_value=None), \
              patch("digitize.connectors.sync_tick._delete_orphans",
                    new_callable=AsyncMock, return_value=0):
             asyncio.run(run_tick("conn-1"))  # must not raise

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -380,6 +380,7 @@ class TestRunTick:
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
+             patch(f"{DB_MODULE}.update_connector_total_files"), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
              patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close, \
@@ -549,6 +550,7 @@ class TestRunTickCancellation:
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
+             patch(f"{DB_MODULE}.update_connector_total_files"), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
              patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close, \
@@ -580,6 +582,7 @@ class TestRunTickCancellation:
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
+             patch(f"{DB_MODULE}.update_connector_total_files"), \
              patch(f"{DB_MODULE}._check_interrupt_call", side_effect=_maybe_cancel), \
              patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner):

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -47,12 +47,13 @@ import pytest
 from digitize.connectors.models import SyncStatus
 from digitize.connectors.sync_tick import (
     _cancel_tick,
-    _check_delete_pending,
+    _check_interrupt_call,
     _classify as _real_classify,
     _complete_tick,
     _delete_orphans,
     _fail_tick,
     _process_new_files,
+    InterruptType,
     run_tick,
 )
 
@@ -190,6 +191,9 @@ class TestProcessNewFiles:
         stack.enter_context(
             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING)
         )
+        stack.enter_context(
+            patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED)
+        )
         return stack
 
     def test_happy_path_completes_without_error(self):
@@ -231,6 +235,9 @@ class TestProcessNewFiles:
             stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
             stack.enter_context(
                 patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING)
+            )
+            stack.enter_context(
+                patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED)
             )
             # Force batch_size=1 so the two files land in separate batches
             stack.enter_context(patch.object(_st_mod, "_BATCH_SIZE", 1))
@@ -371,6 +378,7 @@ class TestRunTick:
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch("digitize.connectors.sync_tick._process_new_files",
@@ -390,6 +398,7 @@ class TestRunTick:
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
              patch(f"{DB_MODULE}.open_new_sync_log", return_value=2), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close:
             asyncio.run(run_tick("conn-1"))
@@ -407,6 +416,7 @@ class TestRunTick:
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.close_sync_log"):
             asyncio.run(run_tick("conn-1"))
@@ -422,6 +432,7 @@ class TestRunTick:
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close:
             asyncio.run(run_tick("conn-1"))
@@ -431,31 +442,48 @@ class TestRunTick:
 
 
 # ---------------------------------------------------------------------------
-# _check_delete_pending
+# _check_interrupt_call
 # ---------------------------------------------------------------------------
 
-class TestCheckDeletePending:
-    def test_raises_cancelled_error_when_delete_pending(self):
-        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.DELETE_PENDING):
-            with pytest.raises(asyncio.CancelledError):
-                _check_delete_pending("conn-1")
+class TestCheckInterruptCall:
+    def test_returns_delete_connector_when_delete_pending(self):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.DELETE_PENDING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED):
+            result = _check_interrupt_call("conn-1", sync_seq=1)
+            assert result == InterruptType.DELETE_CONNECTOR
 
-    def test_does_not_raise_when_syncing(self):
-        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING):
-            _check_delete_pending("conn-1")  # must not raise
+    def test_returns_sync_cancel_when_cancel_pending_on_log(self):
+        """CANCEL_PENDING is read from connector_sync_logs, not from connectors.sync_status."""
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.CANCEL_PENDING):
+            result = _check_interrupt_call("conn-1", sync_seq=5)
+            assert result == InterruptType.SYNC_CANCEL
 
-    def test_does_not_raise_when_none(self):
-        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=None):
-            _check_delete_pending("conn-1")  # must not raise
+    def test_returns_none_when_syncing_and_log_started(self):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED):
+            result = _check_interrupt_call("conn-1", sync_seq=1)
+            assert result is None
 
-    def test_raises_cancelled_error_when_cancel_pending(self):
-        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.CANCEL_PENDING):
-            with pytest.raises(asyncio.CancelledError):
-                _check_delete_pending("conn-1")
+    def test_returns_none_when_connector_status_is_none(self):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=None), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED):
+            result = _check_interrupt_call("conn-1", sync_seq=1)
+            assert result is None
 
-    def test_does_not_raise_when_up_to_date(self):
-        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.UP_TO_DATE):
-            _check_delete_pending("conn-1")  # must not raise
+    def test_returns_none_when_up_to_date(self):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.UP_TO_DATE), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED):
+            result = _check_interrupt_call("conn-1", sync_seq=1)
+            assert result is None
+
+    def test_delete_pending_short_circuits_before_log_check(self):
+        """DELETE_PENDING on the connector row is detected without querying the log."""
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.DELETE_PENDING) as mock_cs, \
+             patch(f"{DB_MODULE}.get_sync_log_status") as mock_ls:
+            result = _check_interrupt_call("conn-1", sync_seq=7)
+        assert result == InterruptType.DELETE_CONNECTOR
+        mock_ls.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -519,6 +547,7 @@ class TestRunTickCancellation:
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=SyncStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncStatus.STARTED), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch("digitize.connectors.sync_tick._process_new_files",
@@ -530,24 +559,25 @@ class TestRunTickCancellation:
         assert mock_close.call_args.kwargs["status"] == SyncStatus.COMPLETED
 
     def test_cancelled_mid_process_closes_log(self):
-        """_check_delete_pending fires inside _process_new_files loop."""
+        """_check_interrupt_call fires inside _process_new_files loop."""
         connector = _connector()
         mock_scanner = self._make_scanner()
         mock_scanner.scan.return_value = [("file.pdf", "ck1")]
 
         call_count = {"n": 0}
 
-        def _maybe_cancel(connector_id):
+        def _maybe_cancel(connector_id, sync_seq):
             call_count["n"] += 1
             if call_count["n"] >= 2:  # second call = inside _process_new_files
-                raise asyncio.CancelledError("delete pending")
+                return InterruptType.SYNC_CANCEL
+            return None
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
              patch(f"{DB_MODULE}.open_new_sync_log", return_value=12), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
-             patch(f"{DB_MODULE}.get_connector_sync_status", side_effect=_maybe_cancel), \
+             patch(f"{DB_MODULE}._check_interrupt_call", side_effect=_maybe_cancel), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner):
             with pytest.raises(asyncio.CancelledError):

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -46,6 +46,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from digitize.connectors.sync_tick import (
+    _cancel_tick,
+    _check_delete_pending,
     _classify as _real_classify,
     _complete_tick,
     _delete_orphans,
@@ -181,6 +183,10 @@ class TestProcessNewFiles:
             patch(f"{DB_MODULE}.ingest", side_effect=ingest_raises)
         )
         stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
+        # cancellation checkpoint must not fire in normal test runs
+        stack.enter_context(
+            patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing")
+        )
         return stack
 
     def test_happy_path_returns_new_count(self):
@@ -227,6 +233,9 @@ class TestProcessNewFiles:
             stack.enter_context(patch(f"{DB_MODULE}.generate_uuid", return_value="job-uuid"))
             stack.enter_context(patch(f"{DB_MODULE}.ingest"))
             stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
+            stack.enter_context(
+                patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing")
+            )
 
             new, failed = asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
 
@@ -371,6 +380,7 @@ class TestRunTick:
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing"), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch("digitize.connectors.sync_tick._process_new_files",
@@ -389,6 +399,7 @@ class TestRunTick:
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
              patch(f"{DB_MODULE}.open_new_sync_log", return_value=2), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing"), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close:
             asyncio.run(run_tick("conn-1"))
@@ -405,6 +416,7 @@ class TestRunTick:
              patch(f"{DB_MODULE}.open_new_sync_log", return_value=3), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing"), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.close_sync_log"):
             asyncio.run(run_tick("conn-1"))
@@ -419,9 +431,133 @@ class TestRunTick:
              patch(f"{DB_MODULE}.open_new_sync_log", return_value=4), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing"), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.close_sync_log") as mock_close:
             asyncio.run(run_tick("conn-1"))
 
         args = mock_close.call_args.kwargs
         assert args["status"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# _check_delete_pending
+# ---------------------------------------------------------------------------
+
+class TestCheckDeletePending:
+    def test_raises_cancelled_error_when_delete_pending(self):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value="delete pending"):
+            with pytest.raises(asyncio.CancelledError):
+                _check_delete_pending("conn-1")
+
+    def test_does_not_raise_when_syncing(self):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing"):
+            _check_delete_pending("conn-1")  # must not raise
+
+    def test_does_not_raise_when_none(self):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value=None):
+            _check_delete_pending("conn-1")  # must not raise
+
+    def test_does_not_raise_when_up_to_date(self):
+        with patch(f"{DB_MODULE}.get_connector_sync_status", return_value="up to date"):
+            _check_delete_pending("conn-1")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _cancel_tick
+# ---------------------------------------------------------------------------
+
+class TestCancelTick:
+    def test_calls_close_sync_log_with_cancelled(self):
+        with patch(f"{DB_MODULE}.close_sync_log") as mock_close:
+            _cancel_tick(5, "conn-1")
+        mock_close.assert_called_once_with(
+            connector_id="conn-1",
+            seq=5,
+            status="cancelled",
+        )
+
+    def test_swallows_close_exception(self):
+        with patch(f"{DB_MODULE}.close_sync_log", side_effect=RuntimeError("write failed")):
+            _cancel_tick(5, "conn-1")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# run_tick — cancellation path
+# ---------------------------------------------------------------------------
+
+class TestRunTickCancellation:
+    """Verify that delete_pending causes the tick to be cancelled and the
+    sync log is closed with status='cancelled'."""
+
+    def _make_scanner(self):
+        scanner = MagicMock()
+        scanner.connect.return_value = None
+        scanner.scan.return_value = []
+        return scanner
+
+    def test_cancelled_at_phase_boundary_closes_log(self):
+        """_check_delete_pending fires before scan — log closed as cancelled."""
+        connector = _connector()
+        mock_scanner = self._make_scanner()
+
+        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+             patch(f"{DB_MODULE}.open_new_sync_log", return_value=10), \
+             patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value="delete pending"), \
+             patch(f"{DB_MODULE}.close_sync_log") as mock_close:
+            with pytest.raises(asyncio.CancelledError):
+                asyncio.run(run_tick("conn-1"))
+
+        args = mock_close.call_args.kwargs
+        assert args["status"] == "cancelled"
+        mock_scanner.close.assert_called_once()
+
+    def test_not_cancelled_when_not_delete_pending(self):
+        """Normal status — tick completes without CancelledError."""
+        connector = _connector()
+        mock_scanner = self._make_scanner()
+
+        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+             patch(f"{DB_MODULE}.open_new_sync_log", return_value=11), \
+             patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
+             patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
+             patch(f"{DB_MODULE}.update_sync_log"), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value="syncing"), \
+             patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
+             patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
+             patch("digitize.connectors.sync_tick._process_new_files",
+                   new_callable=AsyncMock, return_value=(0, 0)), \
+             patch("digitize.connectors.sync_tick._delete_orphans",
+                   new_callable=AsyncMock, return_value=0):
+            asyncio.run(run_tick("conn-1"))  # must not raise
+
+        assert mock_close.call_args.kwargs["status"] == "completed"
+
+    def test_cancelled_mid_process_closes_log(self):
+        """_check_delete_pending fires inside _process_new_files loop."""
+        connector = _connector()
+        mock_scanner = self._make_scanner()
+        mock_scanner.scan.return_value = [("file.pdf", "ck1")]
+
+        call_count = {"n": 0}
+
+        def _maybe_cancel(connector_id):
+            call_count["n"] += 1
+            if call_count["n"] >= 2:  # second call = inside _process_new_files
+                raise asyncio.CancelledError("delete pending")
+
+        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+             patch(f"{DB_MODULE}.open_new_sync_log", return_value=12), \
+             patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
+             patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
+             patch(f"{DB_MODULE}.update_sync_log"), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", side_effect=_maybe_cancel), \
+             patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
+             patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner):
+            with pytest.raises(asyncio.CancelledError):
+                asyncio.run(run_tick("conn-1"))
+
+        args = mock_close.call_args.kwargs
+        assert args["status"] == "cancelled"
+        mock_scanner.close.assert_called_once()

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -242,7 +242,8 @@ class TestProcessNewFiles:
             # Force batch_size=1 so the two files land in separate batches
             stack.enter_context(patch.object(_st_mod, "_BATCH_SIZE", 1))
 
-            asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
+            with pytest.raises(RuntimeError, match="One or more batches failed"):
+                asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
 
         assert call_count["n"] == 2
 
@@ -257,7 +258,8 @@ class TestProcessNewFiles:
         scanner = self._make_scanner(download_raises=RuntimeError("fail"))
         ingest_list = [("docs/report.pdf", "ck1")]
         with self._patches():
-            asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
+            with pytest.raises(RuntimeError, match="One or more batches failed"):
+                asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
 
     def test_add_checksum_entry_called_on_success(self):
         scanner = self._make_scanner()

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -31,7 +31,7 @@ _complete_tick / _fail_tick
 
 run_tick
   - aborts gracefully when connector not found
-  - calls init_sync_log_and_set_syncing, scan, classify, process, orphan, complete in order
+  - calls init_sync_log_and_update_connector, scan, classify, process, orphan, complete in order
   - on scanner.connect failure: _fail_tick is called, scanner.close still runs
   - on scan failure: _fail_tick is called, scanner.close still runs
 """
@@ -367,7 +367,7 @@ class TestRunTick:
 
     def test_aborts_when_connector_not_found(self):
         with patch(f"{DB_MODULE}.get_active_connector", return_value=None), \
-             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing") as mock_open:
+             patch(f"{DB_MODULE}.init_sync_log_and_update_connector") as mock_open:
             asyncio.run(run_tick("missing"))
         mock_open.assert_not_called()
 
@@ -376,7 +376,7 @@ class TestRunTick:
         mock_scanner = self._make_scanner(scan_result=[])
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing", return_value=1) as mock_open, \
+             patch(f"{DB_MODULE}.init_sync_log_and_update_connector", return_value=1) as mock_open, \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
@@ -399,7 +399,7 @@ class TestRunTick:
         mock_scanner = self._make_scanner(connect_raises=ConnectionError("refused"))
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing", return_value=2), \
+             patch(f"{DB_MODULE}.init_sync_log_and_update_connector", return_value=2), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
              patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
@@ -415,7 +415,7 @@ class TestRunTick:
         mock_scanner = self._make_scanner(scan_raises=RuntimeError("scan exploded"))
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing", return_value=3), \
+             patch(f"{DB_MODULE}.init_sync_log_and_update_connector", return_value=3), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
@@ -431,7 +431,7 @@ class TestRunTick:
         mock_scanner = self._make_scanner(scan_raises=IOError("timeout"))
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing", return_value=4), \
+             patch(f"{DB_MODULE}.init_sync_log_and_update_connector", return_value=4), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
@@ -528,7 +528,7 @@ class TestRunTickCancellation:
         mock_scanner = self._make_scanner()
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing", return_value=10), \
+             patch(f"{DB_MODULE}.init_sync_log_and_update_connector", return_value=10), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.DELETE_PENDING), \
              patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close:
@@ -545,7 +545,7 @@ class TestRunTickCancellation:
         mock_scanner = self._make_scanner()
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing", return_value=11), \
+             patch(f"{DB_MODULE}.init_sync_log_and_update_connector", return_value=11), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
@@ -576,7 +576,7 @@ class TestRunTickCancellation:
             return None
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.init_sync_log_and_set_syncing", return_value=12), \
+             patch(f"{DB_MODULE}.init_sync_log_and_update_connector", return_value=12), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -1,0 +1,427 @@
+"""
+Unit tests for services/digitize/connectors/sync_tick.py
+
+Coverage
+--------
+_classify
+  - known checksum → skip (not in ingest_list, not an orphan)
+  - brand-new checksum → added to ingest_list
+  - cross-connector duplicate → add_connector_checksum_entry called inline
+  - cross-connector dup dedup within tick (same checksum twice → one DB write)
+  - intra-tick dedup for brand-new (same checksum two paths → one ingest entry)
+  - orphan detection (owned but absent from scan)
+  - empty scan → all known become orphans, empty ingest_list
+  - full scan with mix of skip / new / cross-connector / orphan
+
+_process_new_files
+  - happy path: download → initialize_job_state → add_connector_checksum_entry → ingest called
+  - per-file failure: exception increments failed counter, staging cleaned up, loop continues
+  - staging directory is removed after each file (success and failure)
+  - returns (new_count, failed_count) correctly
+
+_delete_orphans
+  - removes checksum row and deletes doc when remaining == 0
+  - removes checksum row but skips doc deletion when remaining > 0
+  - logs and continues when remove_connector_checksum_entry raises
+  - returns count of ownership rows removed
+
+_complete_tick / _fail_tick
+  - _complete_tick calls close_sync_log with status='completed' and correct counters
+  - _fail_tick calls close_sync_log with status='failed' and error string
+  - _fail_tick swallows a secondary exception from close_sync_log
+
+run_tick
+  - aborts gracefully when connector not found
+  - calls open_new_sync_log, scan, classify, process, orphan, complete in order
+  - on scanner.connect failure: _fail_tick is called, scanner.close still runs
+  - on scan failure: _fail_tick is called, scanner.close still runs
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from digitize.connectors.sync_tick import (
+    _classify as _real_classify,
+    _complete_tick,
+    _delete_orphans,
+    _fail_tick,
+    _process_new_files,
+    run_tick,
+)
+
+DB_MODULE = "digitize.connectors.sync_tick"
+
+
+# ---------------------------------------------------------------------------
+# Local wrapper so tests can pass keyword args for readability
+# ---------------------------------------------------------------------------
+
+def _classify(connector_id, scanned_files, known, all_cs):
+    return _real_classify(connector_id, scanned_files, known, all_cs)
+
+
+def _connector(connector_id: str = "conn-1", **kwargs):
+    return SimpleNamespace(
+        id=connector_id,
+        type="s3",
+        connection_details={"bucket_name": "b", "access_key_id": "a", "secret_access_key": "s"},
+        allowed_extensions=[".pdf"],
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _classify  (synchronous — no asyncio needed)
+# ---------------------------------------------------------------------------
+
+class TestClassify:
+    def test_known_checksum_is_skipped(self):
+        scanned = [("a.pdf", "ck1")]
+        ingest, orphans = _classify("c1", scanned, known={"ck1"}, all_cs={"ck1"})
+        assert ingest == []
+        assert "ck1" not in orphans
+
+    def test_brand_new_added_to_ingest(self):
+        scanned = [("a.pdf", "ck_new")]
+        ingest, orphans = _classify("c1", scanned, known=set(), all_cs=set())
+        assert ingest == [("a.pdf", "ck_new")]
+        assert orphans == set()
+
+    def test_cross_connector_dup_calls_add_entry(self):
+        scanned = [("a.pdf", "ck_dup")]
+        with patch(f"{DB_MODULE}.lookup_connector_content_by_checksum", return_value="doc-99") as mock_lookup, \
+             patch(f"{DB_MODULE}.add_connector_checksum_entry") as mock_add:
+            ingest, _ = _classify("c1", scanned, known=set(), all_cs={"ck_dup"})
+
+        assert ingest == []
+        mock_lookup.assert_called_once_with("ck_dup")
+        mock_add.assert_called_once_with("c1", "ck_dup", "doc-99")
+
+    def test_cross_connector_dup_dedup_within_tick(self):
+        """Same checksum appearing twice in scanned must only trigger one DB write."""
+        scanned = [("a.pdf", "ck_dup"), ("b.pdf", "ck_dup")]
+        with patch(f"{DB_MODULE}.lookup_connector_content_by_checksum", return_value="doc-99") as mock_lookup, \
+             patch(f"{DB_MODULE}.add_connector_checksum_entry") as mock_add:
+            _classify("c1", scanned, known=set(), all_cs={"ck_dup"})
+
+        mock_lookup.assert_called_once()
+        mock_add.assert_called_once()
+
+    def test_brand_new_intra_tick_dedup(self):
+        """Same brand-new checksum on two paths → only one ingest entry."""
+        scanned = [("a.pdf", "ck_new"), ("b.pdf", "ck_new")]
+        ingest, _ = _classify("c1", scanned, known=set(), all_cs=set())
+        assert len(ingest) == 1
+        assert ingest[0][0] == "a.pdf"
+
+    def test_orphan_detection(self):
+        """Checksum in known but absent from scan → orphan."""
+        scanned = [("a.pdf", "ck1")]
+        known = {"ck1", "ck_orphan"}
+        ingest, orphans = _classify("c1", scanned, known=known, all_cs=known)
+        assert "ck_orphan" in orphans
+        assert "ck1" not in orphans
+
+    def test_empty_scan_all_known_become_orphans(self):
+        ingest, orphans = _classify("c1", [], known={"ck1", "ck2"}, all_cs={"ck1", "ck2"})
+        assert ingest == []
+        assert orphans == {"ck1", "ck2"}
+
+    def test_mixed_scan(self):
+        """skip + new + cross-dup + orphan in one call."""
+        scanned = [
+            ("kept.pdf", "ck_known"),
+            ("new.pdf",  "ck_new"),
+            ("dup.pdf",  "ck_dup"),
+        ]
+        known  = {"ck_known", "ck_orphan"}
+        all_cs = {"ck_known", "ck_dup", "ck_orphan"}
+
+        with patch(f"{DB_MODULE}.lookup_connector_content_by_checksum", return_value="doc-dup"), \
+             patch(f"{DB_MODULE}.add_connector_checksum_entry"):
+            ingest, orphans = _classify("c1", scanned, known=known, all_cs=all_cs)
+
+        assert ingest == [("new.pdf", "ck_new")]
+        assert orphans == {"ck_orphan"}
+
+
+# ---------------------------------------------------------------------------
+# _process_new_files  (async)
+# ---------------------------------------------------------------------------
+
+class TestProcessNewFiles:
+    def _make_scanner(self, download_raises=None):
+        scanner = MagicMock()
+        if download_raises:
+            scanner.download_to.side_effect = download_raises
+        else:
+            scanner.download_to.return_value = "abc123"
+        scanner.verify_integrity.return_value = True
+        return scanner
+
+    def _patches(self, ingest_raises=None):
+        """Return a context-manager stack that patches all external calls."""
+        from contextlib import ExitStack
+        stack = ExitStack()
+        mock_settings = stack.enter_context(patch(f"{DB_MODULE}.settings"))
+        mock_settings.digitize.staging_dir.__truediv__ = MagicMock(return_value=MagicMock())
+
+        stack.enter_context(patch(f"{DB_MODULE}.add_connector_checksum_entry"))
+        stack.enter_context(patch(f"{DB_MODULE}.update_sync_log"))
+        stack.enter_context(
+            patch(f"{DB_MODULE}.initialize_job_state", return_value={"report.pdf": "doc-1"})
+        )
+        stack.enter_context(patch(f"{DB_MODULE}.generate_uuid", return_value="job-uuid-1"))
+        stack.enter_context(
+            patch(f"{DB_MODULE}.ingest", side_effect=ingest_raises)
+        )
+        stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
+        return stack
+
+    def test_happy_path_returns_new_count(self):
+        scanner = self._make_scanner()
+        ingest_list = [("docs/report.pdf", "ck1")]
+        with self._patches():
+            new, failed = asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
+        assert new == 1
+        assert failed == 0
+
+    def test_per_file_failure_increments_failed(self):
+        scanner = self._make_scanner(download_raises=RuntimeError("network down"))
+        ingest_list = [("docs/a.pdf", "ck1"), ("docs/b.pdf", "ck2")]
+        with self._patches():
+            new, failed = asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
+        assert new == 0
+        assert failed == 2
+
+    def test_failure_does_not_stop_loop(self):
+        """First file fails, second succeeds — both are processed."""
+        call_count = {"n": 0}
+
+        def _download(remote_path, local_path):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("first fails")
+            return "ck_local"
+
+        scanner = MagicMock()
+        scanner.download_to.side_effect = _download
+        scanner.verify_integrity.return_value = True
+
+        ingest_list = [("a.pdf", "ck1"), ("b.pdf", "ck2")]
+
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            mock_settings = stack.enter_context(patch(f"{DB_MODULE}.settings"))
+            mock_settings.digitize.staging_dir.__truediv__ = MagicMock(return_value=MagicMock())
+            stack.enter_context(patch(f"{DB_MODULE}.add_connector_checksum_entry"))
+            stack.enter_context(patch(f"{DB_MODULE}.update_sync_log"))
+            stack.enter_context(
+                patch(f"{DB_MODULE}.initialize_job_state", return_value={"b.pdf": "doc-2"})
+            )
+            stack.enter_context(patch(f"{DB_MODULE}.generate_uuid", return_value="job-uuid"))
+            stack.enter_context(patch(f"{DB_MODULE}.ingest"))
+            stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
+
+            new, failed = asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
+
+        assert call_count["n"] == 2
+        assert new == 1
+        assert failed == 1
+
+    def test_staging_dir_cleaned_on_success(self):
+        scanner = self._make_scanner()
+        ingest_list = [("docs/report.pdf", "ck1")]
+        with self._patches() as stack:
+            asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
+        # cleanup is patched — just verifying it was called (no exception means finally ran)
+
+    def test_staging_dir_cleaned_on_failure(self):
+        scanner = self._make_scanner(download_raises=RuntimeError("fail"))
+        ingest_list = [("docs/report.pdf", "ck1")]
+        with self._patches():
+            new, failed = asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
+        assert failed == 1
+
+    def test_add_checksum_entry_called_on_success(self):
+        scanner = self._make_scanner()
+        ingest_list = [("docs/report.pdf", "ck1")]
+        with self._patches() as stack:
+            with patch(f"{DB_MODULE}.add_connector_checksum_entry") as mock_add:
+                asyncio.run(_process_new_files(1, "conn-1", scanner, ingest_list))
+        mock_add.assert_called_once_with("conn-1", "ck1", "doc-1")
+
+
+# ---------------------------------------------------------------------------
+# _delete_orphans  (async)
+# ---------------------------------------------------------------------------
+
+_DELETE_DOC = "digitize.api.v1.connectors._best_effort_delete_document"
+
+
+class TestDeleteOrphans:
+    def test_deletes_doc_when_last_owner(self):
+        with patch(f"{DB_MODULE}.remove_connector_checksum_entry", return_value=(0, "doc-1")) as mock_rm, \
+             patch(_DELETE_DOC) as mock_del:
+            removed = asyncio.run(_delete_orphans("c1", {"ck_orphan"}))
+
+        assert removed == 1
+        mock_rm.assert_called_once_with("c1", "ck_orphan")
+        mock_del.assert_called_once_with("doc-1")
+
+    def test_skips_doc_deletion_when_other_owners_remain(self):
+        with patch(f"{DB_MODULE}.remove_connector_checksum_entry", return_value=(2, "doc-1")), \
+             patch(_DELETE_DOC) as mock_del:
+            removed = asyncio.run(_delete_orphans("c1", {"ck_shared"}))
+
+        assert removed == 1
+        mock_del.assert_not_called()
+
+    def test_continues_after_remove_raises(self):
+        with patch(f"{DB_MODULE}.remove_connector_checksum_entry",
+                   side_effect=RuntimeError("db gone")), \
+             patch(_DELETE_DOC) as mock_del:
+            removed = asyncio.run(_delete_orphans("c1", {"ck_orphan"}))
+
+        assert removed == 0
+        mock_del.assert_not_called()
+
+    def test_returns_correct_removed_count_multiple(self):
+        side_effects = [(0, "doc-1"), (1, "doc-2")]
+        with patch(f"{DB_MODULE}.remove_connector_checksum_entry", side_effect=side_effects), \
+             patch(_DELETE_DOC):
+            removed = asyncio.run(_delete_orphans("c1", {"ck1", "ck2"}))
+
+        assert removed == 2
+
+    def test_empty_orphan_set(self):
+        removed = asyncio.run(_delete_orphans("c1", set()))
+        assert removed == 0
+
+
+# ---------------------------------------------------------------------------
+# _complete_tick / _fail_tick  (synchronous)
+# ---------------------------------------------------------------------------
+
+class TestTickFinalizers:
+    def test_complete_tick_calls_close_sync_log(self):
+        with patch(f"{DB_MODULE}.close_sync_log") as mock_close:
+            _complete_tick(7, "c1", total_files=10, new_files=3, removed_files=1, failed_files=0)
+
+        mock_close.assert_called_once_with(
+            connector_id="c1",
+            seq=7,
+            status="completed",
+            total_files=10,
+            new_files=3,
+            removed_files=1,
+            failed_files=0,
+        )
+
+    def test_fail_tick_calls_close_sync_log_with_error(self):
+        exc = ValueError("disk full")
+        with patch(f"{DB_MODULE}.close_sync_log") as mock_close:
+            _fail_tick(3, "c1", exc)
+
+        mock_close.assert_called_once_with(
+            connector_id="c1",
+            seq=3,
+            status="failed",
+            error="disk full",
+        )
+
+    def test_fail_tick_swallows_close_exception(self):
+        with patch(f"{DB_MODULE}.close_sync_log", side_effect=RuntimeError("write failed")):
+            _fail_tick(3, "c1", ValueError("original"))  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# run_tick  (async, integration-style — all I/O mocked)
+# ---------------------------------------------------------------------------
+
+class TestRunTick:
+    def _make_scanner(self, connect_raises=None, scan_raises=None, scan_result=None):
+        scanner = MagicMock()
+        scanner.connect.side_effect = connect_raises
+        if scan_raises:
+            scanner.scan.side_effect = scan_raises
+        else:
+            scanner.scan.return_value = scan_result or []
+        scanner.download_to.return_value = "deadbeef"
+        scanner.verify_integrity.return_value = True
+        return scanner
+
+    def test_aborts_when_connector_not_found(self):
+        with patch(f"{DB_MODULE}.get_active_connector", return_value=None), \
+             patch(f"{DB_MODULE}.open_new_sync_log") as mock_open:
+            asyncio.run(run_tick("missing"))
+        mock_open.assert_not_called()
+
+    def test_happy_path_calls_phases_in_order(self):
+        connector = _connector()
+        mock_scanner = self._make_scanner(scan_result=[])
+
+        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+             patch(f"{DB_MODULE}.open_new_sync_log", return_value=1) as mock_open, \
+             patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
+             patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
+             patch(f"{DB_MODULE}.update_sync_log"), \
+             patch(f"{DB_MODULE}.close_sync_log") as mock_close, \
+             patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
+             patch("digitize.connectors.sync_tick._process_new_files",
+                   new_callable=AsyncMock, return_value=(0, 0)), \
+             patch("digitize.connectors.sync_tick._delete_orphans",
+                   new_callable=AsyncMock, return_value=0):
+            asyncio.run(run_tick("conn-1"))
+
+        mock_open.assert_called_once_with("conn-1")
+        mock_close.assert_called_once()
+        assert mock_close.call_args.kwargs["status"] == "completed"
+
+    def test_scanner_connect_failure_calls_fail_tick(self):
+        connector = _connector()
+        mock_scanner = self._make_scanner(connect_raises=ConnectionError("refused"))
+
+        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+             patch(f"{DB_MODULE}.open_new_sync_log", return_value=2), \
+             patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
+             patch(f"{DB_MODULE}.close_sync_log") as mock_close:
+            asyncio.run(run_tick("conn-1"))
+
+        args = mock_close.call_args.kwargs
+        assert args["status"] == "failed"
+        assert "refused" in args["error"]
+
+    def test_scanner_close_always_called(self):
+        connector = _connector()
+        mock_scanner = self._make_scanner(scan_raises=RuntimeError("scan exploded"))
+
+        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+             patch(f"{DB_MODULE}.open_new_sync_log", return_value=3), \
+             patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
+             patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
+             patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
+             patch(f"{DB_MODULE}.close_sync_log"):
+            asyncio.run(run_tick("conn-1"))
+
+        mock_scanner.close.assert_called_once()
+
+    def test_scan_failure_calls_fail_tick(self):
+        connector = _connector()
+        mock_scanner = self._make_scanner(scan_raises=IOError("timeout"))
+
+        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+             patch(f"{DB_MODULE}.open_new_sync_log", return_value=4), \
+             patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
+             patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
+             patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
+             patch(f"{DB_MODULE}.close_sync_log") as mock_close:
+            asyncio.run(run_tick("conn-1"))
+
+        args = mock_close.call_args.kwargs
+        assert args["status"] == "failed"

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -366,17 +366,14 @@ class TestRunTick:
         return scanner
 
     def test_aborts_when_connector_not_found(self):
-        with patch(f"{DB_MODULE}.get_active_connector", return_value=None), \
-             patch(f"{DB_MODULE}.init_sync_log_and_update_connector") as mock_open:
-            asyncio.run(run_tick("missing"))
-        mock_open.assert_not_called()
+        with patch(f"{DB_MODULE}.get_active_connector", return_value=None):
+            asyncio.run(run_tick("missing", sync_seq=1))
 
     def test_happy_path_calls_phases_in_order(self):
         connector = _connector()
         mock_scanner = self._make_scanner(scan_result=[])
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.init_sync_log_and_update_connector", return_value=1) as mock_open, \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
@@ -389,9 +386,8 @@ class TestRunTick:
                    new_callable=AsyncMock, return_value=None), \
              patch("digitize.connectors.sync_tick._delete_orphans",
                    new_callable=AsyncMock, return_value=0):
-            asyncio.run(run_tick("conn-1"))
+            asyncio.run(run_tick("conn-1", sync_seq=1))
 
-        mock_open.assert_called_once_with("conn-1")
         mock_close.assert_called_once()
         assert mock_close.call_args.kwargs["status"] == SyncLogStatus.COMPLETED
 
@@ -400,12 +396,11 @@ class TestRunTick:
         mock_scanner = self._make_scanner(connect_raises=ConnectionError("refused"))
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.init_sync_log_and_update_connector", return_value=2), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
              patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close:
-            asyncio.run(run_tick("conn-1"))
+            asyncio.run(run_tick("conn-1", sync_seq=2))
 
         args = mock_close.call_args.kwargs
         assert args["status"] == SyncLogStatus.FAILED
@@ -416,14 +411,13 @@ class TestRunTick:
         mock_scanner = self._make_scanner(scan_raises=RuntimeError("scan exploded"))
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.init_sync_log_and_update_connector", return_value=3), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
              patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector"):
-            asyncio.run(run_tick("conn-1"))
+            asyncio.run(run_tick("conn-1", sync_seq=3))
 
         mock_scanner.close.assert_called_once()
 
@@ -432,14 +426,13 @@ class TestRunTick:
         mock_scanner = self._make_scanner(scan_raises=IOError("timeout"))
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.init_sync_log_and_update_connector", return_value=4), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
              patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close:
-            asyncio.run(run_tick("conn-1"))
+            asyncio.run(run_tick("conn-1", sync_seq=4))
 
         args = mock_close.call_args.kwargs
         assert args["status"] == SyncLogStatus.FAILED
@@ -529,12 +522,11 @@ class TestRunTickCancellation:
         mock_scanner = self._make_scanner()
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.init_sync_log_and_update_connector", return_value=10), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.DELETE_PENDING), \
              patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close:
             with pytest.raises(asyncio.CancelledError):
-                asyncio.run(run_tick("conn-1"))
+                asyncio.run(run_tick("conn-1", sync_seq=10))
 
         args = mock_close.call_args.kwargs
         assert args["status"] == SyncLogStatus.CANCELLED
@@ -546,7 +538,6 @@ class TestRunTickCancellation:
         mock_scanner = self._make_scanner()
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.init_sync_log_and_update_connector", return_value=11), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
@@ -559,7 +550,7 @@ class TestRunTickCancellation:
                    new_callable=AsyncMock, return_value=None), \
              patch("digitize.connectors.sync_tick._delete_orphans",
                    new_callable=AsyncMock, return_value=0):
-            asyncio.run(run_tick("conn-1"))  # must not raise
+            asyncio.run(run_tick("conn-1", sync_seq=11))  # must not raise
 
         assert mock_close.call_args.kwargs["status"] == SyncLogStatus.COMPLETED
 
@@ -578,7 +569,6 @@ class TestRunTickCancellation:
             return None
 
         with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
-             patch(f"{DB_MODULE}.init_sync_log_and_update_connector", return_value=12), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
@@ -587,7 +577,7 @@ class TestRunTickCancellation:
              patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner):
             with pytest.raises(asyncio.CancelledError):
-                asyncio.run(run_tick("conn-1"))
+                asyncio.run(run_tick("conn-1", sync_seq=12))
 
         args = mock_close.call_args.kwargs
         assert args["status"] == SyncLogStatus.CANCELLED

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1352,7 +1352,11 @@ def remove_connector_checksum_entry(
 
     Returns (remaining_owner_count, doc_id), or (0, None) if not found.
     """
-    return db_manager.delete_connector_checksum(connector_id, checksum)
+    doc_id = db_manager.delete_connector_checksum(connector_id, checksum)
+    if doc_id is None:
+        return 0, None
+    remaining = db_manager.count_checksum_owners(checksum)
+    return remaining, doc_id
 
 
 # ----------------------------------------------------------------------------
@@ -1371,7 +1375,9 @@ def init_sync_log_and_update_connector(
 
     Returns the generated seq value.
     """
-    return db_manager.init_sync_log_and_update_connector(connector_id, started_at=started_at)
+    seq = db_manager.insert_sync_log(connector_id, started_at=started_at)
+    db_manager.set_connector_sync_status_syncing(connector_id)
+    return seq
 
 
 def finalize_sync_log_and_update_connector(
@@ -1394,16 +1400,21 @@ def finalize_sync_log_and_update_connector(
 
     Returns True on success, False if the sync-log row was not found.
     """
-    return db_manager.finalize_sync_log_and_update_connector(
+    now = finished_at or datetime.now(timezone.utc)
+    found = db_manager.finalize_sync_log(
         connector_id=connector_id,
         seq=seq,
         status=status,
-        finished_at=finished_at,
+        finished_at=now,
         total_files=total_files,
         new_files=new_files,
         removed_files=removed_files,
         error=error,
     )
+    if not found:
+        return False
+    db_manager.update_connector_after_sync(connector_id, status=status, last_sync_at=now)
+    return True
 
 
 def update_connector_total_files(connector_id: str, total_files: int) -> None:
@@ -1453,7 +1464,9 @@ def list_sync_logs(
 
     Returns (items, total_count).
     """
-    return db_manager.get_sync_logs(connector_id, limit=limit, offset=offset)
+    total = db_manager.count_sync_logs(connector_id)
+    rows = db_manager.get_sync_logs(connector_id, limit=limit, offset=offset)
+    return rows, total
 
 
 def get_sync_log(connector_id: str, seq: int) -> Optional[ConnectorSyncLog]:

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1255,6 +1255,16 @@ def get_connector_sync_status(connector_id: str) -> Optional[str]:
     return db_manager.get_connector_sync_status(connector_id)
 
 
+def try_acquire_sync_lock(connector_id: str) -> bool:
+    """
+    Atomically acquire the sync lock for *connector_id*.
+
+    Sets sync_status='syncing' only when it is not already 'syncing'.
+    Returns True if the lock was acquired, False if already held (or not found).
+    """
+    return db_manager.try_acquire_sync_lock(connector_id)
+
+
 def list_connectors() -> List[Connector]:
     """Return all connectors ordered by attached_at descending."""
     return db_manager.get_all_connectors()

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1265,6 +1265,16 @@ def try_acquire_sync_lock(connector_id: str) -> bool:
     return db_manager.try_acquire_sync_lock(connector_id)
 
 
+def mark_sync_cancel_pending(connector_id: str) -> bool:
+    """
+    Signal a running tick to cancel without deleting the connector.
+
+    Atomically sets sync_status='cancel pending' only when sync_status='syncing'.
+    Returns True if the signal was set (tick was running), False otherwise.
+    """
+    return db_manager.mark_sync_cancel_pending(connector_id)
+
+
 def list_connectors() -> List[Connector]:
     """Return all connectors ordered by attached_at descending."""
     return db_manager.get_all_connectors()

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1255,6 +1255,15 @@ def get_connector_sync_status(connector_id: str) -> Optional[str]:
     return db_manager.get_connector_sync_status(connector_id)
 
 
+def get_active_sync_seq(connector_id: str) -> Optional[int]:
+    """
+    Return the seq of the currently-running sync-log row for connector_id.
+
+    Returns None if no active sync is in progress.
+    """
+    return db_manager.get_active_sync_seq(connector_id)
+
+
 def try_acquire_sync_lock(connector_id: str) -> bool:
     """
     Atomically acquire the sync lock for *connector_id*.

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1286,14 +1286,14 @@ def mark_sync_cancel_pending(connector_id: str) -> bool:
     return db_manager.mark_sync_cancel_pending(connector_id)
 
 
-def mark_sync_delete_pending(connector_id: str) -> bool:
+def mark_connector_delete_pending(connector_id: str) -> bool:
     """
     Signal a running tick that the connector is being deleted.
 
     Atomically sets sync_status='delete pending' only when sync_status='syncing'.
     Returns True if the signal was set (tick was running), False otherwise.
     """
-    return db_manager.mark_sync_delete_pending(connector_id)
+    return db_manager.mark_connector_delete_pending(connector_id)
 
 
 def list_connectors() -> List[Connector]:

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1357,7 +1357,6 @@ def close_sync_log(
     total_files: Optional[int] = None,
     new_files: Optional[int] = None,
     removed_files: Optional[int] = None,
-    failed_files: Optional[int] = None,
     error: Optional[str] = None,
 ) -> bool:
     """
@@ -1373,7 +1372,6 @@ def close_sync_log(
         total_files=total_files,
         new_files=new_files,
         removed_files=removed_files,
-        failed_files=failed_files,
         error=error,
     )
 
@@ -1383,7 +1381,6 @@ def update_sync_log(
     total_files: Optional[int] = None,
     new_files: Optional[int] = None,
     removed_files: Optional[int] = None,
-    failed_files: Optional[int] = None,
 ) -> bool:
     """
     Write live progress counters into an in-progress sync-log row.
@@ -1395,7 +1392,6 @@ def update_sync_log(
         total_files=total_files,
         new_files=new_files,
         removed_files=removed_files,
-        failed_files=failed_files,
     )
 
 

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1418,6 +1418,15 @@ def list_sync_logs(
     return db_manager.get_sync_logs(connector_id, limit=limit, offset=offset)
 
 
+def get_sync_log_status(connector_id: str, seq: int) -> Optional[str]:
+    """
+    Return the status of the connector_sync_logs row for (connector_id, seq).
+
+    Returns None if the row does not exist.
+    """
+    return db_manager.get_sync_log_status(connector_id, seq)
+
+
 # ----------------------------------------------------------------------------
 # Document metadata helper
 # ----------------------------------------------------------------------------

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1275,6 +1275,16 @@ def mark_sync_cancel_pending(connector_id: str) -> bool:
     return db_manager.mark_sync_cancel_pending(connector_id)
 
 
+def mark_sync_delete_pending(connector_id: str) -> bool:
+    """
+    Signal a running tick that the connector is being deleted.
+
+    Atomically sets sync_status='delete pending' only when sync_status='syncing'.
+    Returns True if the signal was set (tick was running), False otherwise.
+    """
+    return db_manager.mark_sync_delete_pending(connector_id)
+
+
 def list_connectors() -> List[Connector]:
     """Return all connectors ordered by attached_at descending."""
     return db_manager.get_all_connectors()

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1245,6 +1245,16 @@ def get_active_connector(connector_id: str) -> Optional[Connector]:
     return db_manager.get_connector_by_id(connector_id)
 
 
+def get_connector_sync_status(connector_id: str) -> Optional[str]:
+    """
+    Return the current sync_status string for a connector.
+
+    Does a minimal SELECT — does not load the full row.
+    Returns None if the connector does not exist.
+    """
+    return db_manager.get_connector_sync_status(connector_id)
+
+
 def list_connectors() -> List[Connector]:
     """Return all connectors ordered by attached_at descending."""
     return db_manager.get_all_connectors()

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1398,7 +1398,8 @@ def close_sync_log(
 
 
 def update_sync_log(
-    log_id: int,
+    connector_id: str,
+    seq: int,
     total_files: Optional[int] = None,
     new_files: Optional[int] = None,
     removed_files: Optional[int] = None,
@@ -1409,7 +1410,8 @@ def update_sync_log(
     Returns True on success, False if the row was not found.
     """
     return db_manager.update_sync_log_progress(
-        log_id=log_id,
+        connector_id=connector_id,
+        seq=seq,
         total_files=total_files,
         new_files=new_files,
         removed_files=removed_files,

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1411,6 +1411,17 @@ def update_connector_total_files(connector_id: str, total_files: int) -> None:
     db_manager.update_connector(connector_id=connector_id, total_files=total_files)
 
 
+def set_connector_error(connector_id: str, error: str) -> None:
+    """Persist an error message on the connector row (best-effort; logs on failure)."""
+    try:
+        db_manager.update_connector(connector_id=connector_id, error=error)
+    except Exception as exc:
+        logger.warning(
+            f"Could not persist error on connector {connector_id!r}: {exc}",
+            exc_info=True,
+        )
+
+
 def update_sync_log(
     connector_id: str,
     seq: int,

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1431,6 +1431,15 @@ def list_sync_logs(
     return db_manager.get_sync_logs(connector_id, limit=limit, offset=offset)
 
 
+def get_sync_log(connector_id: str, seq: int) -> Optional[ConnectorSyncLog]:
+    """
+    Return the connector_sync_logs row for (connector_id, seq).
+
+    Returns None if the row does not exist.
+    """
+    return db_manager.get_sync_log(connector_id, seq)
+
+
 def get_sync_log_status(connector_id: str, seq: int) -> Optional[str]:
     """
     Return the status of the connector_sync_logs row for (connector_id, seq).

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1358,7 +1358,7 @@ def remove_connector_checksum_entry(
 # Sync log helpers
 # ----------------------------------------------------------------------------
 
-def init_sync_log_and_set_syncing(
+def init_sync_log_and_update_connector(
     connector_id: str,
     started_at: Optional[datetime] = None,
 ) -> int:
@@ -1370,7 +1370,7 @@ def init_sync_log_and_set_syncing(
 
     Returns the generated seq value.
     """
-    return db_manager.init_sync_log_and_set_syncing(connector_id, started_at=started_at)
+    return db_manager.init_sync_log_and_update_connector(connector_id, started_at=started_at)
 
 
 def finalize_sync_log_and_update_connector(

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1405,6 +1405,11 @@ def finalize_sync_log_and_update_connector(
     )
 
 
+def update_connector_total_files(connector_id: str, total_files: int) -> None:
+    """Update the total_files count on the connectors table for *connector_id*."""
+    db_manager.update_connector(connector_id=connector_id, total_files=total_files)
+
+
 def update_sync_log(
     connector_id: str,
     seq: int,

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1280,7 +1280,7 @@ def mark_sync_cancel_pending(connector_id: str) -> bool:
 
     Sets connector_sync_logs.status='cancel pending' on the active sync-log row,
     only when connectors.sync_status='syncing'.  The connector row itself stays
-    'syncing' until the tick's close_sync_log() transitions it to 'out of sync'.
+    'syncing' until the tick's finalize_sync_log_and_update_connector() transitions it to 'out of sync'.
     Returns True if the signal was written (tick was running), False otherwise.
     """
     return db_manager.mark_sync_cancel_pending(connector_id)
@@ -1358,19 +1358,22 @@ def remove_connector_checksum_entry(
 # Sync log helpers
 # ----------------------------------------------------------------------------
 
-def open_new_sync_log(
+def init_sync_log_and_set_syncing(
     connector_id: str,
     started_at: Optional[datetime] = None,
 ) -> int:
     """
-    Create a new sync-log row and set connector sync_status to 'syncing'.
+    Initialise a new sync run across two tables:
+      - connector_sync_log: inserts a new row with status=STARTED and an
+        auto-incremented seq (COALESCE(MAX(seq), 0) + 1) scoped to this connector.
+      - connector: sets sync_status=SYNCING on the matching row.
 
     Returns the generated seq value.
     """
-    return db_manager.open_sync_log(connector_id, started_at=started_at)
+    return db_manager.init_sync_log_and_set_syncing(connector_id, started_at=started_at)
 
 
-def close_sync_log(
+def finalize_sync_log_and_update_connector(
     connector_id: str,
     seq: int,
     status: str,
@@ -1381,11 +1384,16 @@ def close_sync_log(
     error: Optional[str] = None,
 ) -> bool:
     """
-    Finalize a sync-log row and update connector last_sync_at / sync_status.
+    Finalize a sync run across two tables:
+      - connector_sync_log: UPDATEs the matching row with status, finished_at,
+        and optional file counts / error message.
+      - connector: UPDATEs last_sync_at to now, and sync_status to the terminal
+        state — CANCELLED/FAILED both map to OUT_OF_SYNC so the scheduler can
+        retry; any other status (e.g. COMPLETED) is written through verbatim.
 
     Returns True on success, False if the sync-log row was not found.
     """
-    return db_manager.close_sync_log(
+    return db_manager.finalize_sync_log_and_update_connector(
         connector_id=connector_id,
         seq=seq,
         status=status,

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1288,10 +1288,11 @@ def mark_sync_cancel_pending(connector_id: str) -> bool:
 
 def mark_connector_delete_pending(connector_id: str) -> bool:
     """
-    Signal a running tick that the connector is being deleted.
+    Set sync_status='delete pending' for the given connector regardless of
+    current status.
 
-    Atomically sets sync_status='delete pending' only when sync_status='syncing'.
-    Returns True if the signal was set (tick was running), False otherwise.
+    Returns True if the connector was found and updated, False if it does
+    not exist.
     """
     return db_manager.mark_connector_delete_pending(connector_id)
 

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1269,8 +1269,10 @@ def mark_sync_cancel_pending(connector_id: str) -> bool:
     """
     Signal a running tick to cancel without deleting the connector.
 
-    Atomically sets sync_status='cancel pending' only when sync_status='syncing'.
-    Returns True if the signal was set (tick was running), False otherwise.
+    Sets connector_sync_logs.status='cancel pending' on the active sync-log row,
+    only when connectors.sync_status='syncing'.  The connector row itself stays
+    'syncing' until the tick's close_sync_log() transitions it to 'out of sync'.
+    Returns True if the signal was written (tick was running), False otherwise.
     """
     return db_manager.mark_sync_cancel_pending(connector_id)
 


### PR DESCRIPTION
--New API Endpoints
POST /v1/connectors/{id}/sync — triggers a manual sync, returns sync_seq
POST /v1/connectors/{cid}/syncs/{sync_seq}/stop — cancels an in-progress sync
GET /v1/connectors/{cid}/syncs/{sync_seq} — fetch status of a specific sync

--Core Sync tick logic 
Contains batch processing, acquire DB lock, dispatch_sync (common for both), allow partial failures on ingestion

--Connector Lifecycle and Deletion 
New status for connector (DELETE_PENDING) and sync cancel (CANCEL_PENDING) that is used to intercept and initiate necessary tear down where applicable 

--Updated tests