### PR TITLE
AISERVICES-1577: Delete catalog namespace based on skip-clean-up flag

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.231
+TAG?=v0.0.232
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.231
+  image: icr.io/ai-services-cicd/ai-services:v0.0.232
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.231
+  image: icr.io/ai-services-cicd/ai-services:v0.0.232
   runtime: ""
   adminPasswordHash: ""
   # workerGatewayPort: port for the gRPC worker gateway. Always active; default is 9090.

--- a/ai-services/internal/pkg/catalog/cli/uninstall/openshift/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/openshift/uninstall.go
@@ -3,36 +3,22 @@ package openshift
 import (
 	"context"
 	"fmt"
-	"time"
 
 	clicommon "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common"
 	utils "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/uninstall/utils"
 	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
-	"github.com/project-ai-services/ai-services/internal/pkg/helm"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	openshiftruntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/openshift"
 	"github.com/project-ai-services/ai-services/internal/pkg/spinner"
 )
 
-const defaultUninstallTimeout = 5 * time.Minute
-
-// UninstallCatalog removes the catalog helm release and optionally cleans up PVCs.
+// UninstallCatalog removes the catalog helm release and optionally cleans up PVCs and catalog namespace.
 func UninstallCatalog(ctx context.Context, opts utils.UninstallOptions) error {
 	catalog := catalogConstants.CatalogAppName
 	namespace := catalog
-
-	// Create a new Helm client
-	helmClient, err := helm.NewHelm(namespace)
-	if err != nil {
-		return fmt.Errorf("failed to create helm client: %w", err)
-	}
-
-	// Check if the catalog release exists
-	if installed, err := clicommon.IsCatalogInstalled(ctx, helmClient, catalog, namespace); err != nil || !installed {
-		return err
-	}
 
 	rt, err := openshiftruntime.NewOpenshiftClientWithNamespace(namespace)
 	if err != nil {
@@ -46,18 +32,34 @@ func UninstallCatalog(ctx context.Context, opts utils.UninstallOptions) error {
 
 	logger.InfolnCtx(ctx, "Proceeding with uninstall...")
 
-	s := spinner.New("Uninstalling catalog '" + catalog + "'...")
+	s := spinner.New("Uninstalling catalog service...")
 	s.Start(ctx)
 
-	if err := helmClient.Uninstall(catalog, &helm.UninstallOpts{Timeout: defaultUninstallTimeout}); err != nil {
+	if err := catalogutils.HelmUninstall(ctx, namespace, catalog); err != nil {
 		s.Fail("failed to uninstall catalog")
 
 		return fmt.Errorf("failed to uninstall catalog: %w", err)
 	}
 
-	s.Stop("Catalog '" + catalog + "' uninstalled successfully")
+	if !opts.SkipCleanup {
+		logger.DebuglnCtx(ctx, "Delete catalog PVCs...")
 
-	return cleanupPVCs(ctx, rt, opts.SkipCleanup, catalog)
+		if err := rt.DeletePVCs(fmt.Sprintf("%s=%s", constants.ApplicationAnnotationKey, catalog)); err != nil {
+			s.Fail("failed to delete catalog pvc")
+
+			return fmt.Errorf("failed to delete PVCs: %w", err)
+		}
+
+		if err := rt.DeleteNamespace(namespace); err != nil {
+			s.Fail("failed to delete catalog namespace")
+
+			return fmt.Errorf("failed to delete '%s' namespace: %w", namespace, err)
+		}
+	}
+
+	s.Stop("Catalog service uninstalled successfully")
+
+	return nil
 }
 
 func confirmDeletion(ctx context.Context, rt runtime.Runtime, autoYes bool) (bool, error) {
@@ -71,20 +73,6 @@ func confirmDeletion(ctx context.Context, rt runtime.Runtime, autoYes bool) (boo
 	}
 
 	return utils.ConfirmDeletion(ctx, pods)
-}
-
-func cleanupPVCs(ctx context.Context, rt runtime.Runtime, skipCleanup bool, catalog string) error {
-	if skipCleanup {
-		return nil
-	}
-
-	logger.DebuglnCtx(ctx, "Cleaning up Persistent Volume Claims...")
-
-	if err := rt.DeletePVCs(fmt.Sprintf("%s=%s", constants.ApplicationAnnotationKey, catalog)); err != nil {
-		return fmt.Errorf("failed to cleanup PVCs: %w", err)
-	}
-
-	return nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/utils/common.go
+++ b/ai-services/internal/pkg/catalog/utils/common.go
@@ -144,7 +144,7 @@ func HelmUninstall(ctx context.Context, namespace, release string) error {
 
 	exists, err := helmClient.IsReleaseExist(release)
 	if err != nil {
-		return fmt.Errorf("failed to check release existence: %w", err)
+		return fmt.Errorf("failed to check '%s' release existence: %w", release, err)
 	}
 
 	if !exists {

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -60,7 +60,7 @@ const (
 	labelPartsCount = 2 // labelPartsCount is used to split label filters in the format "key=value".
 
 	deleteNamespaceGracePeriod = int64(30)       // deleteNamespaceGracePeriod is the grace period in seconds for namespace deletion.
-	deleteNamespaceTimeout     = 5 * time.Minute // deleteNamespaceTimeout is the maximum time to wait for a namespace deletion to complete.
+	deleteNamespaceTimeout     = 3 * time.Minute // deleteNamespaceTimeout is the maximum time to wait for a namespace deletion to complete.
 )
 
 // OpenshiftClient implements the Runtime interface for Openshift.


### PR DESCRIPTION
As part of catalog `uninstall`, this PR adds the missing logic to delete the catalog `namespace` when the skip-cleanup flag is not set.