### PR TITLE
fix: set nginx worker_processes to fixed value to prevent OOMKill

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.228
+TAG?=v0.0.229
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -2,7 +2,7 @@ ui:
   # @description Host port for the RAG UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.49
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.50
 
 backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
@@ -28,7 +28,7 @@ digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.30
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.31
 
 ingest:
   # @hidden

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -1,6 +1,6 @@
 ui:
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.49
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.50
 
 backend:
   # @hidden
@@ -34,7 +34,7 @@ digitize:
 
 digitizeUi:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.30
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.31
 
 instruct:
   # @description API key for vLLM instruct service authentication. If empty, authentication is disabled. Provide a key to enable authentication.

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -2,7 +2,7 @@ ui:
   # @description Host port for the RAG UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.49
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.50
 
 backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
@@ -28,7 +28,7 @@ digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.30
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.31
 
 ingest:
   # @hidden

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -1,6 +1,6 @@
 ui:
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.49
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.50
 
 backend:
   # @hidden
@@ -34,7 +34,7 @@ digitize:
 
 digitizeUi:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.30
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.31
 
 instruct:
   # @hidden

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -2,7 +2,7 @@ ui:
   # @description Host port for the RAG UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.49
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.50
 
 backend:
   # @description Host port for the OpenAI-compatible RAG service. Defaults to unexposed; assign a port to enable external access.
@@ -28,7 +28,7 @@ digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.30
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.31
 
 ingest:
   # @hidden

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -1,5 +1,5 @@
 ui:
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.49
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.50
   resources:
     requests:
       memory: "512Mi"
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.228
+  image: icr.io/ai-services-cicd/ai-services:v0.0.229
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,10 +1,10 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.49
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.50
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.228
+  image: icr.io/ai-services-cicd/ai-services:v0.0.229
   runtime: ""
   adminPasswordHash: ""
   podman:

--- a/ai-services/assets/services/chat/openshift/values.yaml
+++ b/ai-services/assets/services/chat/openshift/values.yaml
@@ -1,5 +1,5 @@
 ui:
-  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.49
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.50
   resources:
     requests:
       memory: "512Mi"

--- a/ai-services/assets/services/chat/podman/values.yaml
+++ b/ai-services/assets/services/chat/podman/values.yaml
@@ -1,6 +1,6 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.49
+  image: icr.io/ai-services-cicd/chatbot-ui:v0.0.50
 
 backend:
   port: ""

--- a/ai-services/assets/services/digitize/openshift/values.yaml
+++ b/ai-services/assets/services/digitize/openshift/values.yaml
@@ -12,7 +12,7 @@ digitize:
       memory: "50Gi"
 
 digitizeUi:
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.30
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.31
   resources:
     requests:
       cpu: "50m"

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -4,7 +4,7 @@ digitize:
   database: "digitize_metadata"
 
 digitizeUi:
-  image: icr.io/ai-services-cicd/digitize-ui:v0.0.30
+  image: icr.io/ai-services-cicd/digitize-ui:v0.0.31
 
 postgres:
   image: icr.io/ai-services-cicd/postgres:18-4

--- a/ui/catalog/Makefile
+++ b/ui/catalog/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= catalog-ui
-TAG ?= v0.0.49
+TAG ?= v0.0.50
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/catalog/nginx.conf.tmpl
+++ b/ui/catalog/nginx.conf.tmpl
@@ -1,10 +1,10 @@
-worker_processes auto;
+worker_processes 2;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /tmp/nginx.pid;
 
 events {
-    worker_connections 1024;
+    worker_connections 256;
 }
 
 http {

--- a/ui/chatbot/Makefile
+++ b/ui/chatbot/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=chatbot-ui
-TAG?=v0.0.49
+TAG?=v0.0.50
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER?=podman

--- a/ui/chatbot/nginx.conf.tmpl
+++ b/ui/chatbot/nginx.conf.tmpl
@@ -1,11 +1,11 @@
-worker_processes  auto;
+worker_processes 1;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /tmp/nginx.pid;
 
 
 events {
-    worker_connections  1024;
+    worker_connections 256;
 }
 
 

--- a/ui/digitize/Makefile
+++ b/ui/digitize/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= digitize-ui
-TAG ?= v0.0.30
+TAG ?= v0.0.31
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/digitize/nginx.conf.tmpl
+++ b/ui/digitize/nginx.conf.tmpl
@@ -1,10 +1,10 @@
-worker_processes auto;
+worker_processes 1;
 
 error_log  /var/log/nginx/error.log warn;
 pid        /tmp/nginx.pid;
 
 events {
-    worker_connections 1024;
+    worker_connections 256;
 }
 
 http {


### PR DESCRIPTION
nginx worker_processes auto reads /proc/cpuinfo (node CPU count) instead of the pod's cpu limit, causing pods to spawn 48 worker processes on a 48-vCPU node and get OOMKilled.

Set worker_processes to a fixed value aligned with each pod's cpu limit:
- catalog (500m limit): 2
- chatbot (50m limit):  1
- digitize (50m limit): 1

Also reduced worker_connections from 1024 to 256 to match the reduced worker footprint.