### PR TITLE
handle sync service if namespace is deleted

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.236
+TAG?=v0.0.237
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.235
+TAG?=v0.0.236
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.236
+  image: icr.io/ai-services-cicd/ai-services:v0.0.237
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.235
+  image: icr.io/ai-services-cicd/ai-services:v0.0.236
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.236
+  image: icr.io/ai-services-cicd/ai-services:v0.0.237
   runtime: ""
   adminPasswordHash: ""
   # workerGatewayPort: port for the gRPC worker gateway. Always active; default is 9090.

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.235
+  image: icr.io/ai-services-cicd/ai-services:v0.0.236
   runtime: ""
   adminPasswordHash: ""
   # workerGatewayPort: port for the gRPC worker gateway. Always active; default is 9090.

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/openshift.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/openshift.go
@@ -31,12 +31,9 @@ func newOpenShiftSync() *openShiftSync {
 
 // FetchPodStatuses fetches all pods labelled with the given templateID using the OpenShift runtime.
 func (s *openShiftSync) FetchPodStatuses(rt runtime.Runtime, templateID string) ([]*PodStatus, error) {
-	exists, err := rt.NamespaceExists()
+	_, err := rt.GetNamespace()
 	if err != nil {
 		return nil, err
-	}
-	if !exists {
-		return nil, fmt.Errorf("namespace does not exist")
 	}
 
 	filteredPods, err := common.FetchFilteredPods(rt, templateID)

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/openshift.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/openshift.go
@@ -31,11 +31,6 @@ func newOpenShiftSync() *openShiftSync {
 
 // FetchPodStatuses fetches all pods labelled with the given templateID using the OpenShift runtime.
 func (s *openShiftSync) FetchPodStatuses(rt runtime.Runtime, templateID string) ([]*PodStatus, error) {
-	_, err := rt.GetNamespace()
-	if err != nil {
-		return nil, err
-	}
-
 	filteredPods, err := common.FetchFilteredPods(rt, templateID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch pods: %w", err)

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/openshift.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/openshift.go
@@ -31,6 +31,14 @@ func newOpenShiftSync() *openShiftSync {
 
 // FetchPodStatuses fetches all pods labelled with the given templateID using the OpenShift runtime.
 func (s *openShiftSync) FetchPodStatuses(rt runtime.Runtime, templateID string) ([]*PodStatus, error) {
+	exists, err := rt.NamespaceExists()
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, fmt.Errorf("namespace does not exist")
+	}
+
 	filteredPods, err := common.FetchFilteredPods(rt, templateID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch pods: %w", err)

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -194,7 +194,7 @@ func (s *SyncService) syncApplication(ctx context.Context, app *models.Applicati
 
 	logger.InfofCtx(ctx, "Syncing application: %s (ID: %s)", app.Name, app.ID)
 
-	// Fail early if the namespace does not exist (OpenShift only — podman has no namespace concept).
+	// Fail early if the namespace does not exist
 	if rt.Type() == runtimeTypes.RuntimeTypeOpenShift {
 		if _, err := rt.GetNamespace(); errors.Is(err, openshiftRuntime.ErrNamespaceNotFound) {
 			return s.updateApplicationStatus(ctx, app, false, []string{err.Error()})

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -401,7 +401,7 @@ func (s *SyncService) determineServiceStatusFromPods(ctx context.Context, appID,
 
 // updateServiceStatusIfChanged updates service status only if it has changed.
 func (s *SyncService) updateServiceStatusIfChanged(ctx context.Context, service models.Service, newStatus models.ServiceStatus, message string) error {
-	if service.Status != newStatus {
+	if service.Status != newStatus || service.Message != message {
 		if err := catalogutils.UpdateServiceStatus(ctx, s.serviceRepo, service.ID, newStatus, message); err != nil {
 			return fmt.Errorf("failed to update service status: %w", err)
 		}
@@ -493,7 +493,7 @@ func (s *SyncService) checkPodsHealth(pods []*PodStatus) (models.ComponentStatus
 
 // updateComponentStatusIfChanged updates component status only if it has changed.
 func (s *SyncService) updateComponentStatusIfChanged(ctx context.Context, component *models.Component, componentID uuid.UUID, newStatus models.ComponentStatus, message string) error {
-	if component.Status != newStatus {
+	if component.Status != newStatus || component.Message != message {
 		if err := catalogutils.UpdateComponentStatus(ctx, s.componentRepo, componentID, newStatus, message); err != nil {
 			return fmt.Errorf("failed to update component status: %w", err)
 		}
@@ -537,8 +537,8 @@ func (s *SyncService) updateApplicationStatus(ctx context.Context, app *models.A
 		message = ""
 	}
 
-	// Update only if status changed
-	if app.Status != newStatus {
+	// Update if status or message changed
+	if app.Status != newStatus || app.Message != message {
 		if err := catalogutils.UpdateApplicationStatus(ctx, s.appRepo, app.ID, newStatus, message); err != nil {
 			return fmt.Errorf("failed to update application status: %w", err)
 		}

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -15,6 +16,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	openshiftRuntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/openshift"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
@@ -191,6 +193,13 @@ func (s *SyncService) syncApplication(ctx context.Context, app *models.Applicati
 	}
 
 	logger.InfofCtx(ctx, "Syncing application: %s (ID: %s)", app.Name, app.ID)
+
+	// Fail early if the namespace does not exist (OpenShift only — podman has no namespace concept).
+	if rt.Type() == runtimeTypes.RuntimeTypeOpenShift {
+		if _, err := rt.GetNamespace(); errors.Is(err, openshiftRuntime.ErrNamespaceNotFound) {
+			return s.updateApplicationStatus(ctx, app, false, []string{err.Error()})
+		}
+	}
 
 	// Track errors during sync
 	errorMessages := []string{}

--- a/ai-services/internal/pkg/runtime/interface.go
+++ b/ai-services/internal/pkg/runtime/interface.go
@@ -24,6 +24,7 @@ type Runtime interface {
 	PodExists(nameOrID string) (bool, error)
 	PodLogs(nameOrID string) error
 	GetPodResources(nameOrID string) (*types.PodResources, error)
+	NamespaceExists() (bool, error)
 
 	// Secret operations
 	ListSecrets(filters map[string][]string) ([]string, error)

--- a/ai-services/internal/pkg/runtime/interface.go
+++ b/ai-services/internal/pkg/runtime/interface.go
@@ -24,7 +24,7 @@ type Runtime interface {
 	PodExists(nameOrID string) (bool, error)
 	PodLogs(nameOrID string) error
 	GetPodResources(nameOrID string) (*types.PodResources, error)
-	NamespaceExists() (bool, error)
+	GetNamespace() (string, error)
 
 	// Secret operations
 	ListSecrets(filters map[string][]string) ([]string, error)

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -186,6 +186,20 @@ func (kc *OpenshiftClient) PullImage(image string) error {
 	return nil
 }
 
+// NamespaceExists reports whether the configured namespace exists.
+func (kc *OpenshiftClient) NamespaceExists() (bool, error) {
+	_, err := kc.KubeClient.CoreV1().Namespaces().Get(kc.Ctx, kc.Namespace, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("failed to check namespace existence: %w", err)
+	}
+
+	return true, nil
+}
+
 // ListPods lists pods with optional filters.
 func (kc *OpenshiftClient) ListPods(filters map[string][]string) ([]types.Pod, error) {
 	labels := client.MatchingLabels{}

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -39,6 +39,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ErrNamespaceNotFound is returned by GetNamespace when the namespace does not exist.
+var ErrNamespaceNotFound = errors.New("namespace not found")
+
 var (
 	scheme = runtime.NewScheme()
 
@@ -186,18 +189,18 @@ func (kc *OpenshiftClient) PullImage(image string) error {
 	return nil
 }
 
-// NamespaceExists reports whether the configured namespace exists.
-func (kc *OpenshiftClient) NamespaceExists() (bool, error) {
-	_, err := kc.KubeClient.CoreV1().Namespaces().Get(kc.Ctx, kc.Namespace, metav1.GetOptions{})
+// GetNamespace fetches the namespace details.
+func (kc *OpenshiftClient) GetNamespace() (string, error) {
+	ns, err := kc.KubeClient.CoreV1().Namespaces().Get(kc.Ctx, kc.Namespace, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return false, nil
+			return "", fmt.Errorf("%w: %s", ErrNamespaceNotFound, kc.Namespace)
 		}
 
-		return false, fmt.Errorf("failed to check namespace existence: %w", err)
+		return "", fmt.Errorf("failed to get namespace: %w", err)
 	}
 
-	return true, nil
+	return ns.Name, nil
 }
 
 // ListPods lists pods with optional filters.

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -491,6 +491,12 @@ func (pc *PodmanClient) UpdateSecret(name, deploymentName string, data map[strin
 	return fmt.Errorf("unsupported method")
 }
 
+func (pc *PodmanClient) NamespaceExists() (bool, error) {
+	logger.ErrorfCtx(pc.Context, "unsupported method called!")
+
+	return false, fmt.Errorf("unsupported method")
+}
+
 // Type returns the runtime type for PodmanClient.
 func (pc *PodmanClient) Type() types.RuntimeType {
 	return types.RuntimeTypePodman

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -491,10 +491,10 @@ func (pc *PodmanClient) UpdateSecret(name, deploymentName string, data map[strin
 	return fmt.Errorf("unsupported method")
 }
 
-func (pc *PodmanClient) NamespaceExists() (bool, error) {
+func (pc *PodmanClient) GetNamespace() (string, error) {
 	logger.ErrorfCtx(pc.Context, "unsupported method called!")
 
-	return false, fmt.Errorf("unsupported method")
+	return "", fmt.Errorf("unsupported method")
 }
 
 // Type returns the runtime type for PodmanClient.


### PR DESCRIPTION
When namespace is deleted, current workflow shows a long message stating pod does not exists (for all pods), we should rather show namespace does not exists