### PR TITLE
Implement routes for workers

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.241
+TAG?=v0.0.242
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.241
+  image: icr.io/ai-services-cicd/ai-services:v0.0.242
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.241
+  image: icr.io/ai-services-cicd/ai-services:v0.0.242
   runtime: ""
   adminPasswordHash: ""
   # workerGatewayPort: port for the gRPC worker gateway. Always active; default is 9090.

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -119,8 +119,6 @@ func buildAPIServerOptions(ctx context.Context, pool *pgxpool.Pool, secretKey, a
 		ApplicationService: apirepository.NewApplicationService(appRepo, svcRepo, compRepo, svcDepRepo, catalogProvider, vars.RuntimeFactory.GetRuntimeType()),
 		WorkerGatewayPort:  workerGatewayPort,
 		WorkerRegistry:     workerReg,
-		WorkerTokenStore:   workerregistry.NewTokenStore(),
-		WorkerRepository:   workerRepo,
 	}
 	cleanup := func() {
 		blacklist.Stop()

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -1532,10 +1532,12 @@ const docTemplate = `{
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerRuntimeType": {
             "type": "string",
             "enum": [
+                "unknown",
                 "podman",
                 "openshift"
             ],
             "x-enum-varnames": [
+                "WorkerRuntimeTypeUnknown",
                 "WorkerRuntimeTypePodman",
                 "WorkerRuntimeTypeOpenShift"
             ]

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -1258,6 +1258,144 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/workers": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all registered workers and their current status from the database.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Workers"
+                ],
+                "summary": "List all workers",
+                "responses": {
+                    "200": {
+                        "description": "List of workers",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.Worker"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Pre-registers a worker by name, creates a pending DB row, and returns a single-use bootstrap token.\nThe operator passes this token when starting the worker daemon (` + "`" + `worker start --token \u003ctoken\u003e` + "`" + `).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Workers"
+                ],
+                "summary": "Register a new worker",
+                "parameters": [
+                    {
+                        "description": "Worker registration request",
+                        "name": "worker",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.createWorkerReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Worker registered; token valid for 24 hours",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.createWorkerResp"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid payload",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/workers/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Permanently removes a worker from the registry and the database.\nIf the worker is currently connected its gRPC stream is also cleaned up.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Workers"
+                ],
+                "summary": "Deregister a worker",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker ID (UUID)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Worker deleted"
+                    },
+                    "400": {
+                        "description": "Invalid worker ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Worker not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1360,6 +1498,60 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.Worker": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "last_heartbeat": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "name": {
+                    "type": "string"
+                },
+                "registered_at": {
+                    "type": "string"
+                },
+                "runtime_type": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerRuntimeType"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerStatus"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerRuntimeType": {
+            "type": "string",
+            "enum": [
+                "podman",
+                "openshift"
+            ],
+            "x-enum-varnames": [
+                "WorkerRuntimeTypePodman",
+                "WorkerRuntimeTypeOpenShift"
+            ]
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "ready",
+                "disconnected"
+            ],
+            "x-enum-varnames": [
+                "WorkerStatusPending",
+                "WorkerStatusReady",
+                "WorkerStatusDisconnected"
+            ]
         },
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Application": {
             "type": "object",
@@ -2046,6 +2238,30 @@ const docTemplate = `{
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 3
+                }
+            }
+        },
+        "internal_pkg_catalog_apiserver_handlers.createWorkerReq": {
+            "type": "object",
+            "required": [
+                "worker_name"
+            ],
+            "properties": {
+                "worker_name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                }
+            }
+        },
+        "internal_pkg_catalog_apiserver_handlers.createWorkerResp": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string"
+                },
+                "worker_name": {
+                    "type": "string"
                 }
             }
         },

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -1252,6 +1252,144 @@
                     }
                 }
             }
+        },
+        "/workers": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all registered workers and their current status from the database.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Workers"
+                ],
+                "summary": "List all workers",
+                "responses": {
+                    "200": {
+                        "description": "List of workers",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.Worker"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Pre-registers a worker by name, creates a pending DB row, and returns a single-use bootstrap token.\nThe operator passes this token when starting the worker daemon (`worker start --token \u003ctoken\u003e`).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Workers"
+                ],
+                "summary": "Register a new worker",
+                "parameters": [
+                    {
+                        "description": "Worker registration request",
+                        "name": "worker",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.createWorkerReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Worker registered; token valid for 24 hours",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.createWorkerResp"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid payload",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/workers/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Permanently removes a worker from the registry and the database.\nIf the worker is currently connected its gRPC stream is also cleaned up.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Workers"
+                ],
+                "summary": "Deregister a worker",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker ID (UUID)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Worker deleted"
+                    },
+                    "400": {
+                        "description": "Invalid worker ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Worker not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1354,6 +1492,60 @@
                     "type": "string"
                 }
             }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.Worker": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "last_heartbeat": {
+                    "type": "string"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "name": {
+                    "type": "string"
+                },
+                "registered_at": {
+                    "type": "string"
+                },
+                "runtime_type": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerRuntimeType"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerStatus"
+                },
+                "updated_at": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerRuntimeType": {
+            "type": "string",
+            "enum": [
+                "podman",
+                "openshift"
+            ],
+            "x-enum-varnames": [
+                "WorkerRuntimeTypePodman",
+                "WorkerRuntimeTypeOpenShift"
+            ]
+        },
+        "github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "ready",
+                "disconnected"
+            ],
+            "x-enum-varnames": [
+                "WorkerStatusPending",
+                "WorkerStatusReady",
+                "WorkerStatusDisconnected"
+            ]
         },
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Application": {
             "type": "object",
@@ -2040,6 +2232,30 @@
                     "type": "string",
                     "maxLength": 100,
                     "minLength": 3
+                }
+            }
+        },
+        "internal_pkg_catalog_apiserver_handlers.createWorkerReq": {
+            "type": "object",
+            "required": [
+                "worker_name"
+            ],
+            "properties": {
+                "worker_name": {
+                    "type": "string",
+                    "maxLength": 100,
+                    "minLength": 1
+                }
+            }
+        },
+        "internal_pkg_catalog_apiserver_handlers.createWorkerResp": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string"
+                },
+                "worker_name": {
+                    "type": "string"
                 }
             }
         },

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -1526,10 +1526,12 @@
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerRuntimeType": {
             "type": "string",
             "enum": [
+                "unknown",
                 "podman",
                 "openshift"
             ],
             "x-enum-varnames": [
+                "WorkerRuntimeTypeUnknown",
                 "WorkerRuntimeTypePodman",
                 "WorkerRuntimeTypeOpenShift"
             ]

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -91,10 +91,12 @@ definitions:
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerRuntimeType:
     enum:
+    - unknown
     - podman
     - openshift
     type: string
     x-enum-varnames:
+    - WorkerRuntimeTypeUnknown
     - WorkerRuntimeTypePodman
     - WorkerRuntimeTypeOpenShift
   github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerStatus:

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -69,6 +69,44 @@ definitions:
       status:
         type: string
     type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.Worker:
+    properties:
+      id:
+        type: string
+      last_heartbeat:
+        type: string
+      metadata:
+        additionalProperties: {}
+        type: object
+      name:
+        type: string
+      registered_at:
+        type: string
+      runtime_type:
+        $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerRuntimeType'
+      status:
+        $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerStatus'
+      updated_at:
+        type: string
+    type: object
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerRuntimeType:
+    enum:
+    - podman
+    - openshift
+    type: string
+    x-enum-varnames:
+    - WorkerRuntimeTypePodman
+    - WorkerRuntimeTypeOpenShift
+  github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.WorkerStatus:
+    enum:
+    - pending
+    - ready
+    - disconnected
+    type: string
+    x-enum-varnames:
+    - WorkerStatusPending
+    - WorkerStatusReady
+    - WorkerStatusDisconnected
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Application:
     properties:
       catalog_id:
@@ -528,6 +566,22 @@ definitions:
         type: string
     required:
     - name
+    type: object
+  internal_pkg_catalog_apiserver_handlers.createWorkerReq:
+    properties:
+      worker_name:
+        maxLength: 100
+        minLength: 1
+        type: string
+    required:
+    - worker_name
+    type: object
+  internal_pkg_catalog_apiserver_handlers.createWorkerResp:
+    properties:
+      token:
+        type: string
+      worker_name:
+        type: string
     type: object
   internal_pkg_catalog_apiserver_handlers.loginReq:
     properties:
@@ -1384,6 +1438,100 @@ paths:
       summary: Get service parameters
       tags:
       - Catalog
+  /workers:
+    get:
+      description: Returns all registered workers and their current status from the
+        database.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of workers
+          schema:
+            items:
+              $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_db_models.Worker'
+            type: array
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List all workers
+      tags:
+      - Workers
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Pre-registers a worker by name, creates a pending DB row, and returns a single-use bootstrap token.
+        The operator passes this token when starting the worker daemon (`worker start --token <token>`).
+      parameters:
+      - description: Worker registration request
+        in: body
+        name: worker
+        required: true
+        schema:
+          $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.createWorkerReq'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Worker registered; token valid for 24 hours
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.createWorkerResp'
+        "400":
+          description: Invalid payload
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Register a new worker
+      tags:
+      - Workers
+  /workers/{id}:
+    delete:
+      description: |-
+        Permanently removes a worker from the registry and the database.
+        If the worker is currently connected its gRPC stream is also cleaned up.
+      parameters:
+      - description: Worker ID (UUID)
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Worker deleted
+        "400":
+          description: Invalid worker ID
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Worker not found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Deregister a worker
+      tags:
+      - Workers
 securityDefinitions:
   BearerAuth:
     description: Type "Bearer" followed by a space and JWT token.

--- a/ai-services/internal/pkg/catalog/apiserver/apiserver.go
+++ b/ai-services/internal/pkg/catalog/apiserver/apiserver.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
-	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/gateway"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/registry"
@@ -55,12 +54,9 @@ type APIServerOptions struct {
 	// WorkerGatewayPort is the port the gRPC worker gateway listens on.
 	// Defaults to 9090 when zero.
 	WorkerGatewayPort int
-	// WorkerRegistry holds the in-memory state of all connected workers.
+	// WorkerRegistry holds the in-memory state of all connected workers and owns
+	// the bootstrap token store.
 	WorkerRegistry *registry.Registry
-	// WorkerTokenStore issues and validates single-use bootstrap tokens for workers.
-	WorkerTokenStore *registry.TokenStore
-	// WorkerRepository is used by the gateway for heartbeat updates and the stale-worker sweeper.
-	WorkerRepository dbrepo.WorkerRepository
 }
 
 // APIserver represents the API server instance, holding the configuration and authentication provider.
@@ -73,8 +69,6 @@ type APIserver struct {
 
 	workerGatewayPort int
 	workerRegistry    *registry.Registry
-	workerTokenStore  *registry.TokenStore
-	workerRepository  dbrepo.WorkerRepository
 }
 
 // NewAPIserver creates a new instance of the API server with the provided options, setting default values where necessary.
@@ -95,8 +89,6 @@ func NewAPIserver(options APIServerOptions) *APIserver {
 		applicationService: options.ApplicationService,
 		workerGatewayPort:  options.WorkerGatewayPort,
 		workerRegistry:     options.WorkerRegistry,
-		workerTokenStore:   options.WorkerTokenStore,
-		workerRepository:   options.WorkerRepository,
 	}
 }
 
@@ -110,14 +102,14 @@ func (a *APIserver) Start(ctx context.Context) error {
 	defer cancel(nil)
 
 	// Start the gRPC worker gateway.
-	gw := gateway.New(a.workerRegistry, a.workerTokenStore, a.workerRepository)
+	gw := gateway.New(a.workerRegistry)
 	gatewayAddr := fmt.Sprintf(":%d", a.workerGatewayPort)
 	if err := gw.Start(ctx, cancel, gatewayAddr); err != nil {
 		return fmt.Errorf("failed to start worker gateway: %w", err)
 	}
 	logger.InfofCtx(ctx, "Worker gateway started on %s", gatewayAddr)
 
-	r := CreateRouter(a.authService, a.tokenManager, a.blacklist, a.applicationService)
+	r := CreateRouter(a.authService, a.tokenManager, a.blacklist, a.applicationService, a.workerRegistry)
 
 	if err := r.Run(fmt.Sprintf(":%d", a.port)); err != nil {
 		return err

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
@@ -1,0 +1,128 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/project-ai-services/ai-services/internal/pkg/worker/registry"
+)
+
+// WorkerHandler handles worker management endpoints.
+type WorkerHandler struct {
+	reg *registry.Registry
+}
+
+// NewWorkerHandler creates a new WorkerHandler.
+func NewWorkerHandler(reg *registry.Registry) *WorkerHandler {
+	return &WorkerHandler{reg: reg}
+}
+
+// createWorkerReq is the request body for registering a new worker.
+type createWorkerReq struct {
+	WorkerName string `json:"worker_name" binding:"required,min=1,max=100"`
+}
+
+// createWorkerResp is the response body for a newly registered worker.
+type createWorkerResp struct {
+	WorkerName string `json:"worker_name"`
+	Token      string `json:"token"`
+}
+
+// CreateWorker godoc
+//
+//	@Summary		Register a new worker
+//	@Description	Pre-registers a worker by name, creates a pending DB row, and returns a single-use bootstrap token.
+//	@Description	The operator passes this token when starting the worker daemon (`worker start --token <token>`).
+//	@Tags			Workers
+//	@Accept			json
+//	@Produce		json
+//	@Param			worker	body		createWorkerReq		true	"Worker registration request"
+//	@Success		201		{object}	createWorkerResp	"Worker registered; token valid for 24 hours"
+//	@Failure		400		{object}	map[string]interface{}	"Invalid payload"
+//	@Failure		500		{object}	map[string]interface{}	"Internal error"
+//	@Security		BearerAuth
+//	@Router			/workers [post]
+func (h *WorkerHandler) CreateWorker(c *gin.Context) {
+	var req createWorkerReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
+
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	token, err := h.reg.Preregister(ctx, req.WorkerName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to register worker"})
+
+		return
+	}
+
+	c.JSON(http.StatusCreated, createWorkerResp{
+		WorkerName: req.WorkerName,
+		Token:      token,
+	})
+}
+
+// ListWorkers godoc
+//
+//	@Summary		List all workers
+//	@Description	Returns all registered workers and their current status from the database.
+//	@Tags			Workers
+//	@Produce		json
+//	@Success		200	{array}		models.Worker			"List of workers"
+//	@Failure		500	{object}	map[string]interface{}	"Internal error"
+//	@Security		BearerAuth
+//	@Router			/workers [get]
+func (h *WorkerHandler) ListWorkers(c *gin.Context) {
+	workers, err := h.reg.List(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list workers"})
+
+		return
+	}
+
+	c.JSON(http.StatusOK, workers)
+}
+
+// DeleteWorker godoc
+//
+//	@Summary		Deregister a worker
+//	@Description	Permanently removes a worker from the registry and the database.
+//	@Description	If the worker is currently connected its gRPC stream is also cleaned up.
+//	@Tags			Workers
+//	@Produce		json
+//	@Param			id	path		string					true	"Worker ID (UUID)"
+//	@Success		204		"Worker deleted"
+//	@Failure		400		{object}	map[string]interface{}	"Invalid worker ID"
+//	@Failure		404		{object}	map[string]interface{}	"Worker not found"
+//	@Failure		500		{object}	map[string]interface{}	"Internal error"
+//	@Security		BearerAuth
+//	@Router			/workers/{id} [delete]
+func (h *WorkerHandler) DeleteWorker(c *gin.Context) {
+	workerID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid worker id"})
+
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	deleted, err := h.reg.Deregister(ctx, workerID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete worker"})
+
+		return
+	}
+
+	if !deleted {
+		c.JSON(http.StatusNotFound, gin.H{"error": "worker not found"})
+
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -51,6 +52,15 @@ func (h *WorkerHandler) CreateWorker(c *gin.Context) {
 	var req createWorkerReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid payload"})
+
+		return
+	}
+
+	// Normalise: trim surrounding whitespace and lowercase so that
+	// "Worker-A", "worker-a", and " worker-a " all resolve to the same name.
+	req.WorkerName = strings.ToLower(strings.TrimSpace(req.WorkerName))
+	if req.WorkerName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "worker_name must not be blank"})
 
 		return
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
@@ -5,8 +5,12 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	dbmodels "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/registry"
 )
+
+// Ensure dbmodels is imported for Swagger documentation.
+var _ dbmodels.Worker
 
 // WorkerHandler handles worker management endpoints.
 type WorkerHandler struct {
@@ -37,8 +41,8 @@ type createWorkerResp struct {
 //	@Tags			Workers
 //	@Accept			json
 //	@Produce		json
-//	@Param			worker	body		createWorkerReq		true	"Worker registration request"
-//	@Success		201		{object}	createWorkerResp	"Worker registered; token valid for 24 hours"
+//	@Param			worker	body		createWorkerReq			true	"Worker registration request"
+//	@Success		201		{object}	createWorkerResp		"Worker registered; token valid for 24 hours"
 //	@Failure		400		{object}	map[string]interface{}	"Invalid payload"
 //	@Failure		500		{object}	map[string]interface{}	"Internal error"
 //	@Security		BearerAuth
@@ -72,7 +76,7 @@ func (h *WorkerHandler) CreateWorker(c *gin.Context) {
 //	@Description	Returns all registered workers and their current status from the database.
 //	@Tags			Workers
 //	@Produce		json
-//	@Success		200	{array}		models.Worker			"List of workers"
+//	@Success		200	{array}		dbmodels.Worker			"List of workers"
 //	@Failure		500	{object}	map[string]interface{}	"Internal error"
 //	@Security		BearerAuth
 //	@Router			/workers [get]
@@ -94,11 +98,11 @@ func (h *WorkerHandler) ListWorkers(c *gin.Context) {
 //	@Description	If the worker is currently connected its gRPC stream is also cleaned up.
 //	@Tags			Workers
 //	@Produce		json
-//	@Param			id	path		string					true	"Worker ID (UUID)"
-//	@Success		204		"Worker deleted"
-//	@Failure		400		{object}	map[string]interface{}	"Invalid worker ID"
-//	@Failure		404		{object}	map[string]interface{}	"Worker not found"
-//	@Failure		500		{object}	map[string]interface{}	"Internal error"
+//	@Param			id	path	string	true	"Worker ID (UUID)"
+//	@Success		204	"Worker deleted"
+//	@Failure		400	{object}	map[string]interface{}	"Invalid worker ID"
+//	@Failure		404	{object}	map[string]interface{}	"Worker not found"
+//	@Failure		500	{object}	map[string]interface{}	"Internal error"
 //	@Security		BearerAuth
 //	@Router			/workers/{id} [delete]
 func (h *WorkerHandler) DeleteWorker(c *gin.Context) {

--- a/ai-services/internal/pkg/catalog/apiserver/router.go
+++ b/ai-services/internal/pkg/catalog/apiserver/router.go
@@ -10,12 +10,13 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/middleware"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
+	"github.com/project-ai-services/ai-services/internal/pkg/worker/registry"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 )
 
 // CreateRouter sets up the Gin router with the necessary routes and authentication middleware for the API server.
-func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist repository.TokenBlacklist, appService repository.ApplicationServiceInterface) *gin.Engine {
+func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist repository.TokenBlacklist, appService repository.ApplicationServiceInterface, workerReg *registry.Registry) *gin.Engine {
 	if mode := os.Getenv("GIN_MODE"); mode != "" {
 		gin.SetMode(mode)
 	}
@@ -41,6 +42,7 @@ func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist r
 	catalogHandler := handlers.NewCatalogHandler()
 	resourcesHandler := handlers.NewResourcesHandler()
 	applicationHandler := handlers.NewApplicationHandler(appService)
+	workerHandler := handlers.NewWorkerHandler(workerReg)
 
 	v1 := router.Group("/api/v1")
 	{
@@ -78,6 +80,14 @@ func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist r
 		applications.PUT("/:id", applicationHandler.UpdateApplication)
 		applications.DELETE("/:id", applicationHandler.DeleteApplication)
 		applications.GET("/:id/ps", applicationHandler.ApplicationPS)
+	}
+
+	workers := v1.Group("workers")
+	workers.Use(middleware.AuthMiddleware(tokenMgr, blacklist))
+	{
+		workers.POST("", workerHandler.CreateWorker)
+		workers.GET("", workerHandler.ListWorkers)
+		workers.DELETE("/:id", workerHandler.DeleteWorker)
 	}
 
 	return router

--- a/ai-services/internal/pkg/catalog/apiserver/router.go
+++ b/ai-services/internal/pkg/catalog/apiserver/router.go
@@ -24,71 +24,70 @@ func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist r
 
 	// Apply RequestID middleware to all routes
 	router.Use(middleware.RequestIDMiddleware())
-
 	// Health check endpoint
-	router.GET("/healthz", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"message": "ok"})
-	})
-
+	router.GET("/healthz", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"message": "ok"}) })
 	// Expose /health for liveness probes
-	router.GET("/health", func(c *gin.Context) {
-		c.JSON(http.StatusOK, gin.H{"message": "ok"})
-	})
-
-	// Swagger documentation endpoint
+	router.GET("/health", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"message": "ok"}) })
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
-	authHandler := handlers.NewAuthHandler(authSvc)
-	catalogHandler := handlers.NewCatalogHandler()
-	resourcesHandler := handlers.NewResourcesHandler()
-	applicationHandler := handlers.NewApplicationHandler(appService)
-	workerHandler := handlers.NewWorkerHandler(workerReg)
-
 	v1 := router.Group("/api/v1")
-	{
-		v1.POST("/auth/login", authHandler.Login)
-		v1.POST("/auth/token", authHandler.TokenLogin)
-		v1.POST("/auth/logout", middleware.AuthMiddleware(tokenMgr, blacklist), authHandler.Logout)
-		v1.POST("/auth/refresh", authHandler.Refresh)
-		v1.GET("/auth/me", middleware.AuthMiddleware(tokenMgr, blacklist), authHandler.Me)
-	}
+	registerAuthRoutes(v1, handlers.NewAuthHandler(authSvc), tokenMgr, blacklist)
 
-	// Catalog endpoints
-	catalog := v1.Group("")
-	catalog.Use(middleware.AuthMiddleware(tokenMgr, blacklist))
-	{
-		catalog.GET("/resources", resourcesHandler.GetResources)
-		catalog.GET("/architectures", catalogHandler.ListArchitectures)
-		catalog.GET("/architectures/:id", catalogHandler.GetArchitectureDetails)
-		catalog.GET("/architectures/:id/deploy-options", catalogHandler.GetArchitectureDeployOptions)
-		catalog.GET("/services", catalogHandler.ListServices)
-		catalog.GET("/services/:id", catalogHandler.GetServiceDetails)
-		catalog.GET("/services/:id/deploy-options", catalogHandler.GetServiceDeployOptions)
-		catalog.GET("/services/:id/params", catalogHandler.GetServiceParams)
-		catalog.GET("/components/:component_type/providers/:provider_id/params", catalogHandler.GetComponentProviderParams)
-		catalog.GET("/connectors", catalogHandler.ListConnectorProviders)
-		catalog.GET("/connectors/:connector_type/providers/:provider_id/params", catalogHandler.GetConnectorProviderParams)
-	}
-
-	applications := v1.Group("applications")
-	applications.Use(middleware.AuthMiddleware(tokenMgr, blacklist))
-	{
-		applications.GET("/", applicationHandler.ListApplications)
-		applications.GET("/:id", applicationHandler.GetApplicationByID)
-		applications.GET("/:id/resources", applicationHandler.GetApplicationResources)
-		applications.POST("/", applicationHandler.CreateApplication)
-		applications.PUT("/:id", applicationHandler.UpdateApplication)
-		applications.DELETE("/:id", applicationHandler.DeleteApplication)
-		applications.GET("/:id/ps", applicationHandler.ApplicationPS)
-	}
-
-	workers := v1.Group("workers")
-	workers.Use(middleware.AuthMiddleware(tokenMgr, blacklist))
-	{
-		workers.POST("", workerHandler.CreateWorker)
-		workers.GET("", workerHandler.ListWorkers)
-		workers.DELETE("/:id", workerHandler.DeleteWorker)
-	}
+	auth := middleware.AuthMiddleware(tokenMgr, blacklist)
+	registerCatalogRoutes(v1, handlers.NewCatalogHandler(), handlers.NewResourcesHandler(), auth)
+	registerApplicationRoutes(v1, handlers.NewApplicationHandler(appService), auth)
+	registerWorkerRoutes(v1, handlers.NewWorkerHandler(workerReg), auth)
 
 	return router
+}
+
+func registerAuthRoutes(v1 *gin.RouterGroup, h *handlers.AuthHandler, tokenMgr *auth.TokenManager, blacklist repository.TokenBlacklist) {
+	authMw := middleware.AuthMiddleware(tokenMgr, blacklist)
+	v1.POST("/auth/login", h.Login)
+	v1.POST("/auth/token", h.TokenLogin)
+	v1.POST("/auth/logout", authMw, h.Logout)
+	v1.POST("/auth/refresh", h.Refresh)
+	v1.GET("/auth/me", authMw, h.Me)
+}
+
+func registerCatalogRoutes(v1 *gin.RouterGroup, catalog *handlers.CatalogHandler, resources *handlers.ResourcesHandler, authMw gin.HandlerFunc) {
+	g := v1.Group("")
+	g.Use(authMw)
+	{
+		g.GET("/resources", resources.GetResources)
+		g.GET("/architectures", catalog.ListArchitectures)
+		g.GET("/architectures/:id", catalog.GetArchitectureDetails)
+		g.GET("/architectures/:id/deploy-options", catalog.GetArchitectureDeployOptions)
+		g.GET("/services", catalog.ListServices)
+		g.GET("/services/:id", catalog.GetServiceDetails)
+		g.GET("/services/:id/deploy-options", catalog.GetServiceDeployOptions)
+		g.GET("/services/:id/params", catalog.GetServiceParams)
+		g.GET("/components/:component_type/providers/:provider_id/params", catalog.GetComponentProviderParams)
+		g.GET("/connectors", catalog.ListConnectorProviders)
+		g.GET("/connectors/:connector_type/providers/:provider_id/params", catalog.GetConnectorProviderParams)
+	}
+}
+
+func registerApplicationRoutes(v1 *gin.RouterGroup, h *handlers.ApplicationHandler, authMw gin.HandlerFunc) {
+	g := v1.Group("applications")
+	g.Use(authMw)
+	{
+		g.GET("/", h.ListApplications)
+		g.GET("/:id", h.GetApplicationByID)
+		g.GET("/:id/resources", h.GetApplicationResources)
+		g.POST("/", h.CreateApplication)
+		g.PUT("/:id", h.UpdateApplication)
+		g.DELETE("/:id", h.DeleteApplication)
+		g.GET("/:id/ps", h.ApplicationPS)
+	}
+}
+
+func registerWorkerRoutes(v1 *gin.RouterGroup, h *handlers.WorkerHandler, authMw gin.HandlerFunc) {
+	g := v1.Group("workers")
+	g.Use(authMw)
+	{
+		g.POST("", h.CreateWorker)
+		g.GET("", h.ListWorkers)
+		g.DELETE("/:id", h.DeleteWorker)
+	}
 }

--- a/ai-services/internal/pkg/catalog/db/migrations/assets/20260801000002_create_workers_table.sql
+++ b/ai-services/internal/pkg/catalog/db/migrations/assets/20260801000002_create_workers_table.sql
@@ -2,7 +2,11 @@
 -- +goose StatementBegin
 
 -- Worker runtime type enum
+-- 'unknown' is the initial value set at pre-registration time; it is
+-- replaced by the real runtime ('podman' | 'openshift') when the worker
+-- connects and calls Register via gRPC.
 CREATE TYPE worker_runtime_type AS ENUM (
+    'unknown',
     'podman',
     'openshift'
 );
@@ -17,7 +21,8 @@ CREATE TYPE worker_status AS ENUM (
 -- ── workers ────────────────────────────────────────────────────────────────────
 -- One row per registered worker.
 --
--- runtime_type:   execution environment the worker runs on (podman | openshift).
+-- runtime_type:   execution environment the worker runs on.
+--                 'unknown' until the worker connects and declares its runtime.
 -- status:         lifecycle state of the worker (pending | ready | disconnected).
 -- last_heartbeat: timestamp of the most recent heartbeat received from the worker;
 --                 NULL until the first heartbeat arrives.
@@ -27,7 +32,7 @@ CREATE TYPE worker_status AS ENUM (
 CREATE TABLE workers (
     id             UUID                PRIMARY KEY DEFAULT gen_random_uuid(),
     name           TEXT                NOT NULL UNIQUE,
-    runtime_type   worker_runtime_type NOT NULL DEFAULT 'podman',
+    runtime_type   worker_runtime_type NOT NULL DEFAULT 'unknown',
     status         worker_status       NOT NULL DEFAULT 'pending',
     last_heartbeat TIMESTAMPTZ,
     metadata       JSONB,

--- a/ai-services/internal/pkg/catalog/db/models/worker.go
+++ b/ai-services/internal/pkg/catalog/db/models/worker.go
@@ -10,6 +10,9 @@ import (
 type WorkerRuntimeType string
 
 const (
+	// WorkerRuntimeTypeUnknown is the initial value stored at pre-registration
+	// time, before the worker connects and declares its runtime.
+	WorkerRuntimeTypeUnknown   WorkerRuntimeType = "unknown"
 	WorkerRuntimeTypePodman    WorkerRuntimeType = "podman"
 	WorkerRuntimeTypeOpenShift WorkerRuntimeType = "openshift"
 )

--- a/ai-services/internal/pkg/catalog/db/repository/worker_repo.go
+++ b/ai-services/internal/pkg/catalog/db/repository/worker_repo.go
@@ -21,12 +21,12 @@ type WorkerUpdate struct {
 
 // WorkerRepository defines the interface for worker data operations.
 type WorkerRepository interface {
-	// Upsert inserts a new worker or updates its runtime_type and registered_at on name conflict.
+	// Upsert inserts a new worker or updates its runtime_type, status, and metadata on name conflict.
 	Upsert(ctx context.Context, worker *models.Worker) error
 	// Update applies a partial update to the fields set in WorkerUpdate; nil fields are left unchanged.
-	Update(ctx context.Context, name string, update WorkerUpdate) error
-	// Delete removes a worker by ID.
-	Delete(ctx context.Context, id uuid.UUID) error
+	Update(ctx context.Context, id uuid.UUID, update WorkerUpdate) error
+	// Delete removes a worker by ID. Returns (false, nil) if no row matched.
+	Delete(ctx context.Context, id uuid.UUID) (bool, error)
 	// GetAll returns all worker rows ordered by registered_at ascending.
 	GetAll(ctx context.Context) ([]models.Worker, error)
 }
@@ -80,7 +80,7 @@ func (r *workerRepo) Upsert(ctx context.Context, worker *models.Worker) error {
 
 // Update performs a partial update on a worker row.
 // Nil fields in WorkerUpdate are left unchanged via COALESCE. updated_at is always refreshed.
-func (r *workerRepo) Update(ctx context.Context, name string, update WorkerUpdate) error {
+func (r *workerRepo) Update(ctx context.Context, id uuid.UUID, update WorkerUpdate) error {
 	var hb sql.NullTime
 	if update.LastHeartbeat != nil {
 		hb = sql.NullTime{Time: *update.LastHeartbeat, Valid: true}
@@ -96,27 +96,28 @@ func (r *workerRepo) Update(ctx context.Context, name string, update WorkerUpdat
 		SET status         = COALESCE($1, status),
 		    last_heartbeat = COALESCE($2, last_heartbeat),
 		    updated_at     = NOW()
-		WHERE name = $3
+		WHERE id = $3
 	`
 
-	_, err := r.pool.Exec(ctx, query, statusArg, hb, name)
+	_, err := r.pool.Exec(ctx, query, statusArg, hb, id)
 	if err != nil {
-		return fmt.Errorf("failed to update worker %q: %w", name, err)
+		return fmt.Errorf("failed to update worker %q: %w", id, err)
 	}
 
 	return nil
 }
 
 // Delete removes a worker by ID.
-func (r *workerRepo) Delete(ctx context.Context, id uuid.UUID) error {
+// Returns (true, nil) if the row was deleted, (false, nil) if no row matched.
+func (r *workerRepo) Delete(ctx context.Context, id uuid.UUID) (bool, error) {
 	query := `DELETE FROM workers WHERE id = $1`
 
-	_, err := r.pool.Exec(ctx, query, id)
+	tag, err := r.pool.Exec(ctx, query, id)
 	if err != nil {
-		return fmt.Errorf("failed to delete worker %q: %w", id, err)
+		return false, fmt.Errorf("failed to delete worker %q: %w", id, err)
 	}
 
-	return nil
+	return tag.RowsAffected() > 0, nil
 }
 
 // GetAll returns all worker rows ordered by registered_at ascending.

--- a/ai-services/internal/pkg/worker/gateway/gateway.go
+++ b/ai-services/internal/pkg/worker/gateway/gateway.go
@@ -10,10 +10,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	workerpb "github.com/project-ai-services/ai-services/internal/pkg/worker/proto"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/registry"
 	"google.golang.org/grpc"
@@ -35,18 +32,12 @@ type Gateway struct {
 	workerpb.UnimplementedWorkerGatewayServer
 
 	registry   *registry.Registry
-	tokenStore *registry.TokenStore
-	repo       repository.WorkerRepository // may be nil in tests
 	grpcServer *grpc.Server
 }
 
-// New creates a Gateway backed by the given registry, token store, and worker repository.
-func New(reg *registry.Registry, ts *registry.TokenStore, repo repository.WorkerRepository) *Gateway {
-	return &Gateway{
-		registry:   reg,
-		tokenStore: ts,
-		repo:       repo,
-	}
+// New creates a Gateway backed by the given registry.
+func New(reg *registry.Registry) *Gateway {
+	return &Gateway{registry: reg}
 }
 
 // Start begins listening on addr (e.g. ":9090") and serves gRPC in a background goroutine.
@@ -84,9 +75,7 @@ func (g *Gateway) Start(ctx context.Context, cancel context.CancelCauseFunc, add
 	return nil
 }
 
-// runSweeper periodically queries the DB for workers whose last_heartbeat has
-// exceeded heartbeatTimeout and marks them disconnected.
-// It runs entirely against the DB — no in-memory state required.
+// runSweeper periodically asks the registry to mark stale workers disconnected.
 func (g *Gateway) runSweeper(ctx context.Context) {
 	ticker := time.NewTicker(sweepInterval)
 	defer ticker.Stop()
@@ -96,34 +85,7 @@ func (g *Gateway) runSweeper(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			g.sweepStaleWorkers(ctx)
-		}
-	}
-}
-
-func (g *Gateway) sweepStaleWorkers(ctx context.Context) {
-	if g.repo == nil {
-		return
-	}
-
-	workers, err := g.repo.GetAll(ctx)
-	if err != nil {
-		logger.WarningfCtx(ctx, "WorkerGateway sweeper: failed to fetch workers: %v", err)
-
-		return
-	}
-
-	now := time.Now()
-
-	for _, w := range workers {
-		if w.Status == models.WorkerStatusDisconnected {
-			continue
-		}
-		if w.LastHeartbeat == nil || now.Sub(*w.LastHeartbeat) > heartbeatTimeout {
-			logger.WarningfCtx(ctx, "WorkerGateway sweeper: worker %s heartbeat timed out — marking disconnected", w.Name)
-			if err := g.repo.Update(ctx, w.Name, repository.WorkerUpdate{Status: utils.Ptr(models.WorkerStatusDisconnected)}); err != nil {
-				logger.WarningfCtx(ctx, "WorkerGateway sweeper: failed to update worker %s: %v", w.Name, err)
-			}
+			g.registry.SweepStale(ctx, heartbeatTimeout)
 		}
 	}
 }
@@ -133,19 +95,21 @@ func (g *Gateway) sweepStaleWorkers(ctx context.Context) {
 // ──────────────────────────────────────────────────────────────────────────────
 
 // Register implements WorkerGatewayServer. Workers call this once at bootstrap.
-// Metadata supplied in the request is persisted to the
-// DB metadata JSON column by registry.Register — no separate handling needed here.
+// The worker name is taken from the token, not from the request — the worker
+// cannot self-assign a name different from what was pre-registered by an admin.
+// Metadata supplied in the request is persisted to the DB metadata JSON column.
 func (g *Gateway) Register(ctx context.Context, req *workerpb.RegisterRequest) (*workerpb.RegisterResponse, error) {
-	workerName := req.GetWorkerName()
-	logger.InfofCtx(ctx, "WorkerGateway: Register request from worker_name=%s", workerName)
+	logger.InfofCtx(ctx, "WorkerGateway: Register request (token=%s)", req.GetPreSharedToken())
 
-	if err := g.tokenStore.Validate(req.GetPreSharedToken()); err != nil {
-		logger.WarningfCtx(ctx, "WorkerGateway: rejected registration for worker %s: %v", workerName, err)
+	// Validate token and recover the pre-registered worker name.
+	workerName, err := g.registry.ValidateToken(req.GetPreSharedToken())
+	if err != nil {
+		logger.WarningfCtx(ctx, "WorkerGateway: rejected registration: %v", err)
 
 		return nil, fmt.Errorf("registration rejected: %w", err)
 	}
 
-	if _, err := g.registry.Register(ctx, req); err != nil {
+	if _, err := g.registry.Register(ctx, workerName, req.GetMetadata()); err != nil {
 		return nil, fmt.Errorf("failed to register worker: %w", err)
 	}
 
@@ -233,7 +197,7 @@ func (g *Gateway) identifyWorker(ctx context.Context, stream grpc.BidiStreamingS
 
 	// Deliver the first message if it is a real result (not a heartbeat).
 	if firstMsg.GetIsHeartbeat() {
-		g.updateHeartbeat(ctx, workerName)
+		g.registry.UpdateHeartbeat(ctx, workerName)
 	} else {
 		g.registry.DeliverResult(firstMsg)
 	}
@@ -242,7 +206,7 @@ func (g *Gateway) identifyWorker(ctx context.Context, stream grpc.BidiStreamingS
 }
 
 // recvLoop reads CommandResults from the stream and dispatches them to waiting callers.
-// Heartbeat messages update last_heartbeat in the DB.
+// Heartbeat messages update last_heartbeat in the DB via the registry.
 // Errors are sent to errCh and the goroutine exits.
 func (g *Gateway) recvLoop(ctx context.Context, stream grpc.BidiStreamingServer[workerpb.CommandResult, workerpb.Command], workerName string, errCh chan<- error) {
 	for {
@@ -257,22 +221,11 @@ func (g *Gateway) recvLoop(ctx context.Context, stream grpc.BidiStreamingServer[
 		}
 
 		if res.GetIsHeartbeat() {
-			g.updateHeartbeat(ctx, workerName)
+			g.registry.UpdateHeartbeat(ctx, workerName)
 
 			continue
 		}
 
 		g.registry.DeliverResult(res)
-	}
-}
-
-// updateHeartbeat writes the current timestamp to last_heartbeat in the DB.
-func (g *Gateway) updateHeartbeat(ctx context.Context, workerName string) {
-	if g.repo == nil {
-		return
-	}
-	now := time.Now()
-	if err := g.repo.Update(ctx, workerName, repository.WorkerUpdate{LastHeartbeat: &now}); err != nil {
-		logger.WarningfCtx(ctx, "WorkerGateway: heartbeat update failed for %s: %v", workerName, err)
 	}
 }

--- a/ai-services/internal/pkg/worker/gateway/gateway.go
+++ b/ai-services/internal/pkg/worker/gateway/gateway.go
@@ -99,7 +99,7 @@ func (g *Gateway) runSweeper(ctx context.Context) {
 // cannot self-assign a name different from what was pre-registered by an admin.
 // Metadata supplied in the request is persisted to the DB metadata JSON column.
 func (g *Gateway) Register(ctx context.Context, req *workerpb.RegisterRequest) (*workerpb.RegisterResponse, error) {
-	logger.InfofCtx(ctx, "WorkerGateway: Register request (token=%s)", req.GetPreSharedToken())
+	logger.InfofCtx(ctx, "WorkerGateway: Register request received")
 
 	// Validate token and recover the pre-registered worker name.
 	workerName, err := g.registry.ValidateToken(req.GetPreSharedToken())
@@ -109,7 +109,7 @@ func (g *Gateway) Register(ctx context.Context, req *workerpb.RegisterRequest) (
 		return nil, fmt.Errorf("registration rejected: %w", err)
 	}
 
-	if _, err := g.registry.Register(ctx, workerName, req.GetMetadata()); err != nil {
+	if _, err := g.registry.Register(ctx, workerName, req.GetRuntimeType(), req.GetMetadata()); err != nil {
 		return nil, fmt.Errorf("failed to register worker: %w", err)
 	}
 

--- a/ai-services/internal/pkg/worker/gateway/gateway_test.go
+++ b/ai-services/internal/pkg/worker/gateway/gateway_test.go
@@ -142,6 +142,7 @@ func TestGateway_Register_ValidToken(t *testing.T) {
 
 	resp, err := client.Register(context.Background(), &workerpb.RegisterRequest{
 		PreSharedToken: token,
+		RuntimeType:    "podman",
 	})
 	if err != nil {
 		t.Fatalf("Register: unexpected error: %v", err)
@@ -180,6 +181,7 @@ func TestGateway_Register_TokenSingleUse(t *testing.T) {
 	// First use succeeds.
 	if _, err := client.Register(context.Background(), &workerpb.RegisterRequest{
 		PreSharedToken: token,
+		RuntimeType:    "podman",
 	}); err != nil {
 		t.Fatalf("first Register: unexpected error: %v", err)
 	}
@@ -187,6 +189,7 @@ func TestGateway_Register_TokenSingleUse(t *testing.T) {
 	// Second use of the same token must fail.
 	if _, err := client.Register(context.Background(), &workerpb.RegisterRequest{
 		PreSharedToken: token,
+		RuntimeType:    "podman",
 	}); err == nil {
 		t.Fatal("second Register: expected error for reused token")
 	}
@@ -251,6 +254,7 @@ func TestGateway_CommandStream_CommandDelivered(t *testing.T) {
 	// Register the worker via the RPC.
 	if _, err := client.Register(context.Background(), &workerpb.RegisterRequest{
 		PreSharedToken: token,
+		RuntimeType:    "podman",
 	}); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
@@ -304,6 +308,7 @@ func TestGateway_CommandStream_ResultRouted(t *testing.T) {
 
 	if _, err := client.Register(context.Background(), &workerpb.RegisterRequest{
 		PreSharedToken: token,
+		RuntimeType:    "podman",
 	}); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
@@ -364,6 +369,7 @@ func TestGateway_CommandStream_Disconnect(t *testing.T) {
 
 	if _, err := client.Register(context.Background(), &workerpb.RegisterRequest{
 		PreSharedToken: token,
+		RuntimeType:    "podman",
 	}); err != nil {
 		t.Fatalf("Register: %v", err)
 	}

--- a/ai-services/internal/pkg/worker/gateway/gateway_test.go
+++ b/ai-services/internal/pkg/worker/gateway/gateway_test.go
@@ -1,0 +1,401 @@
+package gateway
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
+	workerpb "github.com/project-ai-services/ai-services/internal/pkg/worker/proto"
+	"github.com/project-ai-services/ai-services/internal/pkg/worker/registry"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+const bufSize = 1 << 20 // 1 MiB
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Minimal in-memory WorkerRepository used by gateway tests (no DB needed).
+// ──────────────────────────────────────────────────────────────────────────────
+
+type fakeWorkerRepo struct {
+	workers map[string]*models.Worker
+	byID    map[uuid.UUID]*models.Worker
+}
+
+func newFakeWorkerRepo() *fakeWorkerRepo {
+	return &fakeWorkerRepo{
+		workers: make(map[string]*models.Worker),
+		byID:    make(map[uuid.UUID]*models.Worker),
+	}
+}
+
+func (r *fakeWorkerRepo) Upsert(_ context.Context, w *models.Worker) error {
+	if existing, ok := r.workers[w.Name]; ok {
+		w.ID = existing.ID
+	} else {
+		w.ID = uuid.New()
+	}
+	w.RegisteredAt = time.Now()
+	w.UpdatedAt = time.Now()
+	cp := *w
+	r.workers[w.Name] = &cp
+	r.byID[w.ID] = &cp
+	return nil
+}
+
+func (r *fakeWorkerRepo) Update(_ context.Context, id uuid.UUID, u repository.WorkerUpdate) error {
+	w, ok := r.byID[id]
+	if !ok {
+		return nil
+	}
+	if u.Status != nil {
+		w.Status = *u.Status
+	}
+	if u.LastHeartbeat != nil {
+		w.LastHeartbeat = u.LastHeartbeat
+	}
+	return nil
+}
+
+func (r *fakeWorkerRepo) Delete(_ context.Context, id uuid.UUID) (bool, error) {
+	w, ok := r.byID[id]
+	if !ok {
+		return false, nil
+	}
+	delete(r.workers, w.Name)
+	delete(r.byID, id)
+	return true, nil
+}
+
+func (r *fakeWorkerRepo) GetAll(_ context.Context) ([]models.Worker, error) {
+	out := make([]models.Worker, 0, len(r.workers))
+	for _, w := range r.workers {
+		out = append(out, *w)
+	}
+	return out, nil
+}
+
+var _ repository.WorkerRepository = (*fakeWorkerRepo)(nil)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+// preregister calls registry.Preregister and returns the bootstrap token,
+// failing the test on any error.
+func preregister(t *testing.T, reg *registry.Registry, workerName string) string {
+	t.Helper()
+	token, err := reg.Preregister(context.Background(), workerName)
+	if err != nil {
+		t.Fatalf("Preregister(%q): %v", workerName, err)
+	}
+	return token
+}
+
+// startTestGateway creates an in-process gRPC server backed by bufconn and
+// returns a connected client plus a stop func.
+func startTestGateway(t *testing.T, reg *registry.Registry) (workerpb.WorkerGatewayClient, func()) {
+	t.Helper()
+
+	lis := bufconn.Listen(bufSize)
+	gw := New(reg)
+	gw.grpcServer = grpc.NewServer()
+	workerpb.RegisterWorkerGatewayServer(gw.grpcServer, gw)
+
+	go gw.grpcServer.Serve(lis) //nolint:errcheck
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+
+	stop := func() {
+		conn.Close()        //nolint:errcheck
+		gw.grpcServer.Stop()
+		lis.Close() //nolint:errcheck
+	}
+
+	return workerpb.NewWorkerGatewayClient(conn), stop
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Register RPC
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestGateway_Register_ValidToken(t *testing.T) {
+	reg := registry.New(newFakeWorkerRepo())
+	token := preregister(t, reg, "worker-1")
+
+	client, stop := startTestGateway(t, reg)
+	defer stop()
+
+	resp, err := client.Register(context.Background(), &workerpb.RegisterRequest{
+		PreSharedToken: token,
+	})
+	if err != nil {
+		t.Fatalf("Register: unexpected error: %v", err)
+	}
+	if resp.GetWorkerName() != "worker-1" {
+		t.Errorf("expected WorkerName %q, got %q", "worker-1", resp.GetWorkerName())
+	}
+
+	// Worker must now appear in the in-memory registry.
+	if _, ok := reg.Get("worker-1"); !ok {
+		t.Error("expected worker-1 to be in registry after Register")
+	}
+}
+
+func TestGateway_Register_InvalidToken(t *testing.T) {
+	reg := registry.New(newFakeWorkerRepo())
+
+	client, stop := startTestGateway(t, reg)
+	defer stop()
+
+	_, err := client.Register(context.Background(), &workerpb.RegisterRequest{
+		PreSharedToken: "bad-token",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+}
+
+func TestGateway_Register_TokenSingleUse(t *testing.T) {
+	reg := registry.New(newFakeWorkerRepo())
+	token := preregister(t, reg, "worker-1")
+
+	client, stop := startTestGateway(t, reg)
+	defer stop()
+
+	// First use succeeds.
+	if _, err := client.Register(context.Background(), &workerpb.RegisterRequest{
+		PreSharedToken: token,
+	}); err != nil {
+		t.Fatalf("first Register: unexpected error: %v", err)
+	}
+
+	// Second use of the same token must fail.
+	if _, err := client.Register(context.Background(), &workerpb.RegisterRequest{
+		PreSharedToken: token,
+	}); err == nil {
+		t.Fatal("second Register: expected error for reused token")
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// CommandStream RPC
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestGateway_CommandStream_UnregisteredWorker(t *testing.T) {
+	reg := registry.New(newFakeWorkerRepo())
+
+	client, stop := startTestGateway(t, reg)
+	defer stop()
+
+	stream, err := client.CommandStream(context.Background())
+	if err != nil {
+		t.Fatalf("CommandStream: %v", err)
+	}
+
+	// Identify as an unknown worker — should receive Unauthenticated.
+	if err := stream.Send(&workerpb.CommandResult{WorkerName: "nobody"}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	_, err = stream.Recv()
+	if err == nil {
+		t.Fatal("expected error for unregistered worker")
+	}
+}
+
+func TestGateway_CommandStream_MissingWorkerName(t *testing.T) {
+	reg := registry.New(newFakeWorkerRepo())
+
+	client, stop := startTestGateway(t, reg)
+	defer stop()
+
+	stream, err := client.CommandStream(context.Background())
+	if err != nil {
+		t.Fatalf("CommandStream: %v", err)
+	}
+
+	// Send a message with no worker_name — should receive InvalidArgument.
+	if err := stream.Send(&workerpb.CommandResult{WorkerName: ""}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	_, err = stream.Recv()
+	if err == nil {
+		t.Fatal("expected error for missing worker_name")
+	}
+}
+
+func TestGateway_CommandStream_CommandDelivered(t *testing.T) {
+	repo := newFakeWorkerRepo()
+	reg := registry.New(repo)
+	token := preregister(t, reg, "worker-2")
+
+	client, stop := startTestGateway(t, reg)
+	defer stop()
+
+	// Register the worker via the RPC.
+	if _, err := client.Register(context.Background(), &workerpb.RegisterRequest{
+		PreSharedToken: token,
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	stream, err := client.CommandStream(ctx)
+	if err != nil {
+		t.Fatalf("CommandStream: %v", err)
+	}
+
+	// First message identifies the worker (heartbeat).
+	if err := stream.Send(&workerpb.CommandResult{
+		WorkerName:  "worker-2",
+		IsHeartbeat: true,
+	}); err != nil {
+		t.Fatalf("Send identify: %v", err)
+	}
+
+	// Give the gateway a moment to register the stream.
+	time.Sleep(20 * time.Millisecond)
+
+	// Enqueue a command directly onto the worker's channel.
+	entry, ok := reg.Get("worker-2")
+	if !ok {
+		t.Fatal("expected worker-2 in registry after Register RPC")
+	}
+	entry.CommandCh <- &workerpb.Command{
+		CommandId: "test-cmd-1",
+		Type:      workerpb.CommandType_COMMAND_TYPE_LIST_PODS,
+	}
+
+	// The stream must deliver the command to the worker client.
+	got, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv command: %v", err)
+	}
+	if got.GetCommandId() != "test-cmd-1" {
+		t.Errorf("expected command_id %q, got %q", "test-cmd-1", got.GetCommandId())
+	}
+}
+
+func TestGateway_CommandStream_ResultRouted(t *testing.T) {
+	repo := newFakeWorkerRepo()
+	reg := registry.New(repo)
+	token := preregister(t, reg, "worker-3")
+
+	client, stop := startTestGateway(t, reg)
+	defer stop()
+
+	if _, err := client.Register(context.Background(), &workerpb.RegisterRequest{
+		PreSharedToken: token,
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	stream, err := client.CommandStream(ctx)
+	if err != nil {
+		t.Fatalf("CommandStream: %v", err)
+	}
+
+	// First message: identify worker.
+	if err := stream.Send(&workerpb.CommandResult{
+		WorkerName:  "worker-3",
+		IsHeartbeat: true,
+	}); err != nil {
+		t.Fatalf("Send identify: %v", err)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	// Register a waiter before the worker sends back a result.
+	resultCh, err := reg.WaitForResult("worker-3", "cmd-xyz")
+	if err != nil {
+		t.Fatalf("WaitForResult: %v", err)
+	}
+
+	// Worker sends the result.
+	if err := stream.Send(&workerpb.CommandResult{
+		WorkerName: "worker-3",
+		CommandId:  "cmd-xyz",
+		Success:    true,
+	}); err != nil {
+		t.Fatalf("Send result: %v", err)
+	}
+
+	select {
+	case res := <-resultCh:
+		if res.GetCommandId() != "cmd-xyz" {
+			t.Errorf("expected command_id %q, got %q", "cmd-xyz", res.GetCommandId())
+		}
+		if !res.GetSuccess() {
+			t.Error("expected success=true")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for result to be routed")
+	}
+}
+
+func TestGateway_CommandStream_Disconnect(t *testing.T) {
+	repo := newFakeWorkerRepo()
+	reg := registry.New(repo)
+	token := preregister(t, reg, "worker-4")
+
+	client, stop := startTestGateway(t, reg)
+	defer stop()
+
+	if _, err := client.Register(context.Background(), &workerpb.RegisterRequest{
+		PreSharedToken: token,
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	stream, err := client.CommandStream(ctx)
+	if err != nil {
+		t.Fatalf("CommandStream: %v", err)
+	}
+
+	// Identify the worker.
+	if err := stream.Send(&workerpb.CommandResult{
+		WorkerName:  "worker-4",
+		IsHeartbeat: true,
+	}); err != nil {
+		t.Fatalf("Send identify: %v", err)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	if _, ok := reg.Get("worker-4"); !ok {
+		t.Fatal("expected worker-4 in registry after opening stream")
+	}
+
+	// Cancel the client-side context to simulate the worker disconnecting.
+	cancel()
+
+	// Give the gateway time to process the disconnect.
+	time.Sleep(50 * time.Millisecond)
+
+	if _, ok := reg.Get("worker-4"); ok {
+		t.Error("expected worker-4 to be removed from registry after disconnect")
+	}
+}

--- a/ai-services/internal/pkg/worker/proto/worker.pb.go
+++ b/ai-services/internal/pkg/worker/proto/worker.pb.go
@@ -10,12 +10,11 @@
 package proto
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -164,8 +163,11 @@ type RegisterRequest struct {
 	WorkerName     string                 `protobuf:"bytes,1,opt,name=worker_name,json=workerName,proto3" json:"worker_name,omitempty"`
 	PreSharedToken string                 `protobuf:"bytes,2,opt,name=pre_shared_token,json=preSharedToken,proto3" json:"pre_shared_token,omitempty"`
 	Metadata       map[string]string      `protobuf:"bytes,3,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// runtime_type declares the execution environment of the worker
+	// (e.g. "podman", "openshift"). The control plane persists this to the DB.
+	RuntimeType   string `protobuf:"bytes,4,opt,name=runtime_type,json=runtimeType,proto3" json:"runtime_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *RegisterRequest) Reset() {
@@ -217,6 +219,13 @@ func (x *RegisterRequest) GetMetadata() map[string]string {
 		return x.Metadata
 	}
 	return nil
+}
+
+func (x *RegisterRequest) GetRuntimeType() string {
+	if x != nil {
+		return x.RuntimeType
+	}
+	return ""
 }
 
 type RegisterResponse struct {
@@ -428,12 +437,13 @@ var File_internal_pkg_worker_proto_worker_proto protoreflect.FileDescriptor
 
 const file_internal_pkg_worker_proto_worker_proto_rawDesc = "" +
 	"\n" +
-	"&internal/pkg/worker/proto/worker.proto\x12\tworker.v1\"\xdf\x01\n" +
+	"&internal/pkg/worker/proto/worker.proto\x12\tworker.v1\"\x82\x02\n" +
 	"\x0fRegisterRequest\x12\x1f\n" +
 	"\vworker_name\x18\x01 \x01(\tR\n" +
 	"workerName\x12(\n" +
 	"\x10pre_shared_token\x18\x02 \x01(\tR\x0epreSharedToken\x12D\n" +
-	"\bmetadata\x18\x03 \x03(\v2(.worker.v1.RegisterRequest.MetadataEntryR\bmetadata\x1a;\n" +
+	"\bmetadata\x18\x03 \x03(\v2(.worker.v1.RegisterRequest.MetadataEntryR\bmetadata\x12!\n" +
+	"\fruntime_type\x18\x04 \x01(\tR\vruntimeType\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"u\n" +

--- a/ai-services/internal/pkg/worker/proto/worker.pb.go
+++ b/ai-services/internal/pkg/worker/proto/worker.pb.go
@@ -10,11 +10,12 @@
 package proto
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/ai-services/internal/pkg/worker/proto/worker.proto
+++ b/ai-services/internal/pkg/worker/proto/worker.proto
@@ -28,6 +28,9 @@ message RegisterRequest {
   string worker_name      = 1;
   string pre_shared_token = 2;
   map<string, string> metadata = 3;
+  // runtime_type declares the execution environment of the worker
+  // (e.g. "podman", "openshift"). The control plane persists this to the DB.
+  string runtime_type     = 4;
 }
 
 message RegisterResponse {

--- a/ai-services/internal/pkg/worker/registry/registry.go
+++ b/ai-services/internal/pkg/worker/registry/registry.go
@@ -94,7 +94,14 @@ func New(repo repository.WorkerRepository) *Registry {
 // and ensures an in-memory entry with a live CommandCh exists.
 // workerName must come from the validated token — callers must not trust the name
 // the worker declares in its RegisterRequest.
-func (r *Registry) Register(ctx context.Context, workerName string, metadata map[string]string) (*WorkerEntry, error) {
+// runtimeType must be one of the supported values ("podman", "openshift");
+// an unsupported or empty value is rejected with an error.
+func (r *Registry) Register(ctx context.Context, workerName, runtimeType string, metadata map[string]string) (*WorkerEntry, error) {
+	rt, err := runtimeTypeFromString(runtimeType)
+	if err != nil {
+		return nil, err
+	}
+
 	r.mu.Lock()
 	entry, exists := r.workers[workerName]
 	if !exists {
@@ -110,7 +117,7 @@ func (r *Registry) Register(ctx context.Context, workerName string, metadata map
 	if r.repo != nil {
 		w := &models.Worker{
 			Name:        workerName,
-			RuntimeType: models.WorkerRuntimeTypePodman,
+			RuntimeType: rt,
 			Status:      models.WorkerStatusReady,
 			Metadata:    metadataToAny(metadata),
 		}
@@ -138,7 +145,7 @@ func (r *Registry) Preregister(ctx context.Context, workerName string) (string, 
 
 	w := &models.Worker{
 		Name:        workerName,
-		RuntimeType: models.WorkerRuntimeTypePodman,
+		RuntimeType: models.WorkerRuntimeTypeUnknown,
 		Status:      models.WorkerStatusPending,
 	}
 	if err := r.repo.Upsert(ctx, w); err != nil {
@@ -296,6 +303,21 @@ func metadataToAny(m map[string]string) map[string]any {
 	}
 
 	return out
+}
+
+// runtimeTypeFromString maps a runtime type string declared by the worker to the
+// corresponding DB model constant. Returns an error for unsupported or empty values.
+// Supported values: "podman", "openshift".
+func runtimeTypeFromString(s string) (models.WorkerRuntimeType, error) {
+	switch s {
+	case string(models.WorkerRuntimeTypePodman):
+		return models.WorkerRuntimeTypePodman, nil
+	case string(models.WorkerRuntimeTypeOpenShift):
+		return models.WorkerRuntimeTypeOpenShift, nil
+	default:
+		return "", fmt.Errorf("unsupported runtime_type %q: must be %q or %q",
+			s, models.WorkerRuntimeTypePodman, models.WorkerRuntimeTypeOpenShift)
+	}
 }
 
 // ValidateToken checks a bootstrap token, marks it used, and returns the worker name it was

--- a/ai-services/internal/pkg/worker/registry/registry.go
+++ b/ai-services/internal/pkg/worker/registry/registry.go
@@ -26,9 +26,6 @@ const (
 	// 32 allows up to 32 simultaneous deployments targeting the same worker
 	// without any back-pressure on the HTTP layer.
 	commandChannelSize = 32
-
-	// tokenTTLHours is the validity window for single-use bootstrap tokens.
-	tokenTTLHours = 24
 )
 
 // WorkerEntry holds the in-process gRPC plumbing for a single connected worker.
@@ -77,27 +74,27 @@ func (w *WorkerEntry) deliverResult(res *workerpb.CommandResult) {
 
 // Registry tracks all currently-connected workers by name.
 type Registry struct {
-	mu      sync.RWMutex
-	workers map[string]*WorkerEntry
-	repo    repository.WorkerRepository // may be nil in tests
+	mu         sync.RWMutex
+	workers    map[string]*WorkerEntry
+	repo       repository.WorkerRepository // may be nil in tests
+	tokenStore *TokenStore
 }
 
 // New creates a new Registry backed by the given WorkerRepository.
 // Pass nil for tests that do not need DB persistence.
 func New(repo repository.WorkerRepository) *Registry {
 	return &Registry{
-		workers: make(map[string]*WorkerEntry),
-		repo:    repo,
+		workers:    make(map[string]*WorkerEntry),
+		repo:       repo,
+		tokenStore: NewTokenStore(),
 	}
 }
 
-// Register upserts the worker into the DB (persisting name, metadata, status=ready)
+// Register upserts the worker into the DB (status=ready, with provided metadata)
 // and ensures an in-memory entry with a live CommandCh exists.
-// Metadata from the RegisterRequest is stored in the DB
-// metadata JSON column directly — no separate in-memory field is needed.
-func (r *Registry) Register(ctx context.Context, req *workerpb.RegisterRequest) (*WorkerEntry, error) {
-	workerName := req.GetWorkerName()
-
+// workerName must come from the validated token — callers must not trust the name
+// the worker declares in its RegisterRequest.
+func (r *Registry) Register(ctx context.Context, workerName string, metadata map[string]string) (*WorkerEntry, error) {
 	r.mu.Lock()
 	entry, exists := r.workers[workerName]
 	if !exists {
@@ -115,7 +112,7 @@ func (r *Registry) Register(ctx context.Context, req *workerpb.RegisterRequest) 
 			Name:        workerName,
 			RuntimeType: models.WorkerRuntimeTypePodman,
 			Status:      models.WorkerStatusReady,
-			Metadata:    metadataToAny(req.GetMetadata()),
+			Metadata:    metadataToAny(metadata),
 		}
 		if err := r.repo.Upsert(ctx, w); err != nil {
 			logger.WarningfCtx(ctx, "worker registry: DB upsert failed for %s: %v", workerName, err)
@@ -127,6 +124,37 @@ func (r *Registry) Register(ctx context.Context, req *workerpb.RegisterRequest) 
 	}
 
 	return entry, nil
+}
+
+// Preregister creates a pending DB row for a named worker and returns a single-use
+// bootstrap token the operator passes to the worker daemon at startup.
+// If a row already exists (re-registration), it is reset to pending and a new token
+// supersedes the old one. The registry's in-memory map is not touched — the worker
+// is not "connected" until it calls Register via gRPC.
+func (r *Registry) Preregister(ctx context.Context, workerName string) (string, error) {
+	if r.repo == nil {
+		return "", fmt.Errorf("worker registry: no repository configured")
+	}
+
+	w := &models.Worker{
+		Name:        workerName,
+		RuntimeType: models.WorkerRuntimeTypePodman,
+		Status:      models.WorkerStatusPending,
+	}
+	if err := r.repo.Upsert(ctx, w); err != nil {
+		return "", fmt.Errorf("worker registry: DB upsert failed for %s: %w", workerName, err)
+	}
+
+	return r.tokenStore.IssueToken(workerName), nil
+}
+
+// List returns all worker rows from the database ordered by registered_at ascending.
+func (r *Registry) List(ctx context.Context) ([]models.Worker, error) {
+	if r.repo == nil {
+		return nil, nil
+	}
+
+	return r.repo.GetAll(ctx)
 }
 
 // Get returns the in-memory entry for a connected worker, or false if not found.
@@ -142,36 +170,93 @@ func (r *Registry) Get(workerName string) (*WorkerEntry, bool) {
 // The DB row is kept so the worker can reconnect and its history is preserved.
 func (r *Registry) Disconnect(ctx context.Context, workerName string) {
 	r.mu.Lock()
-	_, ok := r.workers[workerName]
-	if ok {
-		delete(r.workers, workerName)
-	}
-	r.mu.Unlock()
-
-	if ok && r.repo != nil {
-		if err := r.repo.Update(ctx, workerName, repository.WorkerUpdate{Status: utils.Ptr(models.WorkerStatusDisconnected)}); err != nil {
-			logger.WarningfCtx(ctx, "worker registry: DB disconnect update failed for %s: %v", workerName, err)
-		}
-	}
-}
-
-// Deregister removes the worker from the in-memory map and hard-deletes its row from the DB.
-// Use this when a worker is permanently decommissioned, not just temporarily offline.
-func (r *Registry) Deregister(ctx context.Context, workerName string) error {
-	r.mu.Lock()
 	entry, ok := r.workers[workerName]
 	if ok {
 		delete(r.workers, workerName)
 	}
 	r.mu.Unlock()
 
-	if r.repo != nil && ok && entry.DBID != uuid.Nil {
-		if err := r.repo.Delete(ctx, entry.DBID); err != nil {
-			return fmt.Errorf("worker registry: DB delete failed for %s: %w", workerName, err)
+	if ok && r.repo != nil && entry.DBID != uuid.Nil {
+		if err := r.repo.Update(ctx, entry.DBID, repository.WorkerUpdate{Status: utils.Ptr(models.WorkerStatusDisconnected)}); err != nil {
+			logger.WarningfCtx(ctx, "worker registry: DB disconnect update failed for %s: %v", workerName, err)
 		}
 	}
+}
 
-	return nil
+// SweepStale fetches all workers from the DB and marks any whose last heartbeat
+// has exceeded timeout as disconnected. It is called by the gateway sweeper.
+func (r *Registry) SweepStale(ctx context.Context, timeout time.Duration) {
+	if r.repo == nil {
+		return
+	}
+
+	workers, err := r.repo.GetAll(ctx)
+	if err != nil {
+		logger.WarningfCtx(ctx, "worker registry: sweeper failed to fetch workers: %v", err)
+
+		return
+	}
+
+	now := time.Now()
+
+	for _, w := range workers {
+		if w.Status == models.WorkerStatusDisconnected {
+			continue
+		}
+		if w.LastHeartbeat == nil || now.Sub(*w.LastHeartbeat) > timeout {
+			logger.WarningfCtx(ctx, "worker registry: worker %s heartbeat timed out — marking disconnected", w.Name)
+			if err := r.repo.Update(ctx, w.ID, repository.WorkerUpdate{Status: utils.Ptr(models.WorkerStatusDisconnected)}); err != nil {
+				logger.WarningfCtx(ctx, "worker registry: failed to update stale worker %s: %v", w.Name, err)
+			}
+		}
+	}
+}
+
+// UpdateHeartbeat writes the current timestamp to last_heartbeat in the DB for the
+// named worker. It is called by the gateway on every heartbeat message.
+func (r *Registry) UpdateHeartbeat(ctx context.Context, workerName string) {
+	if r.repo == nil {
+		return
+	}
+
+	r.mu.RLock()
+	entry, ok := r.workers[workerName]
+	r.mu.RUnlock()
+
+	if !ok || entry.DBID == uuid.Nil {
+		return
+	}
+
+	now := time.Now()
+	if err := r.repo.Update(ctx, entry.DBID, repository.WorkerUpdate{LastHeartbeat: &now}); err != nil {
+		logger.WarningfCtx(ctx, "worker registry: heartbeat update failed for %s: %v", workerName, err)
+	}
+}
+
+// Deregister removes the worker from the in-memory map and hard-deletes its DB row by UUID.
+// Use this when a worker is permanently decommissioned, not just temporarily offline.
+// Returns (true, nil) if a row was deleted, (false, nil) if not found.
+func (r *Registry) Deregister(ctx context.Context, id uuid.UUID) (bool, error) {
+	r.mu.Lock()
+	for name, entry := range r.workers {
+		if entry.DBID == id {
+			delete(r.workers, name)
+
+			break
+		}
+	}
+	r.mu.Unlock()
+
+	if r.repo == nil {
+		return false, nil
+	}
+
+	deleted, err := r.repo.Delete(ctx, id)
+	if err != nil {
+		return false, fmt.Errorf("worker registry: DB delete failed for %s: %w", id, err)
+	}
+
+	return deleted, nil
 }
 
 // DeliverResult routes an incoming CommandResult to the waiting RemoteRuntime call.
@@ -213,58 +298,9 @@ func metadataToAny(m map[string]string) map[string]any {
 	return out
 }
 
-// ──────────────────────────────────────────────────────────────────────────────
-// Bootstrap token store
-// ──────────────────────────────────────────────────────────────────────────────
-
-// TokenRecord holds a single-use bootstrap token.
-type TokenRecord struct {
-	Token     string
-	ExpiresAt time.Time
-	Used      bool
-}
-
-// TokenStore is an in-memory single-use bootstrap token store.
-type TokenStore struct {
-	mu     sync.Mutex
-	tokens map[string]*TokenRecord
-}
-
-// NewTokenStore creates an empty token store.
-func NewTokenStore() *TokenStore {
-	return &TokenStore{tokens: make(map[string]*TokenRecord)}
-}
-
-// IssueToken generates a new 24-hour single-use token and returns it.
-func (ts *TokenStore) IssueToken() string {
-	token := uuid.NewString()
-	ts.mu.Lock()
-	ts.tokens[token] = &TokenRecord{
-		Token:     token,
-		ExpiresAt: time.Now().Add(tokenTTLHours * time.Hour),
-	}
-	ts.mu.Unlock()
-
-	return token
-}
-
-// Validate checks token validity and marks it used. Returns an error if the
-// token is unknown, already used, or expired.
-func (ts *TokenStore) Validate(token string) error {
-	ts.mu.Lock()
-	defer ts.mu.Unlock()
-
-	rec, ok := ts.tokens[token]
-	if !ok {
-		return fmt.Errorf("bootstrap token not found")
-	}
-	if rec.Used {
-		return fmt.Errorf("bootstrap token already used")
-	}
-	if time.Now().After(rec.ExpiresAt) {
-		return fmt.Errorf("bootstrap token expired")
-	}
-	rec.Used = true
-
-	return nil
+// ValidateToken checks a bootstrap token, marks it used, and returns the worker name it was
+// issued for. Exposed on Registry so callers (gateway, tests) do not need to hold a
+// separate TokenStore reference.
+func (r *Registry) ValidateToken(token string) (string, error) {
+	return r.tokenStore.Validate(token)
 }

--- a/ai-services/internal/pkg/worker/registry/registry_test.go
+++ b/ai-services/internal/pkg/worker/registry/registry_test.go
@@ -1,0 +1,313 @@
+package registry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
+	workerpb "github.com/project-ai-services/ai-services/internal/pkg/worker/proto"
+)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Minimal fake repo (no DB) used by tests that need persistence behaviour.
+// ──────────────────────────────────────────────────────────────────────────────
+
+type fakeWorkerRepo struct {
+	workers map[string]*models.Worker
+	byID    map[uuid.UUID]*models.Worker
+}
+
+func newFakeWorkerRepo() *fakeWorkerRepo {
+	return &fakeWorkerRepo{
+		workers: make(map[string]*models.Worker),
+		byID:    make(map[uuid.UUID]*models.Worker),
+	}
+}
+
+func (r *fakeWorkerRepo) Upsert(_ context.Context, w *models.Worker) error {
+	if existing, ok := r.workers[w.Name]; ok {
+		w.ID = existing.ID
+	} else {
+		w.ID = uuid.New()
+	}
+	w.RegisteredAt = time.Now()
+	w.UpdatedAt = time.Now()
+	cp := *w
+	r.workers[w.Name] = &cp
+	r.byID[w.ID] = &cp
+	return nil
+}
+
+func (r *fakeWorkerRepo) Update(_ context.Context, id uuid.UUID, u repository.WorkerUpdate) error {
+	w, ok := r.byID[id]
+	if !ok {
+		return nil
+	}
+	if u.Status != nil {
+		w.Status = *u.Status
+	}
+	if u.LastHeartbeat != nil {
+		w.LastHeartbeat = u.LastHeartbeat
+	}
+	return nil
+}
+
+func (r *fakeWorkerRepo) Delete(_ context.Context, id uuid.UUID) (bool, error) {
+	w, ok := r.byID[id]
+	if !ok {
+		return false, nil
+	}
+	delete(r.workers, w.Name)
+	delete(r.byID, id)
+	return true, nil
+}
+
+func (r *fakeWorkerRepo) GetAll(_ context.Context) ([]models.Worker, error) {
+	out := make([]models.Worker, 0, len(r.workers))
+	for _, w := range r.workers {
+		out = append(out, *w)
+	}
+	return out, nil
+}
+
+var _ repository.WorkerRepository = (*fakeWorkerRepo)(nil)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Preregister tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestRegistry_Preregister_IssuesToken(t *testing.T) {
+	reg := New(newFakeWorkerRepo())
+
+	token, err := reg.Preregister(context.Background(), "worker-a")
+	if err != nil {
+		t.Fatalf("Preregister: unexpected error: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+}
+
+func TestRegistry_Preregister_CreatesPendingRow(t *testing.T) {
+	repo := newFakeWorkerRepo()
+	reg := New(repo)
+
+	if _, err := reg.Preregister(context.Background(), "worker-a"); err != nil {
+		t.Fatalf("Preregister: %v", err)
+	}
+
+	w, ok := repo.workers["worker-a"]
+	if !ok {
+		t.Fatal("expected a DB row for worker-a")
+	}
+	if w.Status != models.WorkerStatusPending {
+		t.Errorf("expected status %q, got %q", models.WorkerStatusPending, w.Status)
+	}
+}
+
+func TestRegistry_Preregister_NoRepo(t *testing.T) {
+	reg := New(nil)
+
+	if _, err := reg.Preregister(context.Background(), "worker-a"); err == nil {
+		t.Fatal("expected error when no repository is configured")
+	}
+}
+
+func TestRegistry_Preregister_TokenIsValidatable(t *testing.T) {
+	reg := New(newFakeWorkerRepo())
+
+	token, err := reg.Preregister(context.Background(), "worker-a")
+	if err != nil {
+		t.Fatalf("Preregister: %v", err)
+	}
+
+	name, err := reg.ValidateToken(token)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if name != "worker-a" {
+		t.Errorf("expected %q, got %q", "worker-a", name)
+	}
+}
+
+func TestRegistry_Preregister_TokenNotReusable(t *testing.T) {
+	reg := New(newFakeWorkerRepo())
+
+	token, err := reg.Preregister(context.Background(), "worker-a")
+	if err != nil {
+		t.Fatalf("Preregister: %v", err)
+	}
+
+	if _, err := reg.ValidateToken(token); err != nil {
+		t.Fatalf("first ValidateToken: %v", err)
+	}
+
+	if _, err := reg.ValidateToken(token); err == nil {
+		t.Fatal("second ValidateToken: expected error for already-used token")
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Registry tests (nil repo — no DB)
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestRegistry_RegisterAddsEntry(t *testing.T) {
+	reg := New(nil)
+
+	entry, err := reg.Register(context.Background(), "worker-1", nil)
+	if err != nil {
+		t.Fatalf("Register: unexpected error: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("expected non-nil entry")
+	}
+	if entry.CommandCh == nil {
+		t.Fatal("expected non-nil CommandCh")
+	}
+	if entry.WorkerName != "worker-1" {
+		t.Errorf("expected WorkerName %q, got %q", "worker-1", entry.WorkerName)
+	}
+}
+
+func TestRegistry_RegisterIdempotent(t *testing.T) {
+	reg := New(nil)
+
+	e1, _ := reg.Register(context.Background(), "worker-1", nil)
+	e2, _ := reg.Register(context.Background(), "worker-1", nil)
+
+	// Both calls must return the same in-memory entry pointer.
+	if e1 != e2 {
+		t.Error("expected same entry on second Register, got a different pointer")
+	}
+}
+
+func TestRegistry_GetKnownWorker(t *testing.T) {
+	reg := New(nil)
+	reg.Register(context.Background(), "worker-1", nil) //nolint:errcheck
+
+	entry, ok := reg.Get("worker-1")
+	if !ok {
+		t.Fatal("expected to find worker-1")
+	}
+	if entry == nil {
+		t.Fatal("expected non-nil entry")
+	}
+}
+
+func TestRegistry_GetUnknownWorker(t *testing.T) {
+	reg := New(nil)
+
+	_, ok := reg.Get("ghost")
+	if ok {
+		t.Fatal("expected not to find unknown worker")
+	}
+}
+
+func TestRegistry_Disconnect(t *testing.T) {
+	reg := New(nil)
+	reg.Register(context.Background(), "worker-1", nil) //nolint:errcheck
+
+	reg.Disconnect(context.Background(), "worker-1")
+
+	_, ok := reg.Get("worker-1")
+	if ok {
+		t.Error("expected worker-1 to be removed after Disconnect")
+	}
+}
+
+func TestRegistry_DisconnectUnknownIsNoop(t *testing.T) {
+	reg := New(nil)
+	// Must not panic.
+	reg.Disconnect(context.Background(), "never-registered")
+}
+
+func TestRegistry_DeregisterUnknown(t *testing.T) {
+	reg := New(nil)
+
+	deleted, err := reg.Deregister(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("Deregister: unexpected error: %v", err)
+	}
+	if deleted {
+		t.Error("expected deleted=false for unknown UUID")
+	}
+}
+
+func TestRegistry_WaitForResult_WorkerNotConnected(t *testing.T) {
+	reg := New(nil)
+
+	_, err := reg.WaitForResult("ghost", "cmd-1")
+	if err == nil {
+		t.Fatal("expected error for unconnected worker")
+	}
+}
+
+func TestRegistry_DeliverResult_Routing(t *testing.T) {
+	reg := New(nil)
+	reg.Register(context.Background(), "worker-1", nil) //nolint:errcheck
+
+	ch, err := reg.WaitForResult("worker-1", "cmd-42")
+	if err != nil {
+		t.Fatalf("WaitForResult: %v", err)
+	}
+
+	res := &workerpb.CommandResult{
+		WorkerName: "worker-1",
+		CommandId:  "cmd-42",
+		Success:    true,
+	}
+	reg.DeliverResult(res)
+
+	select {
+	case got := <-ch:
+		if got.GetCommandId() != "cmd-42" {
+			t.Errorf("expected command_id %q, got %q", "cmd-42", got.GetCommandId())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for result")
+	}
+}
+
+func TestRegistry_DeliverResult_NoWaiter(t *testing.T) {
+	reg := New(nil)
+	reg.Register(context.Background(), "worker-1", nil) //nolint:errcheck
+
+	// Delivering a result with no waiter must not block or panic.
+	reg.DeliverResult(&workerpb.CommandResult{
+		WorkerName: "worker-1",
+		CommandId:  "orphan",
+	})
+}
+
+func TestRegistry_DeliverResult_UnknownWorker(t *testing.T) {
+	reg := New(nil)
+	// Delivering for a worker that has never registered must not panic.
+	reg.DeliverResult(&workerpb.CommandResult{
+		WorkerName: "ghost",
+		CommandId:  "cmd-1",
+	})
+}
+
+func TestRegistry_ValidateToken(t *testing.T) {
+	reg := New(nil)
+	token := reg.tokenStore.IssueToken("worker-x")
+
+	name, err := reg.ValidateToken(token)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if name != "worker-x" {
+		t.Errorf("expected %q, got %q", "worker-x", name)
+	}
+}
+
+func TestRegistry_ValidateToken_Invalid(t *testing.T) {
+	reg := New(nil)
+
+	if _, err := reg.ValidateToken("garbage"); err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+}

--- a/ai-services/internal/pkg/worker/registry/registry_test.go
+++ b/ai-services/internal/pkg/worker/registry/registry_test.go
@@ -157,7 +157,7 @@ func TestRegistry_Preregister_TokenNotReusable(t *testing.T) {
 func TestRegistry_RegisterAddsEntry(t *testing.T) {
 	reg := New(nil)
 
-	entry, err := reg.Register(context.Background(), "worker-1", nil)
+	entry, err := reg.Register(context.Background(), "worker-1", "podman", nil)
 	if err != nil {
 		t.Fatalf("Register: unexpected error: %v", err)
 	}
@@ -172,11 +172,20 @@ func TestRegistry_RegisterAddsEntry(t *testing.T) {
 	}
 }
 
+func TestRegistry_Register_InvalidRuntimeType(t *testing.T) {
+	reg := New(nil)
+
+	_, err := reg.Register(context.Background(), "worker-1", "docker", nil)
+	if err == nil {
+		t.Fatal("expected error for unsupported runtime_type")
+	}
+}
+
 func TestRegistry_RegisterIdempotent(t *testing.T) {
 	reg := New(nil)
 
-	e1, _ := reg.Register(context.Background(), "worker-1", nil)
-	e2, _ := reg.Register(context.Background(), "worker-1", nil)
+	e1, _ := reg.Register(context.Background(), "worker-1", "podman", nil)
+	e2, _ := reg.Register(context.Background(), "worker-1", "podman", nil)
 
 	// Both calls must return the same in-memory entry pointer.
 	if e1 != e2 {
@@ -186,7 +195,7 @@ func TestRegistry_RegisterIdempotent(t *testing.T) {
 
 func TestRegistry_GetKnownWorker(t *testing.T) {
 	reg := New(nil)
-	reg.Register(context.Background(), "worker-1", nil) //nolint:errcheck
+	reg.Register(context.Background(), "worker-1", "podman", nil) //nolint:errcheck
 
 	entry, ok := reg.Get("worker-1")
 	if !ok {
@@ -208,7 +217,7 @@ func TestRegistry_GetUnknownWorker(t *testing.T) {
 
 func TestRegistry_Disconnect(t *testing.T) {
 	reg := New(nil)
-	reg.Register(context.Background(), "worker-1", nil) //nolint:errcheck
+	reg.Register(context.Background(), "worker-1", "podman", nil) //nolint:errcheck
 
 	reg.Disconnect(context.Background(), "worker-1")
 
@@ -247,7 +256,7 @@ func TestRegistry_WaitForResult_WorkerNotConnected(t *testing.T) {
 
 func TestRegistry_DeliverResult_Routing(t *testing.T) {
 	reg := New(nil)
-	reg.Register(context.Background(), "worker-1", nil) //nolint:errcheck
+	reg.Register(context.Background(), "worker-1", "podman", nil) //nolint:errcheck
 
 	ch, err := reg.WaitForResult("worker-1", "cmd-42")
 	if err != nil {
@@ -273,7 +282,7 @@ func TestRegistry_DeliverResult_Routing(t *testing.T) {
 
 func TestRegistry_DeliverResult_NoWaiter(t *testing.T) {
 	reg := New(nil)
-	reg.Register(context.Background(), "worker-1", nil) //nolint:errcheck
+	reg.Register(context.Background(), "worker-1", "podman", nil) //nolint:errcheck
 
 	// Delivering a result with no waiter must not block or panic.
 	reg.DeliverResult(&workerpb.CommandResult{

--- a/ai-services/internal/pkg/worker/registry/token.go
+++ b/ai-services/internal/pkg/worker/registry/token.go
@@ -1,0 +1,68 @@
+package registry
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// tokenTTLHours is the validity window for single-use bootstrap tokens.
+const tokenTTLHours = 24
+
+// TokenRecord holds a single-use bootstrap token bound to a specific worker name.
+type TokenRecord struct {
+	Token      string
+	WorkerName string
+	ExpiresAt  time.Time
+	Used       bool
+}
+
+// TokenStore is an in-memory single-use bootstrap token store.
+type TokenStore struct {
+	mu     sync.Mutex
+	tokens map[string]*TokenRecord
+}
+
+// NewTokenStore creates an empty token store.
+func NewTokenStore() *TokenStore {
+	return &TokenStore{tokens: make(map[string]*TokenRecord)}
+}
+
+// IssueToken generates a new 24-hour single-use token bound to workerName and returns it.
+// The worker must present this exact token when calling Register; the name supplied in
+// the RegisterRequest is ignored — the name bound to the token is authoritative.
+func (ts *TokenStore) IssueToken(workerName string) string {
+	token := uuid.NewString()
+	ts.mu.Lock()
+	ts.tokens[token] = &TokenRecord{
+		Token:      token,
+		WorkerName: workerName,
+		ExpiresAt:  time.Now().Add(tokenTTLHours * time.Hour),
+	}
+	ts.mu.Unlock()
+
+	return token
+}
+
+// Validate checks token validity, marks it used, and returns the worker name it was
+// issued for. Returns an error if the token is unknown, already used, or expired.
+func (ts *TokenStore) Validate(token string) (string, error) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	rec, ok := ts.tokens[token]
+	if !ok {
+		return "", fmt.Errorf("bootstrap token not found")
+	}
+	if rec.Used {
+		return "", fmt.Errorf("bootstrap token already used")
+	}
+	if time.Now().After(rec.ExpiresAt) {
+		return "", fmt.Errorf("bootstrap token expired")
+	}
+	rec.Used = true
+
+	return rec.WorkerName, nil
+}

--- a/ai-services/internal/pkg/worker/registry/token_test.go
+++ b/ai-services/internal/pkg/worker/registry/token_test.go
@@ -1,0 +1,84 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTokenStore_IssueAndValidate(t *testing.T) {
+	ts := NewTokenStore()
+	token := ts.IssueToken("worker-a")
+
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+
+	name, err := ts.Validate(token)
+	if err != nil {
+		t.Fatalf("Validate: unexpected error: %v", err)
+	}
+	if name != "worker-a" {
+		t.Fatalf("expected worker name %q, got %q", "worker-a", name)
+	}
+}
+
+func TestTokenStore_SingleUse(t *testing.T) {
+	ts := NewTokenStore()
+	token := ts.IssueToken("worker-b")
+
+	if _, err := ts.Validate(token); err != nil {
+		t.Fatalf("first Validate: unexpected error: %v", err)
+	}
+
+	if _, err := ts.Validate(token); err == nil {
+		t.Fatal("second Validate: expected error for already-used token")
+	}
+}
+
+func TestTokenStore_UnknownToken(t *testing.T) {
+	ts := NewTokenStore()
+
+	if _, err := ts.Validate("not-a-real-token"); err == nil {
+		t.Fatal("expected error for unknown token")
+	}
+}
+
+func TestTokenStore_ExpiredToken(t *testing.T) {
+	ts := NewTokenStore()
+
+	// Manually inject an expired record.
+	ts.mu.Lock()
+	ts.tokens["expired"] = &TokenRecord{
+		Token:      "expired",
+		WorkerName: "worker-exp",
+		ExpiresAt:  time.Now().Add(-time.Hour),
+	}
+	ts.mu.Unlock()
+
+	if _, err := ts.Validate("expired"); err == nil {
+		t.Fatal("expected error for expired token")
+	}
+}
+
+func TestTokenStore_MultipleWorkers(t *testing.T) {
+	ts := NewTokenStore()
+
+	tokenA := ts.IssueToken("worker-a")
+	tokenB := ts.IssueToken("worker-b")
+
+	nameA, err := ts.Validate(tokenA)
+	if err != nil {
+		t.Fatalf("Validate tokenA: %v", err)
+	}
+	nameB, err := ts.Validate(tokenB)
+	if err != nil {
+		t.Fatalf("Validate tokenB: %v", err)
+	}
+
+	if nameA != "worker-a" {
+		t.Errorf("expected worker-a, got %q", nameA)
+	}
+	if nameB != "worker-b" {
+		t.Errorf("expected worker-b, got %q", nameB)
+	}
+}


### PR DESCRIPTION
Worker gateway infrastructure — gRPC control plane for remote workers

- worker/registry — Registry (in-memory worker map + lifecycle: Register, Preregister, Disconnect, Deregister, SweepStale, UpdateHeartbeat, WaitForResult, DeliverResult) and TokenStore (single-use 24-hour bootstrap tokens).
- worker/gateway — gRPC server (Register RPC + CommandStream bidi-stream) that authenticates workers via token, routes commands to them, and sweeps stale heartbeats. Listens on :9090 by default, always active.
- catalog/apiserver — WorkerGatewayPort + WorkerRegistry wired into APIServerOptions; gateway started in Start(ctx); worker REST routes (POST/GET/DELETE /api/v1/workers) added to the router via WorkerHandler.
- catalog/db/repository/worker_repo.go — WorkerRepository interface with Upsert, Update, Delete, GetAll; full pgx implementation.
- cmd/catalog/apiserver.go — --workergateway-port flag (default 9090), signal.NotifyContext, workerRepo → workerReg wiring.