### PR TITLE
fix: stop image pulls when application is deleted mid-deploy

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.243
+TAG?=v0.0.244
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.243
+  image: icr.io/ai-services-cicd/ai-services:v0.0.244
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.243
+  image: icr.io/ai-services-cicd/ai-services:v0.0.244
   runtime: ""
   adminPasswordHash: ""
   # workerGatewayPort: port for the gRPC worker gateway. Always active; default is 9090.

--- a/ai-services/internal/pkg/application/podman/create.go
+++ b/ai-services/internal/pkg/application/podman/create.go
@@ -114,7 +114,7 @@ func (p *PodmanApplication) validateAndAllocateSpyreCards(ctx context.Context, t
 
 func (p *PodmanApplication) prepareApplicationArtifacts(ctx context.Context, opts types.CreateOptions) error {
 	// Download Container Images
-	if err := p.downloadImagesForTemplate(opts.TemplateName, opts.Name, opts.ImagePullPolicy); err != nil {
+	if err := p.downloadImagesForTemplate(ctx, opts.TemplateName, opts.Name, opts.ImagePullPolicy); err != nil {
 		return err
 	}
 
@@ -285,7 +285,7 @@ func (p *PodmanApplication) fetchSpyreCardsFromPodAnnotations(annotations map[st
 	return spyreCards, spyreCardContainerMap, nil
 }
 
-func (p *PodmanApplication) downloadImagesForTemplate(templateName, appName string, imagePullPolicy image.ImagePullPolicy) error {
+func (p *PodmanApplication) downloadImagesForTemplate(ctx context.Context, templateName, appName string, imagePullPolicy image.ImagePullPolicy) error {
 	// create Images struct and run with the specified policy
 	img := &image.Images{
 		Runtime:     p.runtime,
@@ -293,7 +293,7 @@ func (p *PodmanApplication) downloadImagesForTemplate(templateName, appName stri
 		AppTemplate: templateName,
 	}
 
-	return img.Run(imagePullPolicy)
+	return img.Run(ctx, imagePullPolicy)
 }
 
 func (p *PodmanApplication) executePodTemplates(ctx context.Context, tp templates.Template,

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -246,7 +246,7 @@ func (d *PodmanDeployer) pullImagesForDeployment(ctx context.Context, plan *Depl
 		return nil
 	}
 
-	if err := d.pullImages(imageSet); err != nil {
+	if err := d.pullImages(ctx, imageSet); err != nil {
 		return err
 	}
 
@@ -313,7 +313,7 @@ func (d *PodmanDeployer) extractImagesFromService(ctx context.Context, svc *Serv
 
 // pullImages pulls only missing images from the provided set using the runtime.
 // Images that are already present locally are skipped.
-func (d *PodmanDeployer) pullImages(imageSet map[string]bool) error {
+func (d *PodmanDeployer) pullImages(ctx context.Context, imageSet map[string]bool) error {
 	// Convert map to slice
 	images := make([]string, 0, len(imageSet))
 	for img := range imageSet {
@@ -325,7 +325,7 @@ func (d *PodmanDeployer) pullImages(imageSet map[string]bool) error {
 		Runtime: d.runtime,
 	}
 
-	if err := imgHelper.IfNotPresent(images); err != nil {
+	if err := imgHelper.IfNotPresent(ctx, images); err != nil {
 		return fmt.Errorf("failed to pull images: %w", err)
 	}
 

--- a/ai-services/internal/pkg/image/helper.go
+++ b/ai-services/internal/pkg/image/helper.go
@@ -15,7 +15,7 @@ func PullImageFromRegistry(ctx context.Context, runtime runtime.Runtime, images 
 	for _, image := range images {
 		logger.InfolnCtx(ctx, "Downloading image: "+image+"...")
 		if err := utils.Retry(ctx, vars.RetryCount, vars.RetryInterval, nil, func() error {
-			return runtime.PullImage(image)
+			return runtime.PullImage(ctx, image)
 		}); err != nil {
 			return fmt.Errorf("failed to download image: %w", err)
 		}

--- a/ai-services/internal/pkg/image/images.go
+++ b/ai-services/internal/pkg/image/images.go
@@ -84,7 +84,7 @@ func (img *Images) Run(policy ImagePullPolicy) error {
 	case PullAlways:
 		return img.always(images)
 	case PullIfNotPresent:
-		return img.IfNotPresent(images)
+		return img.IfNotPresent(context.Background(), images)
 	case PullNever:
 		return img.never(images)
 	default:
@@ -101,20 +101,19 @@ func (img *Images) always(images []string) error {
 }
 
 // IfNotPresent pulls only the missing images for a given app template.
-func (img *Images) IfNotPresent(images []string) error {
+func (img *Images) IfNotPresent(ctx context.Context, images []string) error {
 	notFoundImages, err := FetchImagesNotFound(img.Runtime, images)
 	if err != nil {
 		return err
 	}
 
 	if len(notFoundImages) == 0 {
-		ctx := context.Background()
 		logger.InfolnCtx(ctx, "All required container images are already present locally.")
 
 		return nil
 	}
 
-	return PullImageFromRegistry(context.Background(), img.Runtime, notFoundImages)
+	return PullImageFromRegistry(ctx, img.Runtime, notFoundImages)
 }
 
 // never -> never pulls any image.

--- a/ai-services/internal/pkg/image/images.go
+++ b/ai-services/internal/pkg/image/images.go
@@ -73,7 +73,7 @@ func (img *Images) ListImages() ([]string, error) {
 }
 
 // Run executes the image pull policy.
-func (img *Images) Run(policy ImagePullPolicy) error {
+func (img *Images) Run(ctx context.Context, policy ImagePullPolicy) error {
 	// Fetch all images required for the template
 	images, err := img.ListImages()
 	if err != nil {
@@ -82,19 +82,18 @@ func (img *Images) Run(policy ImagePullPolicy) error {
 
 	switch policy {
 	case PullAlways:
-		return img.always(images)
+		return img.always(ctx, images)
 	case PullIfNotPresent:
-		return img.IfNotPresent(context.Background(), images)
+		return img.IfNotPresent(ctx, images)
 	case PullNever:
-		return img.never(images)
+		return img.never(ctx, images)
 	default:
 		return fmt.Errorf("unsupported policy: %s", policy)
 	}
 }
 
 // always -> pulls all the images for a given app template.
-func (img *Images) always(images []string) error {
-	ctx := context.Background()
+func (img *Images) always(ctx context.Context, images []string) error {
 	logger.InfolnCtx(ctx, "Downloading container images required for application template "+img.AppTemplate+":")
 
 	return PullImageFromRegistry(ctx, img.Runtime, images)
@@ -118,7 +117,7 @@ func (img *Images) IfNotPresent(ctx context.Context, images []string) error {
 
 // never -> never pulls any image.
 // It checks whether all the images for given appTemplate is present locally, if not then raises an error.
-func (img *Images) never(images []string) error {
+func (img *Images) never(ctx context.Context, images []string) error {
 	notFoundImages, err := FetchImagesNotFound(img.Runtime, images)
 	if err != nil {
 		return err
@@ -128,7 +127,7 @@ func (img *Images) never(images []string) error {
 		return fmt.Errorf("some required images are not present locally: %v. Either pull the image manually or rerun create command without --image-pull-policy or --skip-image-download flag", notFoundImages)
 	}
 
-	logger.InfolnCtx(context.Background(), "All required container images are present locally.")
+	logger.InfolnCtx(ctx, "All required container images are present locally.")
 
 	return nil
 }

--- a/ai-services/internal/pkg/runtime/interface.go
+++ b/ai-services/internal/pkg/runtime/interface.go
@@ -12,7 +12,7 @@ import (
 type Runtime interface {
 	// Image operations
 	ListImages() ([]types.Image, error)
-	PullImage(image string) error
+	PullImage(ctx context.Context, image string) error
 
 	// Pod operations
 	ListPods(filters map[string][]string) ([]types.Pod, error)

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -183,7 +183,7 @@ func (kc *OpenshiftClient) ListImages() ([]types.Image, error) {
 }
 
 // PullImage pulls a container image.
-func (kc *OpenshiftClient) PullImage(image string) error {
+func (kc *OpenshiftClient) PullImage(_ context.Context, image string) error {
 	logger.Warningln("PullImage is not implemented for OpenshiftClient as image pulling is managed by kubelet.")
 
 	return nil

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -83,8 +83,8 @@ func (pc *PodmanClient) ListImages() ([]types.Image, error) {
 	return toImageList(images), nil
 }
 
-func (pc *PodmanClient) PullImage(image string) error {
-	logger.Infof("Pulling image %s...\n", image)
+func (pc *PodmanClient) PullImage(ctx context.Context, image string) error {
+	logger.InfofCtx(ctx, "Pulling image %s...\n", image)
 
 	// Create pull options with auth file from environment
 	opts := &images.PullOptions{}
@@ -92,11 +92,17 @@ func (pc *PodmanClient) PullImage(image string) error {
 		opts.Authfile = &authFile
 	}
 
-	_, err := images.Pull(pc.Context, image, opts)
+	// podmanCtx merges pc.Context (Podman connection handle) with the caller's
+	// ctx (cancellation signal). We cannot pass ctx directly — the Podman SDK
+	// requires its connection value which only exists in pc.Context.
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	_, err := images.Pull(podCtx, image, opts)
 	if err != nil {
 		return fmt.Errorf("failed to pull image %s: %w", image, err)
 	}
-	logger.Infof("Successfully pulled image %s\n", image)
+	logger.InfofCtx(ctx, "Successfully pulled image %s\n", image)
 
 	return nil
 }


### PR DESCRIPTION
When an application was deleted during deployment, image pulls continued running after deletion completed. The context cancellation signal was not propagated through the pull chain to the Podman SDK.

**Changes**
- Added `context.Context ` to the `Runtime.PullImage` interface
- Threaded `ctx` from `pullImages` down to `runtime.PullImage`
- Added `podmanCtx(`) in the Podman runtime to merge cancellation with the Podman connection context using `context.AfterFunc`


**Result**
Image pulls are now cancelled immediately when a deletion is requested mid-deploy.