### PR TITLE
adding similarity failure tests and exclude from e2e suite

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.234
+TAG?=v0.0.235
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.234
+  image: icr.io/ai-services-cicd/ai-services:v0.0.235
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.234
+  image: icr.io/ai-services-cicd/ai-services:v0.0.235
   runtime: ""
   adminPasswordHash: ""
   # workerGatewayPort: port for the gRPC worker gateway. Always active; default is 9090.

--- a/ai-services/tests/e2e/README.md
+++ b/ai-services/tests/e2e/README.md
@@ -122,12 +122,10 @@ Use Ginkgo label filters to run only the part of the suite you need.
 | `similarity-tests` | Similarity API health and `/v1/similarity-search` behavior |
 | `summarization-tests` | Asynchronous and synchronous summarization API coverage (requires `--template=summarize`) |
 | `app-backup-restore` | Application backup and restore validation for OpenSearch and digitize data |
-| `failure-test` | Bootstrap negative-path coverage |
-| `catalog-configure` | Catalog service configure, uninstall, SSL, reset, and endpoint tests (podman-only) |
-| `catalog-configure && ssl` | SSL certificate deployment and reset tests only |
-| `catalog-configure && non-root` | Non-root user configure and permission tests only |
-| `catalog-configure && negative` | Negative/flag-validation tests that never deploy a catalog |
-| `catalog-configure && endpoints` | Live catalog API endpoint tests (require a running catalog) |
+| `failure-test` | **Umbrella label** — all negative-path tests across bootstrap, catalog, and similarity. **Skipped by default** unless `--run-failure-tests` is passed; use `--label-filter="failure-test"` to further narrow once unlocked |
+| `bootstrap-failure` | Bootstrap domain failure tests only (`bootstrap_failure_test.go`) — requires `--run-failure-tests` |
+| `catalog-failure` | Catalog domain failure tests only (`catalog_failure_test.go`) — requires `--run-failure-tests` |
+| `similarity-failure` | Similarity domain failure tests only (`similarity_failure_test.go`) — requires `--run-failure-tests` |
 
 ### Running Summarization Tests Only
 
@@ -295,154 +293,245 @@ ginkgo -r -tags "exclude_graphdriver_btrfs containers_image_openpgp remote" \
   ./tests/e2e -- --app-name=<appname> --runtime=<runtime>
 ```
 
-## Running Bootstrap Failure Tests
+## Running Failure Tests
 
-Bootstrap failure tests are in `bootstrap_failure_test.go` and cover the three most critical error paths: invalid registry credentials, catalog service unavailability, and missing prerequisites detected by `bootstrap validate`.
+### Overview — why failure tests are excluded by default
 
-These tests are **independent of the main lifecycle** (no running application required) and can be run at any time.
+The three failure test files exercise **intentional error paths** (wrong credentials, bad inputs, unreachable services). They are **not** part of the normal E2E suite run because:
 
-Point the test suite at the binary you just built:
-```bash
-export AI_SERVICES_BIN=<path to ai-services binary>
+- They require specific environment conditions (e.g. a reachable catalog server to test wrong-password rejection).
+- They intentionally make commands fail, which would appear as unexpected failures in a normal run.
+- They should be run deliberately, in isolation, as part of a dedicated failure-scenario validation pass.
+
+Each failure file has a `BeforeEach` guard at the `Describe` level that calls `ginkgo.Skip` unless the `--run-failure-tests` flag is explicitly passed. This mirrors the `--app-name` guard used by Language Support Tests — **no flag, no execution, no accidents**.
+
+The labels (`failure-test`, `bootstrap-failure`, `catalog-failure`, `similarity-failure`, and sub-labels) are retained for **precision targeting** once the flag unlocks execution.
+
+### How the two mechanisms interact
+
 ```
-### Run all Bootstrap failure tests
+Normal full suite run  (make test)
+  └─ --run-failure-tests not passed
+     └─ BeforeEach fires ginkgo.Skip on every failure It() → all 15 skipped ✓
 
-```bash
-ginkgo -r \
-  -tags "exclude_graphdriver_btrfs containers_image_openpgp remote" \
-  --label-filter="failure-test" \
-  --timeout=5m \
-  ./tests/e2e
+Run ALL failure tests
+  └─ pass --run-failure-tests → guard passes → all 15 run ✓
 
-go test -tags "exclude_graphdriver_btrfs containers_image_openpgp remote" \
-   -v -run TestE2E -timeout 5m \
-   -ginkgo.label-filter="failure-test" \
-   -runtime=podman \
-   ./tests/e2e
-```
+Run only one domain
+  └─ pass --run-failure-tests + --label-filter="catalog-failure"
+     └─ guard passes, label narrows to 5 catalog tests ✓
 
-### Run a specific failure category
-
-```bash
-# Registry authentication failures
-ginkgo -r -tags "exclude_graphdriver_btrfs containers_image_openpgp remote"  \ 
-  --label-filter="failure-test && registry" --timeout=2m ./tests/e2e
-
-# Catalog service failures (wrong credentials + unreachable server)
-ginkgo -r \
-  -tags "exclude_graphdriver_btrfs containers_image_openpgp remote" \
-  --label-filter="failure-test && catalog" \
-  --timeout=2m \
-  ./tests/e2e
-
-# Bootstrap validation failures (missing prerequisites)
-ginkgo -r \
-  -tags "exclude_graphdriver_btrfs containers_image_openpgp remote" \
-  --label-filter="failure-test && validation && spyre-independent" \
-  --timeout=2m \
-  ./tests/e2e
-
-# Run only the Spyre-specific failure test
-ginkgo -r \
-  -tags "exclude_graphdriver_btrfs containers_image_openpgp remote" \
-  --label-filter="failure-test && spyre" \
-  --timeout=2m \
-  ./tests/e2e
+Run one sub-category
+  └─ pass --run-failure-tests + --label-filter="failure-test && catalog-configure"
+     └─ guard passes, label narrows to Tests 4 & 5 of catalog_failure_test.go ✓
 ```
 
-### Exclude failure tests from a normal run
+### Label hierarchy
 
-```bash
-ginkgo -r --label-filter="!failure-test" ./tests/e2e
+```
+failure-test                           ← umbrella: selects ALL failure tests by label
+  ├─ bootstrap-failure                 ← domain: bootstrap_failure_test.go (5 tests)
+  │    ├─ registry                     ← sub: invalid registry credentials
+  │    ├─ catalog                      ← sub: wrong catalog password + unreachable server
+  │    └─ validation / spyre           ← sub: bootstrap validate failures
+  ├─ catalog-failure                   ← domain: catalog_failure_test.go (5 tests)
+  │    ├─ catalog-login                ← sub: missing flag, bad URL, whoami without login
+  │    └─ catalog-configure            ← sub: unpaired SSL flags, invalid port
+  └─ similarity-failure                ← domain: similarity_failure_test.go (5 tests)
+       ├─ similarity-input             ← sub: empty query, invalid mode, top_k=0
+       ├─ similarity-connectivity      ← sub: unreachable similarity API
+       └─ similarity-readiness         ← sub: empty vector index (HTTP 503)
 ```
 
-### Environment variables required
+---
 
-The failure tests reuse the same environment variables as the main suite.  No
-additional variables are needed — the tests deliberately supply *wrong* values
-internally and only read the registry/catalog URLs from the environment so they
-know which endpoint to target.
+### Running the full E2E suite (failure tests excluded automatically)
 
-```bash
-export REGISTRY_URL="icr.io"          # used to target the correct registry endpoint
-export CATALOG_SERVER_URL="..."        # optional — auto-discovered from 'catalog info' if absent
-```
-
-### Failure test labels reference
-
-| Label | Tests |
-|---|---|
-| `failure-test` | All tests in `bootstrap_failure_test.go` |
-| `failure-test && registry` | Invalid registry credentials |
-| `failure-test && catalog` | Wrong catalog password + unreachable catalog server |
-| `failure-test && validation` | `bootstrap validate` with missing Podman |
-
-## Running Catalog Failure Tests
-
-### Option 1 — Ginkgo CLI
-
-Always pass `--tags` to exclude C library dependencies.
+No special flag or filter needed. Because `--run-failure-tests` is not passed, the `BeforeEach` guard skips all 15 failure tests automatically.
 
 ```bash
-cd ai-services
+# Using make (recommended — build tags applied automatically)
+make test
 
-# Run all 5 catalog failure tests
-ginkgo -r \
-  --tags "exclude_graphdriver_btrfs containers_image_openpgp remote" \
-  --label-filter="catalog-failure" \
-  --timeout=3m \
-  ./tests/e2e
+# Using make with a JUnit report
+make test-generate-report TEST_ARGS="--timeout=3h" APP_RUNTIME=podman
 
-# Run only login/whoami failures (Tests 1, 2, 3)
-ginkgo -r \
-  --tags "exclude_graphdriver_btrfs containers_image_openpgp remote" \
-  --label-filter="catalog-failure && catalog-login" \
-  --timeout=2m \
-  ./tests/e2e
-
-# Run only configure failures (Tests 4, 5)
-ginkgo -r \
-  --tags "exclude_graphdriver_btrfs containers_image_openpgp remote" \
-  --label-filter="catalog-failure && catalog-configure" \
-  --timeout=2m \
-  ./tests/e2e
-```
-
-Pass `--runtime=podman` after `--` if the default does not match your environment:
-
-```bash
-ginkgo -r \
-  --tags "exclude_graphdriver_btrfs containers_image_openpgp remote" \
-  --label-filter="catalog-failure" \
-  --timeout=3m \
+# Using ginkgo CLI directly
+export TAGS="exclude_graphdriver_btrfs containers_image_openpgp remote"
+ginkgo -r -tags "$TAGS" \
+  --timeout=3h \
   ./tests/e2e -- --runtime=podman
 ```
 
-### Option 2 — `make test`
+> **Note**: the `--label-filter="!failure-test"` approach also works as a belt-and-braces
+> exclusion if preferred, but it is no longer required — the `BeforeEach` guard handles
+> exclusion automatically.
+
+---
+
+### Running ALL failure tests together
+
+Pass `--run-failure-tests` after `--` to unlock all three failure suites in a single pass.
 
 ```bash
-cd ai-services
+# Using make
+make test TEST_ARGS="--timeout=10m" APP_RUNTIME=podman -- --run-failure-tests
 
-make test TEST_ARGS="--label-filter=catalog-failure --timeout=3m"
-
-# With explicit runtime
-make test TEST_ARGS="--label-filter=catalog-failure --timeout=3m" APP_RUNTIME=podman
+# Using ginkgo CLI
+export TAGS="exclude_graphdriver_btrfs containers_image_openpgp remote"
+ginkgo -r -tags "$TAGS" \
+  --timeout=10m \
+  ./tests/e2e -- --runtime=podman --run-failure-tests
 ```
 
+---
+
+### Running a single failure domain
+
+Pass `--run-failure-tests` to unlock, then use a domain label to narrow.
+
+```bash
+export TAGS="exclude_graphdriver_btrfs containers_image_openpgp remote"
+
+# Bootstrap failure tests only (5 tests)
+ginkgo -r -tags "$TAGS" --label-filter="bootstrap-failure" --timeout=5m \
+  ./tests/e2e -- --runtime=podman --run-failure-tests
+
+# Catalog failure tests only (5 tests)
+ginkgo -r -tags "$TAGS" --label-filter="catalog-failure" --timeout=3m \
+  ./tests/e2e -- --runtime=podman --run-failure-tests
+
+# Similarity failure tests only (5 tests)
+ginkgo -r -tags "$TAGS" --label-filter="similarity-failure" --timeout=3m \
+  ./tests/e2e -- --app-name=<deployed-app-name> --runtime=podman --run-failure-tests
+```
+
+Or with `make test`:
+
+```bash
+make test TEST_ARGS="--label-filter=bootstrap-failure  --timeout=5m" APP_RUNTIME=podman         -- --run-failure-tests
+make test TEST_ARGS="--label-filter=catalog-failure    --timeout=3m" APP_RUNTIME=podman         -- --run-failure-tests
+make test TEST_ARGS="--label-filter=similarity-failure --timeout=3m" APP_RUNTIME=podman APP_NAME=<app> -- --run-failure-tests
+```
+
+---
+
+### Running a failure sub-category
+
+Pass `--run-failure-tests` to unlock, then use a sub-label to narrow to a specific category.
+
+```bash
+export TAGS="exclude_graphdriver_btrfs containers_image_openpgp remote"
+
+# Bootstrap — registry authentication only (Test 1)
+ginkgo -r -tags "$TAGS" --label-filter="failure-test && registry"    --timeout=2m \
+  ./tests/e2e -- --runtime=podman --run-failure-tests
+
+# Bootstrap — catalog credential / connectivity failures (Tests 2a, 2b)
+ginkgo -r -tags "$TAGS" --label-filter="failure-test && catalog"     --timeout=2m \
+  ./tests/e2e -- --runtime=podman --run-failure-tests
+
+# Bootstrap — invalid --runtime flag only (Test 3)
+ginkgo -r -tags "$TAGS" --label-filter="failure-test && validation && spyre-independent" --timeout=2m \
+  ./tests/e2e -- --runtime=podman --run-failure-tests
+
+# Bootstrap — missing Spyre accelerator card only (Test 4)
+ginkgo -r -tags "$TAGS" --label-filter="failure-test && spyre"       --timeout=2m \
+  ./tests/e2e -- --runtime=podman --run-failure-tests
+
+# Catalog — login / whoami failures only (Tests 1, 2, 3)
+ginkgo -r -tags "$TAGS" --label-filter="failure-test && catalog-login"     --timeout=2m \
+  ./tests/e2e -- --runtime=podman --run-failure-tests
+
+# Catalog — configure validation failures only (Tests 4, 5)
+ginkgo -r -tags "$TAGS" --label-filter="failure-test && catalog-configure" --timeout=2m \
+  ./tests/e2e -- --runtime=podman --run-failure-tests
+
+# Similarity — input validation failures only (Tests 1, 2, 3)
+ginkgo -r -tags "$TAGS" --label-filter="failure-test && similarity-input"        --timeout=2m \
+  ./tests/e2e -- --app-name=<app> --runtime=podman --run-failure-tests
+
+# Similarity — connectivity failure only (Test 4 — no deployed app needed)
+ginkgo -r -tags "$TAGS" --label-filter="failure-test && similarity-connectivity" --timeout=2m \
+  ./tests/e2e -- --run-failure-tests
+
+# Similarity — empty-index readiness failure (Test 5)
+ginkgo -r -tags "$TAGS" --label-filter="failure-test && similarity-readiness"    --timeout=2m \
+  ./tests/e2e -- --app-name=<app> --runtime=podman --run-failure-tests
+```
+
+---
+
+### Environment variables required by failure tests
+
+Failure tests reuse the same environment variables as the main suite. No additional variables are needed — the tests deliberately supply *wrong* values internally and only read registry/catalog URLs from the environment to know which endpoint to target.
+
+```bash
+export AI_SERVICES_BIN=<path to ai-services binary>   # required by all failure tests
+export REGISTRY_URL="icr.io"                           # used to target the correct registry endpoint
+export CATALOG_SERVER_URL="..."                        # optional — auto-discovered from 'catalog info' if absent
+```
+
+---
+
+### Failure test labels reference
+
+| Label | File | Tests |
+|---|---|---|
+| `failure-test` | all three failure files | All 15 failure tests — umbrella label |
+| `bootstrap-failure` | `bootstrap_failure_test.go` | All 5 bootstrap failure tests |
+| `catalog-failure` | `catalog_failure_test.go` | All 5 catalog failure tests |
+| `similarity-failure` | `similarity_failure_test.go` | All 5 similarity failure tests |
+| `failure-test && registry` | `bootstrap_failure_test.go` | Invalid registry credentials (Test 1) |
+| `failure-test && catalog` | `bootstrap_failure_test.go` | Wrong catalog password + unreachable server (Tests 2a, 2b) |
+| `failure-test && validation` | `bootstrap_failure_test.go` | `bootstrap validate` failures (Tests 3, 4) |
+| `failure-test && spyre` | `bootstrap_failure_test.go` | Missing Spyre accelerator card (Test 4) |
+| `failure-test && catalog-login` | `catalog_failure_test.go` | Missing flag, bad URL, whoami without login (Tests 1, 2, 3) |
+| `failure-test && catalog-configure` | `catalog_failure_test.go` | Unpaired SSL, invalid port (Tests 4, 5) |
+| `failure-test && similarity-input` | `similarity_failure_test.go` | Empty query, invalid mode, top_k=0 (Tests 1, 2, 3) |
+| `failure-test && similarity-connectivity` | `similarity_failure_test.go` | Unreachable similarity API (Test 4) |
+| `failure-test && similarity-readiness` | `similarity_failure_test.go` | Empty vector index HTTP 503 (Test 5) |
+
+---
 
 ### Adding new failure tests
 
-Follow the same component-per-file convention:
+Follow the component-per-file convention:
 
 - Bootstrap failures → `bootstrap_failure_test.go`
+- Catalog failures → `catalog_failure_test.go`
+- Similarity failures → `similarity_failure_test.go`
 - Digitization failures → `digitization_failure_test.go` *(future)*
 - Ingestion failures → `ingestion_failure_test.go` *(future)*
 
-Each failure `It()` block must:
-1. Label itself with `"failure-test"` plus a component label (e.g. `"registry"`).
-2. Assert `err` **is non-nil** (the command must fail).
-3. Call the matching `ValidateXxxFailureOutput()` function in `cli/output.go` to verify the error message is actionable.
-4. Clean up any environment changes in a `defer` block.
+Each new failure `Describe` block **must** include the `BeforeEach` guard as its first statement:
+
+```go
+ginkgo.BeforeEach(func() {
+    if !runFailureTests {
+        ginkgo.Skip(
+            "[FAILURE-TEST][Domain] Skipping — pass --run-failure-tests to opt in to failure test execution",
+        )
+    }
+})
+```
+
+Each failure `It()` block **must**:
+1. Carry **both** the `"failure-test"` umbrella label and its domain label (e.g. `"bootstrap-failure"`).
+2. Carry at least one sub-category label (e.g. `"registry"`, `"catalog-login"`).
+3. Assert `err` **is non-nil** (the command must fail).
+4. Call the matching `ValidateXxxFailureOutput()` function in `cli/output.go` to verify the error message is actionable.
+5. Clean up any environment changes in a `defer` block.
+
+Example `It()` label decoration:
+
+```go
+ginkgo.It(
+    "rejects X when Y",
+    ginkgo.Label("failure-test", "bootstrap-failure", "registry", "spyre-independent"),
+    func() { ... },
+)
+```
 
 ---
 

--- a/ai-services/tests/e2e/bootstrap_failure_test.go
+++ b/ai-services/tests/e2e/bootstrap_failure_test.go
@@ -9,15 +9,24 @@
 //
 // Labels
 //
-//	failure-test   – all tests in this file
-//	registry       – Test 1
-//	catalog        – Test 2 (both sub-cases)
-//	validation     – Test 3 and Test 4
-//	spyre          – Test 4 specifically
+//	failure-test       – all tests in this file (umbrella label, shared with all failure suites)
+//	bootstrap-failure  – all tests in this file (domain label)
+//	registry           – Test 1
+//	catalog            – Test 2 (both sub-cases)
+//	validation         – Test 3 and Test 4
+//	spyre              – Test 4 specifically
 //
-// Running only failure tests:
+// Running ALL failure tests together (all three failure suites):
 //
 //	ginkgo -r --label-filter="failure-test" ./tests/e2e
+//
+// Excluding ALL failure tests from the normal run:
+//
+//	ginkgo -r --label-filter="!failure-test" ./tests/e2e
+//
+// Running only bootstrap failure tests:
+//
+//	ginkgo -r --label-filter="bootstrap-failure" ./tests/e2e
 //
 // Running a specific category:
 //
@@ -25,10 +34,6 @@
 //	ginkgo -r --label-filter="failure-test && catalog"    ./tests/e2e
 //	ginkgo -r --label-filter="failure-test && validation" ./tests/e2e
 //	ginkgo -r --label-filter="failure-test && spyre"      ./tests/e2e
-//
-// Excluding failure tests from the normal run:
-//
-//	ginkgo -r --label-filter="!failure-test" ./tests/e2e
 package e2e
 
 import (
@@ -78,6 +83,19 @@ var _ = ginkgo.Describe("Bootstrap Failure Scenarios",
 	// self-contained and must not depend on the result of a preceding test.
 	func() {
 
+		// ── Default-exclusion guard ───────────────────────────────────────────
+		//
+		// Failure tests are skipped unless --run-failure-tests is explicitly
+		// passed.  This mirrors the --app-name guard used by Language Support
+		// Tests and prevents accidental execution during a normal suite run.
+		ginkgo.BeforeEach(func() {
+			if !runFailureTests {
+				ginkgo.Skip(
+					"[FAILURE-TEST][Bootstrap] Skipping — pass --run-failure-tests to opt in to failure test execution",
+				)
+			}
+		})
+
 		// ── Test 1: Invalid Registry Credentials ─────────────────────────────
 		//
 		// Rationale: An operator who sets the wrong REGISTRY_PASSWORD should
@@ -95,7 +113,7 @@ var _ = ginkgo.Describe("Bootstrap Failure Scenarios",
 			func() {
 				ginkgo.It(
 					"fails gracefully with invalid registry credentials",
-					ginkgo.Label("failure-test", "registry", "spyre-independent"),
+					ginkgo.Label("failure-test", "bootstrap-failure", "registry", "spyre-independent"),
 					func() {
 						// This test has only been validated on the podman runtime.
 						// Skip explicitly on openshift until ported and verified.
@@ -176,7 +194,7 @@ var _ = ginkgo.Describe("Bootstrap Failure Scenarios",
 				// 2a ── Invalid catalog credentials ───────────────────────────
 				ginkgo.It(
 					"fails gracefully with invalid catalog credentials",
-					ginkgo.Label("failure-test", "catalog", "spyre-independent"),
+					ginkgo.Label("failure-test", "bootstrap-failure", "catalog", "spyre-independent"),
 					func() {
 						if appRuntime != "podman" {
 							ginkgo.Skip(
@@ -250,7 +268,7 @@ var _ = ginkgo.Describe("Bootstrap Failure Scenarios",
 				// 2b ── Unreachable catalog server ─────────────────────────
 				ginkgo.It(
 					"fails gracefully when catalog server is unreachable",
-					ginkgo.Label("failure-test", "catalog", "spyre-independent"),
+					ginkgo.Label("failure-test", "bootstrap-failure", "catalog", "spyre-independent"),
 					func() {
 						if appRuntime != "podman" {
 							ginkgo.Skip(
@@ -315,7 +333,7 @@ var _ = ginkgo.Describe("Bootstrap Failure Scenarios",
 			func() {
 				ginkgo.It(
 					"bootstrap validate rejects an invalid --runtime flag value",
-					ginkgo.Label("failure-test", "validation", "spyre-independent"),
+					ginkgo.Label("failure-test", "bootstrap-failure", "validation", "spyre-independent"),
 					func() {
 						ctx, cancel := context.WithTimeout(
 							context.Background(),
@@ -378,7 +396,7 @@ var _ = ginkgo.Describe("Bootstrap Failure Scenarios",
 				//     GHW_CHROOT is restored in a deferred cleanup.
 				ginkgo.It(
 					"bootstrap validate reports missing Spyre accelerator card",
-					ginkgo.Label("failure-test", "validation", "spyre"),
+					ginkgo.Label("failure-test", "bootstrap-failure", "validation", "spyre"),
 					func() {
 						if appRuntime != "podman" {
 							ginkgo.Skip(

--- a/ai-services/tests/e2e/catalog_failure_test.go
+++ b/ai-services/tests/e2e/catalog_failure_test.go
@@ -28,9 +28,18 @@
 //
 // Labels
 //
-//	catalog-failure   – all tests in this file
+//	failure-test      – all tests in this file (umbrella label, shared with all failure suites)
+//	catalog-failure   – all tests in this file (domain label)
 //	catalog-login     – Tests 1, 2, 3
 //	catalog-configure – Tests 4, 5
+//
+// Running ALL failure tests together (all three failure suites):
+//
+//	ginkgo -r --label-filter="failure-test" ./tests/e2e
+//
+// Excluding ALL failure tests from the normal run:
+//
+//	ginkgo -r --label-filter="!failure-test" ./tests/e2e
 //
 // Running only catalog failure tests:
 //
@@ -38,12 +47,8 @@
 //
 // Running by sub-category:
 //
-//	ginkgo -r --label-filter="catalog-failure && catalog-login"     ./tests/e2e
-//	ginkgo -r --label-filter="catalog-failure && catalog-configure" ./tests/e2e
-//
-// Excluding catalog failure tests from the normal run:
-//
-//	ginkgo -r --label-filter="!catalog-failure" ./tests/e2e
+//	ginkgo -r --label-filter="failure-test && catalog-login"     ./tests/e2e
+//	ginkgo -r --label-filter="failure-test && catalog-configure" ./tests/e2e
 package e2e
 
 import (
@@ -73,6 +78,19 @@ var _ = ginkgo.Describe("Catalog Failure Scenarios",
 	// self-contained and must not depend on the result of a preceding test.
 	func() {
 
+		// ── Default-exclusion guard ───────────────────────────────────────────
+		//
+		// Failure tests are skipped unless --run-failure-tests is explicitly
+		// passed.  This mirrors the --app-name guard used by Language Support
+		// Tests and prevents accidental execution during a normal suite run.
+		ginkgo.BeforeEach(func() {
+			if !runFailureTests {
+				ginkgo.Skip(
+					"[FAILURE-TEST][Catalog] Skipping — pass --run-failure-tests to opt in to failure test execution",
+				)
+			}
+		})
+
 		// ── Test 1: Missing required --server flag ────────────────────────────
 		//
 		// Rationale: `catalog login` declares --server as a required cobra flag.
@@ -87,7 +105,7 @@ var _ = ginkgo.Describe("Catalog Failure Scenarios",
 			func() {
 				ginkgo.It(
 					"catalog login rejects invocation with missing --server flag",
-					ginkgo.Label("catalog-failure", "catalog-login", "spyre-independent"),
+					ginkgo.Label("failure-test", "catalog-failure", "catalog-login", "spyre-independent"),
 					func() {
 						ctx, cancel := context.WithTimeout(
 							context.Background(),
@@ -133,7 +151,7 @@ var _ = ginkgo.Describe("Catalog Failure Scenarios",
 				//   "invalid --server URL %q: scheme must be http or https"
 				ginkgo.It(
 					"catalog login rejects a --server URL with invalid scheme",
-					ginkgo.Label("catalog-failure", "catalog-login", "spyre-independent"),
+					ginkgo.Label("failure-test", "catalog-failure", "catalog-login", "spyre-independent"),
 					func() {
 						ctx, cancel := context.WithTimeout(
 							context.Background(),
@@ -184,7 +202,7 @@ var _ = ginkgo.Describe("Catalog Failure Scenarios",
 				//   "no such file or directory" OR "not logged in" OR "credentials"
 				ginkgo.It(
 					"catalog whoami fails when no credentials are stored",
-					ginkgo.Label("catalog-failure", "catalog-login", "spyre-independent"),
+					ginkgo.Label("failure-test", "catalog-failure", "catalog-login", "spyre-independent"),
 					func() {
 						ctx, cancel := context.WithTimeout(
 							context.Background(),
@@ -252,7 +270,7 @@ var _ = ginkgo.Describe("Catalog Failure Scenarios",
 				//   "--ssl-cert and --ssl-key must be used together"
 				ginkgo.It(
 					"catalog configure rejects --ssl-cert without --ssl-key",
-					ginkgo.Label("catalog-failure", "catalog-configure", "spyre-independent"),
+					ginkgo.Label("failure-test", "catalog-failure", "catalog-configure", "spyre-independent"),
 					func() {
 						// catalog configure is not supported on OpenShift — the product
 						// itself returns "openshift runtime is not yet supported for catalog
@@ -311,7 +329,7 @@ var _ = ginkgo.Describe("Catalog Failure Scenarios",
 				//   "invalid HTTPS port 0: must be between 1 and 65535"
 				ginkgo.It(
 					"catalog configure rejects an out-of-range --https-port value",
-					ginkgo.Label("catalog-failure", "catalog-configure", "spyre-independent"),
+					ginkgo.Label("failure-test", "catalog-failure", "catalog-configure", "spyre-independent"),
 					func() {
 						// Same reason as Test 4 — catalog configure is not supported on
 						// OpenShift, so the port validation error we want to assert would

--- a/ai-services/tests/e2e/e2e_suite_test.go
+++ b/ai-services/tests/e2e/e2e_suite_test.go
@@ -40,6 +40,7 @@ var (
 	providedTemplate            string
 	appRuntime                  string
 	deleteExistingApp           bool
+	runFailureTests             bool
 	tempDir                     string
 	tempBinDir                  string
 	aiServiceBin                string
@@ -77,7 +78,9 @@ func init() {
 	flag.StringVar(&providedTemplate, "template", "rag", "Template to use for application creation (rag, summarize, digitize)")
 	flag.BoolVar(&deleteExistingApp, "delete-app", false, "Delete existing app before proceeding ahead with test run")
 	flag.StringVar(&appRuntime, "runtime", "podman", "Runtime on which the app will be deployed")
-
+	flag.BoolVar(&runFailureTests, "run-failure-tests", false,
+		"Opt in to running failure test suites (bootstrap, catalog, similarity). "+
+			"Failure tests are skipped by default to prevent accidental execution during a normal suite run.")
 }
 
 func TestE2E(t *testing.T) {

--- a/ai-services/tests/e2e/rag/similarity.go
+++ b/ai-services/tests/e2e/rag/similarity.go
@@ -1,24 +1,18 @@
 // Package rag — similarity search helpers for E2E failure tests.
 //
-// This file provides PostSimilaritySearchRaw and a set of ValidateSimilarity*
-// functions used by similarity_failure_test.go.
+// PostSimilaritySearchRaw is used exclusively by TC-4 (connectivity failure)
+// in similarity_failure_test.go.  It must live here because it depends on
+// buildPostJSONRequest and sharedRAGClient, which are unexported in this package.
 //
-// Why PostSimilaritySearchRaw and not PostJSON?
-//
-//	PostJSON (evaluator.go) calls handlePostJSONResponse which discards the
-//	response body on non-200 via io.Discard.  Failure tests need to inspect the
-//	JSON error envelope {"error":{"code":"...","message":"...","status":N}} that
-//	the similarity service returns on 4xx/5xx, so a Raw variant that always
-//	returns the body is required.
+// The ValidateSimilarity* functions and parseSimilarityErrorBody have been moved
+// to the similarity package (similarity/similarity.go), which is the natural home
+// for all similarity-api response validation logic.
 package rag
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
@@ -27,13 +21,6 @@ import (
 // similaritySearchPath is the POST endpoint on the similarity service.
 const similaritySearchPath = "/v1/similarity-search"
 
-// HTTP status codes used by the similarity service validate functions.
-const (
-	httpStatusBadRequest          = 400
-	httpStatusUnprocessableEntity = 422
-	httpStatusServiceUnavailable  = 503
-)
-
 // PostSimilaritySearchRaw sends a POST to similarityBaseURL/v1/similarity-search
 // and always returns the raw HTTP status code and response body, regardless of
 // whether the request succeeded or failed.
@@ -41,9 +28,16 @@ const (
 // On a transport-level error (DNS failure, connection refused, context cancelled)
 // statusCode will be 0 and rawBody will be empty.
 //
-// Reuses buildPostJSONRequest (evaluator.go) for consistent TLS, JSON marshalling,
-// and Bearer-token handling, then drives sharedRAGClient directly so the body is
-// not discarded on non-200 responses.
+// Reuse of existing HTTP infrastructure:
+//   - buildPostJSONRequest (evaluator.go) — reused for JSON marshalling, Content-Type,
+//     Bearer-token injection, and the shared TLS-skipping transport configuration.
+//   - sharedRAGClient (evaluator.go)      — reused as the single pooled HTTP client for
+//     all RAG requests, keeping connection behaviour consistent.
+//
+// PostJSON (evaluator.go) cannot be reused here because it calls handlePostJSONResponse,
+// which discards the response body via io.Discard on non-200.  Failure tests must inspect
+// the JSON error envelope {"error":{"code":"...","message":"...","status":N}} that the
+// similarity service returns on 4xx/5xx, so the body must always be returned as-is.
 func PostSimilaritySearchRaw(
 	ctx context.Context,
 	baseURL string,
@@ -79,140 +73,3 @@ func PostSimilaritySearchRaw(
 	return resp.StatusCode, string(bodyBytes), nil
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Private helpers
-// ─────────────────────────────────────────────────────────────────────────────
-
-// similarityErrorEnvelope mirrors the JSON error shape returned by every
-// similarity service endpoint:
-//
-//	{"error":{"code":"...","message":"...","status":N}}
-type similarityErrorEnvelope struct {
-	Error struct {
-		Code    string `json:"code"`
-		Message string `json:"message"`
-		Status  int    `json:"status"`
-	} `json:"error"`
-}
-
-// parseSimilarityErrorBody decodes rawBody into the standard error envelope.
-// Returns a non-nil err if the body cannot be decoded or the envelope is empty.
-func parseSimilarityErrorBody(rawBody string) (code, message string, status int, err error) {
-	var env similarityErrorEnvelope
-	if jsonErr := json.Unmarshal([]byte(rawBody), &env); jsonErr != nil {
-		return "", "", 0, fmt.Errorf("parse similarity error envelope: %w — body: %s", jsonErr, rawBody)
-	}
-	if env.Error.Code == "" {
-		return "", "", 0, fmt.Errorf("similarity error envelope missing 'code' field — body: %s", rawBody)
-	}
-
-	return env.Error.Code, env.Error.Message, env.Error.Status, nil
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Validate* functions — one per failure scenario
-// ─────────────────────────────────────────────────────────────────────────────
-
-// ValidateSimilarityEmptyQueryError asserts that the service correctly rejected
-// an empty query with HTTP 400 and error code EMPTY_INPUT.
-func ValidateSimilarityEmptyQueryError(statusCode int, rawBody string) error {
-	if statusCode != httpStatusBadRequest {
-		return fmt.Errorf("expected HTTP 400 for empty query, got %d — body: %s", statusCode, rawBody)
-	}
-	code, message, _, err := parseSimilarityErrorBody(rawBody)
-	if err != nil {
-		return err
-	}
-	if code != "EMPTY_INPUT" {
-		return fmt.Errorf("expected error code EMPTY_INPUT, got %q — body: %s", code, rawBody)
-	}
-	if !strings.Contains(message, "query is required") {
-		return fmt.Errorf("expected message to contain %q, got %q", "query is required", message)
-	}
-
-	return nil
-}
-
-// ValidateSimilarityInvalidModeError asserts that the service correctly rejected
-// an unsupported mode value with HTTP 400 and error code INVALID_PARAMETER.
-func ValidateSimilarityInvalidModeError(statusCode int, rawBody string) error {
-	if statusCode != httpStatusBadRequest {
-		return fmt.Errorf("expected HTTP 400 for invalid mode, got %d — body: %s", statusCode, rawBody)
-	}
-	code, message, _, err := parseSimilarityErrorBody(rawBody)
-	if err != nil {
-		return err
-	}
-	if code != "INVALID_PARAMETER" {
-		return fmt.Errorf("expected error code INVALID_PARAMETER, got %q — body: %s", code, rawBody)
-	}
-	if !strings.Contains(message, "mode must be one of") {
-		return fmt.Errorf("expected message to contain %q, got %q", "mode must be one of", message)
-	}
-
-	return nil
-}
-
-// ValidateSimilarityInvalidTopKError asserts that the service correctly rejected
-// a top_k value below the minimum (ge=1) with HTTP 422 (Pydantic validation).
-//
-// FastAPI's 422 body uses {"detail":[...]} rather than the custom error envelope,
-// so this validator checks for the HTTP status and the presence of "top_k" in
-// the raw body — a shape-agnostic assertion that works for both response formats.
-func ValidateSimilarityInvalidTopKError(statusCode int, rawBody string) error {
-	if statusCode != httpStatusUnprocessableEntity {
-		return fmt.Errorf("expected HTTP 422 for invalid top_k, got %d — body: %s", statusCode, rawBody)
-	}
-	if !strings.Contains(rawBody, "top_k") {
-		return fmt.Errorf("expected response body to reference %q for top_k validation error — body: %s", "top_k", rawBody)
-	}
-
-	return nil
-}
-
-// ValidateSimilarityUnreachableError asserts that a call to an unreachable host
-// produced a transport-level error (not a structured API error).
-//
-// Checks that err is non-nil and is NOT ErrNonRetriable (which would indicate a
-// structured HTTP response was received), and that the error message contains at
-// least one of the expected connectivity-failure keywords.
-func ValidateSimilarityUnreachableError(err error) error {
-	if err == nil {
-		return errors.New("expected a transport error for unreachable similarity API, but got nil")
-	}
-	if errors.Is(err, ErrNonRetriable) {
-		return fmt.Errorf("expected transport error, got structured API error (ErrNonRetriable): %w", err)
-	}
-	msg := strings.ToLower(err.Error())
-	keywords := []string{"connection", "dial", "no such host", "i/o timeout", "context deadline exceeded"}
-	for _, kw := range keywords {
-		if strings.Contains(msg, kw) {
-			return nil
-		}
-	}
-
-	return fmt.Errorf(
-		"expected transport error to contain one of %v — got: %s",
-		keywords, err.Error(),
-	)
-}
-
-// ValidateSimilarityNotReadyError asserts that the service correctly reported an
-// empty vector index with HTTP 503 and error code VECTOR_STORE_NOT_READY.
-func ValidateSimilarityNotReadyError(statusCode int, rawBody string) error {
-	if statusCode != httpStatusServiceUnavailable {
-		return fmt.Errorf("expected HTTP 503 for empty index, got %d — body: %s", statusCode, rawBody)
-	}
-	code, message, _, err := parseSimilarityErrorBody(rawBody)
-	if err != nil {
-		return err
-	}
-	if code != "VECTOR_STORE_NOT_READY" {
-		return fmt.Errorf("expected error code VECTOR_STORE_NOT_READY, got %q — body: %s", code, rawBody)
-	}
-	if !strings.Contains(message, "Ingest documents first") {
-		return fmt.Errorf("expected message to contain %q, got %q", "Ingest documents first", message)
-	}
-
-	return nil
-}

--- a/ai-services/tests/e2e/rag/similarity.go
+++ b/ai-services/tests/e2e/rag/similarity.go
@@ -1,0 +1,204 @@
+// Package rag — similarity search helpers for E2E failure tests.
+//
+// This file provides PostSimilaritySearchRaw and a set of ValidateSimilarity*
+// functions used by similarity_failure_test.go.
+//
+// Why PostSimilaritySearchRaw and not PostJSON?
+//
+//	PostJSON (evaluator.go) calls handlePostJSONResponse which discards the
+//	response body on non-200 via io.Discard.  Failure tests need to inspect the
+//	JSON error envelope {"error":{"code":"...","message":"...","status":N}} that
+//	the similarity service returns on 4xx/5xx, so a Raw variant that always
+//	returns the body is required.
+package rag
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+)
+
+// similaritySearchPath is the POST endpoint on the similarity service.
+const similaritySearchPath = "/v1/similarity-search"
+
+// PostSimilaritySearchRaw sends a POST to similarityBaseURL/v1/similarity-search
+// and always returns the raw HTTP status code and response body, regardless of
+// whether the request succeeded or failed.
+//
+// On a transport-level error (DNS failure, connection refused, context cancelled)
+// statusCode will be 0 and rawBody will be empty.
+//
+// Reuses buildPostJSONRequest (evaluator.go) for consistent TLS, JSON marshalling,
+// and Bearer-token handling, then drives sharedRAGClient directly so the body is
+// not discarded on non-200 responses.
+func PostSimilaritySearchRaw(
+	ctx context.Context,
+	baseURL string,
+	body map[string]any,
+) (statusCode int, rawBody string, err error) {
+	req, err := buildPostJSONRequest(ctx, baseURL, similaritySearchPath, body)
+	if err != nil {
+		return 0, "", fmt.Errorf("build similarity search request: %w", err)
+	}
+
+	start := time.Now()
+	resp, err := sharedRAGClient.Do(req)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		logger.Infof("[SIM][http] POST %s%s — transport error after %s: %v",
+			baseURL, similaritySearchPath, elapsed.Round(time.Millisecond), err)
+		return 0, "", fmt.Errorf("similarity search request failed: %w", err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	bodyBytes, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return resp.StatusCode, "", fmt.Errorf("read similarity search response body: %w", readErr)
+	}
+
+	logger.Infof("[SIM][http] POST %s%s → HTTP %d in %s",
+		baseURL, similaritySearchPath, resp.StatusCode, elapsed.Round(time.Millisecond))
+
+	return resp.StatusCode, string(bodyBytes), nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Private helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// similarityErrorEnvelope mirrors the JSON error shape returned by every
+// similarity service endpoint:
+//
+//	{"error":{"code":"...","message":"...","status":N}}
+type similarityErrorEnvelope struct {
+	Error struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+		Status  int    `json:"status"`
+	} `json:"error"`
+}
+
+// parseSimilarityErrorBody decodes rawBody into the standard error envelope.
+// Returns a non-nil err if the body cannot be decoded or the envelope is empty.
+func parseSimilarityErrorBody(rawBody string) (code, message string, status int, err error) {
+	var env similarityErrorEnvelope
+	if jsonErr := json.Unmarshal([]byte(rawBody), &env); jsonErr != nil {
+		return "", "", 0, fmt.Errorf("parse similarity error envelope: %w — body: %s", jsonErr, rawBody)
+	}
+	if env.Error.Code == "" {
+		return "", "", 0, fmt.Errorf("similarity error envelope missing 'code' field — body: %s", rawBody)
+	}
+	return env.Error.Code, env.Error.Message, env.Error.Status, nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validate* functions — one per failure scenario
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ValidateSimilarityEmptyQueryError asserts that the service correctly rejected
+// an empty query with HTTP 400 and error code EMPTY_INPUT.
+func ValidateSimilarityEmptyQueryError(statusCode int, rawBody string) error {
+	if statusCode != 400 {
+		return fmt.Errorf("expected HTTP 400 for empty query, got %d — body: %s", statusCode, rawBody)
+	}
+	code, message, _, err := parseSimilarityErrorBody(rawBody)
+	if err != nil {
+		return err
+	}
+	if code != "EMPTY_INPUT" {
+		return fmt.Errorf("expected error code EMPTY_INPUT, got %q — body: %s", code, rawBody)
+	}
+	if !strings.Contains(message, "query is required") {
+		return fmt.Errorf("expected message to contain %q, got %q", "query is required", message)
+	}
+	return nil
+}
+
+// ValidateSimilarityInvalidModeError asserts that the service correctly rejected
+// an unsupported mode value with HTTP 400 and error code INVALID_PARAMETER.
+func ValidateSimilarityInvalidModeError(statusCode int, rawBody string) error {
+	if statusCode != 400 {
+		return fmt.Errorf("expected HTTP 400 for invalid mode, got %d — body: %s", statusCode, rawBody)
+	}
+	code, message, _, err := parseSimilarityErrorBody(rawBody)
+	if err != nil {
+		return err
+	}
+	if code != "INVALID_PARAMETER" {
+		return fmt.Errorf("expected error code INVALID_PARAMETER, got %q — body: %s", code, rawBody)
+	}
+	if !strings.Contains(message, "mode must be one of") {
+		return fmt.Errorf("expected message to contain %q, got %q", "mode must be one of", message)
+	}
+	return nil
+}
+
+// ValidateSimilarityInvalidTopKError asserts that the service correctly rejected
+// a top_k value below the minimum (ge=1) with HTTP 422 (Pydantic validation).
+//
+// FastAPI's 422 body uses {"detail":[...]} rather than the custom error envelope,
+// so this validator checks for the HTTP status and the presence of "top_k" in
+// the raw body — a shape-agnostic assertion that works for both response formats.
+func ValidateSimilarityInvalidTopKError(statusCode int, rawBody string) error {
+	if statusCode != 422 {
+		return fmt.Errorf("expected HTTP 422 for invalid top_k, got %d — body: %s", statusCode, rawBody)
+	}
+	if !strings.Contains(rawBody, "top_k") {
+		return fmt.Errorf("expected response body to reference %q for top_k validation error — body: %s", "top_k", rawBody)
+	}
+	return nil
+}
+
+// ValidateSimilarityUnreachableError asserts that a call to an unreachable host
+// produced a transport-level error (not a structured API error).
+//
+// Checks that err is non-nil and is NOT ErrNonRetriable (which would indicate a
+// structured HTTP response was received), and that the error message contains at
+// least one of the expected connectivity-failure keywords.
+func ValidateSimilarityUnreachableError(err error) error {
+	if err == nil {
+		return errors.New("expected a transport error for unreachable similarity API, but got nil")
+	}
+	if errors.Is(err, ErrNonRetriable) {
+		return fmt.Errorf("expected transport error, got structured API error (ErrNonRetriable): %w", err)
+	}
+	msg := strings.ToLower(err.Error())
+	keywords := []string{"connection", "dial", "no such host", "i/o timeout", "context deadline exceeded"}
+	for _, kw := range keywords {
+		if strings.Contains(msg, kw) {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"expected transport error to contain one of %v — got: %s",
+		keywords, err.Error(),
+	)
+}
+
+// ValidateSimilarityNotReadyError asserts that the service correctly reported an
+// empty vector index with HTTP 503 and error code VECTOR_STORE_NOT_READY.
+func ValidateSimilarityNotReadyError(statusCode int, rawBody string) error {
+	if statusCode != 503 {
+		return fmt.Errorf("expected HTTP 503 for empty index, got %d — body: %s", statusCode, rawBody)
+	}
+	code, message, _, err := parseSimilarityErrorBody(rawBody)
+	if err != nil {
+		return err
+	}
+	if code != "VECTOR_STORE_NOT_READY" {
+		return fmt.Errorf("expected error code VECTOR_STORE_NOT_READY, got %q — body: %s", code, rawBody)
+	}
+	if !strings.Contains(message, "Ingest documents first") {
+		return fmt.Errorf("expected message to contain %q, got %q", "Ingest documents first", message)
+	}
+	return nil
+}

--- a/ai-services/tests/e2e/rag/similarity.go
+++ b/ai-services/tests/e2e/rag/similarity.go
@@ -27,6 +27,13 @@ import (
 // similaritySearchPath is the POST endpoint on the similarity service.
 const similaritySearchPath = "/v1/similarity-search"
 
+// HTTP status codes used by the similarity service validate functions.
+const (
+	httpStatusBadRequest          = 400
+	httpStatusUnprocessableEntity = 422
+	httpStatusServiceUnavailable  = 503
+)
+
 // PostSimilaritySearchRaw sends a POST to similarityBaseURL/v1/similarity-search
 // and always returns the raw HTTP status code and response body, regardless of
 // whether the request succeeded or failed.
@@ -54,6 +61,7 @@ func PostSimilaritySearchRaw(
 	if err != nil {
 		logger.Infof("[SIM][http] POST %s%s — transport error after %s: %v",
 			baseURL, similaritySearchPath, elapsed.Round(time.Millisecond), err)
+
 		return 0, "", fmt.Errorf("similarity search request failed: %w", err)
 	}
 	defer func() {
@@ -97,6 +105,7 @@ func parseSimilarityErrorBody(rawBody string) (code, message string, status int,
 	if env.Error.Code == "" {
 		return "", "", 0, fmt.Errorf("similarity error envelope missing 'code' field — body: %s", rawBody)
 	}
+
 	return env.Error.Code, env.Error.Message, env.Error.Status, nil
 }
 
@@ -107,7 +116,7 @@ func parseSimilarityErrorBody(rawBody string) (code, message string, status int,
 // ValidateSimilarityEmptyQueryError asserts that the service correctly rejected
 // an empty query with HTTP 400 and error code EMPTY_INPUT.
 func ValidateSimilarityEmptyQueryError(statusCode int, rawBody string) error {
-	if statusCode != 400 {
+	if statusCode != httpStatusBadRequest {
 		return fmt.Errorf("expected HTTP 400 for empty query, got %d — body: %s", statusCode, rawBody)
 	}
 	code, message, _, err := parseSimilarityErrorBody(rawBody)
@@ -120,13 +129,14 @@ func ValidateSimilarityEmptyQueryError(statusCode int, rawBody string) error {
 	if !strings.Contains(message, "query is required") {
 		return fmt.Errorf("expected message to contain %q, got %q", "query is required", message)
 	}
+
 	return nil
 }
 
 // ValidateSimilarityInvalidModeError asserts that the service correctly rejected
 // an unsupported mode value with HTTP 400 and error code INVALID_PARAMETER.
 func ValidateSimilarityInvalidModeError(statusCode int, rawBody string) error {
-	if statusCode != 400 {
+	if statusCode != httpStatusBadRequest {
 		return fmt.Errorf("expected HTTP 400 for invalid mode, got %d — body: %s", statusCode, rawBody)
 	}
 	code, message, _, err := parseSimilarityErrorBody(rawBody)
@@ -139,6 +149,7 @@ func ValidateSimilarityInvalidModeError(statusCode int, rawBody string) error {
 	if !strings.Contains(message, "mode must be one of") {
 		return fmt.Errorf("expected message to contain %q, got %q", "mode must be one of", message)
 	}
+
 	return nil
 }
 
@@ -149,12 +160,13 @@ func ValidateSimilarityInvalidModeError(statusCode int, rawBody string) error {
 // so this validator checks for the HTTP status and the presence of "top_k" in
 // the raw body — a shape-agnostic assertion that works for both response formats.
 func ValidateSimilarityInvalidTopKError(statusCode int, rawBody string) error {
-	if statusCode != 422 {
+	if statusCode != httpStatusUnprocessableEntity {
 		return fmt.Errorf("expected HTTP 422 for invalid top_k, got %d — body: %s", statusCode, rawBody)
 	}
 	if !strings.Contains(rawBody, "top_k") {
 		return fmt.Errorf("expected response body to reference %q for top_k validation error — body: %s", "top_k", rawBody)
 	}
+
 	return nil
 }
 
@@ -178,6 +190,7 @@ func ValidateSimilarityUnreachableError(err error) error {
 			return nil
 		}
 	}
+
 	return fmt.Errorf(
 		"expected transport error to contain one of %v — got: %s",
 		keywords, err.Error(),
@@ -187,7 +200,7 @@ func ValidateSimilarityUnreachableError(err error) error {
 // ValidateSimilarityNotReadyError asserts that the service correctly reported an
 // empty vector index with HTTP 503 and error code VECTOR_STORE_NOT_READY.
 func ValidateSimilarityNotReadyError(statusCode int, rawBody string) error {
-	if statusCode != 503 {
+	if statusCode != httpStatusServiceUnavailable {
 		return fmt.Errorf("expected HTTP 503 for empty index, got %d — body: %s", statusCode, rawBody)
 	}
 	code, message, _, err := parseSimilarityErrorBody(rawBody)
@@ -200,5 +213,6 @@ func ValidateSimilarityNotReadyError(statusCode int, rawBody string) error {
 	if !strings.Contains(message, "Ingest documents first") {
 		return fmt.Errorf("expected message to contain %q, got %q", "Ingest documents first", message)
 	}
+
 	return nil
 }

--- a/ai-services/tests/e2e/similarity/similarity.go
+++ b/ai-services/tests/e2e/similarity/similarity.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -432,4 +433,175 @@ func ReproduceValidationError(ctx context.Context, baseURL string) (*SimilarityE
 	}
 
 	return errResp, nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Failure-path validators — used by similarity_failure_test.go
+// ─────────────────────────────────────────────────────────────────────────────
+
+// parseSimilarityErrorBody decodes rawBody into SimilarityErrorResponse.
+// Returns a non-nil err if the body cannot be decoded or Error.Code is empty.
+func parseSimilarityErrorBody(rawBody string) (*SimilarityErrorResponse, error) {
+	var env SimilarityErrorResponse
+	if err := json.Unmarshal([]byte(rawBody), &env); err != nil {
+		return nil, fmt.Errorf("parse similarity error envelope: %w — body: %s", err, rawBody)
+	}
+	if env.Error.Code == "" {
+		return nil, fmt.Errorf("similarity error envelope missing 'code' field — body: %s", rawBody)
+	}
+
+	return &env, nil
+}
+
+// ValidateSimilarityEmptyQueryError asserts that the service correctly rejected
+// an empty query with HTTP 400 and error code EMPTY_INPUT.
+func ValidateSimilarityEmptyQueryError(statusCode int, rawBody string) error {
+	if statusCode != http.StatusBadRequest {
+		return fmt.Errorf("expected HTTP 400 for empty query, got %d — body: %s", statusCode, rawBody)
+	}
+	env, err := parseSimilarityErrorBody(rawBody)
+	if err != nil {
+		return err
+	}
+	if env.Error.Code != "EMPTY_INPUT" {
+		return fmt.Errorf("expected error code EMPTY_INPUT, got %q — body: %s", env.Error.Code, rawBody)
+	}
+	if !strings.Contains(env.Error.Message, "query is required") {
+		return fmt.Errorf("expected message to contain %q, got %q", "query is required", env.Error.Message)
+	}
+
+	return nil
+}
+
+// ValidateSimilarityInvalidModeError asserts that the service correctly rejected
+// an unsupported mode value with HTTP 400 and error code INVALID_PARAMETER.
+func ValidateSimilarityInvalidModeError(statusCode int, rawBody string) error {
+	if statusCode != http.StatusBadRequest {
+		return fmt.Errorf("expected HTTP 400 for invalid mode, got %d — body: %s", statusCode, rawBody)
+	}
+	env, err := parseSimilarityErrorBody(rawBody)
+	if err != nil {
+		return err
+	}
+	if env.Error.Code != "INVALID_PARAMETER" {
+		return fmt.Errorf("expected error code INVALID_PARAMETER, got %q — body: %s", env.Error.Code, rawBody)
+	}
+	if !strings.Contains(env.Error.Message, "mode must be one of") {
+		return fmt.Errorf("expected message to contain %q, got %q", "mode must be one of", env.Error.Message)
+	}
+
+	return nil
+}
+
+// pydanticDetailEntry is one element of the FastAPI 422 {"detail":[...]} array.
+type pydanticDetailEntry struct {
+	Loc  []interface{} `json:"loc"`
+	Msg  string        `json:"msg"`
+	Type string        `json:"type"`
+}
+
+// findTopKDetailEntry searches detail entries for one whose loc contains "top_k"
+// and whose msg contains "greater than or equal to".
+// Returns an error if no matching entry is found or the message is wrong.
+func findTopKDetailEntry(details []pydanticDetailEntry) error {
+	for _, d := range details {
+		for _, loc := range d.Loc {
+			if locStr, ok := loc.(string); ok && locStr == "top_k" {
+				if !strings.Contains(d.Msg, "greater than or equal to") {
+					return fmt.Errorf("expected top_k detail msg to contain %q, got %q",
+						"greater than or equal to", d.Msg)
+				}
+
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf("expected a detail entry with loc containing %q", "top_k")
+}
+
+// parseTopK422Body unmarshals a FastAPI 422 body into a slice of pydanticDetailEntry.
+func parseTopK422Body(rawBody string) ([]pydanticDetailEntry, error) {
+	var env SimilarityErrorResponse
+	if err := json.Unmarshal([]byte(rawBody), &env); err != nil {
+		return nil, fmt.Errorf("parse 422 response body: %w — body: %s", err, rawBody)
+	}
+
+	detailBytes, err := json.Marshal(env.Detail)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshal detail field: %w — body: %s", err, rawBody)
+	}
+
+	var details []pydanticDetailEntry
+	if err := json.Unmarshal(detailBytes, &details); err != nil || len(details) == 0 {
+		return nil, fmt.Errorf("expected non-empty detail array in 422 body — body: %s", rawBody)
+	}
+
+	return details, nil
+}
+
+// ValidateSimilarityInvalidTopKError asserts that the service correctly rejected
+// a top_k value below the minimum (ge=1) with HTTP 422 (Pydantic validation).
+//
+// FastAPI 422 bodies use {"detail":[{"loc":[...],"msg":"...","type":"..."}]}
+// rather than the custom error envelope.  This validator checks:
+//   - HTTP status is 422
+//   - at least one detail entry references "top_k" in its loc array
+//   - the entry's msg contains the expected constraint phrase
+func ValidateSimilarityInvalidTopKError(statusCode int, rawBody string) error {
+	if statusCode != http.StatusUnprocessableEntity {
+		return fmt.Errorf("expected HTTP 422 for invalid top_k, got %d — body: %s", statusCode, rawBody)
+	}
+
+	details, err := parseTopK422Body(rawBody)
+	if err != nil {
+		return err
+	}
+
+	return findTopKDetailEntry(details)
+}
+
+// ValidateSimilarityUnreachableError asserts that a call to an unreachable host
+// produced a transport-level error, by checking that err is non-nil and its
+// message contains at least one known connectivity-failure keyword.
+//
+// Note: this validator is used exclusively with PostSimilaritySearchRaw (rag package),
+// which preserves raw transport errors.  Do not use with SimilaritySearchExpectingError,
+// which wraps transport errors as "request failed: %w".
+func ValidateSimilarityUnreachableError(err error) error {
+	if err == nil {
+		return errors.New("expected a transport error for unreachable similarity API, but got nil")
+	}
+	msg := strings.ToLower(err.Error())
+	keywords := []string{"connection", "dial", "no such host", "i/o timeout", "context deadline exceeded"}
+	for _, kw := range keywords {
+		if strings.Contains(msg, kw) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"expected transport error to contain one of %v — got: %s",
+		keywords, err.Error(),
+	)
+}
+
+// ValidateSimilarityNotReadyError asserts that the service correctly reported an
+// empty vector index with HTTP 503 and error code VECTOR_STORE_NOT_READY.
+func ValidateSimilarityNotReadyError(statusCode int, rawBody string) error {
+	if statusCode != http.StatusServiceUnavailable {
+		return fmt.Errorf("expected HTTP 503 for empty index, got %d — body: %s", statusCode, rawBody)
+	}
+	env, err := parseSimilarityErrorBody(rawBody)
+	if err != nil {
+		return err
+	}
+	if env.Error.Code != "VECTOR_STORE_NOT_READY" {
+		return fmt.Errorf("expected error code VECTOR_STORE_NOT_READY, got %q — body: %s", env.Error.Code, rawBody)
+	}
+	if !strings.Contains(env.Error.Message, "Ingest documents first") {
+		return fmt.Errorf("expected message to contain %q, got %q", "Ingest documents first", env.Error.Message)
+	}
+
+	return nil
 }

--- a/ai-services/tests/e2e/similarity_failure_test.go
+++ b/ai-services/tests/e2e/similarity_failure_test.go
@@ -1,0 +1,508 @@
+// This file covers similarity search FAILURE scenarios — testing that the
+// similarity service correctly rejects bad input, handles unreachable hosts,
+// and reports an empty index before any documents are ingested.
+//
+// Test cases
+//
+//  1. Empty query rejected          – HTTP 400, error code EMPTY_INPUT
+//  2. Invalid mode value rejected   – HTTP 400, error code INVALID_PARAMETER
+//  3. top_k below minimum rejected  – HTTP 422, Pydantic validation
+//  4. Unreachable similarity API    – transport-level connection error
+//  5. Empty vector index (no docs)  – HTTP 503, error code VECTOR_STORE_NOT_READY
+//
+// Runtime compatibility
+//
+//	Tests 1, 2, 3, 4  Run on BOTH podman and openshift runtimes.
+//	                  They exercise HTTP-level validation that fires independently
+//	                  of the runtime (no CLI, no Podman involvement).
+//	                  Tests 1–3 require a running similarity service endpoint;
+//	                  Test 4 uses a deliberately unreachable URL so no live
+//	                  service is needed at all.
+//
+//	Test 5            Requires a live similarity service endpoint.
+//	                  Skips gracefully when appName is empty or the similarity
+//	                  service URL cannot be resolved — absent deployment is an
+//	                  environment gap, not a code failure.
+//
+// Labels
+//
+//	failure-test             – all tests in this file (umbrella label, shared with all failure suites)
+//	similarity-failure       – all tests in this file (domain label)
+//	similarity-input         – Tests 1, 2, 3
+//	similarity-connectivity  – Test 4
+//	similarity-readiness     – Test 5
+//
+// Running ALL failure tests together (all three failure suites):
+//
+//	ginkgo -r --label-filter="failure-test" ./tests/e2e
+//
+// Excluding ALL failure tests from the normal run:
+//
+//	ginkgo -r --label-filter="!failure-test" ./tests/e2e
+//
+// Running only similarity failure tests:
+//
+//	ginkgo -r --label-filter="similarity-failure" ./tests/e2e
+//
+// Running by sub-category:
+//
+//	ginkgo -r --label-filter="failure-test && similarity-input"        ./tests/e2e
+//	ginkgo -r --label-filter="failure-test && similarity-connectivity" ./tests/e2e
+//	ginkgo -r --label-filter="failure-test && similarity-readiness"    ./tests/e2e
+package e2e
+
+import (
+	"context"
+	"time"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/tests/e2e/cli"
+	"github.com/project-ai-services/ai-services/tests/e2e/rag"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+)
+
+// similarityFailureTestTimeout caps how long any single similarity failure test
+// may run.  Tests 1–3 exercise pure HTTP validation (no vectorstore I/O), and
+// Test 4 explicitly uses an unreachable URL — both should resolve in well under
+// 30 seconds.  Critically, this timeout MUST be shorter than sharedRAGClient's
+// global httpClientTimeout (10 minutes) so that TC-4 never hangs waiting for a
+// TCP connection that will never arrive.
+const similarityFailureTestTimeout = 30 * time.Second
+
+// unreachableSimilarityURL points to a host that will never accept TCP
+// connections, used in TC-4 to exercise transport-level error handling.
+// The .invalid TLD is guaranteed by RFC 2606 to never resolve in DNS.
+const unreachableSimilarityURL = "http://similarity.invalid.ais-failure-test.example.com:9999"
+
+// invalidModeValue is a mode string that is not in the accepted set
+// ["dense", "sparse", "hybrid"], used in TC-2.
+const invalidModeValue = "invalid-mode-value"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Similarity Search Failure Scenarios
+// ─────────────────────────────────────────────────────────────────────────────
+
+var _ = ginkgo.Describe("Similarity Search Failure Scenarios",
+	// ginkgo.Ordered is intentionally NOT used here.  Each failure test is fully
+	// self-contained and must not depend on the result of a preceding test.
+	func() {
+
+		// ── Default-exclusion guard ───────────────────────────────────────────
+		//
+		// Failure tests are skipped unless --run-failure-tests is explicitly
+		// passed.  This mirrors the --app-name guard used by Language Support
+		// Tests and prevents accidental execution during a normal suite run.
+		ginkgo.BeforeEach(func() {
+			if !runFailureTests {
+				ginkgo.Skip(
+					"[FAILURE-TEST][Similarity] Skipping — pass --run-failure-tests to opt in to failure test execution",
+				)
+			}
+		})
+
+		// similarityBaseURL is resolved once per Context block by the BeforeEach
+		// below and used by TC-1, TC-2 and TC-3.  It is scoped here (not to the
+		// Describe) so it is invisible to TC-4 and TC-5 which manage their own URLs.
+		var inputValidationSimilarityURL string
+
+		// ── Tests 1, 2, 3: Input Validation Failures ─────────────────────────
+		//
+		// Rationale: These tests verify the three independent input-validation
+		// paths in the similarity service's /v1/similarity-search endpoint.
+		// All fire before the vector store is touched, so no live OpenSearch or
+		// embedding service is required — only the FastAPI process itself.
+		ginkgo.Context("Input Validation Failures",
+			func() {
+				// ── URL resolution — works for both full-suite and standalone runs ──
+				//
+				// When running as part of the full E2E suite the Application Creation
+				// It() block has already run and the similarity service is up.
+				// When running standalone with --label-filter="similarity-input" that
+				// block is skipped, so we must resolve the URL ourselves here.
+				//
+				// The similarity service URL is always resolved from 'application info'
+				// regardless of runtime — on catalog-managed podman the service is
+				// exposed as an HTTPS nip.io URL (e.g. https://similarity-api-<hash>.nip.io),
+				// NOT on localhost:<port>.  The localhost pattern only applies to judge
+				// containers that are started directly by the test suite itself.
+				//
+				// If appName is not set (no deployed application) these tests skip
+				// gracefully — missing deployment is an environment gap, not a code failure.
+				ginkgo.BeforeEach(func() {
+					// appName is always non-empty — BeforeSuite generates a name even when
+					// --app-name is not passed.  Check providedAppName (the raw flag value)
+					// to detect whether the caller targeted a real deployed application.
+					// This skips immediately (zero wait) rather than polling for 2 minutes
+					// against a non-existent auto-generated app name.
+					if providedAppName == "" {
+						ginkgo.Skip(
+							"[FAILURE-TEST][Similarity] Skipping input validation tests — " +
+								"--app-name was not provided; " +
+								"pass --app-name=<app> to target a running application",
+						)
+					}
+	
+					resolveCtx, resolveCancel := context.WithTimeout(
+						context.Background(),
+						2*time.Minute, //nolint:mnd
+					)
+					defer resolveCancel()
+	
+					infoOutput, infoErr := cli.WaitForApplicationInfoURLs(
+						resolveCtx, cfg, appName, appRuntime,
+						2*time.Minute,  //nolint:mnd — maxWait
+						15*time.Second, //nolint:mnd — pollInterval
+					)
+					if infoErr != nil {
+						ginkgo.Skip(
+							"[FAILURE-TEST][Similarity] Skipping input validation tests — " +
+								"could not resolve application info URLs: " + infoErr.Error(),
+						)
+					}
+	
+					inputValidationSimilarityURL = cli.ExtractSimilarityAPIURL(infoOutput)
+					if inputValidationSimilarityURL == "" {
+						ginkgo.Skip(
+							"[FAILURE-TEST][Similarity] Skipping input validation tests — " +
+								"similarity-api URL not found in application info output",
+						)
+					}
+	
+					logger.Infof(
+						"[FAILURE-TEST][Similarity] resolved similarity URL: %s",
+						inputValidationSimilarityURL,
+					)
+				})
+
+				// ── Test 1: Empty query ───────────────────────────────────────
+				//
+				// Rationale: A caller that accidentally sends an empty or
+				// whitespace-only query must receive a clear EMPTY_INPUT error
+				// (HTTP 400) rather than zero results or a crash.
+				//
+				// Layer exercised: app.py line 137:
+				//   if not req.query or not req.query.strip()
+				//
+				// Expected response:
+				//   HTTP 400, {"error":{"code":"EMPTY_INPUT","message":"Input cannot be empty: query is required",...}}
+				ginkgo.It(
+					"rejects an empty query with HTTP 400 EMPTY_INPUT",
+					ginkgo.Label("failure-test", "similarity-failure", "similarity-input", "spyre-independent"),
+					func() {
+						ctx, cancel := withTimeout(similarityFailureTestTimeout)
+						defer cancel()
+
+						logger.Infof("[FAILURE-TEST][Similarity] Sending empty query to %s", inputValidationSimilarityURL)
+
+						statusCode, rawBody, err := rag.PostSimilaritySearchRaw(
+							ctx,
+							inputValidationSimilarityURL,
+							map[string]any{
+								"query": "",
+								"mode":  "dense",
+							},
+						)
+
+						// ── Assertions ────────────────────────────────────────
+						// 1. No transport error — the service must have responded.
+						gomega.Expect(err).NotTo(
+							gomega.HaveOccurred(),
+							"Expected the similarity service to respond (not a transport error) for an empty query",
+						)
+
+						// 2. HTTP 400 with EMPTY_INPUT error code and expected message.
+						gomega.Expect(
+							rag.ValidateSimilarityEmptyQueryError(statusCode, rawBody),
+						).To(gomega.Succeed())
+
+						logger.Infof(
+							"[FAILURE-TEST][Similarity] Correctly rejected empty query — HTTP %d, body: %s",
+							statusCode, rawBody,
+						)
+					},
+				)
+
+				// ── Test 2: Invalid mode value ────────────────────────────────
+				//
+				// Rationale: The mode field only accepts "dense", "sparse", or
+				// "hybrid".  A typo or undocumented value must be rejected with a
+				// clear INVALID_PARAMETER error (HTTP 400) rather than silently
+				// defaulting to another mode.
+				//
+				// Layer exercised: app.py line 140:
+				//   if req.mode not in ["dense", "sparse", "hybrid"]
+				//
+				// Expected response:
+				//   HTTP 400, {"error":{"code":"INVALID_PARAMETER","message":"...mode must be one of...",...}}
+				ginkgo.It(
+					"rejects an unsupported mode value with HTTP 400 INVALID_PARAMETER",
+					ginkgo.Label("failure-test", "similarity-failure", "similarity-input", "spyre-independent"),
+					func() {
+						ctx, cancel := withTimeout(similarityFailureTestTimeout)
+						defer cancel()
+
+						logger.Infof(
+							"[FAILURE-TEST][Similarity] Sending invalid mode %q to %s",
+							invalidModeValue, inputValidationSimilarityURL,
+						)
+
+						statusCode, rawBody, err := rag.PostSimilaritySearchRaw(
+							ctx,
+							inputValidationSimilarityURL,
+							map[string]any{
+								"query": "what is IBM Power?",
+								"mode":  invalidModeValue,
+							},
+						)
+
+						// ── Assertions ────────────────────────────────────────
+						gomega.Expect(err).NotTo(
+							gomega.HaveOccurred(),
+							"Expected the similarity service to respond for an invalid mode value",
+						)
+
+						gomega.Expect(
+							rag.ValidateSimilarityInvalidModeError(statusCode, rawBody),
+						).To(gomega.Succeed())
+
+						logger.Infof(
+							"[FAILURE-TEST][Similarity] Correctly rejected invalid mode — HTTP %d, body: %s",
+							statusCode, rawBody,
+						)
+					},
+				)
+
+				// ── Test 3: top_k below minimum (Pydantic 422) ───────────────
+				//
+				// Rationale: The top_k field has a ge=1 Pydantic constraint.
+				// Passing top_k=0 would cause OpenSearch to crash on a size=0
+				// query; the Pydantic guard must catch this at the FastAPI
+				// boundary before any downstream code runs.
+				//
+				// Layer exercised: SimilaritySearchRequest.top_k Field(ge=1)
+				// — fires as a Pydantic RequestValidationError before the
+				// endpoint handler is called.
+				//
+				// Expected response: HTTP 422 with body referencing "top_k".
+				// Note: FastAPI 422 bodies use {"detail":[...]} (not the custom
+				// error envelope), so we check for HTTP 422 and the "top_k"
+				// field name in the raw body.
+				ginkgo.It(
+					"rejects top_k=0 with HTTP 422 Pydantic validation error",
+					ginkgo.Label("failure-test", "similarity-failure", "similarity-input", "spyre-independent"),
+					func() {
+						ctx, cancel := withTimeout(similarityFailureTestTimeout)
+						defer cancel()
+
+						logger.Infof(
+							"[FAILURE-TEST][Similarity] Sending top_k=0 to %s",
+							inputValidationSimilarityURL,
+						)
+
+						statusCode, rawBody, err := rag.PostSimilaritySearchRaw(
+							ctx,
+							inputValidationSimilarityURL,
+							map[string]any{
+								"query": "what is IBM Power?",
+								"mode":  "dense",
+								"top_k": 0,
+							},
+						)
+
+						// ── Assertions ────────────────────────────────────────
+						gomega.Expect(err).NotTo(
+							gomega.HaveOccurred(),
+							"Expected the similarity service to respond for top_k=0",
+						)
+
+						gomega.Expect(
+							rag.ValidateSimilarityInvalidTopKError(statusCode, rawBody),
+						).To(gomega.Succeed())
+
+						logger.Infof(
+							"[FAILURE-TEST][Similarity] Correctly rejected top_k=0 — HTTP %d, body: %s",
+							statusCode, rawBody,
+						)
+					},
+				)
+			},
+		)
+
+		// ── Test 4: Connectivity Failure ──────────────────────────────────────
+		//
+		// Rationale: When the similarity service is completely unreachable (e.g.
+		// not deployed, wrong host, network partition) callers must receive an
+		// immediate transport-level error — not a timeout hang or silent result.
+		// This test exercises the HTTP client's error path directly, independently
+		// of any deployed service.
+		//
+		// The context timeout (similarityFailureTestTimeout = 30s) is deliberately
+		// shorter than sharedRAGClient's 10-minute global timeout.  This guarantees
+		// that DNS failure or TCP connection refusal causes a rapid context-
+		// deadline-exceeded error rather than a 10-minute hang.
+		ginkgo.Context("Connectivity Failures",
+			func() {
+				ginkgo.It(
+					"returns a transport error when the similarity API is unreachable",
+					ginkgo.Label("failure-test", "similarity-failure", "similarity-connectivity", "spyre-independent"),
+					func() {
+						// Context timeout MUST be shorter than sharedRAGClient.Timeout
+						// (10 minutes) so the test never hangs on DNS/TCP failure.
+						ctx, cancel := withTimeout(similarityFailureTestTimeout)
+						defer cancel()
+
+						logger.Infof(
+							"[FAILURE-TEST][Similarity] Attempting request to unreachable URL: %s",
+							unreachableSimilarityURL,
+						)
+
+						_, _, transportErr := rag.PostSimilaritySearchRaw(
+							ctx,
+							unreachableSimilarityURL,
+							map[string]any{
+								"query": "what is IBM Power?",
+								"mode":  "dense",
+							},
+						)
+
+						// ── Assertions ────────────────────────────────────────
+						// Validate that the error is a transport-level failure
+						// (not a structured API response wrapped as ErrNonRetriable).
+						gomega.Expect(
+							rag.ValidateSimilarityUnreachableError(transportErr),
+						).To(gomega.Succeed())
+
+						logger.Infof(
+							"[FAILURE-TEST][Similarity] Correctly received transport error for unreachable URL. Error: %v",
+							transportErr,
+						)
+					},
+				)
+			},
+		)
+
+		// ── Test 5: Service Readiness Failure ─────────────────────────────────
+		//
+		// Rationale: A freshly deployed stack with no ingested documents must
+		// return HTTP 503 VECTOR_STORE_NOT_READY rather than a silent empty
+		// result list.  This is the most common out-of-the-box failure operators
+		// encounter after first deployment.
+		//
+		// Layer exercised: app.py lines 176–177:
+		//   except db.VectorStoreNotReadyError:
+		//       APIError.raise_error(ErrorCode.VECTOR_STORE_NOT_READY,
+		//                            "Index is empty. Ingest documents first.")
+		//
+		// Skip conditions (environment gap, not a code failure):
+		//   • appName is empty — no application deployed
+		//   • similarity-api URL cannot be resolved from application info
+		ginkgo.Context("Service Readiness Failures",
+			func() {
+				ginkgo.It(
+					"returns HTTP 503 VECTOR_STORE_NOT_READY when the index is empty",
+					ginkgo.Label("failure-test", "similarity-failure", "similarity-readiness"),
+					func() {
+						// Guard: --app-name must be explicitly provided.  appName is always
+						// non-empty (BeforeSuite generates one), so check providedAppName to
+						// skip immediately when no real deployed app is targeted.
+						if providedAppName == "" {
+							ginkgo.Skip(
+								"[FAILURE-TEST][Similarity] Skipping VECTOR_STORE_NOT_READY test — " +
+									"--app-name was not provided; " +
+									"pass --app-name=<app> to target an existing application",
+							)
+						}
+
+						logger.Infof(
+							"[FAILURE-TEST][Similarity] Resolving similarity-api URL for app %q",
+							appName,
+						)
+
+						// Resolve the similarity-api URL with a short cap (2 min) so the
+						// failure test does not block for the suite's full 8-minute default.
+						resolveCtx, resolveCancel := context.WithTimeout(
+							context.Background(),
+							2*time.Minute, //nolint:mnd
+						)
+						defer resolveCancel()
+
+						infoOutput, infoErr := cli.WaitForApplicationInfoURLs(
+							resolveCtx, cfg, appName, appRuntime,
+							2*time.Minute,  //nolint:mnd — maxWait
+							15*time.Second, //nolint:mnd — pollInterval
+						)
+						if infoErr != nil {
+							ginkgo.Skip(
+								"[FAILURE-TEST][Similarity] Skipping VECTOR_STORE_NOT_READY test — " +
+									"could not resolve application info URLs: " + infoErr.Error(),
+							)
+						}
+
+						similarityBaseURL := cli.ExtractSimilarityAPIURL(infoOutput)
+						if similarityBaseURL == "" {
+							ginkgo.Skip(
+								"[FAILURE-TEST][Similarity] Skipping VECTOR_STORE_NOT_READY test — " +
+									"similarity-api URL not found in application info output",
+							)
+						}
+
+						logger.Infof(
+							"[FAILURE-TEST][Similarity] Resolved similarity-api URL: %s",
+							similarityBaseURL,
+						)
+
+						ctx, cancel := withTimeout(similarityFailureTestTimeout)
+						defer cancel()
+	
+						statusCode, rawBody, err := rag.PostSimilaritySearchRaw(
+							ctx,
+							similarityBaseURL,
+							map[string]any{
+								"query": "what is IBM Power?",
+								"mode":  "dense",
+							},
+						)
+	
+						// ── Assertions ────────────────────────────────────────
+						// Transport error means the service is unreachable — different
+						// failure mode, not the empty-index scenario we are testing.
+						gomega.Expect(err).NotTo(
+							gomega.HaveOccurred(),
+							"Expected the similarity service to respond (not a transport error) for empty-index test",
+						)
+	
+						// Skip when the OpenSearch vector index is not empty (HTTP 200).
+						// TC-5 validates the VECTOR_STORE_NOT_READY path which only fires
+						// before any vectors have been written to OpenSearch.
+						//
+						// IMPORTANT: deleting documents via the digitize API does NOT clear
+						// the OpenSearch vector index — the two stores are independent.
+						// HTTP 200 here means vectors are still present in OpenSearch even
+						// if all source documents have been deleted from the document store.
+						// The only reliable way to get a true empty index is to use a
+						// brand-new application that has never had any documents ingested.
+						if statusCode == 200 {
+							ginkgo.Skip(
+								"[FAILURE-TEST][Similarity] Skipping VECTOR_STORE_NOT_READY test — " +
+									"the OpenSearch vector index is not empty (HTTP 200 returned); " +
+									"note: deleting documents via the digitize API does NOT clear the vector index — " +
+									"run this test against a brand-new application that has never had documents ingested",
+							)
+						}
+	
+						gomega.Expect(
+							rag.ValidateSimilarityNotReadyError(statusCode, rawBody),
+						).To(gomega.Succeed())
+	
+						logger.Infof(
+							"[FAILURE-TEST][Similarity] Correctly reported empty index — HTTP %d, body: %s",
+							statusCode, rawBody,
+						)
+					},
+				)
+			},
+		)
+	},
+)

--- a/ai-services/tests/e2e/similarity_failure_test.go
+++ b/ai-services/tests/e2e/similarity_failure_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/tests/e2e/cli"
 	"github.com/project-ai-services/ai-services/tests/e2e/rag"
+	"github.com/project-ai-services/ai-services/tests/e2e/similarity"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	gomega "github.com/onsi/gomega"
@@ -67,7 +68,7 @@ import (
 // may run.  Tests 1–3 exercise pure HTTP validation (no vectorstore I/O), and
 // Test 4 explicitly uses an unreachable URL — both should resolve in well under
 // 30 seconds.  Critically, this timeout MUST be shorter than sharedRAGClient's
-// global httpClientTimeout (10 minutes) so that TC-4 never hangs waiting for a
+// global httpClientTimeout (25 minutes) so that TC-4 never hangs waiting for a
 // TCP connection that will never arrive.
 const similarityFailureTestTimeout = 30 * time.Second
 
@@ -214,7 +215,7 @@ var _ = ginkgo.Describe("Similarity Search Failure Scenarios",
 
 						// 2. HTTP 400 with EMPTY_INPUT error code and expected message.
 						gomega.Expect(
-							rag.ValidateSimilarityEmptyQueryError(statusCode, rawBody),
+							similarity.ValidateSimilarityEmptyQueryError(statusCode, rawBody),
 						).To(gomega.Succeed())
 
 						logger.Infof(
@@ -264,7 +265,7 @@ var _ = ginkgo.Describe("Similarity Search Failure Scenarios",
 						)
 
 						gomega.Expect(
-							rag.ValidateSimilarityInvalidModeError(statusCode, rawBody),
+							similarity.ValidateSimilarityInvalidModeError(statusCode, rawBody),
 						).To(gomega.Succeed())
 
 						logger.Infof(
@@ -318,7 +319,7 @@ var _ = ginkgo.Describe("Similarity Search Failure Scenarios",
 						)
 
 						gomega.Expect(
-							rag.ValidateSimilarityInvalidTopKError(statusCode, rawBody),
+							similarity.ValidateSimilarityInvalidTopKError(statusCode, rawBody),
 						).To(gomega.Succeed())
 
 						logger.Infof(
@@ -339,9 +340,9 @@ var _ = ginkgo.Describe("Similarity Search Failure Scenarios",
 		// of any deployed service.
 		//
 		// The context timeout (similarityFailureTestTimeout = 30s) is deliberately
-		// shorter than sharedRAGClient's 10-minute global timeout.  This guarantees
+		// shorter than sharedRAGClient's 25-minute global timeout.  This guarantees
 		// that DNS failure or TCP connection refusal causes a rapid context-
-		// deadline-exceeded error rather than a 10-minute hang.
+		// deadline-exceeded error rather than a 25-minute hang.
 		ginkgo.Context("Connectivity Failures",
 			func() {
 				ginkgo.It(
@@ -349,7 +350,7 @@ var _ = ginkgo.Describe("Similarity Search Failure Scenarios",
 					ginkgo.Label("failure-test", "similarity-failure", "similarity-connectivity", "spyre-independent"),
 					func() {
 						// Context timeout MUST be shorter than sharedRAGClient.Timeout
-						// (10 minutes) so the test never hangs on DNS/TCP failure.
+						// (25 minutes) so the test never hangs on DNS/TCP failure.
 						ctx, cancel := withTimeout(similarityFailureTestTimeout)
 						defer cancel()
 
@@ -371,7 +372,7 @@ var _ = ginkgo.Describe("Similarity Search Failure Scenarios",
 						// Validate that the error is a transport-level failure
 						// (not a structured API response wrapped as ErrNonRetriable).
 						gomega.Expect(
-							rag.ValidateSimilarityUnreachableError(transportErr),
+							similarity.ValidateSimilarityUnreachableError(transportErr),
 						).To(gomega.Succeed())
 
 						logger.Infof(
@@ -493,7 +494,7 @@ var _ = ginkgo.Describe("Similarity Search Failure Scenarios",
 						}
 	
 						gomega.Expect(
-							rag.ValidateSimilarityNotReadyError(statusCode, rawBody),
+							similarity.ValidateSimilarityNotReadyError(statusCode, rawBody),
 						).To(gomega.Succeed())
 	
 						logger.Infof(


### PR DESCRIPTION
Adding Similarity Failure testcases
Adding support to exclude all Failure testcases from e2e test suite.
We should pass "run-failure-tests" flag when running any failure testcases.   By default it is false, so e2e test can exclude all failure testcases. 
README.md file is updated showing how to use this new flag.

Ran all failure testcases (bootstrap, catalog and similarity) again with the new flag and also the e2e test suite. The result file is attached. I did not attach full e2e test file output, but the failure testcase runs are the complete output.