### PR TITLE
Fix extract & translate image builds

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.247
+TAG?=v0.0.248
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -92,7 +92,7 @@ translate:
   # @description Host port for the Translate API. If unspecified, a random port is assigned.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/translate-service:v0.0.1
+  image: icr.io/ai-services-cicd/translate-service:v0.0.2
   # @hidden
   log_level: "INFO"
   # @description Database name for the TRANSLATE service.
@@ -118,7 +118,7 @@ extract:
   # @description Host port for the Extract API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/extract-service:v0.0.4
+  image: icr.io/ai-services-cicd/extract-service:v0.0.5
   # @hidden
   log_level: "INFO"
   database: "extract_metadata"

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.247
+  image: icr.io/ai-services-cicd/ai-services:v0.0.248
   runtime: "openshift"
   adminPasswordHash: ""
   resources:

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.247
+  image: icr.io/ai-services-cicd/ai-services:v0.0.248
   runtime: ""
   adminPasswordHash: ""
   # workerGatewayPort: port for the gRPC worker gateway. Always active; default is 9090.

--- a/ai-services/assets/services/extract/podman/values.yaml
+++ b/ai-services/assets/services/extract/podman/values.yaml
@@ -1,6 +1,6 @@
 extract:
   port: ""
-  image: icr.io/ai-services-cicd/extract-service:v0.0.4
+  image: icr.io/ai-services-cicd/extract-service:v0.0.5
   log_level: "INFO"
   database: "extract_metadata"
 

--- a/ai-services/assets/services/translate/podman/values.yaml
+++ b/ai-services/assets/services/translate/podman/values.yaml
@@ -1,6 +1,6 @@
 translate:
   port: ""
-  image: icr.io/ai-services-cicd/translate-service:v0.0.1
+  image: icr.io/ai-services-cicd/translate-service:v0.0.2
   log_level: "INFO"
   database: "translate_metadata"
 

--- a/services/extract/Makefile
+++ b/services/extract/Makefile
@@ -1,5 +1,5 @@
 IMAGE=extract-service
-TAG?=v0.0.4
+TAG?=v0.0.5
 
 run:
 	PORT=$${PORT:-6000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/translate/Makefile
+++ b/services/translate/Makefile
@@ -1,5 +1,5 @@
 IMAGE=translate-service
-TAG?=v0.0.1
+TAG?=v0.0.2
 
 run:
 	PORT=$${PORT:-9000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT


### PR DESCRIPTION
Earlier PRs(https://github.com/IBM/project-ai-services/pull/1273 & https://github.com/IBM/project-ai-services/pull/1274) added the image building workflow for extract & translate services.
Raising this PR to actually trigger the build by bumping respective service's versions.