### PR TITLE
migrate info cmd to use catalog api

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.267
+TAG?=v0.0.268
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.267
+  image: icr.io/ai-services-cicd/ai-services:v0.0.268
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.267
+  image: icr.io/ai-services-cicd/ai-services:v0.0.268
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/services/chat/openshift/templates/chat-bot-backend-deployment.yaml
+++ b/ai-services/assets/services/chat/openshift/templates/chat-bot-backend-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
     ai-services.io/service: {{ .Release.Name }}
     ai-services.io/template: {{ .Values.templateID }}
     ai-services.io/version: {{ default .Chart.AppVersion | quote }}
-    ai-services.io/component: api
 spec:
   replicas: 1
   selector:
@@ -20,6 +19,7 @@ spec:
         ai-services.io/template: {{ .Values.templateID }}
         ai-services.io/component: chat-bot-backend
         ai-services.io/version: {{ default .Chart.AppVersion | quote }}
+        ai-services.io/component-type: api
     spec:
       automountServiceAccountToken: false
       containers:

--- a/ai-services/assets/services/chat/openshift/templates/chat-bot-backend-deployment.yaml
+++ b/ai-services/assets/services/chat/openshift/templates/chat-bot-backend-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     ai-services.io/service: {{ .Release.Name }}
     ai-services.io/template: {{ .Values.templateID }}
     ai-services.io/version: {{ default .Chart.AppVersion | quote }}
+    ai-services.io/component: api
 spec:
   replicas: 1
   selector:

--- a/ai-services/assets/services/chat/openshift/templates/chat-bot-ui-deployment.yaml
+++ b/ai-services/assets/services/chat/openshift/templates/chat-bot-ui-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
     ai-services.io/service: {{ .Release.Name }}
     ai-services.io/template: {{ .Values.templateID }}
     ai-services.io/version: {{ default .Chart.AppVersion | quote }}
-    ai-services.io/component: ui
 spec:
   replicas: 1
   selector:
@@ -19,6 +18,7 @@ spec:
         ai-services.io/service: {{ .Release.Name }}
         ai-services.io/template: {{ .Values.templateID }}
         ai-services.io/component: chat-bot-ui
+        ai-services.io/component-type: ui
         ai-services.io/version: {{ default .Chart.AppVersion | quote }}
     spec:
       automountServiceAccountToken: false

--- a/ai-services/assets/services/chat/openshift/templates/chat-bot-ui-deployment.yaml
+++ b/ai-services/assets/services/chat/openshift/templates/chat-bot-ui-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     ai-services.io/service: {{ .Release.Name }}
     ai-services.io/template: {{ .Values.templateID }}
     ai-services.io/version: {{ default .Chart.AppVersion | quote }}
+    ai-services.io/component: ui
 spec:
   replicas: 1
   selector:

--- a/ai-services/assets/services/digitize/openshift/templates/digitize-api-deployment.yaml
+++ b/ai-services/assets/services/digitize/openshift/templates/digitize-api-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     ai-services.io/service: {{ .Release.Name }}
     ai-services.io/template: {{ .Values.templateID }}
     ai-services.io/version: {{ default .Chart.AppVersion | quote }}
+    ai-services.io/component: api
 spec:
   replicas: 1
   selector:

--- a/ai-services/assets/services/digitize/openshift/templates/digitize-api-deployment.yaml
+++ b/ai-services/assets/services/digitize/openshift/templates/digitize-api-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
     ai-services.io/service: {{ .Release.Name }}
     ai-services.io/template: {{ .Values.templateID }}
     ai-services.io/version: {{ default .Chart.AppVersion | quote }}
-    ai-services.io/component: api
 spec:
   replicas: 1
   selector:
@@ -19,6 +18,7 @@ spec:
         ai-services.io/service: {{ .Release.Name }}
         ai-services.io/template: {{ .Values.templateID }}
         ai-services.io/component: digitize-api
+        ai-services.io/component-type: api
         ai-services.io/version: {{ default .Chart.AppVersion | quote }}
     spec:
       automountServiceAccountToken: false

--- a/ai-services/assets/services/digitize/openshift/templates/digitize-ui-deployment.yaml
+++ b/ai-services/assets/services/digitize/openshift/templates/digitize-ui-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
     ai-services.io/service: {{ .Release.Name }}
     ai-services.io/template: {{ .Values.templateID }}
     ai-services.io/version: {{ default .Chart.AppVersion | quote }}
-    ai-services.io/component: ui
 spec:
   replicas: 1
   selector:
@@ -19,6 +18,7 @@ spec:
         ai-services.io/service: {{ .Release.Name }}
         ai-services.io/template: {{ .Values.templateID }}
         ai-services.io/component: digitize-ui
+        ai-services.io/component-type: ui
         ai-services.io/version: {{ default .Chart.AppVersion | quote }}
     spec:
       automountServiceAccountToken: false

--- a/ai-services/assets/services/digitize/openshift/templates/digitize-ui-deployment.yaml
+++ b/ai-services/assets/services/digitize/openshift/templates/digitize-ui-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     ai-services.io/service: {{ .Release.Name }}
     ai-services.io/template: {{ .Values.templateID }}
     ai-services.io/version: {{ default .Chart.AppVersion | quote }}
+    ai-services.io/component: ui
 spec:
   replicas: 1
   selector:

--- a/ai-services/assets/services/similarity/openshift/templates/similarity-api-deployment.yaml
+++ b/ai-services/assets/services/similarity/openshift/templates/similarity-api-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     ai-services.io/service: {{ .Release.Name }}
     ai-services.io/template: {{ .Values.templateID }}
     ai-services.io/version: {{ default .Chart.AppVersion | quote }}
+    ai-services.io/component: api
 spec:
   replicas: 1
   selector:

--- a/ai-services/assets/services/similarity/openshift/templates/similarity-api-deployment.yaml
+++ b/ai-services/assets/services/similarity/openshift/templates/similarity-api-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
     ai-services.io/service: {{ .Release.Name }}
     ai-services.io/template: {{ .Values.templateID }}
     ai-services.io/version: {{ default .Chart.AppVersion | quote }}
-    ai-services.io/component: api
 spec:
   replicas: 1
   selector:
@@ -19,6 +18,7 @@ spec:
         ai-services.io/service: {{ .Release.Name }}
         ai-services.io/template: {{ .Values.templateID }}
         ai-services.io/component: similarity-api
+        ai-services.io/component-type: api
         ai-services.io/version: {{ default .Chart.AppVersion | quote }}
     spec:
       automountServiceAccountToken: false

--- a/ai-services/assets/services/summarize/openshift/templates/summarize-api-deployment.yaml
+++ b/ai-services/assets/services/summarize/openshift/templates/summarize-api-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
     ai-services.io/service: {{ .Release.Name }}
     ai-services.io/template: {{ .Values.templateID }}
     ai-services.io/version: {{ default .Chart.AppVersion | quote }}
-    ai-services.io/component: api
 spec:
   replicas: 1
   selector:
@@ -19,6 +18,7 @@ spec:
         ai-services.io/service: {{ .Release.Name }}
         ai-services.io/template: {{ .Values.templateID }}
         ai-services.io/component: summarize-api
+        ai-services.io/component-type: api
         ai-services.io/version: {{ default .Chart.AppVersion | quote }}
     spec:
       automountServiceAccountToken: false

--- a/ai-services/assets/services/summarize/openshift/templates/summarize-api-deployment.yaml
+++ b/ai-services/assets/services/summarize/openshift/templates/summarize-api-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     ai-services.io/service: {{ .Release.Name }}
     ai-services.io/template: {{ .Values.templateID }}
     ai-services.io/version: {{ default .Chart.AppVersion | quote }}
+    ai-services.io/component: api
 spec:
   replicas: 1
   selector:

--- a/ai-services/cmd/ai-services/cmd/application/info.go
+++ b/ai-services/cmd/ai-services/cmd/application/info.go
@@ -14,6 +14,7 @@ import (
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	cliUtils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
@@ -47,9 +48,8 @@ Arguments:
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
-		// When legacyInfo is true and runtime is podman, use the older/stable code path
-		// For openshift runtime, always use the older/stable code path regardless of legacy flag
-		if legacyInfo && rt == types.RuntimeTypePodman {
+		// When legacyInfo is true, use the older/stable code path
+		if legacyInfo {
 			// Create application instance using factory
 			factory := application.NewFactory(rt)
 			app, err := factory.Create(applicationName)
@@ -65,23 +65,7 @@ Arguments:
 		}
 
 		// Default: use new implementation using catalog
-		// For openshift runtime, always use the older/stable code path
-		if rt == types.RuntimeTypePodman {
-			return renderApplicationInfo(applicationName)
-		}
-
-		// OpenShift runtime uses the older implementation
-		factory := application.NewFactory(rt)
-		app, err := factory.Create(applicationName)
-		if err != nil {
-			return fmt.Errorf("failed to create application instance: %w", err)
-		}
-
-		opts := appTypes.InfoOptions{
-			Name: applicationName,
-		}
-
-		return app.Info(opts)
+		return renderApplicationInfo(applicationName, rt)
 	},
 }
 
@@ -89,7 +73,7 @@ func init() {
 	infoCmd.Flags().BoolVar(&legacyInfo, "legacy", false, "Use legacy application info implementation")
 }
 
-func renderApplicationInfo(appName string) error {
+func renderApplicationInfo(appName string, rt types.RuntimeType) error {
 	appClient, err := catalogClient.NewApplicationClient()
 	if err != nil {
 		return fmt.Errorf("failed to create application client: %w", err)
@@ -120,10 +104,10 @@ func renderApplicationInfo(appName string) error {
 	logger.Infoln("Application Template: " + application.CatalogID)
 	logger.Infoln("Application Version: " + application.Version)
 
-	return printServicesInfo(application.Services, appPS)
+	return printServicesInfo(application.Services, appPS, rt)
 }
 
-func printServicesInfo(services []catalogTypes.ApplicationService, appPS *catalogTypes.ApplicationPSResponse) error {
+func printServicesInfo(services []catalogTypes.ApplicationService, appPS *catalogTypes.ApplicationPSResponse, rt types.RuntimeType) error {
 	catalogProvider, err := catalog.NewCatalogProvider(nil)
 	if err != nil {
 		return fmt.Errorf("failed to create catalog provider: %w", err)
@@ -137,7 +121,7 @@ func printServicesInfo(services []catalogTypes.ApplicationService, appPS *catalo
 		params := map[string]string{}
 		params["SERVICE_NAME"] = service.Type
 
-		uiStatus, apiSatatus := getContainerStatus(appPS.Services, service.CatalogID)
+		uiStatus, apiSatatus := getContainerStatus(appPS.Services, service.CatalogID, rt)
 		params["UI_STATUS"] = uiStatus
 		params["API_STATUS"] = apiSatatus
 
@@ -154,7 +138,7 @@ func printServicesInfo(services []catalogTypes.ApplicationService, appPS *catalo
 			return fmt.Errorf("failed to load service md files: %w", err)
 		}
 
-		err = printInfo(tmpls, params, service.CatalogID)
+		err = printInfo(tmpls, params)
 		if err != nil {
 			return fmt.Errorf("failed to load application info: %w", err)
 		}
@@ -163,9 +147,19 @@ func printServicesInfo(services []catalogTypes.ApplicationService, appPS *catalo
 	return nil
 }
 
-func getContainerStatus(services []catalogTypes.Pod, catalogID string) (string, string) {
-	uiStatus, apiStatus := "", ""
+func getContainerStatus(services []catalogTypes.Pod, catalogID string, rt types.RuntimeType) (string, string) {
+	switch rt {
+	case types.RuntimeTypePodman:
+		return printPodmanContainerStatus(services, catalogID)
+	case types.RuntimeTypeOpenShift:
+		return printOpenshiftPodStatus(services, catalogID)
+	default:
+		return "", ""
+	}
+}
 
+func printPodmanContainerStatus(services []catalogTypes.Pod, catalogID string) (string, string) {
+	uiStatus, apiStatus := "", ""
 	for _, servicePod := range services {
 		if strings.HasPrefix(servicePod.PodName, catalogID) {
 			for _, podContainer := range servicePod.Containers {
@@ -191,7 +185,37 @@ func getContainerStatus(services []catalogTypes.Pod, catalogID string) (string, 
 	return uiStatus, apiStatus
 }
 
-func printInfo(tmpls map[string]*template.Template, params map[string]string, appTemplate string) error {
+/*
+1. For each service fetch all labels
+2. See if that service has ai-services.io/component label
+3. If yes, check if value is api or ui
+4. Update status accordingly.
+*/
+func printOpenshiftPodStatus(services []catalogTypes.Pod, catalogID string) (string, string) {
+	uiStatus, apiStatus := "", ""
+
+	for _, service := range services {
+		if !strings.HasPrefix(service.PodName, catalogID) {
+			continue
+		}
+
+		component := service.Labels[constants.ComponentLabelKey]
+		switch component {
+		case "ui":
+			if service.Healthy {
+				uiStatus = "running"
+			}
+		case "api":
+			if service.Healthy {
+				apiStatus = "running"
+			}
+		}
+	}
+
+	return uiStatus, apiStatus
+}
+
+func printInfo(tmpls map[string]*template.Template, params map[string]string) error {
 	tmpl, ok := tmpls["info.md"]
 	if !ok {
 		logger.Warningf("failed to find info.md template")

--- a/ai-services/cmd/ai-services/cmd/application/info.go
+++ b/ai-services/cmd/ai-services/cmd/application/info.go
@@ -121,9 +121,9 @@ func printServicesInfo(services []catalogTypes.ApplicationService, appPS *catalo
 		params := map[string]string{}
 		params["SERVICE_NAME"] = service.Type
 
-		uiStatus, apiSatatus := getContainerStatus(appPS.Services, service.CatalogID, rt)
+		uiStatus, apiStatus := getContainerStatus(appPS.Services, service.CatalogID, rt)
 		params["UI_STATUS"] = uiStatus
-		params["API_STATUS"] = apiSatatus
+		params["API_STATUS"] = apiStatus
 
 		for _, endpoint := range service.Endpoints {
 			urlType, urlTypeOk := endpoint["type"].(string)
@@ -187,7 +187,7 @@ func printPodmanContainerStatus(services []catalogTypes.Pod, catalogID string) (
 
 /*
 1. For each service fetch all labels
-2. See if that service has ai-services.io/component label
+2. See if that service has ai-services.io/component-type label
 3. If yes, check if value is api or ui
 4. Update status accordingly.
 */

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -2344,6 +2344,12 @@ const docTemplate = `{
                 "healthy": {
                     "type": "boolean"
                 },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "pod_id": {
                     "type": "string"
                 },

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -2338,6 +2338,12 @@
                 "healthy": {
                     "type": "boolean"
                 },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "pod_id": {
                     "type": "string"
                 },

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -398,6 +398,10 @@ definitions:
         type: string
       healthy:
         type: boolean
+      labels:
+        additionalProperties:
+          type: string
+        type: object
       pod_id:
         type: string
       pod_name:

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -1049,6 +1049,7 @@ func loadApplicationPods(rt runtime.Runtime, appID string) ([]types.Pod, error) 
 			Status:     types.Status(strings.ToLower(processedPod.Status)),
 			Healthy:    processedPod.Health == string(consts.Ready),
 			Created:    pod.Created.Format(constants.RFC3339WithTimezone),
+			Labels:     pod.Labels,
 			Containers: containers,
 		}
 

--- a/ai-services/internal/pkg/catalog/types/application_response.go
+++ b/ai-services/internal/pkg/catalog/types/application_response.go
@@ -104,12 +104,13 @@ const (
 
 // Pod represents the details of a pod.
 type Pod struct {
-	PodID      string         `json:"pod_id"`
-	PodName    string         `json:"pod_name"`
-	Status     Status         `json:"status"`
-	Created    string         `json:"created"`
-	Healthy    bool           `json:"healthy"`
-	Containers []PodContainer `json:"containers"`
+	PodID      string            `json:"pod_id"`
+	PodName    string            `json:"pod_name"`
+	Status     Status            `json:"status"`
+	Created    string            `json:"created"`
+	Healthy    bool              `json:"healthy"`
+	Labels     map[string]string `json:"labels,omitempty"`
+	Containers []PodContainer    `json:"containers"`
 }
 
 // PodContainer represents a container in a pod.

--- a/ai-services/internal/pkg/constants/annotations.go
+++ b/ai-services/internal/pkg/constants/annotations.go
@@ -8,5 +8,5 @@ const (
 	PodRoutesAnnotationKey   = "ai-services.io/routes"
 	ApplicationTemplateKey   = "ai-services.io/template"
 	PrerequisiteLabelKey     = "ai-services.io/prerequisite"
-	ComponentLabelKey        = "ai-services.io/component"
+	ComponentLabelKey        = "ai-services.io/component-type"
 )

--- a/ai-services/internal/pkg/constants/annotations.go
+++ b/ai-services/internal/pkg/constants/annotations.go
@@ -8,4 +8,5 @@ const (
 	PodRoutesAnnotationKey   = "ai-services.io/routes"
 	ApplicationTemplateKey   = "ai-services.io/template"
 	PrerequisiteLabelKey     = "ai-services.io/prerequisite"
+	ComponentLabelKey        = "ai-services.io/component"
 )


### PR DESCRIPTION
1. Migrate info cmd to use new implementation of catalog
2. moved legacy and catalog logic to common.go for openshift and podman runtime to consume it.