### PR TITLE
Data Source Connectors: APScheduler & Startup Recovery 

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.248
+TAG?=v0.0.249
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.44
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.45
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.44
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.45
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.44
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.45
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.44
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.45
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.44
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.45
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.248
+  image: icr.io/ai-services-cicd/ai-services:v0.0.249
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.248
+  image: icr.io/ai-services-cicd/ai-services:v0.0.249
   runtime: ""
   adminPasswordHash: ""
   # workerGatewayPort: port for the gRPC worker gateway. Always active; default is 9090.

--- a/ai-services/assets/services/digitize/openshift/values.yaml
+++ b/ai-services/assets/services/digitize/openshift/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.44
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.45
   log_level: "INFO"
   database: "digitize_metadata"
   numShards: 1

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.44
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.45
   log_level: "INFO"
   database: "digitize_metadata"
 

--- a/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
+++ b/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
@@ -942,9 +942,10 @@ $$\text{pool\_size} = \max(N + 4, 8) \quad \text{(where } N = \text{total config
 
 ### Pending PRs
 
-- **PR 7 — Scheduler + Lifespan + Crash Recovery ❌ NOT IMPLEMENTED:**
-  - `scheduler.py` does not exist. No `ConnectorScheduler`, no `register_connector_job`, no `_run_tick_wrapped`, no `AsyncScheduler`, no `AsyncSQLAlchemyDataStore`.
-  - `recover_connector_sync_state()` does not exist in `utils/recovery.py` (only `recover_zombie_jobs()` is present, which handles regular jobs only).
-  - `app.py` `lifespan()` does not start an APScheduler, does not call `recover_connector_sync_state()`, does not re-register connector jobs on startup, and does not set a custom thread pool executor.
-  - `POST /v1/connectors` currently has a code comment reading "Worker start is a no-op stub in PR3 — the worker manager (PR7) will hook in here once implemented." Scheduler registration on connector creation is pending.
-
+- **PR 7 — Scheduler + Lifespan + Crash Recovery ✅:**
+  - `connectors/scheduler.py` created: `register_connector_job`, `remove_connector_job`, `_run_tick_wrapped` (APScheduler v4 `AsyncScheduler` + `SQLAlchemyDataStore` backed by the shared Postgres engine). `apscheduler[sqlalchemy]==4.0.0a6` added to `requirements.txt`.
+  - `recover_connector_sync_state()` added to `utils/recovery.py`: bulk-resets connectors stuck in `'syncing'` → `'out of sync'`; closes open `connector_sync_logs` rows to `'failed'`. DB helpers `reset_syncing_connectors` / `close_open_sync_log` added to `db/manager.py` and `utils/db.py`.
+  - `app.py` `lifespan()` updated: starts `AsyncScheduler` within an `async with` block, calls `recover_connector_sync_state()`, re-registers all existing connector jobs (`fire_immediately=False`), and sizes the default `ThreadPoolExecutor` to `max(N+4, 8)`.
+  - `POST /v1/connectors` now calls `register_connector_job(connector_id, sync_interval, fire_immediately=True)` after the DB insert. The stub comment is removed.
+  - `DELETE /v1/connectors/{id}` now calls `remove_connector_job(connector_id)` before dispatching teardown so no new tick fires after the connector is marked delete-pending.
+  - Unit tests in `tests/test_connector_scheduler.py` cover `_run_tick_wrapped`, `register_connector_job`, `remove_connector_job`, and `recover_connector_sync_state`.

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.44
+TAG?=v0.0.45
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -95,9 +95,10 @@ async def create_connector(body: ConnectorCreateRequest):
                 connector_id, sync_interval, fire_immediately=True
             )
         except Exception as sched_exc:
-            logger.warning(
+            logger.error(
                 f"Scheduler registration failed for {connector_id!r}: {sched_exc}"
             )
+            raise
 
         db_ops.insert_connector(
             connector_id=connector_id,

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -100,8 +100,19 @@ async def create_connector(body: ConnectorCreateRequest):
             f"Connector {connector_id!r} ({body.connector_name!r}) attached "
             f"(type={body.type}, interval={sync_interval}s)"
         )
-        # Worker start is a no-op stub in PR3 — the worker manager (PR7) will hook
-        # in here once implemented.
+
+        # Register the connector with the scheduler so it starts ticking
+        # immediately (fire_immediately=True for the first-ever sync).
+        try:
+            import digitize.connectors.scheduler as _sched
+            await _sched.register_connector_job(
+                connector_id, sync_interval, fire_immediately=True
+            )
+        except Exception as sched_exc:
+            logger.warning(
+                f"Scheduler registration failed for {connector_id!r}: {sched_exc}"
+            )
+
         return Response(
             content=f'{{"connector_id": "{connector_id}"}}',
             status_code=201,
@@ -270,15 +281,26 @@ async def _run_teardown(connector_id: str) -> None:
     and awaited directly from _handle_interrupt in sync_tick (Case A).
 
     Steps:
-      1. Snapshot checksums owned by this connector
-      2. Remove ownership rows; delete documents when last owner
-      3. Sweep residual batch staging directories
-      4. Delete the connector row (cascades to connector_sync_logs)
+      1. Remove the scheduled job so no new ticks fire
+      2. Snapshot checksums owned by this connector
+      3. Remove ownership rows; delete documents when last owner
+      4. Sweep residual batch staging directories
+      5. Delete the connector row (cascades to connector_sync_logs)
     """
     logger.info(f"Starting teardown for connector {connector_id!r}")
     deletion_failed = False
     try:
-        # Steps 1+2: remove checksum ownership; delete orphaned documents
+        # Step 1: Remove the scheduled job so no new ticks fire after this point.
+        try:
+            import digitize.connectors.scheduler as _sched
+            await _sched.remove_connector_job(connector_id)
+        except Exception as sched_exc:
+            deletion_failed = True
+            logger.warning(
+                f"Could not remove scheduler job for {connector_id!r}: {sched_exc}"
+            )
+
+        # Steps 2+3: remove checksum ownership; delete orphaned documents
         owned_checksums = db_ops.list_connector_checksums(connector_id)
         for checksum in owned_checksums:
             try:
@@ -294,7 +316,7 @@ async def _run_teardown(connector_id: str) -> None:
                     exc_info=True,
                 )
 
-        # Step 3: sweep any residual batch staging directories
+        # Step 4: sweep any residual batch staging directories
         if not _sweep_staging_dir(connector_id, settings.digitize.staging_dir / "connectors"):
             deletion_failed = True
 
@@ -303,7 +325,7 @@ async def _run_teardown(connector_id: str) -> None:
             logger.warning(f"Skipping connector row deletion for {connector_id!r} due to teardown failures")
             return
 
-        # Step 4: delete the connector row (cascades to connector_sync_logs)
+        # Step 5: delete the connector row (cascades to connector_sync_logs)
         deleted = db_ops.delete_active_connector(connector_id)
         if not deleted:
             logger.warning(
@@ -485,9 +507,9 @@ async def dispatch_sync(connector_id: str) -> int:
     """Dispatch a sync tick for *connector_id* and return the active sync_seq.
 
     This is the shared core used by both the HTTP handler (``trigger_sync``)
-    and the APScheduler job (``_run_tick_wrapped``).  It contains no FastAPI or
-    HTTP concerns — callers map the exceptions it raises to their own error
-    handling:
+    and the APScheduler (registered directly via ``register_connector_job``).
+    It contains no FastAPI or HTTP concerns — callers map the exceptions it
+    raises to their own error handling:
 
     Raises
     ------
@@ -509,17 +531,10 @@ async def dispatch_sync(connector_id: str) -> int:
 
     APScheduler usage
     -----------------
-    The scheduler can call this directly without any HTTP machinery::
+    The scheduler registers this function directly as the job callable::
 
-        from digitize.api.v1.connectors import dispatch_sync, SyncNotFound, SyncLocked
-
-        async def _run_tick_wrapped(connector_id: str) -> None:
-            try:
-                await dispatch_sync(connector_id)
-            except SyncNotFound:
-                logger.warning(f"Connector {connector_id!r} not found; skipping")
-            except SyncLocked as exc:
-                logger.info(f"Connector {connector_id!r} skipped: {exc}")
+        from digitize.api.v1.connectors import dispatch_sync
+        await sched.add_schedule(func_or_task_id=dispatch_sync, args=[connector_id], ...)
     """
     from digitize.connectors.sync_tick import run_tick
 

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -87,6 +87,18 @@ async def create_connector(body: ConnectorCreateRequest):
 
         sync_interval = settings.digitize.connector.sync_interval_seconds
 
+        # Register the connector with the scheduler so it starts ticking
+        # immediately (fire_immediately=True for the first-ever sync).
+        try:
+            import digitize.connectors.scheduler as _sched
+            await _sched.register_connector_job(
+                connector_id, sync_interval, fire_immediately=True
+            )
+        except Exception as sched_exc:
+            logger.warning(
+                f"Scheduler registration failed for {connector_id!r}: {sched_exc}"
+            )
+
         db_ops.insert_connector(
             connector_id=connector_id,
             name=body.connector_name,
@@ -100,18 +112,6 @@ async def create_connector(body: ConnectorCreateRequest):
             f"Connector {connector_id!r} ({body.connector_name!r}) attached "
             f"(type={body.type}, interval={sync_interval}s)"
         )
-
-        # Register the connector with the scheduler so it starts ticking
-        # immediately (fire_immediately=True for the first-ever sync).
-        try:
-            import digitize.connectors.scheduler as _sched
-            await _sched.register_connector_job(
-                connector_id, sync_interval, fire_immediately=True
-            )
-        except Exception as sched_exc:
-            logger.warning(
-                f"Scheduler registration failed for {connector_id!r}: {sched_exc}"
-            )
 
         return Response(
             content=f'{{"connector_id": "{connector_id}"}}',

--- a/services/digitize/app.py
+++ b/services/digitize/app.py
@@ -43,17 +43,11 @@ diagnostic_logger, stderr_monitor, signal_handler = setup_comprehensive_crash_ha
 
 
 # ------------------------------------------------------------------ #
-# Lifespan                                                            #
+# Startup / shutdown helpers                                          #
 # ------------------------------------------------------------------ #
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    """Manage application lifespan events (startup and shutdown)."""
-    filtered_paths = ["/health", "/v1/jobs"]
-    configure_uvicorn_logging(settings.common.app.log_level, filtered_paths)
-    logger.info("Application starting up...")
-
-    # Language detector for document processing.
+def _init_language_detector():
+    """Initialize the language detector used for document processing."""
     try:
         setup_language_detector(
             [Language.ENGLISH, Language.GERMAN, Language.ITALIAN, Language.FRENCH]
@@ -62,7 +56,13 @@ async def lifespan(app: FastAPI):
     except Exception as exc:
         logger.error(f"Error initializing language detector: {exc}", exc_info=True)
 
-    # Database connection — required for all operations.
+
+def _init_database():
+    """Verify the database connection and initialize the schema.
+
+    Raises RuntimeError if the database is unavailable or schema init fails,
+    since the service requires a database to operate.
+    """
     try:
         if check_db_connection():
             logger.info("✅ Database connection established")
@@ -98,7 +98,9 @@ async def lifespan(app: FastAPI):
         logger.error(f"❌ Database check failed: {exc}", exc_info=True)
         raise RuntimeError(f"Database connection required but failed: {exc}")
 
-    # Orphan / zombie job recovery on startup.
+
+def _recover_zombie_jobs():
+    """Recover orphan / zombie jobs left over from a previous app server run."""
     try:
         zombie_count = recover_zombie_jobs()
         if zombie_count > 0:
@@ -108,9 +110,30 @@ async def lifespan(app: FastAPI):
     except Exception as exc:
         logger.error(f"Error during zombie job recovery: {exc}", exc_info=True)
 
-    # ------------------------------------------------------------------ #
-    # Connector scheduler                                                  #
-    # ------------------------------------------------------------------ #
+
+def _shutdown():
+    """Release resources on application shutdown."""
+    logger.info("Application shutting down...")
+    try:
+        close_db_connections()
+        logger.info("Database connections closed")
+    except Exception as exc:
+        logger.error(f"Error closing database connections: {exc}", exc_info=True)
+
+    stderr_monitor.stop()
+
+
+# ------------------------------------------------------------------ #
+# Connector scheduler                                                 #
+# ------------------------------------------------------------------ #
+
+@asynccontextmanager
+async def _connector_scheduler_lifespan():
+    """Start the connector scheduler and keep it running for the app's lifetime.
+
+    Wraps `yield` in an `async with AsyncScheduler(...)` block so the scheduler
+    stays open until the application shuts down.
+    """
     import digitize.connectors.scheduler as scheduler_module
     from digitize.utils.db import list_connectors
     from apscheduler import AsyncScheduler
@@ -166,15 +189,33 @@ async def lifespan(app: FastAPI):
         # Yield anyway so the service stays up even if the scheduler fails.
         yield
 
-    # Shutdown.
-    logger.info("Application shutting down...")
-    try:
-        close_db_connections()
-        logger.info("Database connections closed")
-    except Exception as exc:
-        logger.error(f"Error closing database connections: {exc}", exc_info=True)
 
-    stderr_monitor.stop()
+# ------------------------------------------------------------------ #
+# Lifespan                                                            #
+# ------------------------------------------------------------------ #
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Manage application lifespan events (startup and shutdown)."""
+    filtered_paths = ["/health", "/v1/jobs"]
+    configure_uvicorn_logging(settings.common.app.log_level, filtered_paths)
+    logger.info("Application starting up...")
+
+    # Language detector for document processing.
+    _init_language_detector()
+
+    # Database connection.
+    _init_database()
+
+    # Orphan / zombie job recovery on startup.
+    _recover_zombie_jobs()
+
+    # Connector scheduler.
+    async with _connector_scheduler_lifespan():
+        yield
+
+    # Shutdown.
+    _shutdown()
 
 
 

--- a/services/digitize/app.py
+++ b/services/digitize/app.py
@@ -33,7 +33,7 @@ set_log_level(settings.common.app.log_level)
 
 from digitize.db.connection import check_db_connection, close_db_connections
 import digitize.utils.jobs as dg_util
-from digitize.utils.recovery import recover_zombie_jobs
+from digitize.utils.recovery import recover_zombie_jobs, recover_connector_sync_state
 
 logger = get_logger("digitize_server")
 diagnostic_logger, stderr_monitor, signal_handler = setup_comprehensive_crash_handler(logger)
@@ -105,7 +105,60 @@ async def lifespan(app: FastAPI):
     except Exception as exc:
         logger.error(f"Error during zombie job recovery: {exc}", exc_info=True)
 
-    yield
+    # ------------------------------------------------------------------ #
+    # Connector scheduler                                                  #
+    # ------------------------------------------------------------------ #
+    import digitize.connectors.scheduler as scheduler_module
+    from digitize.utils.db import list_connectors
+    from apscheduler import AsyncScheduler
+    from apscheduler.datastores.sqlalchemy import SQLAlchemyDataStore
+    from digitize.db.connection import engine as db_engine
+
+    try:
+        data_store = SQLAlchemyDataStore(db_engine)
+        async with AsyncScheduler(data_store=data_store) as sched:
+            scheduler_module._scheduler = sched
+
+            # Connector crash recovery — unlock connectors stuck in 'syncing'.
+            try:
+                recovered = recover_connector_sync_state()
+                if recovered:
+                    logger.info(
+                        f"Connector crash recovery: reset {recovered} stuck connector(s)"
+                    )
+            except Exception as exc:
+                logger.error(
+                    f"Error during connector sync state recovery: {exc}", exc_info=True
+                )
+
+            # Re-register all existing connectors (fire_immediately=False so we
+            # don't trigger a duplicate tick for connectors that are already
+            # up-to-date after crash recovery).
+            try:
+                connectors = list_connectors()
+                for connector in connectors:
+                    await scheduler_module.register_connector_job(
+                        connector.id,
+                        connector.sync_interval_seconds,
+                        fire_immediately=False,
+                    )
+                if connectors:
+                    logger.info(
+                        f"Re-registered {len(connectors)} connector job(s) with scheduler"
+                    )
+            except Exception as exc:
+                logger.error(
+                    f"Error re-registering connector jobs: {exc}", exc_info=True
+                )
+
+            yield
+
+    except Exception as exc:
+        logger.error(
+            f"❌ Failed to start connector scheduler: {exc}", exc_info=True
+        )
+        # Yield anyway so the service stays up even if the scheduler fails.
+        yield
 
     # Shutdown.
     logger.info("Application shutting down...")
@@ -116,6 +169,7 @@ async def lifespan(app: FastAPI):
         logger.error(f"Error closing database connections: {exc}", exc_info=True)
 
     stderr_monitor.stop()
+
 
 
 # ------------------------------------------------------------------ #

--- a/services/digitize/app.py
+++ b/services/digitize/app.py
@@ -118,7 +118,7 @@ async def lifespan(app: FastAPI):
     from digitize.db.connection import engine as db_engine
 
     try:
-        data_store = SQLAlchemyDataStore(db_engine)
+        data_store = SQLAlchemyDataStore(db_engine, schema="scheduler")
         async with AsyncScheduler(data_store=data_store) as sched:
             scheduler_module._scheduler = sched
 

--- a/services/digitize/app.py
+++ b/services/digitize/app.py
@@ -154,6 +154,9 @@ async def lifespan(app: FastAPI):
                     f"Error re-registering connector jobs: {exc}", exc_info=True
                 )
 
+            await sched.start_in_background()
+            logger.info("✅ Connector scheduler started")
+
             yield
 
     except Exception as exc:

--- a/services/digitize/app.py
+++ b/services/digitize/app.py
@@ -14,8 +14,11 @@ This file is responsible only for:
   - Router registration
 """
 
+import os
 import uuid
 from contextlib import asynccontextmanager
+
+os.environ.setdefault("TZ", "UTC")
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request, status

--- a/services/digitize/connectors/scheduler.py
+++ b/services/digitize/connectors/scheduler.py
@@ -1,0 +1,113 @@
+"""
+connectors/scheduler.py — APScheduler-backed connector sync scheduler.
+
+Manages one recurring IntervalTrigger job per connector.  Each job calls
+dispatch_sync() directly — the shared callable used by both the HTTP handler
+and the scheduler.
+
+Module-level state
+------------------
+_scheduler : AsyncScheduler | None
+    Assigned by app.py lifespan before any connector endpoint is called.
+    Must not be referenced at import time.
+
+Usage
+-----
+    # Inside lifespan (app.py):
+    async with AsyncScheduler(data_store=data_store) as sched:
+        import digitize.connectors.scheduler as scheduler_module
+        scheduler_module._scheduler = sched
+        await scheduler_module.register_connector_job(
+            connector_id, interval_seconds, fire_immediately=True
+        )
+        yield
+
+    # After lifespan exit:
+    #   The ``async with`` block runs __aexit__, which stops the scheduler.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from apscheduler import AsyncScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+from common.misc_utils import get_logger
+
+logger = get_logger("connector_scheduler")
+
+# ---------------------------------------------------------------------------
+# Module-level scheduler singleton — set by lifespan in app.py
+# ---------------------------------------------------------------------------
+
+_scheduler: AsyncScheduler | None = None
+
+
+def _get_scheduler() -> AsyncScheduler:
+    if _scheduler is None:
+        raise RuntimeError(
+            "ConnectorScheduler not initialised — "
+            "_scheduler must be set during application lifespan startup"
+        )
+    return _scheduler
+
+
+# ---------------------------------------------------------------------------
+# Public registration / removal helpers
+# ---------------------------------------------------------------------------
+
+async def register_connector_job(
+    connector_id: str,
+    interval_seconds: int,
+    fire_immediately: bool = False,
+) -> None:
+    """Schedule (or reschedule) a recurring sync job for *connector_id*.
+
+    Parameters
+    ----------
+    connector_id:
+        UUID of the connector to schedule.
+    interval_seconds:
+        How often the tick should fire.
+    fire_immediately:
+        When True the first tick fires at ``now()`` instead of waiting
+        one full interval.  Use this when attaching a new connector so
+        the initial scan starts right away.
+    """
+    from digitize.api.v1.connectors import dispatch_sync
+
+    sched = _get_scheduler()
+    kwargs: dict = dict(
+        func_or_task_id=dispatch_sync,
+        trigger=IntervalTrigger(seconds=interval_seconds),
+        args=[connector_id],
+        id=connector_id,
+        max_running_jobs=1,
+    )
+    if fire_immediately:
+        kwargs["next_fire_time"] = datetime.now(timezone.utc)
+
+    await sched.add_schedule(**kwargs)
+    logger.info(
+        f"Registered scheduler job for connector {connector_id!r} "
+        f"(interval={interval_seconds}s, fire_immediately={fire_immediately})"
+    )
+
+
+async def remove_connector_job(connector_id: str) -> None:
+    """Remove the scheduled job for *connector_id*, if it exists.
+
+    Silently ignores the case where no job is registered (e.g., the scheduler
+    was restarted and the job was not re-registered before deletion).
+    """
+    sched = _get_scheduler()
+    try:
+        await sched.remove_schedule(connector_id)
+        logger.info(f"Removed scheduler job for connector {connector_id!r}")
+    except Exception as exc:
+        # LookupError or similar if the schedule doesn't exist — safe to ignore.
+        logger.debug(
+            f"Could not remove scheduler job for {connector_id!r} "
+            f"(may not have been registered): {exc}"
+        )

--- a/services/digitize/connectors/scheduler.py
+++ b/services/digitize/connectors/scheduler.py
@@ -28,7 +28,7 @@ Usage
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from apscheduler import AsyncScheduler
 from apscheduler.triggers.interval import IntervalTrigger
@@ -77,18 +77,16 @@ async def register_connector_job(
     """
     from digitize.api.v1.connectors import dispatch_sync
 
+    now = datetime.now(timezone.utc)
+    start_time = now if fire_immediately else now + timedelta(seconds=interval_seconds)
+
     sched = _get_scheduler()
-    kwargs: dict = dict(
+    await sched.add_schedule(
         func_or_task_id=dispatch_sync,
-        trigger=IntervalTrigger(seconds=interval_seconds),
+        trigger=IntervalTrigger(seconds=interval_seconds, start_time=start_time),
         args=[connector_id],
         id=connector_id,
-        max_running_jobs=1,
     )
-    if fire_immediately:
-        kwargs["next_fire_time"] = datetime.now(timezone.utc)
-
-    await sched.add_schedule(**kwargs)
     logger.info(
         f"Registered scheduler job for connector {connector_id!r} "
         f"(interval={interval_seconds}s, fire_immediately={fire_immediately})"

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -16,8 +16,8 @@ Phases
 
 Caller contract
 ---------------
-Any caller — the HTTP handler (POST /v1/connectors/{id}/syncs) or the future
-APScheduler job (_run_tick_wrapped in scheduler.py) — must follow the same
+Any caller — the HTTP handler (POST /v1/connectors/{id}/syncs) or the
+APScheduler (dispatch_sync in connectors.py) — must follow the same
 three-step preamble before calling run_tick():
 
     acquired = db_ops.try_acquire_sync_lock(connector_id)

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1494,6 +1494,68 @@ class DatabaseManager:
             return False
 
 
+    @staticmethod
+    def reset_syncing_connectors() -> List[str]:
+        """
+        Bulk-reset all connectors stuck in ``'syncing'`` to ``'out of sync'``.
+
+        Called on startup to unlock connectors that were mid-tick when the
+        service crashed.  Returns the list of connector IDs that were reset.
+        """
+        try:
+            with get_db_session() as session:
+                result = session.execute(
+                    update(Connector)
+                    .where(Connector.sync_status == ConnectorStatus.SYNCING)
+                    .values(sync_status=ConnectorStatus.OUT_OF_SYNC)
+                    .returning(Connector.id)
+                )
+                affected = [row[0] for row in result.fetchall()]
+                if affected:
+                    logger.info(
+                        f"reset_syncing_connectors: reset {len(affected)} connector(s) "
+                        f"from syncing to out-of-sync: {affected}"
+                    )
+                return affected
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in reset_syncing_connectors: {e}", exc_info=True)
+            return []
+
+    @staticmethod
+    def close_open_sync_log(connector_id: str, error: str) -> bool:
+        """
+        Close the open (status=STARTED or CANCEL_PENDING) sync-log row for
+        *connector_id* by setting its status to FAILED with *error* and
+        stamping ``finished_at = now()``.
+
+        Returns True if a row was updated, False if none was found.
+        """
+        try:
+            with get_db_session() as session:
+                result = session.execute(
+                    update(ConnectorSyncLog)
+                    .where(
+                        ConnectorSyncLog.connector_id == connector_id,
+                        ConnectorSyncLog.status.in_(
+                            [SyncLogStatus.STARTED, SyncLogStatus.CANCEL_PENDING]
+                        ),
+                    )
+                    .values(
+                        status=SyncLogStatus.FAILED,
+                        finished_at=datetime.now(timezone.utc),
+                        error=error,
+                    )
+                    .returning(ConnectorSyncLog.seq)
+                ).one_or_none()
+                return result is not None
+        except SQLAlchemyError as e:
+            logger.error(
+                f"DB error in close_open_sync_log({connector_id!r}): {e}",
+                exc_info=True,
+            )
+            return False
+
+
 # Singleton instance for easy access
 db_manager = DatabaseManager()
 

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1495,19 +1495,28 @@ class DatabaseManager:
 
 
     @staticmethod
-    def reset_syncing_connectors() -> List[str]:
+    def reset_syncing_connectors(
+        error: str = "Service restarted during sync tick",
+    ) -> List[str]:
         """
         Bulk-reset all connectors stuck in ``'syncing'`` to ``'out of sync'``.
 
         Called on startup to unlock connectors that were mid-tick when the
         service crashed.  Returns the list of connector IDs that were reset.
+
+        Also stamps ``last_sync_error`` and ``error`` on every affected row so
+        that callers can see the crash reason without joining to sync-log rows.
         """
         try:
             with get_db_session() as session:
                 result = session.execute(
                     update(Connector)
                     .where(Connector.sync_status == ConnectorStatus.SYNCING)
-                    .values(sync_status=ConnectorStatus.OUT_OF_SYNC)
+                    .values(
+                        sync_status=ConnectorStatus.OUT_OF_SYNC,
+                        last_sync_error=error,
+                        error=error,
+                    )
                     .returning(Connector.id)
                 )
                 affected = [row[0] for row in result.fetchall()]

--- a/services/digitize/requirements.txt
+++ b/services/digitize/requirements.txt
@@ -8,3 +8,6 @@ boto3==1.38.0
 botocore==1.38.0
 s3transfer==0.12.0
 paramiko==5.0.0
+## APScheduler v4 — AsyncScheduler + AsyncSQLAlchemyDataStore for connector scheduling.
+## sqlalchemy extra pulls in the async store support.
+apscheduler[sqlalchemy]==4.0.0a6

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -185,6 +185,11 @@ def connector_test_client(monkeypatch, tmp_path, mock_db_operations):
     mock_hash_db_manager.find_completed_document_by_hash = Mock(return_value=None)
     monkeypatch.setattr(jobs_router_module, "db_manager", mock_hash_db_manager)
 
+    # Scheduler stubs — prevent RuntimeError from uninitialised _scheduler
+    import digitize.connectors.scheduler as scheduler_module
+    monkeypatch.setattr(scheduler_module, "register_connector_job", AsyncMock())
+    monkeypatch.setattr(scheduler_module, "remove_connector_job", AsyncMock())
+
     return TestClient(digitize_app.app)
 
 

--- a/services/digitize/tests/test_connector_scheduler.py
+++ b/services/digitize/tests/test_connector_scheduler.py
@@ -6,8 +6,8 @@ Coverage
 --------
 scheduler.register_connector_job
   - calls sched.add_schedule with correct kwargs
-  - passes next_fire_time when fire_immediately=True
-  - omits next_fire_time when fire_immediately=False
+  - fire_immediately=True  → trigger.start_time is ~now (fires on first tick)
+  - fire_immediately=False → trigger.start_time is ~now+interval (deferred)
   - raises RuntimeError when _scheduler is None
 
 scheduler.remove_connector_job
@@ -24,6 +24,7 @@ recover_connector_sync_state
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -55,35 +56,46 @@ class TestRegisterConnectorJob:
             sched_mod._scheduler = original
 
     @pytest.mark.asyncio
-    async def test_add_schedule_called_without_fire_immediately(self):
-        """register_connector_job should call add_schedule without next_fire_time."""
+    async def test_add_schedule_deferred_when_not_fire_immediately(self):
+        """fire_immediately=False → trigger.start_time is ~now + interval_seconds."""
         mock_sched = AsyncMock()
         import digitize.connectors.scheduler as sched_mod
         original = sched_mod._scheduler
         sched_mod._scheduler = mock_sched
         try:
+            before = datetime.now(timezone.utc)
             from digitize.connectors.scheduler import register_connector_job
             await register_connector_job("conn-A", 600, fire_immediately=False)
+            after = datetime.now(timezone.utc)
+
             mock_sched.add_schedule.assert_awaited_once()
             _, kwargs = mock_sched.add_schedule.await_args
             assert kwargs["id"] == "conn-A"
-            assert kwargs["max_running_jobs"] == 1
-            assert "next_fire_time" not in kwargs
+            trigger = kwargs["trigger"]
+            # start_time should be ~now + 600s (deferred by one full interval)
+            expected_lo = before + timedelta(seconds=600)
+            expected_hi = after + timedelta(seconds=600)
+            assert expected_lo <= trigger.start_time <= expected_hi
         finally:
             sched_mod._scheduler = original
 
     @pytest.mark.asyncio
-    async def test_add_schedule_called_with_fire_immediately(self):
-        """register_connector_job should include next_fire_time when fire_immediately=True."""
+    async def test_add_schedule_fires_immediately_when_requested(self):
+        """fire_immediately=True → trigger.start_time is ~now (fires on first tick)."""
         mock_sched = AsyncMock()
         import digitize.connectors.scheduler as sched_mod
         original = sched_mod._scheduler
         sched_mod._scheduler = mock_sched
         try:
+            before = datetime.now(timezone.utc)
             from digitize.connectors.scheduler import register_connector_job
             await register_connector_job("conn-B", 300, fire_immediately=True)
+            after = datetime.now(timezone.utc)
+
             _, kwargs = mock_sched.add_schedule.await_args
-            assert "next_fire_time" in kwargs
+            trigger = kwargs["trigger"]
+            # start_time should be ~now (within the call window)
+            assert before <= trigger.start_time <= after
         finally:
             sched_mod._scheduler = original
 

--- a/services/digitize/tests/test_connector_scheduler.py
+++ b/services/digitize/tests/test_connector_scheduler.py
@@ -1,0 +1,190 @@
+"""
+Unit tests for services/digitize/connectors/scheduler.py
+and the connector portion of services/digitize/utils/recovery.py.
+
+Coverage
+--------
+scheduler.register_connector_job
+  - calls sched.add_schedule with correct kwargs
+  - passes next_fire_time when fire_immediately=True
+  - omits next_fire_time when fire_immediately=False
+  - raises RuntimeError when _scheduler is None
+
+scheduler.remove_connector_job
+  - calls sched.remove_schedule with the connector_id
+  - silently handles LookupError (schedule not registered)
+  - raises RuntimeError when _scheduler is None
+
+recover_connector_sync_state
+  - returns 0 and skips close when no syncing connectors
+  - calls close_open_sync_log for each affected connector
+  - logs warning when no open sync log row found
+  - continues past per-connector errors and returns correct count
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Scheduler module path shortcuts
+# ---------------------------------------------------------------------------
+SCHED_MODULE = "digitize.connectors.scheduler"
+RECOVERY_MODULE = "digitize.utils.recovery"
+
+
+# ===========================================================================
+# scheduler.register_connector_job
+# ===========================================================================
+
+class TestRegisterConnectorJob:
+    """Tests for register_connector_job."""
+
+    @pytest.mark.asyncio
+    async def test_raises_when_scheduler_none(self):
+        import digitize.connectors.scheduler as sched_mod
+        original = sched_mod._scheduler
+        sched_mod._scheduler = None
+        try:
+            with pytest.raises(RuntimeError, match="not initialised"):
+                from digitize.connectors.scheduler import register_connector_job
+                await register_connector_job("c1", 300)
+        finally:
+            sched_mod._scheduler = original
+
+    @pytest.mark.asyncio
+    async def test_add_schedule_called_without_fire_immediately(self):
+        """register_connector_job should call add_schedule without next_fire_time."""
+        mock_sched = AsyncMock()
+        import digitize.connectors.scheduler as sched_mod
+        original = sched_mod._scheduler
+        sched_mod._scheduler = mock_sched
+        try:
+            from digitize.connectors.scheduler import register_connector_job
+            await register_connector_job("conn-A", 600, fire_immediately=False)
+            mock_sched.add_schedule.assert_awaited_once()
+            _, kwargs = mock_sched.add_schedule.await_args
+            assert kwargs["id"] == "conn-A"
+            assert kwargs["max_running_jobs"] == 1
+            assert "next_fire_time" not in kwargs
+        finally:
+            sched_mod._scheduler = original
+
+    @pytest.mark.asyncio
+    async def test_add_schedule_called_with_fire_immediately(self):
+        """register_connector_job should include next_fire_time when fire_immediately=True."""
+        mock_sched = AsyncMock()
+        import digitize.connectors.scheduler as sched_mod
+        original = sched_mod._scheduler
+        sched_mod._scheduler = mock_sched
+        try:
+            from digitize.connectors.scheduler import register_connector_job
+            await register_connector_job("conn-B", 300, fire_immediately=True)
+            _, kwargs = mock_sched.add_schedule.await_args
+            assert "next_fire_time" in kwargs
+        finally:
+            sched_mod._scheduler = original
+
+
+# ===========================================================================
+# scheduler.remove_connector_job
+# ===========================================================================
+
+class TestRemoveConnectorJob:
+    """Tests for remove_connector_job."""
+
+    @pytest.mark.asyncio
+    async def test_raises_when_scheduler_none(self):
+        import digitize.connectors.scheduler as sched_mod
+        original = sched_mod._scheduler
+        sched_mod._scheduler = None
+        try:
+            with pytest.raises(RuntimeError, match="not initialised"):
+                from digitize.connectors.scheduler import remove_connector_job
+                await remove_connector_job("c1")
+        finally:
+            sched_mod._scheduler = original
+
+    @pytest.mark.asyncio
+    async def test_calls_remove_schedule(self):
+        mock_sched = AsyncMock()
+        import digitize.connectors.scheduler as sched_mod
+        original = sched_mod._scheduler
+        sched_mod._scheduler = mock_sched
+        try:
+            from digitize.connectors.scheduler import remove_connector_job
+            await remove_connector_job("conn-X")
+            mock_sched.remove_schedule.assert_awaited_once_with("conn-X")
+        finally:
+            sched_mod._scheduler = original
+
+    @pytest.mark.asyncio
+    async def test_silently_handles_lookup_error(self):
+        """remove_connector_job must not raise if the schedule was never registered."""
+        mock_sched = AsyncMock()
+        mock_sched.remove_schedule.side_effect = LookupError("not found")
+        import digitize.connectors.scheduler as sched_mod
+        original = sched_mod._scheduler
+        sched_mod._scheduler = mock_sched
+        try:
+            from digitize.connectors.scheduler import remove_connector_job
+            # Must not raise
+            await remove_connector_job("conn-missing")
+        finally:
+            sched_mod._scheduler = original
+
+
+# ===========================================================================
+# recover_connector_sync_state
+# ===========================================================================
+
+class TestRecoverConnectorSyncState:
+    """Tests for utils/recovery.recover_connector_sync_state."""
+
+    def test_returns_zero_when_no_stuck_connectors(self):
+        with patch(f"{RECOVERY_MODULE}.reset_syncing_connectors", return_value=[]) as mock_reset, \
+             patch(f"{RECOVERY_MODULE}.close_open_sync_log") as mock_close:
+            from digitize.utils.recovery import recover_connector_sync_state
+            result = recover_connector_sync_state()
+            assert result == 0
+            mock_reset.assert_called_once()
+            mock_close.assert_not_called()
+
+    def test_closes_sync_log_for_each_affected_connector(self):
+        affected = ["conn-1", "conn-2"]
+        with patch(f"{RECOVERY_MODULE}.reset_syncing_connectors", return_value=affected), \
+             patch(f"{RECOVERY_MODULE}.close_open_sync_log", return_value=True) as mock_close:
+            from digitize.utils.recovery import recover_connector_sync_state
+            result = recover_connector_sync_state()
+            assert result == 2
+            assert mock_close.call_count == 2
+            mock_close.assert_any_call("conn-1", "Service restarted during sync tick")
+            mock_close.assert_any_call("conn-2", "Service restarted during sync tick")
+
+    def test_logs_warning_when_no_sync_log_found(self):
+        """close_open_sync_log returning False triggers a warning (no exception)."""
+        with patch(f"{RECOVERY_MODULE}.reset_syncing_connectors", return_value=["conn-3"]), \
+             patch(f"{RECOVERY_MODULE}.close_open_sync_log", return_value=False):
+            from digitize.utils.recovery import recover_connector_sync_state
+            # Must not raise even when no open log row exists
+            result = recover_connector_sync_state()
+            assert result == 1
+
+    def test_continues_past_per_connector_error(self):
+        """Errors for individual connectors must be caught; all connectors are attempted."""
+        affected = ["conn-ok", "conn-err"]
+
+        def _close_side_effect(connector_id, error):
+            if connector_id == "conn-err":
+                raise RuntimeError("DB exploded")
+            return True
+
+        with patch(f"{RECOVERY_MODULE}.reset_syncing_connectors", return_value=affected), \
+             patch(f"{RECOVERY_MODULE}.close_open_sync_log",
+                   side_effect=_close_side_effect):
+            from digitize.utils.recovery import recover_connector_sync_state
+            result = recover_connector_sync_state()
+            # Both connectors were in the affected list; count reflects that
+            assert result == 2

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1488,6 +1488,26 @@ def get_sync_log_status(connector_id: str, seq: int) -> Optional[str]:
 
 
 # ----------------------------------------------------------------------------
+# Connector sync-state recovery helpers
+# ----------------------------------------------------------------------------
+
+def reset_syncing_connectors() -> List[str]:
+    """
+    Bulk-set sync_status='out of sync' for every connector currently stuck in
+    'syncing'.  Returns the list of affected connector IDs.
+    """
+    return db_manager.reset_syncing_connectors()
+
+
+def close_open_sync_log(connector_id: str, error: str) -> bool:
+    """
+    Close the open sync-log row for *connector_id* with status=FAILED and
+    the provided *error* string.  Returns True if a row was updated.
+    """
+    return db_manager.close_open_sync_log(connector_id, error)
+
+
+# ----------------------------------------------------------------------------
 # Document metadata helper
 # ----------------------------------------------------------------------------
 

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1491,12 +1491,13 @@ def get_sync_log_status(connector_id: str, seq: int) -> Optional[str]:
 # Connector sync-state recovery helpers
 # ----------------------------------------------------------------------------
 
-def reset_syncing_connectors() -> List[str]:
+def reset_syncing_connectors(error: str = "Service restarted during sync tick") -> List[str]:
     """
     Bulk-set sync_status='out of sync' for every connector currently stuck in
-    'syncing'.  Returns the list of affected connector IDs.
+    'syncing', and stamp ``last_sync_error`` / ``error`` with *error*.
+    Returns the list of affected connector IDs.
     """
-    return db_manager.reset_syncing_connectors()
+    return db_manager.reset_syncing_connectors(error=error)
 
 
 def close_open_sync_log(connector_id: str, error: str) -> bool:

--- a/services/digitize/utils/recovery.py
+++ b/services/digitize/utils/recovery.py
@@ -11,7 +11,12 @@ recovery logic is isolated from the general utility bag.
 
 from common.misc_utils import get_logger, cleanup_staging_directory
 from digitize.models import JobStatus, DocStatus
-from digitize.utils.db import get_all_jobs, get_status_manager
+from digitize.utils.db import (
+    close_open_sync_log,
+    get_all_jobs,
+    get_status_manager,
+    reset_syncing_connectors,
+)
 
 logger = get_logger("recovery")
 
@@ -144,3 +149,48 @@ def recover_zombie_jobs() -> int:
         logger.debug("✅ No zombie jobs found on startup")
 
     return orphan_count
+
+
+def recover_connector_sync_state() -> int:
+    """
+    Recover connectors that were mid-tick when the service crashed.
+
+    On startup this function:
+    1. Bulk-updates every connector whose ``sync_status = 'syncing'`` to
+       ``'out of sync'`` — releasing the sync lock so future ticks can run.
+    2. For each affected connector, closes the still-open ``connector_sync_logs``
+       row (status = 'started' or 'cancel pending') by setting it to
+       ``'failed'`` with an explanatory error message.
+
+    Returns:
+        Number of connectors that were recovered.
+    """
+    _CRASH_ERROR = "Service restarted during sync tick"
+
+    affected_ids = reset_syncing_connectors()
+
+    for connector_id in affected_ids:
+        try:
+            closed = close_open_sync_log(connector_id, _CRASH_ERROR)
+            if closed:
+                logger.info(
+                    f"Closed stale sync log for connector {connector_id!r} after crash recovery"
+                )
+            else:
+                logger.warning(
+                    f"No open sync-log row found for connector {connector_id!r} during crash recovery"
+                )
+        except Exception as exc:
+            logger.error(
+                f"Error closing sync log for connector {connector_id!r}: {exc}",
+                exc_info=True,
+            )
+
+    if affected_ids:
+        logger.info(
+            f"Connector crash recovery: reset {len(affected_ids)} connector(s): {affected_ids}"
+        )
+    else:
+        logger.debug("No stuck connector syncs found on startup")
+
+    return len(affected_ids)

--- a/services/digitize/utils/recovery.py
+++ b/services/digitize/utils/recovery.py
@@ -167,7 +167,7 @@ def recover_connector_sync_state() -> int:
     """
     _CRASH_ERROR = "Service restarted during sync tick"
 
-    affected_ids = reset_syncing_connectors()
+    affected_ids = reset_syncing_connectors(error=_CRASH_ERROR)
 
     for connector_id in affected_ids:
         try:

--- a/services/requirements-test.txt
+++ b/services/requirements-test.txt
@@ -49,3 +49,5 @@ pdfplumber==0.11.9
 RapidFuzz==3.14.5
 docling==2.95.0
 sentence-splitter==1.4
+
+apscheduler[sqlalchemy]==4.0.0a6


### PR DESCRIPTION
-APScheduler logic 
--Schedules and fires a job immediately when a connector is added
--Same job is removed during connector tear down 
--Same job is recovered on restart (without live trigger)

-Startup Recovery 
--When digitize service crashes and comes back up, handles 
1. Marking status of Connectors as OUT OF SYNC 
2. Marking status of ConnectorSyncLog as FAILED
3. Add all jobs back to APScheduler