### PR TITLE
Use Podman volume instead of host path for Caddy config storage

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.284
+TAG?=v0.0.285
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.284
+  image: icr.io/ai-services-cicd/ai-services:v0.0.285
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/metadata.yaml
+++ b/ai-services/assets/catalog/podman/metadata.yaml
@@ -2,6 +2,6 @@ name: ai-services-catalog
 version: 0.0.1
 description: "Catalog Services for Project AI-Service"
 podTemplateExecutions:
-  - [catalog-secret.yaml.tmpl, catalog-db-secret.yaml.tmpl, catalog-db-encryption-secret.yaml.tmpl, auth-secret.yaml.tmpl]
+  - [catalog-secret.yaml.tmpl, catalog-db-secret.yaml.tmpl, catalog-db-encryption-secret.yaml.tmpl, auth-secret.yaml.tmpl, catalog-caddy-cert-secret.yaml.tmpl]
   - [catalog-db.yaml.tmpl, caddy.yaml.tmpl]
   - [catalog.yaml.tmpl]

--- a/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
@@ -8,6 +8,7 @@ metadata:
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/component: "proxy"
     ai-services.io/volume: "caddy-catalog"
+    ai-services.io/volume-skip-cleanup: "true"
   annotations:
     ai-services.io/ports: "127.0.0.1:{{ .Values.caddy.adminPort }}:2019, {{ .Values.caddy.httpsPort }}:443"
 spec:

--- a/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
@@ -7,10 +7,29 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/component: "proxy"
+    ai-services.io/volume: "caddy-catalog"
   annotations:
     ai-services.io/ports: "127.0.0.1:{{ .Values.caddy.adminPort }}:2019, {{ .Values.caddy.httpsPort }}:443"
 spec:
   restartPolicy: always
+  initContainers:
+    - name: generate-caddyfile
+      image: "{{ .Values.caddy.image }}"
+      imagePullPolicy: IfNotPresent
+      command:
+        - "sh"
+        - "-c"
+        - |
+          cat << 'EOF' > /data/caddy/Caddyfile
+          {{- if .Values.caddy.caddyFileContent }}
+{{ .Values.caddy.caddyFileContent }}
+          {{- else }}
+          # No Caddyfile
+          {{- end }}
+          EOF
+      volumeMounts:
+        - name: caddy-data
+          mountPath: /data:z
   containers:
     - name: caddy
       image: "{{ .Values.caddy.image }}"
@@ -21,9 +40,14 @@ spec:
           value: "0.0.0.0:2019"
       volumeMounts:
         - name: caddy-data
-          mountPath: /data/caddy:z
-        - name: caddy-config
+          mountPath: /data:z
+        - name: caddy-data
           mountPath: /config:z
+        {{- if and .Values.caddy.sslCertContent .Values.caddy.sslKeyContent }}
+        - name: caddy-cert-certs
+          mountPath: /etc/secret/ssl
+          readOnly: true
+        {{- end }}
       resources:
         requests:
           memory: "512Mi"
@@ -40,10 +64,10 @@ spec:
         failureThreshold: 3
   volumes:
     - name: caddy-data
-      hostPath:
-        path: {{ .BaseDir }}/common/caddy
-        type: DirectoryOrCreate
-    - name: caddy-config
-      hostPath:
-        path: {{ .BaseDir }}/common/caddy-config
-        type: DirectoryOrCreate
+      persistentVolumeClaim:
+        claimName: "caddy-catalog"
+    {{- if and .Values.caddy.sslCertContent .Values.caddy.sslKeyContent }}
+    - name: caddy-cert-certs
+      secret:
+        secretName: catalog-caddy-cert-secret
+    {{- end }}

--- a/ai-services/assets/catalog/podman/templates/catalog-caddy-cert-secret.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog-caddy-cert-secret.yaml.tmpl
@@ -1,0 +1,15 @@
+{{- if and .Values.caddy.sslCertContent .Values.caddy.sslKeyContent }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: catalog-caddy-cert-secret
+  labels:
+    ai-services.io/application: "{{ .AppName }}"
+    ai-services.io/template: "{{ .AppTemplateName }}"
+    ai-services.io/version: "{{ .Version }}"
+stringData:
+  tls.crt: |-
+{{ .Values.caddy.sslCertContent }}
+  tls.key: |-
+{{ .Values.caddy.sslKeyContent }}
+{{- end }}

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -7,7 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/secret: "catalog-secret"
-    ai-services.io/volume: "podman-auth-secret,catalog-secret,catalog-db-encryption-secret,catalog-bundles,catalog-caddy-cert-secret,caddy-catalog"
+    ai-services.io/volume: "podman-auth-secret,catalog-secret,catalog-db-encryption-secret,catalog-bundles,catalog-caddy-cert-secret"
     ai-services.io/volume-skip-cleanup: "true"
   annotations:
     run.oci.keep_original_groups: "1"

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -7,7 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/secret: "catalog-secret"
-    ai-services.io/volume: "podman-auth-secret,catalog-secret,catalog-db-encryption-secret,catalog-bundles"
+    ai-services.io/volume: "podman-auth-secret,catalog-secret,catalog-db-encryption-secret,catalog-bundles,catalog-caddy-cert-secret,caddy-catalog"
     ai-services.io/volume-skip-cleanup: "true"
   annotations:
     run.oci.keep_original_groups: "1"

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.284
+  image: icr.io/ai-services-cicd/ai-services:v0.0.285
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -31,3 +31,9 @@ caddy:
   image: icr.io/ai-services-cicd/caddy:v2.11.4-2
   adminPort: ""
   httpsPort: ""
+  # caddyFileContent: Generated from the 'Caddyfile.tmpl' template
+  caddyFileContent: ""
+  # Populated from the certificate content specified via '--ssl-cert' during catalog configuration
+  sslCertContent: ""
+  # Populated from the private key content specified via '--ssl-key' during catalog configuration
+  sslKeyContent: ""

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 const (
-	certsDirPath = "/etc/secret/ssl"
+	containerCertPath = "/etc/secret/ssl/tls.crt"
+	containerkeyPath  = "/etc/secret/ssl/tls.key"
 )
 
 // LoadSSLCertificates stages user-provided certificates for the Caddy pod and updates TLS config via Admin API.
@@ -30,10 +30,10 @@ func (c *Context) LoadSSLCertificates(ctx context.Context, baseDir, sslCertPath,
 
 	// Load certificates via Admin API using container paths
 	if err := utils.LoadUserCertificates(
-		sslCertPath,                             // host cert path for validation
-		sslKeyPath,                              // host key path for validation
-		fmt.Sprintf("%s/tls.crt", certsDirPath), // container cert path
-		fmt.Sprintf("%s/tls.key", certsDirPath), // container key path
+		sslCertPath,       // host cert path for validation
+		sslKeyPath,        // host key path for validation
+		containerCertPath, // container cert path
+		containerkeyPath,  // container key path
 		adminURL,
 	); err != nil {
 		return fmt.Errorf("failed to load certificates via Admin API: %w", err)
@@ -54,28 +54,14 @@ func (c *Context) IsCustomCertLoaded(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	type loadFilesEntry struct {
-		Certificate string `json:"certificate"`
-		Key         string `json:"key"`
-	}
-	type certResponse struct {
-		LoadFiles []loadFilesEntry `json:"load_files"`
-	}
-
-	var result certResponse
-	resp, err := resty.New().R().
-		SetResult(&result).
-		Get(adminURL + "/config/apps/tls/certificates")
+	result, err := utils.GetCaddyCertificates(ctx, adminURL)
 	if err != nil {
-		return false, fmt.Errorf("failed to query Caddy certificates config: %w", err)
-	}
-	if resp.IsError() {
-		return false, fmt.Errorf("caddy returned error (status %d): %s", resp.StatusCode(), resp.String())
+		return false, err
 	}
 
 	for _, entry := range result.LoadFiles {
-		if entry.Certificate == fmt.Sprintf("%s/tls.crt", certsDirPath) &&
-			entry.Key == fmt.Sprintf("%s/tls.key", certsDirPath) {
+		if entry.Certificate == containerCertPath &&
+			entry.Key == containerkeyPath {
 			return true, nil
 		}
 	}

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
@@ -79,7 +79,7 @@ func (c *Context) IsCustomCertLoaded(ctx context.Context) (bool, error) {
 			return true, nil
 		}
 	}
-	
+
 	return false, nil
 }
 

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
@@ -48,8 +48,8 @@ func (c *Context) LoadSSLCertificates(ctx context.Context, baseDir, sslCertPath,
 // It queries the Caddy Admin API at /config/apps/tls/certificates and returns true if a load_files entry
 // matching the expected container cert and key paths (/etc/secret/ssl/tls.crt and /etc/secret/ssl/tls.key)
 // is present. Returns false (without error) when the response is null or no matching entry is found.
-func (c *Context) IsCustomCertLoaded() (bool, error) {
-	adminURL, err := c.GetHostAdminURL()
+func (c *Context) IsCustomCertLoaded(ctx context.Context) (bool, error) {
+	adminURL, err := c.GetHostAdminURL(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
@@ -3,19 +3,14 @@ package caddy
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
-	"time"
 
+	"github.com/go-resty/resty/v2"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 const (
-	certsDirName     = "certs"
-	containerDataDir = "/data/caddy"
-	dirPerm          = 0o755
-	filePerm         = 0o644
+	certsDirPath = "/etc/secret/ssl"
 )
 
 // LoadSSLCertificates stages user-provided certificates for the Caddy pod and updates TLS config via Admin API.
@@ -27,28 +22,18 @@ func (c *Context) LoadSSLCertificates(ctx context.Context, baseDir, sslCertPath,
 		return nil
 	}
 
-	// Stage certificates with timestamped filenames (deletes old certificates)
-	certFilename, keyFilename, err := stageCertificates(baseDir, sslCertPath, sslKeyPath)
-	if err != nil {
-		return fmt.Errorf("failed to stage certificates for Caddy: %w", err)
-	}
-
-	// Define staged certificate paths with timestamped filenames
-	stagedCertPath := filepath.Join(baseDir, "common", "caddy", certsDirName, certFilename)
-	stagedKeyPath := filepath.Join(baseDir, "common", "caddy", certsDirName, keyFilename)
-
 	// Get admin URL
 	adminURL, err := c.GetHostAdminURL(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get Caddy admin URL: %w", err)
 	}
 
-	// Load certificates via Admin API with timestamped paths
+	// Load certificates via Admin API using container paths
 	if err := utils.LoadUserCertificates(
-		stagedCertPath,
-		stagedKeyPath,
-		filepath.Join(containerDataDir, certsDirName, certFilename),
-		filepath.Join(containerDataDir, certsDirName, keyFilename),
+		sslCertPath,                             // host cert path for validation
+		sslKeyPath,                              // host key path for validation
+		fmt.Sprintf("%s/tls.crt", certsDirPath), // container cert path
+		fmt.Sprintf("%s/tls.key", certsDirPath), // container key path
 		adminURL,
 	); err != nil {
 		return fmt.Errorf("failed to load certificates via Admin API: %w", err)
@@ -59,59 +44,43 @@ func (c *Context) LoadSSLCertificates(ctx context.Context, baseDir, sslCertPath,
 	return nil
 }
 
-// stageCertificates stages SSL certificates for Caddy to use with timestamped filenames.
-// Deletes old certificate files before staging new ones to ensure only one set exists.
-// Returns the certificate and key filenames for use in loading.
-func stageCertificates(baseDir, sslCertPath, sslKeyPath string) (string, string, error) {
-	caddyDataDir := filepath.Join(baseDir, "common", "caddy")
-	certDir := filepath.Join(caddyDataDir, certsDirName)
-	if err := os.MkdirAll(certDir, dirPerm); err != nil {
-		return "", "", fmt.Errorf("failed to create Caddy cert directory: %w", err)
+// IsCustomCertLoaded checks whether custom SSL certificates are currently loaded in Caddy's live config.
+// It queries the Caddy Admin API at /config/apps/tls/certificates and returns true if a load_files entry
+// matching the expected container cert and key paths (/etc/secret/ssl/tls.crt and /etc/secret/ssl/tls.key)
+// is present. Returns false (without error) when the response is null or no matching entry is found.
+func (c *Context) IsCustomCertLoaded() (bool, error) {
+	adminURL, err := c.GetHostAdminURL()
+	if err != nil {
+		return false, err
 	}
 
-	// Delete old certificate files (tls-*.crt and tls-*.key)
-	oldCerts, _ := filepath.Glob(filepath.Join(certDir, "tls-*.crt"))
-	for _, oldCert := range oldCerts {
-		if err := os.Remove(oldCert); err != nil {
-			logger.Warningf("Failed to remove old certificate %s: %v", oldCert, err)
+	type loadFilesEntry struct {
+		Certificate string `json:"certificate"`
+		Key         string `json:"key"`
+	}
+	type certResponse struct {
+		LoadFiles []loadFilesEntry `json:"load_files"`
+	}
+
+	var result certResponse
+	resp, err := resty.New().R().
+		SetResult(&result).
+		Get(adminURL + "/config/apps/tls/certificates")
+	if err != nil {
+		return false, fmt.Errorf("failed to query Caddy certificates config: %w", err)
+	}
+	if resp.IsError() {
+		return false, fmt.Errorf("caddy returned error (status %d): %s", resp.StatusCode(), resp.String())
+	}
+
+	for _, entry := range result.LoadFiles {
+		if entry.Certificate == fmt.Sprintf("%s/tls.crt", certsDirPath) &&
+			entry.Key == fmt.Sprintf("%s/tls.key", certsDirPath) {
+			return true, nil
 		}
 	}
-	oldKeys, _ := filepath.Glob(filepath.Join(certDir, "tls-*.key"))
-	for _, oldKey := range oldKeys {
-		if err := os.Remove(oldKey); err != nil {
-			logger.Warningf("Failed to remove old key %s: %v", oldKey, err)
-		}
-	}
-
-	// Generate timestamped filenames
-	timestamp := time.Now().Unix()
-	certFilename := fmt.Sprintf("tls-%d.crt", timestamp)
-	keyFilename := fmt.Sprintf("tls-%d.key", timestamp)
-
-	stagedCertPath := filepath.Join(certDir, certFilename)
-	stagedKeyPath := filepath.Join(certDir, keyFilename)
-
-	// Read certificate and key files
-	certBytes, err := os.ReadFile(sslCertPath)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to read certificate file: %w", err)
-	}
-
-	keyBytes, err := os.ReadFile(sslKeyPath)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to read key file: %w", err)
-	}
-
-	// Write staged certificate and key with timestamped filenames
-	if err := os.WriteFile(stagedCertPath, certBytes, filePerm); err != nil {
-		return "", "", fmt.Errorf("failed to write staged certificate file: %w", err)
-	}
-
-	if err := os.WriteFile(stagedKeyPath, keyBytes, filePerm); err != nil {
-		return "", "", fmt.Errorf("failed to write staged key file: %w", err)
-	}
-
-	return certFilename, keyFilename, nil
+	
+	return false, nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -66,18 +64,18 @@ func getHTTPSPort(ctx context.Context, runtime *podman.PodmanClient, caddyPodNam
 	return "", fmt.Errorf("HTTPS port not found in Caddy pod")
 }
 
-// GenerateCaddyfile copies the static Caddyfile to the caddy directory.
-func GenerateCaddyfile(baseDir string) error {
+// GetCaddyFileContent returns caddy file content.
+func GetCaddyFileContent() (string, error) {
 	// Read the Caddyfile template
 	caddyfileContent, err := assets.CatalogFS.ReadFile("catalog/podman/Caddyfile.tmpl")
 	if err != nil {
-		return fmt.Errorf("failed to read Caddyfile template: %w", err)
+		return "", fmt.Errorf("failed to read Caddyfile template: %w", err)
 	}
 
 	// Parse the Caddyfile as a template
 	tmpl, err := template.New("Caddyfile.tmpl").Parse(string(caddyfileContent))
 	if err != nil {
-		return fmt.Errorf("failed to parse Caddyfile template: %w", err)
+		return "", fmt.Errorf("failed to parse Caddyfile template: %w", err)
 	}
 
 	// Prepare template data with the server name constant
@@ -88,21 +86,10 @@ func GenerateCaddyfile(baseDir string) error {
 	// Execute the template
 	var rendered bytes.Buffer
 	if err := tmpl.Execute(&rendered, templateData); err != nil {
-		return fmt.Errorf("failed to execute Caddyfile template: %w", err)
+		return "", fmt.Errorf("failed to execute Caddyfile template: %w", err)
 	}
 
-	// Ensure directory exists and write Caddyfile
-	caddyDir := filepath.Join(baseDir, "common", "caddy")
-	if err := os.MkdirAll(caddyDir, dirPerm); err != nil {
-		return fmt.Errorf("failed to create caddy directory: %w", err)
-	}
-
-	caddyfilePath := filepath.Join(caddyDir, "Caddyfile")
-	if err := os.WriteFile(caddyfilePath, rendered.Bytes(), filePerm); err != nil {
-		return fmt.Errorf("failed to write Caddyfile: %w", err)
-	}
-
-	return nil
+	return rendered.String(), nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/common/podman/deploy/deploy_context.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/deploy/deploy_context.go
@@ -96,7 +96,7 @@ func (d *DeployContext) CheckStatus(ctx context.Context) (bool, []string, error)
 	catalogResourceCount := len(d.templates)
 
 	// Checking if 'catalog-caddy-cert-secret' optional secret is present or not
-	exists, err := d.Runtime.SecretExists(catalogconstants.CatalogCertSecretName)
+	exists, err := d.Runtime.SecretExists(ctx, catalogconstants.CatalogCertSecretName)
 	if err != nil {
 		return false, nil, err
 	}

--- a/ai-services/internal/pkg/catalog/cli/common/podman/deploy/deploy_context.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/deploy/deploy_context.go
@@ -103,7 +103,7 @@ func (d *DeployContext) CheckStatus(ctx context.Context) (bool, []string, error)
 	if exists {
 		existingResources = append(existingResources, catalogconstants.CatalogCertSecretName)
 	} else {
-		// When 'catalog-caddy-cert-secret' secret not created, decerement catalogResourceCount by one,
+		// When 'catalog-caddy-cert-secret' secret not created, decrement catalogResourceCount by one,
 		// as resource is created based on optional flag (--ssl-cert and --ssl-key)
 		catalogResourceCount--
 	}

--- a/ai-services/internal/pkg/catalog/cli/common/podman/deploy/deploy_context.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/deploy/deploy_context.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 	"text/template"
 
@@ -92,7 +93,22 @@ func (d *DeployContext) CheckStatus(ctx context.Context) (bool, []string, error)
 		return false, nil, err
 	}
 
-	return len(existingResources) == len(d.templates), existingResources, nil
+	catalogResourceCount := len(d.templates)
+
+	// Checking if 'catalog-caddy-cert-secret' optional secret is present or not
+	exists, err := d.Runtime.SecretExists(catalogconstants.CatalogCertSecretName)
+	if err != nil {
+		return false, nil, err
+	}
+	if exists {
+		existingResources = append(existingResources, catalogconstants.CatalogCertSecretName)
+	} else {
+		// When 'catalog-caddy-cert-secret' secret not created, decerement catalogResourceCount by one,
+		// as resource is created based on optional flag (--ssl-cert and --ssl-key)
+		catalogResourceCount--
+	}
+
+	return len(existingResources) == catalogResourceCount, existingResources, nil
 }
 
 // GetCaddyPodName extracts the Caddy pod name from templates.
@@ -195,6 +211,13 @@ func (d *DeployContext) executePodTemplate(ctx context.Context, podTemplateName 
 	var rendered bytes.Buffer
 	if err := podTemplate.Execute(&rendered, params); err != nil {
 		return fmt.Errorf("failed to render pod template: %w", err)
+	}
+
+	// If the rendered template is empty, skip deploying it
+	if strings.TrimSpace(rendered.String()) == "" {
+		logger.Infof("%s: Skipping resource deploy as it rendered empty", podTemplateName)
+
+		return nil
 	}
 
 	// Deploy the pod with readiness checks

--- a/ai-services/internal/pkg/catalog/cli/configure/common.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/common.go
@@ -16,4 +16,7 @@ const (
 	ArgParamPodmanURI             = "backend.podman.uri"
 	ArgParamCaddyHTTPSPort        = "caddy.httpsPort"
 	ArgParamWorkerGatewayPort     = "backend.workerGatewayPort"
+	ArgParamCaddyFileContent      = "caddy.caddyFileContent"
+	ArgParamSSLCertFileContent    = "caddy.sslCertContent"
+	ArgParamSSLKeyFileContent     = "caddy.sslKeyContent"
 )

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -99,7 +99,7 @@ func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployConte
 		s.Stop("Catalog service already deployed")
 		logger.Infof("Existing resources: %v\n", existingResources)
 		// Validate domain, HTTPS port, base directory, and certificates haven't changed
-		if err := validateReconfigureParameters(ctx, deployCtx.Runtime, &opts, caddyCtx.GetDomainSuffix()); err != nil {
+		if err := validateReconfigureParameters(ctx, deployCtx.Runtime, &opts, caddyCtx); err != nil {
 			s.Fail("validation failed during reconfigure")
 
 			return nil, fmt.Errorf("reconfigure validation failed: %w", err)

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -18,6 +18,11 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
+const (
+	caddyFileIndent   = 10
+	certContentIndent = 4
+)
+
 // DeployCatalog deploys the catalog service using the assets/catalog template for podman runtime.
 func DeployCatalog(ctx context.Context, opts catalogUtils.PodmanConfigureOptions) error {
 	// Create deployment context without argParams for status check
@@ -74,7 +79,7 @@ func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployConte
 
 	if !isDeployed {
 		// Prepare deployment with domain suffix computation and create Caddy context
-		err = loadCatalogParamValues(deployCtx, passwordHash, opts.HttpsPort, opts.WorkerGatewayPort)
+		err = loadCatalogParamValues(deployCtx, passwordHash, opts.SSLCertPath, opts.SSLKeyPath, opts.HttpsPort, opts.WorkerGatewayPort)
 		if err != nil {
 			s.Fail("failed to load param values")
 
@@ -136,14 +141,15 @@ func handlePostDeployment(ctx context.Context, caddyCtx *caddy.Context, deployCt
 }
 
 // loadCatalogParamValues prepares all necessary data for deployment including domain suffix computation.
-func loadCatalogParamValues(deployCtx *deploy.DeployContext, passwordHash string, httpsPort, workerGatewayPort int) error {
+func loadCatalogParamValues(deployCtx *deploy.DeployContext, passwordHash, sslCertPath, sslKeyPath string, httpsPort, workerGatewayPort int) error {
 	logger.Debugln("loading catalog service param values...")
 
 	// Generate argument parameters
-	argParams, err := generateArgParams(passwordHash, httpsPort, workerGatewayPort)
+	argParams, err := generateArgParams(passwordHash, sslCertPath, sslKeyPath, httpsPort, workerGatewayPort)
 	if err != nil {
 		return fmt.Errorf("failed to generate arg params: %w", err)
 	}
+	// Fill caddy config
 
 	// Prepare values with configure-specific configuration
 	err = deployCtx.PrepareValues(argParams)
@@ -155,7 +161,7 @@ func loadCatalogParamValues(deployCtx *deploy.DeployContext, passwordHash string
 }
 
 // generateArgParams generates the argument parameters for template rendering.
-func generateArgParams(passwordHash string, httpsPort, workerGatewayPort int) (map[string]string, error) {
+func generateArgParams(passwordHash, sslCertPath, sslKeyPath string, httpsPort, workerGatewayPort int) (map[string]string, error) {
 	// Generate database password
 	dbPassword, err := utils.GenerateRandomPassword()
 	if err != nil {
@@ -194,6 +200,21 @@ func generateArgParams(passwordHash string, httpsPort, workerGatewayPort int) (m
 	}
 	podmanSocketPath := strings.TrimPrefix(podmanURI, "unix://")
 
+	// Caddy configuration
+	caddyFileContent, err := caddy.GetCaddyFileContent()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate caddy file: %w", err)
+	}
+	var sslCertContent, sslKeyContent string
+	if sslCertPath != "" && sslKeyPath != "" {
+		certbyte, keyBytes, _, err := utils.ReadAndParseCertificates(sslCertPath, sslKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load ssl certs: %w", err)
+		}
+		sslCertContent = string(certbyte)
+		sslKeyContent = string(keyBytes)
+	}
+
 	// Set configure-specific values
 	argParams := make(map[string]string)
 	argParams[configure.ArgParamAdminPasswordHash] = passwordHash
@@ -203,6 +224,9 @@ func generateArgParams(passwordHash string, httpsPort, workerGatewayPort int) (m
 	argParams[configure.ArgParamDBPassword] = dbPassword
 	argParams[configure.ArgParamCaddyHTTPSPort] = fmt.Sprintf("%d", httpsPort)
 	argParams[configure.ArgParamWorkerGatewayPort] = fmt.Sprintf("%d", workerGatewayPort)
+	argParams[configure.ArgParamCaddyFileContent] = utils.IndentString(caddyFileContent, caddyFileIndent)
+	argParams[configure.ArgParamSSLCertFileContent] = utils.IndentString(sslCertContent, certContentIndent)
+	argParams[configure.ArgParamSSLKeyFileContent] = utils.IndentString(sslKeyContent, certContentIndent)
 
 	return argParams, nil
 }
@@ -211,8 +235,7 @@ func generateArgParams(passwordHash string, httpsPort, workerGatewayPort int) (m
 // This function:
 // 1. Gets the Caddy pod name from deployment context templates
 // 2. Computes domain configuration (cert domain extraction + domain suffix resolution)
-// 3. Creates Caddy context with pod name and domain suffix
-// 4. Generates and writes Caddyfile.
+// 3. Creates Caddy context with pod name and domain suffix.
 func setupCaddyContext(deployCtx *deploy.DeployContext, opts catalogUtils.PodmanConfigureOptions, s *spinner.Spinner) (*caddy.Context, error) {
 	// Get Caddy pod name from deployment context (templates)
 	caddyPodName, err := deployCtx.GetCaddyPodName()
@@ -234,13 +257,6 @@ func setupCaddyContext(deployCtx *deploy.DeployContext, opts catalogUtils.Podman
 
 	// Create Caddy context with pod name and domain suffix (NO template dependencies)
 	caddyCtx := caddy.NewContext(caddyPodName, domainSuffix)
-
-	// Generate and write Caddyfile before deploying
-	if err := caddy.GenerateCaddyfile(opts.BaseDir); err != nil {
-		s.Fail("failed to generate Caddyfile")
-
-		return nil, fmt.Errorf("failed to generate Caddyfile: %w", err)
-	}
 
 	return caddyCtx, nil
 }

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -53,13 +53,13 @@ func validateReconfigureParameters(ctx context.Context, rt runtime.Runtime, newO
 	}
 
 	// Validate configuration parameters haven't changed
-	if err := validateConfigParameters(existingOpts, newOpts, cadyCtx.GetDomainSuffix()); err != nil {
+	if err := validateConfigParameters(existingOpts, newOpts, caddyCtx.GetDomainSuffix()); err != nil {
 		return err
 	}
 
 	// Validate certificate changes if SSL certificates are provided
 
-	return validateCertificateChanges(rt, newOpts, cadyCtx)
+	return validateCertificateChanges(ctx, rt, newOpts, caddyCtx)
 }
 
 // validateConfigParameters validates domain, HTTPS port, and base directory haven't changed.
@@ -82,8 +82,9 @@ func validateConfigParameters(existingOpts *catalogUtils.PodmanConfigureOptions,
 // validateCertificateChanges prevents switching from custom certificates back to Caddy self-signed certificates.
 // Allows updating custom certificate content (e.g., for expiry or renewal).
 // Uses glob patterns to detect timestamped certificate files.
-func validateCertificateChanges(rt runtime.Runtime, opts *catalogUtils.PodmanConfigureOptions, caddyCtx *caddy.Context) error {
-	isCustomCertLoaded, err := caddyCtx.IsCustomCertLoaded()
+func validateCertificateChanges(ctx context.Context, rt runtime.Runtime, opts *catalogUtils.PodmanConfigureOptions, caddyCtx *caddy.Context) error {
+	// Check if any custom certificates exist from previous deployment
+	isCustomCertLoaded, err := caddyCtx.IsCustomCertLoaded(ctx)
 	if err != nil {
 		return  fmt.Errorf("failed to check if custom cert is loaded: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -59,7 +59,7 @@ func validateReconfigureParameters(ctx context.Context, rt runtime.Runtime, newO
 
 	// Validate certificate changes if SSL certificates are provided
 
-	return validateCertificateChanges(ctx, rt, newOpts, caddyCtx)
+	return validateCertificateChanges(ctx, newOpts, caddyCtx)
 }
 
 // validateConfigParameters validates domain, HTTPS port, and base directory haven't changed.
@@ -82,14 +82,14 @@ func validateConfigParameters(existingOpts *catalogUtils.PodmanConfigureOptions,
 // validateCertificateChanges prevents switching from custom certificates back to Caddy self-signed certificates.
 // Allows updating custom certificate content (e.g., for expiry or renewal).
 // Uses glob patterns to detect timestamped certificate files.
-func validateCertificateChanges(ctx context.Context, rt runtime.Runtime, opts *catalogUtils.PodmanConfigureOptions, caddyCtx *caddy.Context) error {
+func validateCertificateChanges(ctx context.Context, opts *catalogUtils.PodmanConfigureOptions, caddyCtx *caddy.Context) error {
 	// Check if any custom certificates exist from previous deployment
 	isCustomCertLoaded, err := caddyCtx.IsCustomCertLoaded(ctx)
 	if err != nil {
-		return  fmt.Errorf("failed to check if custom cert is loaded: %w", err)
+		return fmt.Errorf("failed to check if custom cert is loaded: %w", err)
 	}
-	
-	// If no SSL paths provided in new config but staged certs exist, block cert type change
+
+	// If no SSL paths provided in new config but custom certs loaded in caddy, block cert type change
 	if (opts.SSLCertPath == "" || opts.SSLKeyPath == "") && isCustomCertLoaded {
 		return fmt.Errorf("certificate type change not allowed: custom certificates are already configured. Cannot switch to Caddy self-signed certificates during reconfigure. Please uninstall the catalog deployment and re-run configure to change certificate type")
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -4,16 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
 	cliutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure/utils"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
-
-const certsDirName = "certs"
 
 // getExistingConfigFromCatalogBackend retrieves the existing configuration from the catalog pod.
 // These values are used to validate that configuration hasn't changed during reconfigure operations.
@@ -47,7 +45,7 @@ func validateRequiredFields(opts *catalogUtils.PodmanConfigureOptions) error {
 
 // validateReconfigureParameters validates that domain, HTTPS port, base directory, and certificates haven't changed during reconfigure.
 // This function performs all validation checks including certificate validation.
-func validateReconfigureParameters(ctx context.Context, rt runtime.Runtime, newOpts *catalogUtils.PodmanConfigureOptions, domainSuffix string) error {
+func validateReconfigureParameters(ctx context.Context, rt runtime.Runtime, newOpts *catalogUtils.PodmanConfigureOptions, caddyCtx *caddy.Context) error {
 	// Get existing configuration from catalog-backend pod
 	existingOpts, err := getExistingConfigFromCatalogBackend(ctx, rt)
 	if err != nil {
@@ -55,13 +53,13 @@ func validateReconfigureParameters(ctx context.Context, rt runtime.Runtime, newO
 	}
 
 	// Validate configuration parameters haven't changed
-	if err := validateConfigParameters(existingOpts, newOpts, domainSuffix); err != nil {
+	if err := validateConfigParameters(existingOpts, newOpts, cadyCtx.GetDomainSuffix()); err != nil {
 		return err
 	}
 
 	// Validate certificate changes if SSL certificates are provided
 
-	return validateCertificateChanges(newOpts)
+	return validateCertificateChanges(rt, newOpts, cadyCtx)
 }
 
 // validateConfigParameters validates domain, HTTPS port, and base directory haven't changed.
@@ -84,19 +82,14 @@ func validateConfigParameters(existingOpts *catalogUtils.PodmanConfigureOptions,
 // validateCertificateChanges prevents switching from custom certificates back to Caddy self-signed certificates.
 // Allows updating custom certificate content (e.g., for expiry or renewal).
 // Uses glob patterns to detect timestamped certificate files.
-func validateCertificateChanges(opts *catalogUtils.PodmanConfigureOptions) error {
-	// Define staged certificate directory
-	certDir := filepath.Join(opts.BaseDir, "common", "caddy", certsDirName)
-
-	// Check if any timestamped certificates exist from previous deployment
-	stagedCerts, _ := filepath.Glob(filepath.Join(certDir, "tls-*.crt"))
-	stagedKeys, _ := filepath.Glob(filepath.Join(certDir, "tls-*.key"))
-
-	stagedCertExists := len(stagedCerts) > 0
-	stagedKeyExists := len(stagedKeys) > 0
-
+func validateCertificateChanges(rt runtime.Runtime, opts *catalogUtils.PodmanConfigureOptions, caddyCtx *caddy.Context) error {
+	isCustomCertLoaded, err := caddyCtx.IsCustomCertLoaded()
+	if err != nil {
+		return  fmt.Errorf("failed to check if custom cert is loaded: %w", err)
+	}
+	
 	// If no SSL paths provided in new config but staged certs exist, block cert type change
-	if (opts.SSLCertPath == "" || opts.SSLKeyPath == "") && stagedCertExists && stagedKeyExists {
+	if (opts.SSLCertPath == "" || opts.SSLKeyPath == "") && isCustomCertLoaded {
 		return fmt.Errorf("certificate type change not allowed: custom certificates are already configured. Cannot switch to Caddy self-signed certificates during reconfigure. Please uninstall the catalog deployment and re-run configure to change certificate type")
 	}
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -35,7 +35,7 @@ func ResetCatalogCertificate(ctx context.Context, sslCertPath, sslKeyPath string
 	}
 
 	// Get existing catalog pod details
-	opts, _, err := catalogUtils.GetCatalogPodConfig(ctx, deployCtx.Runtime)
+	opts, err := prepareCatalogOpts(ctx, deployCtx, sslCertPath, sslKeyPath)
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func ResetCatalogCertificate(ctx context.Context, sslCertPath, sslKeyPath string
 		return fmt.Errorf("failed to get Caddy pod name: %w", err)
 	}
 
-	if err := deleteSecretAndPod(deployCtx, caddyPodName, catalogConstant.CatalogCertSecretName); err != nil {
+	if err := deleteSecretAndPod(ctx, deployCtx, caddyPodName, catalogConstant.CatalogCertSecretName); err != nil {
 		return err
 	}
 
@@ -69,8 +69,8 @@ func ResetCatalogCertificate(ctx context.Context, sslCertPath, sslKeyPath string
 
 // prepareCatalogOpts fetches the current catalog pod config, validates the base dir,
 // and ensures the domain has not changed relative to the new certificates.
-func prepareCatalogOpts(deployCtx *deploy.DeployContext, sslCertPath, sslKeyPath string) (*catalogUtils.PodmanConfigureOptions, error) {
-	opts, _, err := catalogUtils.GetCatalogPodConfig(deployCtx.Runtime)
+func prepareCatalogOpts(ctx context.Context, deployCtx *deploy.DeployContext, sslCertPath, sslKeyPath string) (*catalogUtils.PodmanConfigureOptions, error) {
+	opts, _, err := catalogUtils.GetCatalogPodConfig(ctx, deployCtx.Runtime)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get catalog pod details: %w", err)
 	}
@@ -87,14 +87,14 @@ func prepareCatalogOpts(deployCtx *deploy.DeployContext, sslCertPath, sslKeyPath
 }
 
 // deleteSecretAndPod deletes the caddy cert secret and pod before redeployment.
-func deleteSecretAndPod(deployCtx *deploy.DeployContext, nameOrID, secretName string) error {
+func deleteSecretAndPod(ctx context.Context, deployCtx *deploy.DeployContext, nameOrID, secretName string) error {
 	logger.InfofCtx(context.Background(), "Deleting existing secret %s", secretName)
-	if err := deployCtx.Runtime.DeleteSecret(secretName); err != nil {
+	if err := deployCtx.Runtime.DeleteSecret(ctx, secretName); err != nil {
 		return fmt.Errorf("failed to delete existing catalog secret: %w", err)
 	}
 
 	logger.InfofCtx(context.Background(), "Deleting existing pod %s", nameOrID)
-	if err := deployCtx.Runtime.DeletePod(nameOrID, utils.BoolPtr(true)); err != nil {
+	if err := deployCtx.Runtime.DeletePod(ctx, nameOrID, utils.BoolPtr(true)); err != nil {
 		return fmt.Errorf("failed to delete existing catalog pod: %w", err)
 	}
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
+	catalogConstant "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 // ResetCatalogCertificate resets the SSL certificates for the catalog service.
@@ -35,15 +37,6 @@ func ResetCatalogCertificate(ctx context.Context, sslCertPath, sslKeyPath string
 	// Get existing catalog pod details
 	opts, _, err := catalogUtils.GetCatalogPodConfig(ctx, deployCtx.Runtime)
 	if err != nil {
-		return fmt.Errorf("failed to get catalog pod details: %w", err)
-	}
-
-	if opts.BaseDir == "" {
-		return fmt.Errorf("AI_SERVICES_BASE_DIR not found in catalog configuration")
-	}
-
-	// Validate that domain hasn't changed
-	if err := validateDomainUnchanged(opts, sslCertPath, sslKeyPath); err != nil {
 		return err
 	}
 
@@ -53,8 +46,16 @@ func ResetCatalogCertificate(ctx context.Context, sslCertPath, sslKeyPath string
 		return fmt.Errorf("failed to get Caddy pod name: %w", err)
 	}
 
-	// Create Caddy context for certificate operations
-	caddyCtx := caddy.NewContext(caddyPodName, "")
+	if err := deleteSecretAndPod(deployCtx, caddyPodName, catalogConstant.CatalogCertSecretName); err != nil {
+		return err
+	}
+
+	opts.SSLCertPath = sslCertPath
+	opts.SSLKeyPath = sslKeyPath
+	caddyCtx, err := executeCatalogDeployment(context.Background(), deployCtx, *opts, "")
+	if err != nil {
+		return fmt.Errorf("failed to deploy catalog pod: %w", err)
+	}
 
 	// Load certificates with health check
 	if err := loadCertificatesToCaddy(ctx, caddyCtx, opts.BaseDir, sslCertPath, sslKeyPath); err != nil {
@@ -62,6 +63,40 @@ func ResetCatalogCertificate(ctx context.Context, sslCertPath, sslKeyPath string
 	}
 
 	logger.InfolnCtx(ctx, "SSL certificates reset successfully")
+
+	return nil
+}
+
+// prepareCatalogOpts fetches the current catalog pod config, validates the base dir,
+// and ensures the domain has not changed relative to the new certificates.
+func prepareCatalogOpts(deployCtx *deploy.DeployContext, sslCertPath, sslKeyPath string) (*catalogUtils.PodmanConfigureOptions, error) {
+	opts, _, err := catalogUtils.GetCatalogPodConfig(deployCtx.Runtime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get catalog pod details: %w", err)
+	}
+
+	if opts.BaseDir == "" {
+		return nil, fmt.Errorf("AI_SERVICES_BASE_DIR not found in catalog configuration")
+	}
+
+	if err := validateDomainUnchanged(opts, sslCertPath, sslKeyPath); err != nil {
+		return nil, err
+	}
+
+	return opts, nil
+}
+
+// deleteSecretAndPod deletes the caddy cert secret and pod before redeployment.
+func deleteSecretAndPod(deployCtx *deploy.DeployContext, nameOrID, secretName string) error {
+	logger.InfofCtx(context.Background(), "Deleting existing secret %s", secretName)
+	if err := deployCtx.Runtime.DeleteSecret(secretName); err != nil {
+		return fmt.Errorf("failed to delete existing catalog secret: %w", err)
+	}
+
+	logger.InfofCtx(context.Background(), "Deleting existing pod %s", nameOrID)
+	if err := deployCtx.Runtime.DeletePod(nameOrID, utils.BoolPtr(true)); err != nil {
+		return fmt.Errorf("failed to delete existing catalog pod: %w", err)
+	}
 
 	return nil
 }

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -55,7 +55,7 @@ func ResetCatalogCertificate(ctx context.Context, sslCertPath, sslKeyPath string
 
 	opts.SSLCertPath = sslCertPath
 	opts.SSLKeyPath = sslKeyPath
-	caddyCtx, err := executeCatalogDeployment(context.Background(), deployCtx, *opts, "")
+	caddyCtx, err := executeCatalogDeployment(ctx, deployCtx, *opts, "")
 	if err != nil {
 		return fmt.Errorf("failed to deploy catalog pod: %w", err)
 	}
@@ -91,12 +91,12 @@ func prepareCatalogOpts(ctx context.Context, deployCtx *deploy.DeployContext, ss
 
 // deleteSecretAndPod deletes the caddy cert secret and pod before redeployment.
 func deleteSecretAndPod(ctx context.Context, deployCtx *deploy.DeployContext, nameOrID, secretName string) error {
-	logger.InfofCtx(context.Background(), "Deleting existing secret %s", secretName)
+	logger.InfofCtx(ctx, "Deleting existing secret %s", secretName)
 	if err := deployCtx.Runtime.DeleteSecret(ctx, secretName); err != nil {
 		return fmt.Errorf("failed to delete existing catalog secret: %w", err)
 	}
 
-	logger.InfofCtx(context.Background(), "Deleting existing pod %s", nameOrID)
+	logger.InfofCtx(ctx, "Deleting existing pod %s", nameOrID)
 	if err := deployCtx.Runtime.DeletePod(ctx, nameOrID, utils.BoolPtr(true)); err != nil {
 		return fmt.Errorf("failed to delete existing catalog pod: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -46,6 +46,9 @@ func ResetCatalogCertificate(ctx context.Context, sslCertPath, sslKeyPath string
 		return fmt.Errorf("failed to get Caddy pod name: %w", err)
 	}
 
+	// Delete the cert secret and Caddy pod to reset the custom certificate.
+	// For self-signed certs, the secret may not exist, but execution never reaches here
+	// because a domain change is rejected earlier.
 	if err := deleteSecretAndPod(ctx, deployCtx, caddyPodName, catalogConstant.CatalogCertSecretName); err != nil {
 		return err
 	}

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -62,6 +62,17 @@ func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.P
 	secretsToDelete, secretsToSkip := fetchSecretsToDelete(pods)
 	secretsToDelete = append(secretsToDelete, catalogConstants.PodmanAuthSecret, catalogConstants.CatalogConnectorSecretName)
 
+	// Checking if 'catalog-caddy-cert-secret' is created as part of catalog configure
+	// If secret is created adding it to 'secretsToDelete' list
+	exists, err := rt.SecretExists(catalogConstants.CatalogCertSecretName)
+	if err != nil {
+		return err
+	}
+	if exists {
+		secretsToDelete = append(secretsToDelete, catalogConstants.CatalogCertSecretName)
+	}
+
+
 	volumesToDelete, volumesToSkip := fetchVolumesToDelete(pods)
 
 	// Delete catalog pods
@@ -76,12 +87,6 @@ func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.P
 
 	// Delete volumes (only those without skip-cleanup label)
 	if err := deleteVolumes(ctx, rt, volumesToDelete); err != nil {
-		return err
-	}
-
-	// Delete caddy data
-	caddyDataPath := filepath.Join(baseDir, "common")
-	if err := dataDeletion(caddyDataPath); err != nil {
 		return err
 	}
 

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -64,7 +64,7 @@ func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.P
 
 	// Checking if 'catalog-caddy-cert-secret' is created as part of catalog configure
 	// If secret is created adding it to 'secretsToDelete' list
-	exists, err := rt.SecretExists(catalogConstants.CatalogCertSecretName)
+	exists, err := rt.SecretExists(ctx, catalogConstants.CatalogCertSecretName)
 	if err != nil {
 		return err
 	}

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -72,7 +72,6 @@ func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.P
 		secretsToDelete = append(secretsToDelete, catalogConstants.CatalogCertSecretName)
 	}
 
-
 	volumesToDelete, volumesToSkip := fetchVolumesToDelete(pods)
 
 	// Delete catalog pods

--- a/ai-services/internal/pkg/catalog/constants/catalog.go
+++ b/ai-services/internal/pkg/catalog/constants/catalog.go
@@ -54,6 +54,8 @@ const (
 	PodmanAuthSecret = "podman-auth-secret"
 	// CatalogSecretName represents the catalog secret name.
 	CatalogSecretName = "catalog-secret"
+	// CatalogCertSecretName represents caddy cert secret name.
+	CatalogCertSecretName = "catalog-caddy-cert-secret"
 	// CatalogDBSecretName represents the catalog database secret name used in OpenShift deployments.
 	CatalogDBSecretName = "catalog-db-secret"
 	// CatalogConnectorSecretName represents the catalog connector encryption key secret name.

--- a/ai-services/internal/pkg/utils/cert.go
+++ b/ai-services/internal/pkg/utils/cert.go
@@ -237,7 +237,7 @@ func ExtractDomainFromCertificate(certPath string) (string, error) {
 // LoadUserCertificates validates staged certificate files on the host and updates Caddy to load them from container-visible paths.
 func LoadUserCertificates(hostCertPath, hostKeyPath, caddyCertPath, caddyKeyPath, adminURL string) error {
 	// Read and parse staged host-side certificate files
-	_, keyBytes, cert, err := readAndParseCertificates(hostCertPath, hostKeyPath)
+	_, keyBytes, cert, err := ReadAndParseCertificates(hostCertPath, hostKeyPath)
 	if err != nil {
 		return err
 	}
@@ -255,8 +255,8 @@ func LoadUserCertificates(hostCertPath, hostKeyPath, caddyCertPath, caddyKeyPath
 	return nil
 }
 
-// readAndParseCertificates reads and parses certificate and key files.
-func readAndParseCertificates(certPath, keyPath string) ([]byte, []byte, *x509.Certificate, error) {
+// ReadAndParseCertificates reads and parses certificate and key files.
+func ReadAndParseCertificates(certPath, keyPath string) ([]byte, []byte, *x509.Certificate, error) {
 	certBytes, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to read certificate: %w", err)

--- a/ai-services/internal/pkg/utils/cert.go
+++ b/ai-services/internal/pkg/utils/cert.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
@@ -20,6 +21,17 @@ const (
 	// caddyAPITimeout is the timeout duration for Caddy API requests.
 	caddyAPITimeout = 10 * time.Second
 )
+
+// LoadFilesEntry represents a single certificate/key pair entry in Caddy's load_files configuration.
+type LoadFilesEntry struct {
+	Certificate string `json:"certificate"`
+	Key         string `json:"key"`
+}
+
+// CertResponse represents the response from Caddy's /config/apps/tls/certificates endpoint.
+type CertResponse struct {
+	LoadFiles []LoadFilesEntry `json:"load_files"`
+}
 
 // ComputeDomainSuffix resolves the domain suffix used for certificate and routing
 // configuration. Priority: cert domain > custom domain name > hostIP.nip.io.
@@ -417,6 +429,23 @@ func loadCertificatesIntoCaddy(certPath, keyPath, adminURL string) error {
 	}
 
 	return nil
+}
+
+// GetCaddyCertificates queries the Caddy Admin API and returns the current TLS certificates configuration.
+func GetCaddyCertificates(ctx context.Context, adminURL string) (*CertResponse, error) {
+	var result CertResponse
+	client := resty.New().SetTimeout(caddyAPITimeout)
+	resp, err := client.R().
+		SetResult(&result).
+		Get(adminURL + "/config/apps/tls/certificates")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query Caddy certificates config: %w", err)
+	}
+	if resp.IsError() {
+		return nil, fmt.Errorf("caddy returned error (status %d): %s", resp.StatusCode(), resp.String())
+	}
+
+	return &result, nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -765,3 +765,19 @@ func ConvertRawJsontoMap(raw json.RawMessage) (map[string]any, error) {
 
 	return result, nil
 }
+
+// IndentString adds indentation (leading spaces) to every line of the input string.
+func IndentString(s string, spaces int) string {
+	if s == "" {
+		return ""
+	}
+	prefix := strings.Repeat(" ", spaces)
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if i > 0 {
+			lines[i] = prefix + line
+		}
+	}
+
+	return prefix + strings.Join(lines, "\n")
+}


### PR DESCRIPTION
Replaced the host path bind mount with a Podman-managed volume for storing Caddy configuration, avoiding host filesystem dependencies and solving permission issue for non root caddy user.