### PR TITLE
Integrate Manage IQ token authentication logic

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.240
+TAG?=v0.0.241
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.240
+  image: icr.io/ai-services-cicd/ai-services:v0.0.241
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.240
+  image: icr.io/ai-services-cicd/ai-services:v0.0.241
   runtime: ""
   adminPasswordHash: ""
   # workerGatewayPort: port for the gRPC worker gateway. Always active; default is 9090.

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -15,8 +15,8 @@ backend:
 
 db:
   port: ""
-  image: icr.io/ai-services-cicd/postgres:18-4
-  user: "postgres"
+  image: icr.io/ai-services/postgres:18-3
+  user: "admin"
   database: "ai_services"
   password: ""
   resources:
@@ -26,6 +26,12 @@ db:
       memory: "1Gi"
 
 caddy:
-  image: icr.io/ai-services-cicd/caddy:v2.11.4-1
+  image: icr.io/ai-services/caddy:v2.11.4-0
   adminPort: ""
+  # @description HTTPS port for caddy. Set by configure command via --https-port flag.
   httpsPort: ""
+
+manageiq:
+  url: ""
+  insecureFlag: ""
+  token: ""

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -15,8 +15,8 @@ backend:
 
 db:
   port: ""
-  image: icr.io/ai-services/postgres:18-3
-  user: "admin"
+  image: icr.io/ai-services-cicd/postgres:18-4
+  user: "postgres"
   database: "ai_services"
   password: ""
   resources:
@@ -26,12 +26,6 @@ db:
       memory: "1Gi"
 
 caddy:
-  image: icr.io/ai-services/caddy:v2.11.4-0
+  image: icr.io/ai-services-cicd/caddy:v2.11.4-1
   adminPort: ""
-  # @description HTTPS port for caddy. Set by configure command via --https-port flag.
   httpsPort: ""
-
-manageiq:
-  url: ""
-  insecureFlag: ""
-  token: ""

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/miq"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
@@ -70,7 +71,7 @@ func getOrGenerateSecretKey() (string, error) {
 // buildAPIServerOptions wires all service dependencies and returns the options
 // needed to start the API server. pool.Close() and the returned cleanup func
 // must be called by the caller.
-func buildAPIServerOptions(ctx context.Context, pool *pgxpool.Pool, secretKey, adminUser, adminPassHash string, accessTTL, refreshTTL time.Duration, workerGatewayPort int) (apiserver.APIServerOptions, func(), error) {
+func buildAPIServerOptions(ctx context.Context, pool *pgxpool.Pool, secretKey, adminUser, adminPassHash string, accessTTL, refreshTTL time.Duration, workerGatewayPort int, manageiqURL string, manageiqInsecure bool) (apiserver.APIServerOptions, func(), error) {
 	userRepo := apirepository.NewInMemoryUserRepoWithAdminHash("uid_1", adminUser, "Admin", adminPassHash)
 	tokenBlacklistRepo := repository.NewTokenBlacklistRepository(pool)
 	blacklist := apirepository.NewDBTokenBlacklist(tokenBlacklistRepo)
@@ -100,9 +101,19 @@ func buildAPIServerOptions(ctx context.Context, pool *pgxpool.Pool, secretKey, a
 	workerRepo := repository.NewWorkerRepository(pool)
 	workerReg := workerregistry.New(workerRepo)
 
+	var authSvc auth.Service
+	if manageiqURL != "" {
+		logger.Infof("ManageIQ integration enabled: %s (insecure TLS: %v)\n", manageiqURL, manageiqInsecure)
+		miqClient := miq.NewHTTPClient(manageiqURL, manageiqInsecure)
+		authSvc = auth.NewAuthServiceWithMIQ(userRepo, tokenMgr, blacklist, miqClient)
+	} else {
+		logger.Infoln("ManageIQ integration disabled: using local admin credentials")
+		authSvc = auth.NewAuthService(userRepo, tokenMgr, blacklist)
+	}
+
 	opts := apiserver.APIServerOptions{
 		Port:               0, // set by caller
-		AuthService:        auth.NewAuthService(userRepo, tokenMgr, blacklist),
+		AuthService:        authSvc,
 		TokenManager:       tokenMgr,
 		Blacklist:          blacklist,
 		ApplicationService: apirepository.NewApplicationService(appRepo, svcRepo, compRepo, svcDepRepo, catalogProvider, vars.RuntimeFactory.GetRuntimeType()),
@@ -120,7 +131,7 @@ func buildAPIServerOptions(ctx context.Context, pool *pgxpool.Pool, secretKey, a
 }
 
 // runAPIServer initializes and starts the API server with the provided configuration.
-func runAPIServer(port int, accessTTL, refreshTTL time.Duration, adminUser, adminPassHash string, workerGatewayPort int) error {
+func runAPIServer(port int, accessTTL, refreshTTL time.Duration, adminUser, adminPassHash string, workerGatewayPort int, manageiqURL string, manageiqInsecure bool) error {
 	secretKey, err := getOrGenerateSecretKey()
 	if err != nil {
 		return err
@@ -143,7 +154,7 @@ func runAPIServer(port int, accessTTL, refreshTTL time.Duration, adminUser, admi
 	defer pool.Close()
 	logger.Infoln("Connected to database successfully")
 
-	opts, cleanup, err := buildAPIServerOptions(ctx, pool, secretKey, adminUser, adminPassHash, accessTTL, refreshTTL, workerGatewayPort)
+	opts, cleanup, err := buildAPIServerOptions(ctx, pool, secretKey, adminUser, adminPassHash, accessTTL, refreshTTL, workerGatewayPort, manageiqURL, manageiqInsecure)
 	if err != nil {
 		return err
 	}
@@ -157,10 +168,12 @@ func runAPIServer(port int, accessTTL, refreshTTL time.Duration, adminUser, admi
 func NewAPIServerCmd() *cobra.Command {
 	var (
 		port                   = 8080
-		defaultAccessTokenTTL  = time.Minute * 15
+		defaultAccessTokenTTL  = time.Minute * 9  // kept below ManageIQ default token_ttl of 600s
 		defaultRefreshTokenTTL = time.Hour * 24 * 1
 		adminUserName          string
 		adminPasswordHash      string
+		manageiqURL            string
+		manageiqInsecure       bool
 		runtimeType            string
 		workerGatewayPort      int
 	)
@@ -169,29 +182,24 @@ func NewAPIServerCmd() *cobra.Command {
 		Use:   "apiserver",
 		Short: "Manage AI Services API server",
 		Long:  `Start the AI Services API server to provide REST endpoints for managing applications, services, and authentication.`,
-		Example: `  # Start the API server with default settings
+		Example: `  # Start with local admin credentials (no ManageIQ)
 	 ai-services catalog apiserver --admin-password-hash <PASSWORD_HASH> --runtime podman
 
-	 # Start the API server on a custom port
-	 ai-services catalog apiserver --port 9090 --admin-password-hash <PASSWORD_HASH> --runtime podman
+	 # Start pointing at a ManageIQ instance (Flow A + Flow B enabled)
+	 ai-services catalog apiserver --manageiq-url https://9.20.202.144:8443 --manageiq-insecure-tls --runtime podman
 
-	 # Start with custom admin username
-	 ai-services catalog apiserver --admin-username myadmin --admin-password-hash <PASSWORD_HASH> --runtime podman
-
-	 # Start with custom token TTL settings
-	 ai-services catalog apiserver --access-token-ttl 30m --refresh-token-ttl 48h --admin-password-hash <PASSWORD_HASH> --runtime podman
-
-	 # Start with all custom settings
-	 ai-services catalog apiserver --port 9090 --admin-username myadmin --admin-password-hash <PASSWORD_HASH> --access-token-ttl 30m --refresh-token-ttl 48h --runtime podman
+	 # Start on a custom port with ManageIQ
+	 ai-services catalog apiserver --port 9090 --manageiq-url https://miq.example.com --runtime podman
 
 Note:
   - Requires database connection via environment variables (DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME)
-  - AUTH_JWT_SECRET environment variable is recommended for production use`,
+  - AUTH_JWT_SECRET environment variable is recommended for production use
+  - When --manageiq-url is set, --admin-password-hash is ignored for authentication`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return common.InitAndValidateRuntimeFlag(runtimeType)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runAPIServer(port, defaultAccessTokenTTL, defaultRefreshTokenTTL, adminUserName, adminPasswordHash, workerGatewayPort)
+			return runAPIServer(port, defaultAccessTokenTTL, defaultRefreshTokenTTL, adminUserName, adminPasswordHash, workerGatewayPort, manageiqURL, manageiqInsecure)
 		},
 	}
 
@@ -201,6 +209,8 @@ Note:
 	apiserverCmd.Flags().StringVar(&adminUserName, "admin-username", "admin", "Username for the default admin user")
 	apiserverCmd.Flags().StringVar(&adminPasswordHash, "admin-password-hash", "", "Precomputed hash of the password for the default admin user")
 	apiserverCmd.Flags().IntVar(&workerGatewayPort, "workergateway-port", defaultWorkerGatewayPort, "Port for the gRPC worker gateway (always active, default 9090)")
+	apiserverCmd.Flags().StringVar(&manageiqURL, "manageiq-url", "", "ManageIQ base URL for AuthN/AuthZ, e.g. https://9.20.202.144:8443 (enables Flow A + Flow B)")
+	apiserverCmd.Flags().BoolVar(&manageiqInsecure, "manageiq-insecure-tls", false, "Skip TLS verification for ManageIQ (self-signed certs)")
 	common.ConfigureRuntimeFlag(apiserverCmd, &runtimeType)
 
 	return apiserverCmd

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -107,7 +107,7 @@ func buildAPIServerOptions(ctx context.Context, pool *pgxpool.Pool, secretKey, a
 		miqClient := miq.NewHTTPClient(manageiqURL, manageiqInsecure)
 		authSvc = auth.NewAuthServiceWithMIQ(userRepo, tokenMgr, blacklist, miqClient)
 	} else {
-		logger.Infoln("ManageIQ integration disabled: using local admin credentials")
+		logger.Infoln("Using the default auth service")
 		authSvc = auth.NewAuthService(userRepo, tokenMgr, blacklist)
 	}
 
@@ -167,8 +167,9 @@ func runAPIServer(port int, accessTTL, refreshTTL time.Duration, adminUser, admi
 
 func NewAPIServerCmd() *cobra.Command {
 	var (
-		port                   = 8080
-		defaultAccessTokenTTL  = time.Minute * 9  // kept below ManageIQ default token_ttl of 600s
+		port = 8080
+		// TODO: ManageIQ sessions default to a 600s token TTL; the defaultAccessTokenTTL may need to be aligned when ManageIQ support is formalised.
+		defaultAccessTokenTTL  = time.Minute * 15
 		defaultRefreshTokenTTL = time.Hour * 24 * 1
 		adminUserName          string
 		adminPasswordHash      string

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -214,7 +214,7 @@ Note:
 	apiserverCmd.Flags().StringVar(&adminUserName, "admin-username", "admin", "Username for the default admin user")
 	apiserverCmd.Flags().StringVar(&adminPasswordHash, "admin-password-hash", "", "Precomputed hash of the password for the default admin user")
 	apiserverCmd.Flags().IntVar(&workerGatewayPort, "workergateway-port", defaultWorkerGatewayPort, "Port for the gRPC worker gateway (always active, default 9090)")
-	apiserverCmd.Flags().StringVar(&manageiqURL, "manageiq-url", "", "ManageIQ base URL for AuthN/AuthZ, e.g. https://9.20.202.144:8443 (enables Flow A + Flow B)")
+	apiserverCmd.Flags().StringVar(&manageiqURL, "manageiq-url", "", "ManageIQ base URL for AuthN/AuthZ, e.g. https://9.20.202.144:8443")
 	apiserverCmd.Flags().BoolVar(&manageiqInsecure, "manageiq-insecure-tls", false, "Skip TLS verification for ManageIQ (self-signed certs)")
 	// Hide the ManageIQ flags
 	_ = apiserverCmd.Flags().MarkHidden("manageiq-url")

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -182,19 +182,24 @@ func NewAPIServerCmd() *cobra.Command {
 		Use:   "apiserver",
 		Short: "Manage AI Services API server",
 		Long:  `Start the AI Services API server to provide REST endpoints for managing applications, services, and authentication.`,
-		Example: `  # Start with local admin credentials (no ManageIQ)
+		Example: ` # Start the API server with default settings
 	 ai-services catalog apiserver --admin-password-hash <PASSWORD_HASH> --runtime podman
 
-	 # Start pointing at a ManageIQ instance (Flow A + Flow B enabled)
-	 ai-services catalog apiserver --manageiq-url https://9.20.202.144:8443 --manageiq-insecure-tls --runtime podman
+	 # Start the API server on a custom port
+	 ai-services catalog apiserver --port 9090 --admin-password-hash <PASSWORD_HASH> --runtime podman
 
-	 # Start on a custom port with ManageIQ
-	 ai-services catalog apiserver --port 9090 --manageiq-url https://miq.example.com --runtime podman
+	 # Start with custom admin username
+	 ai-services catalog apiserver --admin-username myadmin --admin-password-hash <PASSWORD_HASH> --runtime podman
+
+	 # Start with custom token TTL settings
+	 ai-services catalog apiserver --access-token-ttl 30m --refresh-token-ttl 48h --admin-password-hash <PASSWORD_HASH> --runtime podman
+
+	 # Start with all custom settings
+	 ai-services catalog apiserver --port 9090 --admin-username myadmin --admin-password-hash <PASSWORD_HASH> --access-token-ttl 30m --refresh-token-ttl 48h --runtime podman
 
 Note:
   - Requires database connection via environment variables (DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME)
-  - AUTH_JWT_SECRET environment variable is recommended for production use
-  - When --manageiq-url is set, --admin-password-hash is ignored for authentication`,
+  - AUTH_JWT_SECRET environment variable is recommended for production use`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return common.InitAndValidateRuntimeFlag(runtimeType)
 		},
@@ -211,6 +216,9 @@ Note:
 	apiserverCmd.Flags().IntVar(&workerGatewayPort, "workergateway-port", defaultWorkerGatewayPort, "Port for the gRPC worker gateway (always active, default 9090)")
 	apiserverCmd.Flags().StringVar(&manageiqURL, "manageiq-url", "", "ManageIQ base URL for AuthN/AuthZ, e.g. https://9.20.202.144:8443 (enables Flow A + Flow B)")
 	apiserverCmd.Flags().BoolVar(&manageiqInsecure, "manageiq-insecure-tls", false, "Skip TLS verification for ManageIQ (self-signed certs)")
+	// Hide the ManageIQ flags
+	_ = apiserverCmd.Flags().MarkHidden("manageiq-url")
+	_ = apiserverCmd.Flags().MarkHidden("manageiq-insecure-tls")
 	common.ConfigureRuntimeFlag(apiserverCmd, &runtimeType)
 
 	return apiserverCmd

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -37,9 +37,6 @@ var (
 	domainName  string
 	sslCertPath string
 	sslKeyPath  string
-	// ManageIQ flags for catalog configure command.
-	manageiqURL      string
-	manageiqInsecure bool
 	// HTTPS port flag for catalog configure command.
 	httpsPort int
 	// WorkerGateway port — always active, defaults to 9090.
@@ -385,21 +382,6 @@ func initConfigurePodmanDeployFlags() {
 			"Note: Supported for podman runtime only.\n"+
 			"Example: --ssl-key /path/to/key.pem\n",
 	)
-	// ManageIQ integration flags
-	configureCmd.Flags().StringVar(
-		&manageiqURL,
-		"manageiq-url",
-		"",
-		"ManageIQ base URL for AuthN/AuthZ, e.g. https://9.20.202.144:8443 (enables Flow A + Flow B).\n"+
-			"Example: --manageiq-url https://miq.example.com\n",
-	)
-
-	configureCmd.Flags().BoolVar(
-		&manageiqInsecure,
-		"manageiq-insecure-tls",
-		false,
-		"Skip TLS verification for ManageIQ (use for self-signed certificates).\n",
-	)
 }
 
 func initConfigurePodmanResetFlags() {
@@ -440,9 +422,7 @@ func buildFlagValidator() *flagvalidator.FlagValidator {
 		AddPodmanFlag("ssl-cert", nil).
 		AddPodmanFlag("ssl-key", nil).
 		AddPodmanFlag("reset-podman-auth", nil).
-		AddPodmanFlag("reset-certificate", nil).
-		AddPodmanFlag("manageiq-url", nil).
-		AddPodmanFlag("manageiq-insecure-tls", nil)
+		AddPodmanFlag("reset-certificate", nil)
 
 	// OpenShift-only flags.
 	builder.AddOpenShiftFlag("timeout", nil)

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -37,6 +37,9 @@ var (
 	domainName  string
 	sslCertPath string
 	sslKeyPath  string
+	// ManageIQ flags for catalog configure command.
+	manageiqURL      string
+	manageiqInsecure bool
 	// HTTPS port flag for catalog configure command.
 	httpsPort int
 	// WorkerGateway port — always active, defaults to 9090.
@@ -382,6 +385,21 @@ func initConfigurePodmanDeployFlags() {
 			"Note: Supported for podman runtime only.\n"+
 			"Example: --ssl-key /path/to/key.pem\n",
 	)
+	// ManageIQ integration flags
+	configureCmd.Flags().StringVar(
+		&manageiqURL,
+		"manageiq-url",
+		"",
+		"ManageIQ base URL for AuthN/AuthZ, e.g. https://9.20.202.144:8443 (enables Flow A + Flow B).\n"+
+			"Example: --manageiq-url https://miq.example.com\n",
+	)
+
+	configureCmd.Flags().BoolVar(
+		&manageiqInsecure,
+		"manageiq-insecure-tls",
+		false,
+		"Skip TLS verification for ManageIQ (use for self-signed certificates).\n",
+	)
 }
 
 func initConfigurePodmanResetFlags() {
@@ -422,7 +440,9 @@ func buildFlagValidator() *flagvalidator.FlagValidator {
 		AddPodmanFlag("ssl-cert", nil).
 		AddPodmanFlag("ssl-key", nil).
 		AddPodmanFlag("reset-podman-auth", nil).
-		AddPodmanFlag("reset-certificate", nil)
+		AddPodmanFlag("reset-certificate", nil).
+		AddPodmanFlag("manageiq-url", nil).
+		AddPodmanFlag("manageiq-insecure-tls", nil)
 
 	// OpenShift-only flags.
 	builder.AddOpenShiftFlag("timeout", nil)

--- a/ai-services/cmd/ai-services/cmd/catalog/login.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/login.go
@@ -51,7 +51,7 @@ To get the Catalog backend endpoint, use: ai-services catalog info`,
   ai-services catalog login --server <catalog_backend_endpoint> --username admin --insecure --runtime podman`,
 
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return validateLoginFlags(runtimeType, serverURL, username, miqToken)
+			return validateLoginFlags(runtimeType, serverURL, username, miqToken, passwordStdin)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if miqToken != "" {
@@ -65,7 +65,7 @@ To get the Catalog backend endpoint, use: ai-services catalog info`,
 	cmd.Flags().StringVar(&serverURL, "server", "", "Catalog backend endpoint (required)")
 	cmd.Flags().StringVar(&username, "username", "", "Username to authenticate with (required)")
 	cmd.Flags().BoolVar(&passwordStdin, "password-stdin", false, "Read password from stdin instead of an interactive prompt")
-	cmd.Flags().StringVar(&miqToken, "miq-token", "", "ManageIQ token for token passthrough login (Flow B / IBM Power Mission Control)")
+	cmd.Flags().StringVar(&miqToken, "miq-token", "", "ManageIQ token for token passthrough login")
 	_ = cmd.Flags().MarkHidden("miq-token")
 	cmd.Flags().BoolVar(&insecure, "insecure", false, "Skip TLS certificate verification (NOT for production use)")
 	common.ConfigureRuntimeFlag(cmd, &runtimeType)
@@ -145,7 +145,7 @@ func promptPassword(passwordStdin bool) (string, error) {
 }
 
 // validateLoginFlags validates all PreRunE checks for the login command.
-func validateLoginFlags(runtimeType, serverURL, username, miqToken string) error {
+func validateLoginFlags(runtimeType, serverURL, username, miqToken string, passwordStdin bool) error {
 	if err := common.InitAndValidateRuntimeFlag(runtimeType); err != nil {
 		return err
 	}
@@ -156,8 +156,8 @@ func validateLoginFlags(runtimeType, serverURL, username, miqToken string) error
 	if miqToken == "" && username == "" {
 		return fmt.Errorf("one of --username or --miq-token is required")
 	}
-	if miqToken != "" && username != "" {
-		return fmt.Errorf("--username and --miq-token are mutually exclusive")
+	if miqToken != "" && (username != "" || passwordStdin) {
+		return fmt.Errorf("--miq-token cannot be used with --username or --password-stdin")
 	}
 
 	return nil

--- a/ai-services/cmd/ai-services/cmd/catalog/login.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/login.go
@@ -22,6 +22,7 @@ func NewLoginCmd() *cobra.Command {
 		serverURL     string
 		username      string
 		passwordStdin bool
+		miqToken      string
 		insecure      bool
 		runtimeType   string
 	)
@@ -29,50 +30,88 @@ func NewLoginCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to the catalog API server",
-		Long: `Authenticate with the catalog API server using a username and password.
+		Long: `Authenticate with the catalog API server using either a username and password
+(Flow A), or a pre-existing ManageIQ token (Flow B).
 
-The generated access and refresh tokens are stored in the OS user config directory
-and are used automatically by subsequent catalog commands. The exact path is
-printed after a successful login.
+Flow A — Interactive login with username and password:
+  The Catalog API authenticates your credentials against ManageIQ and issues
+  an internal JWT.
 
-The stored access token is reused for subsequent commands as long as it is still
-valid. It is refreshed automatically only when it is about to expire, avoiding
-unnecessary round-trips to the server.
+Flow B — ManageIQ token passthrough (IBM Power Mission Control):
+  Supply a ManageIQ token via --miq-token. The Catalog API validates it against
+  ManageIQ and issues an internal JWT without requiring a password.
+
+The resulting tokens are stored in the OS user config directory and reused
+automatically by subsequent catalog commands.
 
 To get the Catalog backend endpoint, use: ai-services catalog info`,
-		Example: `  # Interactive login (password is prompted securely)
+		Example: `  # Flow A: interactive login (password is prompted securely)
   ai-services catalog login --server <catalog_backend_endpoint> --username admin --runtime podman
 
-  # Non-interactive login via stdin pipe (password not recorded in shell history)
+  # Flow A: non-interactive via stdin
   echo "$MY_PASSWORD" | ai-services catalog login --server <catalog_backend_endpoint> --username admin --password-stdin --runtime podman
 
-  # Login with insecure TLS (skip certificate verification)
-  ai-services catalog login --server <catalog_backend_endpoint> --username admin --insecure --runtime podman`,
+  # Flow B: ManageIQ token passthrough (IBM Power Mission Control)
+  ai-services catalog login --server <catalog_backend_endpoint> --miq-token <miq_token> --runtime podman
+
+  # Flow B: with insecure TLS (self-signed cert)
+  ai-services catalog login --server <catalog_backend_endpoint> --miq-token <miq_token> --insecure --runtime podman`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := common.InitAndValidateRuntimeFlag(runtimeType); err != nil {
 				return err
 			}
+			if err := validateServerURL(serverURL); err != nil {
+				return err
+			}
+			// Exactly one auth method must be provided.
+			if miqToken == "" && username == "" {
+				return fmt.Errorf("one of --username or --miq-token is required")
+			}
+			if miqToken != "" && username != "" {
+				return fmt.Errorf("--username and --miq-token are mutually exclusive")
+			}
 
-			return validateServerURL(serverURL)
+			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if miqToken != "" {
+				return runLoginWithMIQToken(serverURL, miqToken, insecure)
+			}
+
 			return runLogin(serverURL, username, passwordStdin, insecure)
 		},
 	}
 
 	cmd.Flags().StringVar(&serverURL, "server", "", "Catalog backend endpoint (required)")
-	cmd.Flags().StringVar(&username, "username", "", "Username to authenticate with (required)")
+	cmd.Flags().StringVar(&username, "username", "", "Username for password-based login (Flow A)")
 	cmd.Flags().BoolVar(&passwordStdin, "password-stdin", false, "Read password from stdin instead of an interactive prompt")
+	cmd.Flags().StringVar(&miqToken, "miq-token", "", "ManageIQ token for token passthrough login (Flow B / IBM Power Mission Control)")
 	cmd.Flags().BoolVar(&insecure, "insecure", false, "Skip TLS certificate verification (NOT for production use)")
 	common.ConfigureRuntimeFlag(cmd, &runtimeType)
 
 	_ = cmd.MarkFlagRequired("server")
-	_ = cmd.MarkFlagRequired("username")
 
 	return cmd
 }
 
-// runLogin executes the login flow with the provided parameters.
+// runLoginWithMIQToken executes Flow B: exchange a ManageIQ token for a Catalog API JWT.
+func runLoginWithMIQToken(serverURL, miqToken string, insecure bool) error {
+	if insecure {
+		logger.Warningln("WARNING: TLS certificate verification is disabled. This should NOT be used in production environments.")
+	}
+
+	logger.Infof("Logging in to %s using ManageIQ token...\n", serverURL)
+
+	if _, err := client.NewWithMIQToken(serverURL, miqToken, insecure); err != nil {
+		return fmt.Errorf("login failed: %w", err)
+	}
+
+	logger.Infoln("Login successful.")
+
+	return nil
+}
+
+// runLogin executes Flow A: authenticate with username and password.
 func runLogin(serverURL, username string, passwordStdin, insecure bool) error {
 	password, err := promptPassword(passwordStdin)
 	if err != nil {

--- a/ai-services/cmd/ai-services/cmd/catalog/login.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/login.go
@@ -30,48 +30,28 @@ func NewLoginCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to the catalog API server",
-		Long: `Authenticate with the catalog API server using either a username and password
-(Flow A), or a pre-existing ManageIQ token (Flow B).
+		Long: `Authenticate with the catalog API server using a username and password.
 
-Flow A — Interactive login with username and password:
-  The Catalog API authenticates your credentials against ManageIQ and issues
-  an internal JWT.
+The generated access and refresh tokens are stored in the OS user config directory
+and are used automatically by subsequent catalog commands. The exact path is
+printed after a successful login.
 
-Flow B — ManageIQ token passthrough (IBM Power Mission Control):
-  Supply a ManageIQ token via --miq-token. The Catalog API validates it against
-  ManageIQ and issues an internal JWT without requiring a password.
-
-The resulting tokens are stored in the OS user config directory and reused
-automatically by subsequent catalog commands.
+The stored access token is reused for subsequent commands as long as it is still
+valid. It is refreshed automatically only when it is about to expire, avoiding
+unnecessary round-trips to the server.
 
 To get the Catalog backend endpoint, use: ai-services catalog info`,
-		Example: `  # Flow A: interactive login (password is prompted securely)
+		Example: ` # Interactive login (password is prompted securely)
   ai-services catalog login --server <catalog_backend_endpoint> --username admin --runtime podman
 
-  # Flow A: non-interactive via stdin
+  # Non-interactive login via stdin pipe (password not recorded in shell history)
   echo "$MY_PASSWORD" | ai-services catalog login --server <catalog_backend_endpoint> --username admin --password-stdin --runtime podman
 
-  # Flow B: ManageIQ token passthrough (IBM Power Mission Control)
-  ai-services catalog login --server <catalog_backend_endpoint> --miq-token <miq_token> --runtime podman
+   # Login with insecure TLS (skip certificate verification)
+  ai-services catalog login --server <catalog_backend_endpoint> --username admin --insecure --runtime podman`,
 
-  # Flow B: with insecure TLS (self-signed cert)
-  ai-services catalog login --server <catalog_backend_endpoint> --miq-token <miq_token> --insecure --runtime podman`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := common.InitAndValidateRuntimeFlag(runtimeType); err != nil {
-				return err
-			}
-			if err := validateServerURL(serverURL); err != nil {
-				return err
-			}
-			// Exactly one auth method must be provided.
-			if miqToken == "" && username == "" {
-				return fmt.Errorf("one of --username or --miq-token is required")
-			}
-			if miqToken != "" && username != "" {
-				return fmt.Errorf("--username and --miq-token are mutually exclusive")
-			}
-
-			return nil
+			return validateLoginFlags(runtimeType, serverURL, username, miqToken)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if miqToken != "" {
@@ -83,9 +63,10 @@ To get the Catalog backend endpoint, use: ai-services catalog info`,
 	}
 
 	cmd.Flags().StringVar(&serverURL, "server", "", "Catalog backend endpoint (required)")
-	cmd.Flags().StringVar(&username, "username", "", "Username for password-based login (Flow A)")
+	cmd.Flags().StringVar(&username, "username", "", "Username to authenticate with (required)")
 	cmd.Flags().BoolVar(&passwordStdin, "password-stdin", false, "Read password from stdin instead of an interactive prompt")
 	cmd.Flags().StringVar(&miqToken, "miq-token", "", "ManageIQ token for token passthrough login (Flow B / IBM Power Mission Control)")
+	_ = cmd.Flags().MarkHidden("miq-token")
 	cmd.Flags().BoolVar(&insecure, "insecure", false, "Skip TLS certificate verification (NOT for production use)")
 	common.ConfigureRuntimeFlag(cmd, &runtimeType)
 
@@ -161,6 +142,25 @@ func promptPassword(passwordStdin bool) (string, error) {
 	}
 
 	return password, nil
+}
+
+// validateLoginFlags validates all PreRunE checks for the login command.
+func validateLoginFlags(runtimeType, serverURL, username, miqToken string) error {
+	if err := common.InitAndValidateRuntimeFlag(runtimeType); err != nil {
+		return err
+	}
+	if err := validateServerURL(serverURL); err != nil {
+		return err
+	}
+	// Exactly one auth method must be provided.
+	if miqToken == "" && username == "" {
+		return fmt.Errorf("one of --username or --miq-token is required")
+	}
+	if miqToken != "" && username != "" {
+		return fmt.Errorf("--username and --miq-token are mutually exclusive")
+	}
+
+	return nil
 }
 
 // validateServerURL returns an error if raw is not a valid http or https URL.

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -797,6 +797,60 @@ const docTemplate = `{
                 }
             }
         },
+        "/auth/token": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "**Experimental** — This endpoint is under active development and may change without notice.\nIBM Power Mission Control use this\nendpoint to exchange a pre-existing ManageIQ token for an internal JWT\nwithout supplying username/password credentials.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Exchange a ManageIQ token for a Catalog API JWT",
+                "responses": {
+                    "200": {
+                        "description": "Returns access_token, refresh_token, and token_type",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or expired ManageIQ token",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "403": {
+                        "description": "ManageIQ token does not have required permissions",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "ManageIQ resource not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "503": {
+                        "description": "ManageIQ unavailable or returned an unexpected server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/components/{component_type}/providers/{provider_id}/params": {
             "get": {
                 "security": [

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -791,6 +791,60 @@
                 }
             }
         },
+        "/auth/token": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "**Experimental** — This endpoint is under active development and may change without notice.\nIBM Power Mission Control use this\nendpoint to exchange a pre-existing ManageIQ token for an internal JWT\nwithout supplying username/password credentials.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Exchange a ManageIQ token for a Catalog API JWT",
+                "responses": {
+                    "200": {
+                        "description": "Returns access_token, refresh_token, and token_type",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or expired ManageIQ token",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "403": {
+                        "description": "ManageIQ token does not have required permissions",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "ManageIQ resource not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "503": {
+                        "description": "ManageIQ unavailable or returned an unexpected server error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/components/{component_type}/providers/{provider_id}/params": {
             "get": {
                 "security": [

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -1068,6 +1068,46 @@ paths:
       summary: Refresh access token
       tags:
       - Authentication
+  /auth/token:
+    post:
+      description: |-
+        **Experimental** — This endpoint is under active development and may change without notice.
+        IBM Power Mission Control use this
+        endpoint to exchange a pre-existing ManageIQ token for an internal JWT
+        without supplying username/password credentials.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Returns access_token, refresh_token, and token_type
+          schema:
+            additionalProperties: true
+            type: object
+        "401":
+          description: Invalid or expired ManageIQ token
+          schema:
+            additionalProperties: true
+            type: object
+        "403":
+          description: ManageIQ token does not have required permissions
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: ManageIQ resource not found
+          schema:
+            additionalProperties: true
+            type: object
+        "503":
+          description: ManageIQ unavailable or returned an unexpected server error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Exchange a ManageIQ token for a Catalog API JWT
+      tags:
+      - Authentication
   /components/{component_type}/providers/{provider_id}/params:
     get:
       description: Retrieves the configuration schema (JSON Schema) for a specific

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/auth_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/auth_handler.go
@@ -160,7 +160,8 @@ func (h *AuthHandler) Me(c *gin.Context) {
 // TokenLogin godoc
 //
 //	@Summary		Exchange a ManageIQ token for a Catalog API JWT
-//	@Description	IBM Power Mission Control and other ManageIQ-integrated products use this
+//	@Description	**Experimental** — This endpoint is under active development and may change without notice.
+//	@Description	IBM Power Mission Control use this
 //	@Description	endpoint to exchange a pre-existing ManageIQ token for an internal JWT
 //	@Description	without supplying username/password credentials.
 //	@Tags			Authentication

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/auth_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/auth_handler.go
@@ -168,11 +168,14 @@ func (h *AuthHandler) Me(c *gin.Context) {
 //	@Security		BearerAuth
 //	@Success		200	{object}	map[string]interface{}	"Returns access_token, refresh_token, and token_type"
 //	@Failure		401	{object}	map[string]interface{}	"Invalid or expired ManageIQ token"
-//	@Failure		503	{object}	map[string]interface{}	"ManageIQ client not configured"
+//	@Failure		403	{object}	map[string]interface{}	"ManageIQ token does not have required permissions"
+//	@Failure		404	{object}	map[string]interface{}	"ManageIQ resource not found"
+//	@Failure		503	{object}	map[string]interface{}	"ManageIQ unavailable or returned an unexpected server error"
 //	@Router			/auth/token [post]
 func (h *AuthHandler) TokenLogin(c *gin.Context) {
-	raw := strings.TrimPrefix(c.GetHeader("Authorization"), "Bearer ")
-	if raw == "" {
+	authHeader := c.GetHeader("Authorization")
+	raw := strings.TrimPrefix(authHeader, "Bearer ")
+	if !strings.HasPrefix(authHeader, "Bearer ") || raw == "" {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "missing ManageIQ token in Authorization header"})
 
 		return
@@ -182,6 +185,12 @@ func (h *AuthHandler) TokenLogin(c *gin.Context) {
 	if err != nil {
 		if errors.Is(err, miq.ErrUnauthorized) {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired ManageIQ token"})
+
+			return
+		}
+		var manageIQErr *miq.ManageIQError
+		if errors.As(err, &manageIQErr) && manageIQErr.StatusCode >= 400 && manageIQErr.StatusCode < 500 {
+			c.JSON(manageIQErr.StatusCode, gin.H{"error": manageIQErr.Message})
 
 			return
 		}

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/auth_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/auth_handler.go
@@ -1,11 +1,14 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/middleware"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/miq"
 )
 
 type AuthHandler struct {
@@ -151,5 +154,45 @@ func (h *AuthHandler) Me(c *gin.Context) {
 		"id":       u.ID,
 		"username": u.UserName,
 		"name":     u.Name,
+	})
+}
+
+// TokenLogin godoc
+//
+//	@Summary		Exchange a ManageIQ token for a Catalog API JWT
+//	@Description	IBM Power Mission Control and other ManageIQ-integrated products use this
+//	@Description	endpoint to exchange a pre-existing ManageIQ token for an internal JWT
+//	@Description	without supplying username/password credentials.
+//	@Tags			Authentication
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Success		200	{object}	map[string]interface{}	"Returns access_token, refresh_token, and token_type"
+//	@Failure		401	{object}	map[string]interface{}	"Invalid or expired ManageIQ token"
+//	@Failure		503	{object}	map[string]interface{}	"ManageIQ client not configured"
+//	@Router			/auth/token [post]
+func (h *AuthHandler) TokenLogin(c *gin.Context) {
+	raw := strings.TrimPrefix(c.GetHeader("Authorization"), "Bearer ")
+	if raw == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "missing ManageIQ token in Authorization header"})
+
+		return
+	}
+
+	access, refresh, err := h.svc.LoginWithToken(c.Request.Context(), raw)
+	if err != nil {
+		if errors.Is(err, miq.ErrUnauthorized) {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired ManageIQ token"})
+
+			return
+		}
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": err.Error()})
+
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"access_token":  access,
+		"refresh_token": refresh,
+		"token_type":    "Bearer",
 	})
 }

--- a/ai-services/internal/pkg/catalog/apiserver/repository/token_store.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/token_store.go
@@ -92,4 +92,13 @@ func (b *DBTokenBlacklist) gc() {
 	}
 }
 
+
+// NoopTokenBlacklist is a no-op implementation of TokenBlacklist for use in tests.
+type NoopTokenBlacklist struct{}
+
+func (n *NoopTokenBlacklist) Add(_ context.Context, _ string, _ string, _ time.Time) {}
+func (n *NoopTokenBlacklist) Contains(_ context.Context, _ string, _ string) bool    { return false }
+func (n *NoopTokenBlacklist) Stop()                                                   {}
+
+
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/repository/token_store.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/token_store.go
@@ -92,13 +92,11 @@ func (b *DBTokenBlacklist) gc() {
 	}
 }
 
-
 // NoopTokenBlacklist is a no-op implementation of TokenBlacklist for use in tests.
 type NoopTokenBlacklist struct{}
 
 func (n *NoopTokenBlacklist) Add(_ context.Context, _ string, _ string, _ time.Time) {}
 func (n *NoopTokenBlacklist) Contains(_ context.Context, _ string, _ string) bool    { return false }
-func (n *NoopTokenBlacklist) Stop()                                                   {}
-
+func (n *NoopTokenBlacklist) Stop()                                                  {}
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/repository/user_repo.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/user_repo.go
@@ -35,7 +35,7 @@ func NewInMemoryUserRepo() *InMemoryUserRepo {
 // with a precomputed hash.
 func NewInMemoryUserRepoWithAdminHash(id, username, name, passwordHash string) *InMemoryUserRepo {
 	r := NewInMemoryUserRepo()
-	r.add(&models.User{
+	r.Upsert(&models.User{
 		ID:           id,
 		UserName:     username,
 		PasswordHash: passwordHash,
@@ -45,7 +45,10 @@ func NewInMemoryUserRepoWithAdminHash(id, username, name, passwordHash string) *
 	return r
 }
 
-func (r *InMemoryUserRepo) add(u *models.User) {
+// Upsert inserts or replaces a user entry. Safe for concurrent use.
+// Used both for seeding the admin user and for populating entries after a
+// ManageIQ token exchange (Flow B / IBM Power Mission Control passthrough).
+func (r *InMemoryUserRepo) Upsert(u *models.User) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.users[u.ID] = u

--- a/ai-services/internal/pkg/catalog/apiserver/router.go
+++ b/ai-services/internal/pkg/catalog/apiserver/router.go
@@ -45,6 +45,7 @@ func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist r
 	v1 := router.Group("/api/v1")
 	{
 		v1.POST("/auth/login", authHandler.Login)
+		v1.POST("/auth/token", authHandler.TokenLogin)
 		v1.POST("/auth/logout", middleware.AuthMiddleware(tokenMgr, blacklist), authHandler.Logout)
 		v1.POST("/auth/refresh", authHandler.Refresh)
 		v1.GET("/auth/me", middleware.AuthMiddleware(tokenMgr, blacklist), authHandler.Me)

--- a/ai-services/internal/pkg/catalog/apiserver/services/auth/service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/auth/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
 	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/miq"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 )
 
@@ -25,6 +26,9 @@ const (
 
 type Service interface {
 	Login(ctx context.Context, username, password string) (accessToken, refreshToken string, err error)
+	// LoginWithToken exchanges a pre-existing ManageIQ token (e.g. from IBM Power
+	// Mission Control) for an internal Catalog API JWT without requiring credentials.
+	LoginWithToken(ctx context.Context, miqToken string) (accessToken, refreshToken string, err error)
 	Logout(ctx context.Context, accessToken, refreshToken string) error
 	RefreshTokens(ctx context.Context, refreshToken string) (newAccess, newRefresh string, err error)
 	GetUser(ctx context.Context, id string) (*models.User, error)
@@ -34,10 +38,17 @@ type service struct {
 	users     repository.UserRepository
 	tokens    *TokenManager
 	blacklist repository.TokenBlacklist
+	miqClient miq.Client
 }
 
+// NewAuthService creates an auth service without a ManageIQ client (local password mode).
 func NewAuthService(users repository.UserRepository, tokens *TokenManager, blacklist repository.TokenBlacklist) Service {
 	return &service{users: users, tokens: tokens, blacklist: blacklist}
+}
+
+// NewAuthServiceWithMIQ creates an auth service backed by ManageIQ for token passthrough.
+func NewAuthServiceWithMIQ(users repository.UserRepository, tokens *TokenManager, blacklist repository.TokenBlacklist, miqClient miq.Client) Service {
+	return &service{users: users, tokens: tokens, blacklist: blacklist, miqClient: miqClient}
 }
 
 var ErrInvalidCredentials = errors.New("invalid credentials")
@@ -55,6 +66,40 @@ func (s *service) Login(ctx context.Context, username, password string) (string,
 		return "", "", err
 	}
 	refresh, _, err := s.tokens.GenerateRefreshToken(u.ID)
+	if err != nil {
+		return "", "", err
+	}
+
+	return access, refresh, nil
+}
+
+// LoginWithToken validates a ManageIQ token by calling the MIQ API, resolves the caller's
+// identity and group membership, and issues an internal Catalog API JWT pair.
+// This is Flow B: used by IBM Power Mission Control which already holds a MIQ token.
+func (s *service) LoginWithToken(ctx context.Context, miqToken string) (string, string, error) {
+	if s.miqClient == nil {
+		return "", "", errors.New("ManageIQ client not configured")
+	}
+
+	info, err := s.miqClient.GetUserByToken(ctx, miqToken)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Seed the in-memory user repo so /auth/me works after token exchange.
+	if repo, ok := s.users.(*repository.InMemoryUserRepo); ok {
+		repo.Upsert(&models.User{
+			ID:       info.ExternalID,
+			UserName: info.UserName,
+			Name:     info.FullName,
+		})
+	}
+
+	access, _, err := s.tokens.GenerateAccessToken(info.ExternalID)
+	if err != nil {
+		return "", "", err
+	}
+	refresh, _, err := s.tokens.GenerateRefreshToken(info.ExternalID)
 	if err != nil {
 		return "", "", err
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/services/auth/service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/auth/service.go
@@ -87,18 +87,20 @@ func (s *service) LoginWithToken(ctx context.Context, miqToken string) (string, 
 	}
 
 	// Seed the in-memory user repo so /auth/me works after token exchange.
+	// ID must match the JWT subject (info.ExternalID) so GetByID resolves correctly.
 	if repo, ok := s.users.(*repository.InMemoryUserRepo); ok {
 		repo.Upsert(&models.User{
+			ID:       info.ExternalID,
 			UserName: info.UserName,
 			Name:     info.FullName,
 		})
 	}
 
-	access, _, err := s.tokens.GenerateAccessToken(info.UserName)
+	access, _, err := s.tokens.GenerateAccessToken(info.ExternalID)
 	if err != nil {
 		return "", "", err
 	}
-	refresh, _, err := s.tokens.GenerateRefreshToken(info.UserName)
+	refresh, _, err := s.tokens.GenerateRefreshToken(info.ExternalID)
 	if err != nil {
 		return "", "", err
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/services/auth/service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/auth/service.go
@@ -89,17 +89,16 @@ func (s *service) LoginWithToken(ctx context.Context, miqToken string) (string, 
 	// Seed the in-memory user repo so /auth/me works after token exchange.
 	if repo, ok := s.users.(*repository.InMemoryUserRepo); ok {
 		repo.Upsert(&models.User{
-			ID:       info.ExternalID,
 			UserName: info.UserName,
 			Name:     info.FullName,
 		})
 	}
 
-	access, _, err := s.tokens.GenerateAccessToken(info.ExternalID)
+	access, _, err := s.tokens.GenerateAccessToken(info.UserName)
 	if err != nil {
 		return "", "", err
 	}
-	refresh, _, err := s.tokens.GenerateRefreshToken(info.ExternalID)
+	refresh, _, err := s.tokens.GenerateRefreshToken(info.UserName)
 	if err != nil {
 		return "", "", err
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/services/auth/service_test.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/auth/service_test.go
@@ -95,6 +95,7 @@ func TestLoginWithToken_MIQClientError(t *testing.T) {
 func TestLoginWithToken_UserSeededInRepo(t *testing.T) {
 	stub := &stubMIQClient{
 		info: &miq.UserInfo{
+			ExternalID: "42",
 			UserName:   "operator1",
 			FullName:   "Op User",
 			Groups:     []string{"EvmGroup-operator"},

--- a/ai-services/internal/pkg/catalog/apiserver/services/auth/service_test.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/auth/service_test.go
@@ -1,0 +1,118 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/miq"
+)
+
+// ---------------------------------------------------------------------------
+// stub MIQ client
+// ---------------------------------------------------------------------------
+
+type stubMIQClient struct {
+	info *miq.UserInfo
+	err  error
+}
+
+func (s *stubMIQClient) GetUserByToken(_ context.Context, _ string) (*miq.UserInfo, error) {
+	return s.info, s.err
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func newService(t *testing.T, miqClient miq.Client) auth.Service {
+	t.Helper()
+	tokenMgr := auth.NewTokenManager("test-secret-32-bytes-long-enough!", 15*60*1000000000 /* 15m */, 24*3600*1000000000 /* 24h */)
+	users := repository.NewInMemoryUserRepo()
+	return auth.NewAuthServiceWithMIQ(users, tokenMgr, &repository.NoopTokenBlacklist{}, miqClient)
+}
+
+// ---------------------------------------------------------------------------
+// LoginWithToken tests
+// ---------------------------------------------------------------------------
+
+func TestLoginWithToken_Success(t *testing.T) {
+	stub := &stubMIQClient{
+		info: &miq.UserInfo{
+			ExternalID: "1",
+			UserName:   "admin",
+			FullName:   "Administrator",
+			Groups:     []string{"EvmGroup-super_administrator"},
+		},
+	}
+	svc := newService(t, stub)
+
+	access, refresh, err := svc.LoginWithToken(context.Background(), "valid-miq-token")
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, access, "access token must be non-empty")
+	assert.NotEmpty(t, refresh, "refresh token must be non-empty")
+	assert.NotEqual(t, access, refresh, "access and refresh tokens must differ")
+}
+
+func TestLoginWithToken_InvalidMIQToken(t *testing.T) {
+	stub := &stubMIQClient{err: miq.ErrUnauthorized}
+	svc := newService(t, stub)
+
+	access, refresh, err := svc.LoginWithToken(context.Background(), "bad-token")
+
+	assert.Empty(t, access)
+	assert.Empty(t, refresh)
+	assert.ErrorIs(t, err, miq.ErrUnauthorized)
+}
+
+func TestLoginWithToken_MIQClientNotConfigured(t *testing.T) {
+	tokenMgr := auth.NewTokenManager("test-secret-32-bytes-long-enough!", 15*60*1000000000, 24*3600*1000000000)
+	users := repository.NewInMemoryUserRepo()
+	// NewAuthService (no MIQ client) — LoginWithToken must return an error.
+	svc := auth.NewAuthService(users, tokenMgr, &repository.NoopTokenBlacklist{})
+
+	_, _, err := svc.LoginWithToken(context.Background(), "any-token")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not configured")
+}
+
+func TestLoginWithToken_MIQClientError(t *testing.T) {
+	stub := &stubMIQClient{err: errors.New("connection refused")}
+	svc := newService(t, stub)
+
+	_, _, err := svc.LoginWithToken(context.Background(), "token")
+
+	require.Error(t, err)
+	assert.EqualError(t, err, "connection refused")
+}
+
+func TestLoginWithToken_UserSeededInRepo(t *testing.T) {
+	stub := &stubMIQClient{
+		info: &miq.UserInfo{
+			ExternalID: "42",
+			UserName:   "operator1",
+			FullName:   "Op User",
+			Groups:     []string{"EvmGroup-operator"},
+		},
+	}
+	tokenMgr := auth.NewTokenManager("test-secret-32-bytes-long-enough!", 15*60*1000000000, 24*3600*1000000000)
+	users := repository.NewInMemoryUserRepo()
+	svc := auth.NewAuthServiceWithMIQ(users, tokenMgr, &repository.NoopTokenBlacklist{}, stub)
+
+	_, _, err := svc.LoginWithToken(context.Background(), "valid-token")
+	require.NoError(t, err)
+
+	// After LoginWithToken the user must be findable via GetUser so /auth/me works.
+	u, err := svc.GetUser(context.Background(), "42")
+	require.NoError(t, err)
+	assert.Equal(t, "42", u.ID)
+	assert.Equal(t, "operator1", u.UserName)
+	assert.Equal(t, "Op User", u.Name)
+}

--- a/ai-services/internal/pkg/catalog/apiserver/services/auth/service_test.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/auth/service_test.go
@@ -44,7 +44,6 @@ func newService(t *testing.T, miqClient miq.Client) auth.Service {
 func TestLoginWithToken_Success(t *testing.T) {
 	stub := &stubMIQClient{
 		info: &miq.UserInfo{
-			ExternalID: "1",
 			UserName:   "admin",
 			FullName:   "Administrator",
 			Groups:     []string{"EvmGroup-super_administrator"},
@@ -96,7 +95,6 @@ func TestLoginWithToken_MIQClientError(t *testing.T) {
 func TestLoginWithToken_UserSeededInRepo(t *testing.T) {
 	stub := &stubMIQClient{
 		info: &miq.UserInfo{
-			ExternalID: "42",
 			UserName:   "operator1",
 			FullName:   "Op User",
 			Groups:     []string{"EvmGroup-operator"},

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -26,11 +26,15 @@ func DeployCatalog(ctx context.Context, opts catalogUtils.PodmanConfigureOptions
 		return err
 	}
 
-	// Collect and hash password
-	// If secret exist passwordHash will be empty
-	passwordHash, err := catalogUtils.CollectAndHashPassword(deployCtx.Runtime)
-	if err != nil {
-		return err
+	// Collect and hash password.
+	// Skipped when ManageIQ is configured (external AuthN/AuthZ handles auth).
+	// Also skipped when the secret already exists (CollectAndHashPassword returns "").
+	var passwordHash string
+	if opts.ManageiqURL == "" {
+		passwordHash, err = catalogUtils.CollectAndHashPassword(deployCtx.Runtime)
+		if err != nil {
+			return err
+		}
 	}
 
 	caddyCtx, err := executeCatalogDeployment(ctx, deployCtx, opts, passwordHash)

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -26,15 +26,11 @@ func DeployCatalog(ctx context.Context, opts catalogUtils.PodmanConfigureOptions
 		return err
 	}
 
-	// Collect and hash password.
-	// Skipped when ManageIQ is configured (external AuthN/AuthZ handles auth).
-	// Also skipped when the secret already exists (CollectAndHashPassword returns "").
-	var passwordHash string
-	if opts.ManageiqURL == "" {
-		passwordHash, err = catalogUtils.CollectAndHashPassword(deployCtx.Runtime)
-		if err != nil {
-			return err
-		}
+	// Collect and hash password
+	// If secret exist passwordHash will be empty
+	passwordHash, err := catalogUtils.CollectAndHashPassword(deployCtx.Runtime)
+	if err != nil {
+		return err
 	}
 
 	caddyCtx, err := executeCatalogDeployment(ctx, deployCtx, opts, passwordHash)

--- a/ai-services/internal/pkg/catalog/client/client.go
+++ b/ai-services/internal/pkg/catalog/client/client.go
@@ -164,6 +164,63 @@ func (c *Client) Login(username, password string) (LoginResponse, error) {
 	return resp, nil
 }
 
+// LoginWithMIQToken calls POST /api/v1/auth/token, passing the ManageIQ token in
+// the Authorization header. Used by IBM Power Mission Control (Flow B).
+func (c *Client) LoginWithMIQToken(miqToken string) (LoginResponse, error) {
+	var resp LoginResponse
+	httpResp, err := c.httpClient.R().
+		SetHeader("Authorization", "Bearer "+miqToken).
+		SetResult(&resp).
+		Post("/api/v1/auth/token")
+	if err != nil {
+		return LoginResponse{}, fmt.Errorf("token login request: %w", err)
+	}
+
+	if httpResp.IsError() {
+		return LoginResponse{}, fmt.Errorf("token login failed: server returned HTTP %d: %s", httpResp.StatusCode(), httpResp.String())
+	}
+
+	return resp, nil
+}
+
+// NewWithMIQToken creates a Client by exchanging a ManageIQ token for a Catalog API JWT.
+// This is Flow B: used by IBM Power Mission Control which already holds a MIQ token.
+// The resulting tokens are saved to the local config file exactly like NewWithLogin.
+func NewWithMIQToken(serverURL, miqToken string, insecure bool) (*Client, error) {
+	restyClient := resty.New().SetBaseURL(serverURL)
+	if insecure {
+		restyClient.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}) //nolint:gosec
+	}
+
+	c := &Client{
+		serverURL:  serverURL,
+		httpClient: restyClient,
+	}
+
+	resp, err := c.LoginWithMIQToken(miqToken)
+	if err != nil {
+		return nil, err
+	}
+
+	c.creds = config.Credentials{
+		ServerURL:    serverURL,
+		AccessToken:  resp.AccessToken,
+		RefreshToken: resp.RefreshToken,
+		Insecure:     insecure,
+	}
+	c.httpClient.SetAuthToken(resp.AccessToken)
+
+	if exp, err := jwtExpiry(resp.AccessToken); err == nil {
+		c.creds.AccessTokenExpiry = exp
+	}
+
+	if err := config.Save(c.creds); err != nil {
+		return nil, fmt.Errorf("save credentials: %w", err)
+	}
+
+	return c, nil
+}
+
 // RefreshToken calls POST /api/v1/auth/refresh using the stored refresh token
 // and updates the in-memory credentials (and persists them to disk).
 func (c *Client) RefreshToken() error {

--- a/ai-services/internal/pkg/catalog/miq/client.go
+++ b/ai-services/internal/pkg/catalog/miq/client.go
@@ -14,6 +14,18 @@ import (
 // ErrUnauthorized is returned when ManageIQ rejects the token with a 401.
 var ErrUnauthorized = errors.New("unauthorized: invalid or expired ManageIQ token")
 
+// ManageIQError is returned when ManageIQ responds with a non-2xx status other
+// than 401. StatusCode carries the original HTTP status from ManageIQ so
+// callers can distinguish 4xx client errors from 5xx server errors.
+type ManageIQError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *ManageIQError) Error() string {
+	return fmt.Sprintf("miq: status %d: %s", e.StatusCode, e.Message)
+}
+
 // Client defines the ManageIQ operations needed by the Catalog API.
 type Client interface {
 	// GetUserByToken validates miqToken against ManageIQ and returns the
@@ -62,13 +74,17 @@ func (c *HTTPClient) GetUserByToken(ctx context.Context, miqToken string) (*User
 		return nil, ErrUnauthorized
 	}
 	if resp.IsError() {
-		return nil, fmt.Errorf("miq: unexpected status %d: %s", resp.StatusCode(), errResp.Error.Message)
+		return nil, &ManageIQError{StatusCode: resp.StatusCode(), Message: errResp.Error.Message}
 	}
 	if result.Identity.UserID == "" {
 		return nil, ErrUnauthorized
 	}
 
 	// Extract numeric user ID from user_href, e.g. ".../api/users/1" → "1".
+	if result.Identity.UserHref == "" {
+		return nil, fmt.Errorf("miq: identity missing user_href for user %q", result.Identity.UserID)
+	}
+
 	externalID := path.Base(result.Identity.UserHref)
 
 	return &UserInfo{

--- a/ai-services/internal/pkg/catalog/miq/client.go
+++ b/ai-services/internal/pkg/catalog/miq/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 
 	"github.com/go-resty/resty/v2"
 )
@@ -37,24 +38,22 @@ func NewHTTPClient(baseURL string, insecureSkipTLS bool) *HTTPClient {
 	return &HTTPClient{http: r}
 }
 
-// GetUserByToken calls GET /api/users with the supplied MIQ token as X-Auth-Token
-// and returns the caller's identity and group membership.
+// GetUserByToken calls GET /api?attributes=identity with the supplied MIQ token
+// as X-Auth-Token and returns the caller's identity and group membership.
+// The numeric user ID is extracted from the identity.user_href path segment.
 //
 // Validated against ManageIQ API v4.4.0-pre at https://9.20.202.144:8443.
 func (c *HTTPClient) GetUserByToken(ctx context.Context, miqToken string) (*UserInfo, error) {
-	var result miqUsersResponse
+	var result miqIdentityResponse
 	var errResp ErrorResponse
 
 	resp, err := c.http.R().
 		SetContext(ctx).
 		SetHeader("X-Auth-Token", miqToken).
-		SetQueryParams(map[string]string{
-			"expand":     "resources",
-			"attributes": "userid,name,miq_groups",
-		}).
+		SetQueryParam("attributes", "identity").
 		SetResult(&result).
 		SetError(&errResp).
-		Get("/api/users")
+		Get("/api")
 	if err != nil {
 		return nil, fmt.Errorf("miq: request failed: %w", err)
 	}
@@ -65,22 +64,17 @@ func (c *HTTPClient) GetUserByToken(ctx context.Context, miqToken string) (*User
 	if resp.IsError() {
 		return nil, fmt.Errorf("miq: unexpected status %d: %s", resp.StatusCode(), errResp.Error.Message)
 	}
-	if len(result.Resources) == 0 {
+	if result.Identity.UserID == "" {
 		return nil, ErrUnauthorized
 	}
 
-	u := result.Resources[0]
-	groups := make([]string, 0, len(u.MIQGroups))
-	for _, g := range u.MIQGroups {
-		if g.Description != "" {
-			groups = append(groups, g.Description)
-		}
-	}
+	// Extract numeric user ID from user_href, e.g. ".../api/users/1" → "1".
+	externalID := path.Base(result.Identity.UserHref)
 
 	return &UserInfo{
-		ExternalID: u.ID,
-		UserName:   u.UserID,
-		FullName:   u.Name,
-		Groups:     groups,
+		ExternalID: externalID,
+		UserName:   result.Identity.UserID,
+		FullName:   result.Identity.Name,
+		Groups:     result.Identity.Groups,
 	}, nil
 }

--- a/ai-services/internal/pkg/catalog/miq/client.go
+++ b/ai-services/internal/pkg/catalog/miq/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 
 	"github.com/go-resty/resty/v2"
 )
@@ -37,8 +38,9 @@ func NewHTTPClient(baseURL string, insecureSkipTLS bool) *HTTPClient {
 	return &HTTPClient{http: r}
 }
 
-// GetUserByToken calls GET /api with the supplied MIQ token as X-Auth-Token
-// and returns the caller's identity and group membership.
+// GetUserByToken calls GET /api?attributes=identity with the supplied MIQ token
+// as X-Auth-Token and returns the caller's identity and group membership.
+// The numeric user ID is extracted from the identity.user_href path segment.
 //
 // Validated against ManageIQ API v4.4.0-pre at https://9.20.202.144:8443.
 func (c *HTTPClient) GetUserByToken(ctx context.Context, miqToken string) (*UserInfo, error) {
@@ -48,9 +50,7 @@ func (c *HTTPClient) GetUserByToken(ctx context.Context, miqToken string) (*User
 	resp, err := c.http.R().
 		SetContext(ctx).
 		SetHeader("X-Auth-Token", miqToken).
-		SetQueryParams(map[string]string{
-			"attributes": "identity",
-		}).
+		SetQueryParam("attributes", "identity").
 		SetResult(&result).
 		SetError(&errResp).
 		Get("/api")
@@ -68,8 +68,11 @@ func (c *HTTPClient) GetUserByToken(ctx context.Context, miqToken string) (*User
 		return nil, ErrUnauthorized
 	}
 
+	// Extract numeric user ID from user_href, e.g. ".../api/users/1" → "1".
+	externalID := path.Base(result.Identity.UserHref)
+
 	return &UserInfo{
-		//ExternalID: result.Identity.ID,
+		ExternalID: externalID,
 		UserName:   result.Identity.UserID,
 		FullName:   result.Identity.Name,
 		Groups:     result.Identity.Groups,

--- a/ai-services/internal/pkg/catalog/miq/client.go
+++ b/ai-services/internal/pkg/catalog/miq/client.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"path"
 
 	"github.com/go-resty/resty/v2"
 )
@@ -38,9 +37,8 @@ func NewHTTPClient(baseURL string, insecureSkipTLS bool) *HTTPClient {
 	return &HTTPClient{http: r}
 }
 
-// GetUserByToken calls GET /api?attributes=identity with the supplied MIQ token
-// as X-Auth-Token and returns the caller's identity and group membership.
-// The numeric user ID is extracted from the identity.user_href path segment.
+// GetUserByToken calls GET /api with the supplied MIQ token as X-Auth-Token
+// and returns the caller's identity and group membership.
 //
 // Validated against ManageIQ API v4.4.0-pre at https://9.20.202.144:8443.
 func (c *HTTPClient) GetUserByToken(ctx context.Context, miqToken string) (*UserInfo, error) {
@@ -50,7 +48,9 @@ func (c *HTTPClient) GetUserByToken(ctx context.Context, miqToken string) (*User
 	resp, err := c.http.R().
 		SetContext(ctx).
 		SetHeader("X-Auth-Token", miqToken).
-		SetQueryParam("attributes", "identity").
+		SetQueryParams(map[string]string{
+			"attributes": "identity",
+		}).
 		SetResult(&result).
 		SetError(&errResp).
 		Get("/api")
@@ -68,11 +68,8 @@ func (c *HTTPClient) GetUserByToken(ctx context.Context, miqToken string) (*User
 		return nil, ErrUnauthorized
 	}
 
-	// Extract numeric user ID from user_href, e.g. ".../api/users/1" → "1".
-	externalID := path.Base(result.Identity.UserHref)
-
 	return &UserInfo{
-		ExternalID: externalID,
+		//ExternalID: result.Identity.ID,
 		UserName:   result.Identity.UserID,
 		FullName:   result.Identity.Name,
 		Groups:     result.Identity.Groups,

--- a/ai-services/internal/pkg/catalog/miq/client.go
+++ b/ai-services/internal/pkg/catalog/miq/client.go
@@ -1,0 +1,86 @@
+package miq
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/go-resty/resty/v2"
+)
+
+// ErrUnauthorized is returned when ManageIQ rejects the token with a 401.
+var ErrUnauthorized = errors.New("unauthorized: invalid or expired ManageIQ token")
+
+// Client defines the ManageIQ operations needed by the Catalog API.
+type Client interface {
+	// GetUserByToken validates miqToken against ManageIQ and returns the
+	// caller's identity and group membership. Returns ErrUnauthorized if
+	// ManageIQ responds with 401.
+	GetUserByToken(ctx context.Context, miqToken string) (*UserInfo, error)
+}
+
+// HTTPClient is the production implementation of Client.
+type HTTPClient struct {
+	http *resty.Client
+}
+
+// NewHTTPClient creates a ManageIQ HTTP client.
+// Set insecureSkipTLS=true when the ManageIQ instance uses a self-signed cert.
+func NewHTTPClient(baseURL string, insecureSkipTLS bool) *HTTPClient {
+	r := resty.New().
+		SetBaseURL(baseURL).
+		SetTLSClientConfig(&tls.Config{InsecureSkipVerify: insecureSkipTLS}). //nolint:gosec
+		SetHeader("Accept", "application/json")
+
+	return &HTTPClient{http: r}
+}
+
+// GetUserByToken calls GET /api/users with the supplied MIQ token as X-Auth-Token
+// and returns the caller's identity and group membership.
+//
+// Validated against ManageIQ API v4.4.0-pre at https://9.20.202.144:8443.
+func (c *HTTPClient) GetUserByToken(ctx context.Context, miqToken string) (*UserInfo, error) {
+	var result miqUsersResponse
+	var errResp ErrorResponse
+
+	resp, err := c.http.R().
+		SetContext(ctx).
+		SetHeader("X-Auth-Token", miqToken).
+		SetQueryParams(map[string]string{
+			"expand":     "resources",
+			"attributes": "userid,name,miq_groups",
+		}).
+		SetResult(&result).
+		SetError(&errResp).
+		Get("/api/users")
+	if err != nil {
+		return nil, fmt.Errorf("miq: request failed: %w", err)
+	}
+
+	if resp.StatusCode() == http.StatusUnauthorized {
+		return nil, ErrUnauthorized
+	}
+	if resp.IsError() {
+		return nil, fmt.Errorf("miq: unexpected status %d: %s", resp.StatusCode(), errResp.Error.Message)
+	}
+	if len(result.Resources) == 0 {
+		return nil, ErrUnauthorized
+	}
+
+	u := result.Resources[0]
+	groups := make([]string, 0, len(u.MIQGroups))
+	for _, g := range u.MIQGroups {
+		if g.Description != "" {
+			groups = append(groups, g.Description)
+		}
+	}
+
+	return &UserInfo{
+		ExternalID: u.ID,
+		UserName:   u.UserID,
+		FullName:   u.Name,
+		Groups:     groups,
+	}, nil
+}

--- a/ai-services/internal/pkg/catalog/miq/client_test.go
+++ b/ai-services/internal/pkg/catalog/miq/client_test.go
@@ -151,3 +151,63 @@ func TestGetUserByToken_UserHrefIDExtraction(t *testing.T) {
 	assert.Equal(t, "99", info.ExternalID)
 	assert.Equal(t, "testuser", info.UserName)
 }
+
+func TestGetUserByToken_4xxError_ReturnsManageIQError(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		message    string
+	}{
+		{"forbidden", http.StatusForbidden, "user does not have access"},
+		{"not found", http.StatusNotFound, "resource not found"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.statusCode)
+				json.NewEncoder(w).Encode(map[string]any{
+					"error": map[string]any{
+						"kind":    "bad_request",
+						"message": tc.message,
+					},
+				})
+			})
+
+			client := miq.NewHTTPClient(stub.URL, false)
+			info, err := client.GetUserByToken(context.Background(), "token")
+
+			assert.Nil(t, info)
+			require.Error(t, err)
+			assert.NotErrorIs(t, err, miq.ErrUnauthorized)
+
+			var miqErr *miq.ManageIQError
+			require.ErrorAs(t, err, &miqErr)
+			assert.Equal(t, tc.statusCode, miqErr.StatusCode)
+			assert.Equal(t, tc.message, miqErr.Message)
+		})
+	}
+}
+
+func TestGetUserByToken_MissingUserHref_ReturnsError(t *testing.T) {
+	// ManageIQ returns a valid userid but omits user_href — ExternalID cannot be resolved.
+	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"identity": map[string]any{
+				"userid": "admin",
+				"name":   "Administrator",
+				// user_href intentionally absent
+			},
+		})
+	})
+
+	client := miq.NewHTTPClient(stub.URL, false)
+	info, err := client.GetUserByToken(context.Background(), "token")
+
+	assert.Nil(t, info)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, miq.ErrUnauthorized)
+	assert.Contains(t, err.Error(), "user_href")
+}

--- a/ai-services/internal/pkg/catalog/miq/client_test.go
+++ b/ai-services/internal/pkg/catalog/miq/client_test.go
@@ -18,13 +18,12 @@ import (
 // ---------------------------------------------------------------------------
 
 // identityResponse builds the JSON body returned by GET /api?attributes=identity.
-func identityResponse(userID, name, userHref string, groups []string) map[string]any {
+func identityResponse(userid, name string, groups []string) map[string]any {
 	return map[string]any{
 		"identity": map[string]any{
-			"userid":    userID,
-			"name":      name,
-			"user_href": userHref,
-			"groups":    groups,
+			"userid": userid,
+			"name":   name,
+			"groups": groups,
 		},
 	}
 }
@@ -42,49 +41,40 @@ func newStub(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 // ---------------------------------------------------------------------------
 
 func TestGetUserByToken_Success(t *testing.T) {
-	var stub *httptest.Server
-	stub = newStub(t, func(w http.ResponseWriter, r *http.Request) {
+	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
 		assert.Equal(t, "/api", r.URL.Path)
 		assert.Equal(t, "valid-miq-token", r.Header.Get("X-Auth-Token"))
 		assert.Equal(t, "identity", r.URL.Query().Get("attributes"))
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(identityResponse(
-			"admin",
-			"Administrator",
-			stub.URL+"/api/users/1",
-			[]string{"EvmGroup-super_administrator"},
-		))
+		json.NewEncoder(w).Encode(identityResponse("admin", "Administrator", []string{
+			"EvmGroup-super_administrator",
+		}))
 	})
 
 	client := miq.NewHTTPClient(stub.URL, false)
 	info, err := client.GetUserByToken(context.Background(), "valid-miq-token")
 
 	require.NoError(t, err)
-	assert.Equal(t, "1", info.ExternalID)
 	assert.Equal(t, "admin", info.UserName)
 	assert.Equal(t, "Administrator", info.FullName)
 	assert.Equal(t, []string{"EvmGroup-super_administrator"}, info.Groups)
 }
 
 func TestGetUserByToken_MultipleGroups(t *testing.T) {
-	var stub *httptest.Server
-	stub = newStub(t, func(w http.ResponseWriter, r *http.Request) {
+	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(identityResponse(
-			"operator1",
-			"Op User",
-			stub.URL+"/api/users/42",
-			[]string{"EvmGroup-operator", "EvmGroup-auditor"},
-		))
+		json.NewEncoder(w).Encode(identityResponse("operator1", "Op User", []string{
+			"EvmGroup-operator",
+			"EvmGroup-auditor",
+		}))
 	})
 
 	client := miq.NewHTTPClient(stub.URL, false)
 	info, err := client.GetUserByToken(context.Background(), "some-token")
 
 	require.NoError(t, err)
-	assert.Equal(t, "42", info.ExternalID)
 	assert.ElementsMatch(t, []string{"EvmGroup-operator", "EvmGroup-auditor"}, info.Groups)
 }
 
@@ -109,7 +99,7 @@ func TestGetUserByToken_InvalidToken_Returns401(t *testing.T) {
 }
 
 func TestGetUserByToken_EmptyIdentity_Returns401(t *testing.T) {
-	// ManageIQ may return 200 with an empty identity block for an unknown session.
+	// ManageIQ may return 200 with an empty identity block.
 	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{"identity": map[string]any{}})
@@ -132,24 +122,4 @@ func TestGetUserByToken_ServerError(t *testing.T) {
 
 	require.Error(t, err)
 	assert.NotErrorIs(t, err, miq.ErrUnauthorized)
-}
-
-func TestGetUserByToken_UserHrefIDExtraction(t *testing.T) {
-	// Verify the numeric ID is correctly extracted from user_href regardless of base URL.
-	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(identityResponse(
-			"testuser",
-			"Test User",
-			"https://9.20.202.144:8443/api/users/99",
-			[]string{"EvmGroup-operator"},
-		))
-	})
-
-	client := miq.NewHTTPClient(stub.URL, false)
-	info, err := client.GetUserByToken(context.Background(), "token")
-
-	require.NoError(t, err)
-	assert.Equal(t, "99", info.ExternalID)
-	assert.Equal(t, "testuser", info.UserName)
 }

--- a/ai-services/internal/pkg/catalog/miq/client_test.go
+++ b/ai-services/internal/pkg/catalog/miq/client_test.go
@@ -1,0 +1,159 @@
+package miq_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/miq"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// usersResponse builds the JSON body returned by GET /api/users.
+func usersResponse(id, userid, name string, groups []string) map[string]any {
+	miqGroups := make([]map[string]any, 0, len(groups))
+	for _, g := range groups {
+		miqGroups = append(miqGroups, map[string]any{"description": g})
+	}
+	return map[string]any{
+		"resources": []map[string]any{
+			{
+				"id":         id,
+				"userid":     userid,
+				"name":       name,
+				"miq_groups": miqGroups,
+			},
+		},
+	}
+}
+
+// newStub creates a test HTTP server. handler receives full control of responses.
+func newStub(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests — httptest stub, no real ManageIQ required
+// ---------------------------------------------------------------------------
+
+func TestGetUserByToken_Success(t *testing.T) {
+	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/api/users", r.URL.Path)
+		assert.Equal(t, "valid-miq-token", r.Header.Get("X-Auth-Token"))
+		assert.Equal(t, "resources", r.URL.Query().Get("expand"))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(usersResponse("1", "admin", "Administrator", []string{
+			"EvmGroup-super_administrator",
+		}))
+	})
+
+	client := miq.NewHTTPClient(stub.URL, false)
+	info, err := client.GetUserByToken(context.Background(), "valid-miq-token")
+
+	require.NoError(t, err)
+	assert.Equal(t, "1", info.ExternalID)
+	assert.Equal(t, "admin", info.UserName)
+	assert.Equal(t, "Administrator", info.FullName)
+	assert.Equal(t, []string{"EvmGroup-super_administrator"}, info.Groups)
+}
+
+func TestGetUserByToken_MultipleGroups(t *testing.T) {
+	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(usersResponse("42", "operator1", "Op User", []string{
+			"EvmGroup-operator",
+			"EvmGroup-auditor",
+		}))
+	})
+
+	client := miq.NewHTTPClient(stub.URL, false)
+	info, err := client.GetUserByToken(context.Background(), "some-token")
+
+	require.NoError(t, err)
+	assert.Equal(t, "42", info.ExternalID)
+	assert.ElementsMatch(t, []string{"EvmGroup-operator", "EvmGroup-auditor"}, info.Groups)
+}
+
+func TestGetUserByToken_InvalidToken_Returns401(t *testing.T) {
+	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"kind":    "unauthorized",
+				"message": "Invalid Authentication Token bad-token specified",
+				"klass":   "Api::BaseController::Authentication::AuthenticationError",
+			},
+		})
+	})
+
+	client := miq.NewHTTPClient(stub.URL, false)
+	info, err := client.GetUserByToken(context.Background(), "bad-token")
+
+	assert.Nil(t, info)
+	assert.ErrorIs(t, err, miq.ErrUnauthorized)
+}
+
+func TestGetUserByToken_EmptyResourceList_Returns401(t *testing.T) {
+	// ManageIQ may return 200 with an empty resources array for an unknown user.
+	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"resources": []any{}})
+	})
+
+	client := miq.NewHTTPClient(stub.URL, false)
+	info, err := client.GetUserByToken(context.Background(), "token")
+
+	assert.Nil(t, info)
+	assert.ErrorIs(t, err, miq.ErrUnauthorized)
+}
+
+func TestGetUserByToken_ServerError(t *testing.T) {
+	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	client := miq.NewHTTPClient(stub.URL, false)
+	_, err := client.GetUserByToken(context.Background(), "token")
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, miq.ErrUnauthorized)
+}
+
+func TestGetUserByToken_GroupsWithEmptyDescriptionSkipped(t *testing.T) {
+	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"resources": []map[string]any{
+				{
+					"id":     "5",
+					"userid": "testuser",
+					"name":   "Test User",
+					"miq_groups": []map[string]any{
+						{"description": "EvmGroup-operator"},
+						{"description": ""},  // should be skipped
+					},
+				},
+			},
+		})
+	})
+
+	client := miq.NewHTTPClient(stub.URL, false)
+	info, err := client.GetUserByToken(context.Background(), "token")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"EvmGroup-operator"}, info.Groups)
+}

--- a/ai-services/internal/pkg/catalog/miq/client_test.go
+++ b/ai-services/internal/pkg/catalog/miq/client_test.go
@@ -17,20 +17,14 @@ import (
 // helpers
 // ---------------------------------------------------------------------------
 
-// usersResponse builds the JSON body returned by GET /api/users.
-func usersResponse(id, userid, name string, groups []string) map[string]any {
-	miqGroups := make([]map[string]any, 0, len(groups))
-	for _, g := range groups {
-		miqGroups = append(miqGroups, map[string]any{"description": g})
-	}
+// identityResponse builds the JSON body returned by GET /api?attributes=identity.
+func identityResponse(userID, name, userHref string, groups []string) map[string]any {
 	return map[string]any{
-		"resources": []map[string]any{
-			{
-				"id":         id,
-				"userid":     userid,
-				"name":       name,
-				"miq_groups": miqGroups,
-			},
+		"identity": map[string]any{
+			"userid":    userID,
+			"name":      name,
+			"user_href": userHref,
+			"groups":    groups,
 		},
 	}
 }
@@ -48,16 +42,20 @@ func newStub(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 // ---------------------------------------------------------------------------
 
 func TestGetUserByToken_Success(t *testing.T) {
-	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+	var stub *httptest.Server
+	stub = newStub(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/users", r.URL.Path)
+		assert.Equal(t, "/api", r.URL.Path)
 		assert.Equal(t, "valid-miq-token", r.Header.Get("X-Auth-Token"))
-		assert.Equal(t, "resources", r.URL.Query().Get("expand"))
+		assert.Equal(t, "identity", r.URL.Query().Get("attributes"))
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(usersResponse("1", "admin", "Administrator", []string{
-			"EvmGroup-super_administrator",
-		}))
+		json.NewEncoder(w).Encode(identityResponse(
+			"admin",
+			"Administrator",
+			stub.URL+"/api/users/1",
+			[]string{"EvmGroup-super_administrator"},
+		))
 	})
 
 	client := miq.NewHTTPClient(stub.URL, false)
@@ -71,12 +69,15 @@ func TestGetUserByToken_Success(t *testing.T) {
 }
 
 func TestGetUserByToken_MultipleGroups(t *testing.T) {
-	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+	var stub *httptest.Server
+	stub = newStub(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(usersResponse("42", "operator1", "Op User", []string{
-			"EvmGroup-operator",
-			"EvmGroup-auditor",
-		}))
+		json.NewEncoder(w).Encode(identityResponse(
+			"operator1",
+			"Op User",
+			stub.URL+"/api/users/42",
+			[]string{"EvmGroup-operator", "EvmGroup-auditor"},
+		))
 	})
 
 	client := miq.NewHTTPClient(stub.URL, false)
@@ -107,11 +108,11 @@ func TestGetUserByToken_InvalidToken_Returns401(t *testing.T) {
 	assert.ErrorIs(t, err, miq.ErrUnauthorized)
 }
 
-func TestGetUserByToken_EmptyResourceList_Returns401(t *testing.T) {
-	// ManageIQ may return 200 with an empty resources array for an unknown user.
+func TestGetUserByToken_EmptyIdentity_Returns401(t *testing.T) {
+	// ManageIQ may return 200 with an empty identity block for an unknown session.
 	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"resources": []any{}})
+		json.NewEncoder(w).Encode(map[string]any{"identity": map[string]any{}})
 	})
 
 	client := miq.NewHTTPClient(stub.URL, false)
@@ -133,27 +134,22 @@ func TestGetUserByToken_ServerError(t *testing.T) {
 	assert.NotErrorIs(t, err, miq.ErrUnauthorized)
 }
 
-func TestGetUserByToken_GroupsWithEmptyDescriptionSkipped(t *testing.T) {
+func TestGetUserByToken_UserHrefIDExtraction(t *testing.T) {
+	// Verify the numeric ID is correctly extracted from user_href regardless of base URL.
 	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
-			"resources": []map[string]any{
-				{
-					"id":     "5",
-					"userid": "testuser",
-					"name":   "Test User",
-					"miq_groups": []map[string]any{
-						{"description": "EvmGroup-operator"},
-						{"description": ""},  // should be skipped
-					},
-				},
-			},
-		})
+		json.NewEncoder(w).Encode(identityResponse(
+			"testuser",
+			"Test User",
+			"https://9.20.202.144:8443/api/users/99",
+			[]string{"EvmGroup-operator"},
+		))
 	})
 
 	client := miq.NewHTTPClient(stub.URL, false)
 	info, err := client.GetUserByToken(context.Background(), "token")
 
 	require.NoError(t, err)
-	assert.Equal(t, []string{"EvmGroup-operator"}, info.Groups)
+	assert.Equal(t, "99", info.ExternalID)
+	assert.Equal(t, "testuser", info.UserName)
 }

--- a/ai-services/internal/pkg/catalog/miq/client_test.go
+++ b/ai-services/internal/pkg/catalog/miq/client_test.go
@@ -18,12 +18,13 @@ import (
 // ---------------------------------------------------------------------------
 
 // identityResponse builds the JSON body returned by GET /api?attributes=identity.
-func identityResponse(userid, name string, groups []string) map[string]any {
+func identityResponse(userID, name, userHref string, groups []string) map[string]any {
 	return map[string]any{
 		"identity": map[string]any{
-			"userid": userid,
-			"name":   name,
-			"groups": groups,
+			"userid":    userID,
+			"name":      name,
+			"user_href": userHref,
+			"groups":    groups,
 		},
 	}
 }
@@ -41,16 +42,20 @@ func newStub(t *testing.T, handler http.HandlerFunc) *httptest.Server {
 // ---------------------------------------------------------------------------
 
 func TestGetUserByToken_Success(t *testing.T) {
-	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+	var stub *httptest.Server
+	stub = newStub(t, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
 		assert.Equal(t, "/api", r.URL.Path)
 		assert.Equal(t, "valid-miq-token", r.Header.Get("X-Auth-Token"))
 		assert.Equal(t, "identity", r.URL.Query().Get("attributes"))
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(identityResponse("admin", "Administrator", []string{
-			"EvmGroup-super_administrator",
-		}))
+		json.NewEncoder(w).Encode(identityResponse(
+			"admin",
+			"Administrator",
+			stub.URL+"/api/users/1",
+			[]string{"EvmGroup-super_administrator"},
+		))
 	})
 
 	client := miq.NewHTTPClient(stub.URL, false)
@@ -63,12 +68,15 @@ func TestGetUserByToken_Success(t *testing.T) {
 }
 
 func TestGetUserByToken_MultipleGroups(t *testing.T) {
-	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+	var stub *httptest.Server
+	stub = newStub(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(identityResponse("operator1", "Op User", []string{
-			"EvmGroup-operator",
-			"EvmGroup-auditor",
-		}))
+		json.NewEncoder(w).Encode(identityResponse(
+			"operator1",
+			"Op User",
+			stub.URL+"/api/users/42",
+			[]string{"EvmGroup-operator", "EvmGroup-auditor"},
+		))
 	})
 
 	client := miq.NewHTTPClient(stub.URL, false)
@@ -99,7 +107,7 @@ func TestGetUserByToken_InvalidToken_Returns401(t *testing.T) {
 }
 
 func TestGetUserByToken_EmptyIdentity_Returns401(t *testing.T) {
-	// ManageIQ may return 200 with an empty identity block.
+	// ManageIQ may return 200 with an empty identity block for an unknown session.
 	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{"identity": map[string]any{}})
@@ -122,4 +130,24 @@ func TestGetUserByToken_ServerError(t *testing.T) {
 
 	require.Error(t, err)
 	assert.NotErrorIs(t, err, miq.ErrUnauthorized)
+}
+
+func TestGetUserByToken_UserHrefIDExtraction(t *testing.T) {
+	// Verify the numeric ID is correctly extracted from user_href regardless of base URL.
+	stub := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(identityResponse(
+			"testuser",
+			"Test User",
+			"https://9.20.202.144:8443/api/users/99",
+			[]string{"EvmGroup-operator"},
+		))
+	})
+
+	client := miq.NewHTTPClient(stub.URL, false)
+	info, err := client.GetUserByToken(context.Background(), "token")
+
+	require.NoError(t, err)
+	assert.Equal(t, "99", info.ExternalID)
+	assert.Equal(t, "testuser", info.UserName)
 }

--- a/ai-services/internal/pkg/catalog/miq/helpers_test.go
+++ b/ai-services/internal/pkg/catalog/miq/helpers_test.go
@@ -1,0 +1,8 @@
+package miq_test
+
+import "crypto/tls"
+
+// cryptoTLSConfig returns a *tls.Config used by integration test helpers.
+func cryptoTLSConfig(insecure bool) *tls.Config {
+	return &tls.Config{InsecureSkipVerify: insecure} //nolint:gosec
+}

--- a/ai-services/internal/pkg/catalog/miq/integration_test.go
+++ b/ai-services/internal/pkg/catalog/miq/integration_test.go
@@ -1,0 +1,213 @@
+package miq_test
+
+// Integration tests for the ManageIQ HTTP client.
+//
+// These tests connect to a real ManageIQ instance.
+// They are skipped automatically unless the following environment variables are set:
+//
+//	MIQ_URL  - base URL, e.g. https://9.20.202.144:8443
+//	MIQ_USER - username, e.g. admin
+//	MIQ_PASS - password, e.g. smartvm
+//
+// Run with:
+//
+//	MIQ_URL=https://9.20.202.144:8443 MIQ_USER=admin MIQ_PASS=smartvm \
+//	  go test ./internal/pkg/catalog/miq/... -v -run Integration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/miq"
+)
+
+// miqEnv holds the integration test configuration read from env vars.
+type miqEnv struct {
+	url  string
+	user string
+	pass string
+}
+
+// integrationEnv reads the env vars and skips the test if any are missing.
+func integrationEnv(t *testing.T) miqEnv {
+	t.Helper()
+	url := os.Getenv("MIQ_URL")
+	user := os.Getenv("MIQ_USER")
+	pass := os.Getenv("MIQ_PASS")
+	if url == "" || user == "" || pass == "" {
+		t.Skip("skipping integration test: MIQ_URL, MIQ_USER, MIQ_PASS not set")
+	}
+	return miqEnv{url: url, user: user, pass: pass}
+}
+
+// acquireMIQToken performs Basic-auth against GET /api/auth and returns the token.
+// Mirrors what the Catalog API does internally for Flow A.
+func acquireMIQToken(t *testing.T, env miqEnv) string {
+	t.Helper()
+	var result struct {
+		Token string `json:"auth_token"`
+	}
+	resp, err := resty.New().
+		SetBaseURL(env.url).
+		SetTLSClientConfig(cryptoTLSConfig(true)).
+		R().
+		SetBasicAuth(env.user, env.pass).
+		SetResult(&result).
+		Get("/api/auth")
+	require.NoError(t, err, "acquire MIQ token: HTTP request failed")
+	require.Equal(t, http.StatusOK, resp.StatusCode(),
+		"acquire MIQ token: expected 200, got %d: %s", resp.StatusCode(), resp.String())
+	require.NotEmpty(t, result.Token, "acquire MIQ token: auth_token is empty")
+	t.Logf("acquired MIQ token: %s…", result.Token[:8])
+	return result.Token
+}
+
+// ---------------------------------------------------------------------------
+// Smoke test — connectivity
+// ---------------------------------------------------------------------------
+
+func TestIntegration_APIRoot_Reachable(t *testing.T) {
+	env := integrationEnv(t)
+
+	// GET /api on this ManageIQ instance requires authentication (returns 401 without
+	// credentials). We verify the endpoint is reachable and returns a known error shape.
+	resp, err := resty.New().
+		SetBaseURL(env.url).
+		SetTLSClientConfig(cryptoTLSConfig(true)).
+		R().
+		Get("/api")
+
+	require.NoError(t, err, "ManageIQ API must be reachable")
+	assert.Contains(t, []int{http.StatusOK, http.StatusUnauthorized}, resp.StatusCode(),
+		"expected 200 or 401 from /api, got %d", resp.StatusCode())
+	t.Logf("ManageIQ /api responded HTTP %d — instance reachable", resp.StatusCode())
+}
+
+// ---------------------------------------------------------------------------
+// GetUserByToken — valid token
+// ---------------------------------------------------------------------------
+
+func TestIntegration_GetUserByToken_ValidToken(t *testing.T) {
+	env := integrationEnv(t)
+	token := acquireMIQToken(t, env)
+
+	client := miq.NewHTTPClient(env.url, true)
+	info, err := client.GetUserByToken(context.Background(), token)
+
+	require.NoError(t, err)
+	t.Logf("ExternalID : %s", info.ExternalID)
+	t.Logf("UserName   : %s", info.UserName)
+	t.Logf("FullName   : %s", info.FullName)
+	t.Logf("Groups     : %v", info.Groups)
+
+	assert.NotEmpty(t, info.ExternalID)
+	assert.NotEmpty(t, info.UserName)
+	assert.NotEmpty(t, info.FullName)
+	assert.NotEmpty(t, info.Groups)
+	assert.Equal(t, env.user, info.UserName,
+		"UserName must match the login username")
+	assert.Contains(t, info.Groups, "EvmGroup-super_administrator",
+		"admin user must belong to EvmGroup-super_administrator")
+}
+
+// ---------------------------------------------------------------------------
+// GetUserByToken — invalid token
+// ---------------------------------------------------------------------------
+
+func TestIntegration_GetUserByToken_InvalidToken(t *testing.T) {
+	env := integrationEnv(t)
+
+	client := miq.NewHTTPClient(env.url, true)
+	info, err := client.GetUserByToken(context.Background(), "invalid-token-value")
+
+	assert.Nil(t, info)
+	assert.ErrorIs(t, err, miq.ErrUnauthorized)
+}
+
+// ---------------------------------------------------------------------------
+// GetUserByToken — revoked token
+// ---------------------------------------------------------------------------
+
+func TestIntegration_GetUserByToken_RevokedToken(t *testing.T) {
+	env := integrationEnv(t)
+	token := acquireMIQToken(t, env)
+
+	// Revoke via DELETE /api/auth.
+	resp, err := resty.New().
+		SetBaseURL(env.url).
+		SetTLSClientConfig(cryptoTLSConfig(true)).
+		R().
+		SetHeader("X-Auth-Token", token).
+		Delete("/api/auth")
+	require.NoError(t, err)
+	require.Contains(t, []int{http.StatusOK, http.StatusNoContent}, resp.StatusCode(),
+		"logout should return 200 or 204, got %d", resp.StatusCode())
+	t.Logf("token revoked (HTTP %d)", resp.StatusCode())
+
+	client := miq.NewHTTPClient(env.url, true)
+	info, err := client.GetUserByToken(context.Background(), token)
+
+	assert.Nil(t, info)
+	assert.ErrorIs(t, err, miq.ErrUnauthorized)
+}
+
+// ---------------------------------------------------------------------------
+// GetUserByToken — field cross-check
+// ---------------------------------------------------------------------------
+
+func TestIntegration_GetUserByToken_UserFields(t *testing.T) {
+	env := integrationEnv(t)
+	token := acquireMIQToken(t, env)
+
+	client := miq.NewHTTPClient(env.url, true)
+	info, err := client.GetUserByToken(context.Background(), token)
+	require.NoError(t, err)
+
+	for _, g := range info.Groups {
+		assert.NotEmpty(t, g)
+		assert.Contains(t, g, "EvmGroup",
+			"group %q should contain 'EvmGroup'", g)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Full round-trip: token → GetUserByToken → cross-check via direct API call
+// ---------------------------------------------------------------------------
+
+func TestIntegration_FullRoundTrip(t *testing.T) {
+	env := integrationEnv(t)
+	token := acquireMIQToken(t, env)
+
+	client := miq.NewHTTPClient(env.url, true)
+	info, err := client.GetUserByToken(context.Background(), token)
+	require.NoError(t, err)
+
+	// Cross-check: directly filter /api/users by userid and compare.
+	var direct struct {
+		Resources []struct {
+			UserID string `json:"userid"`
+		} `json:"resources"`
+	}
+	resp, err := resty.New().
+		SetBaseURL(env.url).
+		SetTLSClientConfig(cryptoTLSConfig(true)).
+		R().
+		SetHeader("X-Auth-Token", token).
+		SetQueryParam("filter[]", fmt.Sprintf("userid=%s", info.UserName)).
+		SetQueryParam("expand", "resources").
+		SetResult(&direct).
+		Get("/api/users")
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode())
+	require.NotEmpty(t, direct.Resources)
+	assert.Equal(t, info.UserName, direct.Resources[0].UserID,
+		"userid from GetUserByToken must match direct /api/users lookup")
+}

--- a/ai-services/internal/pkg/catalog/miq/integration_test.go
+++ b/ai-services/internal/pkg/catalog/miq/integration_test.go
@@ -102,12 +102,10 @@ func TestIntegration_GetUserByToken_ValidToken(t *testing.T) {
 	info, err := client.GetUserByToken(context.Background(), token)
 
 	require.NoError(t, err)
-	t.Logf("ExternalID : %s", info.ExternalID)
 	t.Logf("UserName   : %s", info.UserName)
 	t.Logf("FullName   : %s", info.FullName)
 	t.Logf("Groups     : %v", info.Groups)
 
-	assert.NotEmpty(t, info.ExternalID)
 	assert.NotEmpty(t, info.UserName)
 	assert.NotEmpty(t, info.FullName)
 	assert.NotEmpty(t, info.Groups)

--- a/ai-services/internal/pkg/catalog/miq/models.go
+++ b/ai-services/internal/pkg/catalog/miq/models.go
@@ -6,34 +6,29 @@ type AuthResponse struct {
 	TokenTTL int    `json:"token_ttl"`
 }
 
-// miqGroup represents one entry in the miq_groups array on a user resource.
-type miqGroup struct {
-	Description string `json:"description"`
-}
-
 // UserInfo carries the identity fields the Catalog API needs from ManageIQ.
 type UserInfo struct {
-	// ExternalID is the ManageIQ numeric user ID (string form of the "id" field).
+	// ExternalID is the ManageIQ numeric user ID extracted from identity.user_href.
 	ExternalID string
 	// UserName is the ManageIQ userid field.
 	UserName string
 	// FullName is the ManageIQ name field.
 	FullName string
-	// Groups is the list of miq_groups descriptions for this user.
+	// Groups is the list of group descriptions for this user.
 	Groups []string
 }
 
-// miqUserResource is the JSON shape returned by GET /api/users with expand=resources.
-type miqUserResource struct {
-	ID       string     `json:"id"`
-	UserID   string     `json:"userid"`
-	Name     string     `json:"name"`
-	MIQGroups []miqGroup `json:"miq_groups"`
+// miqIdentity is the "identity" block returned by GET /api?attributes=identity.
+type miqIdentity struct {
+	UserID   string   `json:"userid"`
+	Name     string   `json:"name"`
+	UserHref string   `json:"user_href"`
+	Groups   []string `json:"groups"`
 }
 
-// miqUsersResponse is the top-level JSON shape for GET /api/users.
-type miqUsersResponse struct {
-	Resources []miqUserResource `json:"resources"`
+// miqIdentityResponse is the top-level JSON shape for GET /api?attributes=identity.
+type miqIdentityResponse struct {
+	Identity miqIdentity `json:"identity"`
 }
 
 // ErrorResponse is the JSON error body returned by ManageIQ on failure.

--- a/ai-services/internal/pkg/catalog/miq/models.go
+++ b/ai-services/internal/pkg/catalog/miq/models.go
@@ -6,29 +6,34 @@ type AuthResponse struct {
 	TokenTTL int    `json:"token_ttl"`
 }
 
+// Group represents one entry in the miq_groups array on a user resource.
+// type Group struct {
+// 	Description string `json:"description"`
+// }
+
 // UserInfo carries the identity fields the Catalog API needs from ManageIQ.
 type UserInfo struct {
-	// ExternalID is the ManageIQ numeric user ID extracted from identity.user_href.
-	ExternalID string
+	// ExternalID is the ManageIQ numeric user ID (string form of the "id" field).
+	//ExternalID string
 	// UserName is the ManageIQ userid field.
 	UserName string
 	// FullName is the ManageIQ name field.
 	FullName string
-	// Groups is the list of group descriptions for this user.
+	// Groups is the list of miq_groups descriptions for this user.
 	Groups []string
 }
 
-// miqIdentity is the "identity" block returned by GET /api?attributes=identity.
-type miqIdentity struct {
-	UserID   string   `json:"userid"`
-	Name     string   `json:"name"`
-	UserHref string   `json:"user_href"`
-	Groups   []string `json:"groups"`
+// miqIdentityResource is the JSON shape returned by GET /api with attributes=identity.
+type miqIdentityResource struct {
+	//ID       string     `json:"id"`
+	UserID   string     `json:"userid"`
+	Name     string     `json:"name"`
+	Groups   []string    `json:"groups"`
 }
 
-// miqIdentityResponse is the top-level JSON shape for GET /api?attributes=identity.
+// miqIdentityResponse is the top-level JSON shape for GET /api.
 type miqIdentityResponse struct {
-	Identity miqIdentity `json:"identity"`
+	Identity miqIdentityResource `json:"identity"`
 }
 
 // ErrorResponse is the JSON error body returned by ManageIQ on failure.

--- a/ai-services/internal/pkg/catalog/miq/models.go
+++ b/ai-services/internal/pkg/catalog/miq/models.go
@@ -6,34 +6,29 @@ type AuthResponse struct {
 	TokenTTL int    `json:"token_ttl"`
 }
 
-// Group represents one entry in the miq_groups array on a user resource.
-// type Group struct {
-// 	Description string `json:"description"`
-// }
-
 // UserInfo carries the identity fields the Catalog API needs from ManageIQ.
 type UserInfo struct {
-	// ExternalID is the ManageIQ numeric user ID (string form of the "id" field).
-	//ExternalID string
+	// ExternalID is the ManageIQ numeric user ID extracted from identity.user_href.
+	ExternalID string
 	// UserName is the ManageIQ userid field.
 	UserName string
 	// FullName is the ManageIQ name field.
 	FullName string
-	// Groups is the list of miq_groups descriptions for this user.
+	// Groups is the list of group descriptions for this user.
 	Groups []string
 }
 
-// miqIdentityResource is the JSON shape returned by GET /api with attributes=identity.
-type miqIdentityResource struct {
-	//ID       string     `json:"id"`
-	UserID   string     `json:"userid"`
-	Name     string     `json:"name"`
-	Groups   []string    `json:"groups"`
+// miqIdentity is the "identity" block returned by GET /api?attributes=identity.
+type miqIdentity struct {
+	UserID   string   `json:"userid"`
+	Name     string   `json:"name"`
+	UserHref string   `json:"user_href"`
+	Groups   []string `json:"groups"`
 }
 
-// miqIdentityResponse is the top-level JSON shape for GET /api.
+// miqIdentityResponse is the top-level JSON shape for GET /api?attributes=identity.
 type miqIdentityResponse struct {
-	Identity miqIdentityResource `json:"identity"`
+	Identity miqIdentity `json:"identity"`
 }
 
 // ErrorResponse is the JSON error body returned by ManageIQ on failure.

--- a/ai-services/internal/pkg/catalog/miq/models.go
+++ b/ai-services/internal/pkg/catalog/miq/models.go
@@ -1,0 +1,45 @@
+package miq
+
+// AuthResponse is returned by GET /api/auth on successful Basic-auth.
+type AuthResponse struct {
+	Token    string `json:"auth_token"`
+	TokenTTL int    `json:"token_ttl"`
+}
+
+// miqGroup represents one entry in the miq_groups array on a user resource.
+type miqGroup struct {
+	Description string `json:"description"`
+}
+
+// UserInfo carries the identity fields the Catalog API needs from ManageIQ.
+type UserInfo struct {
+	// ExternalID is the ManageIQ numeric user ID (string form of the "id" field).
+	ExternalID string
+	// UserName is the ManageIQ userid field.
+	UserName string
+	// FullName is the ManageIQ name field.
+	FullName string
+	// Groups is the list of miq_groups descriptions for this user.
+	Groups []string
+}
+
+// miqUserResource is the JSON shape returned by GET /api/users with expand=resources.
+type miqUserResource struct {
+	ID       string     `json:"id"`
+	UserID   string     `json:"userid"`
+	Name     string     `json:"name"`
+	MIQGroups []miqGroup `json:"miq_groups"`
+}
+
+// miqUsersResponse is the top-level JSON shape for GET /api/users.
+type miqUsersResponse struct {
+	Resources []miqUserResource `json:"resources"`
+}
+
+// ErrorResponse is the JSON error body returned by ManageIQ on failure.
+type ErrorResponse struct {
+	Error struct {
+		Kind    string `json:"kind"`
+		Message string `json:"message"`
+	} `json:"error"`
+}

--- a/docs/proposals/manageiq-authn-authz-plan.md
+++ b/docs/proposals/manageiq-authn-authz-plan.md
@@ -2,20 +2,23 @@
 
 ## Top-Level Overview
 
-**Goal:** Replace the current single-admin in-memory authentication in the Catalog API Server with
-ManageIQ as the authoritative Identity Provider (IdP). Two authentication flows are supported:
+**Goal:** Extend the Catalog API Server to support ManageIQ as an Identity Provider (IdP) alongside
+the existing local admin authentication. ManageIQ integration is opt-in: when `--manageiq-url` is
+not configured the server falls back to local admin credentials. Two authentication flows are
+planned; **only Flow B is currently implemented**:
 
-- **Flow A — Interactive login:** A user supplies username + password; the Catalog API authenticates against ManageIQ, fetches their groups, and issues an internal JWT.
-- **Flow B — ManageIQ token passthrough:** An external product such as **IBM Power Mission Control** already holds a ManageIQ token from its own session and sends it directly to the Catalog API. The Catalog API validates the token against ManageIQ, resolves the identity and groups, and issues an internal JWT. IBM Power Mission Control does nothing beyond forwarding the token.
+- **Flow A — Interactive login (⚠️ Not yet implemented):** A user supplies username + password; the Catalog API authenticates against ManageIQ, fetches their groups, and issues an internal JWT.
+- **Flow B — ManageIQ token passthrough (✅ Implemented):** An external product such as **IBM Power Mission Control** already holds a ManageIQ token from its own session and sends it directly to the Catalog API. The Catalog API validates the token against ManageIQ, resolves the identity and groups, and issues an internal JWT. IBM Power Mission Control does nothing beyond forwarding the token. 
 
 **Scope:**
+
 - Go Catalog API Server (`ai-services/internal/pkg/catalog/`)
 - A new ManageIQ HTTP client package
-- Extended JWT claims (roles, group membership)
-- New role-based route guards in Gin middleware
+- Extended JWT claims with no roles or group membership
 - New `POST /api/v1/auth/token` endpoint for the token passthrough flow (Flow B)
 
 **Non-Goals:**
+
 - Python AI services (chatbot, digitize, similarity) — out of scope for this phase
 - Replacing the token blacklist mechanism (it stays PostgreSQL-backed)
 - OIDC discovery / full OAuth2 PKCE flow (covered in a follow-on if needed)
@@ -24,8 +27,9 @@ ManageIQ as the authoritative Identity Provider (IdP). Two authentication flows 
 **Integration Strategy (Phase 1):** Two-call Token Introspection
 Both flows converge on the same two MIQ API calls for identity resolution (validated against
 `https://9.20.202.144:8443`, API v4.4.0-pre):
+
 1. `GET /api/auth` — (Flow A only) validates credentials and returns a bearer token + `token_ttl`
-2. `GET /api/users?filter[]=userid=X&expand=resources&attributes=userid,name,miq_groups,current_group` — fetches identity and group membership for role mapping using the MIQ token
+2. `GET /api?attributes=identity` with `X-Auth-Token: miq_token` — fetches caller identity and group membership; numeric user ID extracted from `identity.user_href`
 
 Note: `GET /api/auth?requester_type=ui` only echoes a refreshed token; it does **not** return user identity or groups on this version.
 
@@ -51,13 +55,13 @@ graph TD
 ```mermaid
 graph TD
     User[User / CLI / UI] -->|Credentials| MIQ[ManageIQ\nIdentity Provider]
-    MIQ -->|User Identity + Roles + Groups| CatalogAPI[Catalog API Server\nGo / Gin]
+    MIQ -->|User Identity + Groups| CatalogAPI[Catalog API Server\nGo / Gin]
     CatalogAPI -->|Token Introspection| MIQ
 
-    CatalogAPI -->|Issues internal JWT\nwith MIQ roles embedded| JWT[Internal JWT\nwith RBAC claims]
+    CatalogAPI -->|Issues internal JWT| JWT[Internal JWT]
     JWT -->|AuthMiddleware validates| ProtectedRoutes[Protected Routes]
 
-    subgraph RBAC [Role-Based Access Control]
+    subgraph RBAC [Role-Based Access Control   ⚠️ not yet implemented]
         ProtectedRoutes -->|role = admin| AdminOps[Deploy Applications\nManage Catalog]
         ProtectedRoutes -->|role = operator| OperatorOps[Deploy + Read]
         ProtectedRoutes -->|role = viewer| ViewOps[Read Catalog\nView Applications]
@@ -68,7 +72,7 @@ graph TD
 
 ---
 
-### Integration Flow A — Interactive Login
+### Integration Flow A — Interactive Login ⚠️ Not yet implemented
 
 ```mermaid
 sequenceDiagram
@@ -80,8 +84,8 @@ sequenceDiagram
     CatalogAPI->>MIQ: GET /api/auth\nBasic-auth username:password
     MIQ-->>CatalogAPI: auth_token + token_ttl=600s
 
-    CatalogAPI->>MIQ: GET /api/users?filter[]=userid=X\n?attributes=userid,name,miq_groups,current_group
-    MIQ-->>CatalogAPI: userid + name + miq_groups
+    CatalogAPI->>MIQ: GET /api?attributes=identity\nX-Auth-Token: miq_token
+    MIQ-->>CatalogAPI: identity.userid + identity.name + identity.user_href + identity.groups
 
     CatalogAPI->>CatalogAPI: Map miq_groups to internal role\nadmin/operator/viewer
     CatalogAPI-->>User: Internal JWT with role embedded\nTTL capped at 9m
@@ -108,40 +112,14 @@ sequenceDiagram
     note over PMC: PMC already holds a MIQ token\nfrom its own session
     PMC->>CatalogAPI: POST /api/v1/auth/token\nAuthorization: Bearer miq_token
 
-    CatalogAPI->>MIQ: GET /api/users?filter[]=userid=X\nX-Auth-Token: miq_token
-    MIQ-->>CatalogAPI: 200 userid + miq_groups\nOR 401 if token invalid/expired
+    CatalogAPI->>MIQ: GET /api?attributes=identity\nX-Auth-Token: miq_token
+    MIQ-->>CatalogAPI: 200 identity.userid + identity.name + identity.user_href + identity.groups<br/>OR 4xx or 500 if token invalid/expired or server errors
 
-    CatalogAPI->>CatalogAPI: Map miq_groups to internal role\nadmin/operator/viewer
-    CatalogAPI-->>PMC: Internal JWT with role embedded\nTTL capped at 9m
+    CatalogAPI-->>PMC: Internal JWT pair\nTTL capped at 9m
 
     PMC->>CatalogAPI: GET /api/v1/applications\nAuthorization: Bearer internal-jwt
-    CatalogAPI->>CatalogAPI: AuthMiddleware validates JWT\n+ checks blacklist + enforces role
+    CatalogAPI->>CatalogAPI: AuthMiddleware validates JWT
     CatalogAPI-->>PMC: Response
-```
-
----
-
-### Integration Flow — OIDC/OAuth2 Phase 2
-
-```mermaid
-sequenceDiagram
-    actor User
-    participant MIQ as ManageIQ OIDC Provider
-    participant CatalogAPI as Catalog API
-
-    User->>CatalogAPI: POST /api/v1/auth/oidc/callback\ncode from OIDC flow
-    CatalogAPI->>MIQ: POST /oauth/token\nexchange authorization code
-    MIQ-->>CatalogAPI: id_token + access_token
-
-    CatalogAPI->>MIQ: GET /oauth/userinfo
-    MIQ-->>CatalogAPI: sub + email + groups + roles
-
-    CatalogAPI->>CatalogAPI: Map OIDC claims to internal roles
-    CatalogAPI-->>User: Internal JWT with roles embedded
-
-    User->>CatalogAPI: API requests with internal JWT
-    CatalogAPI->>CatalogAPI: Validate JWT, enforce RBAC
-    CatalogAPI-->>User: Response
 ```
 
 ---
@@ -151,40 +129,28 @@ sequenceDiagram
 ```mermaid
 graph LR
     subgraph L1 [1 - MIQ Client]
-        A[ManageIQ HTTP Client\nToken introspection\nUserInfo fetch]
+        A[ManageIQ HTTP Client\nGetUserByToken\nErrUnauthorized / ManageIQError]
     end
 
-    subgraph L2 [2 - Role Mapping]
-        B[RoleMapper\nMIQ groups to internal roles\nadmin / operator / viewer]
+    subgraph L2 [2 - Auth Service]
+        B[LoginWithToken - Flow B IBM PMC passthrough\nseeds in-memory user repo]
     end
 
-    subgraph L3 [3 - JWT Claims]
-        C[Extend JWT customClaims\nAdd Role field\nValidateAccessToken returns role]
+    subgraph L3 [3 - Auth Handler]
+        C[POST /auth/token\nreturns JWT pair]
     end
 
-    subgraph L4 [4 - Auth Service]
-        D[Login - Flow A username+password\nLoginWithToken - Flow B IBM PMC passthrough\nrole embedded at issue time]
-    end
-
-    subgraph L5 [5 - Auth Middleware]
-        E[AuthMiddleware sets CtxRoleKey\nRequireRole guard on write routes]
-    end
-
-    subgraph L6 [6 - Config and Deployment]
-        F[values.yaml / MANAGEIQ_URL env vars\nInstallation docs]
-    end
-
-    L1 --> L2 --> L3 --> L4 --> L5 --> L6
+    L1 --> L2 --> L3
 ```
 
 ---
 
-### RBAC Role Hierarchy
+### RBAC Role Hierarchy ⚠️ Not yet implemented
 
 ```mermaid
 graph TD
     MIQRoles["miq_groups description field
-    from GET /api/users"] --> Mapping["Role Mapping Config
+    from GET /api?attributes=identity"] --> Mapping["Role Mapping Config
     MIQ_ROLE_ADMIN_GROUPS
     MIQ_ROLE_OPERATOR_GROUPS"]
 
@@ -202,280 +168,3 @@ graph TD
 ```
 
 ---
-
-## Sub-Tasks
-
----
-
-### Sub-Task 1 — ManageIQ HTTP Client Package
-
-**Intent:**  
-Encapsulate all communication with ManageIQ into a dedicated, testable Go package. This isolates
-ManageIQ API details from the rest of the codebase and makes it easy to swap authentication strategies
-(token introspect → OIDC) later.
-
-**Expected Outcomes:**
-- New package `internal/pkg/catalog/miq/` with a `Client` interface and concrete HTTP implementation
-- `Client.Authenticate(ctx, username, password)` — calls `GET /api/auth` with Basic-auth; returns `AuthResponse{Token, TTL}`
-- `Client.GetUser(ctx, miqToken, userID)` — calls `GET /api/users/{id}?attributes=userid,name,miq_groups,current_group`; returns `UserInfo`
-- `UserInfo` struct carries `UserName`, `FullName`, `ExternalID`, `Groups []string`, `CurrentGroup string`
-- Error type `ErrUnauthorized` mapped from `error.kind == "unauthorized"` and klass `Api::BaseController::Authentication::AuthenticationError`
-- `InsecureSkipTLS bool` field on the client (required for self-signed certs like `9.20.202.144`)
-- Unit tests using an `httptest` server stub for both API calls
-
-**Todo List:**
-1. Create `internal/pkg/catalog/miq/client.go` with the `Client` interface
-2. Implement `HTTPClient` struct using `go-resty` (already a project dependency)
-3. Add `UserInfo`, `AuthResponse`, and `ErrorResponse` models in `internal/pkg/catalog/miq/models.go`
-4. Implement `Authenticate`: `GET /api/auth` with Basic-auth header; parse `auth_token` + `token_ttl`
-5. Implement `GetUser`: `GET /api/users/{id}?attributes=userid,name,miq_groups,current_group`; parse `miq_groups[].description` into `Groups`
-6. Map HTTP 401 + `error.kind=unauthorized` to `ErrUnauthorized` sentinel error
-7. Create `internal/pkg/catalog/miq/client_test.go` with httptest stubs for both endpoints
-8. Add `MANAGEIQ_URL` and `MANAGEIQ_INSECURE_SKIP_TLS` to the config package
-
-**Relevant Context:**
-- Validated API: `GET /api/auth` (Basic-auth) and `GET /api/users/{id}` on ManageIQ v4.4.0-pre
-- `go-resty` client already in `go.mod` at `github.com/go-resty/resty/v2`
-- Existing HTTP patterns in `internal/pkg/catalog/client/` can guide the style
-- Config loading in `internal/pkg/catalog/config/`
-- See `docs/proposals/manageiq-authn-authz-curl-validation.md` for exact request/response shapes
-
-**Status:** `[ ] pending`
-
----
-
-### Sub-Task 2 — Role Mapping & RBAC Model
-
-**Intent:**  
-Define the mapping from ManageIQ group/role names to internal RBAC roles. This mapping must be
-configuration-driven so operators can adapt it without code changes.
-
-**Expected Outcomes:**
-- New `internal/pkg/catalog/apiserver/models/role.go` with `Role` type and constants: `RoleAdmin`, `RoleOperator`, `RoleViewer`
-- A `RoleMapper` that reads a YAML/env-based mapping and translates `[]string` of MIQ groups → `Role`
-- Default mapping documented in `values.yaml` and the config package
-- Unit tests covering mapping edge cases (no groups, unknown group, multiple groups)
-
-**Todo List:**
-1. Define `Role` type and constants in `models/role.go`
-2. Create `internal/pkg/catalog/apiserver/services/auth/rolemapper.go` with `MapGroupsToRole(groups []string) Role`
-3. Load mapping from environment variables (e.g., `MIQ_ROLE_ADMIN_GROUPS`, `MIQ_ROLE_OPERATOR_GROUPS`)
-4. Add defaults using **hyphen format**: `EvmGroup-super_administrator`, `EvmGroup-administrator` → `admin`; `EvmGroup-operator` → `operator`; everything else → `viewer`
-5. Write unit tests in `rolemapper_test.go`
-6. Document mapping config in `docs/proposals/manageiq-authn-authz-plan.md` (this file)
-
-**Relevant Context:**
-- **Validated group name format** (hyphen, not double-colon): `EvmGroup-super_administrator`, `EvmGroup-administrator`, `EvmGroup-operator`, `EvmGroup-auditor`
-- Group strings come from `miq_groups[].description` on `GET /api/users/{id}` — not from `/api/auth`
-- Existing `models/user.go` for model conventions
-- `internal/pkg/catalog/constants/` for constant patterns
-
-**Status:** `[ ] pending`
-
----
-
-### Sub-Task 3 — Extend JWT Claims with Roles
-
-**Intent:**  
-The internal JWT must carry the user's RBAC role so the auth middleware can enforce it without
-hitting ManageIQ on every request. The role is embedded at login time and is valid for the token
-lifetime.
-
-**Expected Outcomes:**
-- `customClaims` in `services/auth/jwt.go` extended with `Role string` field
-- `GenerateAccessToken` / `GenerateRefreshToken` accept `role` parameter
-- `ValidateAccessToken` returns `(userID, role, expiry, error)`
-- Existing callers of token generation updated
-- Backward compatibility: tokens without role field treated as `viewer`
-
-**Todo List:**
-1. Add `Role string` to `customClaims` struct in `jwt.go`
-2. Update `GenerateAccessToken(userID, role string)` and `GenerateRefreshToken(userID, role string)` signatures
-3. Update `ValidateAccessToken` to return role alongside userID and expiry
-4. Update `AuthMiddleware` to set `CtxRoleKey` in the Gin context alongside `CtxUserIDKey`
-5. Update all call sites in `services/auth/service.go`
-6. Update unit tests
-
-**Relevant Context:**
-- `ai-services/internal/pkg/catalog/apiserver/services/auth/jwt.go` — current `customClaims`
-- `ai-services/internal/pkg/catalog/apiserver/middleware/auth.go` — sets `CtxUserIDKey` and `CtxRawTokenKey`
-- `ai-services/internal/pkg/catalog/apiserver/services/auth/service.go` — calls `GenerateAccessToken`
-
-**Status:** `[ ] pending`
-
----
-
-### Sub-Task 4 — MIQ-Backed Auth Service & Login Handler (Flow A)
-
-**Intent:**
-Replace the single-admin PBKDF2 password check with a ManageIQ-backed interactive login flow. On
-`POST /api/v1/auth/login`, the Catalog API authenticates against ManageIQ using the supplied
-username + password, fetches user identity and group membership, maps roles, and issues an internal JWT.
-
-**Expected Outcomes:**
-- `auth.Service.Login` delegates to `miq.Client` via two-call flow
-- User struct populated from ManageIQ `UserInfo` (no local password storage)
-- Role embedded in issued JWT
-- Existing `POST /api/v1/auth/login` endpoint signature unchanged (`username` + `password` body)
-- Graceful 503 if ManageIQ is unreachable
-- `--manageiq-url` and `--manageiq-insecure-tls` CLI flags added to the `catalog apiserver` command
-
-**Todo List:**
-1. Add `miqClient miq.Client` to `auth.service` struct
-2. Rewrite `service.Login` as a two-call flow:
-   - Call `miqClient.Authenticate(ctx, username, password)` → returns `miqToken`
-   - Call `miqClient.GetUserByToken(ctx, miqToken)` → returns `UserInfo` with `Groups`
-3. Call `RoleMapper.MapGroupsToRole` on `UserInfo.Groups` (hyphen-format group names)
-4. Pass role to `GenerateAccessToken` / `GenerateRefreshToken`
-5. Wire `miq.Client` in `cmd/catalog/apiserver.go` (read `MANAGEIQ_URL`, `MANAGEIQ_INSECURE_SKIP_TLS` env)
-6. Add `--manageiq-url` and `--manageiq-insecure-tls` CLI flags in `cmd/catalog/apiserver.go`
-7. Keep `NewInMemoryUserRepo` for the `/auth/me` path — populated from `UserInfo` at login time
-8. Integration test: mock ManageIQ (`/api/auth` + `/api/users` stubs) → login → JWT decode → role check
-
-**Relevant Context:**
-- `ai-services/cmd/ai-services/cmd/catalog/apiserver.go` — server startup and wiring
-- `ai-services/internal/pkg/catalog/apiserver/handlers/auth_handler.go` — `Login` handler
-- `ai-services/internal/pkg/catalog/apiserver/services/auth/service.go` — `Login` method
-- `ai-services/internal/pkg/catalog/apiserver/repository/user_repo.go` — `InMemoryUserRepo`
-
-**Status:** `[ ] pending`
-
----
-
-### Sub-Task 4b — IBM Power Mission Control Token Passthrough (Flow B)
-
-**Intent:**
-IBM Power Mission Control already holds a ManageIQ session token from its own auth lifecycle and
-sends it directly to the Catalog API — it does nothing beyond forwarding the token. The Catalog API
-receives the raw MIQ token, validates it against ManageIQ by calling `GET /api/users` with that token
-as `X-Auth-Token`, resolves the identity and groups, maps the role, and issues its own internal JWT.
-The flow converges on exactly the same identity resolution and JWT issuance path as Flow A.
-
-**Expected Outcomes:**
-- New `POST /api/v1/auth/token` endpoint; accepts `Authorization: Bearer <miq_token>` header
-- `auth.Service.LoginWithToken(ctx, miqToken string)` added to the `Service` interface
-- Implementation calls `miqClient.GetUserByToken(ctx, miqToken)` directly (no `/api/auth` call — the token is already known)
-- On valid token: role mapped from `miq_groups`, internal JWT issued — identical shape and TTL to Flow A
-- On invalid/expired MIQ token: ManageIQ returns 401 → Catalog API returns 401 to IBM PMC
-- No new env vars required — reuses `MANAGEIQ_URL` / `MANAGEIQ_INSECURE_SKIP_TLS`
-
-**Todo List:**
-1. Add `GetUserByToken(ctx context.Context, miqToken string) (*UserInfo, error)` to `miq.Client` interface
-2. Implement: `GET /api/users?filter[]=userid=X&expand=resources&attributes=userid,name,miq_groups,current_group` with `X-Auth-Token: miqToken`; map HTTP 401 → `ErrUnauthorized`
-3. Add `LoginWithToken(ctx context.Context, miqToken string) (access, refresh string, err error)` to `auth.Service` interface
-4. Implement `LoginWithToken` in `service.go`: call `GetUserByToken` → `RoleMapper.MapGroupsToRole` → `GenerateAccessToken` / `GenerateRefreshToken` → seed in-memory user repo entry
-5. Add `TokenLogin` handler in `auth_handler.go`: read `Authorization: Bearer` header → call `svc.LoginWithToken` → return same JSON shape as `Login`
-6. Register `POST /api/v1/auth/token` in `router.go` (no auth middleware — it is itself an auth endpoint)
-7. Update Sub-Task 1's `miq.Client` to share `GetUserByToken` between both flows (Flow A calls it after `Authenticate`; Flow B calls it directly)
-8. Unit test: stub MIQ `GET /api/users` returning valid user → assert JWT contains correct role
-9. Unit test: stub MIQ returning 401 → assert handler returns 401
-
-**Relevant Context:**
-- `ai-services/internal/pkg/catalog/apiserver/handlers/auth_handler.go` — `Login` handler as the pattern
-- `ai-services/internal/pkg/catalog/apiserver/router.go` — `v1.POST("/auth/login")` registration pattern
-- `ai-services/internal/pkg/catalog/apiserver/services/auth/service.go` — `Login` as the service pattern
-- curl validation: `GET /api/users?filter[]=userid=admin&expand=resources&attributes=userid,name,miq_groups,current_group` with `X-Auth-Token` header confirmed working against `https://9.20.202.144:8443`
-
----
-
-### Sub-Task 5 — RBAC Route Guards in Auth Middleware
-
-**Intent:**  
-Protect write/destructive endpoints from lower-privileged roles. After Sub-Task 3 embeds the role
-in the JWT, the middleware and route groups can enforce `RequireRole(RoleAdmin)` guards on sensitive
-operations.
-
-**Expected Outcomes:**
-- New `middleware.RequireRole(role models.Role) gin.HandlerFunc` middleware
-- Admin-only routes (POST/PUT/DELETE on `/applications`) require `RoleAdmin`
-- Read-only routes accessible to `RoleViewer` and above
-- 403 Forbidden returned (not 401) when role is insufficient
-- Existing health/swagger/auth endpoints unaffected
-
-**Todo List:**
-1. Add `RequireRole(minRole Role) gin.HandlerFunc` to `middleware/auth.go`
-2. Define role ordering: `viewer < operator < admin`
-3. Update `router.go` to apply `RequireRole` after `AuthMiddleware` on write routes:
-   - `POST /applications` → `RequireRole(RoleOperator)`
-   - `PUT /applications/:id` → `RequireRole(RoleOperator)`
-   - `DELETE /applications/:id` → `RequireRole(RoleAdmin)`
-4. Return structured JSON error `{"error": "insufficient permissions", "required": "admin"}` on 403
-5. Unit tests for middleware with mock Gin contexts at each role level
-
-**Relevant Context:**
-- `ai-services/internal/pkg/catalog/apiserver/router.go` — route group definitions
-- `ai-services/internal/pkg/catalog/apiserver/middleware/auth.go` — existing `AuthMiddleware`
-
-**Status:** `[ ] pending`
-
----
-
-### Sub-Task 6 — Configuration & Deployment Updates
-
-**Intent:**
-Update deployment configuration (`values.yaml`) to include ManageIQ connection parameters, and
-update the documentation so operators know how to configure the integration.
-
-**Expected Outcomes:**
-- `values.yaml` extended with `manageiq.url`, `manageiq.insecureTLS`, and role mapping entries
-- `docs/INSTALLATION.md` updated with ManageIQ configuration prerequisites
-- `.env.example` updated with new variables
-
-**Todo List:**
-1. Add `manageiq:` section to `ai-services/assets/catalog/podman/values.yaml`
-2. Update `.env.example` with `MANAGEIQ_URL`, `MANAGEIQ_INSECURE_SKIP_TLS`, `MIQ_ROLE_ADMIN_GROUPS`, `MIQ_ROLE_OPERATOR_GROUPS`
-3. Add a "ManageIQ Integration" section to `docs/INSTALLATION.md`
-4. Update Swagger annotations on auth endpoints to reflect new ManageIQ-backed behavior
-
-**Relevant Context:**
-- `ai-services/assets/catalog/podman/values.yaml` — deployment values
-- `.env.example` — environment variable template
-- `docs/INSTALLATION.md` — operator installation guide
-
-**Status:** `[ ] pending`
-
----
-
-## Role Mapping Reference
-
-> Group names sourced from `miq_groups[].description` on `GET /api/users/{id}`.
-> Format uses a **hyphen separator** (`EvmGroup-name`), validated on ManageIQ v4.4.0-pre.
-
-| ManageIQ Group | Internal Role | Permissions |
-|---|---|---|
-| `EvmGroup-super_administrator` | `admin` | Full CRUD on all endpoints |
-| `EvmGroup-administrator` | `admin` | Full CRUD on all endpoints |
-| `EvmGroup-operator` | `operator` | Deploy/update applications; read catalog |
-| `EvmGroup-auditor` | `viewer` | Read-only access to all GET endpoints |
-| Any other / no group | `viewer` | Read-only access to all GET endpoints |
-
----
-
-## Configuration Variables Reference
-
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `MANAGEIQ_URL` | Yes | — | Base URL of ManageIQ, e.g. `https://9.20.202.144:8443` |
-| `MANAGEIQ_INSECURE_SKIP_TLS` | No | `false` | Skip TLS verification — required for self-signed certs |
-| `MIQ_ROLE_ADMIN_GROUPS` | No | `EvmGroup-super_administrator,EvmGroup-administrator` | Comma-separated MIQ group descriptions mapped to `admin` |
-| `MIQ_ROLE_OPERATOR_GROUPS` | No | `EvmGroup-operator` | Comma-separated MIQ group descriptions mapped to `operator` |
-| `AUTH_JWT_SECRET` | No | auto-generated | HMAC-SHA256 secret for internal JWT signing |
-| `AUTH_ACCESS_TOKEN_TTL` | No | `9m` | Internal JWT access token lifetime — capped below MIQ token_ttl of 600s |
-| `AUTH_REFRESH_TOKEN_TTL` | No | `24h` | Internal JWT refresh token lifetime |
-
----
-
-## Decision Record
-
-| # | Decision | Rationale |
-|---|---|---|
-| 1 | Two-call flow over single introspect call | Validated: `/api/auth?requester_type=ui` does not return user identity or groups on v4.4.0-pre; a separate `GET /api/users` call is required |
-| 2 | Internal JWT kept | Avoids ManageIQ round-trip on every API call; existing blacklist mechanism is reused unchanged |
-| 3 | Role embedded in JWT at login time | Roles are stable per session; keeps the hot path stateless |
-| 4 | In-memory user repo kept for `GetUser` | Avoids a MIQ call on `/auth/me`; the repo is populated from `UserInfo` returned at login |
-| 5 | `MANAGEIQ_INSECURE_SKIP_TLS` defaults to `false` | Validated instance uses a self-signed cert; production deployments should use valid certs |
-| 6 | `AUTH_ACCESS_TOKEN_TTL` default changed from `15m` to `9m` | Validated MIQ `token_ttl` is 600s (10 min); internal JWT must not outlive the MIQ session |
-| 7 | Flow B uses a separate endpoint `POST /api/v1/auth/token` | Keeps flows orthogonal; the existing `/auth/login` contract and body schema are unchanged |
-| 8 | Flow B skips `/api/auth` — calls `GET /api/users` directly | IBM PMC already holds the MIQ token; there is no need to authenticate again — only validation is needed |
-| 9 | `GetUserByToken` is shared by both flows | Flow A calls it after `Authenticate`; Flow B calls it directly — no duplicated identity resolution logic |
-| 10 | Python services out of scope | AuthN/AuthZ for Python services is a separate phase; no changes needed there |

--- a/docs/proposals/manageiq-authn-authz-plan.md
+++ b/docs/proposals/manageiq-authn-authz-plan.md
@@ -1,0 +1,481 @@
+# ManageIQ AuthN/AuthZ Integration Plan
+
+## Top-Level Overview
+
+**Goal:** Replace the current single-admin in-memory authentication in the Catalog API Server with
+ManageIQ as the authoritative Identity Provider (IdP). Two authentication flows are supported:
+
+- **Flow A — Interactive login:** A user supplies username + password; the Catalog API authenticates against ManageIQ, fetches their groups, and issues an internal JWT.
+- **Flow B — ManageIQ token passthrough:** An external product such as **IBM Power Mission Control** already holds a ManageIQ token from its own session and sends it directly to the Catalog API. The Catalog API validates the token against ManageIQ, resolves the identity and groups, and issues an internal JWT. IBM Power Mission Control does nothing beyond forwarding the token.
+
+**Scope:**
+- Go Catalog API Server (`ai-services/internal/pkg/catalog/`)
+- A new ManageIQ HTTP client package
+- Extended JWT claims (roles, group membership)
+- New role-based route guards in Gin middleware
+- New `POST /api/v1/auth/token` endpoint for the token passthrough flow (Flow B)
+
+**Non-Goals:**
+- Python AI services (chatbot, digitize, similarity) — out of scope for this phase
+- Replacing the token blacklist mechanism (it stays PostgreSQL-backed)
+- OIDC discovery / full OAuth2 PKCE flow (covered in a follow-on if needed)
+- ManageIQ token generation or management — that is IBM Power Mission Control's responsibility
+
+**Integration Strategy (Phase 1):** Two-call Token Introspection
+Both flows converge on the same two MIQ API calls for identity resolution (validated against
+`https://9.20.202.144:8443`, API v4.4.0-pre):
+1. `GET /api/auth` — (Flow A only) validates credentials and returns a bearer token + `token_ttl`
+2. `GET /api/users?filter[]=userid=X&expand=resources&attributes=userid,name,miq_groups,current_group` — fetches identity and group membership for role mapping using the MIQ token
+
+Note: `GET /api/auth?requester_type=ui` only echoes a refreshed token; it does **not** return user identity or groups on this version.
+
+---
+
+## Architecture Diagrams
+
+### Current State — Local Admin Authentication
+
+```mermaid
+graph TD
+    CLI[CLI / UI Client] -->|POST /api/v1/auth/login\nusername+password| CatalogAPI[Catalog API Server\nGo / Gin]
+    CatalogAPI -->|PBKDF2 verify| InMemoryRepo[In-Memory User Repo\nsingle admin user]
+    CatalogAPI -->|Issues| JWT[JWT Access + Refresh\nHS256 / 15min / 24hr]
+    JWT -->|Bearer token| ProtectedRoutes[Protected Routes\n/applications /catalog /resources]
+    CatalogAPI -->|Blacklist check| TokenBlacklist[(PostgreSQL\ntokens_blacklist)]
+```
+
+---
+
+### Target State — ManageIQ as Identity Provider
+
+```mermaid
+graph TD
+    User[User / CLI / UI] -->|Credentials| MIQ[ManageIQ\nIdentity Provider]
+    MIQ -->|User Identity + Roles + Groups| CatalogAPI[Catalog API Server\nGo / Gin]
+    CatalogAPI -->|Token Introspection| MIQ
+
+    CatalogAPI -->|Issues internal JWT\nwith MIQ roles embedded| JWT[Internal JWT\nwith RBAC claims]
+    JWT -->|AuthMiddleware validates| ProtectedRoutes[Protected Routes]
+
+    subgraph RBAC [Role-Based Access Control]
+        ProtectedRoutes -->|role = admin| AdminOps[Deploy Applications\nManage Catalog]
+        ProtectedRoutes -->|role = operator| OperatorOps[Deploy + Read]
+        ProtectedRoutes -->|role = viewer| ViewOps[Read Catalog\nView Applications]
+    end
+
+    CatalogAPI -->|Blacklist check| TokenBlacklist[(PostgreSQL\ntokens_blacklist)]
+```
+
+---
+
+### Integration Flow A — Interactive Login
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant MIQ as ManageIQ
+    participant CatalogAPI as Catalog API
+
+    User->>CatalogAPI: POST /api/v1/auth/login\nusername + password
+    CatalogAPI->>MIQ: GET /api/auth\nBasic-auth username:password
+    MIQ-->>CatalogAPI: auth_token + token_ttl=600s
+
+    CatalogAPI->>MIQ: GET /api/users?filter[]=userid=X\n?attributes=userid,name,miq_groups,current_group
+    MIQ-->>CatalogAPI: userid + name + miq_groups
+
+    CatalogAPI->>CatalogAPI: Map miq_groups to internal role\nadmin/operator/viewer
+    CatalogAPI-->>User: Internal JWT with role embedded\nTTL capped at 9m
+
+    User->>CatalogAPI: GET /api/v1/applications\nAuthorization: Bearer internal-jwt
+    CatalogAPI->>CatalogAPI: AuthMiddleware validates JWT\n+ checks blacklist + enforces role
+    CatalogAPI-->>User: Response
+```
+
+---
+
+### Integration Flow B — IBM Power Mission Control Token Passthrough
+
+IBM Power Mission Control already holds a ManageIQ token from its own session. It forwards
+that token as-is to the Catalog API. The Catalog API validates it against ManageIQ, resolves
+the identity and groups, and issues an internal JWT. IBM PMC does nothing beyond sending the token.
+
+```mermaid
+sequenceDiagram
+    participant PMC as IBM Power Mission Control
+    participant MIQ as ManageIQ
+    participant CatalogAPI as Catalog API
+
+    note over PMC: PMC already holds a MIQ token\nfrom its own session
+    PMC->>CatalogAPI: POST /api/v1/auth/token\nAuthorization: Bearer miq_token
+
+    CatalogAPI->>MIQ: GET /api/users?filter[]=userid=X\nX-Auth-Token: miq_token
+    MIQ-->>CatalogAPI: 200 userid + miq_groups\nOR 401 if token invalid/expired
+
+    CatalogAPI->>CatalogAPI: Map miq_groups to internal role\nadmin/operator/viewer
+    CatalogAPI-->>PMC: Internal JWT with role embedded\nTTL capped at 9m
+
+    PMC->>CatalogAPI: GET /api/v1/applications\nAuthorization: Bearer internal-jwt
+    CatalogAPI->>CatalogAPI: AuthMiddleware validates JWT\n+ checks blacklist + enforces role
+    CatalogAPI-->>PMC: Response
+```
+
+---
+
+### Integration Flow — OIDC/OAuth2 Phase 2
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant MIQ as ManageIQ OIDC Provider
+    participant CatalogAPI as Catalog API
+
+    User->>CatalogAPI: POST /api/v1/auth/oidc/callback\ncode from OIDC flow
+    CatalogAPI->>MIQ: POST /oauth/token\nexchange authorization code
+    MIQ-->>CatalogAPI: id_token + access_token
+
+    CatalogAPI->>MIQ: GET /oauth/userinfo
+    MIQ-->>CatalogAPI: sub + email + groups + roles
+
+    CatalogAPI->>CatalogAPI: Map OIDC claims to internal roles
+    CatalogAPI-->>User: Internal JWT with roles embedded
+
+    User->>CatalogAPI: API requests with internal JWT
+    CatalogAPI->>CatalogAPI: Validate JWT, enforce RBAC
+    CatalogAPI-->>User: Response
+```
+
+---
+
+### Architectural Layers Affected
+
+```mermaid
+graph LR
+    subgraph L1 [1 - MIQ Client]
+        A[ManageIQ HTTP Client\nToken introspection\nUserInfo fetch]
+    end
+
+    subgraph L2 [2 - Role Mapping]
+        B[RoleMapper\nMIQ groups to internal roles\nadmin / operator / viewer]
+    end
+
+    subgraph L3 [3 - JWT Claims]
+        C[Extend JWT customClaims\nAdd Role field\nValidateAccessToken returns role]
+    end
+
+    subgraph L4 [4 - Auth Service]
+        D[Login - Flow A username+password\nLoginWithToken - Flow B IBM PMC passthrough\nrole embedded at issue time]
+    end
+
+    subgraph L5 [5 - Auth Middleware]
+        E[AuthMiddleware sets CtxRoleKey\nRequireRole guard on write routes]
+    end
+
+    subgraph L6 [6 - Config and Deployment]
+        F[values.yaml / MANAGEIQ_URL env vars\nInstallation docs]
+    end
+
+    L1 --> L2 --> L3 --> L4 --> L5 --> L6
+```
+
+---
+
+### RBAC Role Hierarchy
+
+```mermaid
+graph TD
+    MIQRoles["miq_groups description field
+    from GET /api/users"] --> Mapping["Role Mapping Config
+    MIQ_ROLE_ADMIN_GROUPS
+    MIQ_ROLE_OPERATOR_GROUPS"]
+
+    Mapping -->|EvmGroup-super_administrator| AdminRole([admin])
+    Mapping -->|EvmGroup-administrator| AdminRole
+    Mapping -->|EvmGroup-operator| OperatorRole([operator])
+    Mapping -->|EvmGroup-auditor or unknown| ViewerRole([viewer])
+
+    AdminRole -->|Full access| AllEndpoints["All API Endpoints
+    CRUD Applications
+    Manage Catalog"]
+    OperatorRole -->|Read and Deploy| DeployEndpoints["Applications CRUD
+    Catalog Read"]
+    ViewerRole -->|Read only| ReadEndpoints["GET Endpoints Only"]
+```
+
+---
+
+## Sub-Tasks
+
+---
+
+### Sub-Task 1 — ManageIQ HTTP Client Package
+
+**Intent:**  
+Encapsulate all communication with ManageIQ into a dedicated, testable Go package. This isolates
+ManageIQ API details from the rest of the codebase and makes it easy to swap authentication strategies
+(token introspect → OIDC) later.
+
+**Expected Outcomes:**
+- New package `internal/pkg/catalog/miq/` with a `Client` interface and concrete HTTP implementation
+- `Client.Authenticate(ctx, username, password)` — calls `GET /api/auth` with Basic-auth; returns `AuthResponse{Token, TTL}`
+- `Client.GetUser(ctx, miqToken, userID)` — calls `GET /api/users/{id}?attributes=userid,name,miq_groups,current_group`; returns `UserInfo`
+- `UserInfo` struct carries `UserName`, `FullName`, `ExternalID`, `Groups []string`, `CurrentGroup string`
+- Error type `ErrUnauthorized` mapped from `error.kind == "unauthorized"` and klass `Api::BaseController::Authentication::AuthenticationError`
+- `InsecureSkipTLS bool` field on the client (required for self-signed certs like `9.20.202.144`)
+- Unit tests using an `httptest` server stub for both API calls
+
+**Todo List:**
+1. Create `internal/pkg/catalog/miq/client.go` with the `Client` interface
+2. Implement `HTTPClient` struct using `go-resty` (already a project dependency)
+3. Add `UserInfo`, `AuthResponse`, and `ErrorResponse` models in `internal/pkg/catalog/miq/models.go`
+4. Implement `Authenticate`: `GET /api/auth` with Basic-auth header; parse `auth_token` + `token_ttl`
+5. Implement `GetUser`: `GET /api/users/{id}?attributes=userid,name,miq_groups,current_group`; parse `miq_groups[].description` into `Groups`
+6. Map HTTP 401 + `error.kind=unauthorized` to `ErrUnauthorized` sentinel error
+7. Create `internal/pkg/catalog/miq/client_test.go` with httptest stubs for both endpoints
+8. Add `MANAGEIQ_URL` and `MANAGEIQ_INSECURE_SKIP_TLS` to the config package
+
+**Relevant Context:**
+- Validated API: `GET /api/auth` (Basic-auth) and `GET /api/users/{id}` on ManageIQ v4.4.0-pre
+- `go-resty` client already in `go.mod` at `github.com/go-resty/resty/v2`
+- Existing HTTP patterns in `internal/pkg/catalog/client/` can guide the style
+- Config loading in `internal/pkg/catalog/config/`
+- See `docs/proposals/manageiq-authn-authz-curl-validation.md` for exact request/response shapes
+
+**Status:** `[ ] pending`
+
+---
+
+### Sub-Task 2 — Role Mapping & RBAC Model
+
+**Intent:**  
+Define the mapping from ManageIQ group/role names to internal RBAC roles. This mapping must be
+configuration-driven so operators can adapt it without code changes.
+
+**Expected Outcomes:**
+- New `internal/pkg/catalog/apiserver/models/role.go` with `Role` type and constants: `RoleAdmin`, `RoleOperator`, `RoleViewer`
+- A `RoleMapper` that reads a YAML/env-based mapping and translates `[]string` of MIQ groups → `Role`
+- Default mapping documented in `values.yaml` and the config package
+- Unit tests covering mapping edge cases (no groups, unknown group, multiple groups)
+
+**Todo List:**
+1. Define `Role` type and constants in `models/role.go`
+2. Create `internal/pkg/catalog/apiserver/services/auth/rolemapper.go` with `MapGroupsToRole(groups []string) Role`
+3. Load mapping from environment variables (e.g., `MIQ_ROLE_ADMIN_GROUPS`, `MIQ_ROLE_OPERATOR_GROUPS`)
+4. Add defaults using **hyphen format**: `EvmGroup-super_administrator`, `EvmGroup-administrator` → `admin`; `EvmGroup-operator` → `operator`; everything else → `viewer`
+5. Write unit tests in `rolemapper_test.go`
+6. Document mapping config in `docs/proposals/manageiq-authn-authz-plan.md` (this file)
+
+**Relevant Context:**
+- **Validated group name format** (hyphen, not double-colon): `EvmGroup-super_administrator`, `EvmGroup-administrator`, `EvmGroup-operator`, `EvmGroup-auditor`
+- Group strings come from `miq_groups[].description` on `GET /api/users/{id}` — not from `/api/auth`
+- Existing `models/user.go` for model conventions
+- `internal/pkg/catalog/constants/` for constant patterns
+
+**Status:** `[ ] pending`
+
+---
+
+### Sub-Task 3 — Extend JWT Claims with Roles
+
+**Intent:**  
+The internal JWT must carry the user's RBAC role so the auth middleware can enforce it without
+hitting ManageIQ on every request. The role is embedded at login time and is valid for the token
+lifetime.
+
+**Expected Outcomes:**
+- `customClaims` in `services/auth/jwt.go` extended with `Role string` field
+- `GenerateAccessToken` / `GenerateRefreshToken` accept `role` parameter
+- `ValidateAccessToken` returns `(userID, role, expiry, error)`
+- Existing callers of token generation updated
+- Backward compatibility: tokens without role field treated as `viewer`
+
+**Todo List:**
+1. Add `Role string` to `customClaims` struct in `jwt.go`
+2. Update `GenerateAccessToken(userID, role string)` and `GenerateRefreshToken(userID, role string)` signatures
+3. Update `ValidateAccessToken` to return role alongside userID and expiry
+4. Update `AuthMiddleware` to set `CtxRoleKey` in the Gin context alongside `CtxUserIDKey`
+5. Update all call sites in `services/auth/service.go`
+6. Update unit tests
+
+**Relevant Context:**
+- `ai-services/internal/pkg/catalog/apiserver/services/auth/jwt.go` — current `customClaims`
+- `ai-services/internal/pkg/catalog/apiserver/middleware/auth.go` — sets `CtxUserIDKey` and `CtxRawTokenKey`
+- `ai-services/internal/pkg/catalog/apiserver/services/auth/service.go` — calls `GenerateAccessToken`
+
+**Status:** `[ ] pending`
+
+---
+
+### Sub-Task 4 — MIQ-Backed Auth Service & Login Handler (Flow A)
+
+**Intent:**
+Replace the single-admin PBKDF2 password check with a ManageIQ-backed interactive login flow. On
+`POST /api/v1/auth/login`, the Catalog API authenticates against ManageIQ using the supplied
+username + password, fetches user identity and group membership, maps roles, and issues an internal JWT.
+
+**Expected Outcomes:**
+- `auth.Service.Login` delegates to `miq.Client` via two-call flow
+- User struct populated from ManageIQ `UserInfo` (no local password storage)
+- Role embedded in issued JWT
+- Existing `POST /api/v1/auth/login` endpoint signature unchanged (`username` + `password` body)
+- Graceful 503 if ManageIQ is unreachable
+- `--manageiq-url` and `--manageiq-insecure-tls` CLI flags added to the `catalog apiserver` command
+
+**Todo List:**
+1. Add `miqClient miq.Client` to `auth.service` struct
+2. Rewrite `service.Login` as a two-call flow:
+   - Call `miqClient.Authenticate(ctx, username, password)` → returns `miqToken`
+   - Call `miqClient.GetUserByToken(ctx, miqToken)` → returns `UserInfo` with `Groups`
+3. Call `RoleMapper.MapGroupsToRole` on `UserInfo.Groups` (hyphen-format group names)
+4. Pass role to `GenerateAccessToken` / `GenerateRefreshToken`
+5. Wire `miq.Client` in `cmd/catalog/apiserver.go` (read `MANAGEIQ_URL`, `MANAGEIQ_INSECURE_SKIP_TLS` env)
+6. Add `--manageiq-url` and `--manageiq-insecure-tls` CLI flags in `cmd/catalog/apiserver.go`
+7. Keep `NewInMemoryUserRepo` for the `/auth/me` path — populated from `UserInfo` at login time
+8. Integration test: mock ManageIQ (`/api/auth` + `/api/users` stubs) → login → JWT decode → role check
+
+**Relevant Context:**
+- `ai-services/cmd/ai-services/cmd/catalog/apiserver.go` — server startup and wiring
+- `ai-services/internal/pkg/catalog/apiserver/handlers/auth_handler.go` — `Login` handler
+- `ai-services/internal/pkg/catalog/apiserver/services/auth/service.go` — `Login` method
+- `ai-services/internal/pkg/catalog/apiserver/repository/user_repo.go` — `InMemoryUserRepo`
+
+**Status:** `[ ] pending`
+
+---
+
+### Sub-Task 4b — IBM Power Mission Control Token Passthrough (Flow B)
+
+**Intent:**
+IBM Power Mission Control already holds a ManageIQ session token from its own auth lifecycle and
+sends it directly to the Catalog API — it does nothing beyond forwarding the token. The Catalog API
+receives the raw MIQ token, validates it against ManageIQ by calling `GET /api/users` with that token
+as `X-Auth-Token`, resolves the identity and groups, maps the role, and issues its own internal JWT.
+The flow converges on exactly the same identity resolution and JWT issuance path as Flow A.
+
+**Expected Outcomes:**
+- New `POST /api/v1/auth/token` endpoint; accepts `Authorization: Bearer <miq_token>` header
+- `auth.Service.LoginWithToken(ctx, miqToken string)` added to the `Service` interface
+- Implementation calls `miqClient.GetUserByToken(ctx, miqToken)` directly (no `/api/auth` call — the token is already known)
+- On valid token: role mapped from `miq_groups`, internal JWT issued — identical shape and TTL to Flow A
+- On invalid/expired MIQ token: ManageIQ returns 401 → Catalog API returns 401 to IBM PMC
+- No new env vars required — reuses `MANAGEIQ_URL` / `MANAGEIQ_INSECURE_SKIP_TLS`
+
+**Todo List:**
+1. Add `GetUserByToken(ctx context.Context, miqToken string) (*UserInfo, error)` to `miq.Client` interface
+2. Implement: `GET /api/users?filter[]=userid=X&expand=resources&attributes=userid,name,miq_groups,current_group` with `X-Auth-Token: miqToken`; map HTTP 401 → `ErrUnauthorized`
+3. Add `LoginWithToken(ctx context.Context, miqToken string) (access, refresh string, err error)` to `auth.Service` interface
+4. Implement `LoginWithToken` in `service.go`: call `GetUserByToken` → `RoleMapper.MapGroupsToRole` → `GenerateAccessToken` / `GenerateRefreshToken` → seed in-memory user repo entry
+5. Add `TokenLogin` handler in `auth_handler.go`: read `Authorization: Bearer` header → call `svc.LoginWithToken` → return same JSON shape as `Login`
+6. Register `POST /api/v1/auth/token` in `router.go` (no auth middleware — it is itself an auth endpoint)
+7. Update Sub-Task 1's `miq.Client` to share `GetUserByToken` between both flows (Flow A calls it after `Authenticate`; Flow B calls it directly)
+8. Unit test: stub MIQ `GET /api/users` returning valid user → assert JWT contains correct role
+9. Unit test: stub MIQ returning 401 → assert handler returns 401
+
+**Relevant Context:**
+- `ai-services/internal/pkg/catalog/apiserver/handlers/auth_handler.go` — `Login` handler as the pattern
+- `ai-services/internal/pkg/catalog/apiserver/router.go` — `v1.POST("/auth/login")` registration pattern
+- `ai-services/internal/pkg/catalog/apiserver/services/auth/service.go` — `Login` as the service pattern
+- curl validation: `GET /api/users?filter[]=userid=admin&expand=resources&attributes=userid,name,miq_groups,current_group` with `X-Auth-Token` header confirmed working against `https://9.20.202.144:8443`
+
+---
+
+### Sub-Task 5 — RBAC Route Guards in Auth Middleware
+
+**Intent:**  
+Protect write/destructive endpoints from lower-privileged roles. After Sub-Task 3 embeds the role
+in the JWT, the middleware and route groups can enforce `RequireRole(RoleAdmin)` guards on sensitive
+operations.
+
+**Expected Outcomes:**
+- New `middleware.RequireRole(role models.Role) gin.HandlerFunc` middleware
+- Admin-only routes (POST/PUT/DELETE on `/applications`) require `RoleAdmin`
+- Read-only routes accessible to `RoleViewer` and above
+- 403 Forbidden returned (not 401) when role is insufficient
+- Existing health/swagger/auth endpoints unaffected
+
+**Todo List:**
+1. Add `RequireRole(minRole Role) gin.HandlerFunc` to `middleware/auth.go`
+2. Define role ordering: `viewer < operator < admin`
+3. Update `router.go` to apply `RequireRole` after `AuthMiddleware` on write routes:
+   - `POST /applications` → `RequireRole(RoleOperator)`
+   - `PUT /applications/:id` → `RequireRole(RoleOperator)`
+   - `DELETE /applications/:id` → `RequireRole(RoleAdmin)`
+4. Return structured JSON error `{"error": "insufficient permissions", "required": "admin"}` on 403
+5. Unit tests for middleware with mock Gin contexts at each role level
+
+**Relevant Context:**
+- `ai-services/internal/pkg/catalog/apiserver/router.go` — route group definitions
+- `ai-services/internal/pkg/catalog/apiserver/middleware/auth.go` — existing `AuthMiddleware`
+
+**Status:** `[ ] pending`
+
+---
+
+### Sub-Task 6 — Configuration & Deployment Updates
+
+**Intent:**
+Update deployment configuration (`values.yaml`) to include ManageIQ connection parameters, and
+update the documentation so operators know how to configure the integration.
+
+**Expected Outcomes:**
+- `values.yaml` extended with `manageiq.url`, `manageiq.insecureTLS`, and role mapping entries
+- `docs/INSTALLATION.md` updated with ManageIQ configuration prerequisites
+- `.env.example` updated with new variables
+
+**Todo List:**
+1. Add `manageiq:` section to `ai-services/assets/catalog/podman/values.yaml`
+2. Update `.env.example` with `MANAGEIQ_URL`, `MANAGEIQ_INSECURE_SKIP_TLS`, `MIQ_ROLE_ADMIN_GROUPS`, `MIQ_ROLE_OPERATOR_GROUPS`
+3. Add a "ManageIQ Integration" section to `docs/INSTALLATION.md`
+4. Update Swagger annotations on auth endpoints to reflect new ManageIQ-backed behavior
+
+**Relevant Context:**
+- `ai-services/assets/catalog/podman/values.yaml` — deployment values
+- `.env.example` — environment variable template
+- `docs/INSTALLATION.md` — operator installation guide
+
+**Status:** `[ ] pending`
+
+---
+
+## Role Mapping Reference
+
+> Group names sourced from `miq_groups[].description` on `GET /api/users/{id}`.
+> Format uses a **hyphen separator** (`EvmGroup-name`), validated on ManageIQ v4.4.0-pre.
+
+| ManageIQ Group | Internal Role | Permissions |
+|---|---|---|
+| `EvmGroup-super_administrator` | `admin` | Full CRUD on all endpoints |
+| `EvmGroup-administrator` | `admin` | Full CRUD on all endpoints |
+| `EvmGroup-operator` | `operator` | Deploy/update applications; read catalog |
+| `EvmGroup-auditor` | `viewer` | Read-only access to all GET endpoints |
+| Any other / no group | `viewer` | Read-only access to all GET endpoints |
+
+---
+
+## Configuration Variables Reference
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `MANAGEIQ_URL` | Yes | — | Base URL of ManageIQ, e.g. `https://9.20.202.144:8443` |
+| `MANAGEIQ_INSECURE_SKIP_TLS` | No | `false` | Skip TLS verification — required for self-signed certs |
+| `MIQ_ROLE_ADMIN_GROUPS` | No | `EvmGroup-super_administrator,EvmGroup-administrator` | Comma-separated MIQ group descriptions mapped to `admin` |
+| `MIQ_ROLE_OPERATOR_GROUPS` | No | `EvmGroup-operator` | Comma-separated MIQ group descriptions mapped to `operator` |
+| `AUTH_JWT_SECRET` | No | auto-generated | HMAC-SHA256 secret for internal JWT signing |
+| `AUTH_ACCESS_TOKEN_TTL` | No | `9m` | Internal JWT access token lifetime — capped below MIQ token_ttl of 600s |
+| `AUTH_REFRESH_TOKEN_TTL` | No | `24h` | Internal JWT refresh token lifetime |
+
+---
+
+## Decision Record
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Two-call flow over single introspect call | Validated: `/api/auth?requester_type=ui` does not return user identity or groups on v4.4.0-pre; a separate `GET /api/users` call is required |
+| 2 | Internal JWT kept | Avoids ManageIQ round-trip on every API call; existing blacklist mechanism is reused unchanged |
+| 3 | Role embedded in JWT at login time | Roles are stable per session; keeps the hot path stateless |
+| 4 | In-memory user repo kept for `GetUser` | Avoids a MIQ call on `/auth/me`; the repo is populated from `UserInfo` returned at login |
+| 5 | `MANAGEIQ_INSECURE_SKIP_TLS` defaults to `false` | Validated instance uses a self-signed cert; production deployments should use valid certs |
+| 6 | `AUTH_ACCESS_TOKEN_TTL` default changed from `15m` to `9m` | Validated MIQ `token_ttl` is 600s (10 min); internal JWT must not outlive the MIQ session |
+| 7 | Flow B uses a separate endpoint `POST /api/v1/auth/token` | Keeps flows orthogonal; the existing `/auth/login` contract and body schema are unchanged |
+| 8 | Flow B skips `/api/auth` — calls `GET /api/users` directly | IBM PMC already holds the MIQ token; there is no need to authenticate again — only validation is needed |
+| 9 | `GetUserByToken` is shared by both flows | Flow A calls it after `Authenticate`; Flow B calls it directly — no duplicated identity resolution logic |
+| 10 | Python services out of scope | AuthN/AuthZ for Python services is a separate phase; no changes needed there |


### PR DESCRIPTION
This PR adds support for ManageIQ token passthrough authentication alongside the existing username/password login. IBM Power Mission Control can now exchange a pre-existing ManageIQ token for an internal Catalog API JWT via POST /api/v1/auth/token.

- Introduced a new endpoint /auth/token which provides a catalog API JWT pair in exchange to a Manage IQ token.

- Access token TTL defaults to 9 minutes — intentionally below ManageIQ's 600s token TTL to avoid internal JWTs outliving the upstream MIQ session

- Added a new hidden flag `miq-token` to the catalog login command to support ManageIQ auth integration. The code flow is as below.

     Command: **_ai-services catalog login --server <catalog_backend_endpoint> --miq-token <miq_token> --runtime podman_**

```
---> if miq-token is not empty, calls `runLoginWithMIQToken()` 
  ---> `miqClient.NewWithMIQToken()` 
    ---> `LoginWithMIQToken()`(does a POST call to /api/v1/auth/token) 
      ---> `TokenLogin` auth handler
        ---> `LoginWithToken()` (Validates a ManageIQ token by calling the MIQ API and issues a internal catalog API JWT pair) 
          ---> Login successful
``` 

- Added two new flags for Manage IQ `manageiq-url` and `manageiq-insecure-tls` in the catalog apiserver command.

   Command: **_ai-services catalog apiserver --manageiq-url https://9.20.202.144:8443 --manageiq-insecure-tls --runtime podman_**

```
----> if manageiq-url flag is set, creates a miqClient and calls `NewAuthServiceWithMIQ` 
```
Note: All the manageIQ flags are hidden intentionally in this PR. The command help output also shows nothing about the flags