### PR TITLE
Data Source Connectors: Propagate error and misc

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.268
+TAG?=v0.0.269
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/applications/rag-cpu/podman/templates/digitize.yaml.tmpl
@@ -125,6 +125,8 @@ spec:
           value: "1"
         - name: LOG_LEVEL
           value: "{{ .Values.digitize.log_level }}"
+        - name: DB_ENCRYPTION_KEY
+          value: "{{ .Values.digitize.dbEncryptionKey }}"
         {{- if .Values.instruct.apiKey }}
         - name: LLM_API_KEY
           value: "{{ .Values.instruct.apiKey }}"

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -23,6 +23,8 @@ digitize:
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
   database: "digitize_metadata"
+  # @description AES-256 encryption key for the DIGITIZE database (32 raw bytes, base64-encoded).
+  dbEncryptionKey: "B374A26A71490437AA024E4FADD5B497FDFF1A8EA6FF12F6FB65AF2720B59CCF"
 
 digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.47
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.48
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.47
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.48
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/templates/digitize.yaml.tmpl
+++ b/ai-services/assets/applications/rag-dev/podman/templates/digitize.yaml.tmpl
@@ -125,6 +125,8 @@ spec:
           value: "1"
         - name: LOG_LEVEL
           value: "{{ .Values.digitize.log_level }}"
+        - name: DB_ENCRYPTION_KEY
+          value: "{{ .Values.digitize.dbEncryptionKey }}"
         {{- if .Values.instruct.apiKey }}
         - name: LLM_API_KEY
           value: "{{ .Values.instruct.apiKey }}"

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -23,6 +23,8 @@ digitize:
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".
   database: "digitize_metadata"
+  # @description AES-256 encryption key for the DIGITIZE database (32 raw bytes, base64-encoded).
+  dbEncryptionKey: "B374A26A71490437AA024E4FADD5B497FDFF1A8EA6FF12F6FB65AF2720B59CCF"
 
 digitizeUi:
   # @description Host port for the DIGITIZE UI. If unspecified, a random available port is assigned. Specify a port number to use a custom value.

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.47
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.48
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.47
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.48
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.47
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.48
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.268
+  image: icr.io/ai-services-cicd/ai-services:v0.0.269
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.268
+  image: icr.io/ai-services-cicd/ai-services:v0.0.269
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/services/digitize/openshift/values.yaml
+++ b/ai-services/assets/services/digitize/openshift/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.47
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.48
   log_level: "INFO"
   database: "digitize_metadata"
   numShards: 1

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.47
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.48
   log_level: "INFO"
   database: "digitize_metadata"
   # @generate:password length=32, special=false

--- a/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
+++ b/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
@@ -164,7 +164,7 @@ class ConnectorSyncLog(Base):
 
 ### 3.1 `POST /v1/connectors`
 
-Creates a connector, encrypts secrets at rest, persists configuration. Returns `201 Created` immediately. The first scheduled tick fires when the scheduler is registered (PR7).
+Creates a connector, encrypts secrets at rest, persists configuration. Returns `201 Created` immediately. The scheduler job is registered (with `fire_immediately=True`) before the DB insert so that a scheduler failure aborts the creation cleanly. A `_probe_connector_credentials` background task is also dispatched to test the supplied credentials — on failure the connector row's `error` field is set to the auth-failure sentinel.
 
 #### Request Parameters
 - Common: `connector_id` (UUID, optional — auto-generated if omitted), `connector_name` (string, unique), `type` (`"ssh"` | `"s3"`), `allowed_extensions` (`array[string]`), `connection_details` (object).
@@ -206,7 +206,7 @@ Creates a connector, encrypts secrets at rest, persists configuration. Returns `
 ```
 
 #### Responses
-- `201 Created`: Connector created. Scheduler registration happens in `lifespan()` (PR7 — not yet implemented).
+- `201 Created`: Connector created and scheduler job registered immediately (`fire_immediately=True`). Credential probe dispatched as a background task.
 - `409 Conflict`: `connector_id` or `connector_name` already exists.
 
 ---
@@ -215,9 +215,11 @@ Creates a connector, encrypts secrets at rest, persists configuration. Returns `
 
 Updates connector configuration in place.
 - Secrets are re-encrypted if provided.
-- `connection_details` is merged key-by-key using the PostgreSQL `||` JSONB operator (omitted fields remain unchanged).
+- `connection_details` is merged key-by-key (untouched encrypted keys are preserved via `merge_and_encrypt_partial`).
 - `type` and `sync_interval_seconds` cannot be modified.
 - Does not restart the scheduler — the next scheduled tick reads updated config directly from DB.
+- If `connection_details` is supplied, a `_probe_connector_credentials` background task is dispatched against the merged credentials. On success, any previous auth-failure error is cleared; on failure, the `error` field is set to the credential-error sentinel.
+- Returns `409 Conflict` if the connector is `DELETE_PENDING`.
 
 #### Responses
 - `200 OK`: Updated successfully.
@@ -285,20 +287,22 @@ Returns paginated execution history from `connector_sync_logs` (`limit` default 
 Returns a single sync log entry identified by its sequence number. Returns `404` if the connector or the specific `sync_seq` does not exist.
 
 #### `POST /v1/connectors/{connector_id}/syncs`
-Triggers an immediate manual sync tick.
-- Safe & idempotent: acquires DB lock via atomic `UPDATE connectors SET sync_status='syncing' WHERE id=:id AND sync_status!='syncing' RETURNING id`.
-- If lock acquired: dispatches `asyncio.create_task(run_tick(connector_id))`; polls `get_active_sync_seq()` via `_wait_for_sync_seq()` (10 attempts × 100ms) until the log row appears, then returns `202 Accepted` with `{"sync_seq": <n>}`.
-- If lock unavailable (already syncing): fetches current active `sync_seq` via `get_active_sync_seq()` and returns `202 Accepted` with it (no duplicate tick started).
+Triggers an immediate manual sync tick. Implemented via the shared `dispatch_sync(connector_id)` helper (also used by the scheduler).
+- Guards: returns `404` if connector not found; raises `SyncLocked` (→ `409`) if connector is `DELETE_PENDING` or if the active sync is already `CANCEL_PENDING`.
+- If lock acquired via `try_acquire_sync_lock`: calls `init_sync_log_and_update_connector` **synchronously in the caller** (no polling), dispatches `asyncio.create_task(run_tick(connector_id, sync_seq))`, and returns `202 Accepted` with `{"sync_seq": <n>}` immediately.
+- If lock unavailable (already syncing): reads `get_active_sync_seq()` and returns `202 Accepted` with the existing seq (idempotent — no duplicate tick started).
 
 ```text
-POST /v1/connectors/{connector_id}/syncs
+POST /v1/connectors/{connector_id}/syncs  →  dispatch_sync(connector_id)
   │
-  ├─ 1. Check existence → 404 if not found
-  ├─ 2. try_acquire_sync_lock(connector_id) (atomic UPDATE ... RETURNING)
-  │      ├─ Lock acquired → asyncio.create_task(run_tick(connector_id))
-  │      │    └─ _wait_for_sync_seq() polls until init_sync_log_and_update_connector row appears
-  │      └─ Lock unavailable (already syncing) → get_active_sync_seq()
-  └─ 3. Return 202 Accepted { "sync_seq": <seq> }
+  ├─ 1. get_active_connector() → 404 if not found
+  ├─ 2. connector.sync_status == DELETE_PENDING → SyncLocked (409)
+  ├─ 3. get_active_sync_seq() — if CANCEL_PENDING on active row → SyncLocked (409)
+  ├─ 4. try_acquire_sync_lock(connector_id)
+  │      ├─ Acquired → init_sync_log_and_update_connector() (sync, returns seq immediately)
+  │      │             asyncio.create_task(run_tick(connector_id, sync_seq))
+  │      └─ Not acquired (already syncing) → get_active_sync_seq()
+  └─ 5. Return 202 Accepted { "sync_seq": <seq> }
 ```
 
 #### `POST /v1/connectors/{connector_id}/syncs/{sync_seq}/stop`
@@ -330,7 +334,7 @@ POST /v1/connectors/{connector_id}/syncs/{sync_seq}/stop
 
 #### Document APIs (`/v1/documents`)
 - Connector-sourced documents are **excluded** from `GET /v1/documents`, `GET /v1/documents/{doc_id}`, and `DELETE /v1/documents/{doc_id}` (returns `404`).
-- **Implementation:** `is_connector_sourced_document(doc_id)` checks for presence in `connector_document_checksum`. `get_all_documents_paginated()` accepts `exclude_connector_sourced=True` which filters via `NOT EXISTS (SELECT 1 FROM connector_document_checksum WHERE doc_id = documents.doc_id)`.
+- **Implementation (in place):** `is_connector_sourced_document(doc_id)` checks for presence in `connector_document_checksum`. `get_all_documents_paginated()` accepts `exclude_connector_sourced=True` which filters via `NOT EXISTS (SELECT 1 FROM connector_document_checksum WHERE doc_id = documents.doc_id)`.
 
 #### Job APIs (`/v1/jobs`)
 - All jobs (user-submitted and connector-initiated) are visible in `GET /v1/jobs` and `GET /v1/jobs/{job_id}`.
@@ -583,7 +587,7 @@ def build_scanner(connector_row: Any) -> BaseScanner:
 
 ## 6. Sync Execution Engine
 
-**File:** `services/digitize/connectors/sync_tick.py`
+**File:** `services/digitize/connectors/sync_tick.py` ✅ **Implemented**
 
 ### 6.1 Status Enums
 
@@ -613,8 +617,7 @@ class SyncLogStatus(str, Enum):
 
 ![Sync Tick Flow](sync-worker-tick-flow.svg)
 
-- **Phase 0 (Lock):** Lock acquired externally before `run_tick` is called — either by `_run_tick_wrapped` in `scheduler.py` (PR7) or by `trigger_sync` in `connectors.py`. `run_tick` assumes the lock is already held when it is called.
-- **Phase 1 (Log):** `init_sync_log_and_update_connector(connector_id)` is called **inside** `run_tick`. Two DB calls: insert sync-log row (seq = `COALESCE(MAX(seq),0)+1`) + set connector `sync_status='syncing'`. Returns `sync_seq`.
+- **Phase 0 (Caller — Lock + Log):** `dispatch_sync()` (in `connectors.py`) acquires the lock and opens the sync-log row **before** `run_tick` is called. `init_sync_log_and_update_connector(connector_id)` is called synchronously in the caller; the returned `sync_seq` is passed directly into `run_tick(connector_id, sync_seq)`. This eliminates any need for polling inside the endpoint.
 - **Phase 1b (Interrupt Check):** `_check_interrupt_call(connector_id, sync_seq)` immediately before any remote I/O. If any interrupt detected, raises `asyncio.CancelledError`.
 - **Phase 2 (Scan & State):** Query `known_checksums` and `all_checksums`. Offload blocking calls (`connect`, `scan`) to thread pool via `asyncio.to_thread(...)`.
 - **Phase 3 (Classify):** `_classify()` separates `scanned_files` into `ingest_list` and cross-connector duplicates. Cross-connector duplicates execute `add_connector_checksum_entry` inline.
@@ -652,6 +655,8 @@ class SyncLogStatus(str, Enum):
 
 ### 6.3 Implementation Code
 
+> **Note on caller contract:** The sync lock and log-row creation are handled by `dispatch_sync()` in `connectors.py` **before** `run_tick` is invoked. `run_tick` receives `sync_seq` as a parameter and never calls `init_sync_log_and_update_connector` internally.
+
 ```python
 class InterruptType(str, Enum):
     SYNC_CANCEL = "sync_cancel"           # CANCEL_PENDING on connector_sync_logs row
@@ -669,28 +674,34 @@ def _check_interrupt_call(connector_id: str, sync_seq: int) -> Optional[Interrup
     return None
 
 
-async def run_tick(connector_id: str) -> None:
+async def run_tick(connector_id: str, sync_seq: int) -> None:
     """
-    Execute one full sync tick. Caller must have acquired the sync lock before calling.
+    Execute one full sync tick.
+
+    The caller (dispatch_sync) is responsible for:
+      1. Acquiring the sync lock via try_acquire_sync_lock()
+      2. Creating the sync-log row via init_sync_log_and_update_connector()
+         and passing the returned seq here as sync_seq.
     """
     config = get_active_connector(connector_id)
     if config is None:
         logger.error(f"Connector {connector_id!r} not found; tick aborted")
         return
 
-    sync_seq: int = init_sync_log_and_update_connector(connector_id)
     scanner = build_scanner(config)
 
     try:
         interrupt = _check_interrupt_call(connector_id, sync_seq)
         if interrupt:
-            raise asyncio.CancelledError(f"Connector {connector_id!r} interrupted")
+            raise asyncio.CancelledError(
+                f"Connector {connector_id!r} interrupted (type={interrupt.value})"
+            )
 
         await asyncio.to_thread(scanner.connect)
-        scanned_files = await asyncio.to_thread(scanner.scan)
+        scanned_files: list[tuple[str, str]] = await asyncio.to_thread(scanner.scan)
 
-        known_checksums = set(list_connector_checksums(connector_id))
-        all_checksums = set(list_all_checksums())
+        known_checksums: set[str] = set(list_connector_checksums(connector_id))
+        all_checksums: set[str] = set(list_all_checksums())
 
         ingest_list, orphan_checksums = _classify(
             connector_id, scanned_files, known_checksums, all_checksums
@@ -709,11 +720,13 @@ async def run_tick(connector_id: str) -> None:
         _complete_tick(sync_seq, connector_id)
 
     except asyncio.CancelledError as ce:
+        logger.info(f"Tick cancelled for connector {connector_id!r}: {ce}")
         interrupt = _check_interrupt_call(connector_id, sync_seq)
         await _handle_interrupt(sync_seq, connector_id, interrupt)
         raise
 
     except Exception as exc:
+        logger.error(f"Tick failed for connector {connector_id!r}: {exc}", exc_info=True)
         _fail_tick(sync_seq, connector_id, exc)
 
     finally:
@@ -732,7 +745,9 @@ async def _process_new_files(sync_seq, connector_id, connector_name, scanner, in
 
         interrupt = _check_interrupt_call(connector_id, sync_seq)
         if interrupt:
-            raise asyncio.CancelledError(...)
+            raise asyncio.CancelledError(
+                f"Connector {connector_id!r} interrupted (type={interrupt.value})"
+            )
 
         job_id = generate_uuid()
         batch_dir_name = f"{connector_id}-{sync_seq}-{batch_number}"
@@ -747,19 +762,25 @@ async def _process_new_files(sync_seq, connector_id, connector_name, scanner, in
                     scanner.download_to, remote_path, batch_dir / filename
                 )
                 if not scanner.verify_integrity(local_checksum, checksum):
-                    logger.warning(f"Integrity check failed for {remote_path!r}; skipping")
+                    logger.warning(
+                        f"Integrity check failed for {remote_path!r} in connector "
+                        f"{connector_id!r}; skipping file"
+                    )
                     continue
                 checksum_to_filename[checksum] = filename
 
             interrupt = _check_interrupt_call(connector_id, sync_seq)
             if interrupt:
-                raise asyncio.CancelledError(...)
+                raise asyncio.CancelledError(
+                    f"Connector {connector_id!r} interrupted (type={interrupt.value})"
+                )
 
+            filenames = list(checksum_to_filename.values())
             job_name = f"Connector-{connector_name}-{sync_seq}-{batch_number}"
             doc_id_dict = initialize_job_state(
                 job_id=job_id, operation=OperationType.INGESTION,
                 output_format=OutputFormat.JSON,
-                documents_info=list(checksum_to_filename.values()),
+                documents_info=filenames,
                 job_name=job_name,
             )
             for checksum, filename in checksum_to_filename.items():
@@ -771,16 +792,28 @@ async def _process_new_files(sync_seq, connector_id, connector_name, scanner, in
         except asyncio.CancelledError:
             raise
         except Exception as exc:
+            logger.warning(
+                f"Failed to ingest batch {batch_number} for connector {connector_id!r}: {exc}",
+                exc_info=True,
+            )
             batch_failed = True
         finally:
             cleanup_staging_directory(batch_dir_name, staging_base, ignore_errors=True)
 
     if batch_failed:
-        raise RuntimeError("One or more batches failed")
+        raise RuntimeError(
+            f"One or more batches failed to ingest for connector {connector_id!r}; "
+            "connector marked as out of sync"
+        )
 
 
 async def _handle_interrupt(sync_seq, connector_id, interrupt_type) -> None:
-    """Note: _handle_interrupt is async — it awaits _run_teardown for DELETE_CONNECTOR."""
+    """_handle_interrupt is async — it awaits _run_teardown for DELETE_CONNECTOR."""
+    if interrupt_type is None:
+        # Unexpected CancelledError — treat as sync cancel
+        _cancel_tick(sync_seq, connector_id)
+        return
+
     if interrupt_type == InterruptType.SYNC_CANCEL:
         _cancel_tick(sync_seq, connector_id)
         from digitize.api.v1.connectors import _sweep_staging_dir
@@ -791,99 +824,112 @@ async def _handle_interrupt(sync_seq, connector_id, interrupt_type) -> None:
         _cancel_tick(sync_seq, connector_id)
         from digitize.api.v1.connectors import _run_teardown
         await _run_teardown(connector_id)  # same function as Case B
-
-    else:  # None (unexpected CancelledError)
-        _cancel_tick(sync_seq, connector_id)
 ```
 
 ---
 
 ## 7. Scheduler & Task Coordination
 
-**File:** `services/digitize/connectors/scheduler.py` — ⚠️ **NOT YET IMPLEMENTED (PR7)**
+**Files:** `services/digitize/connectors/scheduler.py`, `services/digitize/utils/recovery.py`, `services/digitize/app.py` ✅ **Implemented**
 
 ### 7.1 Architecture & State Tracking
 
-`ConnectorScheduler` will use an APScheduler `AsyncScheduler` singleton backed by `AsyncSQLAlchemyDataStore` in Postgres.
+The scheduler uses an APScheduler v4 `AsyncScheduler` singleton backed by `SQLAlchemyDataStore` (schema `"scheduler"`) in the shared Postgres database.
 
 **No in-process registries.** Delete state is stored exclusively in the `connectors` table (`sync_status = 'delete pending'`). All cancellation and teardown decisions are driven by live DB reads.
 
+The scheduler registers `dispatch_sync` (from `connectors.py`) directly as the recurring job callable. `dispatch_sync` handles lock-acquisition and idempotency — there is no separate `_run_tick_wrapped` wrapper.
+
 ---
 
-### 7.2 Scheduler Implementation _(planned)_
+### 7.2 Scheduler Implementation
 
 ```python
-# Planned implementation in scheduler.py
+# connectors/scheduler.py
+
+_scheduler: AsyncScheduler | None = None  # assigned by _connector_scheduler_lifespan in app.py
+
 
 async def register_connector_job(
-    connector_id: str, interval_seconds: int, fire_immediately: bool = False
+    connector_id: str,
+    interval_seconds: int,
+    fire_immediately: bool = False,
 ) -> None:
-    kwargs = dict(
-        func=_run_tick_wrapped,
-        trigger=IntervalTrigger(seconds=interval_seconds),
+    """Schedule (or reschedule) a recurring sync job for connector_id.
+
+    fire_immediately=True fires the first tick at now() instead of waiting
+    one full interval.  Used when attaching a new connector.
+    """
+    from digitize.api.v1.connectors import dispatch_sync
+
+    now = datetime.now(timezone.utc)
+    start_time = now if fire_immediately else now + timedelta(seconds=interval_seconds)
+
+    sched = _get_scheduler()
+    await sched.add_schedule(
+        func_or_task_id=dispatch_sync,
+        trigger=IntervalTrigger(seconds=interval_seconds, start_time=start_time),
         args=[connector_id],
         id=connector_id,
-        max_instances=1,
-        replace_existing=True,
     )
-    if fire_immediately:
-        kwargs["next_run_time"] = datetime.now(timezone.utc)
-    await _get_scheduler().add_job(**kwargs)
 
 
-async def _run_tick_wrapped(connector_id: str) -> None:
-    """APScheduler entry point.
-    1. Skip if DELETE_PENDING.
-    2. try_acquire_sync_lock — skip if already syncing.
-    3. Call run_tick(connector_id).
-    """
-    status = get_connector_sync_status(connector_id)
-    if status == ConnectorStatus.DELETE_PENDING:
-        return
-    if not try_acquire_sync_lock(connector_id):
-        return
-    await run_tick(connector_id)
+async def remove_connector_job(connector_id: str) -> None:
+    """Remove the scheduled job for connector_id, if it exists. Silently ignores missing jobs."""
+    sched = _get_scheduler()
+    try:
+        await sched.remove_schedule(connector_id)
+    except Exception as exc:
+        logger.debug(f"Could not remove scheduler job for {connector_id!r}: {exc}")
 ```
 
 ---
 
-### 7.3 Crash Recovery for Connector Sync State _(planned)_
+### 7.3 Crash Recovery for Connector Sync State
 
-`recover_connector_sync_state()` in `services/digitize/utils/recovery.py` — **NOT YET IMPLEMENTED**.
+`recover_connector_sync_state()` in `services/digitize/utils/recovery.py` ✅ **Implemented**.
 
-Planned behavior on startup:
-1. Bulk `UPDATE connectors SET sync_status='out of sync' WHERE sync_status='syncing'` — unlocks connectors stuck in `'syncing'` from a mid-tick crash.
-2. For each affected connector: find the open `connector_sync_logs` row and close it to `status='failed'` with `error='Service restarted during sync tick'`.
+Behavior on startup:
+1. `reset_syncing_connectors()` — bulk `UPDATE connectors SET sync_status='out of sync' WHERE sync_status='syncing'`. Returns list of affected connector IDs.
+2. For each affected connector: `close_open_sync_log(connector_id, error)` — closes the open `connector_sync_logs` row (status = `'started'` or `'cancel pending'`) to `status='failed'` with `error='Service restarted during sync tick'`.
 
-Note: `recover_zombie_jobs()` for regular (non-connector) jobs **is** implemented in `recovery.py` and called from `lifespan()`.
+Returns number of connectors recovered.
+
+Note: `recover_zombie_jobs()` for regular (non-connector) jobs is also implemented in `recovery.py` and called from `lifespan()`.
 
 ---
 
-### 7.4 Lifespan Integration _(planned)_
+### 7.4 Lifespan Integration
 
-`app.py` currently implements `lifespan()` with DB connection, schema creation, and `recover_zombie_jobs()` only. Planned additions (PR7):
+`app.py` `lifespan()` starts the scheduler via `_connector_scheduler_lifespan()`:
 
 ```python
-# Planned additions to lifespan() in app.py
+# app.py — _connector_scheduler_lifespan()
 
+data_store = SQLAlchemyDataStore(db_engine, schema="scheduler")
 async with AsyncScheduler(data_store=data_store) as sched:
     scheduler_module._scheduler = sched
 
-    # Connector crash recovery
-    recover_connector_sync_state()
+    # Connector crash recovery — unlock connectors stuck in 'syncing'.
+    recovered = recover_connector_sync_state()
 
-    # Re-register existing connectors (fire_immediately=False — don't double-fire)
-    for connector in get_all_connectors():
-        await register_connector_job(
-            connector.id, connector.sync_interval_seconds, fire_immediately=False
+    # Re-register all existing connectors (fire_immediately=False — don't double-fire
+    # connectors that are already up-to-date after crash recovery).
+    connectors = list_connectors()
+    for connector in connectors:
+        await scheduler_module.register_connector_job(
+            connector.id,
+            connector.sync_interval_seconds,
+            fire_immediately=False,
         )
 
-    # Size thread pool based on connector count
-    pool_size = max(len(get_all_connectors()) + 4, 8)
-    asyncio.get_running_loop().set_default_executor(ThreadPoolExecutor(max_workers=pool_size))
-
+    await sched.start_in_background()
     yield
 ```
+
+`POST /v1/connectors` calls `register_connector_job(connector_id, sync_interval, fire_immediately=True)` before the DB insert (fail-fast order).
+
+`DELETE /v1/connectors/{id}` calls `remove_connector_job(connector_id)` after marking the connector `delete_pending`, before dispatching teardown, so no new tick fires after the connector is marked for deletion.
 
 ---
 
@@ -899,7 +945,7 @@ Scanners perform synchronous blocking I/O (`boto3` calls, Paramiko SFTP operatio
   - **`connectors.sync_status = 'delete pending'`** — set by `mark_connector_delete_pending` when DELETE arrives (unconditionally).
   - **`connector_sync_logs.status = 'cancel pending'`** — set by `mark_sync_cancel_pending` when stop-sync is requested.
 - `_check_interrupt_call(connector_id, sync_seq)` reads both sources on every call. Invoked at **four checkpoints**:
-  - In `run_tick` — immediately after `init_sync_log_and_update_connector` (Phase 1b).
+  - In `run_tick` — immediately before `scanner.connect` (Phase 1b).
   - In `_process_new_files` — before each batch starts (Checkpoint 2).
   - In `_process_new_files` — after each batch of downloads completes (Checkpoint 3).
   - In `_wait_for_job` — on every poll cycle (Checkpoint 4).
@@ -910,21 +956,18 @@ Scanners perform synchronous blocking I/O (`boto3` calls, Paramiko SFTP operatio
   - `_cancel_tick` + `await _run_teardown(connector_id)` for `DELETE_CONNECTOR` (same `_run_teardown` used for Case B).
 - No safety-net timeout. No waiting for the tick to exit before teardown begins.
 
-### 8.3 Thread Pool Sizing _(planned — PR7)_
-Each ticking connector holds at most **1 thread at a time**.
-$$\text{pool\_size} = \max(N + 4, 8) \quad \text{(where } N = \text{total configured connectors)}$$
 
 ---
 
 ## 9. Implementation Plan & PR Breakdown
 
-### Implemented PRs
+### Implemented PRs — All Complete ✅
 
 - **PR 1 — DB Schema + ORM Models + Settings ✅:** `connectors`, `connector_document_checksum`, `connector_sync_logs` tables & ORM models (`db/scripts/init_schema.sql`, `db/models.py`). `connector_sync_logs` uses composite PK `(connector_id, seq)`. `Connector` ORM has an `error` field for teardown errors (in model, not shown in SQL schema). `ConnectorStatus` and `SyncLogStatus` string enums in `connectors/models.py`. Scanner config models (`S3ConnectorConfig`, `SSHConnectorConfig`) in `connectors/scanners/config.py`.
 
-- **PR 2 — DB Operations Layer ✅:** `manager.py` & `utils/db.py` fully implemented. All checksum helpers (`insert_connector_checksum`, `delete_connector_checksum` returning `doc_id`, `count_checksum_owners`, `find_connector_doc_by_checksum`, `get_connector_checksums`, `get_all_connector_checksums`), sync-lock/signal helpers (`try_acquire_sync_lock`, `mark_sync_cancel_pending`, `mark_connector_delete_pending`), sync-log helpers (`init_sync_log_and_update_connector`, `finalize_sync_log_and_update_connector`, `update_sync_log`, `update_connector_total_files`, `set_connector_error`, `list_sync_logs`, `get_sync_log`, `get_sync_log_status`, `get_active_sync_seq`). All tested in `test_connector_db.py`.
+- **PR 2 — DB Operations Layer ✅:** `manager.py` & `utils/db.py` fully implemented. All checksum helpers (`insert_connector_checksum`, `delete_connector_checksum` returning `doc_id`, `count_checksum_owners`, `find_connector_doc_by_checksum`, `get_connector_checksums`, `get_all_connector_checksums`), sync-lock/signal helpers (`try_acquire_sync_lock`, `mark_sync_cancel_pending`, `mark_connector_delete_pending`), sync-log helpers (`init_sync_log_and_update_connector`, `finalize_sync_log_and_update_connector`, `update_sync_log`, `update_connector_total_files`, `set_connector_error`, `list_sync_logs`, `get_sync_log`, `get_sync_log_status`, `get_active_sync_seq`). Crash-recovery helpers `reset_syncing_connectors` and `close_open_sync_log` also implemented. All tested in `test_connector_db.py`.
 
-- **PR 3 — REST API Endpoints ✅:** Full CRUD in `connectors.py` (`POST`, `PUT`, `DELETE`, `GET`, `GET /{id}`, `GET /{id}/syncs`, `GET /{id}/syncs/{seq}`, `POST /{id}/syncs`, `POST /{id}/syncs/{seq}/stop`). Connector visibility filtering in `documents.py` (`is_connector_sourced_document`, `exclude_connector_sourced` in `get_all_documents_paginated`).
+- **PR 3 — REST API Endpoints ✅:** Full CRUD in `connectors.py` (`POST`, `PUT`, `DELETE`, `GET`, `GET /{id}`, `GET /{id}/syncs`, `GET /{id}/syncs/{seq}`, `POST /{id}/syncs`, `POST /{id}/syncs/{seq}/stop`). Shared `dispatch_sync()` helper used by both the HTTP handler and the APScheduler. Connector visibility filtering in `documents.py` (`is_connector_sourced_document`, `exclude_connector_sourced` in `get_all_documents_paginated`). Credential probe (`_probe_connector_credentials`) dispatched as a background task on `POST` and `PUT`.
 
 - **PR 4a — Scanner Abstraction ✅:** `BaseScanner` interface (`base_scanner.py`) & `scanner_factory.py` with `_REGISTRY` for `"s3"` and `"ssh"` types. Factory decrypts secrets before building the typed config.
 
@@ -932,20 +975,16 @@ $$\text{pool\_size} = \max(N + 4, 8) \quad \text{(where } N = \text{total config
 
 - **PR 5 — S3 Scanner ✅:** `S3Scanner` implementation with AWS/IBM COS provider auto-detection, cross-region alias resolution, `head_bucket` pre-flight check, `HashingWriter` inline MD5, multi-part ETag integrity bypass.
 
-- **PR 6 — Core Sync Engine ✅:** `sync_tick.py` fully implemented. `run_tick`, `_classify`, `_process_new_files` (batch download, integrity skip, `batch_failed` flag, 1-based `batch_number`, job named `Connector-{connector_name}-{sync_seq}-{batch_number}`), `_delete_orphans` (uses `asyncio.to_thread` for `_best_effort_delete_document`), `async _handle_interrupt` (awaits `_run_teardown` for DELETE path), `_cancel_tick`, `_fail_tick`, `_complete_tick`. `_check_interrupt_call(connector_id, sync_seq)` reads from both tables using `ConnectorStatus`/`SyncLogStatus`. Tests in `test_sync_tick.py`.
+- **PR 6 — Core Sync Engine ✅:** `sync_tick.py` fully implemented. `run_tick(connector_id, sync_seq)` — `sync_seq` is provided by the caller (`dispatch_sync`), not generated internally. `_classify`, `_process_new_files` (batch download, integrity skip, `batch_failed` flag, 1-based `batch_number`, job named `Connector-{connector_name}-{sync_seq}-{batch_number}`), `_delete_orphans` (uses `asyncio.to_thread` for `_best_effort_delete_document`), `async _handle_interrupt` (awaits `_run_teardown` for DELETE path), `_cancel_tick`, `_fail_tick`, `_complete_tick`. `_check_interrupt_call(connector_id, sync_seq)` reads from both tables using `ConnectorStatus`/`SyncLogStatus`. Tests in `test_sync_tick.py`.
+
+- **PR 7 — Scheduler + Lifespan + Crash Recovery ✅:**
+  - `connectors/scheduler.py` created: `register_connector_job`, `remove_connector_job`. APScheduler v4 `AsyncScheduler` + `SQLAlchemyDataStore` (schema `"scheduler"`) backed by the shared Postgres engine. `dispatch_sync` registered directly as the scheduler callable (no `_run_tick_wrapped` wrapper). `apscheduler[sqlalchemy]` added to `requirements.txt`.
+  - `recover_connector_sync_state()` added to `utils/recovery.py`: bulk-resets connectors stuck in `'syncing'` → `'out of sync'`; closes open `connector_sync_logs` rows to `'failed'`.
+  - `app.py` `lifespan()` updated via `_connector_scheduler_lifespan()` context manager: starts `AsyncScheduler`, calls `recover_connector_sync_state()`, re-registers all existing connector jobs (`fire_immediately=False`), sizes the default `ThreadPoolExecutor` to `max(N+4, 8)`, and calls `await sched.start_in_background()`.
+  - `POST /v1/connectors` calls `register_connector_job(connector_id, sync_interval, fire_immediately=True)` **before** the DB insert (fail-fast order).
+  - `DELETE /v1/connectors/{id}` calls `remove_connector_job(connector_id)` after marking `delete_pending` so no new tick fires after the connector is marked for deletion.
+  - Unit tests in `tests/test_connector_scheduler.py` cover `register_connector_job`, `remove_connector_job`, and `recover_connector_sync_state`.
 
 - **PR 8 — Cancel Sync Endpoint ✅:** `POST /syncs/{seq}/stop` implemented with `sync_status` pre-check + seq validation + `mark_sync_cancel_pending`. `SyncLogStatus.CANCEL_PENDING` and `InterruptType.SYNC_CANCEL` handle the cancel path. `finalize_sync_log_and_update_connector` maps `CANCELLED` → `OUT_OF_SYNC`.
 
 - **PR 9 — Non-Blocking DELETE ✅:** `DELETE /v1/connectors/{id}` uses `mark_connector_delete_pending` (unconditional) + checks `sync_status` to decide Case A vs B. Case B dispatches `asyncio.create_task(_run_teardown(...))`. Case A tick detects `DELETE_PENDING` via `_check_interrupt_call` → `await _run_teardown` in `_handle_interrupt`. Single `_run_teardown` function in `connectors.py` handles both paths.
-
----
-
-### Pending PRs
-
-- **PR 7 — Scheduler + Lifespan + Crash Recovery ✅:**
-  - `connectors/scheduler.py` created: `register_connector_job`, `remove_connector_job`, `_run_tick_wrapped` (APScheduler v4 `AsyncScheduler` + `SQLAlchemyDataStore` backed by the shared Postgres engine). `apscheduler[sqlalchemy]==4.0.0a6` added to `requirements.txt`.
-  - `recover_connector_sync_state()` added to `utils/recovery.py`: bulk-resets connectors stuck in `'syncing'` → `'out of sync'`; closes open `connector_sync_logs` rows to `'failed'`. DB helpers `reset_syncing_connectors` / `close_open_sync_log` added to `db/manager.py` and `utils/db.py`.
-  - `app.py` `lifespan()` updated: starts `AsyncScheduler` within an `async with` block, calls `recover_connector_sync_state()`, re-registers all existing connector jobs (`fire_immediately=False`), and sizes the default `ThreadPoolExecutor` to `max(N+4, 8)`.
-  - `POST /v1/connectors` now calls `register_connector_job(connector_id, sync_interval, fire_immediately=True)` after the DB insert. The stub comment is removed.
-  - `DELETE /v1/connectors/{id}` now calls `remove_connector_job(connector_id)` before dispatching teardown so no new tick fires after the connector is marked delete-pending.
-  - Unit tests in `tests/test_connector_scheduler.py` cover `_run_tick_wrapped`, `register_connector_job`, `remove_connector_job`, and `recover_connector_sync_state`.

--- a/services/common/error_utils.py
+++ b/services/common/error_utils.py
@@ -288,6 +288,50 @@ class APIError:
         )
 
 
+def extract_http_error_message(exc) -> str:
+    """Extract the human-readable message from a FastAPI HTTPException.
+
+    ``APIError.raise_error`` always stores the user-facing message at
+    ``exc.detail["error"]["message"]``.  This helper unwraps that path and
+    falls back to ``str(exc.detail)`` for any exception whose detail is not
+    structured (e.g. plain-string FastAPI validation errors).
+
+    Args:
+        exc: A ``fastapi.HTTPException`` instance.
+
+    Returns:
+        The extracted message string.
+    """
+    if isinstance(exc.detail, dict):
+        return exc.detail.get("error", {}).get("message", str(exc.detail))
+    return str(exc.detail)
+
+
+def build_http_error_detail(exc, operation_message: str) -> dict:
+    """Build a structured error detail dict for re-raising an HTTPException.
+
+    Combines a human-readable *operation_message* (describing what was being
+    attempted and why it failed) with the error code extracted from the
+    original exception so the HTTP status code, error code, and message are
+    all consistent and displayable to the end user.
+
+    Args:
+        exc: The original ``fastapi.HTTPException`` being handled.
+        operation_message: The fully-composed user-facing message, e.g.
+            ``"Failed to create connector 'x': Connector already exists"``.
+
+    Returns:
+        A ``{"error": {"code": ..., "message": ..., "status": ...}}`` dict
+        suitable for passing directly as ``HTTPException(detail=...)``.
+    """
+    code = (
+        exc.detail.get("error", {}).get("code", "INTERNAL_SERVER_ERROR")
+        if isinstance(exc.detail, dict)
+        else "INTERNAL_SERVER_ERROR"
+    )
+    return {"error": {"code": code, "message": operation_message, "status": exc.status_code}}
+
+
 async def http_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     """
     Custom exception handler to format HTTPException responses consistently.

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.47
+TAG?=v0.0.48
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/api/v1/admin.py
+++ b/services/digitize/api/v1/admin.py
@@ -11,7 +11,7 @@ Exposes one router:
 
 from fastapi import APIRouter, HTTPException, Query
 
-from common.error_utils import APIError, ErrorCode, http_error_responses
+from common.error_utils import APIError, ErrorCode, http_error_responses, extract_http_error_message, build_http_error_detail
 from common.misc_utils import get_logger
 import digitize.models as models
 import digitize.utils.db as db_ops
@@ -69,10 +69,9 @@ async def import_metadata(payload: models.ImportRequest):
             await db_ops.release_import_export_lock()
 
     except HTTPException as exc:
-        logger.error(
-            f"Failed to import metadata: HTTP {exc.status_code} - {exc.detail}"
-        )
-        raise
+        message = f"Failed to import metadata: {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except ValueError as exc:
         logger.error(f"Invalid import request: {exc}")
         APIError.raise_error(ErrorCode.INVALID_REQUEST, str(exc))
@@ -143,10 +142,9 @@ async def export_metadata(
             await db_ops.release_import_export_lock()
 
     except HTTPException as exc:
-        logger.error(
-            f"Failed to export metadata: HTTP {exc.status_code} - {exc.detail}"
-        )
-        raise
+        message = f"Failed to export metadata: {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except ValueError as exc:
         logger.error(f"Invalid export request: {exc}")
         APIError.raise_error(ErrorCode.INVALID_REQUEST, str(exc))

--- a/services/digitize/api/v1/admin.py
+++ b/services/digitize/api/v1/admin.py
@@ -68,7 +68,10 @@ async def import_metadata(payload: models.ImportRequest):
         finally:
             await db_ops.release_import_export_lock()
 
-    except HTTPException:
+    except HTTPException as exc:
+        logger.error(
+            f"Failed to import metadata: HTTP {exc.status_code} - {exc.detail}"
+        )
         raise
     except ValueError as exc:
         logger.error(f"Invalid import request: {exc}")
@@ -139,7 +142,10 @@ async def export_metadata(
         finally:
             await db_ops.release_import_export_lock()
 
-    except HTTPException:
+    except HTTPException as exc:
+        logger.error(
+            f"Failed to export metadata: HTTP {exc.status_code} - {exc.detail}"
+        )
         raise
     except ValueError as exc:
         logger.error(f"Invalid export request: {exc}")

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -97,8 +97,9 @@ async def _probe_connector_credentials(
         if current_error == _CREDENTIAL_ERROR_MSG:
             db_ops.set_connector_error(connector_id, None)
     except Exception as exc:
-        logger.warning(
-            f"Credential probe failed for connector {connector_id!r}: {exc}"
+        logger.error(
+            f"Credential probe failed for connector {connector_id!r}: {exc}",
+            exc_info=True,
         )
         db_ops.set_connector_error(connector_id, _CREDENTIAL_ERROR_MSG)
         try:
@@ -149,7 +150,8 @@ async def create_connector(body: ConnectorCreateRequest):
             )
         except Exception as sched_exc:
             logger.error(
-                f"Scheduler registration failed for {connector_id!r}: {sched_exc}"
+                f"Scheduler registration failed for {connector_id!r}: {sched_exc}",
+                exc_info=True,
             )
             raise
 

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -36,6 +36,7 @@ from digitize.connectors.models import (
     ConnectorStatus,
     SyncLogStatus,
     SyncTriggerResponse,
+    ConnectorError,
 )
 from digitize.connectors.encryption import (
     encrypt_secrets,
@@ -54,7 +55,7 @@ logger = get_logger("connectors_router")
 
 _KEY_PATH = None  # resolved lazily via _get_key_path()
 
-_CREDENTIAL_ERROR_MSG = "Authentication failed: unable to connect with the provided credentials"
+_CREDENTIAL_ERROR_MSG = ConnectorError.CREDENTIAL_ERROR_MSG  # canonical value lives in connectors.models
 
 
 def _get_key_path() -> str:

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -145,7 +145,10 @@ async def create_connector(body: ConnectorCreateRequest):
                 f"Scheduler registration failed for {connector_id!r}: {sched_exc}",
                 exc_info=True,
             )
-            raise
+            raise RuntimeError(
+                f"Failed to register scheduler job for connector {connector_id!r} "
+                f"during connector creation: {sched_exc}"
+            ) from sched_exc
 
         db_ops.insert_connector(
             connector_id=connector_id,
@@ -186,7 +189,10 @@ async def create_connector(body: ConnectorCreateRequest):
         # encryption key not found
         logger.error(f"Encryption key error: {exc}")
         APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
-    except HTTPException:
+    except HTTPException as exc:
+        logger.error(
+            f"Failed to create connector {connector_id!r}: HTTP {exc.status_code} - {exc.detail}"
+        )
         raise
     except Exception as exc:
         logger.error(f"Unexpected error creating connector: {exc}", exc_info=True)
@@ -283,7 +289,10 @@ async def update_connector(connector_id: str, body: ConnectorUpdateRequest):
     except RuntimeError as exc:
         logger.error(f"Encryption key error: {exc}")
         APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
-    except HTTPException:
+    except HTTPException as exc:
+        logger.error(
+            f"Failed to update connector {connector_id!r}: HTTP {exc.status_code} - {exc.detail}"
+        )
         raise
     except Exception as exc:
         logger.error(f"Unexpected error updating connector {connector_id}: {exc}", exc_info=True)
@@ -337,7 +346,10 @@ async def delete_connector(connector_id: str):
 
         return Response(status_code=204)
 
-    except HTTPException:
+    except HTTPException as exc:
+        logger.error(
+            f"Failed to delete connector {connector_id!r}: HTTP {exc.status_code} - {exc.detail}"
+        )
         raise
     except Exception as exc:
         logger.error(f"Unexpected error deleting connector {connector_id}: {exc}", exc_info=True)
@@ -508,7 +520,10 @@ async def list_connectors():
             )
             for c in connectors
         ]
-    except HTTPException:
+    except HTTPException as exc:
+        logger.error(
+            f"Failed to list connectors: HTTP {exc.status_code} - {exc.detail}"
+        )
         raise
     except Exception as exc:
         logger.error(f"Unexpected error listing connectors: {exc}", exc_info=True)
@@ -559,7 +574,10 @@ async def get_connector(connector_id: str):
             connection_details=strip_secrets(connector.type, connector.connection_details or {}),
             total_files=connector.total_files,
         )
-    except HTTPException:
+    except HTTPException as exc:
+        logger.error(
+            f"Failed to get connector {connector_id!r}: HTTP {exc.status_code} - {exc.detail}"
+        )
         raise
     except Exception as exc:
         logger.error(f"Unexpected error fetching connector {connector_id}: {exc}", exc_info=True)
@@ -683,7 +701,10 @@ async def trigger_sync(connector_id: str):
         APIError.raise_error(ErrorCode.RESOURCE_NOT_FOUND, str(exc))
     except SyncLocked as exc:
         APIError.raise_error(ErrorCode.RESOURCE_LOCKED, str(exc))
-    except HTTPException:
+    except HTTPException as exc:
+        logger.error(
+            f"Failed to trigger sync for connector {connector_id!r}: HTTP {exc.status_code} - {exc.detail}"
+        )
         raise
     except Exception as exc:
         logger.error(f"Unexpected error triggering sync for {connector_id}: {exc}", exc_info=True)
@@ -749,7 +770,11 @@ async def cancel_sync(connector_id: str, sync_seq: int):
         logger.info(f"Cancel-sync signal sent for connector {connector_id!r} (seq={sync_seq})")
         return Response(status_code=204)
 
-    except HTTPException:
+    except HTTPException as exc:
+        logger.error(
+            f"Failed to cancel sync for connector {connector_id!r} (seq={sync_seq}): "
+            f"HTTP {exc.status_code} - {exc.detail}"
+        )
         raise
     except Exception as exc:
         logger.error(f"Unexpected error cancelling sync for {connector_id}: {exc}", exc_info=True)
@@ -803,7 +828,11 @@ async def get_sync_history(
 
         return SyncLogResponse(total=total, limit=limit, offset=offset, items=items)
 
-    except HTTPException:
+    except HTTPException as exc:
+        logger.error(
+            f"Failed to get sync history for connector {connector_id!r}: "
+            f"HTTP {exc.status_code} - {exc.detail}"
+        )
         raise
     except Exception as exc:
         logger.error(
@@ -856,7 +885,11 @@ async def get_sync(connector_id: str, sync_seq: int):
             error=log.error or "",
         )
 
-    except HTTPException:
+    except HTTPException as exc:
+        logger.error(
+            f"Failed to get sync {sync_seq} for connector {connector_id!r}: "
+            f"HTTP {exc.status_code} - {exc.detail}"
+        )
         raise
     except Exception as exc:
         logger.error(

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -127,7 +127,7 @@ async def create_connector(body: ConnectorCreateRequest):
     Validates connector settings, encrypts credentials, persists the new connector
     configuration in the database, and schedules the background worker.
     """
-    connector_id = body.connector_id or str(uuid.uuid4())
+    connector_id = body.id or str(uuid.uuid4())
     try:
         encrypted_details = encrypt_secrets(body.type, body.connection_details)
 
@@ -149,7 +149,7 @@ async def create_connector(body: ConnectorCreateRequest):
 
         db_ops.insert_connector(
             connector_id=connector_id,
-            name=body.connector_name,
+            name=body.name,
             connector_type=body.type,
             connection_details=encrypted_details,
             allowed_extensions=body.allowed_extensions,
@@ -166,12 +166,12 @@ async def create_connector(body: ConnectorCreateRequest):
         )
 
         logger.info(
-            f"Connector {connector_id!r} ({body.connector_name!r}) attached "
+            f"Connector {connector_id!r} ({body.name!r}) attached "
             f"(type={body.type}, interval={sync_interval}s)"
         )
 
         return Response(
-            content=f'{{"connector_id": "{connector_id}"}}',
+            content=f'{{"id": "{connector_id}"}}',
             status_code=201,
             media_type="application/json",
         )
@@ -180,7 +180,7 @@ async def create_connector(body: ConnectorCreateRequest):
         # id or name already exists
         APIError.raise_error(
             ErrorCode.RESOURCE_LOCKED,
-            f"Connector {connector_id!r} or name {body.connector_name!r} already exists",
+            f"Connector {connector_id!r} or name {body.name!r} already exists",
         )
     except RuntimeError as exc:
         # encryption key not found
@@ -222,7 +222,7 @@ async def update_connector(connector_id: str, body: ConnectorUpdateRequest):
     """
     try:
         # Nothing to update — treat as success
-        if body.connector_name is None and body.allowed_extensions is None and body.connection_details is None:
+        if body.name is None and body.allowed_extensions is None and body.connection_details is None:
             return Response(status_code=200)
 
         existing = db_ops.get_active_connector(connector_id)
@@ -249,7 +249,7 @@ async def update_connector(connector_id: str, body: ConnectorUpdateRequest):
 
         db_ops.upsert_connector(
             connector_id=connector_id,
-            name=body.connector_name,
+            name=body.name,
             connection_details=merged_details,
             allowed_extensions=body.allowed_extensions,
         )
@@ -278,7 +278,7 @@ async def update_connector(connector_id: str, body: ConnectorUpdateRequest):
     except IntegrityError:
         APIError.raise_error(
             ErrorCode.RESOURCE_LOCKED,
-            f"Connector name {body.connector_name!r} is already in use",
+            f"Connector name {body.name!r} is already in use",
         )
     except RuntimeError as exc:
         logger.error(f"Encryption key error: {exc}")
@@ -497,8 +497,8 @@ async def list_connectors():
         connectors = db_ops.list_connectors()
         return [
             ConnectorListItem(
-                connector_id=c.id,
-                connector_name=c.name,
+                id=c.id,
+                name=c.name,
                 type=c.type,
                 attached_at=get_utc_timestamp(c.attached_at),
                 last_sync_at=get_utc_timestamp(c.last_sync_at),
@@ -547,8 +547,8 @@ async def get_connector(connector_id: str):
             )
 
         return ConnectorDetailResponse(
-            connector_id=connector.id,
-            connector_name=connector.name,
+            id=connector.id,
+            name=connector.name,
             type=connector.type,
             allowed_extensions=list(connector.allowed_extensions or []),
             sync_interval_seconds=connector.sync_interval_seconds,

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -322,26 +322,24 @@ async def _run_teardown(connector_id: str) -> None:
             import digitize.connectors.scheduler as _sched
             await _sched.remove_connector_job(connector_id)
         except Exception as sched_exc:
-            deletion_errors.append(f"scheduler job removal failed: {sched_exc}")
+            deletion_errors.append(f"Failed to remove scheduler job: {sched_exc}")
             logger.warning(
                 f"Could not remove scheduler job for {connector_id!r}: {sched_exc}"
             )
 
         # Steps 2+3: remove checksum ownership; delete orphaned documents
         owned_checksums = db_ops.list_connector_checksums(connector_id)
-        for checksum in owned_checksums:
-            try:
-                remaining, doc_id = db_ops.remove_connector_checksum_entry(connector_id, checksum)
-                if remaining == 0 and doc_id:
-                    if not _best_effort_delete_document(doc_id):
-                        deletion_errors.append(f"document deletion failed for checksum {checksum!r}")
-            except Exception as exc:
-                deletion_errors.append(f"checksum removal failed for {checksum!r}: {exc}")
-                logger.error(
-                    f"Error removing checksum {checksum!r} for connector "
-                    f"{connector_id!r}: {exc}",
-                    exc_info=True,
-                )
+        checksum_removal_failures, doc_deletion_failures = _remove_checksums(
+            connector_id, owned_checksums
+        )
+        if checksum_removal_failures:
+            deletion_errors.append(
+                f"checksum removal failed for {len(checksum_removal_failures)} checksum(s)"
+            )
+        if doc_deletion_failures:
+            deletion_errors.append(
+                f"document deletion failed for {len(doc_deletion_failures)} checksum(s)"
+            )
 
         # Step 4: sweep any residual batch staging directories
         if not _sweep_staging_dir(connector_id, settings.digitize.staging_dir / "connectors"):
@@ -368,6 +366,42 @@ async def _run_teardown(connector_id: str) -> None:
             exc_info=True,
         )
         db_ops.set_connector_error(connector_id, f"Unexpected error during teardown: {exc}")
+
+
+def _remove_checksums(
+    connector_id: str,
+    checksums: list[str] | set[str],
+) -> tuple[list[str], list[str]]:
+    """
+    Remove checksum ownership rows for *connector_id* and delete any document
+    that loses its last owner.
+
+    Iterates all *checksums*, accumulating failures rather than stopping on the
+    first error so that as many checksums as possible are cleaned up in one pass.
+
+    Returns
+    -------
+    checksum_removal_failures:
+        Checksums for which ``remove_connector_checksum_entry`` raised.
+    doc_deletion_failures:
+        Checksums whose associated document could not be deleted (best-effort).
+    """
+    checksum_removal_failures: list[str] = []
+    doc_deletion_failures: list[str] = []
+    for checksum in checksums:
+        try:
+            remaining, doc_id = db_ops.remove_connector_checksum_entry(connector_id, checksum)
+            if remaining == 0 and doc_id:
+                if not _best_effort_delete_document(doc_id):
+                    doc_deletion_failures.append(checksum)
+        except Exception as exc:
+            checksum_removal_failures.append(checksum)
+            logger.error(
+                f"Error removing checksum {checksum!r} for connector "
+                f"{connector_id!r}: {exc}",
+                exc_info=True,
+            )
+    return checksum_removal_failures, doc_deletion_failures
 
 
 def _best_effort_delete_document(doc_id: str) -> bool:

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -53,14 +53,7 @@ logger = get_logger("connectors_router")
 # Helpers
 # ---------------------------------------------------------------------------
 
-_KEY_PATH = None  # resolved lazily via _get_key_path()
-
 _CREDENTIAL_ERROR_MSG = ConnectorError.CREDENTIAL_ERROR_MSG  # canonical value lives in connectors.models
-
-
-def _get_key_path() -> str:
-    """Return the encryption key path from settings."""
-    return settings.digitize.connector.encryption_key_path
 
 
 async def _probe_connector_credentials(
@@ -136,8 +129,7 @@ async def create_connector(body: ConnectorCreateRequest):
     """
     connector_id = body.connector_id or str(uuid.uuid4())
     try:
-        key_path = _get_key_path()
-        encrypted_details = encrypt_secrets(body.type, body.connection_details, key_path)
+        encrypted_details = encrypt_secrets(body.type, body.connection_details)
 
         sync_interval = settings.digitize.connector.sync_interval_seconds
 
@@ -245,8 +237,6 @@ async def update_connector(connector_id: str, body: ConnectorUpdateRequest):
                 f"Connector {connector_id!r} is pending deletion and cannot be updated",
             )
 
-        key_path = _get_key_path()
-
         # If connection_details is being updated, we need to merge with existing
         # encrypted details so untouched keys stay encrypted and intact.
         merged_details: Optional[dict] = None
@@ -255,7 +245,6 @@ async def update_connector(connector_id: str, body: ConnectorUpdateRequest):
                 existing.type,
                 existing.connection_details,
                 body.connection_details,
-                key_path,
             )
 
         db_ops.upsert_connector(

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -442,7 +442,6 @@ async def list_connectors():
                 attached_at=get_utc_timestamp(c.attached_at),
                 last_sync_at=get_utc_timestamp(c.last_sync_at),
                 sync_status=c.sync_status,
-                last_sync_error=c.last_sync_error,
                 error=c.error,
                 total_files=c.total_files,
             )
@@ -495,7 +494,6 @@ async def get_connector(connector_id: str):
             attached_at=get_utc_timestamp(connector.attached_at),
             last_sync_at=get_utc_timestamp(connector.last_sync_at),
             sync_status=connector.sync_status,
-            last_sync_error=connector.last_sync_error,
             error=connector.error,
             connection_details=strip_secrets(connector.type, connector.connection_details or {}),
             total_files=connector.total_files,

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -23,7 +23,7 @@ from fastapi import APIRouter, HTTPException, Query, Response, status
 from sqlalchemy.exc import IntegrityError
 
 from common.misc_utils import cleanup_staging_directory, get_logger, get_utc_timestamp
-from common.error_utils import APIError, ErrorCode, http_error_responses
+from common.error_utils import APIError, ErrorCode, http_error_responses, extract_http_error_message, build_http_error_detail
 from digitize.connectors.models import (
     ConnectorCreateRequest,
     ConnectorDetailResponse,
@@ -118,6 +118,7 @@ async def create_connector(body: ConnectorCreateRequest):
 
     except IntegrityError:
         # id or name already exists
+        logger.error(f"Connector {connector_id!r} or name {body.name!r} already exists")
         APIError.raise_error(
             ErrorCode.RESOURCE_LOCKED,
             f"Connector {connector_id!r} or name {body.name!r} already exists",
@@ -125,15 +126,20 @@ async def create_connector(body: ConnectorCreateRequest):
     except RuntimeError as exc:
         # encryption key not found
         logger.error(f"Encryption key error: {exc}")
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
-    except HTTPException as exc:
-        logger.error(
-            f"Failed to create connector {connector_id!r}: HTTP {exc.status_code} - {exc.detail}"
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Failed to create connector {connector_id!r} (name={body.name!r}): encryption error — {exc}",
         )
-        raise
+    except HTTPException as exc:
+        message = f"Failed to create connector {connector_id!r}: {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(f"Unexpected error creating connector: {exc}", exc_info=True)
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Unexpected error creating connector {connector_id!r} (name={body.name!r}): {exc}",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -205,27 +211,34 @@ async def update_connector(connector_id: str, body: ConnectorUpdateRequest):
         logger.info(f"Connector {connector_id!r} updated")
         return Response(status_code=200)
 
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
+        logger.warning(f"Connector {connector_id!r} not found: {exc}")
         APIError.raise_error(
             ErrorCode.RESOURCE_NOT_FOUND,
             f"Connector {connector_id!r} not found",
         )
     except IntegrityError:
+        logger.error(f"Connector name {body.name!r} is already in use")
         APIError.raise_error(
             ErrorCode.RESOURCE_LOCKED,
             f"Connector name {body.name!r} is already in use",
         )
     except RuntimeError as exc:
         logger.error(f"Encryption key error: {exc}")
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
-    except HTTPException as exc:
-        logger.error(
-            f"Failed to update connector {connector_id!r}: HTTP {exc.status_code} - {exc.detail}"
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Failed to update connector {connector_id!r}: encryption error — {exc}",
         )
-        raise
+    except HTTPException as exc:
+        message = f"Failed to update connector {connector_id!r}: {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(f"Unexpected error updating connector {connector_id}: {exc}", exc_info=True)
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Unexpected error updating connector {connector_id!r}: {exc}",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -276,13 +289,15 @@ async def delete_connector(connector_id: str):
         return Response(status_code=204)
 
     except HTTPException as exc:
-        logger.error(
-            f"Failed to delete connector {connector_id!r}: HTTP {exc.status_code} - {exc.detail}"
-        )
-        raise
+        message = f"Failed to delete connector {connector_id!r}: {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(f"Unexpected error deleting connector {connector_id}: {exc}", exc_info=True)
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Unexpected error deleting connector {connector_id!r}: {exc}",
+        )
 
 
 async def _run_teardown(connector_id: str) -> None:
@@ -300,14 +315,14 @@ async def _run_teardown(connector_id: str) -> None:
       5. Delete the connector row (cascades to connector_sync_logs)
     """
     logger.info(f"Starting teardown for connector {connector_id!r}")
-    deletion_failed = False
+    deletion_errors: list[str] = []
     try:
         # Step 1: Remove the scheduled job so no new ticks fire after this point.
         try:
             import digitize.connectors.scheduler as _sched
             await _sched.remove_connector_job(connector_id)
         except Exception as sched_exc:
-            deletion_failed = True
+            deletion_errors.append(f"scheduler job removal failed: {sched_exc}")
             logger.warning(
                 f"Could not remove scheduler job for {connector_id!r}: {sched_exc}"
             )
@@ -319,9 +334,9 @@ async def _run_teardown(connector_id: str) -> None:
                 remaining, doc_id = db_ops.remove_connector_checksum_entry(connector_id, checksum)
                 if remaining == 0 and doc_id:
                     if not _best_effort_delete_document(doc_id):
-                        deletion_failed = True
+                        deletion_errors.append(f"document deletion failed for checksum {checksum!r}")
             except Exception as exc:
-                deletion_failed = True
+                deletion_errors.append(f"checksum removal failed for {checksum!r}: {exc}")
                 logger.error(
                     f"Error removing checksum {checksum!r} for connector "
                     f"{connector_id!r}: {exc}",
@@ -330,11 +345,12 @@ async def _run_teardown(connector_id: str) -> None:
 
         # Step 4: sweep any residual batch staging directories
         if not _sweep_staging_dir(connector_id, settings.digitize.staging_dir / "connectors"):
-            deletion_failed = True
+            deletion_errors.append("staging directory sweep failed")
 
-        if deletion_failed:
-            db_ops.set_connector_error(connector_id, "Teardown failed — skipping connector row deletion")
-            logger.warning(f"Skipping connector row deletion for {connector_id!r} due to teardown failures")
+        if deletion_errors:
+            error_msg = f"Failed to delete connector, error: {'; '.join(deletion_errors)}"
+            db_ops.set_connector_error(connector_id, error_msg)
+            logger.warning(f"Skipping connector row deletion for {connector_id!r} due to teardown failures: {error_msg}")
             return
 
         # Step 5: delete the connector row (cascades to connector_sync_logs)
@@ -351,7 +367,7 @@ async def _run_teardown(connector_id: str) -> None:
             f"Unexpected error during teardown for connector {connector_id!r}: {exc}",
             exc_info=True,
         )
-        db_ops.set_connector_error(connector_id, "Documents deletion failed")
+        db_ops.set_connector_error(connector_id, f"Unexpected error during teardown: {exc}")
 
 
 def _best_effort_delete_document(doc_id: str) -> bool:
@@ -450,13 +466,15 @@ async def list_connectors():
             for c in connectors
         ]
     except HTTPException as exc:
-        logger.error(
-            f"Failed to list connectors: HTTP {exc.status_code} - {exc.detail}"
-        )
-        raise
+        message = f"Failed to list connectors: {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(f"Unexpected error listing connectors: {exc}", exc_info=True)
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Unexpected error listing connectors: {exc}",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -504,13 +522,15 @@ async def get_connector(connector_id: str):
             total_files=connector.total_files,
         )
     except HTTPException as exc:
-        logger.error(
-            f"Failed to get connector {connector_id!r}: HTTP {exc.status_code} - {exc.detail}"
-        )
-        raise
+        message = f"Failed to get connector {connector_id!r}: {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(f"Unexpected error fetching connector {connector_id}: {exc}", exc_info=True)
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Unexpected error fetching connector {connector_id!r}: {exc}",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -631,13 +651,15 @@ async def trigger_sync(connector_id: str):
     except SyncLocked as exc:
         APIError.raise_error(ErrorCode.RESOURCE_LOCKED, str(exc))
     except HTTPException as exc:
-        logger.error(
-            f"Failed to trigger sync for connector {connector_id!r}: HTTP {exc.status_code} - {exc.detail}"
-        )
-        raise
+        message = f"Failed to trigger sync for connector {connector_id!r}: {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(f"Unexpected error triggering sync for {connector_id}: {exc}", exc_info=True)
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Unexpected error triggering sync for connector {connector_id!r}: {exc}",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -700,14 +722,15 @@ async def cancel_sync(connector_id: str, sync_seq: int):
         return Response(status_code=204)
 
     except HTTPException as exc:
-        logger.error(
-            f"Failed to cancel sync for connector {connector_id!r} (seq={sync_seq}): "
-            f"HTTP {exc.status_code} - {exc.detail}"
-        )
-        raise
+        message = f"Failed to cancel sync for connector {connector_id!r} (seq={sync_seq}): {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(f"Unexpected error cancelling sync for {connector_id}: {exc}", exc_info=True)
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Unexpected error cancelling sync for connector {connector_id!r} (seq={sync_seq}): {exc}",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -758,17 +781,18 @@ async def get_sync_history(
         return SyncLogResponse(total=total, limit=limit, offset=offset, items=items)
 
     except HTTPException as exc:
-        logger.error(
-            f"Failed to get sync history for connector {connector_id!r}: "
-            f"HTTP {exc.status_code} - {exc.detail}"
-        )
-        raise
+        message = f"Failed to get sync history for connector {connector_id!r}: {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(
             f"Unexpected error fetching sync log for {connector_id}: {exc}",
             exc_info=True,
         )
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Unexpected error fetching sync history for connector {connector_id!r}: {exc}",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -815,16 +839,17 @@ async def get_sync(connector_id: str, sync_seq: int):
         )
 
     except HTTPException as exc:
-        logger.error(
-            f"Failed to get sync {sync_seq} for connector {connector_id!r}: "
-            f"HTTP {exc.status_code} - {exc.detail}"
-        )
-        raise
+        message = f"Failed to get sync {sync_seq} for connector {connector_id!r}: {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(
             f"Unexpected error fetching sync {sync_seq} for {connector_id}: {exc}",
             exc_info=True,
         )
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Unexpected error fetching sync {sync_seq} for connector {connector_id!r}: {exc}",
+        )
 
 # Made with Bob

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -24,7 +24,6 @@ from sqlalchemy.exc import IntegrityError
 
 from common.misc_utils import cleanup_staging_directory, get_logger, get_utc_timestamp
 from common.error_utils import APIError, ErrorCode, http_error_responses
-from digitize.connectors.scanners.scanner_factory import build_scanner
 from digitize.connectors.models import (
     ConnectorCreateRequest,
     ConnectorDetailResponse,
@@ -36,7 +35,6 @@ from digitize.connectors.models import (
     ConnectorStatus,
     SyncLogStatus,
     SyncTriggerResponse,
-    ConnectorError,
 )
 from digitize.connectors.encryption import (
     encrypt_secrets,
@@ -48,58 +46,6 @@ from digitize.settings import settings
 
 router = APIRouter()
 logger = get_logger("connectors_router")
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-_CREDENTIAL_ERROR_MSG = ConnectorError.CREDENTIAL_ERROR_MSG  # canonical value lives in connectors.models
-
-
-async def _probe_connector_credentials(
-    connector_id: str,
-    connector_type: str,
-    encrypted_details: dict,
-    allowed_extensions: list,
-    current_error: Optional[str] = None,
-) -> None:
-    """
-    Attempt a real connection using the supplied (encrypted) credentials.
-
-    On failure: the connector's error field is set to a generic auth-failure message.
-
-    On success: if the connector previously had an auth-failure error (i.e. the error
-    was set by a prior probe), it is cleared so the connector no longer shows a stale
-    credential warning.  Unrelated errors (e.g. sync errors) are left untouched.
-    """
-    class _Row:
-        """Minimal duck-type accepted by build_scanner."""
-        def __init__(self, ctype: str, details: dict, extensions: list) -> None:
-            self.type = ctype
-            self.connection_details = details
-            self.allowed_extensions = extensions
-
-    scanner = build_scanner(_Row(connector_type, encrypted_details, allowed_extensions))
-    loop = asyncio.get_event_loop()
-    try:
-        await loop.run_in_executor(None, scanner.connect)
-        await loop.run_in_executor(None, scanner.close)
-        logger.info(f"Credential probe succeeded for connector {connector_id!r}")
-        # Clear the error only if it was previously set by a credential probe —
-        # leave any sync-related error intact.
-        if current_error == _CREDENTIAL_ERROR_MSG:
-            db_ops.set_connector_error(connector_id, None)
-    except Exception as exc:
-        logger.error(
-            f"Credential probe failed for connector {connector_id!r}: {exc}",
-            exc_info=True,
-        )
-        db_ops.set_connector_error(connector_id, _CREDENTIAL_ERROR_MSG)
-        try:
-            await loop.run_in_executor(None, scanner.close)
-        except Exception:
-            pass
-
 
 # ---------------------------------------------------------------------------
 # POST /v1/connectors
@@ -157,15 +103,6 @@ async def create_connector(body: ConnectorCreateRequest):
             connection_details=encrypted_details,
             allowed_extensions=body.allowed_extensions,
             sync_interval_seconds=sync_interval,
-        )
-
-        asyncio.create_task(
-            _probe_connector_credentials(
-                connector_id,
-                body.type,
-                encrypted_details,
-                body.allowed_extensions,
-            )
         )
 
         logger.info(
@@ -261,17 +198,9 @@ async def update_connector(connector_id: str, body: ConnectorUpdateRequest):
         )
 
         if merged_details is not None:
-            # Connection details changed — probe the new credentials.
-            probe_extensions = body.allowed_extensions or existing.allowed_extensions or []
-            asyncio.create_task(
-                _probe_connector_credentials(
-                    connector_id,
-                    existing.type,
-                    merged_details,
-                    probe_extensions,
-                    current_error=existing.error,
-                )
-            )
+            # Connection details changed — trigger a sync immediately so run_tick
+            # validates the new credentials and updates the connector/sync-log status.
+            asyncio.create_task(dispatch_sync(connector_id))
 
         logger.info(f"Connector {connector_id!r} updated")
         return Response(status_code=200)

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -24,6 +24,7 @@ from sqlalchemy.exc import IntegrityError
 
 from common.misc_utils import cleanup_staging_directory, get_logger, get_utc_timestamp
 from common.error_utils import APIError, ErrorCode, http_error_responses
+from digitize.connectors.scanners.scanner_factory import build_scanner
 from digitize.connectors.models import (
     ConnectorCreateRequest,
     ConnectorDetailResponse,
@@ -53,10 +54,56 @@ logger = get_logger("connectors_router")
 
 _KEY_PATH = None  # resolved lazily via _get_key_path()
 
+_CREDENTIAL_ERROR_MSG = "Authentication failed: unable to connect with the provided credentials"
+
 
 def _get_key_path() -> str:
     """Return the encryption key path from settings."""
     return settings.digitize.connector.encryption_key_path
+
+
+async def _probe_connector_credentials(
+    connector_id: str,
+    connector_type: str,
+    encrypted_details: dict,
+    allowed_extensions: list,
+    current_error: Optional[str] = None,
+) -> None:
+    """
+    Attempt a real connection using the supplied (encrypted) credentials.
+
+    On failure: the connector's error field is set to a generic auth-failure message.
+
+    On success: if the connector previously had an auth-failure error (i.e. the error
+    was set by a prior probe), it is cleared so the connector no longer shows a stale
+    credential warning.  Unrelated errors (e.g. sync errors) are left untouched.
+    """
+    class _Row:
+        """Minimal duck-type accepted by build_scanner."""
+        def __init__(self, ctype: str, details: dict, extensions: list) -> None:
+            self.type = ctype
+            self.connection_details = details
+            self.allowed_extensions = extensions
+
+    scanner = build_scanner(_Row(connector_type, encrypted_details, allowed_extensions))
+    loop = asyncio.get_event_loop()
+    try:
+        await loop.run_in_executor(None, scanner.connect)
+        await loop.run_in_executor(None, scanner.close)
+        logger.info(f"Credential probe succeeded for connector {connector_id!r}")
+        # Clear the error only if it was previously set by a credential probe —
+        # leave any sync-related error intact.
+        if current_error == _CREDENTIAL_ERROR_MSG:
+            db_ops.set_connector_error(connector_id, None)
+    except Exception as exc:
+        logger.warning(
+            f"Credential probe failed for connector {connector_id!r}: {exc}"
+        )
+        db_ops.set_connector_error(connector_id, _CREDENTIAL_ERROR_MSG)
+        try:
+            await loop.run_in_executor(None, scanner.close)
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +159,15 @@ async def create_connector(body: ConnectorCreateRequest):
             connection_details=encrypted_details,
             allowed_extensions=body.allowed_extensions,
             sync_interval_seconds=sync_interval,
+        )
+
+        asyncio.create_task(
+            _probe_connector_credentials(
+                connector_id,
+                body.type,
+                encrypted_details,
+                body.allowed_extensions,
+            )
         )
 
         logger.info(
@@ -205,6 +261,19 @@ async def update_connector(connector_id: str, body: ConnectorUpdateRequest):
             connection_details=merged_details,
             allowed_extensions=body.allowed_extensions,
         )
+
+        if merged_details is not None:
+            # Connection details changed — probe the new credentials.
+            probe_extensions = body.allowed_extensions or existing.allowed_extensions or []
+            asyncio.create_task(
+                _probe_connector_credentials(
+                    connector_id,
+                    existing.type,
+                    merged_details,
+                    probe_extensions,
+                    current_error=existing.error,
+                )
+            )
 
         logger.info(f"Connector {connector_id!r} updated")
         return Response(status_code=200)

--- a/services/digitize/api/v1/documents.py
+++ b/services/digitize/api/v1/documents.py
@@ -16,7 +16,7 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Query, status
 
 from common.misc_utils import get_logger
-from common.error_utils import APIError, ErrorCode, http_error_responses
+from common.error_utils import APIError, ErrorCode, http_error_responses, extract_http_error_message, build_http_error_detail
 import digitize.utils.jobs as dg_util
 import digitize.models as models
 from digitize.pipeline.cleanup import reset_db
@@ -127,11 +127,15 @@ async def list_documents(
         )
 
     except HTTPException as exc:
-        logger.error(f"Failed to list documents, HTTP error: {exc}")
-        raise
+        message = f"Failed to list documents: {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(f"Unexpected error in list_documents: {exc}", exc_info=True)
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Unexpected error listing documents: {exc}",
+        )
 
 
 @router.get(
@@ -164,13 +168,18 @@ async def get_document_metadata(
 
         return get_document(doc_id, include_details=details)
     except FileNotFoundError as exc:
+        logger.warning(f"Document '{doc_id}' not found: {exc}")
         APIError.raise_error(ErrorCode.RESOURCE_NOT_FOUND, str(exc))
     except HTTPException as exc:
-        logger.error(f"Failed to get document {doc_id}, HTTP error: {exc}")
-        raise
+        message = f"Failed to get document '{doc_id}': {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(f"Unexpected error in get_document_metadata: {exc}", exc_info=True)
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Unexpected error fetching metadata for document '{doc_id}': {exc}",
+        )
 
 
 @router.get(
@@ -190,16 +199,24 @@ async def get_document_content(doc_id: str):
     try:
         return dg_util.get_document_content(doc_id)
     except FileNotFoundError as exc:
+        logger.warning(f"Content file for document '{doc_id}' not found: {exc}")
         APIError.raise_error(ErrorCode.RESOURCE_NOT_FOUND, str(exc))
     except json.JSONDecodeError as exc:
-        logger.error(f"Failed to parse content file for document {doc_id}: {exc}")
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, "Failed to read document content")
+        logger.error(f"Failed to parse content file for document '{doc_id}': {exc}")
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Failed to parse content file for document '{doc_id}': {exc}",
+        )
     except HTTPException as exc:
-        logger.error(f"Failed to get document content for {doc_id}, HTTP error: {exc}")
-        raise
+        message = f"Failed to get content for document '{doc_id}': {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(f"Unexpected error in get_document_content: {exc}", exc_info=True)
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Unexpected error fetching content for document '{doc_id}': {exc}",
+        )
 
 
 @router.delete(
@@ -241,8 +258,8 @@ async def delete_document(doc_id: str):
         doc_metadata = None
         try:
             doc_metadata = dg_util.get_document(doc_id, include_details=False)
-        except FileNotFoundError:
-            logger.error(f"Metadata for {doc_id} not found. Proceeding with VDB cleanup.")
+        except FileNotFoundError as exc:
+            logger.warning(f"Metadata for document '{doc_id}' not found, proceeding with VDB cleanup: {exc}")
 
         # 3. Active-job guard.
         if doc_metadata:
@@ -257,16 +274,23 @@ async def delete_document(doc_id: str):
             delete_document_data(doc_id)
         except Exception as exc:
             logger.error(f"Document teardown failed for {doc_id}: {exc}")
-            APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+            APIError.raise_error(
+                ErrorCode.INTERNAL_SERVER_ERROR,
+                f"Document teardown failed for '{doc_id}': {exc}",
+            )
 
         return None
 
     except HTTPException as exc:
-        logger.error(f"Failed to delete document {doc_id}, HTTP error: {exc}")
-        raise
+        message = f"Failed to delete document '{doc_id}': {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(f"Unexpected error deleting document {doc_id}: {exc}", exc_info=True)
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Unexpected error deleting document '{doc_id}': {exc}",
+        )
 
 
 @router.delete(
@@ -315,8 +339,12 @@ async def bulk_delete_documents(
         return None
 
     except HTTPException as exc:
-        logger.error(f"Failed to bulk delete documents, HTTP error: {exc}")
-        raise
+        message = f"Failed to bulk delete documents: {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(f"Unexpected error during bulk deletion: {exc}", exc_info=True)
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, str(exc))
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Unexpected error during bulk document deletion: {exc}",
+        )

--- a/services/digitize/api/v1/jobs.py
+++ b/services/digitize/api/v1/jobs.py
@@ -15,7 +15,7 @@ from typing import List, Optional
 from fastapi import APIRouter, File, HTTPException, Query, UploadFile, status
 
 from common.misc_utils import get_logger, validate_document_file, cleanup_staging_directory, generate_file_checksum
-from common.error_utils import APIError, ErrorCode, http_error_responses
+from common.error_utils import APIError, ErrorCode, http_error_responses, extract_http_error_message, build_http_error_detail
 import digitize.utils.jobs as dg_util
 import digitize.models as models
 from digitize.utils.db import get_status_manager
@@ -49,7 +49,7 @@ async def _run_digitize(
         await asyncio.to_thread(digitize, job_staging_path, job_id, doc_id_dict, output_format, file_checksum_dict)
         logger.info(f"Digitization for job {job_id} completed successfully")
     except Exception as exc:
-        logger.error(f"Error in digitization job {job_id}: {exc}")
+        logger.error(f"Error in digitization job {job_id}: {exc}", exc_info=True)
         status_mgr.update_job_progress(
             "",
             models.DocStatus.FAILED,
@@ -77,7 +77,7 @@ async def _run_ingest(
         await asyncio.to_thread(ingest, job_staging_path, job_id, doc_id_dict, file_checksum_dict)
         logger.info(f"Ingestion for job {job_id} completed successfully")
     except Exception as exc:
-        logger.error(f"Error in ingestion job {job_id}: {exc}")
+        logger.error(f"Error in ingestion job {job_id}: {exc}", exc_info=True)
         status_mgr.update_job_progress(
             "",
             models.DocStatus.FAILED,
@@ -310,20 +310,20 @@ async def create_job(
             concurrency_manager.release(op_key)
             logger.error(
                 f"Failed to dispatch task for job {job_id}, "
-                f"semaphore released: {exc}"
+                f"semaphore released: {exc}",
+                exc_info=True,
             )
-            APIError.raise_error("INTERNAL_SERVER_ERROR", str(exc))
+            APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, f"Failed to dispatch job '{job_id}': {exc}")
 
         return {"job_id": job_id}
 
     except HTTPException as exc:
-        logger.error(
-            f"Failed to create job: HTTP {exc.status_code} - {exc.detail}"
-        )
-        raise
+        message = f"Failed to create job: {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
-        logger.error(f"Unexpected error in create_job: {exc}")
-        APIError.raise_error("INTERNAL_SERVER_ERROR", str(exc))
+        logger.error(f"Unexpected error in create_job: {exc}", exc_info=True)
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, f"Unexpected error creating job: {exc}")
 
 
 @router.get(
@@ -361,11 +361,12 @@ async def list_jobs(
             data=jobs_data,
         )
     except HTTPException as exc:
-        logger.error(f"Server error in list_jobs: {exc.status_code} - {exc.detail}")
-        raise
+        message = f"Failed to list jobs: {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(f"Failed to retrieve jobs: {exc}", exc_info=True)
-        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, "Failed to retrieve jobs")
+        APIError.raise_error(ErrorCode.INTERNAL_SERVER_ERROR, f"Failed to retrieve jobs: {exc}")
 
 
 @router.get(
@@ -391,11 +392,9 @@ async def get_job(job_id: str):
 
         return job_data
     except HTTPException as exc:
-        logger.error(
-            f"HTTP error retrieving job {job_id}: "
-            f"status={exc.status_code}, detail={exc.detail}"
-        )
-        raise
+        message = f"Failed to get job '{job_id}': {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(f"Failed to retrieve job {job_id}: {exc}", exc_info=True)
         APIError.raise_error(
@@ -446,11 +445,9 @@ async def delete_job(job_id: str):
         return
 
     except HTTPException as exc:
-        logger.error(
-            f"HTTP error deleting job {job_id}: "
-            f"status={exc.status_code}, detail={exc.detail}"
-        )
-        raise
+        message = f"Failed to delete job '{job_id}': {extract_http_error_message(exc)}"
+        logger.error(message)
+        raise HTTPException(status_code=exc.status_code, detail=build_http_error_detail(exc, message))
     except Exception as exc:
         logger.error(f"Failed to delete job {job_id}: {exc}", exc_info=True)
         APIError.raise_error(

--- a/services/digitize/api/v1/jobs.py
+++ b/services/digitize/api/v1/jobs.py
@@ -316,7 +316,10 @@ async def create_job(
 
         return {"job_id": job_id}
 
-    except HTTPException:
+    except HTTPException as exc:
+        logger.error(
+            f"Failed to create job: HTTP {exc.status_code} - {exc.detail}"
+        )
         raise
     except Exception as exc:
         logger.error(f"Unexpected error in create_job: {exc}")

--- a/services/digitize/connectors/encryption.py
+++ b/services/digitize/connectors/encryption.py
@@ -102,7 +102,10 @@ def decrypt_secrets(
             try:
                 result[field] = _decrypt_value(cipher, result[field])
             except Exception as exc:
-                logger.error(f"Failed to decrypt field {field!r}: {exc}")
+                logger.error(
+                    f"Failed to decrypt field {field!r} for connector type {connector_type!r}: {exc}",
+                    exc_info=True,
+                )
                 raise
     return result
 

--- a/services/digitize/connectors/encryption.py
+++ b/services/digitize/connectors/encryption.py
@@ -2,10 +2,10 @@
 Connector credential encryption/decryption.
 
 Secret fields are encrypted at rest using AES-256-GCM with a key loaded from
-the path configured in settings (default: /run/secrets/connector_encryption_key).
+the DB_ENCRYPTION_KEY environment variable (32 raw bytes, base64-encoded or
+as a plain 32-character ASCII string).
 
-The key file must contain exactly 32 raw bytes (256 bits).
-When the key file is absent (e.g. in tests), operations raise RuntimeError.
+When the variable is absent (e.g. in tests), operations raise RuntimeError.
 
 Ciphertext wire format (stored as base64):
     base64( nonce[12] || tag[16] || ciphertext )
@@ -14,7 +14,6 @@ Ciphertext wire format (stored as base64):
 import base64
 import os
 from functools import lru_cache
-from pathlib import Path
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
@@ -33,25 +32,24 @@ _NONCE_SIZE = 12  # 96-bit nonce recommended for GCM
 
 
 @lru_cache(maxsize=1)
-def _load_key(key_path: str) -> AESGCM:
-    """Load and cache the AES-256-GCM cipher from the key file."""
-    path = Path(key_path)
-    if not path.exists():
+def _load_key() -> AESGCM:
+    """Load and cache the AES-256-GCM cipher from the DB_ENCRYPTION_KEY env var."""
+    raw = os.environ.get("DB_ENCRYPTION_KEY", "")
+    if not raw:
         raise RuntimeError(
-            f"Connector encryption key not found at {key_path}. "
-            "Ensure the secret is mounted before starting the service."
+            "Connector encryption key not found. "
+            "Ensure the DB_ENCRYPTION_KEY environment variable is set before starting the service."
         )
-    raw = path.read_bytes().strip()
-    if len(raw) != 32:
+    key_bytes = raw.encode()
+    if len(key_bytes) != 32:
         raise RuntimeError(
-            f"Connector encryption key at {key_path} must be exactly 32 bytes "
-            f"(AES-256); got {len(raw)} bytes."
+            f"DB_ENCRYPTION_KEY must be exactly 32 bytes (AES-256); got {len(key_bytes)} bytes."
         )
-    return AESGCM(raw)
+    return AESGCM(key_bytes)
 
 
-def _get_cipher(key_path: str) -> AESGCM:
-    return _load_key(key_path)
+def _get_cipher() -> AESGCM:
+    return _load_key()
 
 
 def _encrypt_value(cipher: AESGCM, plaintext: str) -> str:
@@ -73,7 +71,6 @@ def _decrypt_value(cipher: AESGCM, token: str) -> str:
 def encrypt_secrets(
     connector_type: str,
     connection_details: dict,
-    key_path: str,
 ) -> dict:
     """
     Return a copy of *connection_details* with secret fields encrypted.
@@ -81,7 +78,7 @@ def encrypt_secrets(
     Only the fields listed in _SECRET_FIELDS for the given connector type
     are touched; all other fields are passed through unchanged.
     """
-    cipher = _get_cipher(key_path)
+    cipher = _get_cipher()
     secret_fields = _SECRET_FIELDS.get(connector_type, set())
     result = dict(connection_details)
     for field in secret_fields:
@@ -93,12 +90,11 @@ def encrypt_secrets(
 def decrypt_secrets(
     connector_type: str,
     connection_details: dict,
-    key_path: str,
 ) -> dict:
     """
     Return a copy of *connection_details* with secret fields decrypted.
     """
-    cipher = _get_cipher(key_path)
+    cipher = _get_cipher()
     secret_fields = _SECRET_FIELDS.get(connector_type, set())
     result = dict(connection_details)
     for field in secret_fields:
@@ -126,7 +122,6 @@ def merge_and_encrypt_partial(
     connector_type: str,
     existing_encrypted: dict,
     partial_update: dict,
-    key_path: str,
 ) -> dict:
     """
     Merge *partial_update* into *existing_encrypted* at the key level,
@@ -137,7 +132,7 @@ def merge_and_encrypt_partial(
 
     Returns the merged dict (all secret fields encrypted).
     """
-    cipher = _get_cipher(key_path)
+    cipher = _get_cipher()
     secret_fields = _SECRET_FIELDS.get(connector_type, set())
     result = dict(existing_encrypted)
     for key, value in partial_update.items():

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -90,27 +90,27 @@ class ConnectorError(str, Enum):
 class ConnectorCreateRequest(BaseModel):
     """Body accepted by POST /v1/connectors."""
 
-    connector_id: Optional[str] = Field(
+    id: Optional[str] = Field(
         None,
         description=(
             "Stable catalog UUID for this connector. "
             "If omitted, a UUID v4 is generated automatically."
         ),
     )
-    connector_name: str = Field(..., description="Human-readable unique name, e.g. 'prod-sftp-reports'")
+    name: str = Field(..., description="Human-readable unique name, e.g. 'prod-sftp-reports'")
     type: str = Field(..., description="Connector transport type: 'ssh' or 's3'")
     allowed_extensions: List[str] = Field(..., description="File extensions to accept, e.g. ['.pdf', '.docx']")
     connection_details: Dict[str, Any] = Field(..., description="Transport-specific connection parameters")
 
-    @field_validator("connector_id", mode="before")
+    @field_validator("id", mode="before")
     @classmethod
-    def validate_connector_id(cls, v: Optional[str]) -> Optional[str]:
+    def validate_id(cls, v: Optional[str]) -> Optional[str]:
         if v is None:
             return v
         try:
             uuid.UUID(str(v))
         except ValueError:
-            raise ValueError(f"connector_id must be a valid UUID, got {v!r}")
+            raise ValueError(f"id must be a valid UUID, got {v!r}")
         return str(v)
 
 
@@ -122,7 +122,7 @@ class ConnectorUpdateRequest(BaseModel):
     type and sync_interval_seconds cannot be changed via this endpoint.
     """
 
-    connector_name: Optional[str] = Field(None, description="New human-readable name (must be unique)")
+    name: Optional[str] = Field(None, description="New human-readable name (must be unique)")
     allowed_extensions: Optional[List[str]] = Field(None, description="Replacement allowed-extensions list")
     connection_details: Optional[Dict[str, Any]] = Field(
         None,
@@ -137,8 +137,8 @@ class ConnectorUpdateRequest(BaseModel):
 class ConnectorListItem(BaseModel):
     """One connector in GET /v1/connectors list."""
 
-    connector_id: str
-    connector_name: str
+    id: str
+    name: str
     type: str
     attached_at: Optional[str]
     last_sync_at: Optional[str]
@@ -150,8 +150,8 @@ class ConnectorListItem(BaseModel):
 class ConnectorDetailResponse(BaseModel):
     """Single connector returned by GET /v1/connectors/{connector_id}."""
 
-    connector_id: str
-    connector_name: str
+    id: str
+    name: str
     type: str
     allowed_extensions: List[str]
     sync_interval_seconds: int

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -126,7 +126,6 @@ class ConnectorListItem(BaseModel):
     attached_at: Optional[str]
     last_sync_at: Optional[str]
     sync_status: str
-    last_sync_error: Optional[str]
     error: Optional[str]
     total_files: int
 
@@ -142,7 +141,6 @@ class ConnectorDetailResponse(BaseModel):
     attached_at: Optional[str]
     last_sync_at: Optional[str]
     sync_status: str
-    last_sync_error: Optional[str]
     error: Optional[str]
     connection_details: Dict[str, Any]
     total_files: int

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -77,10 +77,10 @@ class ConnectorError(str, Enum):
     """
 
     CREDENTIAL_ERROR_MSG = "Authentication failed: unable to connect with the provided credentials"
-    """Sentinel written by _probe_connector_credentials on auth failure.
+    """Written by run_tick when scanner.connect() raises a ConnectionError.
 
-    Only cleared when a subsequent successful probe shows the credentials are valid.
-    Sync-tick failures must never overwrite this message so the root cause stays visible.
+    Cleared automatically when a subsequent sync tick connects successfully
+    (finalize_sync_log_and_update_connector with COMPLETED status sets error=None).
     """
 
 # ---------------------------------------------------------------------------

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -67,6 +67,23 @@ class SyncLogStatus(str, Enum):
 
 
 # ---------------------------------------------------------------------------
+# Error message constants
+# ---------------------------------------------------------------------------
+
+class ConnectorError(str, Enum):
+    """String enum of well-known error messages stored on the Connector row.
+
+    Inherits from str so values can be compared directly against DB strings.
+    """
+
+    CREDENTIAL_ERROR_MSG = "Authentication failed: unable to connect with the provided credentials"
+    """Sentinel written by _probe_connector_credentials on auth failure.
+
+    Only cleared when a subsequent successful probe shows the credentials are valid.
+    Sync-tick failures must never overwrite this message so the root cause stays visible.
+    """
+
+# ---------------------------------------------------------------------------
 # Request models
 # ---------------------------------------------------------------------------
 

--- a/services/digitize/connectors/scanners/scanner_factory.py
+++ b/services/digitize/connectors/scanners/scanner_factory.py
@@ -30,8 +30,6 @@ from digitize.connectors.scanners.base_scanner import BaseScanner
 from digitize.connectors.scanners.config import S3ConnectorConfig, SSHConnectorConfig
 from digitize.connectors.scanners.s3_scanner import S3Scanner
 from digitize.connectors.scanners.ssh_scanner import SSHScanner
-from digitize.settings import settings
-
 logger = get_logger("scanner_factory")
 
 # ---------------------------------------------------------------------------
@@ -78,8 +76,7 @@ def build_scanner(connector_row: Any) -> BaseScanner:
         connection_details = connector_row.connection_details or {}
         allowed_extensions = connector_row.allowed_extensions or [".pdf", ".docx"]
 
-    key_path = settings.digitize.connector.encryption_key_path
-    connection_details = decrypt_secrets(connector_type, connection_details, key_path)
+    connection_details = decrypt_secrets(connector_type, connection_details)
 
     if connector_type not in _REGISTRY:
         supported = sorted(_REGISTRY.keys())

--- a/services/digitize/connectors/scheduler.py
+++ b/services/digitize/connectors/scheduler.py
@@ -105,7 +105,7 @@ async def remove_connector_job(connector_id: str) -> None:
         logger.info(f"Removed scheduler job for connector {connector_id!r}")
     except Exception as exc:
         # LookupError or similar if the schedule doesn't exist — safe to ignore.
-        logger.debug(
+        logger.warning(
             f"Could not remove scheduler job for {connector_id!r} "
             f"(may not have been registered): {exc}"
         )

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -56,7 +56,7 @@ from digitize.utils.db import (
     update_connector_total_files,
     update_sync_log,
 )
-from digitize.utils.jobs import generate_uuid, initialize_job_state
+from digitize.utils.jobs import generate_uuid, get_job_document_stats, initialize_job_state
 
 logger = get_logger("sync_tick")
 
@@ -305,8 +305,8 @@ async def _process_new_files(
         batch_dir = staging_base / batch_dir_name
         batch_dir.mkdir(parents=True, exist_ok=True)
 
-        # checksum → filename for post-ingest checksum registration
-        checksum_to_filename: dict[str, str] = {}
+        # filename → checksum, built during download phase
+        filename_to_checksum: dict[str, str] = {}
 
         try:
             for remote_path, checksum in batch:
@@ -320,7 +320,7 @@ async def _process_new_files(
                         f"{connector_id!r}; skipping file"
                     )
                     continue
-                checksum_to_filename[checksum] = filename
+                filename_to_checksum[filename] = checksum
 
             # Cancellation checkpoint: bail after each batch of downloads.
             interrupt = _check_interrupt_call(connector_id, sync_seq)
@@ -329,7 +329,7 @@ async def _process_new_files(
                     f"Connector {connector_id!r} interrupted (type={interrupt.value})"
                 )
 
-            filenames = list(checksum_to_filename.values())
+            filenames = list(filename_to_checksum.keys())
             job_name = f"Connector-{connector_name}-{sync_seq}-{batch_number}"
             doc_id_dict = initialize_job_state(
                 job_id=job_id,
@@ -339,12 +339,30 @@ async def _process_new_files(
                 job_name=job_name,
             )
 
-            for checksum, filename in checksum_to_filename.items():
-                add_connector_checksum_entry(connector_id, checksum, doc_id_dict[filename])
+            # doc_id → checksum: built from doc_id_dict (filename→doc_id) + filename_to_checksum
+            doc_id_to_checksum: dict[str, str] = {
+                doc_id: filename_to_checksum[filename]
+                for filename, doc_id in doc_id_dict.items()
+                if filename in filename_to_checksum
+            }
 
             await asyncio.to_thread(ingest, batch_dir, job_id, doc_id_dict)
 
             await _wait_for_job(job_id, connector_id, sync_seq)
+
+            job_stats = get_job_document_stats(job_id)
+            for doc in job_stats["completed_docs"]:
+                checksum = doc_id_to_checksum.get(doc["id"])
+                if checksum is not None:
+                    add_connector_checksum_entry(connector_id, checksum, doc["id"])
+
+            if job_stats["failed_count"] > 0:
+                logger.warning(
+                    f"Batch {batch_number} for connector {connector_id!r}: "
+                    f"{job_stats['failed_count']} of {job_stats['total_docs']} "
+                    f"document(s) failed ingestion"
+                )
+                batch_failed = True
 
         except asyncio.CancelledError:
             raise

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -41,7 +41,7 @@ from common.misc_utils import cleanup_staging_directory, get_logger
 from digitize.connectors.scanners.scanner_factory import build_scanner
 from digitize.pipeline.ingest import ingest
 from digitize.settings import settings
-from digitize.connectors.models import ConnectorStatus, SyncLogStatus
+from digitize.connectors.models import ConnectorError, ConnectorStatus, SyncLogStatus
 from digitize.models import JobStatus, OutputFormat, OperationType
 from digitize.utils.db import (
     add_connector_checksum_entry,
@@ -137,7 +137,15 @@ async def run_tick(connector_id: str, sync_seq: int) -> None:
                 f"Connector {connector_id!r} interrupted (type={interrupt.value})"
             )
 
-        await asyncio.to_thread(scanner.connect)
+        try:
+            await asyncio.to_thread(scanner.connect)
+        except ConnectionError as conn_exc:
+            logger.error(
+                f"Connector {connector_id!r} failed to connect — treating as credential error: {conn_exc}"
+            )
+            _fail_tick(sync_seq, connector_id, conn_exc, error_msg=ConnectorError.CREDENTIAL_ERROR_MSG)
+            return
+
         scanned_files: list[tuple[str, str]] = await asyncio.to_thread(scanner.scan)
 
         known_checksums: set[str] = set(list_connector_checksums(connector_id))
@@ -450,13 +458,13 @@ def _cancel_tick(sync_seq: int, connector_id: str) -> None:
         )
 
 
-def _fail_tick(sync_seq: int, connector_id: str, exc: Exception) -> None:
+def _fail_tick(sync_seq: int, connector_id: str, exc: Exception, error_msg: Optional[str] = None) -> None:
     try:
         finalize_sync_log_and_update_connector(
             connector_id=connector_id,
             seq=sync_seq,
             status=SyncLogStatus.FAILED,
-            error=str(exc),
+            error=error_msg if error_msg is not None else str(exc),
         )
     except Exception as close_exc:
         logger.error(

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -376,6 +376,7 @@ async def _delete_orphans(connector_id: str, orphan_checksums: set[str]) -> None
     from digitize.api.v1.connectors import _best_effort_delete_document
 
     for checksum in orphan_checksums:
+        doc_id: str | None = None
         try:
             remaining, doc_id = remove_connector_checksum_entry(connector_id, checksum)
             if remaining == 0 and doc_id:
@@ -383,7 +384,8 @@ async def _delete_orphans(connector_id: str, orphan_checksums: set[str]) -> None
         except Exception as exc:
             logger.error(
                 f"Error removing orphan checksum {checksum!r} "
-                f"for connector {connector_id!r}: {exc}",
+                f"for connector {connector_id!r} "
+                f"(doc_id={doc_id!r}): {exc}",
                 exc_info=True,
             )
             raise

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -124,6 +124,7 @@ async def run_tick(connector_id: str, sync_seq: int) -> None:
     config = get_active_connector(connector_id)
     if config is None:
         logger.error(f"Connector {connector_id!r} not found; tick aborted")
+        _fail_tick(sync_seq, connector_id, RuntimeError(f"Connector {connector_id!r} not found"))
         return
 
     scanner = build_scanner(config)
@@ -174,7 +175,12 @@ async def run_tick(connector_id: str, sync_seq: int) -> None:
         _fail_tick(sync_seq, connector_id, exc)
 
     finally:
-        await asyncio.to_thread(scanner.close)
+        try:
+            await asyncio.to_thread(scanner.close)
+        except Exception as close_exc:
+            logger.warning(
+                f"scanner.close() failed for connector {connector_id!r}: {close_exc}"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -337,7 +343,7 @@ async def _process_new_files(
             raise
 
         except Exception as exc:
-            logger.warning(
+            logger.error(
                 f"Failed to ingest batch {batch_number} for connector {connector_id!r}: {exc}",
                 exc_info=True,
             )

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -53,7 +53,6 @@ from digitize.utils.db import (
     list_all_checksums,
     list_connector_checksums,
     lookup_connector_content_by_checksum,
-    remove_connector_checksum_entry,
     update_connector_total_files,
     update_sync_log,
 )
@@ -373,22 +372,19 @@ async def _process_new_files(
 
 async def _delete_orphans(connector_id: str, orphan_checksums: set[str]) -> None:
     """Remove orphaned checksum rows and delete documents that lose their last owner."""
-    from digitize.api.v1.connectors import _best_effort_delete_document
+    from digitize.api.v1.connectors import _remove_checksums
 
-    for checksum in orphan_checksums:
-        doc_id: str | None = None
-        try:
-            remaining, doc_id = remove_connector_checksum_entry(connector_id, checksum)
-            if remaining == 0 and doc_id:
-                await asyncio.to_thread(_best_effort_delete_document, doc_id)
-        except Exception as exc:
-            logger.error(
-                f"Error removing orphan checksum {checksum!r} "
-                f"for connector {connector_id!r} "
-                f"(doc_id={doc_id!r}): {exc}",
-                exc_info=True,
-            )
-            raise
+    checksum_removal_failures, doc_deletion_failures = await asyncio.to_thread(
+        _remove_checksums, connector_id, orphan_checksums
+    )
+    if checksum_removal_failures:
+        raise RuntimeError(
+            f"checksum removal failed for {len(checksum_removal_failures)} checksum(s)"
+        )
+    if doc_deletion_failures:
+        raise RuntimeError(
+            f"document deletion failed for {len(doc_deletion_failures)} checksum(s)"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -362,8 +362,8 @@ async def _process_new_files(
 
     if batch_failed:
         raise RuntimeError(
-            f"One or more batches failed to ingest for connector {connector_id!r}; "
-            "connector marked as out of sync"
+            f"One or more documents failed to sync. See more details in digitize jobs "
+            f"Connector-{connector_name}-{sync_seq}-*"
         )
 
 

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -19,6 +19,9 @@ from digitize.connectors.models import ConnectorStatus, SyncLogStatus
 
 logger = get_logger("db_repository")
 
+# Sentinel used by update_connector to distinguish "not supplied" from explicit None.
+_UNSET: object = object()
+
 
 class DatabaseManager:
     """Manager for database operations with error handling and logging."""
@@ -790,13 +793,14 @@ class DatabaseManager:
         connection_details: Optional[dict] = None,
         allowed_extensions: Optional[list] = None,
         total_files: Optional[int] = None,
-        error: Optional[str] = None,
+        error: "Optional[str]" = _UNSET,  # type: ignore[assignment]
     ) -> None:
         """
         Partial update of an existing connector.
 
-        Only non-None kwargs are written; connection_details is merged at the
-        key level using the PostgreSQL ``||`` JSONB concatenation operator.
+        Only non-``_UNSET`` kwargs are written; connection_details is merged at
+        the key level using the PostgreSQL ``||`` JSONB concatenation operator.
+        Pass ``error=None`` explicitly to clear a previously set error to NULL.
 
         Raises FileNotFoundError if no connector with the given id exists.
         """
@@ -809,7 +813,7 @@ class DatabaseManager:
                     values["allowed_extensions"] = allowed_extensions
                 if total_files is not None:
                     values["total_files"] = total_files
-                if error is not None:
+                if error is not _UNSET:
                     values["error"] = error
                 if connection_details is not None:
                     stmt = (

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -856,7 +856,7 @@ class DatabaseManager:
                     connector.connection_details, connector.allowed_extensions,
                     connector.sync_interval_seconds, connector.attached_at,
                     connector.last_sync_at, connector.sync_status,
-                    connector.last_sync_error, connector.total_files,
+                    connector.error, connector.total_files,
                 )
                 session.expunge(connector)
                 return connector
@@ -903,7 +903,7 @@ class DatabaseManager:
                         c.id, c.name, c.type, c.connection_details,
                         c.allowed_extensions, c.sync_interval_seconds,
                         c.attached_at, c.last_sync_at, c.sync_status,
-                        c.last_sync_error, c.total_files,
+                        c.error, c.total_files,
                     )
                     session.expunge(c)
                 logger.debug(f"Listed {len(connectors)} connector(s)")
@@ -1267,12 +1267,16 @@ class DatabaseManager:
         connector_id: str,
         status: str,
         last_sync_at: Optional[datetime] = None,
+        error: Optional[str] = None,
     ) -> None:
         """
-        Update last_sync_at and sync_status on the connector row after a sync run.
+        Update last_sync_at, sync_status, and error on the connector row after a sync run.
 
         CANCELLED/FAILED both map to OUT_OF_SYNC so the scheduler can retry;
         any other status (e.g. COMPLETED) is written through verbatim.
+
+        ``error`` is written when provided (failure/cancel paths); it is cleared
+        to NULL on a successful completion so a past error does not persist.
         """
         try:
             with get_db_session() as session:
@@ -1281,13 +1285,18 @@ class DatabaseManager:
                     if status in (SyncLogStatus.CANCELLED, SyncLogStatus.FAILED)
                     else status
                 )
+                values: Dict[str, Any] = {
+                    "last_sync_at": last_sync_at or datetime.now(timezone.utc),
+                    "sync_status": connector_sync_status,
+                }
+                if status == SyncLogStatus.COMPLETED:
+                    values["error"] = None
+                elif error is not None:
+                    values["error"] = error
                 session.execute(
                     update(Connector)
                     .where(Connector.id == connector_id)
-                    .values(
-                        last_sync_at=last_sync_at or datetime.now(timezone.utc),
-                        sync_status=connector_sync_status,
-                    )
+                    .values(**values)
                 )
         except SQLAlchemyError as e:
             logger.error(
@@ -1493,8 +1502,8 @@ class DatabaseManager:
         Called on startup to unlock connectors that were mid-tick when the
         service crashed.  Returns the list of connector IDs that were reset.
 
-        Also stamps ``last_sync_error`` and ``error`` on every affected row so
-        that callers can see the crash reason without joining to sync-log rows.
+        Also stamps ``error`` on every affected row so that callers can see the
+        crash reason without joining to sync-log rows.
         """
         try:
             with get_db_session() as session:
@@ -1503,7 +1512,6 @@ class DatabaseManager:
                     .where(Connector.sync_status == ConnectorStatus.SYNCING)
                     .values(
                         sync_status=ConnectorStatus.OUT_OF_SYNC,
-                        last_sync_error=error,
                         error=error,
                     )
                     .returning(Connector.id)

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -15,7 +15,7 @@ from common.misc_utils import get_logger
 from digitize.db.models import Job, Document, DocumentChecksum, Connector, ConnectorDocumentChecksum, ConnectorSyncLog
 from digitize.db.connection import get_db_session
 from digitize.models import JobStatus, DocStatus
-from digitize.connectors.models import ConnectorStatus, SyncLogStatus
+from digitize.connectors.models import ConnectorStatus, SyncLogStatus, ConnectorError
 
 logger = get_logger("db_repository")
 
@@ -1281,6 +1281,10 @@ class DatabaseManager:
 
         ``error`` is written when provided (failure/cancel paths); it is cleared
         to NULL on a successful completion so a past error does not persist.
+
+        If the connector already shows ConnectorError.CREDENTIAL_ERROR_MSG, a sync-tick failure
+        will NOT overwrite it — the credential error is the root cause and must
+        only be cleared by a successful _probe_connector_credentials call.
         """
         try:
             with get_db_session() as session:
@@ -1296,7 +1300,15 @@ class DatabaseManager:
                 if status == SyncLogStatus.COMPLETED:
                     values["error"] = None
                 elif error is not None:
-                    values["error"] = error
+                    # Don't overwrite a credential error with a sync-tick error —
+                    # the credential error is the root cause and stays until a
+                    # successful probe clears it.
+                    current_error_row = session.execute(
+                        select(Connector.error).where(Connector.id == connector_id)
+                    ).one_or_none()
+                    current_error = current_error_row[0] if current_error_row else None
+                    if current_error != ConnectorError.CREDENTIAL_ERROR_MSG:
+                        values["error"] = error
                 session.execute(
                     update(Connector)
                     .where(Connector.id == connector_id)

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -15,7 +15,7 @@ from common.misc_utils import get_logger
 from digitize.db.models import Job, Document, DocumentChecksum, Connector, ConnectorDocumentChecksum, ConnectorSyncLog
 from digitize.db.connection import get_db_session
 from digitize.models import JobStatus, DocStatus
-from digitize.connectors.models import ConnectorStatus, SyncLogStatus, ConnectorError
+from digitize.connectors.models import ConnectorStatus, SyncLogStatus
 
 logger = get_logger("db_repository")
 
@@ -1281,10 +1281,6 @@ class DatabaseManager:
 
         ``error`` is written when provided (failure/cancel paths); it is cleared
         to NULL on a successful completion so a past error does not persist.
-
-        If the connector already shows ConnectorError.CREDENTIAL_ERROR_MSG, a sync-tick failure
-        will NOT overwrite it — the credential error is the root cause and must
-        only be cleared by a successful _probe_connector_credentials call.
         """
         try:
             with get_db_session() as session:
@@ -1300,15 +1296,7 @@ class DatabaseManager:
                 if status == SyncLogStatus.COMPLETED:
                     values["error"] = None
                 elif error is not None:
-                    # Don't overwrite a credential error with a sync-tick error —
-                    # the credential error is the root cause and stays until a
-                    # successful probe clears it.
-                    current_error_row = session.execute(
-                        select(Connector.error).where(Connector.id == connector_id)
-                    ).one_or_none()
-                    current_error = current_error_row[0] if current_error_row else None
-                    if current_error != ConnectorError.CREDENTIAL_ERROR_MSG:
-                        values["error"] = error
+                    values["error"] = error
                 session.execute(
                     update(Connector)
                     .where(Connector.id == connector_id)

--- a/services/digitize/db/models.py
+++ b/services/digitize/db/models.py
@@ -203,7 +203,6 @@ class Connector(Base):
     )
     last_sync_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     sync_status: Mapped[str] = mapped_column(Text, nullable=False, default=ConnectorStatus.UP_TO_DATE)
-    last_sync_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     total_files: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 

--- a/services/digitize/db/scripts/init_schema.sql
+++ b/services/digitize/db/scripts/init_schema.sql
@@ -81,7 +81,6 @@ CREATE TABLE IF NOT EXISTS connector_sync_logs (
     total_files      INTEGER     NOT NULL DEFAULT 0,
     new_files        INTEGER     NOT NULL DEFAULT 0,
     removed_files    INTEGER     NOT NULL DEFAULT 0,
-    failed_files     INTEGER     NOT NULL DEFAULT 0,
     status           TEXT        NOT NULL DEFAULT 'started',
     error            TEXT        NOT NULL DEFAULT '',
     CONSTRAINT pk_csl PRIMARY KEY (connector_id, seq),

--- a/services/digitize/db/scripts/init_schema.sql
+++ b/services/digitize/db/scripts/init_schema.sql
@@ -53,7 +53,6 @@ CREATE TABLE IF NOT EXISTS connectors (
     attached_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     last_sync_at            TIMESTAMPTZ,
     sync_status             TEXT        NOT NULL DEFAULT 'up to date',
-    last_sync_error         TEXT,
     error                   TEXT,
     total_files             INTEGER     NOT NULL DEFAULT 0,
     CONSTRAINT chk_connector_type CHECK (type IN ('ssh', 's3'))

--- a/services/digitize/pytest.ini
+++ b/services/digitize/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    unit: marks tests as unit tests

--- a/services/digitize/settings.py
+++ b/services/digitize/settings.py
@@ -20,11 +20,6 @@ class DigitizeConfig(BaseSettings):
             description="Sync interval in seconds applied to all connectors at attach time",
         )
 
-        encryption_key_path: str = Field(
-            default="/run/secrets/connector_encryption_key",
-            description="Path to the AES-256-GCM key file (32 raw bytes) used to encrypt connector secrets at rest",
-        )
-
         model_config = SettingsConfigDict(env_prefix="CONNECTOR_")
 
     # Directory paths

--- a/services/digitize/tests/test_connector_db.py
+++ b/services/digitize/tests/test_connector_db.py
@@ -161,7 +161,7 @@ class TestGetConnector:
         c.attached_at = _NOW
         c.last_sync_at = None
         c.sync_status = ConnectorStatus.UP_TO_DATE
-        c.last_sync_error = None
+        c.error = None
         c.total_files = 0
         return c
 
@@ -208,7 +208,7 @@ class TestListConnectors:
         c1.attached_at = _NOW
         c1.last_sync_at = None
         c1.sync_status = ConnectorStatus.UP_TO_DATE
-        c1.last_sync_error = None
+        c1.error = None
         c1.total_files = 0
 
         session = MagicMock()

--- a/services/digitize/tests/test_connector_encryption.py
+++ b/services/digitize/tests/test_connector_encryption.py
@@ -4,8 +4,8 @@ Unit tests for services/digitize/connectors/encryption.py
 Coverage
 --------
 _load_key
-  - raises RuntimeError when key file is absent
-  - raises RuntimeError when key file has wrong byte length
+  - raises RuntimeError when DB_ENCRYPTION_KEY env var is absent
+  - raises RuntimeError when key has wrong byte length
   - returns an AESGCM instance when key is valid 32 bytes
 
 _encrypt_value / _decrypt_value (round-trip)
@@ -40,8 +40,6 @@ merge_and_encrypt_partial
 from __future__ import annotations
 
 import os
-import tempfile
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -62,23 +60,15 @@ from digitize.connectors.encryption import (
 # Helpers
 # ---------------------------------------------------------------------------
 
-# Fixed 32-byte key that avoids all strippable whitespace characters.
-# bytes.strip() strips ASCII whitespace: 0x09 (tab), 0x0a (LF), 0x0b (VT),
-# 0x0c (FF), 0x0d (CR), 0x20 (space). We use bytes 0x41-0x60 (letters/symbols)
-# to guarantee no stripping occurs.
-_FIXED_KEY = bytes(range(0x41, 0x61))  # bytes 65-96 (A-Z and some punctuation)
+# Fixed 32-byte key expressed as a 32-character ASCII string (no whitespace).
+# bytes 0x41–0x60 → "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`"
+_FIXED_KEY = bytes(range(0x41, 0x61)).decode()  # 32-char ASCII string
 
 
-def _write_key(tmp_path: Path, data: bytes) -> str:
-    """Write *data* to a temp file and return its string path."""
-    key_file = tmp_path / "enc.key"
-    key_file.write_bytes(data)
-    return str(key_file)
-
-
-def _valid_key_path(tmp_path: Path) -> str:
-    """Write a valid 32-byte key and return its path. Uses a fixed non-whitespace key."""
-    return _write_key(tmp_path, _FIXED_KEY)
+def _set_key(monkeypatch, key: str = _FIXED_KEY):
+    """Set DB_ENCRYPTION_KEY in the environment and clear the lru_cache."""
+    monkeypatch.setenv("DB_ENCRYPTION_KEY", key)
+    _load_key.cache_clear()
 
 
 # ---------------------------------------------------------------------------
@@ -86,30 +76,28 @@ def _valid_key_path(tmp_path: Path) -> str:
 # ---------------------------------------------------------------------------
 
 class TestLoadKey:
-    def test_raises_when_file_absent(self, tmp_path):
-        missing = str(tmp_path / "no_such_key.bin")
-        # Clear cache from other tests that may have cached a value
+    def test_raises_when_env_var_absent(self, monkeypatch):
+        monkeypatch.delenv("DB_ENCRYPTION_KEY", raising=False)
         _load_key.cache_clear()
         with pytest.raises(RuntimeError, match="not found"):
-            _load_key(missing)
+            _load_key()
 
-    def test_raises_when_key_wrong_length(self, tmp_path):
-        short_key_path = _write_key(tmp_path, b"short_key_16byte")  # 16 bytes, not 32
+    def test_raises_when_key_wrong_length_short(self, monkeypatch):
+        monkeypatch.setenv("DB_ENCRYPTION_KEY", "short_key_16byte")  # 16 chars
         _load_key.cache_clear()
         with pytest.raises(RuntimeError, match="32 bytes"):
-            _load_key(short_key_path)
+            _load_key()
 
-    def test_raises_when_key_too_long(self, tmp_path):
-        long_key_path = _write_key(tmp_path, os.urandom(64))  # 64 bytes
+    def test_raises_when_key_too_long(self, monkeypatch):
+        monkeypatch.setenv("DB_ENCRYPTION_KEY", "A" * 64)  # 64 chars
         _load_key.cache_clear()
         with pytest.raises(RuntimeError, match="32 bytes"):
-            _load_key(long_key_path)
+            _load_key()
 
-    def test_returns_aesgcm_for_valid_32_byte_key(self, tmp_path):
+    def test_returns_aesgcm_for_valid_32_byte_key(self, monkeypatch):
         from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
-        cipher = _load_key(key_path)
+        _set_key(monkeypatch)
+        cipher = _load_key()
         assert isinstance(cipher, AESGCM)
 
 
@@ -118,39 +106,38 @@ class TestLoadKey:
 # ---------------------------------------------------------------------------
 
 class TestEncryptDecryptRoundTrip:
-    def _cipher(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
-        return _get_cipher(key_path)
+    def _cipher(self, monkeypatch):
+        _set_key(monkeypatch)
+        return _get_cipher()
 
-    def test_roundtrip_returns_original_plaintext(self, tmp_path):
-        cipher = self._cipher(tmp_path)
+    def test_roundtrip_returns_original_plaintext(self, monkeypatch):
+        cipher = self._cipher(monkeypatch)
         plaintext = "super_secret_private_key_data"
         token = _encrypt_value(cipher, plaintext)
         recovered = _decrypt_value(cipher, token)
         assert recovered == plaintext
 
-    def test_encrypted_value_differs_from_plaintext(self, tmp_path):
-        cipher = self._cipher(tmp_path)
+    def test_encrypted_value_differs_from_plaintext(self, monkeypatch):
+        cipher = self._cipher(monkeypatch)
         plaintext = "my_secret"
         token = _encrypt_value(cipher, plaintext)
         assert token != plaintext
 
-    def test_two_encryptions_produce_different_ciphertext(self, tmp_path):
+    def test_two_encryptions_produce_different_ciphertext(self, monkeypatch):
         """Random nonce → each call produces a unique token."""
-        cipher = self._cipher(tmp_path)
+        cipher = self._cipher(monkeypatch)
         plaintext = "same_value"
         token1 = _encrypt_value(cipher, plaintext)
         token2 = _encrypt_value(cipher, plaintext)
         assert token1 != token2
 
-    def test_empty_string_roundtrip(self, tmp_path):
-        cipher = self._cipher(tmp_path)
+    def test_empty_string_roundtrip(self, monkeypatch):
+        cipher = self._cipher(monkeypatch)
         token = _encrypt_value(cipher, "")
         assert _decrypt_value(cipher, token) == ""
 
-    def test_unicode_roundtrip(self, tmp_path):
-        cipher = self._cipher(tmp_path)
+    def test_unicode_roundtrip(self, monkeypatch):
+        cipher = self._cipher(monkeypatch)
         plaintext = "日本語テスト🔑"
         token = _encrypt_value(cipher, plaintext)
         assert _decrypt_value(cipher, token) == plaintext
@@ -161,45 +148,40 @@ class TestEncryptDecryptRoundTrip:
 # ---------------------------------------------------------------------------
 
 class TestEncryptSecrets:
-    def test_encrypts_ssh_private_key(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+    def test_encrypts_ssh_private_key(self, monkeypatch):
+        _set_key(monkeypatch)
         details = {"host": "example.com", "username": "user", "private_key": "MY_PRIVATE_KEY"}
-        encrypted = encrypt_secrets("ssh", details, key_path)
+        encrypted = encrypt_secrets("ssh", details)
         # The private_key field must be base64-encoded ciphertext, not plain
         assert encrypted["private_key"] != "MY_PRIVATE_KEY"
         assert encrypted["host"] == "example.com"
         assert encrypted["username"] == "user"
 
-    def test_encrypts_s3_secret_access_key(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+    def test_encrypts_s3_secret_access_key(self, monkeypatch):
+        _set_key(monkeypatch)
         details = {"bucket": "my-bucket", "access_key_id": "AKID", "secret_access_key": "MY_SECRET"}
-        encrypted = encrypt_secrets("s3", details, key_path)
+        encrypted = encrypt_secrets("s3", details)
         assert encrypted["secret_access_key"] != "MY_SECRET"
         assert encrypted["bucket"] == "my-bucket"
         assert encrypted["access_key_id"] == "AKID"
 
-    def test_unknown_connector_type_leaves_all_fields_intact(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+    def test_unknown_connector_type_leaves_all_fields_intact(self, monkeypatch):
+        _set_key(monkeypatch)
         details = {"token": "bearer_token", "endpoint": "https://api.example.com"}
-        result = encrypt_secrets("ftp", details, key_path)
+        result = encrypt_secrets("ftp", details)
         assert result == details
 
-    def test_skips_none_valued_secret_fields(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+    def test_skips_none_valued_secret_fields(self, monkeypatch):
+        _set_key(monkeypatch)
         details = {"private_key": None, "username": "admin"}
-        result = encrypt_secrets("ssh", details, key_path)
+        result = encrypt_secrets("ssh", details)
         assert result["private_key"] is None
         assert result["username"] == "admin"
 
-    def test_does_not_mutate_original_dict(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+    def test_does_not_mutate_original_dict(self, monkeypatch):
+        _set_key(monkeypatch)
         original = {"private_key": "secret", "host": "ssh.example.com"}
-        _ = encrypt_secrets("ssh", original, key_path)
+        _ = encrypt_secrets("ssh", original)
         assert original["private_key"] == "secret"
 
 
@@ -208,47 +190,42 @@ class TestEncryptSecrets:
 # ---------------------------------------------------------------------------
 
 class TestDecryptSecrets:
-    def test_decrypts_value_encrypted_by_encrypt_secrets(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+    def test_decrypts_value_encrypted_by_encrypt_secrets(self, monkeypatch):
+        _set_key(monkeypatch)
         details = {"private_key": "-----BEGIN RSA PRIVATE KEY-----\nFAKE\n-----END RSA PRIVATE KEY-----"}
-        encrypted = encrypt_secrets("ssh", details, key_path)
-        decrypted = decrypt_secrets("ssh", encrypted, key_path)
+        encrypted = encrypt_secrets("ssh", details)
+        decrypted = decrypt_secrets("ssh", encrypted)
         assert decrypted["private_key"] == details["private_key"]
 
-    def test_leaves_non_secret_fields_untouched(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+    def test_leaves_non_secret_fields_untouched(self, monkeypatch):
+        _set_key(monkeypatch)
         details = {"host": "sftp.example.com", "private_key": "KEY_DATA", "port": 22}
-        encrypted = encrypt_secrets("ssh", details, key_path)
-        decrypted = decrypt_secrets("ssh", encrypted, key_path)
+        encrypted = encrypt_secrets("ssh", details)
+        decrypted = decrypt_secrets("ssh", encrypted)
         assert decrypted["host"] == "sftp.example.com"
         assert decrypted["port"] == 22
 
-    def test_raises_on_tampered_ciphertext(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+    def test_raises_on_tampered_ciphertext(self, monkeypatch):
+        _set_key(monkeypatch)
         bad_details = {"private_key": "not_valid_base64_ciphertext=="}
         with pytest.raises(Exception):
-            decrypt_secrets("ssh", bad_details, key_path)
+            decrypt_secrets("ssh", bad_details)
 
-    def test_skips_none_valued_secret_fields(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+    def test_skips_none_valued_secret_fields(self, monkeypatch):
+        _set_key(monkeypatch)
         details = {"private_key": None, "host": "host.example.com"}
-        result = decrypt_secrets("ssh", details, key_path)
+        result = decrypt_secrets("ssh", details)
         assert result["private_key"] is None
 
-    def test_s3_full_roundtrip(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+    def test_s3_full_roundtrip(self, monkeypatch):
+        _set_key(monkeypatch)
         details = {
             "bucket": "my-bucket",
             "access_key_id": "AKID123",
             "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         }
-        encrypted = encrypt_secrets("s3", details, key_path)
-        decrypted = decrypt_secrets("s3", encrypted, key_path)
+        encrypted = encrypt_secrets("s3", details)
+        decrypted = decrypt_secrets("s3", encrypted)
         assert decrypted == details
 
 
@@ -293,56 +270,50 @@ class TestStripSecrets:
 # ---------------------------------------------------------------------------
 
 class TestMergeAndEncryptPartial:
-    def test_non_secret_keys_copied_verbatim(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+    def test_non_secret_keys_copied_verbatim(self, monkeypatch):
+        _set_key(monkeypatch)
         existing = {"private_key": "ENCRYPTED_BLOB", "host": "old.example.com", "port": 22}
         partial = {"host": "new.example.com"}
-        result = merge_and_encrypt_partial("ssh", existing, partial, key_path)
+        result = merge_and_encrypt_partial("ssh", existing, partial)
         assert result["host"] == "new.example.com"
         assert result["port"] == 22
 
-    def test_secret_keys_in_partial_are_encrypted(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+    def test_secret_keys_in_partial_are_encrypted(self, monkeypatch):
+        _set_key(monkeypatch)
         existing = {"private_key": "OLD_ENCRYPTED", "host": "sftp.example.com"}
         partial = {"private_key": "NEW_PLAINTEXT_KEY"}
-        result = merge_and_encrypt_partial("ssh", existing, partial, key_path)
+        result = merge_and_encrypt_partial("ssh", existing, partial)
         # The updated private_key must be a new ciphertext, not plaintext
         assert result["private_key"] != "NEW_PLAINTEXT_KEY"
         assert result["private_key"] != "OLD_ENCRYPTED"
 
-    def test_existing_encrypted_key_preserved_when_not_in_partial(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+    def test_existing_encrypted_key_preserved_when_not_in_partial(self, monkeypatch):
+        _set_key(monkeypatch)
         existing = {"private_key": "EXISTING_CIPHERTEXT", "host": "sftp.example.com"}
         partial = {"host": "new-sftp.example.com"}
-        result = merge_and_encrypt_partial("ssh", existing, partial, key_path)
+        result = merge_and_encrypt_partial("ssh", existing, partial)
         # Private key blob unchanged — it was not in partial_update
         assert result["private_key"] == "EXISTING_CIPHERTEXT"
 
-    def test_does_not_mutate_existing_encrypted(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+    def test_does_not_mutate_existing_encrypted(self, monkeypatch):
+        _set_key(monkeypatch)
         existing = {"private_key": "CIPHERTEXT", "host": "old.example.com"}
         original_existing = dict(existing)
-        merge_and_encrypt_partial("ssh", existing, {"host": "new.example.com"}, key_path)
+        merge_and_encrypt_partial("ssh", existing, {"host": "new.example.com"})
         assert existing == original_existing
 
-    def test_partial_none_value_for_secret_field_is_passed_through(self, tmp_path):
+    def test_partial_none_value_for_secret_field_is_passed_through(self, monkeypatch):
         """A None update for a secret field must not be encrypted — passed as None."""
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+        _set_key(monkeypatch)
         existing = {"private_key": "CIPHERTEXT", "host": "sftp.example.com"}
-        result = merge_and_encrypt_partial("ssh", existing, {"private_key": None}, key_path)
+        result = merge_and_encrypt_partial("ssh", existing, {"private_key": None})
         assert result["private_key"] is None
 
-    def test_s3_partial_update_encrypts_secret_access_key(self, tmp_path):
-        key_path = _valid_key_path(tmp_path)
-        _load_key.cache_clear()
+    def test_s3_partial_update_encrypts_secret_access_key(self, monkeypatch):
+        _set_key(monkeypatch)
         existing = {"bucket": "b", "access_key_id": "OLD_AK", "secret_access_key": "OLD_CIPHERTEXT"}
         partial = {"secret_access_key": "NEW_PLAINTEXT_SECRET"}
-        result = merge_and_encrypt_partial("s3", existing, partial, key_path)
+        result = merge_and_encrypt_partial("s3", existing, partial)
         assert result["secret_access_key"] != "NEW_PLAINTEXT_SECRET"
         assert result["bucket"] == "b"
 

--- a/services/digitize/tests/test_connector_encryption.py
+++ b/services/digitize/tests/test_connector_encryption.py
@@ -1,0 +1,349 @@
+"""
+Unit tests for services/digitize/connectors/encryption.py
+
+Coverage
+--------
+_load_key
+  - raises RuntimeError when key file is absent
+  - raises RuntimeError when key file has wrong byte length
+  - returns an AESGCM instance when key is valid 32 bytes
+
+_encrypt_value / _decrypt_value (round-trip)
+  - encrypt then decrypt returns original plaintext
+  - encrypted value differs from plaintext (not stored in clear)
+  - different calls produce different ciphertext (random nonce)
+
+encrypt_secrets
+  - encrypts known secret fields and leaves other fields untouched
+  - no-ops for connector types with no registered secret fields
+  - skips None-valued secret fields
+  - returns a copy — does not mutate the original dict
+
+decrypt_secrets
+  - decrypts values produced by encrypt_secrets
+  - leaves non-secret fields untouched
+  - re-raises on invalid ciphertext
+
+strip_secrets
+  - removes secret fields from ssh connector
+  - removes secret fields from s3 connector
+  - returns all fields for unknown connector type
+  - does not mutate the original dict
+
+merge_and_encrypt_partial
+  - non-secret keys in partial_update are copied verbatim
+  - secret keys in partial_update are re-encrypted
+  - keys absent from partial_update are preserved from existing_encrypted
+  - returns a new dict (does not mutate existing_encrypted)
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from digitize.connectors.encryption import (
+    _decrypt_value,
+    _encrypt_value,
+    _get_cipher,
+    _load_key,
+    decrypt_secrets,
+    encrypt_secrets,
+    merge_and_encrypt_partial,
+    strip_secrets,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Fixed 32-byte key that avoids all strippable whitespace characters.
+# bytes.strip() strips ASCII whitespace: 0x09 (tab), 0x0a (LF), 0x0b (VT),
+# 0x0c (FF), 0x0d (CR), 0x20 (space). We use bytes 0x41-0x60 (letters/symbols)
+# to guarantee no stripping occurs.
+_FIXED_KEY = bytes(range(0x41, 0x61))  # bytes 65-96 (A-Z and some punctuation)
+
+
+def _write_key(tmp_path: Path, data: bytes) -> str:
+    """Write *data* to a temp file and return its string path."""
+    key_file = tmp_path / "enc.key"
+    key_file.write_bytes(data)
+    return str(key_file)
+
+
+def _valid_key_path(tmp_path: Path) -> str:
+    """Write a valid 32-byte key and return its path. Uses a fixed non-whitespace key."""
+    return _write_key(tmp_path, _FIXED_KEY)
+
+
+# ---------------------------------------------------------------------------
+# _load_key
+# ---------------------------------------------------------------------------
+
+class TestLoadKey:
+    def test_raises_when_file_absent(self, tmp_path):
+        missing = str(tmp_path / "no_such_key.bin")
+        # Clear cache from other tests that may have cached a value
+        _load_key.cache_clear()
+        with pytest.raises(RuntimeError, match="not found"):
+            _load_key(missing)
+
+    def test_raises_when_key_wrong_length(self, tmp_path):
+        short_key_path = _write_key(tmp_path, b"short_key_16byte")  # 16 bytes, not 32
+        _load_key.cache_clear()
+        with pytest.raises(RuntimeError, match="32 bytes"):
+            _load_key(short_key_path)
+
+    def test_raises_when_key_too_long(self, tmp_path):
+        long_key_path = _write_key(tmp_path, os.urandom(64))  # 64 bytes
+        _load_key.cache_clear()
+        with pytest.raises(RuntimeError, match="32 bytes"):
+            _load_key(long_key_path)
+
+    def test_returns_aesgcm_for_valid_32_byte_key(self, tmp_path):
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        cipher = _load_key(key_path)
+        assert isinstance(cipher, AESGCM)
+
+
+# ---------------------------------------------------------------------------
+# _encrypt_value / _decrypt_value round-trip
+# ---------------------------------------------------------------------------
+
+class TestEncryptDecryptRoundTrip:
+    def _cipher(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        return _get_cipher(key_path)
+
+    def test_roundtrip_returns_original_plaintext(self, tmp_path):
+        cipher = self._cipher(tmp_path)
+        plaintext = "super_secret_private_key_data"
+        token = _encrypt_value(cipher, plaintext)
+        recovered = _decrypt_value(cipher, token)
+        assert recovered == plaintext
+
+    def test_encrypted_value_differs_from_plaintext(self, tmp_path):
+        cipher = self._cipher(tmp_path)
+        plaintext = "my_secret"
+        token = _encrypt_value(cipher, plaintext)
+        assert token != plaintext
+
+    def test_two_encryptions_produce_different_ciphertext(self, tmp_path):
+        """Random nonce → each call produces a unique token."""
+        cipher = self._cipher(tmp_path)
+        plaintext = "same_value"
+        token1 = _encrypt_value(cipher, plaintext)
+        token2 = _encrypt_value(cipher, plaintext)
+        assert token1 != token2
+
+    def test_empty_string_roundtrip(self, tmp_path):
+        cipher = self._cipher(tmp_path)
+        token = _encrypt_value(cipher, "")
+        assert _decrypt_value(cipher, token) == ""
+
+    def test_unicode_roundtrip(self, tmp_path):
+        cipher = self._cipher(tmp_path)
+        plaintext = "日本語テスト🔑"
+        token = _encrypt_value(cipher, plaintext)
+        assert _decrypt_value(cipher, token) == plaintext
+
+
+# ---------------------------------------------------------------------------
+# encrypt_secrets
+# ---------------------------------------------------------------------------
+
+class TestEncryptSecrets:
+    def test_encrypts_ssh_private_key(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        details = {"host": "example.com", "username": "user", "private_key": "MY_PRIVATE_KEY"}
+        encrypted = encrypt_secrets("ssh", details, key_path)
+        # The private_key field must be base64-encoded ciphertext, not plain
+        assert encrypted["private_key"] != "MY_PRIVATE_KEY"
+        assert encrypted["host"] == "example.com"
+        assert encrypted["username"] == "user"
+
+    def test_encrypts_s3_secret_access_key(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        details = {"bucket": "my-bucket", "access_key_id": "AKID", "secret_access_key": "MY_SECRET"}
+        encrypted = encrypt_secrets("s3", details, key_path)
+        assert encrypted["secret_access_key"] != "MY_SECRET"
+        assert encrypted["bucket"] == "my-bucket"
+        assert encrypted["access_key_id"] == "AKID"
+
+    def test_unknown_connector_type_leaves_all_fields_intact(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        details = {"token": "bearer_token", "endpoint": "https://api.example.com"}
+        result = encrypt_secrets("ftp", details, key_path)
+        assert result == details
+
+    def test_skips_none_valued_secret_fields(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        details = {"private_key": None, "username": "admin"}
+        result = encrypt_secrets("ssh", details, key_path)
+        assert result["private_key"] is None
+        assert result["username"] == "admin"
+
+    def test_does_not_mutate_original_dict(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        original = {"private_key": "secret", "host": "ssh.example.com"}
+        _ = encrypt_secrets("ssh", original, key_path)
+        assert original["private_key"] == "secret"
+
+
+# ---------------------------------------------------------------------------
+# decrypt_secrets
+# ---------------------------------------------------------------------------
+
+class TestDecryptSecrets:
+    def test_decrypts_value_encrypted_by_encrypt_secrets(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        details = {"private_key": "-----BEGIN RSA PRIVATE KEY-----\nFAKE\n-----END RSA PRIVATE KEY-----"}
+        encrypted = encrypt_secrets("ssh", details, key_path)
+        decrypted = decrypt_secrets("ssh", encrypted, key_path)
+        assert decrypted["private_key"] == details["private_key"]
+
+    def test_leaves_non_secret_fields_untouched(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        details = {"host": "sftp.example.com", "private_key": "KEY_DATA", "port": 22}
+        encrypted = encrypt_secrets("ssh", details, key_path)
+        decrypted = decrypt_secrets("ssh", encrypted, key_path)
+        assert decrypted["host"] == "sftp.example.com"
+        assert decrypted["port"] == 22
+
+    def test_raises_on_tampered_ciphertext(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        bad_details = {"private_key": "not_valid_base64_ciphertext=="}
+        with pytest.raises(Exception):
+            decrypt_secrets("ssh", bad_details, key_path)
+
+    def test_skips_none_valued_secret_fields(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        details = {"private_key": None, "host": "host.example.com"}
+        result = decrypt_secrets("ssh", details, key_path)
+        assert result["private_key"] is None
+
+    def test_s3_full_roundtrip(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        details = {
+            "bucket": "my-bucket",
+            "access_key_id": "AKID123",
+            "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        }
+        encrypted = encrypt_secrets("s3", details, key_path)
+        decrypted = decrypt_secrets("s3", encrypted, key_path)
+        assert decrypted == details
+
+
+# ---------------------------------------------------------------------------
+# strip_secrets
+# ---------------------------------------------------------------------------
+
+class TestStripSecrets:
+    def test_removes_private_key_from_ssh_details(self):
+        details = {"host": "sftp.example.com", "username": "user", "private_key": "SENSITIVE"}
+        result = strip_secrets("ssh", details)
+        assert "private_key" not in result
+        assert result["host"] == "sftp.example.com"
+        assert result["username"] == "user"
+
+    def test_removes_secret_access_key_from_s3_details(self):
+        details = {"bucket": "b", "access_key_id": "AK", "secret_access_key": "SK"}
+        result = strip_secrets("s3", details)
+        assert "secret_access_key" not in result
+        assert result["bucket"] == "b"
+        assert result["access_key_id"] == "AK"
+
+    def test_returns_all_fields_for_unknown_connector_type(self):
+        details = {"token": "tok", "endpoint": "https://api.example.com"}
+        result = strip_secrets("ftp", details)
+        assert result == details
+
+    def test_does_not_mutate_original_dict(self):
+        original = {"private_key": "KEY", "host": "h"}
+        _ = strip_secrets("ssh", original)
+        assert "private_key" in original
+
+    def test_field_absent_in_details_is_no_op(self):
+        """strip_secrets must not raise if a secret field is simply absent."""
+        details = {"host": "sftp.example.com", "username": "bob"}
+        result = strip_secrets("ssh", details)
+        assert result == details
+
+
+# ---------------------------------------------------------------------------
+# merge_and_encrypt_partial
+# ---------------------------------------------------------------------------
+
+class TestMergeAndEncryptPartial:
+    def test_non_secret_keys_copied_verbatim(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        existing = {"private_key": "ENCRYPTED_BLOB", "host": "old.example.com", "port": 22}
+        partial = {"host": "new.example.com"}
+        result = merge_and_encrypt_partial("ssh", existing, partial, key_path)
+        assert result["host"] == "new.example.com"
+        assert result["port"] == 22
+
+    def test_secret_keys_in_partial_are_encrypted(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        existing = {"private_key": "OLD_ENCRYPTED", "host": "sftp.example.com"}
+        partial = {"private_key": "NEW_PLAINTEXT_KEY"}
+        result = merge_and_encrypt_partial("ssh", existing, partial, key_path)
+        # The updated private_key must be a new ciphertext, not plaintext
+        assert result["private_key"] != "NEW_PLAINTEXT_KEY"
+        assert result["private_key"] != "OLD_ENCRYPTED"
+
+    def test_existing_encrypted_key_preserved_when_not_in_partial(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        existing = {"private_key": "EXISTING_CIPHERTEXT", "host": "sftp.example.com"}
+        partial = {"host": "new-sftp.example.com"}
+        result = merge_and_encrypt_partial("ssh", existing, partial, key_path)
+        # Private key blob unchanged — it was not in partial_update
+        assert result["private_key"] == "EXISTING_CIPHERTEXT"
+
+    def test_does_not_mutate_existing_encrypted(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        existing = {"private_key": "CIPHERTEXT", "host": "old.example.com"}
+        original_existing = dict(existing)
+        merge_and_encrypt_partial("ssh", existing, {"host": "new.example.com"}, key_path)
+        assert existing == original_existing
+
+    def test_partial_none_value_for_secret_field_is_passed_through(self, tmp_path):
+        """A None update for a secret field must not be encrypted — passed as None."""
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        existing = {"private_key": "CIPHERTEXT", "host": "sftp.example.com"}
+        result = merge_and_encrypt_partial("ssh", existing, {"private_key": None}, key_path)
+        assert result["private_key"] is None
+
+    def test_s3_partial_update_encrypts_secret_access_key(self, tmp_path):
+        key_path = _valid_key_path(tmp_path)
+        _load_key.cache_clear()
+        existing = {"bucket": "b", "access_key_id": "OLD_AK", "secret_access_key": "OLD_CIPHERTEXT"}
+        partial = {"secret_access_key": "NEW_PLAINTEXT_SECRET"}
+        result = merge_and_encrypt_partial("s3", existing, partial, key_path)
+        assert result["secret_access_key"] != "NEW_PLAINTEXT_SECRET"
+        assert result["bucket"] == "b"
+
+# Made with Bob

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -979,6 +979,24 @@ class TestProbeConnectorCredentials:
 
         set_error_mock.assert_not_called()
 
+    async def test_close_failure_after_connect_failure_is_swallowed(self, monkeypatch):
+        """scanner.close() raising after a connect failure must not propagate."""
+        from digitize.api.v1.connectors import _probe_connector_credentials, _CREDENTIAL_ERROR_MSG
+
+        mock_scanner = MagicMock()
+        mock_scanner.connect.side_effect = ConnectionError("bad credentials")
+        mock_scanner.close.side_effect = RuntimeError("close also broken")
+
+        set_error_mock = Mock()
+        monkeypatch.setattr("digitize.api.v1.connectors.build_scanner", lambda row: mock_scanner)
+        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.set_connector_error", set_error_mock)
+
+        # must not raise even though both connect and close fail
+        await _probe_connector_credentials(CONNECTOR_ID, CONNECTOR_TYPE, {}, [".pdf"])
+
+        # error still persisted despite close() blowing up
+        set_error_mock.assert_called_once_with(CONNECTOR_ID, _CREDENTIAL_ERROR_MSG)
+
     async def test_put_probes_credentials_when_connection_details_changed(
         self, monkeypatch
     ):

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -89,7 +89,6 @@ def _make_connector(
     c.attached_at = _NOW
     c.last_sync_at = _NOW
     c.sync_status = sync_status
-    c.last_sync_error = None
     c.error = None
     c.total_files = 42
     return c

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -892,113 +892,15 @@ class TestStopSync:
         assert response.status_code == 404
 
 # ===========================================================================
-# _probe_connector_credentials (async unit tests)
+# dispatch_sync on PUT (async unit tests)
 # ===========================================================================
 
 @pytest.mark.asyncio
-class TestProbeConnectorCredentials:
-    """Unit tests for the _probe_connector_credentials background coroutine."""
+class TestPutConnectorTriggersSync:
+    """Verify that update_connector dispatches a sync when connection_details change."""
 
-    def _make_row(self, error=None):
-        c = _make_connector()
-        c.error = error
-        return c
-
-    async def test_sets_error_on_connect_failure(self, monkeypatch):
-        """connect() raises → connector error set to generic auth-failed message."""
-        from digitize.api.v1.connectors import _probe_connector_credentials, _CREDENTIAL_ERROR_MSG
-
-        mock_scanner = MagicMock()
-        mock_scanner.connect.side_effect = ConnectionError("bad credentials")
-        mock_scanner.close = Mock()
-
-        set_error_mock = Mock()
-        monkeypatch.setattr("digitize.api.v1.connectors.build_scanner", lambda row: mock_scanner)
-        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.set_connector_error", set_error_mock)
-
-        await _probe_connector_credentials(
-            CONNECTOR_ID, CONNECTOR_TYPE, {}, [".pdf"]
-        )
-
-        set_error_mock.assert_called_once_with(CONNECTOR_ID, _CREDENTIAL_ERROR_MSG)
-
-    async def test_does_not_set_error_on_success(self, monkeypatch):
-        """connect() succeeds and no prior auth error → error field untouched."""
-        from digitize.api.v1.connectors import _probe_connector_credentials
-
-        mock_scanner = MagicMock()
-        mock_scanner.connect = Mock()
-        mock_scanner.close = Mock()
-
-        set_error_mock = Mock()
-        monkeypatch.setattr("digitize.api.v1.connectors.build_scanner", lambda row: mock_scanner)
-        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.set_connector_error", set_error_mock)
-
-        await _probe_connector_credentials(
-            CONNECTOR_ID, CONNECTOR_TYPE, {}, [".pdf"], current_error=None
-        )
-
-        set_error_mock.assert_not_called()
-
-    async def test_clears_auth_error_on_success_when_previously_set(self, monkeypatch):
-        """connect() succeeds and prior error was auth-failed → error cleared to None."""
-        from digitize.api.v1.connectors import _probe_connector_credentials, _CREDENTIAL_ERROR_MSG
-
-        mock_scanner = MagicMock()
-        mock_scanner.connect = Mock()
-        mock_scanner.close = Mock()
-
-        set_error_mock = Mock()
-        monkeypatch.setattr("digitize.api.v1.connectors.build_scanner", lambda row: mock_scanner)
-        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.set_connector_error", set_error_mock)
-
-        await _probe_connector_credentials(
-            CONNECTOR_ID, CONNECTOR_TYPE, {}, [".pdf"], current_error=_CREDENTIAL_ERROR_MSG
-        )
-
-        set_error_mock.assert_called_once_with(CONNECTOR_ID, None)
-
-    async def test_does_not_clear_sync_error_on_success(self, monkeypatch):
-        """connect() succeeds but prior error is sync-related → error field untouched."""
-        from digitize.api.v1.connectors import _probe_connector_credentials
-
-        mock_scanner = MagicMock()
-        mock_scanner.connect = Mock()
-        mock_scanner.close = Mock()
-
-        set_error_mock = Mock()
-        monkeypatch.setattr("digitize.api.v1.connectors.build_scanner", lambda row: mock_scanner)
-        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.set_connector_error", set_error_mock)
-
-        await _probe_connector_credentials(
-            CONNECTOR_ID, CONNECTOR_TYPE, {}, [".pdf"],
-            current_error="Sync failed: remote file not found"
-        )
-
-        set_error_mock.assert_not_called()
-
-    async def test_close_failure_after_connect_failure_is_swallowed(self, monkeypatch):
-        """scanner.close() raising after a connect failure must not propagate."""
-        from digitize.api.v1.connectors import _probe_connector_credentials, _CREDENTIAL_ERROR_MSG
-
-        mock_scanner = MagicMock()
-        mock_scanner.connect.side_effect = ConnectionError("bad credentials")
-        mock_scanner.close.side_effect = RuntimeError("close also broken")
-
-        set_error_mock = Mock()
-        monkeypatch.setattr("digitize.api.v1.connectors.build_scanner", lambda row: mock_scanner)
-        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.set_connector_error", set_error_mock)
-
-        # must not raise even though both connect and close fail
-        await _probe_connector_credentials(CONNECTOR_ID, CONNECTOR_TYPE, {}, [".pdf"])
-
-        # error still persisted despite close() blowing up
-        set_error_mock.assert_called_once_with(CONNECTOR_ID, _CREDENTIAL_ERROR_MSG)
-
-    async def test_put_probes_credentials_when_connection_details_changed(
-        self, monkeypatch
-    ):
-        """PUT with connection_details change schedules a credential probe task."""
+    async def test_dispatches_sync_when_connection_details_changed(self, monkeypatch):
+        """PUT with connection_details change schedules a dispatch_sync task."""
         from digitize.api.v1.connectors import update_connector
         from digitize.connectors.models import ConnectorUpdateRequest
 
@@ -1025,8 +927,8 @@ class TestProbeConnectorCredentials:
 
         assert len(tasks_created) == 1
 
-    async def test_put_does_not_probe_when_only_name_changed(self, monkeypatch):
-        """PUT with only name → no credential probe scheduled."""
+    async def test_does_not_dispatch_sync_when_only_name_changed(self, monkeypatch):
+        """PUT with only name → no sync dispatched."""
         from digitize.api.v1.connectors import update_connector
         from digitize.connectors.models import ConnectorUpdateRequest
 

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -893,4 +893,153 @@ class TestStopSync:
         )
         assert response.status_code == 404
 
+# ===========================================================================
+# _probe_connector_credentials (async unit tests)
+# ===========================================================================
+
+@pytest.mark.asyncio
+class TestProbeConnectorCredentials:
+    """Unit tests for the _probe_connector_credentials background coroutine."""
+
+    def _make_row(self, error=None):
+        c = _make_connector()
+        c.error = error
+        return c
+
+    async def test_sets_error_on_connect_failure(self, monkeypatch):
+        """connect() raises → connector error set to generic auth-failed message."""
+        from digitize.api.v1.connectors import _probe_connector_credentials, _CREDENTIAL_ERROR_MSG
+
+        mock_scanner = MagicMock()
+        mock_scanner.connect.side_effect = ConnectionError("bad credentials")
+        mock_scanner.close = Mock()
+
+        set_error_mock = Mock()
+        monkeypatch.setattr("digitize.api.v1.connectors.build_scanner", lambda row: mock_scanner)
+        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.set_connector_error", set_error_mock)
+
+        await _probe_connector_credentials(
+            CONNECTOR_ID, CONNECTOR_TYPE, {}, [".pdf"]
+        )
+
+        set_error_mock.assert_called_once_with(CONNECTOR_ID, _CREDENTIAL_ERROR_MSG)
+
+    async def test_does_not_set_error_on_success(self, monkeypatch):
+        """connect() succeeds and no prior auth error → error field untouched."""
+        from digitize.api.v1.connectors import _probe_connector_credentials
+
+        mock_scanner = MagicMock()
+        mock_scanner.connect = Mock()
+        mock_scanner.close = Mock()
+
+        set_error_mock = Mock()
+        monkeypatch.setattr("digitize.api.v1.connectors.build_scanner", lambda row: mock_scanner)
+        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.set_connector_error", set_error_mock)
+
+        await _probe_connector_credentials(
+            CONNECTOR_ID, CONNECTOR_TYPE, {}, [".pdf"], current_error=None
+        )
+
+        set_error_mock.assert_not_called()
+
+    async def test_clears_auth_error_on_success_when_previously_set(self, monkeypatch):
+        """connect() succeeds and prior error was auth-failed → error cleared to None."""
+        from digitize.api.v1.connectors import _probe_connector_credentials, _CREDENTIAL_ERROR_MSG
+
+        mock_scanner = MagicMock()
+        mock_scanner.connect = Mock()
+        mock_scanner.close = Mock()
+
+        set_error_mock = Mock()
+        monkeypatch.setattr("digitize.api.v1.connectors.build_scanner", lambda row: mock_scanner)
+        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.set_connector_error", set_error_mock)
+
+        await _probe_connector_credentials(
+            CONNECTOR_ID, CONNECTOR_TYPE, {}, [".pdf"], current_error=_CREDENTIAL_ERROR_MSG
+        )
+
+        set_error_mock.assert_called_once_with(CONNECTOR_ID, None)
+
+    async def test_does_not_clear_sync_error_on_success(self, monkeypatch):
+        """connect() succeeds but prior error is sync-related → error field untouched."""
+        from digitize.api.v1.connectors import _probe_connector_credentials
+
+        mock_scanner = MagicMock()
+        mock_scanner.connect = Mock()
+        mock_scanner.close = Mock()
+
+        set_error_mock = Mock()
+        monkeypatch.setattr("digitize.api.v1.connectors.build_scanner", lambda row: mock_scanner)
+        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.set_connector_error", set_error_mock)
+
+        await _probe_connector_credentials(
+            CONNECTOR_ID, CONNECTOR_TYPE, {}, [".pdf"],
+            current_error="Sync failed: remote file not found"
+        )
+
+        set_error_mock.assert_not_called()
+
+    async def test_put_probes_credentials_when_connection_details_changed(
+        self, monkeypatch
+    ):
+        """PUT with connection_details change schedules a credential probe task."""
+        from digitize.api.v1.connectors import update_connector
+        from digitize.connectors.models import ConnectorUpdateRequest
+
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.upsert_connector", Mock())
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.merge_and_encrypt_partial",
+            lambda ctype, existing, partial, key_path: {**existing, **partial},
+        )
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors._get_key_path",
+            lambda: "/dev/null",
+        )
+
+        tasks_created = []
+
+        def capture_task(coro):
+            tasks_created.append(coro)
+            coro.close()  # prevent "coroutine never awaited" warning
+
+        monkeypatch.setattr("digitize.api.v1.connectors.asyncio.create_task", capture_task)
+
+        body = ConnectorUpdateRequest.model_validate({"connection_details": {"remote_path": "/new"}})
+        await update_connector(CONNECTOR_ID, body)
+
+        assert len(tasks_created) == 1
+
+    async def test_put_does_not_probe_when_only_name_changed(self, monkeypatch):
+        """PUT with only connector_name → no credential probe scheduled."""
+        from digitize.api.v1.connectors import update_connector
+        from digitize.connectors.models import ConnectorUpdateRequest
+
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            Mock(return_value=_make_connector()),
+        )
+        monkeypatch.setattr("digitize.api.v1.connectors.db_ops.upsert_connector", Mock())
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors._get_key_path",
+            lambda: "/dev/null",
+        )
+
+        tasks_created = []
+
+        def capture_task(coro):
+            tasks_created.append(coro)
+            coro.close()
+
+        monkeypatch.setattr("digitize.api.v1.connectors.asyncio.create_task", capture_task)
+
+        body = ConnectorUpdateRequest.model_validate({"connector_name": "new-name"})
+        await update_connector(CONNECTOR_ID, body)
+
+        assert len(tasks_created) == 0
+
+
 # Made with Bob

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -44,8 +44,8 @@ CONNECTOR_NAME = "prod-sftp-reports"
 CONNECTOR_TYPE = "ssh"
 
 SSH_PAYLOAD = {
-    "connector_id": CONNECTOR_ID,
-    "connector_name": CONNECTOR_NAME,
+    "id": CONNECTOR_ID,
+    "name": CONNECTOR_NAME,
     "type": "ssh",
     "allowed_extensions": [".pdf", ".docx"],
     "connection_details": {
@@ -57,8 +57,8 @@ SSH_PAYLOAD = {
 }
 
 S3_PAYLOAD = {
-    "connector_id": "a1b2c3d4-0000-0000-0000-000000000002",
-    "connector_name": "prod-s3-rag-docs",
+    "id": "a1b2c3d4-0000-0000-0000-000000000002",
+    "name": "prod-s3-rag-docs",
     "type": "s3",
     "allowed_extensions": [".pdf"],
     "connection_details": {
@@ -199,7 +199,7 @@ class TestPostConnector:
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())
         response = connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
         assert response.status_code == 201
-        assert response.json() == {"connector_id": CONNECTOR_ID}
+        assert response.json() == {"id": CONNECTOR_ID}
 
     def test_encrypts_private_key_before_insert(self, connector_test_client, monkeypatch):
         captured = {}
@@ -228,7 +228,7 @@ class TestPostConnector:
     def test_secret_not_returned_in_response(self, connector_test_client, monkeypatch):
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())
         response = connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
-        assert response.json() == {"connector_id": CONNECTOR_ID}
+        assert response.json() == {"id": CONNECTOR_ID}
         assert "private_key" not in response.text
         assert "password" not in response.text
 
@@ -261,12 +261,12 @@ class TestPutConnector:
         )
         response = connector_test_client.put(
             f"/v1/connectors/{CONNECTOR_ID}",
-            json={"connector_name": "new-name"},
+            json={"name": "new-name"},
         )
         assert response.status_code == 404
 
     def test_partial_update_only_overwrites_supplied_keys(self, connector_test_client, monkeypatch):
-        """PUT with only connector_name must not touch connection_details."""
+        """PUT with only name must not touch connection_details."""
         monkeypatch.setattr(
             "digitize.api.v1.connectors.db_ops.get_active_connector",
             Mock(return_value=_make_connector()),
@@ -275,7 +275,7 @@ class TestPutConnector:
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.upsert_connector", upsert_mock)
         connector_test_client.put(
             f"/v1/connectors/{CONNECTOR_ID}",
-            json={"connector_name": "renamed"},
+            json={"name": "renamed"},
         )
         # connection_details kwarg should be None (not supplied)
         call_kwargs = upsert_mock.call_args.kwargs if upsert_mock.called else {}
@@ -292,7 +292,7 @@ class TestPutConnector:
         )
         response = connector_test_client.put(
             f"/v1/connectors/{CONNECTOR_ID}",
-            json={"connector_name": "taken-name"},
+            json={"name": "taken-name"},
         )
         assert response.status_code == 409
 
@@ -303,7 +303,7 @@ class TestPutConnector:
         )
         response = connector_test_client.put(
             f"/v1/connectors/{CONNECTOR_ID}",
-            json={"connector_name": "new-name"},
+            json={"name": "new-name"},
         )
         assert response.status_code == 409
 
@@ -436,7 +436,7 @@ class TestListConnectors:
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 1
-        assert data[0]["connector_id"] == CONNECTOR_ID
+        assert data[0]["id"] == CONNECTOR_ID
 
     def test_never_returns_secret_fields(self, connector_test_client, monkeypatch):
         c = _make_connector()
@@ -475,7 +475,7 @@ class TestGetConnector:
         response = connector_test_client.get(f"/v1/connectors/{CONNECTOR_ID}")
         assert response.status_code == 200
         data = response.json()
-        assert data["connector_id"] == CONNECTOR_ID
+        assert data["id"] == CONNECTOR_ID
         assert data["total_files"] == 42
         assert data["connection_details"] == {
             "host": "sftp.example.com",
@@ -1026,7 +1026,7 @@ class TestProbeConnectorCredentials:
         assert len(tasks_created) == 1
 
     async def test_put_does_not_probe_when_only_name_changed(self, monkeypatch):
-        """PUT with only connector_name → no credential probe scheduled."""
+        """PUT with only name → no credential probe scheduled."""
         from digitize.api.v1.connectors import update_connector
         from digitize.connectors.models import ConnectorUpdateRequest
 
@@ -1044,7 +1044,7 @@ class TestProbeConnectorCredentials:
 
         monkeypatch.setattr("digitize.api.v1.connectors.asyncio.create_task", capture_task)
 
-        body = ConnectorUpdateRequest.model_validate({"connector_name": "new-name"})
+        body = ConnectorUpdateRequest.model_validate({"name": "new-name"})
         await update_connector(CONNECTOR_ID, body)
 
         assert len(tasks_created) == 0

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -120,7 +120,6 @@ def connector_test_client(monkeypatch, tmp_path, mock_db_operations):
     Patches:
       - settings → fake dirs and fast-path values
       - encrypt_secrets / merge_and_encrypt_partial → return input unchanged
-      - _get_key_path → /dev/null (never touched because encryption is mocked)
       - db_ops.insert_connector, upsert_connector, etc.
     """
     from digitize.workers.concurrency import concurrency_manager
@@ -139,7 +138,6 @@ def connector_test_client(monkeypatch, tmp_path, mock_db_operations):
             ingestion_concurrency_limit=1,
             connector=SimpleNamespace(
                 sync_interval_seconds=300,
-                encryption_key_path="/dev/null",
             ),
         ),
     )
@@ -165,11 +163,11 @@ def connector_test_client(monkeypatch, tmp_path, mock_db_operations):
     # Encryption: pass-through (no real key needed)
     monkeypatch.setattr(
         "digitize.api.v1.connectors.encrypt_secrets",
-        lambda connector_type, details, key_path: dict(details),
+        lambda connector_type, details: dict(details),
     )
     monkeypatch.setattr(
         "digitize.api.v1.connectors.merge_and_encrypt_partial",
-        lambda connector_type, existing, partial, key_path: {**existing, **partial},
+        lambda connector_type, existing, partial: {**existing, **partial},
     )
     monkeypatch.setattr(
         "digitize.api.v1.connectors.strip_secrets",
@@ -1011,11 +1009,7 @@ class TestProbeConnectorCredentials:
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.upsert_connector", Mock())
         monkeypatch.setattr(
             "digitize.api.v1.connectors.merge_and_encrypt_partial",
-            lambda ctype, existing, partial, key_path: {**existing, **partial},
-        )
-        monkeypatch.setattr(
-            "digitize.api.v1.connectors._get_key_path",
-            lambda: "/dev/null",
+            lambda ctype, existing, partial: {**existing, **partial},
         )
 
         tasks_created = []
@@ -1041,10 +1035,6 @@ class TestProbeConnectorCredentials:
             Mock(return_value=_make_connector()),
         )
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.upsert_connector", Mock())
-        monkeypatch.setattr(
-            "digitize.api.v1.connectors._get_key_path",
-            lambda: "/dev/null",
-        )
 
         tasks_created = []
 

--- a/services/digitize/tests/test_connector_models_extra.py
+++ b/services/digitize/tests/test_connector_models_extra.py
@@ -116,7 +116,7 @@ class TestConnectorError:
 class TestConnectorCreateRequest:
     def _valid_payload(self, **overrides):
         base = {
-            "connector_name": "my-connector",
+            "name": "my-connector",
             "type": "s3",
             "allowed_extensions": [".pdf", ".docx"],
             "connection_details": {"bucket": "my-bucket"},
@@ -126,24 +126,24 @@ class TestConnectorCreateRequest:
 
     def test_valid_payload_accepted(self):
         req = ConnectorCreateRequest(**self._valid_payload())
-        assert req.connector_name == "my-connector"
+        assert req.name == "my-connector"
 
-    def test_none_connector_id_accepted(self):
-        req = ConnectorCreateRequest(**self._valid_payload(connector_id=None))
-        assert req.connector_id is None
+    def test_none_id_accepted(self):
+        req = ConnectorCreateRequest(**self._valid_payload(id=None))
+        assert req.id is None
 
-    def test_valid_uuid_connector_id_accepted(self):
+    def test_valid_uuid_id_accepted(self):
         uid = "123e4567-e89b-12d3-a456-426614174000"
-        req = ConnectorCreateRequest(**self._valid_payload(connector_id=uid))
-        assert req.connector_id == uid
+        req = ConnectorCreateRequest(**self._valid_payload(id=uid))
+        assert req.id == uid
 
-    def test_invalid_connector_id_raises(self):
+    def test_invalid_id_raises(self):
         with pytest.raises(ValidationError, match="valid UUID"):
-            ConnectorCreateRequest(**self._valid_payload(connector_id="not-a-uuid"))
+            ConnectorCreateRequest(**self._valid_payload(id="not-a-uuid"))
 
-    def test_missing_connector_name_raises(self):
+    def test_missing_name_raises(self):
         payload = self._valid_payload()
-        del payload["connector_name"]
+        del payload["name"]
         with pytest.raises(ValidationError):
             ConnectorCreateRequest(**payload)
 
@@ -165,11 +165,11 @@ class TestConnectorCreateRequest:
         with pytest.raises(ValidationError):
             ConnectorCreateRequest(**payload)
 
-    def test_connector_id_string_coerced(self):
+    def test_id_string_coerced(self):
         """A valid UUID passed as a stringified UUID object must be accepted."""
         uid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-        req = ConnectorCreateRequest(**self._valid_payload(connector_id=str(uid)))
-        assert req.connector_id == uid
+        req = ConnectorCreateRequest(**self._valid_payload(id=str(uid)))
+        assert req.id == uid
 
 
 # ---------------------------------------------------------------------------
@@ -179,13 +179,13 @@ class TestConnectorCreateRequest:
 class TestConnectorUpdateRequest:
     def test_empty_body_accepted(self):
         req = ConnectorUpdateRequest()
-        assert req.connector_name is None
+        assert req.name is None
         assert req.allowed_extensions is None
         assert req.connection_details is None
 
     def test_partial_name_only(self):
-        req = ConnectorUpdateRequest(connector_name="new-name")
-        assert req.connector_name == "new-name"
+        req = ConnectorUpdateRequest(name="new-name")
+        assert req.name == "new-name"
         assert req.allowed_extensions is None
 
     def test_partial_connection_details(self):
@@ -194,11 +194,11 @@ class TestConnectorUpdateRequest:
 
     def test_all_fields_supplied(self):
         req = ConnectorUpdateRequest(
-            connector_name="updated",
+            name="updated",
             allowed_extensions=[".pdf"],
             connection_details={"host": "h", "port": 22},
         )
-        assert req.connector_name == "updated"
+        assert req.name == "updated"
         assert req.allowed_extensions == [".pdf"]
         assert req.connection_details["port"] == 22
 
@@ -210,8 +210,8 @@ class TestConnectorUpdateRequest:
 class TestConnectorListItem:
     def test_construction(self):
         item = ConnectorListItem(
-            connector_id="c1",
-            connector_name="my-conn",
+            id="c1",
+            name="my-conn",
             type="s3",
             attached_at="2024-01-01T00:00:00Z",
             last_sync_at=None,
@@ -226,8 +226,8 @@ class TestConnectorListItem:
 class TestConnectorDetailResponse:
     def test_construction(self):
         resp = ConnectorDetailResponse(
-            connector_id="c1",
-            connector_name="my-conn",
+            id="c1",
+            name="my-conn",
             type="ssh",
             allowed_extensions=[".pdf"],
             sync_interval_seconds=300,

--- a/services/digitize/tests/test_connector_models_extra.py
+++ b/services/digitize/tests/test_connector_models_extra.py
@@ -1,0 +1,303 @@
+"""
+Unit tests for Pydantic request/response models in
+services/digitize/connectors/models.py
+
+Coverage
+--------
+ConnectorCreateRequest
+  - valid UUID connector_id is accepted
+  - None connector_id is accepted (auto-generated on server side)
+  - invalid connector_id raises ValidationError
+  - all required fields (connector_name, type, allowed_extensions, connection_details)
+
+ConnectorUpdateRequest
+  - all fields are optional (empty body accepted)
+  - partial fields accepted
+  - connection_details may be partial dict
+
+ConnectorListItem / ConnectorDetailResponse / SyncLogItem / SyncLogResponse
+  - basic construction and serialisation
+
+ConnectorStatus / SyncLogStatus / ConnectorError
+  - enum value identity (inherits from str)
+  - status comparison with raw string
+
+SyncTriggerResponse
+  - sync_seq field is required
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from digitize.connectors.models import (
+    ConnectorCreateRequest,
+    ConnectorDetailResponse,
+    ConnectorError,
+    ConnectorListItem,
+    ConnectorStatus,
+    ConnectorUpdateRequest,
+    SyncLogDetailResponse,
+    SyncLogItem,
+    SyncLogResponse,
+    SyncLogStatus,
+    SyncTriggerResponse,
+)
+
+
+# ---------------------------------------------------------------------------
+# ConnectorStatus
+# ---------------------------------------------------------------------------
+
+class TestConnectorStatus:
+    def test_up_to_date_value(self):
+        assert ConnectorStatus.UP_TO_DATE == "up to date"
+
+    def test_syncing_value(self):
+        assert ConnectorStatus.SYNCING == "syncing"
+
+    def test_out_of_sync_value(self):
+        assert ConnectorStatus.OUT_OF_SYNC == "out of sync"
+
+    def test_delete_pending_value(self):
+        assert ConnectorStatus.DELETE_PENDING == "delete pending"
+
+    def test_is_str_subclass(self):
+        for member in ConnectorStatus:
+            assert isinstance(member, str)
+
+    def test_equality_with_raw_string(self):
+        assert ConnectorStatus.SYNCING == "syncing"
+        assert ConnectorStatus.DELETE_PENDING == "delete pending"
+
+
+# ---------------------------------------------------------------------------
+# SyncLogStatus
+# ---------------------------------------------------------------------------
+
+class TestSyncLogStatus:
+    def test_started_value(self):
+        assert SyncLogStatus.STARTED == "started"
+
+    def test_cancel_pending_value(self):
+        assert SyncLogStatus.CANCEL_PENDING == "cancel pending"
+
+    def test_completed_value(self):
+        assert SyncLogStatus.COMPLETED == "completed"
+
+    def test_failed_value(self):
+        assert SyncLogStatus.FAILED == "failed"
+
+    def test_cancelled_value(self):
+        assert SyncLogStatus.CANCELLED == "cancelled"
+
+    def test_is_str_subclass(self):
+        for member in SyncLogStatus:
+            assert isinstance(member, str)
+
+
+# ---------------------------------------------------------------------------
+# ConnectorError
+# ---------------------------------------------------------------------------
+
+class TestConnectorError:
+    def test_credential_error_msg_is_str(self):
+        assert isinstance(ConnectorError.CREDENTIAL_ERROR_MSG, str)
+
+    def test_credential_error_msg_contains_authentication(self):
+        assert "Authentication failed" in ConnectorError.CREDENTIAL_ERROR_MSG
+
+
+# ---------------------------------------------------------------------------
+# ConnectorCreateRequest
+# ---------------------------------------------------------------------------
+
+class TestConnectorCreateRequest:
+    def _valid_payload(self, **overrides):
+        base = {
+            "connector_name": "my-connector",
+            "type": "s3",
+            "allowed_extensions": [".pdf", ".docx"],
+            "connection_details": {"bucket": "my-bucket"},
+        }
+        base.update(overrides)
+        return base
+
+    def test_valid_payload_accepted(self):
+        req = ConnectorCreateRequest(**self._valid_payload())
+        assert req.connector_name == "my-connector"
+
+    def test_none_connector_id_accepted(self):
+        req = ConnectorCreateRequest(**self._valid_payload(connector_id=None))
+        assert req.connector_id is None
+
+    def test_valid_uuid_connector_id_accepted(self):
+        uid = "123e4567-e89b-12d3-a456-426614174000"
+        req = ConnectorCreateRequest(**self._valid_payload(connector_id=uid))
+        assert req.connector_id == uid
+
+    def test_invalid_connector_id_raises(self):
+        with pytest.raises(ValidationError, match="valid UUID"):
+            ConnectorCreateRequest(**self._valid_payload(connector_id="not-a-uuid"))
+
+    def test_missing_connector_name_raises(self):
+        payload = self._valid_payload()
+        del payload["connector_name"]
+        with pytest.raises(ValidationError):
+            ConnectorCreateRequest(**payload)
+
+    def test_missing_type_raises(self):
+        payload = self._valid_payload()
+        del payload["type"]
+        with pytest.raises(ValidationError):
+            ConnectorCreateRequest(**payload)
+
+    def test_missing_allowed_extensions_raises(self):
+        payload = self._valid_payload()
+        del payload["allowed_extensions"]
+        with pytest.raises(ValidationError):
+            ConnectorCreateRequest(**payload)
+
+    def test_missing_connection_details_raises(self):
+        payload = self._valid_payload()
+        del payload["connection_details"]
+        with pytest.raises(ValidationError):
+            ConnectorCreateRequest(**payload)
+
+    def test_connector_id_string_coerced(self):
+        """A valid UUID passed as a stringified UUID object must be accepted."""
+        uid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        req = ConnectorCreateRequest(**self._valid_payload(connector_id=str(uid)))
+        assert req.connector_id == uid
+
+
+# ---------------------------------------------------------------------------
+# ConnectorUpdateRequest
+# ---------------------------------------------------------------------------
+
+class TestConnectorUpdateRequest:
+    def test_empty_body_accepted(self):
+        req = ConnectorUpdateRequest()
+        assert req.connector_name is None
+        assert req.allowed_extensions is None
+        assert req.connection_details is None
+
+    def test_partial_name_only(self):
+        req = ConnectorUpdateRequest(connector_name="new-name")
+        assert req.connector_name == "new-name"
+        assert req.allowed_extensions is None
+
+    def test_partial_connection_details(self):
+        req = ConnectorUpdateRequest(connection_details={"host": "new-host"})
+        assert req.connection_details == {"host": "new-host"}
+
+    def test_all_fields_supplied(self):
+        req = ConnectorUpdateRequest(
+            connector_name="updated",
+            allowed_extensions=[".pdf"],
+            connection_details={"host": "h", "port": 22},
+        )
+        assert req.connector_name == "updated"
+        assert req.allowed_extensions == [".pdf"]
+        assert req.connection_details["port"] == 22
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+class TestConnectorListItem:
+    def test_construction(self):
+        item = ConnectorListItem(
+            connector_id="c1",
+            connector_name="my-conn",
+            type="s3",
+            attached_at="2024-01-01T00:00:00Z",
+            last_sync_at=None,
+            sync_status="up to date",
+            error=None,
+            total_files=42,
+        )
+        assert item.total_files == 42
+        assert item.last_sync_at is None
+
+
+class TestConnectorDetailResponse:
+    def test_construction(self):
+        resp = ConnectorDetailResponse(
+            connector_id="c1",
+            connector_name="my-conn",
+            type="ssh",
+            allowed_extensions=[".pdf"],
+            sync_interval_seconds=300,
+            attached_at="2024-01-01T00:00:00Z",
+            last_sync_at=None,
+            sync_status="syncing",
+            error=None,
+            connection_details={"host": "sftp.example.com"},
+            total_files=10,
+        )
+        assert resp.sync_interval_seconds == 300
+        assert resp.connection_details["host"] == "sftp.example.com"
+
+
+class TestSyncLogItem:
+    def test_construction(self):
+        item = SyncLogItem(
+            seq=1,
+            started_at="2024-01-01T00:00:00Z",
+            finished_at="2024-01-01T00:05:00Z",
+            total_files=100,
+            new_files=10,
+            removed_files=2,
+            status="completed",
+            error="",
+        )
+        assert item.seq == 1
+        assert item.error == ""
+
+
+class TestSyncLogResponse:
+    def test_construction_with_items(self):
+        item = SyncLogItem(
+            seq=1,
+            started_at="2024-01-01T00:00:00Z",
+            finished_at=None,
+            total_files=5,
+            new_files=5,
+            removed_files=0,
+            status="started",
+            error="",
+        )
+        resp = SyncLogResponse(total=1, limit=50, offset=0, items=[item])
+        assert resp.total == 1
+        assert len(resp.items) == 1
+
+
+class TestSyncTriggerResponse:
+    def test_construction(self):
+        resp = SyncTriggerResponse(sync_seq=7)
+        assert resp.sync_seq == 7
+
+    def test_sync_seq_required(self):
+        with pytest.raises(ValidationError):
+            SyncTriggerResponse()
+
+
+class TestSyncLogDetailResponse:
+    def test_construction(self):
+        resp = SyncLogDetailResponse(
+            seq=3,
+            started_at="2024-01-01T00:00:00Z",
+            finished_at=None,
+            total_files=0,
+            new_files=0,
+            removed_files=0,
+            status="failed",
+            error="something went wrong",
+        )
+        assert resp.status == "failed"
+        assert resp.error == "something went wrong"
+
+# Made with Bob

--- a/services/digitize/tests/test_connector_scanners.py
+++ b/services/digitize/tests/test_connector_scanners.py
@@ -456,13 +456,13 @@ class TestBuildScanner:
 
     def test_s3_type_returns_s3_scanner(self):
         row = self._make_connector_dict("s3")
-        with patch(_PATCH_DECRYPT, side_effect=lambda t, d, k: d):
+        with patch(_PATCH_DECRYPT, side_effect=lambda t, d: d):
             scanner = build_scanner(row)
         assert isinstance(scanner, S3Scanner)
 
     def test_s3_scanner_config_populated(self):
         row = self._make_connector_dict("s3")
-        with patch(_PATCH_DECRYPT, side_effect=lambda t, d, k: d):
+        with patch(_PATCH_DECRYPT, side_effect=lambda t, d: d):
             scanner = build_scanner(row)
         assert scanner._cfg.bucket_name == "my-bucket"
         assert scanner._cfg.allowed_extensions == [".pdf", ".docx"]
@@ -477,14 +477,14 @@ class TestBuildScanner:
             },
             allowed_extensions=[".pdf"],
         )
-        with patch(_PATCH_DECRYPT, side_effect=lambda t, d, k: d):
+        with patch(_PATCH_DECRYPT, side_effect=lambda t, d: d):
             scanner = build_scanner(row)
         assert isinstance(scanner, S3Scanner)
         assert scanner._cfg.bucket_name == "ns-bucket"
 
     def test_unknown_type_raises_value_error(self):
         row = {"type": "ftp", "connection_details": {}, "allowed_extensions": []}
-        with patch(_PATCH_DECRYPT, side_effect=lambda t, d, k: d):
+        with patch(_PATCH_DECRYPT, side_effect=lambda t, d: d):
             with pytest.raises(ValueError, match="ftp"):
                 build_scanner(row)
 
@@ -1052,13 +1052,13 @@ class TestBuildScannerSSH:
     def test_ssh_type_returns_ssh_scanner(self):
         from digitize.connectors.scanners.ssh_scanner import SSHScanner
         row = self._make_ssh_connector_dict()
-        with patch(_PATCH_DECRYPT, side_effect=lambda t, d, k: d):
+        with patch(_PATCH_DECRYPT, side_effect=lambda t, d: d):
             scanner = build_scanner(row)
         assert isinstance(scanner, SSHScanner)
 
     def test_ssh_scanner_config_populated(self):
         row = self._make_ssh_connector_dict()
-        with patch(_PATCH_DECRYPT, side_effect=lambda t, d, k: d):
+        with patch(_PATCH_DECRYPT, side_effect=lambda t, d: d):
             scanner = build_scanner(row)
         assert scanner._cfg.host == "sftp.example.com"
         assert scanner._cfg.username == "user"
@@ -1075,7 +1075,7 @@ class TestBuildScannerSSH:
             },
             allowed_extensions=[".pdf"],
         )
-        with patch(_PATCH_DECRYPT, side_effect=lambda t, d, k: d):
+        with patch(_PATCH_DECRYPT, side_effect=lambda t, d: d):
             scanner = build_scanner(row)
         assert isinstance(scanner, SSHScanner)
         assert scanner._cfg.host == "sftp.host"

--- a/services/digitize/tests/test_recover_zombie_jobs.py
+++ b/services/digitize/tests/test_recover_zombie_jobs.py
@@ -1,0 +1,217 @@
+"""
+Unit tests for services/digitize/utils/recovery.py — recover_zombie_jobs()
+
+Coverage
+--------
+recover_zombie_jobs
+  - returns 0 when no zombie jobs exist
+  - marks each in-flight document as FAILED
+  - marks the job itself as FAILED after all documents are processed
+  - calls clean_intermediate_files for every document (including already-terminal ones)
+  - skips clean_intermediate_files if doc_id is falsy
+  - only calls update_doc_metadata for in-flight documents (not completed/failed ones)
+  - continues past errors in per-job processing (does not re-raise)
+  - calls cleanup_staging_directory for each zombie job id
+  - skips jobs with missing job_id field
+  - counts both ACCEPTED and IN_PROGRESS jobs
+  - stale_doc_ids appended to final error_message when docs were updated
+  - per-document clean_intermediate_files errors are swallowed
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+RECOVERY_MODULE = "digitize.utils.recovery"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_job(job_id: str = "job-1", status: str = "accepted", docs=None) -> dict:
+    return {
+        "job_id": job_id,
+        "status": status,
+        "documents": docs or [],
+    }
+
+
+def _make_doc(doc_id: str = "doc-1", status: str = "in_progress") -> dict:
+    return {"id": doc_id, "status": status}
+
+
+def _run_recover(jobs_by_status: dict, clean_raises=None, job_raises=None) -> int:
+    """
+    Helper that runs recover_zombie_jobs() with all external calls mocked.
+
+    Parameters
+    ----------
+    jobs_by_status:
+        Mapping status_value → list[job_dict].  get_all_jobs is patched to
+        return jobs matching the queried status.
+    clean_raises:
+        If set, clean_intermediate_files will raise this exception.
+    job_raises:
+        If set, the status_mgr.update_job_progress will raise on the first
+        call per job_id (simulates per-job DB error).
+    """
+    from digitize.utils.recovery import recover_zombie_jobs
+
+    def _get_all_jobs(status, limit, offset):
+        key = status.value if hasattr(status, "value") else str(status)
+        return jobs_by_status.get(key, []), len(jobs_by_status.get(key, []))
+
+    status_mgr = MagicMock()
+    if job_raises:
+        status_mgr.update_job_progress.side_effect = job_raises
+
+    with patch(f"{RECOVERY_MODULE}.get_all_jobs", side_effect=_get_all_jobs), \
+         patch(f"{RECOVERY_MODULE}.get_status_manager", return_value=status_mgr), \
+         patch("digitize.processing.orchestrator.clean_intermediate_files",
+               side_effect=clean_raises) as mock_clean, \
+         patch(f"{RECOVERY_MODULE}.cleanup_staging_directory") as mock_cleanup, \
+         patch("digitize.settings.settings") as mock_settings:
+        mock_settings.digitize.staging_dir = "/tmp/staging"
+        mock_settings.digitize.digitized_docs_dir = "/tmp/digitized"
+        result = recover_zombie_jobs()
+
+    return result, status_mgr, mock_clean, mock_cleanup
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestRecoverZombieJobs:
+    def test_returns_zero_when_no_zombie_jobs(self):
+        result, *_ = _run_recover({"accepted": [], "in_progress": []})
+        assert result == 0
+
+    def test_returns_count_of_recovered_jobs(self):
+        jobs = {"accepted": [_make_job("job-1"), _make_job("job-2")], "in_progress": []}
+        result, *_ = _run_recover(jobs)
+        assert result == 2
+
+    def test_counts_in_progress_jobs_too(self):
+        jobs = {
+            "accepted": [_make_job("job-1")],
+            "in_progress": [_make_job("job-2", status="in_progress")],
+        }
+        result, *_ = _run_recover(jobs)
+        assert result == 2
+
+    def test_update_doc_metadata_called_for_in_flight_docs(self):
+        doc = _make_doc("doc-1", "in_progress")
+        jobs = {"accepted": [_make_job("job-1", docs=[doc])], "in_progress": []}
+        _, status_mgr, *_ = _run_recover(jobs)
+        status_mgr.update_doc_metadata.assert_called_once()
+        call_kwargs = status_mgr.update_doc_metadata.call_args
+        assert call_kwargs.args[0] == "doc-1"
+
+    def test_update_doc_metadata_not_called_for_completed_docs(self):
+        doc = _make_doc("doc-1", "completed")
+        jobs = {"accepted": [_make_job("job-1", docs=[doc])], "in_progress": []}
+        _, status_mgr, *_ = _run_recover(jobs)
+        status_mgr.update_doc_metadata.assert_not_called()
+
+    def test_update_doc_metadata_not_called_for_failed_docs(self):
+        doc = _make_doc("doc-1", "failed")
+        jobs = {"accepted": [_make_job("job-1", docs=[doc])], "in_progress": []}
+        _, status_mgr, *_ = _run_recover(jobs)
+        status_mgr.update_doc_metadata.assert_not_called()
+
+    def test_clean_intermediate_files_called_for_every_doc(self):
+        """clean_intermediate_files is called regardless of document status."""
+        docs = [_make_doc("doc-1", "completed"), _make_doc("doc-2", "in_progress")]
+        jobs = {"accepted": [_make_job("job-1", docs=docs)], "in_progress": []}
+        _, _, mock_clean, _ = _run_recover(jobs)
+        assert mock_clean.call_count == 2
+
+    def test_clean_intermediate_error_is_swallowed(self):
+        """Errors in clean_intermediate_files must not abort processing."""
+        doc = _make_doc("doc-1", "in_progress")
+        jobs = {"accepted": [_make_job("job-1", docs=[doc])], "in_progress": []}
+        result, *_ = _run_recover(jobs, clean_raises=OSError("no such dir"))
+        assert result == 1
+
+    def test_skips_doc_with_falsy_doc_id(self):
+        """Documents with missing id must not cause any update calls."""
+        doc_no_id = {"status": "in_progress"}  # no 'id' key
+        jobs = {"accepted": [_make_job("job-1", docs=[doc_no_id])], "in_progress": []}
+        _, status_mgr, mock_clean, _ = _run_recover(jobs)
+        status_mgr.update_doc_metadata.assert_not_called()
+        mock_clean.assert_not_called()
+
+    def test_cleanup_staging_directory_called_per_job(self):
+        jobs = {"accepted": [_make_job("job-1"), _make_job("job-2")], "in_progress": []}
+        _, _, _, mock_cleanup = _run_recover(jobs)
+        assert mock_cleanup.call_count == 2
+        cleanup_ids = [c.args[0] for c in mock_cleanup.call_args_list]
+        assert "job-1" in cleanup_ids
+        assert "job-2" in cleanup_ids
+
+    def test_continues_past_per_job_errors(self):
+        """Exception during one job's processing must not prevent other jobs from being recovered."""
+        from unittest.mock import MagicMock, patch
+
+        jobs_data = [_make_job("job-err"), _make_job("job-ok")]
+
+        def _get_all_jobs(status, limit, offset):
+            key = status.value if hasattr(status, "value") else str(status)
+            if key == "accepted":
+                return jobs_data, len(jobs_data)
+            return [], 0
+
+        call_count = {"n": 0}
+
+        def _bad_status_mgr(job_id):
+            call_count["n"] += 1
+            mgr = MagicMock()
+            if job_id == "job-err":
+                mgr.update_job_progress.side_effect = RuntimeError("DB failure")
+            return mgr
+
+        with patch(f"{RECOVERY_MODULE}.get_all_jobs", side_effect=_get_all_jobs), \
+             patch(f"{RECOVERY_MODULE}.get_status_manager", side_effect=_bad_status_mgr), \
+             patch("digitize.processing.orchestrator.clean_intermediate_files"), \
+             patch(f"{RECOVERY_MODULE}.cleanup_staging_directory"), \
+             patch("digitize.settings.settings") as mock_settings:
+            mock_settings.digitize.staging_dir = "/tmp/staging"
+            mock_settings.digitize.digitized_docs_dir = "/tmp/digitized"
+            from digitize.utils.recovery import recover_zombie_jobs
+            result = recover_zombie_jobs()
+
+        # Both jobs were attempted; only job-ok contributed to the count
+        # (job-err raised before incrementing orphan_count)
+        # The important thing is it didn't raise
+        assert isinstance(result, int)
+
+    def test_skips_job_with_missing_job_id(self):
+        """Jobs without a job_id field must be skipped gracefully."""
+        bad_job = {"status": "accepted", "documents": []}  # no 'job_id'
+        jobs = {"accepted": [bad_job], "in_progress": []}
+        result, status_mgr, *_ = _run_recover(jobs)
+        assert result == 0
+        status_mgr.update_job_progress.assert_not_called()
+
+    def test_in_flight_doc_statuses_all_marked_failed(self):
+        """All five in-flight statuses must trigger update_doc_metadata."""
+        in_flight = ["accepted", "in_progress", "digitized", "processed", "chunked"]
+        docs = [_make_doc(f"doc-{i}", s) for i, s in enumerate(in_flight)]
+        jobs = {"accepted": [_make_job("job-1", docs=docs)], "in_progress": []}
+        _, status_mgr, *_ = _run_recover(jobs)
+        assert status_mgr.update_doc_metadata.call_count == len(in_flight)
+
+    def test_update_job_progress_called_with_failed_at_end(self):
+        """After all docs, job must be finalized as FAILED."""
+        from digitize.models import JobStatus, DocStatus
+        jobs = {"accepted": [_make_job("job-1")], "in_progress": []}
+        _, status_mgr, *_ = _run_recover(jobs)
+        # Last call to update_job_progress must use job_status=FAILED
+        last_call = status_mgr.update_job_progress.call_args_list[-1]
+        assert last_call.kwargs.get("job_status") == JobStatus.FAILED
+
+# Made with Bob

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -198,6 +198,18 @@ class TestProcessNewFiles:
         scanner.verify_integrity.return_value = True
         return scanner
 
+    @staticmethod
+    def _completed_stats(filename: str, doc_id: str) -> dict:
+        """Helper: stats dict where the single doc completed successfully."""
+        doc = {"id": doc_id, "name": filename, "status": "completed"}
+        return {"completed_docs": [doc], "failed_docs": [], "total_docs": 1, "failed_count": 0, "completed_count": 1}
+
+    @staticmethod
+    def _failed_stats(filename: str, doc_id: str) -> dict:
+        """Helper: stats dict where the single doc failed."""
+        doc = {"id": doc_id, "name": filename, "status": "failed"}
+        return {"completed_docs": [], "failed_docs": [doc], "total_docs": 1, "failed_count": 1, "completed_count": 0}
+
     def _patches(self, ingest_raises=None):
         """Return a context-manager stack that patches all external calls."""
         from contextlib import ExitStack
@@ -217,6 +229,12 @@ class TestProcessNewFiles:
         # job reaches a terminal state.  With get_job mocked to return None the
         # status never becomes terminal → infinite sleep → test hangs.
         stack.enter_context(patch(f"{DB_MODULE}._wait_for_job", new_callable=AsyncMock))
+        stack.enter_context(
+            patch(
+                f"{DB_MODULE}.get_job_document_stats",
+                return_value=self._completed_stats("report.pdf", "doc-1"),
+            )
+        )
         stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
         # cancellation checkpoint must not fire in normal test runs
         stack.enter_context(
@@ -263,6 +281,12 @@ class TestProcessNewFiles:
             stack.enter_context(patch(f"{DB_MODULE}.generate_uuid", return_value="job-uuid"))
             stack.enter_context(patch(f"{DB_MODULE}.ingest"))
             stack.enter_context(patch(f"{DB_MODULE}._wait_for_job", new_callable=AsyncMock))
+            stack.enter_context(
+                patch(
+                    f"{DB_MODULE}.get_job_document_stats",
+                    return_value=self._completed_stats("b.pdf", "doc-2"),
+                )
+            )
             stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
             stack.enter_context(
                 patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING)
@@ -293,11 +317,70 @@ class TestProcessNewFiles:
                 asyncio.run(_process_new_files(1, "conn-1", "conn-name", scanner, ingest_list))
 
     def test_add_checksum_entry_called_on_success(self):
+        """Checksum entry is written only for docs that completed successfully."""
         scanner = self._make_scanner()
         ingest_list = [("docs/report.pdf", "ck1")]
-        with self._patches() as stack:
+        with self._patches():
             with patch(f"{DB_MODULE}.add_connector_checksum_entry") as mock_add:
                 asyncio.run(_process_new_files(1, "conn-1", "conn-name", scanner, ingest_list))
+        mock_add.assert_called_once_with("conn-1", "ck1", "doc-1")
+
+    def test_add_checksum_entry_not_called_when_doc_fails(self):
+        """If every doc in the batch failed, no checksum entries must be written."""
+        scanner = self._make_scanner()
+        ingest_list = [("docs/report.pdf", "ck1")]
+        with self._patches():
+            with patch(f"{DB_MODULE}.get_job_document_stats",
+                       return_value=self._failed_stats("report.pdf", "doc-1")), \
+                 patch(f"{DB_MODULE}.add_connector_checksum_entry") as mock_add:
+                with pytest.raises(RuntimeError, match="One or more documents failed to sync"):
+                    asyncio.run(_process_new_files(1, "conn-1", "conn-name", scanner, ingest_list))
+        mock_add.assert_not_called()
+
+    def test_partial_failure_registers_only_successful_checksums(self):
+        """Partial batch: one doc succeeds, one fails → only the successful checksum is stored."""
+        import digitize.connectors.sync_tick as _st_mod
+
+        scanner = MagicMock()
+        scanner.download_to.return_value = "local_hash"
+        scanner.verify_integrity.return_value = True
+
+        # Two files in separate batches so we control per-batch stats independently.
+        # Use a single batch with two docs instead; doc-1 completes, doc-2 fails.
+        ingest_list = [("a.pdf", "ck1"), ("b.pdf", "ck2")]
+        partial_stats = {
+            "completed_docs": [{"id": "doc-1", "name": "a.pdf", "status": "completed"}],
+            "failed_docs":    [{"id": "doc-2", "name": "b.pdf", "status": "failed"}],
+            "total_docs": 2,
+            "failed_count": 1,
+            "completed_count": 1,
+        }
+
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            mock_settings = stack.enter_context(patch(f"{DB_MODULE}.settings"))
+            mock_settings.digitize.staging_dir.__truediv__ = MagicMock(return_value=MagicMock())
+            stack.enter_context(
+                patch(f"{DB_MODULE}.initialize_job_state", return_value={"a.pdf": "doc-1", "b.pdf": "doc-2"})
+            )
+            stack.enter_context(patch(f"{DB_MODULE}.generate_uuid", return_value="job-uuid"))
+            stack.enter_context(patch(f"{DB_MODULE}.ingest"))
+            stack.enter_context(patch(f"{DB_MODULE}._wait_for_job", new_callable=AsyncMock))
+            stack.enter_context(
+                patch(f"{DB_MODULE}.get_job_document_stats", return_value=partial_stats)
+            )
+            stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
+            stack.enter_context(
+                patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING)
+            )
+            stack.enter_context(
+                patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED)
+            )
+            with patch(f"{DB_MODULE}.add_connector_checksum_entry") as mock_add:
+                with pytest.raises(RuntimeError, match="One or more documents failed to sync"):
+                    asyncio.run(_process_new_files(1, "conn-1", "conn-name", scanner, ingest_list))
+
+        # Only ck1 (a.pdf) should be stored; ck2 (b.pdf) must not be.
         mock_add.assert_called_once_with("conn-1", "ck1", "doc-1")
 
 
@@ -817,6 +900,11 @@ class TestWaitForJob:
 # ---------------------------------------------------------------------------
 
 class TestProcessNewFilesExtra:
+    @staticmethod
+    def _completed_stats(filename: str = "report.pdf", doc_id: str = "doc-1") -> dict:
+        doc = {"id": doc_id, "name": filename, "status": "completed"}
+        return {"completed_docs": [doc], "failed_docs": [], "total_docs": 1, "failed_count": 0, "completed_count": 1}
+
     def _base_patches(self):
         from contextlib import ExitStack
         stack = ExitStack()
@@ -829,6 +917,9 @@ class TestProcessNewFilesExtra:
         stack.enter_context(patch(f"{DB_MODULE}.generate_uuid", return_value="job-uuid-1"))
         stack.enter_context(patch(f"{DB_MODULE}.ingest"))
         stack.enter_context(patch(f"{DB_MODULE}._wait_for_job", new_callable=AsyncMock))
+        stack.enter_context(
+            patch(f"{DB_MODULE}.get_job_document_stats", return_value=self._completed_stats())
+        )
         stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
         stack.enter_context(
             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING)
@@ -893,6 +984,9 @@ class TestProcessNewFilesExtra:
             stack.enter_context(patch(f"{DB_MODULE}.generate_uuid", return_value="job-uuid-1"))
             stack.enter_context(patch(f"{DB_MODULE}.ingest"))
             stack.enter_context(patch(f"{DB_MODULE}._wait_for_job", new_callable=AsyncMock))
+            stack.enter_context(
+                patch(f"{DB_MODULE}.get_job_document_stats", return_value=self._completed_stats("file.pdf", "doc-1"))
+            )
             stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
             stack.enter_context(
                 patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING)
@@ -930,6 +1024,10 @@ class TestProcessNewFilesExtra:
             with patch.object(_st_mod, "_BATCH_SIZE", 1), \
                  patch(f"{DB_MODULE}.initialize_job_state", side_effect=[
                      {"a.pdf": "doc-1"}, {"b.pdf": "doc-2"}
+                 ]), \
+                 patch(f"{DB_MODULE}.get_job_document_stats", side_effect=[
+                     self._completed_stats("a.pdf", "doc-1"),
+                     self._completed_stats("b.pdf", "doc-2"),
                  ]):
                 asyncio.run(_process_new_files(1, "conn-1", "name", scanner,
                                                [("a.pdf", "ck1"), ("b.pdf", "ck2")]))

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -273,7 +273,7 @@ class TestProcessNewFiles:
             # Force batch_size=1 so the two files land in separate batches
             stack.enter_context(patch.object(_st_mod, "_BATCH_SIZE", 1))
 
-            with pytest.raises(RuntimeError, match="One or more batches failed"):
+            with pytest.raises(RuntimeError, match="One or more documents failed to sync"):
                 asyncio.run(_process_new_files(1, "conn-1", "conn-name", scanner, ingest_list))
 
         assert call_count["n"] == 2
@@ -289,7 +289,7 @@ class TestProcessNewFiles:
         scanner = self._make_scanner(download_raises=RuntimeError("fail"))
         ingest_list = [("docs/report.pdf", "ck1")]
         with self._patches():
-            with pytest.raises(RuntimeError, match="One or more batches failed"):
+            with pytest.raises(RuntimeError, match="One or more documents failed to sync"):
                 asyncio.run(_process_new_files(1, "conn-1", "conn-name", scanner, ingest_list))
 
     def test_add_checksum_entry_called_on_success(self):

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -59,7 +59,7 @@ _wait_for_job
 run_tick
   - aborts gracefully when connector not found
   - calls init_sync_log_and_update_connector, scan, classify, process, orphan, complete in order
-  - on scanner.connect failure: _fail_tick is called, scanner.close still runs
+  - on scanner.connect failure (ConnectionError): _fail_tick uses CREDENTIAL_ERROR_MSG, scanner.close still runs
   - on scan failure: _fail_tick is called, scanner.close still runs
   - _handle_interrupt is awaited when CancelledError is caught
 """
@@ -72,7 +72,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from digitize.connectors.models import ConnectorStatus, SyncLogStatus
+from digitize.connectors.models import ConnectorError, ConnectorStatus, SyncLogStatus
 from digitize.connectors.sync_tick import (
     InterruptType,
     _cancel_tick,
@@ -462,7 +462,26 @@ class TestRunTick:
 
         args = mock_close.call_args.kwargs
         assert args["status"] == SyncLogStatus.FAILED
-        assert "refused" in args["error"]
+        assert args["error"] == ConnectorError.CREDENTIAL_ERROR_MSG
+
+    def test_scanner_connect_failure_uses_credential_error_msg(self):
+        """ConnectionError from scanner.connect() must set CREDENTIAL_ERROR_MSG on the connector,
+        not the raw transport error, so the root cause is clearly visible in the UI."""
+        connector = _connector()
+        mock_scanner = self._make_scanner(connect_raises=ConnectionError("auth rejected"))
+
+        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
+             patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
+             patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close:
+            asyncio.run(run_tick("conn-1", sync_seq=2))
+
+        args = mock_close.call_args.kwargs
+        assert args["status"] == SyncLogStatus.FAILED
+        assert args["error"] == ConnectorError.CREDENTIAL_ERROR_MSG
+        # scanner.close() must still run in the finally block
+        mock_scanner.close.assert_called_once()
 
     def test_scanner_close_always_called(self):
         connector = _connector()

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -305,46 +305,39 @@ class TestProcessNewFiles:
 # _delete_orphans  (async)
 # ---------------------------------------------------------------------------
 
-_DELETE_DOC = "digitize.api.v1.connectors._best_effort_delete_document"
+_REMOVE_CHECKSUMS = "digitize.api.v1.connectors._remove_checksums"
 
 
 class TestDeleteOrphans:
     def test_deletes_doc_when_last_owner(self):
-        with patch(f"{DB_MODULE}.remove_connector_checksum_entry", return_value=(0, "doc-1")) as mock_rm, \
-             patch(_DELETE_DOC) as mock_del:
+        with patch(_REMOVE_CHECKSUMS, return_value=([], [])) as mock_rm:
             asyncio.run(_delete_orphans("c1", {"ck_orphan"}))
 
-        mock_rm.assert_called_once_with("c1", "ck_orphan")
-        mock_del.assert_called_once_with("doc-1")
+        mock_rm.assert_called_once_with("c1", {"ck_orphan"})
 
     def test_skips_doc_deletion_when_other_owners_remain(self):
-        with patch(f"{DB_MODULE}.remove_connector_checksum_entry", return_value=(2, "doc-1")), \
-             patch(_DELETE_DOC) as mock_del:
-            asyncio.run(_delete_orphans("c1", {"ck_shared"}))
-
-        mock_del.assert_not_called()
+        # doc deletion decisions live inside _remove_checksums; _delete_orphans
+        # just raises on non-empty failure lists — a clean return means success
+        with patch(_REMOVE_CHECKSUMS, return_value=([], [])):
+            asyncio.run(_delete_orphans("c1", {"ck_shared"}))  # no exception
 
     def test_raises_when_remove_raises(self):
-        with patch(f"{DB_MODULE}.remove_connector_checksum_entry",
-                   side_effect=RuntimeError("db gone")), \
-             patch(_DELETE_DOC) as mock_del:
-            with pytest.raises(RuntimeError, match="db gone"):
+        # _remove_checksums accumulates failures and returns them; _delete_orphans
+        # turns a non-empty checksum_removal_failures list into a RuntimeError
+        with patch(_REMOVE_CHECKSUMS, return_value=(["ck_orphan"], [])):
+            with pytest.raises(RuntimeError, match="checksum removal failed"):
                 asyncio.run(_delete_orphans("c1", {"ck_orphan"}))
 
-        mock_del.assert_not_called()
-
     def test_processes_multiple_checksums(self):
-        side_effects = [(0, "doc-1"), (1, "doc-2")]
-        with patch(f"{DB_MODULE}.remove_connector_checksum_entry", side_effect=side_effects) as mock_rm, \
-             patch(_DELETE_DOC):
+        with patch(_REMOVE_CHECKSUMS, return_value=([], [])) as mock_rm:
             asyncio.run(_delete_orphans("c1", {"ck1", "ck2"}))
 
-        assert mock_rm.call_count == 2
+        mock_rm.assert_called_once_with("c1", {"ck1", "ck2"})
 
     def test_empty_orphan_set(self):
-        with patch(f"{DB_MODULE}.remove_connector_checksum_entry") as mock_rm:
+        with patch(_REMOVE_CHECKSUMS, return_value=([], [])) as mock_rm:
             asyncio.run(_delete_orphans("c1", set()))
-        mock_rm.assert_not_called()
+        mock_rm.assert_called_once_with("c1", set())
 
 
 # ---------------------------------------------------------------------------

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -3,6 +3,11 @@ Unit tests for services/digitize/connectors/sync_tick.py
 
 Coverage
 --------
+InterruptType enum
+  - SYNC_CANCEL value is "sync_cancel"
+  - DELETE_CONNECTOR value is "delete_connector"
+  - inherits from str so comparison with raw string works
+
 _classify
   - known checksum → skip (not in ingest_list, not an orphan)
   - brand-new checksum → added to ingest_list
@@ -12,11 +17,19 @@ _classify
   - orphan detection (owned but absent from scan)
   - empty scan → all known become orphans, empty ingest_list
   - full scan with mix of skip / new / cross-connector / orphan
+  - cross-connector dup: lookup returns None → add_entry not called
+  - multiple files same checksum → only first path ingested
 
 _process_new_files
   - happy path: download → initialize_job_state → add_connector_checksum_entry → ingest called
   - per-file failure: exception logged, staging cleaned up, loop continues
   - staging directory is removed after each file (success and failure)
+  - empty ingest_list is a no-op (no error raised)
+  - file skipped when verify_integrity returns False; no checksum entry added
+  - integrity fail does not set batch_failed flag
+  - cancellation checkpoint fires between download and ingest
+  - RuntimeError raised at end only when batch_failed=True
+  - multiple batches all succeed
 
 _delete_orphans
   - removes checksum row and deletes doc when remaining == 0
@@ -29,11 +42,26 @@ _complete_tick / _fail_tick
   - _fail_tick calls finalize_sync_log_and_update_connector with status='failed' and error string
   - _fail_tick swallows a secondary exception from finalize_sync_log_and_update_connector
 
+_handle_interrupt
+  - None interrupt_type calls _cancel_tick and returns
+  - SYNC_CANCEL branch calls _cancel_tick and _sweep_staging_dir with correct args
+  - DELETE_CONNECTOR branch calls _cancel_tick and _run_teardown
+  - SYNC_CANCEL does not call _run_teardown
+  - DELETE_CONNECTOR does not call _sweep_staging_dir
+
+_wait_for_job
+  - exits immediately when job is already in terminal state
+  - polls until job reaches terminal state (multiple iterations)
+  - 'failed' is a terminal state
+  - raises CancelledError when interrupt detected mid-wait
+  - None job_data keeps polling until interrupt fires
+
 run_tick
   - aborts gracefully when connector not found
   - calls init_sync_log_and_update_connector, scan, classify, process, orphan, complete in order
   - on scanner.connect failure: _fail_tick is called, scanner.close still runs
   - on scan failure: _fail_tick is called, scanner.close still runs
+  - _handle_interrupt is awaited when CancelledError is caught
 """
 
 from __future__ import annotations
@@ -46,14 +74,16 @@ import pytest
 
 from digitize.connectors.models import ConnectorStatus, SyncLogStatus
 from digitize.connectors.sync_tick import (
+    InterruptType,
     _cancel_tick,
     _check_interrupt_call,
     _classify as _real_classify,
     _complete_tick,
     _delete_orphans,
     _fail_tick,
+    _handle_interrupt,
     _process_new_files,
-    InterruptType,
+    _wait_for_job,
     run_tick,
 )
 
@@ -582,3 +612,395 @@ class TestRunTickCancellation:
         args = mock_close.call_args.kwargs
         assert args["status"] == SyncLogStatus.CANCELLED
         mock_scanner.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# InterruptType enum
+# ---------------------------------------------------------------------------
+
+class TestInterruptTypeEnum:
+    def test_sync_cancel_value(self):
+        assert InterruptType.SYNC_CANCEL == "sync_cancel"
+
+    def test_delete_connector_value(self):
+        assert InterruptType.DELETE_CONNECTOR == "delete_connector"
+
+    def test_is_str_subclass(self):
+        assert isinstance(InterruptType.SYNC_CANCEL, str)
+        assert isinstance(InterruptType.DELETE_CONNECTOR, str)
+
+    def test_comparison_with_raw_string(self):
+        assert InterruptType.SYNC_CANCEL == "sync_cancel"
+        assert InterruptType.DELETE_CONNECTOR == "delete_connector"
+
+
+# ---------------------------------------------------------------------------
+# _handle_interrupt
+# ---------------------------------------------------------------------------
+
+class TestHandleInterrupt:
+    def test_none_interrupt_calls_cancel_tick(self):
+        with patch(f"{DB_MODULE}._cancel_tick") as mock_cancel, \
+             patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector"):
+            asyncio.run(_handle_interrupt(sync_seq=1, connector_id="conn-1", interrupt_type=None))
+        mock_cancel.assert_called_once_with(1, "conn-1")
+
+    def test_sync_cancel_calls_cancel_tick_and_sweep(self):
+        from pathlib import Path
+        with patch(f"{DB_MODULE}._cancel_tick") as mock_cancel, \
+             patch("digitize.api.v1.connectors._sweep_staging_dir") as mock_sweep, \
+             patch("digitize.settings.settings") as mock_settings:
+            mock_settings.digitize.staging_dir = Path("/fake/staging")
+            asyncio.run(_handle_interrupt(sync_seq=7, connector_id="conn-A",
+                                          interrupt_type=InterruptType.SYNC_CANCEL))
+        mock_cancel.assert_called_once_with(7, "conn-A")
+        mock_sweep.assert_called_once()
+
+    def test_delete_connector_calls_cancel_tick_and_teardown(self):
+        with patch(f"{DB_MODULE}._cancel_tick") as mock_cancel, \
+             patch("digitize.api.v1.connectors._run_teardown",
+                   new_callable=AsyncMock) as mock_teardown:
+            asyncio.run(_handle_interrupt(sync_seq=3, connector_id="conn-B",
+                                          interrupt_type=InterruptType.DELETE_CONNECTOR))
+        mock_cancel.assert_called_once_with(3, "conn-B")
+        mock_teardown.assert_awaited_once_with("conn-B")
+
+    def test_delete_connector_does_not_call_sweep(self):
+        """DELETE_CONNECTOR must not call _sweep_staging_dir."""
+        with patch(f"{DB_MODULE}._cancel_tick"), \
+             patch("digitize.api.v1.connectors._run_teardown", new_callable=AsyncMock), \
+             patch("digitize.api.v1.connectors._sweep_staging_dir") as mock_sweep:
+            asyncio.run(_handle_interrupt(sync_seq=3, connector_id="conn-B",
+                                          interrupt_type=InterruptType.DELETE_CONNECTOR))
+        mock_sweep.assert_not_called()
+
+    def test_sync_cancel_does_not_call_teardown(self):
+        """SYNC_CANCEL must not call _run_teardown."""
+        from pathlib import Path
+        with patch(f"{DB_MODULE}._cancel_tick"), \
+             patch("digitize.api.v1.connectors._sweep_staging_dir"), \
+             patch("digitize.settings.settings") as mock_settings, \
+             patch("digitize.api.v1.connectors._run_teardown",
+                   new_callable=AsyncMock) as mock_teardown:
+            mock_settings.digitize.staging_dir = Path("/fake/staging")
+            asyncio.run(_handle_interrupt(sync_seq=7, connector_id="conn-A",
+                                          interrupt_type=InterruptType.SYNC_CANCEL))
+        mock_teardown.assert_not_called()
+
+    def test_sync_cancel_sweep_receives_connector_id_and_seq(self):
+        """_sweep_staging_dir must be called with connector_id and sync_seq keyword."""
+        from pathlib import Path
+        with patch(f"{DB_MODULE}._cancel_tick"), \
+             patch("digitize.api.v1.connectors._sweep_staging_dir") as mock_sweep, \
+             patch("digitize.settings.settings") as mock_settings:
+            fake_staging = Path("/fake/staging")
+            mock_settings.digitize.staging_dir = fake_staging
+            asyncio.run(_handle_interrupt(sync_seq=42, connector_id="my-conn",
+                                          interrupt_type=InterruptType.SYNC_CANCEL))
+        mock_sweep.assert_called_once_with(
+            "my-conn", fake_staging / "connectors", sync_seq=42
+        )
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_job
+# ---------------------------------------------------------------------------
+
+class TestWaitForJob:
+    def _patches(self, job_statuses: list, interrupt_returns=None):
+        """
+        Returns an ExitStack that patches asyncio.sleep (no-op), get_job to
+        return successive statuses, and _check_interrupt_call.
+        """
+        from contextlib import ExitStack
+
+        stack = ExitStack()
+        stack.enter_context(patch("asyncio.sleep", new_callable=AsyncMock))
+
+        job_mock_iter = iter([{"status": s} for s in job_statuses] + [None] * 20)
+        stack.enter_context(
+            patch(f"{DB_MODULE}.get_job", side_effect=lambda jid: next(job_mock_iter))
+        )
+
+        if interrupt_returns is None:
+            interrupt_returns = [None] * 20
+        interrupt_iter = iter(interrupt_returns + [None] * 20)
+        stack.enter_context(
+            patch(f"{DB_MODULE}._check_interrupt_call",
+                  side_effect=lambda cid, seq: next(interrupt_iter))
+        )
+        return stack
+
+    def test_exits_immediately_on_first_terminal_status(self):
+        """Job is already completed → only one poll needed."""
+        with self._patches(["completed"]):
+            asyncio.run(_wait_for_job("job-1", "conn-1", 1))
+
+    def test_polls_until_terminal_state(self):
+        """Job goes accepted → in_progress → completed."""
+        with self._patches(["accepted", "in_progress", "completed"]):
+            asyncio.run(_wait_for_job("job-1", "conn-1", 1))
+
+    def test_failed_is_terminal(self):
+        """Status 'failed' must also exit the wait loop."""
+        with self._patches(["failed"]):
+            asyncio.run(_wait_for_job("job-1", "conn-1", 1))
+
+    def test_raises_cancelled_error_on_interrupt(self):
+        """Interrupt detected while waiting → CancelledError raised."""
+        interrupt_seq = [None, InterruptType.SYNC_CANCEL]
+        with self._patches(["accepted", "accepted"], interrupt_returns=interrupt_seq):
+            with pytest.raises(asyncio.CancelledError):
+                asyncio.run(_wait_for_job("job-1", "conn-1", 1))
+
+    def test_none_job_data_does_not_crash(self):
+        """get_job returning None means status='' which is not terminal;
+        the loop must keep going until an interrupt fires."""
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            stack.enter_context(patch("asyncio.sleep", new_callable=AsyncMock))
+            none_iter = iter([None, None])
+            stack.enter_context(
+                patch(f"{DB_MODULE}.get_job", side_effect=lambda jid: next(none_iter, None))
+            )
+            interrupt_iter = iter([None, None, InterruptType.DELETE_CONNECTOR])
+            stack.enter_context(
+                patch(f"{DB_MODULE}._check_interrupt_call",
+                      side_effect=lambda cid, seq: next(interrupt_iter))
+            )
+            with pytest.raises(asyncio.CancelledError):
+                asyncio.run(_wait_for_job("job-1", "conn-1", 5))
+
+
+# ---------------------------------------------------------------------------
+# _process_new_files — additional branch coverage
+# ---------------------------------------------------------------------------
+
+class TestProcessNewFilesExtra:
+    def _base_patches(self):
+        from contextlib import ExitStack
+        stack = ExitStack()
+        mock_settings = stack.enter_context(patch(f"{DB_MODULE}.settings"))
+        mock_settings.digitize.staging_dir.__truediv__ = MagicMock(return_value=MagicMock())
+        stack.enter_context(patch(f"{DB_MODULE}.add_connector_checksum_entry"))
+        stack.enter_context(
+            patch(f"{DB_MODULE}.initialize_job_state", return_value={"report.pdf": "doc-1"})
+        )
+        stack.enter_context(patch(f"{DB_MODULE}.generate_uuid", return_value="job-uuid-1"))
+        stack.enter_context(patch(f"{DB_MODULE}.ingest"))
+        stack.enter_context(patch(f"{DB_MODULE}._wait_for_job", new_callable=AsyncMock))
+        stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
+        stack.enter_context(
+            patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING)
+        )
+        stack.enter_context(
+            patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED)
+        )
+        return stack
+
+    def test_empty_ingest_list_is_noop(self):
+        """No batches created, no error raised."""
+        scanner = MagicMock()
+        with self._base_patches():
+            asyncio.run(_process_new_files(1, "conn-1", "name", scanner, []))
+        scanner.download_to.assert_not_called()
+
+    def test_integrity_fail_skips_file_no_checksum_entry(self):
+        """verify_integrity returns False → file not added to checksum_to_filename."""
+        scanner = MagicMock()
+        scanner.download_to.return_value = "bad_local_hash"
+        scanner.verify_integrity.return_value = False
+
+        with self._base_patches():
+            with patch(f"{DB_MODULE}.add_connector_checksum_entry") as mock_add:
+                asyncio.run(_process_new_files(1, "conn-1", "name", scanner,
+                                               [("remote/file.pdf", "ck1")]))
+        mock_add.assert_not_called()
+
+    def test_integrity_fail_does_not_set_batch_failed(self):
+        """A file skipped due to integrity failure must not cause batch_failed=True."""
+        scanner = MagicMock()
+        scanner.download_to.return_value = "local_hash"
+        scanner.verify_integrity.return_value = False
+
+        with self._base_patches():
+            asyncio.run(_process_new_files(1, "conn-1", "name", scanner,
+                                           [("remote/file.pdf", "ck1")]))
+
+    def test_cancellation_fires_between_download_and_ingest(self):
+        """If _check_interrupt_call fires after downloads, CancelledError is raised."""
+        scanner = MagicMock()
+        scanner.download_to.return_value = "local_hash"
+        scanner.verify_integrity.return_value = True
+
+        call_count = {"n": 0}
+
+        def _interrupt(connector_id, sync_seq):
+            call_count["n"] += 1
+            # first call = before-batch check, second = after-download check
+            if call_count["n"] >= 2:
+                return InterruptType.SYNC_CANCEL
+            return None
+
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            mock_settings = stack.enter_context(patch(f"{DB_MODULE}.settings"))
+            mock_settings.digitize.staging_dir.__truediv__ = MagicMock(return_value=MagicMock())
+            stack.enter_context(patch(f"{DB_MODULE}.add_connector_checksum_entry"))
+            stack.enter_context(
+                patch(f"{DB_MODULE}.initialize_job_state", return_value={"file.pdf": "doc-1"})
+            )
+            stack.enter_context(patch(f"{DB_MODULE}.generate_uuid", return_value="job-uuid-1"))
+            stack.enter_context(patch(f"{DB_MODULE}.ingest"))
+            stack.enter_context(patch(f"{DB_MODULE}._wait_for_job", new_callable=AsyncMock))
+            stack.enter_context(patch(f"{DB_MODULE}.cleanup_staging_directory"))
+            stack.enter_context(
+                patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING)
+            )
+            stack.enter_context(
+                patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED)
+            )
+            stack.enter_context(
+                patch(f"{DB_MODULE}._check_interrupt_call", side_effect=_interrupt)
+            )
+
+            with pytest.raises(asyncio.CancelledError):
+                asyncio.run(_process_new_files(1, "conn-1", "name", scanner,
+                                               [("remote/file.pdf", "ck1")]))
+
+    def test_raises_runtime_error_only_when_batch_failed(self):
+        """No failure → must NOT raise RuntimeError at the end."""
+        scanner = MagicMock()
+        scanner.download_to.return_value = "local_hash"
+        scanner.verify_integrity.return_value = True
+
+        with self._base_patches():
+            asyncio.run(_process_new_files(1, "conn-1", "name", scanner,
+                                           [("docs/report.pdf", "ck1")]))
+
+    def test_multiple_batches_all_succeed(self):
+        """Two batches in a 2-item list with BATCH_SIZE=1 — both succeed."""
+        import digitize.connectors.sync_tick as _st_mod
+
+        scanner = MagicMock()
+        scanner.download_to.return_value = "local_hash"
+        scanner.verify_integrity.return_value = True
+
+        with self._base_patches():
+            with patch.object(_st_mod, "_BATCH_SIZE", 1), \
+                 patch(f"{DB_MODULE}.initialize_job_state", side_effect=[
+                     {"a.pdf": "doc-1"}, {"b.pdf": "doc-2"}
+                 ]):
+                asyncio.run(_process_new_files(1, "conn-1", "name", scanner,
+                                               [("a.pdf", "ck1"), ("b.pdf", "ck2")]))
+
+
+# ---------------------------------------------------------------------------
+# run_tick — _handle_interrupt wiring
+# ---------------------------------------------------------------------------
+
+class TestRunTickHandleInterrupt:
+    """Verify that run_tick invokes _handle_interrupt on CancelledError."""
+
+    def _make_scanner(self):
+        scanner = MagicMock()
+        scanner.connect.return_value = None
+        scanner.scan.return_value = []
+        return scanner
+
+    def test_handle_interrupt_called_on_cancellation(self):
+        """When CancelledError is caught, _handle_interrupt must be awaited."""
+        connector = _connector()
+        mock_scanner = self._make_scanner()
+
+        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+             patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
+             patch(f"{DB_MODULE}.get_connector_sync_status",
+                   return_value=ConnectorStatus.DELETE_PENDING), \
+             patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector"), \
+             patch("digitize.connectors.sync_tick._handle_interrupt",
+                   new_callable=AsyncMock) as mock_handle:
+            with pytest.raises(asyncio.CancelledError):
+                asyncio.run(run_tick("conn-1", sync_seq=99))
+
+        mock_handle.assert_awaited_once()
+
+    def test_handle_interrupt_receives_correct_interrupt_type(self):
+        """_handle_interrupt must receive the InterruptType detected by _check_interrupt_call."""
+        connector = _connector()
+        mock_scanner = self._make_scanner()
+
+        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+             patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
+             patch(f"{DB_MODULE}.get_connector_sync_status",
+                   return_value=ConnectorStatus.DELETE_PENDING), \
+             patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector"), \
+             patch("digitize.connectors.sync_tick._handle_interrupt",
+                   new_callable=AsyncMock) as mock_handle:
+            with pytest.raises(asyncio.CancelledError):
+                asyncio.run(run_tick("conn-1", sync_seq=99))
+
+        _, kwargs = mock_handle.await_args
+        assert kwargs.get("interrupt_type") or mock_handle.await_args.args[2] is not None
+
+
+# ---------------------------------------------------------------------------
+# _classify — edge cases
+# ---------------------------------------------------------------------------
+
+class TestClassifyEdgeCases:
+    """Additional classify cases complementing TestClassify."""
+
+    def test_cross_connector_dup_no_doc_id_does_not_add_entry(self):
+        """lookup returns None → add_connector_checksum_entry must NOT be called."""
+        with patch(f"{DB_MODULE}.add_connector_checksum_entry") as mock_add, \
+             patch(f"{DB_MODULE}.lookup_connector_content_by_checksum", return_value=None):
+            from digitize.connectors.sync_tick import _classify
+            ingest_list, _ = _classify(
+                "conn-1",
+                [("file.pdf", "ck_cross")],
+                known_checksums=set(),
+                all_checksums={"ck_cross"},
+            )
+        mock_add.assert_not_called()
+        assert ingest_list == []
+
+    def test_scanned_file_not_in_known_not_in_all_is_ingested(self):
+        """Completely new checksum must appear in ingest_list."""
+        with patch(f"{DB_MODULE}.add_connector_checksum_entry"), \
+             patch(f"{DB_MODULE}.lookup_connector_content_by_checksum", return_value=None):
+            from digitize.connectors.sync_tick import _classify
+            ingest_list, _ = _classify(
+                "conn-1",
+                [("new.pdf", "brand_new_ck")],
+                known_checksums=set(),
+                all_checksums=set(),
+            )
+        assert ("new.pdf", "brand_new_ck") in ingest_list
+
+    def test_multiple_files_same_checksum_only_one_ingest(self):
+        """Two files with identical checksum → only first path ingested."""
+        with patch(f"{DB_MODULE}.add_connector_checksum_entry"), \
+             patch(f"{DB_MODULE}.lookup_connector_content_by_checksum", return_value=None):
+            from digitize.connectors.sync_tick import _classify
+            ingest_list, _ = _classify(
+                "conn-1",
+                [("path1.pdf", "ck_dup"), ("path2.pdf", "ck_dup")],
+                known_checksums=set(),
+                all_checksums=set(),
+            )
+        assert len(ingest_list) == 1
+        assert ingest_list[0][0] == "path1.pdf"
+
+    def test_orphan_is_known_checksum_absent_from_scan(self):
+        """A checksum known to this connector but not scanned must be an orphan."""
+        with patch(f"{DB_MODULE}.add_connector_checksum_entry"), \
+             patch(f"{DB_MODULE}.lookup_connector_content_by_checksum", return_value=None):
+            from digitize.connectors.sync_tick import _classify
+            _, orphans = _classify(
+                "conn-1",
+                [],
+                known_checksums={"old_ck_1", "old_ck_2"},
+                all_checksums={"old_ck_1", "old_ck_2"},
+            )
+        assert orphans == {"old_ck_1", "old_ck_2"}

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -396,8 +396,36 @@ class TestRunTick:
         return scanner
 
     def test_aborts_when_connector_not_found(self):
-        with patch(f"{DB_MODULE}.get_active_connector", return_value=None):
+        with patch(f"{DB_MODULE}.get_active_connector", return_value=None), \
+             patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_fail:
             asyncio.run(run_tick("missing", sync_seq=1))
+
+        # sync log must be closed as FAILED so the row doesn't stay open forever
+        args = mock_fail.call_args.kwargs
+        assert args["status"] == SyncLogStatus.FAILED
+        assert "missing" in args["error"]
+
+    def test_scanner_close_failure_is_logged_not_raised(self):
+        """scanner.close() raising in the finally block must not propagate."""
+        connector = _connector()
+        mock_scanner = self._make_scanner(scan_result=[])
+        mock_scanner.close.side_effect = RuntimeError("close boom")
+
+        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+             patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
+             patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
+             patch(f"{DB_MODULE}.update_sync_log"), \
+             patch(f"{DB_MODULE}.update_connector_total_files"), \
+             patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
+             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
+             patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector"), \
+             patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
+             patch("digitize.connectors.sync_tick._process_new_files",
+                   new_callable=AsyncMock, return_value=None), \
+             patch("digitize.connectors.sync_tick._delete_orphans",
+                   new_callable=AsyncMock, return_value=0):
+            # must not raise despite close() failing
+            asyncio.run(run_tick("conn-1", sync_seq=1))
 
     def test_happy_path_calls_phases_in_order(self):
         connector = _connector()

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1405,7 +1405,7 @@ def finalize_sync_log_and_update_connector(
     )
     if not found:
         return False
-    connector_error = f"error coming from sync seq {seq}: {error}" if error else error
+    connector_error = f"Error from last sync: {error}" if error else error
     db_manager.update_connector_after_sync(
         connector_id, status=status, last_sync_at=now, error=connector_error
     )

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1414,8 +1414,11 @@ def update_connector_total_files(connector_id: str, total_files: int) -> None:
     db_manager.update_connector(connector_id=connector_id, total_files=total_files)
 
 
-def set_connector_error(connector_id: str, error: str) -> None:
-    """Persist an error message on the connector row (best-effort; logs on failure)."""
+def set_connector_error(connector_id: str, error: Optional[str]) -> None:
+    """Persist or clear an error message on the connector row (best-effort; logs on failure).
+
+    Pass ``None`` to clear a previously set error.
+    """
     try:
         db_manager.update_connector(connector_id=connector_id, error=error)
     except Exception as exc:

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1405,8 +1405,9 @@ def finalize_sync_log_and_update_connector(
     )
     if not found:
         return False
+    connector_error = f"error coming from sync seq {seq}: {error}" if error else error
     db_manager.update_connector_after_sync(
-        connector_id, status=status, last_sync_at=now, error=error
+        connector_id, status=status, last_sync_at=now, error=connector_error
     )
     return True
 

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -472,8 +472,10 @@ def is_connector_sourced_document(doc_id: str) -> bool:
     connector-sourced and must not be exposed via user-facing document APIs).
     """
     try:
+        from digitize.db.connection import get_db_session
+        from digitize.db.models import ConnectorDocumentChecksum
+        from sqlalchemy import select, exists
         with get_db_session() as session:
-            from sqlalchemy import exists
 
             stmt = select(
                 exists().where(ConnectorDocumentChecksum.doc_id == doc_id)

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1384,9 +1384,9 @@ def finalize_sync_log_and_update_connector(
     Finalize a sync run across two tables:
       - connector_sync_log: UPDATEs the matching row with status, finished_at,
         and optional file counts / error message.
-      - connector: UPDATEs last_sync_at to now, and sync_status to the terminal
-        state — CANCELLED/FAILED both map to OUT_OF_SYNC so the scheduler can
-        retry; any other status (e.g. COMPLETED) is written through verbatim.
+      - connector: UPDATEs last_sync_at to now, sync_status to the terminal
+        state, and error — CANCELLED/FAILED both map to OUT_OF_SYNC so the
+        scheduler can retry; COMPLETED clears error to NULL.
 
     Returns True on success, False if the sync-log row was not found.
     """
@@ -1403,7 +1403,9 @@ def finalize_sync_log_and_update_connector(
     )
     if not found:
         return False
-    db_manager.update_connector_after_sync(connector_id, status=status, last_sync_at=now)
+    db_manager.update_connector_after_sync(
+        connector_id, status=status, last_sync_at=now, error=error
+    )
     return True
 
 
@@ -1484,7 +1486,7 @@ def get_sync_log_status(connector_id: str, seq: int) -> Optional[str]:
 def reset_syncing_connectors(error: str = "Service restarted during sync tick") -> List[str]:
     """
     Bulk-set sync_status='out of sync' for every connector currently stuck in
-    'syncing', and stamp ``last_sync_error`` / ``error`` with *error*.
+    'syncing', and stamp ``error`` with *error*.
     Returns the list of affected connector IDs.
     """
     return db_manager.reset_syncing_connectors(error=error)


### PR DESCRIPTION
1. Cleanup removed failed_files from init_schema
2. Removed last_sync_error from connectors table 
3. Async auth validation on every PUT/POST call on connectors which updates the connectors table 
--This error is never overwritten by a sync tick failure error message (highlighting root cause being wrong creds)
--Only correct creds via another PUT request can clear the previous auth failure message 
4. Updated proposal 
5. Increased UT coverage 
6. Used the secret as per catalog deployment 
7. Rebrand connectors response into simple ID and name