### PR TITLE
fix: preserve existing secrets on OpenShift re-configure

### DIFF
--- a/ai-services/assets/catalog/openshift/templates/catalog-db-encryption-secret.yaml
+++ b/ai-services/assets/catalog/openshift/templates/catalog-db-encryption-secret.yaml
@@ -1,4 +1,4 @@
-{{- if not (lookup "v1" "Secret" .Release.Namespace "catalog-db-encryption-secret") }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "catalog-db-encryption-secret" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,5 +10,4 @@ metadata:
     ai-services.io/component: catalog
 type: Opaque
 stringData:
-  db-encryption-key: {{ .Values.backend.dbEncryptionKey | quote }}
-{{- end }}  
+  db-encryption-key: {{ if $existingSecret }}{{ index $existingSecret.data "db-encryption-key" | b64dec | quote }}{{ else }}{{ .Values.backend.dbEncryptionKey | quote }}{{ end }}

--- a/ai-services/assets/catalog/openshift/templates/catalog-db-encryption-secret.yaml
+++ b/ai-services/assets/catalog/openshift/templates/catalog-db-encryption-secret.yaml
@@ -1,4 +1,4 @@
-{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "catalog-db-encryption-secret" }}
+{{- if not (lookup "v1" "Secret" .Release.Namespace "catalog-db-encryption-secret") }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,4 +10,5 @@ metadata:
     ai-services.io/component: catalog
 type: Opaque
 stringData:
-  db-encryption-key: {{ if $existingSecret }}{{ index $existingSecret.data "db-encryption-key" | b64dec | quote }}{{ else }}{{ .Values.backend.dbEncryptionKey | quote }}{{ end }}
+  db-encryption-key: {{ .Values.backend.dbEncryptionKey | quote }}
+{{- end }}  

--- a/ai-services/assets/catalog/openshift/templates/catalog-db-secret.yaml
+++ b/ai-services/assets/catalog/openshift/templates/catalog-db-secret.yaml
@@ -1,4 +1,4 @@
-{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "catalog-db-secret" }}
+{{- if not (lookup "v1" "Secret" .Release.Namespace "catalog-db-secret") }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,4 +10,5 @@ metadata:
     ai-services.io/component: database
 type: Opaque
 stringData:
-  db-password: {{ if $existingSecret }}{{ index $existingSecret.data "db-password" | b64dec | quote }}{{ else }}{{ .Values.db.password | quote }}{{ end }}
+  db-password: {{ .Values.db.password | quote }}
+{{- end }}

--- a/ai-services/assets/catalog/openshift/templates/catalog-db-secret.yaml
+++ b/ai-services/assets/catalog/openshift/templates/catalog-db-secret.yaml
@@ -1,4 +1,4 @@
-{{- if not (lookup "v1" "Secret" .Release.Namespace "catalog-db-secret") }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "catalog-db-secret" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,5 +10,4 @@ metadata:
     ai-services.io/component: database
 type: Opaque
 stringData:
-  db-password: {{ .Values.db.password | quote }}
-{{- end }}
+  db-password: {{ if $existingSecret }}{{ index $existingSecret.data "db-password" | b64dec | quote }}{{ else }}{{ .Values.db.password | quote }}{{ end }}

--- a/ai-services/assets/catalog/openshift/templates/catalog-db-secret.yaml
+++ b/ai-services/assets/catalog/openshift/templates/catalog-db-secret.yaml
@@ -1,3 +1,4 @@
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "catalog-db-secret" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,4 +10,4 @@ metadata:
     ai-services.io/component: database
 type: Opaque
 stringData:
-  db-password: {{ .Values.db.password | quote }}
+  db-password: {{ if $existingSecret }}{{ index $existingSecret.data "db-password" | b64dec | quote }}{{ else }}{{ .Values.db.password | quote }}{{ end }}

--- a/ai-services/assets/catalog/openshift/templates/catalog-secret.yaml
+++ b/ai-services/assets/catalog/openshift/templates/catalog-secret.yaml
@@ -1,3 +1,4 @@
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "catalog-secret" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,4 +10,4 @@ metadata:
     ai-services.io/component: catalog
 type: Opaque
 stringData:
-  admin-password: {{ .Values.backend.adminPasswordHash | quote }}
+  admin-password: {{ if $existingSecret }}{{ index $existingSecret.data "admin-password" | b64dec | quote }}{{ else }}{{ .Values.backend.adminPasswordHash | quote }}{{ end }}

--- a/ai-services/assets/catalog/openshift/templates/catalog-secret.yaml
+++ b/ai-services/assets/catalog/openshift/templates/catalog-secret.yaml
@@ -1,4 +1,4 @@
-{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "catalog-secret" }}
+{{- if not (lookup "v1" "Secret" .Release.Namespace "catalog-secret") }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,4 +10,5 @@ metadata:
     ai-services.io/component: catalog
 type: Opaque
 stringData:
-  admin-password: {{ if $existingSecret }}{{ index $existingSecret.data "admin-password" | b64dec | quote }}{{ else }}{{ .Values.backend.adminPasswordHash | quote }}{{ end }}
+  admin-password: {{ .Values.backend.adminPasswordHash | quote }}
+{{- end }}

--- a/ai-services/assets/catalog/openshift/templates/catalog-secret.yaml
+++ b/ai-services/assets/catalog/openshift/templates/catalog-secret.yaml
@@ -1,4 +1,4 @@
-{{- if not (lookup "v1" "Secret" .Release.Namespace "catalog-secret") }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "catalog-secret" }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,5 +10,4 @@ metadata:
     ai-services.io/component: catalog
 type: Opaque
 stringData:
-  admin-password: {{ .Values.backend.adminPasswordHash | quote }}
-{{- end }}
+  admin-password: {{ if $existingSecret }}{{ index $existingSecret.data "admin-password" | b64dec | quote }}{{ else }}{{ .Values.backend.adminPasswordHash | quote }}{{ end }}


### PR DESCRIPTION
## Problem
On every re-run of catalog configure on OpenShift, the Helm upgrade was silently overwriting the db-password in catalog-db-secret and admin-password in catalog-secret with empty strings.

## Fix
Use lookup in both secret templates to consider existing secrets data