### PR TITLE
feat: propagate context through Runtime interface for cancellation support

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.274
+TAG?=v0.0.275
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.274
+  image: icr.io/ai-services-cicd/ai-services:v0.0.275
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.274
+  image: icr.io/ai-services-cicd/ai-services:v0.0.275
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/cmd/ai-services/cmd/application/backup.go
+++ b/ai-services/cmd/ai-services/cmd/application/backup.go
@@ -1,7 +1,6 @@
 package application
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -77,7 +76,7 @@ Supported targets:
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		applicationName := args[0]
-		ctx := context.Background()
+		ctx := cmd.Context()
 
 		// Once precheck passes, silence usage for any later internal errors
 		cmd.SilenceUsage = true

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -86,12 +86,12 @@ Arguments:
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		appName := args[0]
-		ctx := context.Background()
+		ctx := cmd.Context()
 
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true
 
-		if err := doBootstrapValidate(); err != nil {
+		if err := doBootstrapValidate(ctx); err != nil {
 			return err
 		}
 
@@ -120,7 +120,7 @@ Arguments:
 		}
 
 		// Default: use catalog way of deploying application
-		return createApp(appName)
+		return createApp(ctx, appName)
 	},
 }
 
@@ -143,7 +143,7 @@ func createExample() string {
   ai-services application create rag --template rag --runtime openshift`
 }
 
-func doBootstrapValidate() error {
+func doBootstrapValidate(ctx context.Context) error {
 	skip := helpers.ParseSkipChecks(skipChecks)
 	if len(skip) > 0 {
 		logger.Warningf("Skipping validation checks (skipped: %v)\n", skipChecks)
@@ -152,7 +152,7 @@ func doBootstrapValidate() error {
 	// Create bootstrap instance based on runtime
 	factory := bootstrap.NewBootstrapFactory(vars.RuntimeFactory.GetRuntimeType())
 
-	if err := factory.Validate(skip); err != nil {
+	if err := factory.Validate(ctx, skip); err != nil {
 		return fmt.Errorf("bootstrap validation failed: %w", err)
 	}
 
@@ -384,20 +384,20 @@ func validateSkipChecksFlag(cmd *cobra.Command) error {
 	return nil
 }
 
-func createApp(appName string) error {
+func createApp(ctx context.Context, appName string) error {
 	// 1. Initialize catalog client
-	appClient, err := catalogClient.NewApplicationClient()
+	appClient, err := catalogClient.NewApplicationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create application client: %w", err)
 	}
 
 	// 2. Check if application already exists
-	if err := checkApplicationExists(appClient, appName); err != nil {
+	if err := checkApplicationExists(ctx, appClient, appName); err != nil {
 		return err
 	}
 
 	// 3. Build the catalog API payload
-	payload, err := buildCatalogPayload(appName)
+	payload, err := buildCatalogPayload(ctx, appName)
 	if err != nil {
 		return err
 	}
@@ -405,9 +405,9 @@ func createApp(appName string) error {
 	// 4. Create application via catalog API
 	logger.Infof("Creating application '%s' using template '%s'...\n", appName, templateName)
 	var resp *apiModels.CreateApplicationResponse
-	err = utils.Retry(context.Background(), vars.RetryCount, vars.RetryInterval, nil, func() error {
+	err = utils.Retry(ctx, vars.RetryCount, vars.RetryInterval, nil, func() error {
 		var createErr error
-		resp, createErr = appClient.CreateApplication(payload)
+		resp, createErr = appClient.CreateApplication(ctx, payload)
 
 		return createErr
 	})
@@ -418,12 +418,12 @@ func createApp(appName string) error {
 	logger.Infof("Application creation initiated (ID: %s)\n", resp.ID)
 
 	// 5. Poll for application status
-	return pollApplicationStatus(appClient, appName, resp.ID)
+	return pollApplicationStatus(ctx, appClient, appName, resp.ID)
 }
 
 // checkApplicationExists checks if an application with the given name already exists.
-func checkApplicationExists(appClient *catalogClient.ApplicationClient, appName string) error {
-	existingApp, err := cliutils.GetAppByName(appClient, appName)
+func checkApplicationExists(ctx context.Context, appClient *catalogClient.ApplicationClient, appName string) error {
+	existingApp, err := cliutils.GetAppByName(ctx, appClient, appName)
 	if err != nil && !strings.Contains(err.Error(), "not found") {
 		return err
 	}
@@ -436,7 +436,7 @@ func checkApplicationExists(appClient *catalogClient.ApplicationClient, appName 
 }
 
 // buildCatalogPayload builds the catalog API payload for the given template.
-func buildCatalogPayload(appName string) (*apiModels.CreateApplicationRequest, error) {
+func buildCatalogPayload(ctx context.Context, appName string) (*apiModels.CreateApplicationRequest, error) {
 	// Initialize catalog provider
 	provider, err := catalog.NewCatalogProvider(nil)
 	if err != nil {
@@ -453,14 +453,14 @@ func buildCatalogPayload(appName string) (*apiModels.CreateApplicationRequest, e
 
 	// Build the payload
 	if isArchitecture {
-		return buildArchitecturePayload(provider, templateName, appName)
+		return buildArchitecturePayload(ctx, provider, templateName, appName)
 	}
 
-	return buildServicePayload(templateName, appName)
+	return buildServicePayload(ctx, templateName, appName)
 }
 
 // pollApplicationStatus polls the application status until it's ready or fails.
-func pollApplicationStatus(appClient *catalogClient.ApplicationClient, appName, id string) error {
+func pollApplicationStatus(ctx context.Context, appClient *catalogClient.ApplicationClient, appName, id string) error {
 	logger.Infof("Waiting for application '%s' to be ready...\n", appName)
 
 	ticker := time.NewTicker(pollInterval)
@@ -474,12 +474,12 @@ func pollApplicationStatus(appClient *catalogClient.ApplicationClient, appName, 
 			return fmt.Errorf("timeout waiting for application '%s' to be ready", appName)
 
 		case <-ticker.C:
-			app, err := appClient.GetApplicationWithRefresh(id)
+			app, err := appClient.GetApplicationWithRefresh(ctx, id)
 			if err != nil {
 				return fmt.Errorf("failed to get application status: %w", err)
 			}
 
-			done, err := handleApplicationStatus(app, appName)
+			done, err := handleApplicationStatus(ctx, app, appName)
 			if err != nil {
 				return err
 			}
@@ -491,13 +491,13 @@ func pollApplicationStatus(appClient *catalogClient.ApplicationClient, appName, 
 }
 
 // handleApplicationStatus handles the application status and returns (done, error).
-func handleApplicationStatus(app *catalogTypes.Application, appName string) (bool, error) {
+func handleApplicationStatus(ctx context.Context, app *catalogTypes.Application, appName string) (bool, error) {
 	switch app.Status {
 	case "Running":
 		logger.Infof("Application '%s' is ready!\n", appName)
 
 		// Print next steps after successful deployment
-		if err := printNextSteps(app); err != nil {
+		if err := printNextSteps(ctx, app); err != nil {
 			logger.Warningf("Failed to display next steps: %v\n", err)
 		}
 
@@ -527,14 +527,14 @@ func handleApplicationStatus(app *catalogTypes.Application, appName string) (boo
 }
 
 // printNextSteps prints the next steps for the deployed application.
-func printNextSteps(app *catalogTypes.Application) error {
-	appClient, err := catalogClient.NewApplicationClient()
+func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
+	appClient, err := catalogClient.NewApplicationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create application client: %w", err)
 	}
 
 	// Get full application details with services
-	application, err := appClient.GetApplication(app.ID)
+	application, err := appClient.GetApplication(ctx, app.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get application: %w", err)
 	}
@@ -603,7 +603,7 @@ func printNextStepsMD(tmpls map[string]*template.Template, params map[string]str
 }
 
 // buildArchitecturePayload builds the payload for an architecture deployment.
-func buildArchitecturePayload(provider *catalog.CatalogProvider, archID, appName string) (*apiModels.CreateApplicationRequest, error) {
+func buildArchitecturePayload(ctx context.Context, provider *catalog.CatalogProvider, archID, appName string) (*apiModels.CreateApplicationRequest, error) {
 	// Load architecture metadata
 	arch, err := provider.LoadArchitecture(archID)
 	if err != nil {
@@ -611,13 +611,13 @@ func buildArchitecturePayload(provider *catalog.CatalogProvider, archID, appName
 	}
 
 	// Create application client for API calls
-	appClient, err := catalogClient.NewApplicationClient()
+	appClient, err := catalogClient.NewApplicationClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create application client: %w", err)
 	}
 
 	// Get deploy options for the architecture
-	deployOptions, err := appClient.GetArchitectureDeployOptions(archID)
+	deployOptions, err := appClient.GetArchitectureDeployOptions(ctx, archID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get deploy options: %w", err)
 	}
@@ -639,7 +639,7 @@ func buildArchitecturePayload(provider *catalog.CatalogProvider, archID, appName
 			return nil, fmt.Errorf("deploy options not found for service '%s'", svcRef.ID)
 		}
 
-		svc, err := buildServiceEntryWithDeployOptions(appClient, svcRef.ID, svcDeployOpts)
+		svc, err := buildServiceEntryWithDeployOptions(ctx, appClient, svcRef.ID, svcDeployOpts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build service '%s': %w", svcRef.ID, err)
 		}
@@ -655,20 +655,20 @@ func buildArchitecturePayload(provider *catalog.CatalogProvider, archID, appName
 }
 
 // buildServicePayload builds the payload for a standalone service deployment.
-func buildServicePayload(serviceID, appName string) (*apiModels.CreateApplicationRequest, error) {
+func buildServicePayload(ctx context.Context, serviceID, appName string) (*apiModels.CreateApplicationRequest, error) {
 	// Create application client for API calls
-	appClient, err := catalogClient.NewApplicationClient()
+	appClient, err := catalogClient.NewApplicationClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create application client: %w", err)
 	}
 
 	// Get deploy options for the service
-	deployOptions, err := appClient.GetServiceDeployOptions(serviceID)
+	deployOptions, err := appClient.GetServiceDeployOptions(ctx, serviceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get deploy options: %w", err)
 	}
 
-	svc, err := buildServiceEntryWithDeployOptions(appClient, serviceID, deployOptions)
+	svc, err := buildServiceEntryWithDeployOptions(ctx, appClient, serviceID, deployOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build service: %w", err)
 	}
@@ -682,7 +682,7 @@ func buildServicePayload(serviceID, appName string) (*apiModels.CreateApplicatio
 }
 
 // buildServiceEntryWithDeployOptions builds a single service entry with its components using deploy options.
-func buildServiceEntryWithDeployOptions(appClient *catalogClient.ApplicationClient, serviceID string, deployOptions *catalogTypes.DeployOptionsService) (apiModels.Service, error) {
+func buildServiceEntryWithDeployOptions(ctx context.Context, appClient *catalogClient.ApplicationClient, serviceID string, deployOptions *catalogTypes.DeployOptionsService) (apiModels.Service, error) {
 	// Build components list from deploy options
 	components := make([]apiModels.Component, 0, len(deployOptions.Components))
 	for _, compDeployOpt := range deployOptions.Components {
@@ -717,7 +717,7 @@ func buildServiceEntryWithDeployOptions(appClient *catalogClient.ApplicationClie
 		}
 
 		// Fetch schema and apply defaults, merging with user params
-		componentParamsAny, err := applySchemaDefaults(appClient, compDeployOpt.Type, providerID, userParams)
+		componentParamsAny, err := applySchemaDefaults(ctx, appClient, compDeployOpt.Type, providerID, userParams)
 		if err != nil {
 			logger.Warningf("Failed to apply schema defaults for %s/%s: %v\n", compDeployOpt.Type, providerID, err)
 			// Continue with user-provided params only
@@ -945,9 +945,9 @@ func collectProviderSelection(compDeployOpt catalogTypes.DeployOptionsComponent,
 
 // applySchemaDefaults fetches the component provider schema and applies default values.
 // User-provided params override defaults.
-func applySchemaDefaults(appClient *catalogClient.ApplicationClient, componentType, providerID string, userParams map[string]string) (map[string]any, error) {
+func applySchemaDefaults(ctx context.Context, appClient *catalogClient.ApplicationClient, componentType, providerID string, userParams map[string]string) (map[string]any, error) {
 	// Fetch schema from API
-	schema, err := appClient.GetComponentProviderParams(componentType, providerID)
+	schema, err := appClient.GetComponentProviderParams(ctx, componentType, providerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch schema: %w", err)
 	}

--- a/ai-services/cmd/ai-services/cmd/application/delete.go
+++ b/ai-services/cmd/ai-services/cmd/application/delete.go
@@ -182,6 +182,9 @@ func waitForApplicationDeletion(ctx context.Context, appClient *catalogClient.Ap
 		maxAttempts  = 12
 	)
 
+	timer := time.NewTimer(pollInterval)
+	defer timer.Stop()
+
 	for range maxAttempts {
 		// Check if application still exists via API
 		app, err := appClient.GetApplication(ctx, appID)
@@ -204,9 +207,10 @@ func waitForApplicationDeletion(ctx context.Context, appClient *catalogClient.Ap
 
 		// Wait before next poll, but honour context cancellation
 		select {
-		case <-time.After(pollInterval):
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-timer.C:
+			timer.Reset(pollInterval)
 		}
 	}
 

--- a/ai-services/cmd/ai-services/cmd/application/delete.go
+++ b/ai-services/cmd/ai-services/cmd/application/delete.go
@@ -202,8 +202,12 @@ func waitForApplicationDeletion(ctx context.Context, appClient *catalogClient.Ap
 			// Application still exists, continue polling
 		}
 
-		// Wait before next poll
-		time.Sleep(pollInterval)
+		// Wait before next poll, but honour context cancellation
+		select {
+		case <-time.After(pollInterval):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 
 	return fmt.Errorf("timeout waiting for application deletion after %v", maxAttempts*pollInterval)

--- a/ai-services/cmd/ai-services/cmd/application/delete.go
+++ b/ai-services/cmd/ai-services/cmd/application/delete.go
@@ -82,7 +82,7 @@ Arguments:
 		}
 
 		// Default: use new implementation via catalog
-		return deleteApplication(applicationName)
+		return deleteApplication(cmd.Context(), applicationName)
 	},
 }
 
@@ -126,12 +126,12 @@ func buildDeleteFlagValidator() *flagvalidator.FlagValidator {
 	return builder.Build()
 }
 
-func deleteApplication(appName string) error {
-	appClient, err := catalogClient.NewApplicationClient()
+func deleteApplication(ctx context.Context, appName string) error {
+	appClient, err := catalogClient.NewApplicationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create application client: %w", err)
 	}
-	app, err := cliUtils.GetAppByName(appClient, appName)
+	app, err := cliUtils.GetAppByName(ctx, appClient, appName)
 	if err != nil {
 		return err
 	}
@@ -157,8 +157,8 @@ func deleteApplication(appName string) error {
 
 	// Retry deletion if it fails
 	logger.Infof("Deleting application %s...\n", appName)
-	err = utils.Retry(context.Background(), vars.RetryCount, vars.RetryInterval, nil, func() error {
-		return appClient.DeleteApplication(app.ID, &deleteParams)
+	err = utils.Retry(ctx, vars.RetryCount, vars.RetryInterval, nil, func() error {
+		return appClient.DeleteApplication(ctx, app.ID, &deleteParams)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to delete application after %d retries: %w", vars.RetryCount, err)
@@ -166,7 +166,7 @@ func deleteApplication(appName string) error {
 
 	// Poll to verify deletion is complete
 	logger.Infof("Waiting for application %s to be deleted...\n", appName)
-	if err := waitForApplicationDeletion(appClient, app.ID); err != nil {
+	if err := waitForApplicationDeletion(ctx, appClient, app.ID); err != nil {
 		return fmt.Errorf("failed to verify application deletion: %w", err)
 	}
 
@@ -176,7 +176,7 @@ func deleteApplication(appName string) error {
 }
 
 // waitForApplicationDeletion polls the application status until it's fully deleted.
-func waitForApplicationDeletion(appClient *catalogClient.ApplicationClient, appID string) error {
+func waitForApplicationDeletion(ctx context.Context, appClient *catalogClient.ApplicationClient, appID string) error {
 	const (
 		pollInterval = 5 * time.Second
 		maxAttempts  = 12
@@ -184,7 +184,7 @@ func waitForApplicationDeletion(appClient *catalogClient.ApplicationClient, appI
 
 	for range maxAttempts {
 		// Check if application still exists via API
-		app, err := appClient.GetApplication(appID)
+		app, err := appClient.GetApplication(ctx, appID)
 		if err != nil {
 			// Check if it's an HTTPError with 404 status code
 			var httpErr *catalogClient.HTTPError

--- a/ai-services/cmd/ai-services/cmd/application/image/image.go
+++ b/ai-services/cmd/ai-services/cmd/application/image/image.go
@@ -25,13 +25,13 @@ var ImageCmd = &cobra.Command{
 }
 
 // getCatalogImages is a helper that creates a catalog provider and collects images.
-func getCatalogImages(templateID string) ([]string, error) {
+func getCatalogImages(ctx context.Context, templateID string) ([]string, error) {
 	provider, err := catalog.NewCatalogProvider(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create catalog provider: %w", err)
 	}
 
-	images, err := provider.GetCatalogImages(context.Background(), templateID)
+	images, err := provider.GetCatalogImages(ctx, templateID)
 	if err != nil {
 		return nil, err
 	}

--- a/ai-services/cmd/ai-services/cmd/application/image/list.go
+++ b/ai-services/cmd/ai-services/cmd/application/image/list.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -28,13 +29,13 @@ var listCmd = &cobra.Command{
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true
 
-		return list(templateName)
+		return list(cmd.Context(), templateName)
 	},
 }
 
-func list(templateName string) error {
+func list(ctx context.Context, templateName string) error {
 	if !legacyImage && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
-		return listCatalogImages(templateName)
+		return listCatalogImages(ctx, templateName)
 	}
 
 	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypeOpenShift {
@@ -60,8 +61,8 @@ func list(templateName string) error {
 }
 
 // listCatalogImages lists container images for services or architectures from the catalog.
-func listCatalogImages(templateID string) error {
-	images, err := getCatalogImages(templateID)
+func listCatalogImages(ctx context.Context, templateID string) error {
+	images, err := getCatalogImages(ctx, templateID)
 	if err != nil {
 		return err
 	}

--- a/ai-services/cmd/ai-services/cmd/application/image/pull.go
+++ b/ai-services/cmd/ai-services/cmd/application/image/pull.go
@@ -30,13 +30,13 @@ var pullCmd = &cobra.Command{
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true
 
-		return pull(templateName)
+		return pull(cmd.Context(), templateName)
 	},
 }
 
-func pull(template string) error {
+func pull(ctx context.Context, template string) error {
 	if !legacyImage && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
-		return pullCatalogImages(templateName)
+		return pullCatalogImages(ctx, templateName)
 	}
 
 	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypeOpenShift {
@@ -60,12 +60,12 @@ func pull(template string) error {
 	}
 
 	// Use shared helper function with retry logic
-	return image.PullImageFromRegistry(context.Background(), runtimeClient, images)
+	return image.PullImageFromRegistry(ctx, runtimeClient, images)
 }
 
 // pullCatalogImages pulls container images for services or architectures from the catalog.
-func pullCatalogImages(templateID string) error {
-	images, err := getCatalogImages(templateID)
+func pullCatalogImages(ctx context.Context, templateID string) error {
+	images, err := getCatalogImages(ctx, templateID)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func pullCatalogImages(templateID string) error {
 	}
 
 	// Use shared helper function with retry logic
-	if err := image.PullImageFromRegistry(context.Background(), runtimeClient, images); err != nil {
+	if err := image.PullImageFromRegistry(ctx, runtimeClient, images); err != nil {
 		return err
 	}
 

--- a/ai-services/cmd/ai-services/cmd/application/info.go
+++ b/ai-services/cmd/ai-services/cmd/application/info.go
@@ -46,6 +46,7 @@ Arguments:
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true
 
+		ctx := cmd.Context()
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
 		// When legacyInfo is true, use the older/stable code path
@@ -61,7 +62,7 @@ Arguments:
 				Name: applicationName,
 			}
 
-			return app.Info(opts)
+			return app.Info(ctx, opts)
 		}
 
 		// Default: use new implementation using catalog

--- a/ai-services/cmd/ai-services/cmd/application/info.go
+++ b/ai-services/cmd/ai-services/cmd/application/info.go
@@ -2,6 +2,7 @@ package application
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 	"text/template"
@@ -66,7 +67,7 @@ Arguments:
 		}
 
 		// Default: use new implementation using catalog
-		return renderApplicationInfo(applicationName, rt)
+		return renderApplicationInfo(ctx, applicationName, rt)
 	},
 }
 
@@ -74,13 +75,13 @@ func init() {
 	infoCmd.Flags().BoolVar(&legacyInfo, "legacy", false, "Use legacy application info implementation")
 }
 
-func renderApplicationInfo(appName string, rt types.RuntimeType) error {
-	appClient, err := catalogClient.NewApplicationClient()
+func renderApplicationInfo(ctx context.Context, appName string, rt types.RuntimeType) error {
+	appClient, err := catalogClient.NewApplicationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create application client: %w", err)
 	}
 
-	app, err := cliUtils.GetAppByName(appClient, appName)
+	app, err := cliUtils.GetAppByName(ctx, appClient, appName)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			logger.Warningf("Application: '%s' does not exist", appName)
@@ -91,12 +92,12 @@ func renderApplicationInfo(appName string, rt types.RuntimeType) error {
 		return err
 	}
 
-	application, err := appClient.GetApplication(app.ID)
+	application, err := appClient.GetApplication(ctx, app.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get application: %w", err)
 	}
 
-	appPS, err := appClient.GetApplicationPS(app.ID)
+	appPS, err := appClient.GetApplicationPS(ctx, app.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get application pods: %w", err)
 	}

--- a/ai-services/cmd/ai-services/cmd/application/logs.go
+++ b/ai-services/cmd/ai-services/cmd/application/logs.go
@@ -72,11 +72,11 @@ Arguments:
 		namespace := applicationName
 
 		if !legacyLogs {
-			appClient, err := catalogClient.NewApplicationClient()
+			appClient, err := catalogClient.NewApplicationClient(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to create application client: %w", err)
 			}
-			app, err := utils.GetAppByName(appClient, applicationName)
+			app, err := utils.GetAppByName(ctx, appClient, applicationName)
 			if err != nil {
 				return err
 			}

--- a/ai-services/cmd/ai-services/cmd/application/logs.go
+++ b/ai-services/cmd/ai-services/cmd/application/logs.go
@@ -67,6 +67,7 @@ Arguments:
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true
 
+		ctx := cmd.Context()
 		rt := vars.RuntimeFactory.GetRuntimeType()
 		namespace := applicationName
 
@@ -98,7 +99,7 @@ Arguments:
 			ContainerNameOrID: containerNameOrID,
 		}
 
-		return app.Logs(opts)
+		return app.Logs(ctx, opts)
 	},
 }
 

--- a/ai-services/cmd/ai-services/cmd/application/model/download.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/download.go
@@ -53,8 +53,10 @@ func init() {
 }
 
 func download(cmd *cobra.Command) error {
+	ctx := cmd.Context()
+
 	if !legacyModel && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
-		return downloadCatalogModels(templateName)
+		return downloadCatalogModels(ctx, templateName)
 	}
 
 	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypeOpenShift {
@@ -70,7 +72,7 @@ func download(cmd *cobra.Command) error {
 	}
 	logger.Infoln("Downloaded Models in application template" + templateName + ":")
 	for _, model := range models {
-		err := helpers.DownloadModel(model, modelDirectory)
+		err := helpers.DownloadModel(ctx, model, modelDirectory)
 		if err != nil {
 			return fmt.Errorf("failed to download model: %w", err)
 		}
@@ -80,8 +82,8 @@ func download(cmd *cobra.Command) error {
 }
 
 // downloadCatalogModels downloads models for services or architectures from the catalog.
-func downloadCatalogModels(templateID string) error {
-	models, err := getCatalogModels(templateID, "watsonx")
+func downloadCatalogModels(ctx context.Context, templateID string) error {
+	models, err := getCatalogModels(ctx, templateID, "watsonx")
 	if err != nil {
 		return err
 	}
@@ -98,7 +100,7 @@ func downloadCatalogModels(templateID string) error {
 	for _, model := range models {
 		logger.Infof("Downloading model: %s\n", model)
 
-		if err := helpers.DownloadModelContainer(context.Background(), model, modelDirectory); err != nil {
+		if err := helpers.DownloadModelContainer(ctx, model, modelDirectory); err != nil {
 			return fmt.Errorf("failed to download model %s: %w", model, err)
 		}
 	}

--- a/ai-services/cmd/ai-services/cmd/application/model/list.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/list.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
@@ -43,7 +44,7 @@ func init() {
 
 func list(cmd *cobra.Command) error {
 	if !legacyModel && vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
-		return listCatalogModels(templateName)
+		return listCatalogModels(cmd.Context(), templateName)
 	}
 
 	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypeOpenShift {
@@ -66,8 +67,8 @@ func list(cmd *cobra.Command) error {
 }
 
 // listCatalogModels lists models for services or architectures from the catalog.
-func listCatalogModels(templateID string) error {
-	models, err := getCatalogModels(templateID)
+func listCatalogModels(ctx context.Context, templateID string) error {
+	models, err := getCatalogModels(ctx, templateID)
 	if err != nil {
 		return err
 	}

--- a/ai-services/cmd/ai-services/cmd/application/model/model.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/model.go
@@ -50,13 +50,13 @@ func models(template string) ([]string, error) {
 
 // getCatalogModels is a helper that creates a catalog provider and collects models.
 // excludeComponentProviders is a variadic parameter that allows excluding specific component provider by ID.
-func getCatalogModels(templateID string, excludeComponentProviders ...string) ([]string, error) {
+func getCatalogModels(ctx context.Context, templateID string, excludeComponentProviders ...string) ([]string, error) {
 	provider, err := catalog.NewCatalogProvider(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create catalog provider: %w", err)
 	}
 
-	models, err := provider.GetCatalogModels(context.Background(), templateID, excludeComponentProviders...)
+	models, err := provider.GetCatalogModels(ctx, templateID, excludeComponentProviders...)
 	if err != nil {
 		return nil, err
 	}

--- a/ai-services/cmd/ai-services/cmd/application/ps.go
+++ b/ai-services/cmd/ai-services/cmd/application/ps.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -101,7 +102,7 @@ Arguments:
 		}
 
 		// Default: use new implementation via catalog
-		return renderApplicationPS(opts)
+		return renderApplicationPS(ctx, opts)
 	},
 }
 
@@ -142,13 +143,13 @@ func buildPsFlagValidator() *flagvalidator.FlagValidator {
 
 // renderApplicationPS retrieves and processes the PS information for multiple application IDs.
 // It fetches the process status for each application using the catalog API and prints the results in tabular format.
-func renderApplicationPS(opts appTypes.ListOptions) error {
-	appClient, err := catalogClient.NewApplicationClient()
+func renderApplicationPS(ctx context.Context, opts appTypes.ListOptions) error {
+	appClient, err := catalogClient.NewApplicationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create application client: %w", err)
 	}
 
-	applicationList, err := cliUtils.FetchApplications(appClient, opts.ApplicationName)
+	applicationList, err := cliUtils.FetchApplications(ctx, appClient, opts.ApplicationName)
 	if err != nil {
 		return err
 	}
@@ -169,7 +170,7 @@ func renderApplicationPS(opts appTypes.ListOptions) error {
 	// Process each application ID
 	for _, app := range applicationList {
 		// Get PS information for the application
-		psResp, err := appClient.GetApplicationPS(app.ID)
+		psResp, err := appClient.GetApplicationPS(ctx, app.ID)
 		if err != nil {
 			return fmt.Errorf("failed to fetch application: %w", err)
 		}

--- a/ai-services/cmd/ai-services/cmd/application/ps.go
+++ b/ai-services/cmd/ai-services/cmd/application/ps.go
@@ -70,6 +70,8 @@ Arguments:
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true
 
+		ctx := cmd.Context()
+
 		var applicationName string
 		if len(args) > 0 {
 			applicationName = args[0]
@@ -90,7 +92,7 @@ Arguments:
 				return fmt.Errorf("failed to create application instance: %w", err)
 			}
 
-			_, err = app.List(opts)
+			_, err = app.List(ctx, opts)
 			if err != nil {
 				return fmt.Errorf("failed to fetch application: %w", err)
 			}

--- a/ai-services/cmd/ai-services/cmd/application/restore.go
+++ b/ai-services/cmd/ai-services/cmd/application/restore.go
@@ -1,7 +1,6 @@
 package application
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -85,7 +84,7 @@ Note:
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		applicationName := args[0]
-		ctx := context.Background()
+		ctx := cmd.Context()
 
 		rt := vars.RuntimeFactory.GetRuntimeType()
 		logger.Infof("Runtime: %s\n", rt)

--- a/ai-services/cmd/ai-services/cmd/application/start.go
+++ b/ai-services/cmd/ai-services/cmd/application/start.go
@@ -72,11 +72,11 @@ Note:
 
 		// For podman runtime with default mode, validate application name using catalog API
 		if !legacyStart && rt == types.RuntimeTypePodman {
-			appClient, err := catalogClient.NewApplicationClient()
+			appClient, err := catalogClient.NewApplicationClient(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to create application client: %w", err)
 			}
-			if _, err := utils.GetAppByName(appClient, applicationName); err != nil {
+			if _, err := utils.GetAppByName(ctx, appClient, applicationName); err != nil {
 				return err
 			}
 		}

--- a/ai-services/cmd/ai-services/cmd/application/start.go
+++ b/ai-services/cmd/ai-services/cmd/application/start.go
@@ -67,6 +67,7 @@ Note:
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true
 
+		ctx := cmd.Context()
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
 		// For podman runtime with default mode, validate application name using catalog API
@@ -96,7 +97,7 @@ Note:
 			Legacy:   legacyStart,
 		}
 
-		return app.Start(opts)
+		return app.Start(ctx, opts)
 	},
 }
 

--- a/ai-services/cmd/ai-services/cmd/application/stop.go
+++ b/ai-services/cmd/ai-services/cmd/application/stop.go
@@ -58,6 +58,7 @@ Note:
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true
 
+		ctx := cmd.Context()
 		rt := vars.RuntimeFactory.GetRuntimeType()
 
 		// For podman runtime with default mode, validate application name using catalog API
@@ -85,7 +86,7 @@ Note:
 			Legacy:   legacyStop,
 		}
 
-		return app.Stop(opts)
+		return app.Stop(ctx, opts)
 	},
 }
 

--- a/ai-services/cmd/ai-services/cmd/application/stop.go
+++ b/ai-services/cmd/ai-services/cmd/application/stop.go
@@ -63,11 +63,11 @@ Note:
 
 		// For podman runtime with default mode, validate application name using catalog API
 		if !legacyStop && rt == types.RuntimeTypePodman {
-			appClient, err := catalogClient.NewApplicationClient()
+			appClient, err := catalogClient.NewApplicationClient(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to create application client: %w", err)
 			}
-			if _, err := utils.GetAppByName(appClient, applicationName); err != nil {
+			if _, err := utils.GetAppByName(ctx, appClient, applicationName); err != nil {
 				return err
 			}
 		}

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -43,13 +43,13 @@ func NewParametersCmd() *cobra.Command {
 			// Try to load as architecture first
 			arch, err := provider.LoadArchitecture(templateID)
 			if err == nil {
-				return displayArchitectureParameters(provider, templateID, arch.Services)
+				return displayArchitectureParameters(cmd.Context(), provider, templateID, arch.Services)
 			}
 
 			// Try to load as service
 			service, err := provider.LoadService(templateID)
 			if err == nil {
-				return displayServiceParameters(provider, templateID, service.Dependencies)
+				return displayServiceParameters(cmd.Context(), provider, templateID, service.Dependencies)
 			}
 
 			return fmt.Errorf("template '%s' not found as service or architecture", templateID)
@@ -63,21 +63,21 @@ func NewParametersCmd() *cobra.Command {
 }
 
 // displayServiceParameters displays all parameters for a specific service.
-func displayServiceParameters(provider *catalog.CatalogProvider, serviceID string, dependencies []catalogTypes.DependencyReference) error {
+func displayServiceParameters(ctx context.Context, provider *catalog.CatalogProvider, serviceID string, dependencies []catalogTypes.DependencyReference) error {
 	logger.Infof("Supported Parameters for '%s':", serviceID)
 
 	// Display service's own parameters
-	schema, err := provider.GetServiceParams(context.Background(), serviceID)
+	schema, err := provider.GetServiceParams(ctx, serviceID)
 	if err == nil && schema != nil {
 		displaySchemaParameters(schema, serviceID)
 	}
 
 	// Display component parameters
-	return displayComponentsParameters(provider, dependencies, nil)
+	return displayComponentsParameters(ctx, provider, dependencies, nil)
 }
 
 // displayArchitectureParameters displays all parameters for all services in an architecture.
-func displayArchitectureParameters(provider *catalog.CatalogProvider, archID string, services []catalogTypes.ServiceReference) error {
+func displayArchitectureParameters(ctx context.Context, provider *catalog.CatalogProvider, archID string, services []catalogTypes.ServiceReference) error {
 	logger.Infof("Supported Parameters for '%s':", archID)
 
 	// Track displayed components to avoid duplicates
@@ -85,7 +85,7 @@ func displayArchitectureParameters(provider *catalog.CatalogProvider, archID str
 
 	// Display parameters for each service in the architecture
 	for _, svcRef := range services {
-		if err := displayServiceInArchitecture(provider, svcRef.ID, displayedComponents); err != nil {
+		if err := displayServiceInArchitecture(ctx, provider, svcRef.ID, displayedComponents); err != nil {
 			continue
 		}
 	}
@@ -94,7 +94,7 @@ func displayArchitectureParameters(provider *catalog.CatalogProvider, archID str
 }
 
 // displayServiceInArchitecture displays parameters for a single service within an architecture.
-func displayServiceInArchitecture(provider *catalog.CatalogProvider, serviceID string, displayedComponents map[string]bool) error {
+func displayServiceInArchitecture(ctx context.Context, provider *catalog.CatalogProvider, serviceID string, displayedComponents map[string]bool) error {
 	// Load the service to get its dependencies
 	service, err := provider.LoadService(serviceID)
 	if err != nil {
@@ -102,18 +102,18 @@ func displayServiceInArchitecture(provider *catalog.CatalogProvider, serviceID s
 	}
 
 	// Display service parameters
-	schema, err := provider.GetServiceParams(context.Background(), serviceID)
+	schema, err := provider.GetServiceParams(ctx, serviceID)
 	if err == nil && schema != nil {
 		displaySchemaParameters(schema, serviceID)
 	}
 
 	// Display component parameters for this service
-	return displayComponentsParameters(provider, service.Dependencies, displayedComponents)
+	return displayComponentsParameters(ctx, provider, service.Dependencies, displayedComponents)
 }
 
 // displayComponentsParameters displays parameters for components based on dependencies.
 // If displayedComponents map is provided, it will track and skip duplicates.
-func displayComponentsParameters(provider *catalog.CatalogProvider, dependencies []catalogTypes.DependencyReference, displayedComponents map[string]bool) error {
+func displayComponentsParameters(ctx context.Context, provider *catalog.CatalogProvider, dependencies []catalogTypes.DependencyReference, displayedComponents map[string]bool) error {
 	if len(dependencies) == 0 {
 		return nil
 	}
@@ -137,7 +137,7 @@ func displayComponentsParameters(provider *catalog.CatalogProvider, dependencies
 					displayedComponents[componentKey] = true
 				}
 
-				schema, err := provider.GetComponentProviderParams(context.Background(), comp.ComponentType, comp.ID)
+				schema, err := provider.GetComponentProviderParams(ctx, comp.ComponentType, comp.ID)
 				if err == nil && schema != nil {
 					displaySchemaParameters(schema, componentKey)
 				}

--- a/ai-services/cmd/ai-services/cmd/bootstrap/bootstrap.go
+++ b/ai-services/cmd/ai-services/cmd/bootstrap/bootstrap.go
@@ -79,11 +79,11 @@ func bootstrapRunE(skipChecks *[]string) func(*cobra.Command, []string) error {
 			return fmt.Errorf("failed to create bootstrap instance: %w", err)
 		}
 
-		if configureErr := bootstrapInstance.Configure(); configureErr != nil {
+		if configureErr := bootstrapInstance.Configure(cmd.Context()); configureErr != nil {
 			return fmt.Errorf("failed to run bootstrap configure: %w", configureErr)
 		}
 
-		if err := factory.Validate(skip); err != nil {
+		if err := factory.Validate(cmd.Context(), skip); err != nil {
 			logger.Infof("Please refer to troubleshooting guide for more information: %s", troubleshootingGuide)
 
 			return fmt.Errorf("failed to run bootstrap validate: %w", err)

--- a/ai-services/cmd/ai-services/cmd/bootstrap/configure.go
+++ b/ai-services/cmd/ai-services/cmd/bootstrap/configure.go
@@ -29,7 +29,7 @@ func configureCmd() *cobra.Command {
 				return fmt.Errorf("failed to create bootstrap instance: %w", err)
 			}
 
-			if err := bootstrapInstance.Configure(); err != nil {
+			if err := bootstrapInstance.Configure(cmd.Context()); err != nil {
 				return fmt.Errorf("bootstrap configuration failed: %w", err)
 			}
 

--- a/ai-services/cmd/ai-services/cmd/bootstrap/validate.go
+++ b/ai-services/cmd/ai-services/cmd/bootstrap/validate.go
@@ -46,7 +46,7 @@ func validateCmd() *cobra.Command {
 			}
 
 			factory := bootstrap.NewBootstrapFactory(vars.RuntimeFactory.GetRuntimeType())
-			if err := factory.Validate(skip); err != nil {
+			if err := factory.Validate(cmd.Context(), skip); err != nil {
 				logger.Infof("Please refer to troubleshooting guide for more information: %s", troubleshootingGuide)
 
 				return fmt.Errorf("bootstrap validation failed: %w", err)

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -101,12 +101,14 @@ SSL/TLS certificate management, HTTPS port configuration, and credential/certifi
 		return validateConfigureFlags()
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
 		if resetPasswordFlag {
-			return runResetPassword()
+			return runResetPassword(ctx)
 		} else if resetPodmanAuthFlag {
-			return runResetPodmanAuth()
+			return runResetPodmanAuth(ctx)
 		} else if resetCertificateFlag {
-			return runResetCertificate()
+			return runResetCertificate(ctx)
 		}
 
 		return runConfigure()
@@ -233,9 +235,9 @@ func validateResetCertificateFlags(cmd *cobra.Command, flagName string) error {
 	return nil
 }
 
-func runResetCertificate() error {
+func runResetCertificate(ctx context.Context) error {
 	// Call ResetCatalogCertificate with certificate paths
-	return catalogPodman.ResetCatalogCertificate(catalogUtils.SanitizeFilePath(sslCertPath), catalogUtils.SanitizeFilePath(sslKeyPath))
+	return catalogPodman.ResetCatalogCertificate(ctx, catalogUtils.SanitizeFilePath(sslCertPath), catalogUtils.SanitizeFilePath(sslKeyPath))
 }
 
 func initConfigureCommonFlags() {
@@ -361,22 +363,22 @@ func buildFlagValidator() *flagvalidator.FlagValidator {
 	return builder.Build()
 }
 
-func runResetPassword() error {
+func runResetPassword(ctx context.Context) error {
 	rt := vars.RuntimeFactory.GetRuntimeType()
 	switch rt {
 	case types.RuntimeTypePodman:
-		return catalogPodman.ResetCatalogPassword()
+		return catalogPodman.ResetCatalogPassword(ctx)
 
 	case types.RuntimeTypeOpenShift:
-		return catalogOpenShift.ResetCatalogPassword()
+		return catalogOpenShift.ResetCatalogPassword(ctx)
 
 	default:
 		return fmt.Errorf("unsupported runtime: %s", rt)
 	}
 }
 
-func runResetPodmanAuth() error {
-	return catalogPodman.ResetPodmanAuth()
+func runResetPodmanAuth(ctx context.Context) error {
+	return catalogPodman.ResetPodmanAuth(ctx)
 }
 
 func initConfigureOpenShiftFlags() {

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -111,7 +111,7 @@ SSL/TLS certificate management, HTTPS port configuration, and credential/certifi
 			return runResetCertificate(ctx)
 		}
 
-		return runConfigure()
+		return runConfigure(ctx)
 	},
 }
 
@@ -127,9 +127,8 @@ func init() {
 }
 
 // runConfigure executes the catalog configuration process.
-func runConfigure() error {
+func runConfigure(ctx context.Context) error {
 	rt := vars.RuntimeFactory.GetRuntimeType()
-	ctx := context.Background()
 	// Deploy catalog service based on runtime
 	switch rt {
 	case types.RuntimeTypePodman:

--- a/ai-services/cmd/ai-services/cmd/catalog/login.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/login.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -54,11 +55,12 @@ To get the Catalog backend endpoint, use: ai-services catalog info`,
 			return validateLoginFlags(runtimeType, serverURL, username, miqToken, passwordStdin)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			if miqToken != "" {
-				return runLoginWithMIQToken(serverURL, miqToken, insecure)
+				return runLoginWithMIQToken(ctx, serverURL, miqToken, insecure)
 			}
 
-			return runLogin(serverURL, username, passwordStdin, insecure)
+			return runLogin(ctx, serverURL, username, passwordStdin, insecure)
 		},
 	}
 
@@ -76,14 +78,14 @@ To get the Catalog backend endpoint, use: ai-services catalog info`,
 }
 
 // runLoginWithMIQToken executes Flow B: exchange a ManageIQ token for a Catalog API JWT.
-func runLoginWithMIQToken(serverURL, miqToken string, insecure bool) error {
+func runLoginWithMIQToken(ctx context.Context, serverURL, miqToken string, insecure bool) error {
 	if insecure {
 		logger.Warningln("WARNING: TLS certificate verification is disabled. This should NOT be used in production environments.")
 	}
 
 	logger.Infof("Logging in to %s using ManageIQ token...\n", serverURL)
 
-	if _, err := client.NewWithMIQToken(serverURL, miqToken, insecure); err != nil {
+	if _, err := client.NewWithMIQToken(ctx, serverURL, miqToken, insecure); err != nil {
 		return fmt.Errorf("login failed: %w", err)
 	}
 
@@ -93,7 +95,7 @@ func runLoginWithMIQToken(serverURL, miqToken string, insecure bool) error {
 }
 
 // runLogin executes Flow A: authenticate with username and password.
-func runLogin(serverURL, username string, passwordStdin, insecure bool) error {
+func runLogin(ctx context.Context, serverURL, username string, passwordStdin, insecure bool) error {
 	password, err := promptPassword(passwordStdin)
 	if err != nil {
 		return err
@@ -106,7 +108,7 @@ func runLogin(serverURL, username string, passwordStdin, insecure bool) error {
 
 	logger.Infof("Logging in to %s as %q...\n", serverURL, username)
 
-	if _, err := client.NewWithLogin(serverURL, username, password, insecure); err != nil {
+	if _, err := client.NewWithLogin(ctx, serverURL, username, password, insecure); err != nil {
 		return fmt.Errorf("login failed: %w", err)
 	}
 

--- a/ai-services/cmd/ai-services/cmd/catalog/logout.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/logout.go
@@ -30,6 +30,8 @@ the locally stored credentials.`,
 			// Once precheck passes, silence usage for any *later* internal errors.
 			cmd.SilenceUsage = true
 
+			ctx := cmd.Context()
+
 			// Load credentials to check if the user is logged in.
 			creds, err := config.Load()
 			if err != nil {
@@ -41,7 +43,7 @@ the locally stored credentials.`,
 			// Build a client from the stored credentials and call the server logout endpoint.
 			// We use New() which also refreshes the token; if refresh fails we still
 			// want to clean up local credentials, so we handle both paths.
-			c, err := client.New()
+			c, err := client.New(ctx)
 			if err != nil {
 				// Token may already be expired – still remove local credentials.
 				logger.Warningf("could not reach server (%v). Removing local credentials anyway.\n", err)
@@ -49,7 +51,7 @@ the locally stored credentials.`,
 				return config.Delete()
 			}
 
-			if err := c.Logout(); err != nil {
+			if err := c.Logout(ctx); err != nil {
 				return fmt.Errorf("logout failed: %w", err)
 			}
 

--- a/ai-services/cmd/ai-services/cmd/catalog/uninstall.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/uninstall.go
@@ -37,7 +37,7 @@ Examples:
 			return common.InitAndValidateRuntimeFlag(runtimeType)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return uninstall.Uninstall(cliutils.UninstallOptions{
+			return uninstall.Uninstall(cmd.Context(), cliutils.UninstallOptions{
 				Runtime:     vars.RuntimeFactory.GetRuntimeType(),
 				AutoYes:     uninstallAutoYes,
 				SkipCleanup: skipCleanup,

--- a/ai-services/cmd/ai-services/cmd/catalog/whoami.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/whoami.go
@@ -32,12 +32,14 @@ Note:
 			// Once precheck passes, silence usage for any *later* internal errors.
 			cmd.SilenceUsage = true
 
-			c, err := client.New()
+			ctx := cmd.Context()
+
+			c, err := client.New(ctx)
 			if err != nil {
 				return err
 			}
 
-			info, err := c.Me()
+			info, err := c.Me(ctx)
 			if err != nil {
 				return fmt.Errorf("get user info: %w", err)
 			}

--- a/ai-services/cmd/ai-services/cmd/catalog/worker.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/worker.go
@@ -51,12 +51,14 @@ Pass the token to the worker node and run:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 
-			c, err := client.New()
+			ctx := cmd.Context()
+
+			c, err := client.New(ctx)
 			if err != nil {
 				return err
 			}
 
-			resp, err := c.CreateWorker(args[0])
+			resp, err := c.CreateWorker(ctx, args[0])
 			if err != nil {
 				return err
 			}
@@ -85,12 +87,14 @@ func newWorkerListCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 
-			c, err := client.New()
+			ctx := cmd.Context()
+
+			c, err := client.New(ctx)
 			if err != nil {
 				return err
 			}
 
-			workers, err := c.ListWorkers()
+			workers, err := c.ListWorkers(ctx)
 			if err != nil {
 				return err
 			}
@@ -116,12 +120,14 @@ If the worker is currently connected its gRPC stream is also cleaned up.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 
-			c, err := client.New()
+			ctx := cmd.Context()
+
+			c, err := client.New(ctx)
 			if err != nil {
 				return err
 			}
 
-			if err := c.DeleteWorkerByName(args[0]); err != nil {
+			if err := c.DeleteWorkerByName(ctx, args[0]); err != nil {
 				return err
 			}
 

--- a/ai-services/cmd/ai-services/cmd/mustgather/mustgather.go
+++ b/ai-services/cmd/ai-services/cmd/mustgather/mustgather.go
@@ -84,7 +84,7 @@ func mustGatherRun(cmd *cobra.Command, _ []string) error {
 		applicationName: applicationName,
 	}
 
-	outDir, err := gatherer.gather(opts)
+	outDir, err := gatherer.gather(cmd.Context(), opts)
 	if err != nil {
 		return fmt.Errorf("must-gather failed: %w", err)
 	}

--- a/ai-services/cmd/ai-services/cmd/mustgather/podman.go
+++ b/ai-services/cmd/ai-services/cmd/mustgather/podman.go
@@ -76,7 +76,7 @@ func (g *podmanGatherer) gather(opts gatherOptions) (string, error) {
 
 	logger.InfofCtx(ctx, "Output directory: %s\n", outDir)
 
-	catalogInstalled, err := checkCatalogInstalled(rt)
+	catalogInstalled, err := checkCatalogInstalled(ctx, rt)
 	if err != nil {
 		logger.WarningfCtx(ctx, "Failed to check catalog installation: %v\n", err)
 	}
@@ -106,8 +106,8 @@ func (g *podmanGatherer) gather(opts gatherOptions) (string, error) {
 // ai-services.io/application=ai-services label is present, confirming that
 // the catalog has been installed (covers catalog, db, and caddy pods — any one
 // of them is sufficient).
-func checkCatalogInstalled(rt *podmanRuntime.PodmanClient) (bool, error) {
-	pods, err := rt.ListPods(map[string][]string{
+func checkCatalogInstalled(ctx context.Context, rt *podmanRuntime.PodmanClient) (bool, error) {
+	pods, err := rt.ListPods(ctx, map[string][]string{
 		"label": {fmt.Sprintf("ai-services.io/application=%s", catalogConstants.CatalogAppName)},
 	})
 	if err != nil {
@@ -124,7 +124,7 @@ func checkCatalogInstalled(rt *podmanRuntime.PodmanClient) (bool, error) {
 func (g *podmanGatherer) resolveBaseDir(ctx context.Context, rt *podmanRuntime.PodmanClient) {
 	g.baseDir = pkgutils.GetBaseDir() // safe fallback
 
-	config, _, err := catalogUtils.GetCatalogPodConfig(rt)
+	config, _, err := catalogUtils.GetCatalogPodConfig(ctx, rt)
 	if err != nil {
 		if errors.Is(err, catalogUtils.ErrCatalogPodNotFound) {
 			logger.WarninglnCtx(ctx, "Catalog backend pod is stopped — base directory resolved to default.")

--- a/ai-services/cmd/ai-services/cmd/mustgather/podman.go
+++ b/ai-services/cmd/ai-services/cmd/mustgather/podman.go
@@ -57,8 +57,7 @@ func newPodmanGatherer() *podmanGatherer {
 //     no catalog pods exist at all (catalog was never installed).
 //   - Always-on: system info, secrets, network, volumes — Podman-level data
 //     that is useful regardless of catalog state.
-func (g *podmanGatherer) gather(opts gatherOptions) (string, error) {
-	ctx := context.Background()
+func (g *podmanGatherer) gather(ctx context.Context, opts gatherOptions) (string, error) {
 
 	logger.InfolnCtx(ctx, "Starting must-gather for Podman runtime…")
 
@@ -156,7 +155,7 @@ func (g *podmanGatherer) createOutputDir(base string) (string, error) {
 // collectApplicationPods uses the catalog API to discover pod names for every
 // application (or a single named one), then collects inspect/logs/env for each.
 func (g *podmanGatherer) collectApplicationPods(ctx context.Context, outDir, appName string) {
-	appClient, err := catalogClient.NewApplicationClient()
+	appClient, err := catalogClient.NewApplicationClient(ctx)
 	if err != nil {
 		logger.WarningfCtx(ctx, "Catalog client unavailable, skipping application pod collection: %v\n", err)
 
@@ -182,7 +181,7 @@ func (g *podmanGatherer) collectApplicationPods(ctx context.Context, outDir, app
 // appropriate warning on error or empty result. Returns (apps, true) on
 // success, (nil, false) when the caller should skip collection.
 func fetchApplicationsForGather(ctx context.Context, appClient *catalogClient.ApplicationClient, appName string) ([]catalogTypes.Application, bool) {
-	apps, err := cliUtils.FetchApplications(appClient, appName)
+	apps, err := cliUtils.FetchApplications(ctx, appClient, appName)
 	if err != nil {
 		if appName != "" {
 			logger.WarningfCtx(ctx, "Application %q not found: %v\n", appName, err)
@@ -210,7 +209,7 @@ func fetchApplicationsForGather(ctx context.Context, appClient *catalogClient.Ap
 // each pod. Extracted to keep collectApplicationPods within complexity limits.
 func (g *podmanGatherer) collectPodsForApps(ctx context.Context, appClient *catalogClient.ApplicationClient, podsDir string, apps []catalogTypes.Application) {
 	for _, app := range apps {
-		psResp, err := appClient.GetApplicationPS(app.ID)
+		psResp, err := appClient.GetApplicationPS(ctx, app.ID)
 		if err != nil {
 			logger.WarningfCtx(ctx, "Failed to get PS for application %q: %v\n", app.Name, err)
 

--- a/ai-services/cmd/ai-services/cmd/mustgather/podman.go
+++ b/ai-services/cmd/ai-services/cmd/mustgather/podman.go
@@ -58,7 +58,6 @@ func newPodmanGatherer() *podmanGatherer {
 //   - Always-on: system info, secrets, network, volumes — Podman-level data
 //     that is useful regardless of catalog state.
 func (g *podmanGatherer) gather(ctx context.Context, opts gatherOptions) (string, error) {
-
 	logger.InfolnCtx(ctx, "Starting must-gather for Podman runtime…")
 
 	rt, err := podmanRuntime.NewPodmanClient()

--- a/ai-services/internal/pkg/application/common/backup/digitize.go
+++ b/ai-services/internal/pkg/application/common/backup/digitize.go
@@ -3,6 +3,7 @@ package common
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -99,13 +100,14 @@ func NewDigitizeBackupClient(serviceURL string) *DigitizeBackupClient {
 }
 
 // CallExportAPI calls the digitize Export API.
-func (c *DigitizeBackupClient) CallExportAPI() (*DigitizeExportResponse, error) {
+func (c *DigitizeBackupClient) CallExportAPI(ctx context.Context) (*DigitizeExportResponse, error) {
 	logger.Infoln("Calling digitize Export API...")
 
 	var exportResponse DigitizeExportResponse
 
 	logger.Infoln("Sending export request to: /v1/export?limit=-1")
 	resp, err := c.client.R().
+		SetContext(ctx).
 		SetQueryParam("limit", ExportAllRecordsLimit).
 		SetResult(&exportResponse).
 		Get("/v1/export")

--- a/ai-services/internal/pkg/application/common/ps.go
+++ b/ai-services/internal/pkg/application/common/ps.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -14,13 +15,13 @@ import (
 )
 
 // FetchFilteredPods Fetch all pods for a given app based on label.
-func FetchFilteredPods(r runtime.Runtime, appName string) ([]types.Pod, error) {
+func FetchFilteredPods(ctx context.Context, r runtime.Runtime, appName string) ([]types.Pod, error) {
 	listFilters := map[string][]string{}
 	if appName != "" {
 		listFilters["label"] = []string{fmt.Sprintf("ai-services.io/application=%s", appName)}
 	}
 
-	pods, err := r.ListPods(listFilters)
+	pods, err := r.ListPods(ctx, listFilters)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods: %w", err)
 	}
@@ -29,7 +30,7 @@ func FetchFilteredPods(r runtime.Runtime, appName string) ([]types.Pod, error) {
 }
 
 // PopulateTable Set table headers and rows.
-func PopulateTable(r runtime.Runtime, opts appTypes.ListOptions, pods []types.Pod) {
+func PopulateTable(ctx context.Context, r runtime.Runtime, opts appTypes.ListOptions, pods []types.Pod) {
 	// fetch the table writer object
 	printer := utils.NewTableWriter()
 	defer printer.CloseTableWriter()
@@ -38,7 +39,7 @@ func PopulateTable(r runtime.Runtime, opts appTypes.ListOptions, pods []types.Po
 	setTableHeaders(printer, opts.OutputWide)
 
 	// render each pod info as rows in the table
-	renderPodRows(r, printer, pods, opts.OutputWide)
+	renderPodRows(ctx, r, printer, pods, opts.OutputWide)
 }
 
 func setTableHeaders(printer *utils.Printer, outputWide bool) {
@@ -49,13 +50,13 @@ func setTableHeaders(printer *utils.Printer, outputWide bool) {
 	}
 }
 
-func renderPodRows(r runtime.Runtime, printer *utils.Printer, pods []types.Pod, wideOutput bool) {
+func renderPodRows(ctx context.Context, r runtime.Runtime, printer *utils.Printer, pods []types.Pod, wideOutput bool) {
 	for _, pod := range pods {
-		processAndAppendPodRow(r, printer, pod, wideOutput)
+		processAndAppendPodRow(ctx, r, printer, pod, wideOutput)
 	}
 }
 
-func processAndAppendPodRow(r runtime.Runtime, printer *utils.Printer, pod types.Pod, wideOutput bool) {
+func processAndAppendPodRow(ctx context.Context, r runtime.Runtime, printer *utils.Printer, pod types.Pod, wideOutput bool) {
 	appName := fetchPodNameFromLabels(pod.Labels)
 	if appName == "" {
 		// skip pods which are not linked to ai-services
@@ -63,7 +64,7 @@ func processAndAppendPodRow(r runtime.Runtime, printer *utils.Printer, pod types
 	}
 
 	// do pod inspect
-	pInfo, err := r.InspectPod(pod.ID)
+	pInfo, err := r.InspectPod(ctx, pod.ID)
 	if err != nil {
 		// log and skip pod if inspect failed
 		logger.Errorf("Failed to do pod inspect: '%s' with error: %v", pod.ID, err)
@@ -72,7 +73,7 @@ func processAndAppendPodRow(r runtime.Runtime, printer *utils.Printer, pod types
 	}
 
 	// fetch pod row
-	rows := buildPodRow(r, appName, pInfo, wideOutput)
+	rows := buildPodRow(ctx, r, appName, pInfo, wideOutput)
 	// append pod row to the table
 	printer.AppendRow(rows...)
 }
@@ -81,15 +82,15 @@ func fetchPodNameFromLabels(labels map[string]string) string {
 	return labels[constants.ApplicationAnnotationKey]
 }
 
-func buildPodRow(r runtime.Runtime, appName string, pod *types.Pod, wideOutput bool) []string {
-	status := getPodStatus(r, pod)
+func buildPodRow(ctx context.Context, r runtime.Runtime, appName string, pod *types.Pod, wideOutput bool) []string {
+	status := getPodStatus(ctx, r, pod)
 
 	// if wide option flag is not set, then return appName, podName and status only
 	if !wideOutput {
 		return []string{appName, pod.Name, status}
 	}
 
-	containerNames := getContainerNames(r, pod)
+	containerNames := getContainerNames(ctx, r, pod)
 
 	podPorts, err := getPodPorts(pod)
 	if err != nil {
@@ -123,11 +124,11 @@ func getPodPorts(pInfo *types.Pod) ([]string, error) {
 	return podPorts, nil
 }
 
-func getContainerNames(r runtime.Runtime, pod *types.Pod) []string {
+func getContainerNames(ctx context.Context, r runtime.Runtime, pod *types.Pod) []string {
 	containerNames := []string{}
 
 	for _, container := range pod.Containers {
-		cInfo, err := r.InspectContainer(container.ID)
+		cInfo, err := r.InspectContainer(ctx, container.ID)
 		if err != nil {
 			// skip container if inspect failed
 			logger.Debugf("failed to do container inspect for pod: '%s', containerID: '%s' with error: %v", pod.Name, container.ID, err)
@@ -149,12 +150,12 @@ func getContainerNames(r runtime.Runtime, pod *types.Pod) []string {
 	return containerNames
 }
 
-func getPodStatus(r runtime.Runtime, pInfo *types.Pod) string {
+func getPodStatus(ctx context.Context, r runtime.Runtime, pInfo *types.Pod) string {
 	// if the pod Status is running, make sure to check if its healthy or not, otherwise fallback to default pod state
 	if pInfo.State == "Running" {
 		healthyContainers := 0
 		for _, container := range pInfo.Containers {
-			cInfo, err := r.InspectContainer(container.ID)
+			cInfo, err := r.InspectContainer(ctx, container.ID)
 			if err != nil {
 				// skip container if inspect failed
 				logger.Debugf("failed to do container inspect for pod: '%s', containerID: '%s' with error: %v", pInfo.Name, container.ID, err)

--- a/ai-services/internal/pkg/application/common/restore/digitize.go
+++ b/ai-services/internal/pkg/application/common/restore/digitize.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -179,7 +180,7 @@ func NewDigitizeRestoreClient(serviceURL string) *DigitizeRestoreClient {
 }
 
 // CallImportAPI calls the digitize service Import API with the metadata payload.
-func (c *DigitizeRestoreClient) CallImportAPI(payload map[string]interface{}) error {
+func (c *DigitizeRestoreClient) CallImportAPI(ctx context.Context, payload map[string]interface{}) error {
 	logger.Infoln("Calling digitize Import API...")
 
 	// Prepare response container
@@ -188,6 +189,7 @@ func (c *DigitizeRestoreClient) CallImportAPI(payload map[string]interface{}) er
 	// Make the API call using the reusable HTTP client
 	logger.Infoln("Sending import request to: /v1/import")
 	resp, err := c.client.R().
+		SetContext(ctx).
 		SetBody(payload).
 		SetResult(&importResponse).
 		Post("/v1/import")

--- a/ai-services/internal/pkg/application/interface.go
+++ b/ai-services/internal/pkg/application/interface.go
@@ -16,19 +16,19 @@ type Application interface {
 	Delete(ctx context.Context, opts types.DeleteOptions) error
 
 	// Start starts a stopped application.
-	Start(opts types.StartOptions) error
+	Start(ctx context.Context, opts types.StartOptions) error
 
 	// Stop stops a running application.
-	Stop(opts types.StopOptions) error
+	Stop(ctx context.Context, opts types.StopOptions) error
 
 	// List returns information about running applications.
-	List(opts types.ListOptions) ([]types.ApplicationInfo, error)
+	List(ctx context.Context, opts types.ListOptions) ([]types.ApplicationInfo, error)
 
 	// Info displays detailed information about an application.
-	Info(opts types.InfoOptions) error
+	Info(ctx context.Context, opts types.InfoOptions) error
 
 	// Logs displays logs from an application pod.
-	Logs(opts types.LogsOptions) error
+	Logs(ctx context.Context, opts types.LogsOptions) error
 
 	// Restore restores application data from a backup file.
 	Restore(ctx context.Context, opts types.RestoreOptions) error

--- a/ai-services/internal/pkg/application/openshift/backup.go
+++ b/ai-services/internal/pkg/application/openshift/backup.go
@@ -82,7 +82,7 @@ func (o *OpenshiftApplication) backupDigitize(ctx context.Context, appName, back
 	// Create digitize backup client and call Export API
 	client := commonBackup.NewDigitizeBackupClient(digitizeURL)
 
-	exportResponse, err := client.CallExportAPI()
+	exportResponse, err := client.CallExportAPI(ctx)
 	if err != nil {
 		return err
 	}

--- a/ai-services/internal/pkg/application/openshift/create.go
+++ b/ai-services/internal/pkg/application/openshift/create.go
@@ -47,7 +47,7 @@ func (o *OpenshiftApplication) Create(ctx context.Context, opts types.CreateOpti
 	logger.Infoln("-------")
 
 	// Step5: Print the next steps to be performed at the end of create
-	if err := helpers.PrintNextSteps(tp, o.runtime, opts.Name, opts.TemplateName); err != nil {
+	if err := helpers.PrintNextSteps(ctx, tp, o.runtime, opts.Name, opts.TemplateName); err != nil {
 		// do not want to fail the overall create if we cannot print next steps
 		logger.Infof("failed to display next steps: %v\n", err)
 

--- a/ai-services/internal/pkg/application/openshift/delete.go
+++ b/ai-services/internal/pkg/application/openshift/delete.go
@@ -64,7 +64,7 @@ func (o *OpenshiftApplication) Delete(ctx context.Context, opts types.DeleteOpti
 	if !opts.SkipCleanup {
 		logger.Debugln("Cleaning up Persistent Volume Claims...")
 
-		if err := o.runtime.DeletePVCs(fmt.Sprintf("ai-services.io/application=%s", app)); err != nil {
+		if err := o.runtime.DeletePVCs(ctx, fmt.Sprintf("ai-services.io/application=%s", app)); err != nil {
 			return fmt.Errorf("failed to cleanup PVCs: %w", err)
 		}
 	}

--- a/ai-services/internal/pkg/application/openshift/info.go
+++ b/ai-services/internal/pkg/application/openshift/info.go
@@ -46,7 +46,7 @@ func (o *OpenshiftApplication) Info(ctx context.Context, opts types.InfoOptions)
 	// Step3: Read and print the info.md file
 	tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
 
-	if err := helpers.PrintInfo(tp, o.runtime, opts.Name, appTemplate); err != nil {
+	if err := helpers.PrintInfo(ctx, tp, o.runtime, opts.Name, appTemplate); err != nil {
 		// not failing if overall info command, if we cannot display Info
 		logger.Errorf("failed to display info: %v\n", err)
 

--- a/ai-services/internal/pkg/application/openshift/info.go
+++ b/ai-services/internal/pkg/application/openshift/info.go
@@ -13,8 +13,7 @@ import (
 )
 
 // Info displays detailed information about an application.
-func (o *OpenshiftApplication) Info(opts types.InfoOptions) error {
-	ctx := context.Background()
+func (o *OpenshiftApplication) Info(ctx context.Context, opts types.InfoOptions) error {
 	// Step1: Do List pods and filter for given application name
 
 	listFilters := map[string][]string{}

--- a/ai-services/internal/pkg/application/openshift/info.go
+++ b/ai-services/internal/pkg/application/openshift/info.go
@@ -1,6 +1,7 @@
 package openshift
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/assets"
@@ -13,6 +14,7 @@ import (
 
 // Info displays detailed information about an application.
 func (o *OpenshiftApplication) Info(opts types.InfoOptions) error {
+	ctx := context.Background()
 	// Step1: Do List pods and filter for given application name
 
 	listFilters := map[string][]string{}
@@ -20,7 +22,7 @@ func (o *OpenshiftApplication) Info(opts types.InfoOptions) error {
 		listFilters["label"] = []string{fmt.Sprintf("ai-services.io/application=%s", opts.Name)}
 	}
 
-	pods, err := o.runtime.ListPods(listFilters)
+	pods, err := o.runtime.ListPods(ctx, listFilters)
 	if err != nil {
 		return fmt.Errorf("failed to list pods: %w", err)
 	}

--- a/ai-services/internal/pkg/application/openshift/logs.go
+++ b/ai-services/internal/pkg/application/openshift/logs.go
@@ -1,6 +1,7 @@
 package openshift
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application/types"
@@ -9,11 +10,12 @@ import (
 
 // Logs displays logs from an application pod.
 func (o *OpenshiftApplication) Logs(opts types.LogsOptions) error {
+	ctx := context.Background()
 	logger.Warningln("Press Ctrl+C to exit the logs and return to the terminal.")
 	logger.Infof("Fetching logs for application pod: %s", opts.PodName)
 
 	if opts.ContainerNameOrID == "" {
-		if err := o.runtime.PodLogs(opts.PodName); err != nil {
+		if err := o.runtime.PodLogs(ctx, opts.PodName); err != nil {
 			return fmt.Errorf("failed to fetch pod: %s logs; err: %w", opts.PodName, err)
 		}
 
@@ -21,7 +23,7 @@ func (o *OpenshiftApplication) Logs(opts types.LogsOptions) error {
 	}
 
 	// Fetch container logs
-	exists, err := o.runtime.ContainerExists(opts.ContainerNameOrID)
+	exists, err := o.runtime.ContainerExists(ctx, opts.ContainerNameOrID)
 	if err != nil {
 		return err
 	}
@@ -30,7 +32,7 @@ func (o *OpenshiftApplication) Logs(opts types.LogsOptions) error {
 	}
 
 	logger.Infof("Fetching logs for container: %s", opts.ContainerNameOrID)
-	if err := o.runtime.ContainerLogs(opts.ContainerNameOrID); err != nil {
+	if err := o.runtime.ContainerLogs(ctx, opts.ContainerNameOrID); err != nil {
 		return fmt.Errorf("failed to fetch container: %s logs; err: %w", opts.ContainerNameOrID, err)
 	}
 

--- a/ai-services/internal/pkg/application/openshift/logs.go
+++ b/ai-services/internal/pkg/application/openshift/logs.go
@@ -9,8 +9,7 @@ import (
 )
 
 // Logs displays logs from an application pod.
-func (o *OpenshiftApplication) Logs(opts types.LogsOptions) error {
-	ctx := context.Background()
+func (o *OpenshiftApplication) Logs(ctx context.Context, opts types.LogsOptions) error {
 	logger.Warningln("Press Ctrl+C to exit the logs and return to the terminal.")
 	logger.Infof("Fetching logs for application pod: %s", opts.PodName)
 

--- a/ai-services/internal/pkg/application/openshift/ps.go
+++ b/ai-services/internal/pkg/application/openshift/ps.go
@@ -1,6 +1,7 @@
 package openshift
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application/common"
@@ -14,8 +15,9 @@ func (o *OpenshiftApplication) List(opts appTypes.ListOptions) ([]appTypes.Appli
 		return nil, fmt.Errorf("application name is required for openshift runtime")
 	}
 
+	ctx := context.Background()
 	// filter and fetch pods based on appName
-	pods, err := common.FetchFilteredPods(o.runtime, opts.ApplicationName)
+	pods, err := common.FetchFilteredPods(ctx, o.runtime, opts.ApplicationName)
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +30,7 @@ func (o *OpenshiftApplication) List(opts appTypes.ListOptions) ([]appTypes.Appli
 	}
 
 	// set table headers and rows
-	common.PopulateTable(o.runtime, opts, pods)
+	common.PopulateTable(ctx, o.runtime, opts, pods)
 
 	return nil, nil
 }

--- a/ai-services/internal/pkg/application/openshift/ps.go
+++ b/ai-services/internal/pkg/application/openshift/ps.go
@@ -10,12 +10,11 @@ import (
 )
 
 // List returns information about running applications.
-func (o *OpenshiftApplication) List(opts appTypes.ListOptions) ([]appTypes.ApplicationInfo, error) {
+func (o *OpenshiftApplication) List(ctx context.Context, opts appTypes.ListOptions) ([]appTypes.ApplicationInfo, error) {
 	if opts.ApplicationName == "" {
 		return nil, fmt.Errorf("application name is required for openshift runtime")
 	}
 
-	ctx := context.Background()
 	// filter and fetch pods based on appName
 	pods, err := common.FetchFilteredPods(ctx, o.runtime, opts.ApplicationName)
 	if err != nil {

--- a/ai-services/internal/pkg/application/openshift/restore.go
+++ b/ai-services/internal/pkg/application/openshift/restore.go
@@ -72,7 +72,7 @@ func (o *OpenshiftApplication) getDigitizeAPIURL(ctx context.Context, appName st
 	logger.Infof("Fetching digitize route from OpenShift...\n")
 
 	// List all routes in the namespace using the runtime interface
-	routes, err := o.runtime.ListRoutes("")
+	routes, err := o.runtime.ListRoutes(ctx, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to list routes: %w", err)
 	}

--- a/ai-services/internal/pkg/application/openshift/restore.go
+++ b/ai-services/internal/pkg/application/openshift/restore.go
@@ -58,7 +58,7 @@ func (o *OpenshiftApplication) restoreDigitize(ctx context.Context, appName, bac
 
 	// Create digitize restore client and call Import API
 	client := commonrestore.NewDigitizeRestoreClient(digitizeURL)
-	if err := client.CallImportAPI(importPayload); err != nil {
+	if err := client.CallImportAPI(ctx, importPayload); err != nil {
 		return err
 	}
 

--- a/ai-services/internal/pkg/application/openshift/start.go
+++ b/ai-services/internal/pkg/application/openshift/start.go
@@ -1,12 +1,14 @@
 package openshift
 
 import (
+	"context"
+
 	"github.com/project-ai-services/ai-services/internal/pkg/application/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 )
 
 // Start starts a stopped application.
-func (o *OpenshiftApplication) Start(opts types.StartOptions) error {
+func (o *OpenshiftApplication) Start(_ context.Context, opts types.StartOptions) error {
 	logger.Warningln("Not supported for openshift runtime")
 
 	return nil

--- a/ai-services/internal/pkg/application/openshift/stop.go
+++ b/ai-services/internal/pkg/application/openshift/stop.go
@@ -1,12 +1,14 @@
 package openshift
 
 import (
+	"context"
+
 	"github.com/project-ai-services/ai-services/internal/pkg/application/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 )
 
 // Stop stops a running application.
-func (o *OpenshiftApplication) Stop(opts types.StopOptions) error {
+func (o *OpenshiftApplication) Stop(_ context.Context, opts types.StopOptions) error {
 	logger.Warningln("Not implemented")
 
 	return nil

--- a/ai-services/internal/pkg/application/podman/backup.go
+++ b/ai-services/internal/pkg/application/podman/backup.go
@@ -39,7 +39,7 @@ func (p *PodmanApplication) backupOpenSearch(ctx context.Context, appName, backu
 	logger.Infoln("OpenSearch Backup (Sidecar Container Approach)")
 
 	// Get application details from catalog API
-	appDetails, err := cliUtils.GetAppDetailsWithComponents(appName)
+	appDetails, err := cliUtils.GetAppDetailsWithComponents(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("failed to get application details: %w", err)
 	}
@@ -98,7 +98,7 @@ func (p *PodmanApplication) backupDigitize(ctx context.Context, appName, backupF
 	logger.Infof("Backing up digitize metadata for application: %s\n", appName)
 	logger.Infoln("Digitize Export (API-based Approach)")
 
-	appDetails, err := cliUtils.GetAppDetailsWithComponents(appName)
+	appDetails, err := cliUtils.GetAppDetailsWithComponents(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("failed to get application details: %w", err)
 	}
@@ -119,7 +119,7 @@ func (p *PodmanApplication) backupDigitize(ctx context.Context, appName, backupF
 
 	// Create digitize backup client and call Export API
 	client := commonBackup.NewDigitizeBackupClient(digitizeURL)
-	exportResponse, err := client.CallExportAPI()
+	exportResponse, err := client.CallExportAPI(ctx)
 	if err != nil {
 		return err
 	}

--- a/ai-services/internal/pkg/application/podman/create.go
+++ b/ai-services/internal/pkg/application/podman/create.go
@@ -147,7 +147,7 @@ func (p *PodmanApplication) deployApplication(ctx context.Context, opts types.Cr
 	logger.Infoln("-------")
 
 	// print the next steps to be performed at the end of create
-	if err := helpers.PrintNextSteps(tp, p.runtime, opts.Name, opts.TemplateName); err != nil {
+	if err := helpers.PrintNextSteps(ctx, tp, p.runtime, opts.Name, opts.TemplateName); err != nil {
 		// do not want to fail the overall create if we cannot print next steps
 		logger.Infof("failed to display next steps: %v\n", err)
 
@@ -173,7 +173,7 @@ func (p *PodmanApplication) downloadModels(ctx context.Context, templateName, ap
 	for _, model := range models {
 		s.UpdateMessage("Downloading model: " + model + "...")
 		err = utils.Retry(ctx, vars.RetryCount, vars.RetryInterval, nil, func() error {
-			return helpers.DownloadModel(model, utils.GetModelsPath())
+			return helpers.DownloadModel(ctx, model, utils.GetModelsPath())
 		})
 		if err != nil {
 			s.Fail("failed to download model: " + model)

--- a/ai-services/internal/pkg/application/podman/create.go
+++ b/ai-services/internal/pkg/application/podman/create.go
@@ -87,7 +87,7 @@ func (p *PodmanApplication) Create(ctx context.Context, opts types.CreateOptions
 func (p *PodmanApplication) validateAndAllocateSpyreCards(ctx context.Context, templateName, appName string, tmpls map[string]*template.Template) ([]string, error) {
 	tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
 
-	reqSpyreCardsCount, err := p.calculateReqSpyreCards(tp, utils.ExtractMapKeys(tmpls), templateName, appName)
+	reqSpyreCardsCount, err := p.calculateReqSpyreCards(ctx, tp, utils.ExtractMapKeys(tmpls), templateName, appName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculateReqSpyreCards: %w", err)
 	}
@@ -212,7 +212,7 @@ func (p *PodmanApplication) validateSpyreCardRequirements(req int, actual int) e
 	return nil
 }
 
-func (p *PodmanApplication) calculateReqSpyreCards(tp templates.Template, podTemplateFileNames []string, appTemplateName, appName string) (int, error) {
+func (p *PodmanApplication) calculateReqSpyreCards(ctx context.Context, tp templates.Template, podTemplateFileNames []string, appTemplateName, appName string) (int, error) {
 	totalReqSpyreCounts := 0
 
 	// Calculate Req Spyre Counts
@@ -224,7 +224,7 @@ func (p *PodmanApplication) calculateReqSpyreCards(tp templates.Template, podTem
 		}
 
 		// check if pod already exists and skip counting if it does exists
-		exists, err := p.runtime.PodExists(podSpec.Name)
+		exists, err := p.runtime.PodExists(ctx, podSpec.Name)
 		if err != nil {
 			return totalReqSpyreCounts, fmt.Errorf("failed to check pod status: %w", err)
 		}

--- a/ai-services/internal/pkg/application/podman/delete.go
+++ b/ai-services/internal/pkg/application/podman/delete.go
@@ -14,11 +14,11 @@ import (
 )
 
 // Delete removes an application and its associated resources.
-func (p *PodmanApplication) Delete(_ context.Context, opts appTypes.DeleteOptions) error {
+func (p *PodmanApplication) Delete(ctx context.Context, opts appTypes.DeleteOptions) error {
 	appDir := filepath.Join(utils.GetApplicationsPath(), filepath.Base(opts.Name))
 	appExists := utils.FileExists(appDir)
 
-	pods, err := p.runtime.ListPods(map[string][]string{
+	pods, err := p.runtime.ListPods(ctx, map[string][]string{
 		"label": {fmt.Sprintf("ai-services.io/application=%s", opts.Name)},
 	})
 	if err != nil {
@@ -49,7 +49,7 @@ func (p *PodmanApplication) Delete(_ context.Context, opts appTypes.DeleteOption
 
 	logger.Infoln("Proceeding with deletion...")
 
-	if err := p.podsDeletion(pods); err != nil {
+	if err := p.podsDeletion(ctx, pods); err != nil {
 		return err
 	}
 
@@ -92,13 +92,13 @@ func (p *PodmanApplication) deleteConfirmation(appName string, podsExists, appEx
 	return confirmDelete, nil
 }
 
-func (p *PodmanApplication) podsDeletion(pods []types.Pod) error {
+func (p *PodmanApplication) podsDeletion(ctx context.Context, pods []types.Pod) error {
 	var errors []string
 
 	for _, pod := range pods {
 		logger.Infof("Deleting pod: %s\n", pod.Name)
 
-		if err := p.runtime.DeletePod(pod.ID, utils.BoolPtr(true)); err != nil {
+		if err := p.runtime.DeletePod(ctx, pod.ID, utils.BoolPtr(true)); err != nil {
 			errors = append(errors, fmt.Sprintf("pod %s: %v", pod.Name, err))
 
 			continue

--- a/ai-services/internal/pkg/application/podman/info.go
+++ b/ai-services/internal/pkg/application/podman/info.go
@@ -1,6 +1,7 @@
 package podman
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/assets"
@@ -13,6 +14,7 @@ import (
 
 // Info displays detailed information about an application.
 func (p *PodmanApplication) Info(opts types.InfoOptions) error {
+	ctx := context.Background()
 	// Step1: Do List pods and filter for given application name
 
 	listFilters := map[string][]string{}
@@ -20,7 +22,7 @@ func (p *PodmanApplication) Info(opts types.InfoOptions) error {
 		listFilters["label"] = []string{fmt.Sprintf("ai-services.io/application=%s", opts.Name)}
 	}
 
-	pods, err := p.runtime.ListPods(listFilters)
+	pods, err := p.runtime.ListPods(ctx, listFilters)
 	if err != nil {
 		return fmt.Errorf("failed to list pods: %w", err)
 	}

--- a/ai-services/internal/pkg/application/podman/info.go
+++ b/ai-services/internal/pkg/application/podman/info.go
@@ -13,8 +13,7 @@ import (
 )
 
 // Info displays detailed information about an application.
-func (p *PodmanApplication) Info(opts types.InfoOptions) error {
-	ctx := context.Background()
+func (p *PodmanApplication) Info(ctx context.Context, opts types.InfoOptions) error {
 	// Step1: Do List pods and filter for given application name
 
 	listFilters := map[string][]string{}

--- a/ai-services/internal/pkg/application/podman/info.go
+++ b/ai-services/internal/pkg/application/podman/info.go
@@ -46,7 +46,7 @@ func (p *PodmanApplication) Info(ctx context.Context, opts types.InfoOptions) er
 	// Step3: Read and print the info.md file
 	tp := templates.NewEmbedTemplateProvider(&assets.ApplicationFS)
 
-	if err := helpers.PrintInfo(tp, p.runtime, opts.Name, appTemplate); err != nil {
+	if err := helpers.PrintInfo(ctx, tp, p.runtime, opts.Name, appTemplate); err != nil {
 		// not failing if overall info command, if we cannot display Info
 		logger.Errorf("failed to display info: %v\n", err)
 

--- a/ai-services/internal/pkg/application/podman/logs.go
+++ b/ai-services/internal/pkg/application/podman/logs.go
@@ -1,6 +1,7 @@
 package podman
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application/types"
@@ -9,11 +10,12 @@ import (
 
 // Logs displays logs from an application pod.
 func (p *PodmanApplication) Logs(opts types.LogsOptions) error {
+	ctx := context.Background()
 	logger.Warningln("Press Ctrl+C to exit the logs and return to the terminal.")
 	logger.Infof("Fetching logs for application pod: %s", opts.PodName)
 
 	if opts.ContainerNameOrID == "" {
-		if err := p.runtime.PodLogs(opts.PodName); err != nil {
+		if err := p.runtime.PodLogs(ctx, opts.PodName); err != nil {
 			return fmt.Errorf("failed to fetch pod: %s logs; err: %w", opts.PodName, err)
 		}
 
@@ -21,7 +23,7 @@ func (p *PodmanApplication) Logs(opts types.LogsOptions) error {
 	}
 
 	// Fetch container logs
-	exists, err := p.runtime.ContainerExists(opts.ContainerNameOrID)
+	exists, err := p.runtime.ContainerExists(ctx, opts.ContainerNameOrID)
 	if err != nil {
 		return err
 	}
@@ -30,7 +32,7 @@ func (p *PodmanApplication) Logs(opts types.LogsOptions) error {
 	}
 
 	logger.Infof("Fetching logs for container: %s", opts.ContainerNameOrID)
-	if err := p.runtime.ContainerLogs(opts.ContainerNameOrID); err != nil {
+	if err := p.runtime.ContainerLogs(ctx, opts.ContainerNameOrID); err != nil {
 		return fmt.Errorf("failed to fetch container: %s logs; err: %w", opts.ContainerNameOrID, err)
 	}
 

--- a/ai-services/internal/pkg/application/podman/logs.go
+++ b/ai-services/internal/pkg/application/podman/logs.go
@@ -9,8 +9,7 @@ import (
 )
 
 // Logs displays logs from an application pod.
-func (p *PodmanApplication) Logs(opts types.LogsOptions) error {
-	ctx := context.Background()
+func (p *PodmanApplication) Logs(ctx context.Context, opts types.LogsOptions) error {
 	logger.Warningln("Press Ctrl+C to exit the logs and return to the terminal.")
 	logger.Infof("Fetching logs for application pod: %s", opts.PodName)
 

--- a/ai-services/internal/pkg/application/podman/ps.go
+++ b/ai-services/internal/pkg/application/podman/ps.go
@@ -10,8 +10,7 @@ import (
 )
 
 // List returns information about running applications.
-func (p *PodmanApplication) List(opts appTypes.ListOptions) ([]appTypes.ApplicationInfo, error) {
-	ctx := context.Background()
+func (p *PodmanApplication) List(ctx context.Context, opts appTypes.ListOptions) ([]appTypes.ApplicationInfo, error) {
 	// filter and fetch pods based on appName
 	pods, err := common.FetchFilteredPods(ctx, p.runtime, opts.ApplicationName)
 	if err != nil {

--- a/ai-services/internal/pkg/application/podman/ps.go
+++ b/ai-services/internal/pkg/application/podman/ps.go
@@ -1,6 +1,8 @@
 package podman
 
 import (
+	"context"
+
 	"github.com/project-ai-services/ai-services/internal/pkg/application/common"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
@@ -9,8 +11,9 @@ import (
 
 // List returns information about running applications.
 func (p *PodmanApplication) List(opts appTypes.ListOptions) ([]appTypes.ApplicationInfo, error) {
+	ctx := context.Background()
 	// filter and fetch pods based on appName
-	pods, err := common.FetchFilteredPods(p.runtime, opts.ApplicationName)
+	pods, err := common.FetchFilteredPods(ctx, p.runtime, opts.ApplicationName)
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +30,7 @@ func (p *PodmanApplication) List(opts appTypes.ListOptions) ([]appTypes.Applicat
 	defer printer.CloseTableWriter()
 
 	// set table headers and rows
-	common.PopulateTable(p.runtime, opts, pods)
+	common.PopulateTable(ctx, p.runtime, opts, pods)
 
 	return nil, nil
 }

--- a/ai-services/internal/pkg/application/podman/restore.go
+++ b/ai-services/internal/pkg/application/podman/restore.go
@@ -20,7 +20,7 @@ func (p *PodmanApplication) Restore(ctx context.Context, opts types.RestoreOptio
 	logger.Infof("Backup file: %s\n", opts.BackupFile)
 
 	// Get application details from catalog API using existing utility
-	appDetails, err := cliUtils.GetAppDetailsWithComponents(opts.Name)
+	appDetails, err := cliUtils.GetAppDetailsWithComponents(ctx, opts.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get application details: %w", err)
 	}
@@ -82,7 +82,7 @@ func (p *PodmanApplication) restoreDigitize(ctx context.Context, appDetails *cat
 
 	// Create digitize restore client and call Import API
 	client := commonrestore.NewDigitizeRestoreClient(digitizeURL)
-	if err := client.CallImportAPI(importPayload); err != nil {
+	if err := client.CallImportAPI(ctx, importPayload); err != nil {
 		return err
 	}
 

--- a/ai-services/internal/pkg/application/podman/start.go
+++ b/ai-services/internal/pkg/application/podman/start.go
@@ -14,8 +14,7 @@ import (
 )
 
 // Start starts a stopped application.
-func (p *PodmanApplication) Start(opts appTypes.StartOptions) error {
-	ctx := context.Background()
+func (p *PodmanApplication) Start(ctx context.Context, opts appTypes.StartOptions) error {
 	var pods []types.Pod
 	var err error
 	// if legacy flag is set, get pods from runtime; otherwise use catalog API

--- a/ai-services/internal/pkg/application/podman/start.go
+++ b/ai-services/internal/pkg/application/podman/start.go
@@ -1,6 +1,7 @@
 package podman
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -14,11 +15,12 @@ import (
 
 // Start starts a stopped application.
 func (p *PodmanApplication) Start(opts appTypes.StartOptions) error {
+	ctx := context.Background()
 	var pods []types.Pod
 	var err error
 	// if legacy flag is set, get pods from runtime; otherwise use catalog API
 	if opts.Legacy {
-		pods, err = p.fetchPodsFromRuntime(opts.Name)
+		pods, err = p.fetchPodsFromRuntime(ctx, opts.Name)
 		if err != nil {
 			return err
 		}
@@ -36,7 +38,7 @@ func (p *PodmanApplication) Start(opts appTypes.StartOptions) error {
 	}
 
 	// Filter pods based on provided pod names or annotation
-	podsToStart, err := p.fetchPodsToStart(pods, opts.PodNames)
+	podsToStart, err := p.fetchPodsToStart(ctx, pods, opts.PodNames)
 	if err != nil {
 		return err
 	}
@@ -46,12 +48,12 @@ func (p *PodmanApplication) Start(opts appTypes.StartOptions) error {
 		return nil
 	}
 
-	return p.confirmAndStartPods(podsToStart, opts.AutoYes, opts.SkipLogs)
+	return p.confirmAndStartPods(ctx, podsToStart, opts.AutoYes, opts.SkipLogs)
 }
 
 // Start implementation helper methods.
-func (p *PodmanApplication) fetchPodsFromRuntime(appName string) ([]types.Pod, error) {
-	pods, err := p.runtime.ListPods(map[string][]string{
+func (p *PodmanApplication) fetchPodsFromRuntime(ctx context.Context, appName string) ([]types.Pod, error) {
+	pods, err := p.runtime.ListPods(ctx, map[string][]string{
 		"label": {fmt.Sprintf("ai-services.io/application=%s", appName)},
 	})
 	if err != nil {
@@ -61,15 +63,15 @@ func (p *PodmanApplication) fetchPodsFromRuntime(appName string) ([]types.Pod, e
 	return pods, nil
 }
 
-func (p *PodmanApplication) fetchPodsToStart(pods []types.Pod, podNames []string) ([]types.Pod, error) {
+func (p *PodmanApplication) fetchPodsToStart(ctx context.Context, pods []types.Pod, podNames []string) ([]types.Pod, error) {
 	if len(podNames) > 0 {
 		return p.filterPodsByNameForStart(pods, podNames)
 	}
 	// No pod names provided, start pods based on annotation
-	return p.filterPodsByAnnotationForStart(pods)
+	return p.filterPodsByAnnotationForStart(ctx, pods)
 }
 
-func (p *PodmanApplication) confirmAndStartPods(podsToStart []types.Pod, autoYes, skipLogs bool) error {
+func (p *PodmanApplication) confirmAndStartPods(ctx context.Context, podsToStart []types.Pod, autoYes, skipLogs bool) error {
 	p.logPodsToStart(podsToStart)
 	printLogs := p.shouldPrintLogs(podsToStart, skipLogs)
 
@@ -87,12 +89,12 @@ func (p *PodmanApplication) confirmAndStartPods(podsToStart []types.Pod, autoYes
 
 	logger.Infoln("Proceeding to start pods...")
 
-	if err := p.startPods(podsToStart); err != nil {
+	if err := p.startPods(ctx, podsToStart); err != nil {
 		return err
 	}
 
 	if printLogs {
-		if err := p.printPodLogs(podsToStart); err != nil {
+		if err := p.printPodLogs(ctx, podsToStart); err != nil {
 			return err
 		}
 	}
@@ -117,11 +119,11 @@ func (p *PodmanApplication) shouldPrintLogs(podsToStart []types.Pod, skipLogs bo
 	return true
 }
 
-func (p *PodmanApplication) startPods(podsToStart []types.Pod) error {
+func (p *PodmanApplication) startPods(ctx context.Context, podsToStart []types.Pod) error {
 	var errors []string
 	for _, pod := range podsToStart {
 		logger.Infof("Starting the pod: %s\n", pod.Name)
-		podData, err := p.runtime.InspectPod(pod.Name)
+		podData, err := p.runtime.InspectPod(ctx, pod.Name)
 		if err != nil {
 			errMsg := fmt.Sprintf("%s: %v", pod.Name, err)
 			errors = append(errors, errMsg)
@@ -134,7 +136,7 @@ func (p *PodmanApplication) startPods(podsToStart []types.Pod) error {
 
 			continue
 		}
-		if err := p.runtime.StartPod(pod.ID); err != nil {
+		if err := p.runtime.StartPod(ctx, pod.ID); err != nil {
 			errMsg := fmt.Sprintf("%s: %v", pod.Name, err)
 			errors = append(errors, errMsg)
 
@@ -151,10 +153,10 @@ func (p *PodmanApplication) startPods(podsToStart []types.Pod) error {
 	return nil
 }
 
-func (p *PodmanApplication) printPodLogs(podsToStart []types.Pod) error {
+func (p *PodmanApplication) printPodLogs(ctx context.Context, podsToStart []types.Pod) error {
 	logger.Infof("\n--- Following logs for pod: %s ---\n", podsToStart[0].Name)
 
-	if err := p.runtime.PodLogs(podsToStart[0].Name); err != nil {
+	if err := p.runtime.PodLogs(ctx, podsToStart[0].Name); err != nil {
 		if strings.Contains(err.Error(), "signal: interrupt") || strings.Contains(err.Error(), "context canceled") {
 			logger.Infoln("Log following stopped.")
 
@@ -190,13 +192,13 @@ func (p *PodmanApplication) filterPodsByNameForStart(pods []types.Pod, podNames 
 	return podsToStart, nil
 }
 
-func (p *PodmanApplication) filterPodsByAnnotationForStart(pods []types.Pod) ([]types.Pod, error) {
+func (p *PodmanApplication) filterPodsByAnnotationForStart(ctx context.Context, pods []types.Pod) ([]types.Pod, error) {
 	var podsToStart []types.Pod
 
 outerloop:
 	for _, pod := range pods {
 		for _, container := range pod.Containers {
-			data, err := p.runtime.InspectContainer(container.Name)
+			data, err := p.runtime.InspectContainer(ctx, container.Name)
 			if err != nil {
 				return podsToStart, fmt.Errorf("failed to inspect container %s: %w", container.Name, err)
 			}

--- a/ai-services/internal/pkg/application/podman/start.go
+++ b/ai-services/internal/pkg/application/podman/start.go
@@ -24,7 +24,7 @@ func (p *PodmanApplication) Start(ctx context.Context, opts appTypes.StartOption
 			return err
 		}
 	} else {
-		pods, err = cliutils.GetPodsFromApplicationsPS(opts.Name)
+		pods, err = cliutils.GetPodsFromApplicationsPS(ctx, opts.Name)
 		if err != nil {
 			return err
 		}

--- a/ai-services/internal/pkg/application/podman/stop.go
+++ b/ai-services/internal/pkg/application/podman/stop.go
@@ -1,6 +1,7 @@
 package podman
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -13,7 +14,8 @@ import (
 
 // Stop stops a running application.
 func (p *PodmanApplication) Stop(opts appTypes.StopOptions) error {
-	pods, err := p.listApplicationPods(opts)
+	ctx := context.Background()
+	pods, err := p.listApplicationPods(ctx, opts)
 	if err != nil {
 		return err
 	}
@@ -57,14 +59,14 @@ func (p *PodmanApplication) Stop(opts appTypes.StopOptions) error {
 
 	logger.Infof("Proceeding to stop pods...\n")
 
-	return p.stopPods(podsToStop)
+	return p.stopPods(ctx, podsToStop)
 }
 
 // listApplicationPods retrieves pods for the given application.
-func (p *PodmanApplication) listApplicationPods(opts appTypes.StopOptions) ([]types.Pod, error) {
+func (p *PodmanApplication) listApplicationPods(ctx context.Context, opts appTypes.StopOptions) ([]types.Pod, error) {
 	// if legacy flag is set, get pods from runtime; otherwise use catalog API
 	if opts.Legacy {
-		pods, err := p.runtime.ListPods(map[string][]string{
+		pods, err := p.runtime.ListPods(ctx, map[string][]string{
 			"label": {fmt.Sprintf("ai-services.io/application=%s", opts.Name)},
 		})
 		if err != nil {
@@ -108,12 +110,12 @@ func (p *PodmanApplication) fetchPodsToStop(pods []types.Pod, podNames []string,
 	return podsToStop, nil
 }
 
-func (p *PodmanApplication) stopPods(podsToStop []types.Pod) error {
+func (p *PodmanApplication) stopPods(ctx context.Context, podsToStop []types.Pod) error {
 	var errors []string
 	for _, pod := range podsToStop {
 		logger.Infof("Stopping the pod: %s\n", pod.Name)
 
-		if err := p.runtime.StopPod(pod.ID); err != nil {
+		if err := p.runtime.StopPod(ctx, pod.ID); err != nil {
 			errMsg := fmt.Sprintf("%s: %v", pod.Name, err)
 			errors = append(errors, errMsg)
 

--- a/ai-services/internal/pkg/application/podman/stop.go
+++ b/ai-services/internal/pkg/application/podman/stop.go
@@ -13,8 +13,7 @@ import (
 )
 
 // Stop stops a running application.
-func (p *PodmanApplication) Stop(opts appTypes.StopOptions) error {
-	ctx := context.Background()
+func (p *PodmanApplication) Stop(ctx context.Context, opts appTypes.StopOptions) error {
 	pods, err := p.listApplicationPods(ctx, opts)
 	if err != nil {
 		return err

--- a/ai-services/internal/pkg/application/podman/stop.go
+++ b/ai-services/internal/pkg/application/podman/stop.go
@@ -75,7 +75,7 @@ func (p *PodmanApplication) listApplicationPods(ctx context.Context, opts appTyp
 		return pods, nil
 	}
 
-	return cliutils.GetPodsFromApplicationsPS(opts.Name)
+	return cliutils.GetPodsFromApplicationsPS(ctx, opts.Name)
 }
 
 func (p *PodmanApplication) fetchPodsToStop(pods []types.Pod, podNames []string, appName string) ([]types.Pod, error) {

--- a/ai-services/internal/pkg/bootstrap/interface.go
+++ b/ai-services/internal/pkg/bootstrap/interface.go
@@ -1,6 +1,10 @@
 package bootstrap
 
-import "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+import (
+	"context"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+)
 
 // Bootstrap defines the interface for environment bootstrapping operations.
 // Different runtimes implement this interface to provide
@@ -8,7 +12,7 @@ import "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 type Bootstrap interface {
 	// Configure performs the complete configuration of the environment.
 	// This includes installing dependencies, configuring runtime, and setting up hardware.
-	Configure() error
+	Configure(ctx context.Context) error
 
 	// Type returns the runtime type this bootstrap implementation supports.
 	Type() types.RuntimeType

--- a/ai-services/internal/pkg/bootstrap/openshift/configure.go
+++ b/ai-services/internal/pkg/bootstrap/openshift/configure.go
@@ -28,7 +28,7 @@ const (
 	machineConfigFolder       = "01-machine-config"
 )
 
-func (o *OpenshiftBootstrap) Configure() error {
+func (o *OpenshiftBootstrap) Configure(ctx context.Context) error {
 	logger.Infoln("Configuring OpenShift cluster")
 	client, err := openshift.NewOpenshiftClient()
 	if err != nil {
@@ -37,9 +37,9 @@ func (o *OpenshiftBootstrap) Configure() error {
 
 	// 1. Apply machine-config
 	s := spinner.New("Applying the configurations")
-	s.Start(client.Ctx)
+	s.Start(ctx)
 
-	if err := applyYamlsFromFolder(client, machineConfigFolder); err != nil {
+	if err := applyYamlsFromFolder(ctx, client, machineConfigFolder); err != nil {
 		s.Fail("failed to apply the configurations")
 
 		return fmt.Errorf("error occurred while applying the configurations: %w", err)
@@ -47,21 +47,21 @@ func (o *OpenshiftBootstrap) Configure() error {
 	s.Stop("Configurations applied successfully")
 
 	// 2. Apply operators (namespaces, operatorgroups, subscriptions)
-	if err := applyYamlsFromFolder(client, operatorFolder); err != nil {
+	if err := applyYamlsFromFolder(ctx, client, operatorFolder); err != nil {
 		return fmt.Errorf("error occurred while applying operator configurations: %w", err)
 	}
 
 	// 3. Apply operands (CRs) - Does SpyreClusterPolicy configure + applying operand yamls
 	s = spinner.New("Applying operand configurations")
-	s.Start(client.Ctx)
+	s.Start(ctx)
 
-	if err := configureSCP(client, s); err != nil {
+	if err := configureSCP(ctx, client, s); err != nil {
 		s.Fail("failed to configure spyre cluster policy")
 
 		return fmt.Errorf("error occurred while configuring spyre cluster policy: %w", err)
 	}
 
-	if err := applyYamlsFromFolder(client, operandFolder); err != nil {
+	if err := applyYamlsFromFolder(ctx, client, operandFolder); err != nil {
 		s.Fail("failed to apply operand configurations")
 
 		return fmt.Errorf("error occurred while applying operand configurations: %w", err)
@@ -69,7 +69,7 @@ func (o *OpenshiftBootstrap) Configure() error {
 	s.Stop("Operand configurations applied successfully")
 
 	// 4. Wait for all CRs to be ready
-	if err := waitForAllCRs(client); err != nil {
+	if err := waitForAllCRs(ctx, client); err != nil {
 		return err
 	}
 
@@ -78,12 +78,12 @@ func (o *OpenshiftBootstrap) Configure() error {
 	return nil
 }
 
-func waitForAllCRs(client *openshift.OpenshiftClient) error {
+func waitForAllCRs(ctx context.Context, client *openshift.OpenshiftClient) error {
 	// Wait for SpyreClusterPolicy
 	s := spinner.New("Waiting for SpyreClusterPolicy to be ready")
-	s.Start(client.Ctx)
+	s.Start(ctx)
 
-	err := waitForSpyreClusterPolicy(client)
+	err := waitForSpyreClusterPolicy(ctx, client)
 	if err != nil {
 		s.Fail("SpyreClusterPolicy not ready")
 
@@ -93,9 +93,9 @@ func waitForAllCRs(client *openshift.OpenshiftClient) error {
 
 	// Wait for DSCInitialization
 	s = spinner.New("Waiting for DSCInitialization to be ready")
-	s.Start(client.Ctx)
+	s.Start(ctx)
 
-	err = waitForRHODSResource(client, "DSCInitialization")
+	err = waitForRHODSResource(ctx, client, "DSCInitialization")
 	if err != nil {
 		s.Fail("DSCInitialization not ready")
 
@@ -105,9 +105,9 @@ func waitForAllCRs(client *openshift.OpenshiftClient) error {
 
 	// Wait for DataScienceCluster
 	s = spinner.New("Waiting for DataScienceCluster to be ready")
-	s.Start(client.Ctx)
+	s.Start(ctx)
 
-	err = waitForRHODSResource(client, "DataScienceCluster")
+	err = waitForRHODSResource(ctx, client, "DataScienceCluster")
 	if err != nil {
 		s.Fail("DataScienceCluster not ready")
 
@@ -118,7 +118,7 @@ func waitForAllCRs(client *openshift.OpenshiftClient) error {
 	return nil
 }
 
-func applyYamlsFromFolder(client *openshift.OpenshiftClient, folder string) error {
+func applyYamlsFromFolder(ctx context.Context, client *openshift.OpenshiftClient, folder string) error {
 	tp := templates.NewEmbedTemplateProvider(&assets.BootstrapFS)
 
 	yamls, err := tp.LoadYamls(folder)
@@ -127,7 +127,7 @@ func applyYamlsFromFolder(client *openshift.OpenshiftClient, folder string) erro
 	}
 
 	for _, yaml := range yamls {
-		if err := applyYaml(client, yaml); err != nil {
+		if err := applyYaml(ctx, client, yaml); err != nil {
 			return fmt.Errorf("failed to apply YAML from %s: %w", folder, err)
 		}
 	}
@@ -135,9 +135,9 @@ func applyYamlsFromFolder(client *openshift.OpenshiftClient, folder string) erro
 	return nil
 }
 
-func configureSCP(client *openshift.OpenshiftClient, s *spinner.Spinner) error {
+func configureSCP(ctx context.Context, client *openshift.OpenshiftClient, s *spinner.Spinner) error {
 	// fetch spec from spyre operator alm-example
-	spec, err := fetchSCPSpec(client)
+	spec, err := fetchSCPSpec(ctx, client)
 	if err != nil {
 		return fmt.Errorf("error occurred while fetching spyre cluster policy spec: %w", err)
 	}
@@ -148,14 +148,14 @@ func configureSCP(client *openshift.OpenshiftClient, s *spinner.Spinner) error {
 	}
 
 	// frame and apply the scp yaml
-	if err = frameAndApply(client, spec, s); err != nil {
+	if err = frameAndApply(ctx, client, spec, s); err != nil {
 		return fmt.Errorf("error occurred while applying patch to spyre cluster policy: %w", err)
 	}
 
 	return nil
 }
 
-func fetchSCPSpec(client *openshift.OpenshiftClient) (map[string]any, error) {
+func fetchSCPSpec(ctx context.Context, client *openshift.OpenshiftClient) (map[string]any, error) {
 	// Find Spyre operator config
 	var spyreOp constants.OperatorConfig
 	for _, op := range constants.RequiredOperators {
@@ -166,7 +166,7 @@ func fetchSCPSpec(client *openshift.OpenshiftClient) (map[string]any, error) {
 		}
 	}
 
-	csv, err := fetchOperatorByPackage(client, spyreOp.Name, spyreOp.Namespace)
+	csv, err := fetchOperatorByPackage(ctx, client, spyreOp.Name, spyreOp.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching spyre operator: %w", err)
 	}
@@ -227,10 +227,9 @@ func modifySpec(spec map[string]any, s *spinner.Spinner) error {
 	return nil
 }
 
-func frameAndApply(client *openshift.OpenshiftClient, spec map[string]any, s *spinner.Spinner) error {
+func frameAndApply(ctx context.Context, client *openshift.OpenshiftClient, spec map[string]any, s *spinner.Spinner) error {
 	scp := &unstructured.Unstructured{}
 	c := client.Client
-	ctx := client.Ctx
 	scp.SetName("spyreclusterpolicy")
 	scp.Object = map[string]any{
 		"apiVersion": "spyre.ibm.com/v1alpha1",
@@ -256,7 +255,7 @@ func frameAndApply(client *openshift.OpenshiftClient, spec map[string]any, s *sp
 	return err
 }
 
-func waitForSpyreClusterPolicy(client *openshift.OpenshiftClient) error {
+func waitForSpyreClusterPolicy(ctx context.Context, client *openshift.OpenshiftClient) error {
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "spyre.ibm.com",
@@ -264,8 +263,8 @@ func waitForSpyreClusterPolicy(client *openshift.OpenshiftClient) error {
 		Kind:    "SpyreClusterPolicy",
 	})
 
-	return wait.PollUntilContextTimeout(client.Ctx, constants.OperatorPollInterval, constants.OperatorPollTimeout, true, func(ctx context.Context) (bool, error) {
-		if err := client.Client.Get(ctx, k8stypes.NamespacedName{Name: "spyreclusterpolicy"}, obj); err != nil {
+	return wait.PollUntilContextTimeout(ctx, constants.OperatorPollInterval, constants.OperatorPollTimeout, true, func(pollCtx context.Context) (bool, error) {
+		if err := client.Client.Get(pollCtx, k8stypes.NamespacedName{Name: "spyreclusterpolicy"}, obj); err != nil {
 			if apierrors.IsNotFound(err) {
 				logger.Debugln("SpyreClusterPolicy not found yet, waiting...")
 
@@ -302,15 +301,15 @@ func waitForSpyreClusterPolicy(client *openshift.OpenshiftClient) error {
 	})
 }
 
-func waitForRHODSResource(client *openshift.OpenshiftClient, kind string) error {
-	return wait.PollUntilContextTimeout(client.Ctx, constants.OperatorPollInterval, constants.OperatorPollTimeout, true, func(ctx context.Context) (bool, error) {
+func waitForRHODSResource(ctx context.Context, client *openshift.OpenshiftClient, kind string) error {
+	return wait.PollUntilContextTimeout(ctx, constants.OperatorPollInterval, constants.OperatorPollTimeout, true, func(pollCtx context.Context) (bool, error) {
 		// Get the existing resource from the cluster
 		gvk := schema.GroupVersionKind{
 			Group:   strings.ToLower(kind) + ".opendatahub.io",
 			Version: constants.VersionV2,
 			Kind:    kind,
 		}
-		resource, exists, err := utils.GetExistingCustomResource(client, gvk)
+		resource, exists, err := utils.GetExistingCustomResource(pollCtx, client, gvk)
 		if err != nil {
 			// Handle rate limiting and other transient errors as retryable
 			if utils.IsTransientK8sError(err) {

--- a/ai-services/internal/pkg/bootstrap/openshift/yaml.go
+++ b/ai-services/internal/pkg/bootstrap/openshift/yaml.go
@@ -31,7 +31,7 @@ var (
 	cachedSubscriptionList *operatorsv1alpha1.SubscriptionList
 )
 
-func applyYaml(c *openshift.OpenshiftClient, yaml []byte) error {
+func applyYaml(ctx context.Context, c *openshift.OpenshiftClient, yaml []byte) error {
 	resourceList := []*unstructured.Unstructured{}
 
 	decoder := apiyaml.NewYAMLOrJSONDecoder(bytes.NewReader([]byte(yaml)), yamlDecoderBufSz)
@@ -51,12 +51,12 @@ func applyYaml(c *openshift.OpenshiftClient, yaml []byte) error {
 	}
 
 	// Fetch subscription list once before processing resources
-	if err := loadSubscriptionList(c); err != nil {
+	if err := loadSubscriptionList(ctx, c); err != nil {
 		return fmt.Errorf("failed to load subscription list: %v", err)
 	}
 
 	for _, object := range resourceList {
-		if err := applyObject(c, object); err != nil {
+		if err := applyObject(ctx, c, object); err != nil {
 			return fmt.Errorf("error applying object %v", err.Error())
 		}
 	}
@@ -65,10 +65,10 @@ func applyYaml(c *openshift.OpenshiftClient, yaml []byte) error {
 }
 
 // loadSubscriptionList fetches and caches the subscription list if not already loaded.
-func loadSubscriptionList(c *openshift.OpenshiftClient) error {
+func loadSubscriptionList(ctx context.Context, c *openshift.OpenshiftClient) error {
 	if cachedSubscriptionList == nil {
 		cachedSubscriptionList = &operatorsv1alpha1.SubscriptionList{}
-		err := c.Client.List(c.Ctx, cachedSubscriptionList)
+		err := c.Client.List(ctx, cachedSubscriptionList)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to list subscriptions: %w", err)
 		}
@@ -81,7 +81,7 @@ func loadSubscriptionList(c *openshift.OpenshiftClient) error {
 }
 
 // applyObject applies the desired object against the apiserver.
-func applyObject(c *openshift.OpenshiftClient, object *unstructured.Unstructured) error {
+func applyObject(ctx context.Context, c *openshift.OpenshiftClient, object *unstructured.Unstructured) error {
 	// Retrieve name, namespace, groupVersionKind from given object.
 	name := object.GetName()
 	namespace := object.GetNamespace()
@@ -93,7 +93,7 @@ func applyObject(c *openshift.OpenshiftClient, object *unstructured.Unstructured
 	kind := groupVersionKind.Kind
 
 	// Pre-apply handling based on resource kind
-	skip, err := handlePreApply(c, object, kind)
+	skip, err := handlePreApply(ctx, c, object, kind)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func applyObject(c *openshift.OpenshiftClient, object *unstructured.Unstructured
 	objDesc := fmt.Sprintf("(%s) %s/%s", groupVersionKind.String(), namespace, name)
 
 	// Apply the k8s object with provided version kind in given namespace.
-	err = c.Client.Apply(c.Ctx, client.ApplyConfigurationFromUnstructured(object), &client.ApplyOptions{FieldManager: constants.AIServices, Force: utils.BoolPtr(true)})
+	err = c.Client.Apply(ctx, client.ApplyConfigurationFromUnstructured(object), &client.ApplyOptions{FieldManager: constants.AIServices, Force: utils.BoolPtr(true)})
 	if err != nil {
 		if apierrors.IsForbidden(err) {
 			return fmt.Errorf("missing required permissions to create %s", objDesc)
@@ -114,24 +114,24 @@ func applyObject(c *openshift.OpenshiftClient, object *unstructured.Unstructured
 	}
 
 	// Post-apply handling based on resource kind
-	return handlePostApply(c, object, kind, namespace)
+	return handlePostApply(ctx, c, object, kind, namespace)
 }
 
 // handlePreApply performs pre-apply checks and modifications based on resource kind.
 // Returns true if the resource should be skipped.
-func handlePreApply(c *openshift.OpenshiftClient, object *unstructured.Unstructured, kind string) (bool, error) {
+func handlePreApply(ctx context.Context, c *openshift.OpenshiftClient, object *unstructured.Unstructured, kind string) (bool, error) {
 	switch kind {
 	case "Subscription":
 		s = spinner.New("Applying operator configurations")
-		s.Start(c.Ctx)
+		s.Start(ctx)
 
-		if shouldSkipSubscription(c, object) {
+		if shouldSkipSubscription(ctx, c, object) {
 			return true, nil
 		}
 
 	case "DSCInitialization", "DataScienceCluster":
 		// Handle single-instance RHODS resources
-		if shouldSkipOrUpdateRHODSResource(c, object) {
+		if shouldSkipOrUpdateRHODSResource(ctx, c, object) {
 			return true, nil
 		}
 	}
@@ -140,24 +140,24 @@ func handlePreApply(c *openshift.OpenshiftClient, object *unstructured.Unstructu
 }
 
 // handlePostApply performs post-apply actions based on resource kind.
-func handlePostApply(c *openshift.OpenshiftClient, object *unstructured.Unstructured, kind, namespace string) error {
+func handlePostApply(ctx context.Context, c *openshift.OpenshiftClient, object *unstructured.Unstructured, kind, namespace string) error {
 	switch kind {
 	case "Subscription":
-		return handleSubscriptionPostApply(c, object, namespace)
+		return handleSubscriptionPostApply(ctx, c, object, namespace)
 	default:
 		return nil
 	}
 }
 
 // handleSubscriptionPostApply waits for an operator to be ready after subscription is applied.
-func handleSubscriptionPostApply(c *openshift.OpenshiftClient, object *unstructured.Unstructured, namespace string) error {
+func handleSubscriptionPostApply(ctx context.Context, c *openshift.OpenshiftClient, object *unstructured.Unstructured, namespace string) error {
 	packageName, found, err := unstructured.NestedString(object.Object, "spec", "name")
 	if err != nil || !found || packageName == "" {
 		return nil
 	}
 
 	operatorLabel := getOperatorLabel(packageName)
-	if err := waitForOperator(c, packageName, namespace); err != nil {
+	if err := waitForOperator(ctx, c, packageName, namespace); err != nil {
 		s.Fail(fmt.Sprintf("%s is not ready", operatorLabel))
 
 		return fmt.Errorf("operator %s not ready: %w", packageName, err)
@@ -170,7 +170,7 @@ func handleSubscriptionPostApply(c *openshift.OpenshiftClient, object *unstructu
 
 // shouldSkipSubscription checks if a subscription should be skipped because it already exists.
 // If it exists and is ready, prints a message. Returns true if the subscription should be skipped.
-func shouldSkipSubscription(c *openshift.OpenshiftClient, object *unstructured.Unstructured) bool {
+func shouldSkipSubscription(ctx context.Context, c *openshift.OpenshiftClient, object *unstructured.Unstructured) bool {
 	packageName, found, err := unstructured.NestedString(object.Object, "spec", "name")
 	if err != nil || !found || packageName == "" || cachedSubscriptionList == nil {
 		return false
@@ -189,7 +189,7 @@ func shouldSkipSubscription(c *openshift.OpenshiftClient, object *unstructured.U
 
 		// Get the CSV to check if it's ready
 		csv := &operatorsv1alpha1.ClusterServiceVersion{}
-		if err := c.Client.Get(c.Ctx, client.ObjectKey{
+		if err := c.Client.Get(ctx, client.ObjectKey{
 			Name:      sub.Status.InstalledCSV,
 			Namespace: sub.Namespace,
 		}, csv); err == nil && csv.Status.Phase == operatorsv1alpha1.CSVPhaseSucceeded {
@@ -205,10 +205,10 @@ func shouldSkipSubscription(c *openshift.OpenshiftClient, object *unstructured.U
 }
 
 // fetchOperatorByPackage fetches the CSV for an operator by package name.
-func fetchOperatorByPackage(c *openshift.OpenshiftClient, packageName string, opNS string) (*operatorsv1alpha1.ClusterServiceVersion, error) {
+func fetchOperatorByPackage(ctx context.Context, c *openshift.OpenshiftClient, packageName string, opNS string) (*operatorsv1alpha1.ClusterServiceVersion, error) {
 	// List all subscriptions in the namespace
 	subList := &operatorsv1alpha1.SubscriptionList{}
-	if err := c.Client.List(c.Ctx, subList, client.InNamespace(opNS)); err != nil {
+	if err := c.Client.List(ctx, subList, client.InNamespace(opNS)); err != nil {
 		if apierrors.IsForbidden(err) {
 			return nil, fmt.Errorf("missing required permissions to list subscriptions")
 		}
@@ -236,7 +236,7 @@ func fetchOperatorByPackage(c *openshift.OpenshiftClient, packageName string, op
 	}
 
 	csv := &operatorsv1alpha1.ClusterServiceVersion{}
-	if err := c.Client.Get(c.Ctx, client.ObjectKey{
+	if err := c.Client.Get(ctx, client.ObjectKey{
 		Name:      sub.Status.InstalledCSV,
 		Namespace: opNS,
 	}, csv); err != nil {
@@ -251,9 +251,9 @@ func fetchOperatorByPackage(c *openshift.OpenshiftClient, packageName string, op
 }
 
 // waitForOperator waits for an operator to be ready after installation.
-func waitForOperator(c *openshift.OpenshiftClient, packageName string, opNS string) error {
-	return wait.PollUntilContextTimeout(c.Ctx, constants.OperatorPollInterval, constants.OperatorPollTimeout, true, func(ctx context.Context) (bool, error) {
-		csv, err := fetchOperatorByPackage(c, packageName, opNS)
+func waitForOperator(ctx context.Context, c *openshift.OpenshiftClient, packageName string, opNS string) error {
+	return wait.PollUntilContextTimeout(ctx, constants.OperatorPollInterval, constants.OperatorPollTimeout, true, func(pollCtx context.Context) (bool, error) {
+		csv, err := fetchOperatorByPackage(pollCtx, c, packageName, opNS)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				// keep waiting until timeout
@@ -292,7 +292,7 @@ func getOperatorLabel(packageName string) string {
 
 // shouldSkipOrUpdateRHODSResource handles single-instance RHODS resources (DSC, DSCI).
 // Returns true if the resource should be skipped.
-func shouldSkipOrUpdateRHODSResource(c *openshift.OpenshiftClient, object *unstructured.Unstructured) bool {
+func shouldSkipOrUpdateRHODSResource(ctx context.Context, c *openshift.OpenshiftClient, object *unstructured.Unstructured) bool {
 	kind := object.GetKind()
 
 	// Check if resource already exists
@@ -301,7 +301,7 @@ func shouldSkipOrUpdateRHODSResource(c *openshift.OpenshiftClient, object *unstr
 		Version: constants.VersionV2,
 		Kind:    kind,
 	}
-	existingResource, exists, err := utils.GetExistingCustomResource(c, gvk)
+	existingResource, exists, err := utils.GetExistingCustomResource(ctx, c, gvk)
 	if err != nil {
 		logger.Debugf("Error checking for existing %s: %v", kind, err)
 

--- a/ai-services/internal/pkg/bootstrap/podman/configure.go
+++ b/ai-services/internal/pkg/bootstrap/podman/configure.go
@@ -21,7 +21,6 @@ func (p *PodmanBootstrap) Configure(ctx context.Context) error {
 		return fmt.Errorf("podman bootstrap requires root privileges, either run as root or use sudo")
 	}
 
-
 	// 1. Install and configure Podman if not done
 	if err := ensurePodmanInstalled(ctx); err != nil {
 		return err

--- a/ai-services/internal/pkg/bootstrap/podman/configure.go
+++ b/ai-services/internal/pkg/bootstrap/podman/configure.go
@@ -15,13 +15,12 @@ const (
 )
 
 // Configure performs the complete configuration of the Podman environment.
-func (p *PodmanBootstrap) Configure() error {
+func (p *PodmanBootstrap) Configure(ctx context.Context) error {
 	euid := os.Geteuid()
 	if euid != 0 {
 		return fmt.Errorf("podman bootstrap requires root privileges, either run as root or use sudo")
 	}
 
-	ctx := context.Background()
 
 	// 1. Install and configure Podman if not done
 	if err := ensurePodmanInstalled(ctx); err != nil {

--- a/ai-services/internal/pkg/bootstrap/validate.go
+++ b/ai-services/internal/pkg/bootstrap/validate.go
@@ -19,8 +19,7 @@ type validationResult struct {
 }
 
 // Validate runs all validation checks.
-func (p *BootstrapFactory) Validate(skip map[string]bool) error {
-	ctx := context.Background()
+func (p *BootstrapFactory) Validate(ctx context.Context, skip map[string]bool) error {
 	rules := GetRulesForRuntime()
 
 	var validationErrors []error
@@ -75,7 +74,7 @@ func executeRule(ctx context.Context, rule validators.Rule) validationResult {
 	s := spinner.New("Validating " + ruleName + " ...")
 	s.Start(ctx)
 
-	err := rule.Verify()
+	err := rule.Verify(ctx)
 	if err != nil {
 		s.StopWithHint(err.Error(), rule.Hint())
 

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/resources.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/resources.go
@@ -49,7 +49,7 @@ func (h *ResourcesHandler) GetResources(c *gin.Context) {
 	}
 
 	// Get system info from runtime
-	sysInfo, err := runtimeClient.GetSystemInfo()
+	sysInfo, err := runtimeClient.GetSystemInfo(c.Request.Context())
 	if err != nil {
 		logger.ErrorfCtx(c.Request.Context(), "Could not get system info: %v", err)
 		c.JSON(http.StatusInternalServerError, ErrorResponse{

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -763,7 +763,7 @@ func (s *ApplicationServiceBase) processServiceResources(
 	totals *resourceTotals,
 	countedComponents map[uuid.UUID]bool,
 ) error {
-	if err := s.addServiceResources(service, catalogProvider, runtimeClient, totals); err != nil {
+	if err := s.addServiceResources(ctx, service, catalogProvider, runtimeClient, totals); err != nil {
 		return fmt.Errorf("failed to get service allocated resources: %w", err)
 	}
 
@@ -782,6 +782,7 @@ func addAllocatedResources(runtimeMetadata *clitemplates.AppMetadata, totals *re
 }
 
 func (s *ApplicationServiceBase) addServiceResources(
+	ctx context.Context,
 	service models.Service,
 	catalogProvider *catalog.CatalogProvider,
 	runtimeClient runtime.Runtime,
@@ -794,7 +795,7 @@ func (s *ApplicationServiceBase) addServiceResources(
 
 	addAllocatedResources(runtimeMetadata, totals)
 
-	if err := addUsedResourcesByTemplateID(service.ID.String(), runtimeClient, totals); err != nil {
+	if err := addUsedResourcesByTemplateID(ctx, service.ID.String(), runtimeClient, totals); err != nil {
 		return fmt.Errorf("failed to get service used resources: %w", err)
 	}
 
@@ -848,25 +849,25 @@ func (s *ApplicationServiceBase) processComponentResources(
 
 	addAllocatedResources(runtimeMetadata, totals)
 
-	if err := addUsedResourcesByTemplateID(component.ID.String(), runtimeClient, totals); err != nil {
+	if err := addUsedResourcesByTemplateID(ctx, component.ID.String(), runtimeClient, totals); err != nil {
 		return fmt.Errorf("failed to get component used resources for %s: %w", component.ID, err)
 	}
 
 	return nil
 }
 
-func addUsedResourcesByTemplateID(templateID string, runtimeClient runtime.Runtime, totals *resourceTotals) error {
+func addUsedResourcesByTemplateID(ctx context.Context, templateID string, runtimeClient runtime.Runtime, totals *resourceTotals) error {
 	filters := map[string][]string{
 		"label": {fmt.Sprintf("%s=%s", consts.ApplicationTemplateKey, templateID)},
 	}
 
-	pods, err := runtimeClient.ListPods(filters)
+	pods, err := runtimeClient.ListPods(ctx, filters)
 	if err != nil {
 		return fmt.Errorf("failed to list pods for template %s: %w", templateID, err)
 	}
 
 	for _, pod := range pods {
-		if err := collectPodResources(pod.Name, runtimeClient, totals); err != nil {
+		if err := collectPodResources(ctx, pod.Name, runtimeClient, totals); err != nil {
 			return fmt.Errorf("failed to get used resources for pod %s: %w", pod.Name, err)
 		}
 	}
@@ -874,8 +875,8 @@ func addUsedResourcesByTemplateID(templateID string, runtimeClient runtime.Runti
 	return nil
 }
 
-func collectPodResources(podName string, runtimeClient runtime.Runtime, totals *resourceTotals) error {
-	resources, err := runtimeClient.GetPodResources(podName)
+func collectPodResources(ctx context.Context, podName string, runtimeClient runtime.Runtime, totals *resourceTotals) error {
+	resources, err := runtimeClient.GetPodResources(ctx, podName)
 	if err != nil {
 		return fmt.Errorf("failed to get resources for pod %s: %w", podName, err)
 	}
@@ -958,7 +959,7 @@ func (s *ApplicationServiceBase) collectServicePods(
 	servicePods := make([]types.Pod, 0, len(services))
 
 	for _, service := range services {
-		pod, err := loadApplicationPods(rt, service.ID.String())
+		pod, err := loadApplicationPods(ctx, rt, service.ID.String())
 		if err != nil {
 			return nil, fmt.Errorf("failed to load service pod for service %s: %w", service.ID, err)
 		}
@@ -994,7 +995,7 @@ func (s *ApplicationServiceBase) collectComponentPods(
 				continue
 			}
 
-			componentPod, err := loadApplicationPods(rt, componentID)
+			componentPod, err := loadApplicationPods(ctx, rt, componentID)
 			if err != nil {
 				return nil, fmt.Errorf("failed to load component pod %s: %w", componentID, err)
 			}
@@ -1013,8 +1014,8 @@ func (s *ApplicationServiceBase) collectComponentPods(
 	return componentPods, nil
 }
 
-func loadApplicationPods(rt runtime.Runtime, appID string) ([]types.Pod, error) {
-	filteredPod, err := common.FetchFilteredPods(rt, appID)
+func loadApplicationPods(ctx context.Context, rt runtime.Runtime, appID string) ([]types.Pod, error) {
+	filteredPod, err := common.FetchFilteredPods(ctx, rt, appID)
 	if err != nil {
 		return nil, err
 	}
@@ -1025,7 +1026,7 @@ func loadApplicationPods(rt runtime.Runtime, appID string) ([]types.Pod, error) 
 	appPodList := make([]types.Pod, 0, len(filteredPod))
 
 	for _, pod := range filteredPod {
-		processedPod, err := common.ProcessPod(rt, pod)
+		processedPod, err := common.ProcessPod(ctx, rt, pod)
 		if err != nil {
 			return nil, fmt.Errorf("failed to process pod: %w", err)
 		}

--- a/ai-services/internal/pkg/catalog/apiserver/services/deletion/repository/openshift/deletion.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deletion/repository/openshift/deletion.go
@@ -68,7 +68,7 @@ func (s *OpenshiftDeletion) PerformDeletion(ctx context.Context, appID uuid.UUID
 	// Delete namespace of the application
 	if !keepData && len(errorMessages) == 0 {
 		logger.InfofCtx(ctx, "Deleting '%s' namespace.", s.ns)
-		if err := s.rt.DeleteNamespace(s.ns); err != nil {
+		if err := s.rt.DeleteNamespace(ctx, s.ns); err != nil {
 			errMsg := fmt.Sprintf("failed to delete '%s' namespace: %v", s.ns, err)
 			logger.ErrorlnCtx(ctx, errMsg)
 			errorMessages = append(errorMessages, errMsg)
@@ -176,7 +176,7 @@ func (s *OpenshiftDeletion) deleteServingRuntimeRelease(ctx context.Context, ns 
 		Kind:    "ServingRuntimeList",
 	})
 
-	response, err := s.rt.ListCRD(list, map[string][]string{
+	response, err := s.rt.ListCRD(ctx, list, map[string][]string{
 		"label": {constants.PrerequisiteLabelKey},
 	})
 	if err != nil {
@@ -210,7 +210,7 @@ func (s *OpenshiftDeletion) deleteVolume(ctx context.Context, appID uuid.UUID, r
 	templateLabel := fmt.Sprintf("%s=%s", constants.ApplicationTemplateKey, resourceID)
 	logger.InfofCtx(ctx, "Deleting PVC with '%s' label, from %s namespace", templateLabel, s.ns)
 
-	if err := s.rt.DeletePVCs(templateLabel); err != nil {
+	if err := s.rt.DeletePVCs(ctx, templateLabel); err != nil {
 		errMsg := fmt.Sprintf("failed to delete PVC with label '%s' for app '%s': %s", templateLabel, appID.String(), err.Error())
 		logger.ErrorlnCtx(ctx, errMsg)
 

--- a/ai-services/internal/pkg/catalog/apiserver/services/deletion/repository/podman/deletion.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deletion/repository/podman/deletion.go
@@ -112,7 +112,7 @@ func (s *PodmanDeletion) deleteServices(ctx context.Context, services []models.S
 
 	for _, svc := range services {
 		// List service pods
-		pods, err := s.rt.ListPods(map[string][]string{
+		pods, err := s.rt.ListPods(ctx, map[string][]string{
 			"label": {fmt.Sprintf("ai-services.io/template=%s", svc.ID)},
 		})
 		if err != nil {
@@ -174,7 +174,7 @@ func (s *PodmanDeletion) deleteServices(ctx context.Context, services []models.S
 func (s *PodmanDeletion) deletePods(ctx context.Context, pods []runtimeTypes.Pod, forceDelete bool) []string {
 	var podErrors []string
 	for _, pod := range pods {
-		if err := s.rt.DeletePod(pod.ID, &forceDelete); err != nil {
+		if err := s.rt.DeletePod(ctx, pod.ID, &forceDelete); err != nil {
 			// Ignore "not found" errors - pod already deleted or never existed
 			if catalogutils.IsNotFoundError(err) {
 				logger.InfofCtx(ctx, "Pod %s already deleted or does not exist", pod.ID)
@@ -198,7 +198,7 @@ func (s *PodmanDeletion) deleteOrphanedComponents(ctx context.Context, component
 
 	for _, componentID := range componentIDs {
 		// List component pods
-		pods, err := s.rt.ListPods(map[string][]string{
+		pods, err := s.rt.ListPods(ctx, map[string][]string{
 			"label": {fmt.Sprintf("ai-services.io/template=%s", componentID)},
 		})
 		if err != nil {
@@ -280,7 +280,7 @@ func (s *PodmanDeletion) deleteVolumesFromPods(ctx context.Context, pods []runti
 
 	// Delete each unique volume using the runtime client
 	for volumeName := range volumesToDelete {
-		if err := s.rt.DeleteVolume(volumeName); err != nil {
+		if err := s.rt.DeleteVolume(ctx, volumeName); err != nil {
 			// Ignore "not found" errors - volume already deleted or never existed
 			if catalogutils.IsNotFoundError(err) {
 				logger.InfofCtx(ctx, "Volume %s already deleted or does not exist", volumeName)
@@ -334,7 +334,7 @@ func (s *PodmanDeletion) deleteSecretsFromPods(ctx context.Context, pods []runti
 
 	// Delete each unique secret
 	for secretName := range secretsToDelete {
-		if err := s.rt.DeleteSecret(secretName); err != nil {
+		if err := s.rt.DeleteSecret(ctx, secretName); err != nil {
 			// Ignore "not found" errors - secret already deleted or never existed
 			if catalogutils.IsNotFoundError(err) {
 				logger.InfofCtx(ctx, "Secret %s already deleted or does not exist", secretName)

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/openshift/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/openshift/deployer.go
@@ -223,7 +223,7 @@ func (d *OpenShiftDeployer) deployService(ctx context.Context, ns string, plan *
 // Routes are identified by the label "ai-services.io/service: <releaseName>".
 func (d *OpenShiftDeployer) registerServiceEndpoints(ctx context.Context, ns, releaseName string, svc *ServicePlan) error {
 	labelSelector := fmt.Sprintf("ai-services.io/service=%s", releaseName)
-	routes, err := d.runtime.ListRoutes(labelSelector)
+	routes, err := d.runtime.ListRoutes(ctx, labelSelector)
 	if err != nil {
 		return fmt.Errorf("failed to list routes for release %s: %w", releaseName, err)
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -768,7 +768,7 @@ func (d *PodmanDeployer) deployComponentTemplate(
 	}
 
 	// Check if pod already exists
-	if exists, err := d.runtime.PodExists(finalPodSpec.Name); err != nil {
+	if exists, err := d.runtime.PodExists(ctx, finalPodSpec.Name); err != nil {
 		return fmt.Errorf("failed to check pod existence: %w", err)
 	} else if exists {
 		logger.InfofCtx(ctx, "Pod '%s' already exists, skipping deployment\n", podSpec.Name)
@@ -958,7 +958,7 @@ func (d *PodmanDeployer) deployPodTemplate(
 		}
 	}
 
-	exists, err := d.runtime.PodExists(podSpec.Name)
+	exists, err := d.runtime.PodExists(ctx, podSpec.Name)
 	if err != nil {
 		return nil, "", "", fmt.Errorf("failed to check pod existence: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/interface.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/interface.go
@@ -27,7 +27,7 @@ type RuntimeSync interface {
 	// FetchPodStatuses returns the status of all pods associated with the given template ID.
 	// The templateID is the service or component UUID used as the "ai-services.io/template" label value.
 	// Returns an error when no pods are found or when the runtime call fails.
-	FetchPodStatuses(rt runtime.Runtime, templateID string) ([]*PodStatus, error)
+	FetchPodStatuses(ctx context.Context, rt runtime.Runtime, templateID string) ([]*PodStatus, error)
 
 	// ValidateResources validates the expected runtime-managed resources for the given service or
 	// component instance and returns an error message when a required resource is missing.

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/openshift.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/openshift.go
@@ -31,7 +31,7 @@ func newOpenShiftSync() *openShiftSync {
 
 // FetchPodStatuses fetches all pods labelled with the given templateID using the OpenShift runtime.
 func (s *openShiftSync) FetchPodStatuses(rt runtime.Runtime, templateID string) ([]*PodStatus, error) {
-	filteredPods, err := common.FetchFilteredPods(rt, templateID)
+	filteredPods, err := common.FetchFilteredPods(context.Background(), rt, templateID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch pods: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/openshift.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/openshift.go
@@ -30,8 +30,8 @@ func newOpenShiftSync() *openShiftSync {
 }
 
 // FetchPodStatuses fetches all pods labelled with the given templateID using the OpenShift runtime.
-func (s *openShiftSync) FetchPodStatuses(rt runtime.Runtime, templateID string) ([]*PodStatus, error) {
-	filteredPods, err := common.FetchFilteredPods(context.Background(), rt, templateID)
+func (s *openShiftSync) FetchPodStatuses(ctx context.Context, rt runtime.Runtime, templateID string) ([]*PodStatus, error) {
+	filteredPods, err := common.FetchFilteredPods(ctx, rt, templateID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch pods: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/podman.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/podman.go
@@ -91,14 +91,11 @@ func validateResourceExistenceChecks(ctx context.Context, expectedSecretNames, e
 
 	var errorMessages []string
 
-	secretExistsFn := func(nameOrID string) (bool, error) { return rt.SecretExists(ctx, nameOrID) }
-	volumeExistsFn := func(nameOrID string) (bool, error) { return rt.VolumeExists(ctx, nameOrID) }
-
-	if msg := validateResourceExistence(ctx, expectedSecretNames, "secret", secretExistsFn); msg != "" {
+	if msg := validateResourceExistence(ctx, expectedSecretNames, "secret", rt.SecretExists); msg != "" {
 		errorMessages = append(errorMessages, msg)
 	}
 
-	if msg := validateResourceExistence(ctx, expectedVolumeNames, "volume", volumeExistsFn); msg != "" {
+	if msg := validateResourceExistence(ctx, expectedVolumeNames, "volume", rt.VolumeExists); msg != "" {
 		errorMessages = append(errorMessages, msg)
 	}
 
@@ -106,11 +103,11 @@ func validateResourceExistenceChecks(ctx context.Context, expectedSecretNames, e
 }
 
 // validateResourceExistence is a generic helper to validate resource existence via the provided lookup func.
-func validateResourceExistence(ctx context.Context, resourceNames []string, resourceType string, existsFunc func(string) (bool, error)) string {
+func validateResourceExistence(ctx context.Context, resourceNames []string, resourceType string, existsFunc func(context.Context, string) (bool, error)) string {
 	var missing []string
 
 	for _, name := range resourceNames {
-		exists, err := existsFunc(name)
+		exists, err := existsFunc(ctx, name)
 		if err != nil {
 			logger.ErrorfCtx(ctx, "Failed to check %s existence for %s: %v", resourceType, name, err)
 

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/podman.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/podman.go
@@ -32,7 +32,7 @@ func newPodmanSync(catalogProvider *catalogpkg.CatalogProvider) *podmanSync {
 // FetchPodStatuses fetches all pods labelled with the given templateID and returns their statuses.
 // It uses InspectPod and InspectContainer (via common.ProcessPod) to derive state and health.
 func (s *podmanSync) FetchPodStatuses(rt runtime.Runtime, templateID string) ([]*PodStatus, error) {
-	filteredPods, err := common.FetchFilteredPods(rt, templateID)
+	filteredPods, err := common.FetchFilteredPods(context.Background(), rt, templateID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch pods: %w", err)
 	}
@@ -43,7 +43,7 @@ func (s *podmanSync) FetchPodStatuses(rt runtime.Runtime, templateID string) ([]
 
 	var podStatuses []*PodStatus
 	for _, pod := range filteredPods {
-		processedPod, err := common.ProcessPod(rt, pod)
+		processedPod, err := common.ProcessPod(context.Background(), rt, pod)
 		if err != nil {
 			return nil, fmt.Errorf("failed to process pod: %w", err)
 		}
@@ -91,11 +91,14 @@ func validateResourceExistenceChecks(ctx context.Context, expectedSecretNames, e
 
 	var errorMessages []string
 
-	if msg := validateResourceExistence(ctx, expectedSecretNames, "secret", rt.SecretExists); msg != "" {
+	secretExistsFn := func(nameOrID string) (bool, error) { return rt.SecretExists(ctx, nameOrID) }
+	volumeExistsFn := func(nameOrID string) (bool, error) { return rt.VolumeExists(ctx, nameOrID) }
+
+	if msg := validateResourceExistence(ctx, expectedSecretNames, "secret", secretExistsFn); msg != "" {
 		errorMessages = append(errorMessages, msg)
 	}
 
-	if msg := validateResourceExistence(ctx, expectedVolumeNames, "volume", rt.VolumeExists); msg != "" {
+	if msg := validateResourceExistence(ctx, expectedVolumeNames, "volume", volumeExistsFn); msg != "" {
 		errorMessages = append(errorMessages, msg)
 	}
 

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/podman.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/podman.go
@@ -31,8 +31,8 @@ func newPodmanSync(catalogProvider *catalogpkg.CatalogProvider) *podmanSync {
 
 // FetchPodStatuses fetches all pods labelled with the given templateID and returns their statuses.
 // It uses InspectPod and InspectContainer (via common.ProcessPod) to derive state and health.
-func (s *podmanSync) FetchPodStatuses(rt runtime.Runtime, templateID string) ([]*PodStatus, error) {
-	filteredPods, err := common.FetchFilteredPods(context.Background(), rt, templateID)
+func (s *podmanSync) FetchPodStatuses(ctx context.Context, rt runtime.Runtime, templateID string) ([]*PodStatus, error) {
+	filteredPods, err := common.FetchFilteredPods(ctx, rt, templateID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch pods: %w", err)
 	}
@@ -43,7 +43,7 @@ func (s *podmanSync) FetchPodStatuses(rt runtime.Runtime, templateID string) ([]
 
 	var podStatuses []*PodStatus
 	for _, pod := range filteredPods {
-		processedPod, err := common.ProcessPod(context.Background(), rt, pod)
+		processedPod, err := common.ProcessPod(ctx, rt, pod)
 		if err != nil {
 			return nil, fmt.Errorf("failed to process pod: %w", err)
 		}

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -192,7 +192,7 @@ func (s *SyncService) syncApplication(ctx context.Context, app *models.Applicati
 
 	// Fail early if the namespace does not exist
 	if rt.Type() == runtimeTypes.RuntimeTypeOpenShift {
-		if _, err := rt.GetNamespace(); errors.Is(err, openshiftRuntime.ErrNamespaceNotFound) {
+		if _, err := rt.GetNamespace(ctx); errors.Is(err, openshiftRuntime.ErrNamespaceNotFound) {
 			return s.updateApplicationStatus(ctx, app, false, []string{err.Error()})
 		}
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -328,7 +328,7 @@ func (s *SyncService) syncAllServices(ctx context.Context, rt runtime.Runtime, a
 // Returns: error message (if any) and error.
 func (s *SyncService) syncServicePod(ctx context.Context, rt runtime.Runtime, service models.Service) (string, error) {
 	// Fetch all pods using service ID as template label
-	pods, err := s.runtimeSync.FetchPodStatuses(rt, service.ID.String())
+	pods, err := s.runtimeSync.FetchPodStatuses(ctx, rt, service.ID.String())
 	if err != nil {
 		return s.handleServicePodFetchError(ctx, service, err)
 	}
@@ -414,7 +414,7 @@ func (s *SyncService) syncComponentPod(ctx context.Context, rt runtime.Runtime, 
 	componentID := component.ID
 
 	// Fetch all pods using component ID as template label
-	pods, err := s.runtimeSync.FetchPodStatuses(rt, componentID.String())
+	pods, err := s.runtimeSync.FetchPodStatuses(ctx, rt, componentID.String())
 	if err != nil {
 		return s.handleComponentPodFetchError(ctx, component, componentID, err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/common/common.go
+++ b/ai-services/internal/pkg/catalog/cli/common/common.go
@@ -15,7 +15,7 @@ import (
 // GetCatalogPods return the list of catalog pod.
 func GetCatalogPods(ctx context.Context, rt runtime.Runtime) ([]types.Pod, error) {
 	// Check if catalog pods exist
-	pods, err := rt.ListPods(map[string][]string{
+	pods, err := rt.ListPods(ctx, map[string][]string{
 		"label": {fmt.Sprintf("%s=%s", constants.ApplicationAnnotationKey, catalogConstants.CatalogAppName)},
 	})
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/certificates.go
@@ -1,6 +1,7 @@
 package caddy
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,7 +21,7 @@ const (
 // LoadSSLCertificates stages user-provided certificates for the Caddy pod and updates TLS config via Admin API.
 // Certificate validation is done in the CLI command's PreRunE hook before calling this function.
 // Uses timestamped filenames to ensure Caddy loads fresh certificates without requiring a restart.
-func (c *Context) LoadSSLCertificates(baseDir, sslCertPath, sslKeyPath string) error {
+func (c *Context) LoadSSLCertificates(ctx context.Context, baseDir, sslCertPath, sslKeyPath string) error {
 	logger.Debugln("loading ssl certificate to caddy...")
 	if sslCertPath == "" || sslKeyPath == "" {
 		return nil
@@ -37,7 +38,7 @@ func (c *Context) LoadSSLCertificates(baseDir, sslCertPath, sslKeyPath string) e
 	stagedKeyPath := filepath.Join(baseDir, "common", "caddy", certsDirName, keyFilename)
 
 	// Get admin URL
-	adminURL, err := c.GetHostAdminURL()
+	adminURL, err := c.GetHostAdminURL(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get Caddy admin URL: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/context.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/context.go
@@ -34,7 +34,7 @@ func NewContext(podName string, domainSuffix string) *Context {
 }
 
 // GetHostAdminURL retrieves the Caddy admin URL for host VM use, caching the result.
-func (c *Context) GetHostAdminURL() (string, error) {
+func (c *Context) GetHostAdminURL(ctx context.Context) (string, error) {
 	if c.hostAdminURL != "" {
 		return c.hostAdminURL, nil
 	}
@@ -44,7 +44,7 @@ func (c *Context) GetHostAdminURL() (string, error) {
 		return "", fmt.Errorf("failed to initialize podman client: %w", err)
 	}
 
-	adminPort, err := getCaddyAdminPort(context.Background(), rt, c.podName)
+	adminPort, err := getCaddyAdminPort(ctx, rt, c.podName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get Caddy admin port: %w", err)
 	}
@@ -71,8 +71,8 @@ func (c *Context) GetHTTPSPort(ctx context.Context, rt *podman.PodmanClient) (st
 }
 
 // CreateProxyManager creates a Caddy proxy manager.
-func (c *Context) CreateProxyManager() (proxy.ProxyManager, error) {
-	adminURL, err := c.GetHostAdminURL()
+func (c *Context) CreateProxyManager(ctx context.Context) (proxy.ProxyManager, error) {
+	adminURL, err := c.GetHostAdminURL(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/context.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/context.go
@@ -3,6 +3,7 @@
 package caddy
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
@@ -43,7 +44,7 @@ func (c *Context) GetHostAdminURL() (string, error) {
 		return "", fmt.Errorf("failed to initialize podman client: %w", err)
 	}
 
-	adminPort, err := getCaddyAdminPort(rt, c.podName)
+	adminPort, err := getCaddyAdminPort(context.Background(), rt, c.podName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get Caddy admin port: %w", err)
 	}
@@ -65,8 +66,8 @@ func (c *Context) GetContainerAdminURL() string {
 }
 
 // GetHTTPSPort retrieves the Caddy HTTPS port.
-func (c *Context) GetHTTPSPort(rt *podman.PodmanClient) (string, error) {
-	return getHTTPSPort(rt, c.podName)
+func (c *Context) GetHTTPSPort(ctx context.Context, rt *podman.PodmanClient) (string, error) {
+	return getHTTPSPort(ctx, rt, c.podName)
 }
 
 // CreateProxyManager creates a Caddy proxy manager.

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
@@ -2,6 +2,7 @@ package caddy
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,8 +16,8 @@ import (
 )
 
 // getCaddyAdminPort retrieves the host port mapped to Caddy's admin API (container port 2019).
-func getCaddyAdminPort(runtime *podman.PodmanClient, podName string) (string, error) {
-	pod, err := runtime.InspectPod(podName)
+func getCaddyAdminPort(ctx context.Context, runtime *podman.PodmanClient, podName string) (string, error) {
+	pod, err := runtime.InspectPod(ctx, podName)
 	if err != nil {
 		return "", fmt.Errorf("failed to inspect Caddy pod: %w", err)
 	}
@@ -35,9 +36,9 @@ func getCaddyAdminPort(runtime *podman.PodmanClient, podName string) (string, er
 }
 
 // getHTTPSPort retrieves the HTTPS port from the Caddy pod.
-func getHTTPSPort(runtime *podman.PodmanClient, caddyPodName string) (string, error) {
+func getHTTPSPort(ctx context.Context, runtime *podman.PodmanClient, caddyPodName string) (string, error) {
 	// Get pod details
-	pod, err := runtime.InspectPod(caddyPodName)
+	pod, err := runtime.InspectPod(ctx, caddyPodName)
 	if err != nil {
 		return "", fmt.Errorf("failed to inspect Caddy pod: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/routes.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/routes.go
@@ -74,7 +74,7 @@ func GetCatalogRouteInfo(ctx context.Context, caddyCtx *Context, runtime *podman
 	// Build route domains map by querying Caddy
 	routeDomains := make(map[string]string)
 	for _, info := range routeInfos {
-		processRouteInfo(info, proxyManager, routeDomains)
+		processRouteInfo(ctx, info, proxyManager, routeDomains)
 	}
 
 	// Get Caddy HTTPS port
@@ -134,7 +134,7 @@ func parseRouteEntry(routeEntry, podName string) string {
 
 // processRouteInfo processes route information and populates the routeDomains map.
 // Queries Caddy for each route and adds it to the map with a standardized variable name.
-func processRouteInfo(info TemplateRouteInfo, proxyManager proxy.ProxyManager, routeDomains map[string]string) {
+func processRouteInfo(ctx context.Context, info TemplateRouteInfo, proxyManager proxy.ProxyManager, routeDomains map[string]string) {
 	// Parse routes annotation to extract subdomains
 	// Format: "port:subdomain:type, port:subdomain:type, ..."
 	// Example: "8081:catalog-ui:ui, 8080:catalog-api:api"
@@ -145,7 +145,7 @@ func processRouteInfo(info TemplateRouteInfo, proxyManager proxy.ProxyManager, r
 		}
 
 		// Query Caddy for this route (route ID is the subdomain)
-		actualRoute, err := proxyManager.GetRouteByID(subdomain)
+		actualRoute, err := proxyManager.GetRouteByID(ctx, subdomain)
 		if err != nil {
 			// Log warning but continue - route might not exist yet
 			logger.Warningf("Failed to query route %s from Caddy: %v", subdomain, err)

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/routes.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/routes.go
@@ -64,7 +64,7 @@ func RegisterCatalogRoutes(runtime *podman.PodmanClient, caddyCtx *Context, rout
 
 // GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service.
 // Accepts pre-extracted route infos from templates.
-func GetCatalogRouteInfo(caddyCtx *Context, runtime *podman.PodmanClient, routeInfos []TemplateRouteInfo) (map[string]string, string, error) {
+func GetCatalogRouteInfo(ctx context.Context, caddyCtx *Context, runtime *podman.PodmanClient, routeInfos []TemplateRouteInfo) (map[string]string, string, error) {
 	// Create proxy manager
 	proxyManager, err := caddyCtx.CreateProxyManager()
 	if err != nil {
@@ -78,7 +78,7 @@ func GetCatalogRouteInfo(caddyCtx *Context, runtime *podman.PodmanClient, routeI
 	}
 
 	// Get Caddy HTTPS port
-	httpsPort, err := caddyCtx.GetHTTPSPort(runtime)
+	httpsPort, err := caddyCtx.GetHTTPSPort(ctx, runtime)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to get Caddy HTTPS port: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/routes.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/routes.go
@@ -20,7 +20,7 @@ type TemplateRouteInfo struct {
 
 // RegisterCatalogRoutes registers routes with Caddy and returns route domains.
 // Accepts pre-extracted route infos from templates.
-func RegisterCatalogRoutes(runtime *podman.PodmanClient, caddyCtx *Context, routeInfos []TemplateRouteInfo) (map[string]string, error) {
+func RegisterCatalogRoutes(ctx context.Context, runtime *podman.PodmanClient, caddyCtx *Context, routeInfos []TemplateRouteInfo) (map[string]string, error) {
 	if len(routeInfos) == 0 {
 		logger.Infof("No templates found with routes annotation, skipping route registration\n")
 
@@ -28,7 +28,7 @@ func RegisterCatalogRoutes(runtime *podman.PodmanClient, caddyCtx *Context, rout
 	}
 
 	// Create proxy manager using Caddy context
-	proxyManager, err := caddyCtx.CreateProxyManager()
+	proxyManager, err := caddyCtx.CreateProxyManager(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create proxy manager: %w", err)
 	}
@@ -42,7 +42,7 @@ func RegisterCatalogRoutes(runtime *podman.PodmanClient, caddyCtx *Context, rout
 		logger.Debugf("Registering routes for pod: %s\n", info.PodName)
 
 		// Register routes and get the built routes back
-		routes, err := proxy.RegisterRoutesForAppAndReturn(context.Background(), constants.CatalogAppName, proxyManager, info.RoutesAnnotation, caddyCtx.GetDomainSuffix(), info.PodName)
+		routes, err := proxy.RegisterRoutesForAppAndReturn(ctx, constants.CatalogAppName, proxyManager, info.RoutesAnnotation, caddyCtx.GetDomainSuffix(), info.PodName)
 		if err != nil {
 			registrationErrors = append(registrationErrors, fmt.Errorf("pod %s: %w", info.PodName, err))
 
@@ -66,7 +66,7 @@ func RegisterCatalogRoutes(runtime *podman.PodmanClient, caddyCtx *Context, rout
 // Accepts pre-extracted route infos from templates.
 func GetCatalogRouteInfo(ctx context.Context, caddyCtx *Context, runtime *podman.PodmanClient, routeInfos []TemplateRouteInfo) (map[string]string, string, error) {
 	// Create proxy manager
-	proxyManager, err := caddyCtx.CreateProxyManager()
+	proxyManager, err := caddyCtx.CreateProxyManager(ctx)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create proxy manager: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/common/podman/deploy/deploy_context.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/deploy/deploy_context.go
@@ -81,13 +81,13 @@ func (d *DeployContext) PrepareValues(argParams map[string]string) error {
 }
 
 // CheckStatus checks if the catalog is already deployed.
-func (d *DeployContext) CheckStatus() (bool, []string, error) {
+func (d *DeployContext) CheckStatus(ctx context.Context) (bool, []string, error) {
 	catalogSecrets, err := collectSecretNames(d.TemplateProvider, d.argParams)
 	if err != nil {
 		return false, nil, err
 	}
 
-	existingResources, err := helpers.CheckExistingResourcesForApplication(context.Background(), d.Runtime, catalogconstants.CatalogAppName, catalogSecrets)
+	existingResources, err := helpers.CheckExistingResourcesForApplication(ctx, d.Runtime, catalogconstants.CatalogAppName, catalogSecrets)
 	if err != nil {
 		return false, nil, err
 	}
@@ -106,7 +106,7 @@ func (d *DeployContext) ExtractRouteInfos() ([]caddy.TemplateRouteInfo, error) {
 }
 
 // ExecutePodLayers executes all pod template layers.
-func (d *DeployContext) ExecutePodLayers(baseDir string, caddyCtx *caddy.Context,
+func (d *DeployContext) ExecutePodLayers(ctx context.Context, baseDir string, caddyCtx *caddy.Context,
 	existingResources []string) error {
 	logger.Debugln("executing catalog service resources...")
 
@@ -114,7 +114,7 @@ func (d *DeployContext) ExecutePodLayers(baseDir string, caddyCtx *caddy.Context
 		logger.Infof("\n Executing Layer %d/%d: %v\n", i+1, len(d.appMetadata.PodTemplateExecutions), layer)
 		logger.Infoln("-------")
 
-		if err := d.executeLayer(layer, baseDir, caddyCtx, i, existingResources); err != nil {
+		if err := d.executeLayer(ctx, layer, baseDir, caddyCtx, i, existingResources); err != nil {
 			return err
 		}
 
@@ -125,7 +125,7 @@ func (d *DeployContext) ExecutePodLayers(baseDir string, caddyCtx *caddy.Context
 }
 
 // executeLayer executes a single layer of pod templates.
-func (d *DeployContext) executeLayer(layer []string, baseDir string, caddyCtx *caddy.Context,
+func (d *DeployContext) executeLayer(ctx context.Context, layer []string, baseDir string, caddyCtx *caddy.Context,
 	layerIndex int, existingResources []string) error {
 	var wg sync.WaitGroup
 	errCh := make(chan error, len(layer))
@@ -135,7 +135,7 @@ func (d *DeployContext) executeLayer(layer []string, baseDir string, caddyCtx *c
 		wg.Add(1)
 		go func(t string) {
 			defer wg.Done()
-			if err := d.executePodTemplate(t, baseDir, caddyCtx, existingResources); err != nil {
+			if err := d.executePodTemplate(ctx, t, baseDir, caddyCtx, existingResources); err != nil {
 				errCh <- err
 			}
 		}(podTemplateName)
@@ -159,7 +159,7 @@ func (d *DeployContext) executeLayer(layer []string, baseDir string, caddyCtx *c
 }
 
 // executePodTemplate executes a single pod template.
-func (d *DeployContext) executePodTemplate(podTemplateName string,
+func (d *DeployContext) executePodTemplate(ctx context.Context, podTemplateName string,
 	baseDir string, caddyCtx *caddy.Context, existingResources []string) error {
 	logger.Infof("Processing template: %s\n", catalogconstants.CatalogAppTemplate)
 
@@ -201,7 +201,7 @@ func (d *DeployContext) executePodTemplate(podTemplateName string,
 	reader := bytes.NewReader(rendered.Bytes())
 	podDeployOptions := clipodman.ConstructPodDeployOptions(specs.FetchPodAnnotations(*podSpec))
 
-	if err := clipodman.DeployPodAndReadinessCheck(context.Background(), d.Runtime, podSpec, podTemplateName, reader, podDeployOptions); err != nil {
+	if err := clipodman.DeployPodAndReadinessCheck(ctx, d.Runtime, podSpec, podTemplateName, reader, podDeployOptions); err != nil {
 		return fmt.Errorf("failed to deploy pod: %w", err)
 	}
 

--- a/ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go
@@ -45,7 +45,7 @@ func DeployCatalog(ctx context.Context, opts catalogutils.OpenShiftConfigureOpti
 	}
 
 	// Step 4: Collect and hash password (if secret doesn't exist)
-	passwordHash, err := catalogutils.CollectAndHashPassword(runtime)
+	passwordHash, err := catalogutils.CollectAndHashPassword(ctx, runtime)
 	if err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func generateArgParams(rt *runtimeOpenshift.OpenshiftClient, passwordHash string
 	argParams := make(map[string]string)
 	argParams[configure.ArgParamAdminPasswordHash] = passwordHash
 
-	dbSecretExists, err := rt.SecretExists(catalogconstants.CatalogDBSecretName)
+	dbSecretExists, err := rt.SecretExists(context.Background(), catalogconstants.CatalogDBSecretName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check db secret existence: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go
@@ -53,7 +53,7 @@ func DeployCatalog(ctx context.Context, opts catalogutils.OpenShiftConfigureOpti
 	// Step 5: Prepare values with argument parameters
 	// Pass runtime so generateArgParams can skip re-generating the DB password
 	// when catalog-db-secret already exists (avoids mismatch with existing PVC data).
-	values, err := prepareValues(tp, runtime, passwordHash)
+	values, err := prepareValues(ctx, tp, runtime, passwordHash)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func DeployCatalog(ctx context.Context, opts catalogutils.OpenShiftConfigureOpti
 	logger.Infoln("-------")
 
 	// Step 7: Print next steps with route URLs
-	if err := helpers.PrintNextSteps(tp, runtime, catalogconstants.CatalogAppName, catalogconstants.CatalogAppTemplate); err != nil {
+	if err := helpers.PrintNextSteps(ctx, tp, runtime, catalogconstants.CatalogAppName, catalogconstants.CatalogAppTemplate); err != nil {
 		logger.Infof("failed to display next steps: %v\n", err)
 
 		return nil //nolint:nilerr // intentionally swallow error for non-critical step
@@ -104,9 +104,9 @@ func loadChart(ctx context.Context, tp templates.Template) (chart.Charter, error
 	return chart, nil
 }
 
-func prepareValues(tp templates.Template, rt *runtimeOpenshift.OpenshiftClient, passwordHash string) (map[string]any, error) {
+func prepareValues(ctx context.Context, tp templates.Template, rt *runtimeOpenshift.OpenshiftClient, passwordHash string) (map[string]any, error) {
 	// Generate argument parameters
-	argParams, err := generateArgParams(rt, passwordHash)
+	argParams, err := generateArgParams(ctx, rt, passwordHash)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate arg params: %w", err)
 	}
@@ -120,11 +120,11 @@ func prepareValues(tp templates.Template, rt *runtimeOpenshift.OpenshiftClient, 
 	return values, nil
 }
 
-func generateArgParams(rt *runtimeOpenshift.OpenshiftClient, passwordHash string) (map[string]string, error) {
+func generateArgParams(ctx context.Context, rt *runtimeOpenshift.OpenshiftClient, passwordHash string) (map[string]string, error) {
 	argParams := make(map[string]string)
 	argParams[configure.ArgParamAdminPasswordHash] = passwordHash
 
-	dbSecretExists, err := rt.SecretExists(context.Background(), catalogconstants.CatalogDBSecretName)
+	dbSecretExists, err := rt.SecretExists(ctx, catalogconstants.CatalogDBSecretName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check db secret existence: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/openshift/reset_password.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/openshift/reset_password.go
@@ -55,7 +55,7 @@ func ResetCatalogPassword() error {
 	s.Start(ctx)
 
 	// Update catalog admin password in secret
-	if err := rt.UpdateSecret(catalogConstants.CatalogSecretName, catalogConstants.CatalogDeploymentName, passwordSecretData); err != nil {
+	if err := rt.UpdateSecret(ctx, catalogConstants.CatalogSecretName, catalogConstants.CatalogDeploymentName, passwordSecretData); err != nil {
 		s.Fail("Password reset failed.")
 
 		return fmt.Errorf("failed to reset catalog password: %w", err)

--- a/ai-services/internal/pkg/catalog/cli/configure/openshift/reset_password.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/openshift/reset_password.go
@@ -13,10 +13,9 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/spinner"
 )
 
-func ResetCatalogPassword() error {
+func ResetCatalogPassword(ctx context.Context) error {
 	catalog := catalogConstants.CatalogAppName
 	namespace := catalog
-	ctx := context.Background()
 
 	// Create a new Helm client
 	helmClient, err := helm.NewHelm(namespace)

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -39,7 +39,7 @@ func DeployCatalog(ctx context.Context, opts catalogUtils.PodmanConfigureOptions
 	}
 
 	// Load SSL certificates if provided
-	if err := caddyCtx.LoadSSLCertificates(opts.BaseDir, opts.SSLCertPath, opts.SSLKeyPath); err != nil {
+	if err := caddyCtx.LoadSSLCertificates(ctx, opts.BaseDir, opts.SSLCertPath, opts.SSLKeyPath); err != nil {
 		return err
 	}
 
@@ -65,7 +65,7 @@ func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployConte
 	logger.Debugln("checking for existing resources...")
 
 	// Check existing deployment status
-	isDeployed, existingResources, err := deployCtx.CheckStatus()
+	isDeployed, existingResources, err := deployCtx.CheckStatus(ctx)
 	if err != nil {
 		s.Fail("failed to check existing resources")
 
@@ -82,7 +82,7 @@ func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployConte
 		}
 
 		// Execute pod templates
-		if err := deployCtx.ExecutePodLayers(opts.BaseDir, caddyCtx, existingResources); err != nil {
+		if err := deployCtx.ExecutePodLayers(ctx, opts.BaseDir, caddyCtx, existingResources); err != nil {
 			s.Fail("failed to deploy catalog pod")
 
 			return nil, err
@@ -115,7 +115,7 @@ func handlePostDeployment(ctx context.Context, caddyCtx *caddy.Context, deployCt
 	}
 
 	// Register routes with Caddy and get the registered route domains
-	routeDomains, err := caddy.RegisterCatalogRoutes(deployCtx.Runtime, caddyCtx, routeInfos)
+	routeDomains, err := caddy.RegisterCatalogRoutes(ctx, deployCtx.Runtime, caddyCtx, routeInfos)
 	if err != nil {
 		return fmt.Errorf("route registration failed: %w", err)
 	}
@@ -127,7 +127,7 @@ func handlePostDeployment(ctx context.Context, caddyCtx *caddy.Context, deployCt
 	}
 
 	// Print next steps with proxy route information
-	if err := helpers.PrintNextStepsWithProxy(deployCtx.TemplateProvider, deployCtx.Runtime, catalogconstants.CatalogAppName, catalogconstants.CatalogAppTemplate, routeDomains, httpsPort); err != nil {
+	if err := helpers.PrintNextStepsWithProxy(ctx, deployCtx.TemplateProvider, deployCtx.Runtime, catalogconstants.CatalogAppName, catalogconstants.CatalogAppTemplate, routeDomains, httpsPort); err != nil {
 		// do not want to fail the overall configure if we cannot print next steps
 		logger.Infof("failed to display next steps: %v\n", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -28,7 +28,7 @@ func DeployCatalog(ctx context.Context, opts catalogUtils.PodmanConfigureOptions
 
 	// Collect and hash password
 	// If secret exist passwordHash will be empty
-	passwordHash, err := catalogUtils.CollectAndHashPassword(deployCtx.Runtime)
+	passwordHash, err := catalogUtils.CollectAndHashPassword(ctx, deployCtx.Runtime)
 	if err != nil {
 		return err
 	}
@@ -43,7 +43,7 @@ func DeployCatalog(ctx context.Context, opts catalogUtils.PodmanConfigureOptions
 		return err
 	}
 
-	return handlePostDeployment(caddyCtx, deployCtx)
+	return handlePostDeployment(ctx, caddyCtx, deployCtx)
 }
 
 func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployContext, opts catalogUtils.PodmanConfigureOptions, passwordHash string) (*caddy.Context, error) {
@@ -94,7 +94,7 @@ func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployConte
 		s.Stop("Catalog service already deployed")
 		logger.Infof("Existing resources: %v\n", existingResources)
 		// Validate domain, HTTPS port, base directory, and certificates haven't changed
-		if err := validateReconfigureParameters(deployCtx.Runtime, &opts, caddyCtx.GetDomainSuffix()); err != nil {
+		if err := validateReconfigureParameters(ctx, deployCtx.Runtime, &opts, caddyCtx.GetDomainSuffix()); err != nil {
 			s.Fail("validation failed during reconfigure")
 
 			return nil, fmt.Errorf("reconfigure validation failed: %w", err)
@@ -105,7 +105,7 @@ func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployConte
 }
 
 // handlePostDeployment handles route registration and next steps display after catalog deployment.
-func handlePostDeployment(caddyCtx *caddy.Context, deployCtx *deploy.DeployContext) error {
+func handlePostDeployment(ctx context.Context, caddyCtx *caddy.Context, deployCtx *deploy.DeployContext) error {
 	logger.Debugln("handling post deployment steps...")
 
 	// Extract route infos from deployment context
@@ -121,7 +121,7 @@ func handlePostDeployment(caddyCtx *caddy.Context, deployCtx *deploy.DeployConte
 	}
 
 	// Get Caddy HTTPS port for next steps display
-	httpsPort, err := caddyCtx.GetHTTPSPort(deployCtx.Runtime)
+	httpsPort, err := caddyCtx.GetHTTPSPort(ctx, deployCtx.Runtime)
 	if err != nil {
 		return fmt.Errorf("failed to get Caddy HTTPS port: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -17,8 +17,8 @@ const certsDirName = "certs"
 
 // getExistingConfigFromCatalogBackend retrieves the existing configuration from the catalog pod.
 // These values are used to validate that configuration hasn't changed during reconfigure operations.
-func getExistingConfigFromCatalogBackend(rt runtime.Runtime) (*catalogUtils.PodmanConfigureOptions, error) {
-	opts, _, err := catalogUtils.GetCatalogPodConfig(rt)
+func getExistingConfigFromCatalogBackend(ctx context.Context, rt runtime.Runtime) (*catalogUtils.PodmanConfigureOptions, error) {
+	opts, _, err := catalogUtils.GetCatalogPodConfig(ctx, rt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get catalog pod details: %w", err)
 	}
@@ -47,9 +47,9 @@ func validateRequiredFields(opts *catalogUtils.PodmanConfigureOptions) error {
 
 // validateReconfigureParameters validates that domain, HTTPS port, base directory, and certificates haven't changed during reconfigure.
 // This function performs all validation checks including certificate validation.
-func validateReconfigureParameters(rt runtime.Runtime, newOpts *catalogUtils.PodmanConfigureOptions, domainSuffix string) error {
+func validateReconfigureParameters(ctx context.Context, rt runtime.Runtime, newOpts *catalogUtils.PodmanConfigureOptions, domainSuffix string) error {
 	// Get existing configuration from catalog-backend pod
-	existingOpts, err := getExistingConfigFromCatalogBackend(rt)
+	existingOpts, err := getExistingConfigFromCatalogBackend(ctx, rt)
 	if err != nil {
 		return fmt.Errorf("failed to get existing configuration from catalog-backend: %w", err)
 	}
@@ -127,8 +127,8 @@ func validateDomainUnchanged(existingOpts *catalogUtils.PodmanConfigureOptions, 
 }
 
 // IsCatalogServiceRunning checks if the catalog service is configured and running.
-func IsCatalogServiceRunning(rt runtime.Runtime) (bool, error) {
-	_, _, err := catalogUtils.GetCatalogPodConfig(rt)
+func IsCatalogServiceRunning(ctx context.Context, rt runtime.Runtime) (bool, error) {
+	_, _, err := catalogUtils.GetCatalogPodConfig(ctx, rt)
 	if err != nil {
 		if errors.Is(err, catalogUtils.ErrCatalogPodNotFound) {
 			logger.InfolnCtx(context.Background(), "Catalog service is not configured or running.")
@@ -145,9 +145,9 @@ func IsCatalogServiceRunning(rt runtime.Runtime) (bool, error) {
 
 // validateCatalogServiceAndConfirmReset validates that the catalog service is running
 // and confirms the reset action with the user. Returns true if the operation should proceed.
-func validateCatalogServiceAndConfirmReset(rt runtime.Runtime, resetType string) (bool, error) {
+func validateCatalogServiceAndConfirmReset(ctx context.Context, rt runtime.Runtime, resetType string) (bool, error) {
 	// Validate catalog service is running
-	isCatalogRunning, err := IsCatalogServiceRunning(rt)
+	isCatalogRunning, err := IsCatalogServiceRunning(ctx, rt)
 	if err != nil {
 		return false, err
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -131,8 +131,8 @@ func IsCatalogServiceRunning(ctx context.Context, rt runtime.Runtime) (bool, err
 	_, _, err := catalogUtils.GetCatalogPodConfig(ctx, rt)
 	if err != nil {
 		if errors.Is(err, catalogUtils.ErrCatalogPodNotFound) {
-			logger.InfolnCtx(context.Background(), "Catalog service is not configured or running.")
-			logger.InfolnCtx(context.Background(), "Run 'ai-services catalog configure --runtime podman' to set up the catalog service.")
+			logger.InfolnCtx(ctx, "Catalog service is not configured or running.")
+			logger.InfolnCtx(ctx, "Run 'ai-services catalog configure --runtime podman' to set up the catalog service.")
 
 			return false, nil
 		}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -23,7 +23,7 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 	}
 
 	// Validate catalog service is running
-	isCatalogRunning, err := IsCatalogServiceRunning(deployCtx.Runtime)
+	isCatalogRunning, err := IsCatalogServiceRunning(context.Background(), deployCtx.Runtime)
 	if err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 	}
 
 	// Get existing catalog pod details
-	opts, _, err := catalogUtils.GetCatalogPodConfig(deployCtx.Runtime)
+	opts, _, err := catalogUtils.GetCatalogPodConfig(context.Background(), deployCtx.Runtime)
 	if err != nil {
 		return fmt.Errorf("failed to get catalog pod details: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -13,8 +13,8 @@ import (
 // ResetCatalogCertificate resets the SSL certificates for the catalog service.
 // It stages new certificates and loads them into Caddy via the Admin API without pod restart.
 // Caddy health is verified internally when connecting to the Admin API.
-func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
-	logger.DebuglnCtx(context.Background(), "Resetting catalog SSL certificates...")
+func ResetCatalogCertificate(ctx context.Context, sslCertPath, sslKeyPath string) error {
+	logger.DebuglnCtx(ctx, "Resetting catalog SSL certificates...")
 
 	// Create deployment context to get runtime
 	deployCtx, err := deploy.NewDeployContext()
@@ -23,7 +23,7 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 	}
 
 	// Validate catalog service is running
-	isCatalogRunning, err := IsCatalogServiceRunning(context.Background(), deployCtx.Runtime)
+	isCatalogRunning, err := IsCatalogServiceRunning(ctx, deployCtx.Runtime)
 	if err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 	}
 
 	// Get existing catalog pod details
-	opts, _, err := catalogUtils.GetCatalogPodConfig(context.Background(), deployCtx.Runtime)
+	opts, _, err := catalogUtils.GetCatalogPodConfig(ctx, deployCtx.Runtime)
 	if err != nil {
 		return fmt.Errorf("failed to get catalog pod details: %w", err)
 	}
@@ -61,7 +61,7 @@ func ResetCatalogCertificate(sslCertPath, sslKeyPath string) error {
 		return err
 	}
 
-	logger.InfolnCtx(context.Background(), "SSL certificates reset successfully")
+	logger.InfolnCtx(ctx, "SSL certificates reset successfully")
 
 	return nil
 }

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -57,7 +57,7 @@ func ResetCatalogCertificate(ctx context.Context, sslCertPath, sslKeyPath string
 	caddyCtx := caddy.NewContext(caddyPodName, "")
 
 	// Load certificates with health check
-	if err := loadCertificatesToCaddy(caddyCtx, opts.BaseDir, sslCertPath, sslKeyPath); err != nil {
+	if err := loadCertificatesToCaddy(ctx, caddyCtx, opts.BaseDir, sslCertPath, sslKeyPath); err != nil {
 		return err
 	}
 
@@ -67,19 +67,19 @@ func ResetCatalogCertificate(ctx context.Context, sslCertPath, sslKeyPath string
 }
 
 // loadCertificatesToCaddy checks Caddy health and loads SSL certificates.
-func loadCertificatesToCaddy(caddyCtx *caddy.Context, baseDir, sslCertPath, sslKeyPath string) error {
+func loadCertificatesToCaddy(ctx context.Context, caddyCtx *caddy.Context, baseDir, sslCertPath, sslKeyPath string) error {
 	// Check Caddy health before attempting to load certificates
-	proxyManager, err := caddyCtx.CreateProxyManager()
+	proxyManager, err := caddyCtx.CreateProxyManager(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create proxy manager: %w", err)
 	}
 
-	if err := proxyManager.HealthCheck(); err != nil {
+	if err := proxyManager.HealthCheck(ctx); err != nil {
 		return fmt.Errorf("caddy health check failed - admin API is not accessible: %w", err)
 	}
 
 	// Load new SSL certificates to Caddy
-	if err := caddyCtx.LoadSSLCertificates(baseDir, sslCertPath, sslKeyPath); err != nil {
+	if err := caddyCtx.LoadSSLCertificates(ctx, baseDir, sslCertPath, sslKeyPath); err != nil {
 		return fmt.Errorf("failed to load certificates: %w", err)
 	}
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
@@ -11,7 +11,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
-func ResetCatalogPassword() error {
+func ResetCatalogPassword(ctx context.Context) error {
 	// Create deployment context without argParams for status check
 	deployCtx, err := deploy.NewDeployContext()
 	if err != nil {
@@ -19,7 +19,7 @@ func ResetCatalogPassword() error {
 	}
 
 	// Validate catalog service and confirm reset action
-	shouldProceed, err := validateCatalogServiceAndConfirmReset(context.Background(), deployCtx.Runtime, "password")
+	shouldProceed, err := validateCatalogServiceAndConfirmReset(ctx, deployCtx.Runtime, "password")
 	if err != nil {
 		return err
 	}
@@ -36,24 +36,24 @@ func ResetCatalogPassword() error {
 		return err
 	}
 
-	logger.InfofCtx(context.Background(), "Deleting catalog secret %s", catalogConstant.CatalogSecretName)
-	err = deployCtx.Runtime.DeleteSecret(context.Background(), catalogConstant.CatalogSecretName)
+	logger.InfofCtx(ctx, "Deleting catalog secret %s", catalogConstant.CatalogSecretName)
+	err = deployCtx.Runtime.DeleteSecret(ctx, catalogConstant.CatalogSecretName)
 	if err != nil {
 		return fmt.Errorf("failed to delete existing catalog secret: %w", err)
 	}
 
-	opts, podID, err := catalogUtils.GetCatalogPodConfig(context.Background(), deployCtx.Runtime)
+	opts, podID, err := catalogUtils.GetCatalogPodConfig(ctx, deployCtx.Runtime)
 	if err != nil {
 		return fmt.Errorf("failed to get existing catalog pod details: %w", err)
 	}
 
-	logger.InfofCtx(context.Background(), "Deleting existing catalog pod %s", podID)
-	err = deployCtx.Runtime.DeletePod(context.Background(), podID, utils.BoolPtr(true))
+	logger.InfofCtx(ctx, "Deleting existing catalog pod %s", podID)
+	err = deployCtx.Runtime.DeletePod(ctx, podID, utils.BoolPtr(true))
 	if err != nil {
 		return fmt.Errorf("failed to delete existing catalog pod: %w", err)
 	}
 
-	_, err = executeCatalogDeployment(context.Background(), deployCtx, *opts, passwordHash)
+	_, err = executeCatalogDeployment(ctx, deployCtx, *opts, passwordHash)
 	if err != nil {
 		return fmt.Errorf("failed to deploy catalog pod: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
@@ -19,7 +19,7 @@ func ResetCatalogPassword() error {
 	}
 
 	// Validate catalog service and confirm reset action
-	shouldProceed, err := validateCatalogServiceAndConfirmReset(deployCtx.Runtime, "password")
+	shouldProceed, err := validateCatalogServiceAndConfirmReset(context.Background(), deployCtx.Runtime, "password")
 	if err != nil {
 		return err
 	}
@@ -37,18 +37,18 @@ func ResetCatalogPassword() error {
 	}
 
 	logger.InfofCtx(context.Background(), "Deleting catalog secret %s", catalogConstant.CatalogSecretName)
-	err = deployCtx.Runtime.DeleteSecret(catalogConstant.CatalogSecretName)
+	err = deployCtx.Runtime.DeleteSecret(context.Background(), catalogConstant.CatalogSecretName)
 	if err != nil {
 		return fmt.Errorf("failed to delete existing catalog secret: %w", err)
 	}
 
-	opts, podID, err := catalogUtils.GetCatalogPodConfig(deployCtx.Runtime)
+	opts, podID, err := catalogUtils.GetCatalogPodConfig(context.Background(), deployCtx.Runtime)
 	if err != nil {
 		return fmt.Errorf("failed to get existing catalog pod details: %w", err)
 	}
 
 	logger.InfofCtx(context.Background(), "Deleting existing catalog pod %s", podID)
-	err = deployCtx.Runtime.DeletePod(podID, utils.BoolPtr(true))
+	err = deployCtx.Runtime.DeletePod(context.Background(), podID, utils.BoolPtr(true))
 	if err != nil {
 		return fmt.Errorf("failed to delete existing catalog pod: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
@@ -11,7 +11,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
-func ResetPodmanAuth() error {
+func ResetPodmanAuth(ctx context.Context) error {
 	// Create deployment context without argParams for status check
 	deployCtx, err := deploy.NewDeployContext()
 	if err != nil {
@@ -19,7 +19,7 @@ func ResetPodmanAuth() error {
 	}
 
 	// Validate catalog service and confirm reset action
-	shouldProceed, err := validateCatalogServiceAndConfirmReset(context.Background(), deployCtx.Runtime, "podman auth")
+	shouldProceed, err := validateCatalogServiceAndConfirmReset(ctx, deployCtx.Runtime, "podman auth")
 	if err != nil {
 		return err
 	}
@@ -29,24 +29,24 @@ func ResetPodmanAuth() error {
 	}
 
 	// Delete podman auth secret.
-	logger.InfofCtx(context.Background(), "Deleting catalog podman auth secret %s", catalogConstant.CatalogPodmanAuthSecretName)
-	err = deployCtx.Runtime.DeleteSecret(context.Background(), catalogConstant.CatalogPodmanAuthSecretName)
+	logger.InfofCtx(ctx, "Deleting catalog podman auth secret %s", catalogConstant.CatalogPodmanAuthSecretName)
+	err = deployCtx.Runtime.DeleteSecret(ctx, catalogConstant.CatalogPodmanAuthSecretName)
 	if err != nil {
 		return fmt.Errorf("failed to delete existing catalog podman auth secret: %w", err)
 	}
 
-	opts, podID, err := catalogUtils.GetCatalogPodConfig(context.Background(), deployCtx.Runtime)
+	opts, podID, err := catalogUtils.GetCatalogPodConfig(ctx, deployCtx.Runtime)
 	if err != nil {
 		return fmt.Errorf("failed to get existing catalog pod details: %w", err)
 	}
 
-	logger.InfofCtx(context.Background(), "Deleting existing catalog pod %s", podID)
-	err = deployCtx.Runtime.DeletePod(context.Background(), podID, utils.BoolPtr(true))
+	logger.InfofCtx(ctx, "Deleting existing catalog pod %s", podID)
+	err = deployCtx.Runtime.DeletePod(ctx, podID, utils.BoolPtr(true))
 	if err != nil {
 		return fmt.Errorf("failed to delete existing catalog pod: %w", err)
 	}
 
-	_, err = executeCatalogDeployment(context.Background(), deployCtx, *opts, "")
+	_, err = executeCatalogDeployment(ctx, deployCtx, *opts, "")
 	if err != nil {
 		return fmt.Errorf("failed to deploy catalog pod: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
@@ -19,7 +19,7 @@ func ResetPodmanAuth() error {
 	}
 
 	// Validate catalog service and confirm reset action
-	shouldProceed, err := validateCatalogServiceAndConfirmReset(deployCtx.Runtime, "podman auth")
+	shouldProceed, err := validateCatalogServiceAndConfirmReset(context.Background(), deployCtx.Runtime, "podman auth")
 	if err != nil {
 		return err
 	}
@@ -30,18 +30,18 @@ func ResetPodmanAuth() error {
 
 	// Delete podman auth secret.
 	logger.InfofCtx(context.Background(), "Deleting catalog podman auth secret %s", catalogConstant.CatalogPodmanAuthSecretName)
-	err = deployCtx.Runtime.DeleteSecret(catalogConstant.CatalogPodmanAuthSecretName)
+	err = deployCtx.Runtime.DeleteSecret(context.Background(), catalogConstant.CatalogPodmanAuthSecretName)
 	if err != nil {
 		return fmt.Errorf("failed to delete existing catalog podman auth secret: %w", err)
 	}
 
-	opts, podID, err := catalogUtils.GetCatalogPodConfig(deployCtx.Runtime)
+	opts, podID, err := catalogUtils.GetCatalogPodConfig(context.Background(), deployCtx.Runtime)
 	if err != nil {
 		return fmt.Errorf("failed to get existing catalog pod details: %w", err)
 	}
 
 	logger.InfofCtx(context.Background(), "Deleting existing catalog pod %s", podID)
-	err = deployCtx.Runtime.DeletePod(podID, utils.BoolPtr(true))
+	err = deployCtx.Runtime.DeletePod(context.Background(), podID, utils.BoolPtr(true))
 	if err != nil {
 		return fmt.Errorf("failed to delete existing catalog pod: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/info/common.go
+++ b/ai-services/internal/pkg/catalog/cli/info/common.go
@@ -13,7 +13,7 @@ import (
 func Run(ctx context.Context, runtimeType types.RuntimeType) error {
 	switch runtimeType {
 	case types.RuntimeTypePodman:
-		return podman.DisplayCatalogInfo()
+		return podman.DisplayCatalogInfo(ctx)
 	case types.RuntimeTypeOpenShift:
 		return openshift.DisplayCatalogInfo(ctx)
 	default:

--- a/ai-services/internal/pkg/catalog/cli/info/openshift/info.go
+++ b/ai-services/internal/pkg/catalog/cli/info/openshift/info.go
@@ -51,7 +51,7 @@ func DisplayCatalogInfo(ctx context.Context) error {
 	// Step 3: Read and print the info.md file
 	tp := templates.NewEmbedTemplateProvider(&assets.CatalogFS, "")
 
-	if err := helpers.PrintInfo(tp, runtime, constants.CatalogAppName, catalogTemplate); err != nil {
+	if err := helpers.PrintInfo(ctx, tp, runtime, constants.CatalogAppName, catalogTemplate); err != nil {
 		// not failing overall info command if we cannot display Info
 		logger.Errorf("failed to display info: %v\n", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/info/openshift/info.go
+++ b/ai-services/internal/pkg/catalog/cli/info/openshift/info.go
@@ -27,7 +27,7 @@ func DisplayCatalogInfo(ctx context.Context) error {
 		"label": {fmt.Sprintf("%s=%s", aiconst.ApplicationAnnotationKey, constants.CatalogAppName)},
 	}
 
-	pods, err := runtime.ListPods(listFilters)
+	pods, err := runtime.ListPods(ctx, listFilters)
 	if err != nil {
 		return fmt.Errorf("failed to list pods: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/info/podman/info.go
+++ b/ai-services/internal/pkg/catalog/cli/info/podman/info.go
@@ -1,6 +1,7 @@
 package podman
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/assets"
@@ -16,6 +17,7 @@ import (
 
 // DisplayCatalogInfo displays detailed information about the catalog service.
 func DisplayCatalogInfo() error {
+	ctx := context.Background()
 	// Initialize runtime
 	runtime, err := rt.NewPodmanClient()
 	if err != nil {
@@ -27,7 +29,7 @@ func DisplayCatalogInfo() error {
 		"label": {fmt.Sprintf("ai-services.io/application=%s", constants.CatalogAppName)},
 	}
 
-	pods, err := runtime.ListPods(listFilters)
+	pods, err := runtime.ListPods(ctx, listFilters)
 	if err != nil {
 		return fmt.Errorf("failed to list pods: %w", err)
 	}
@@ -76,7 +78,8 @@ func DisplayCatalogInfo() error {
 // GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service.
 // This orchestrates: deployContext gets pod name and route info from templates,
 // caddy.Context queries Caddy for route domains and HTTPS port.
-func GetCatalogRouteInfo(rt *rt.PodmanClient) (map[string]string, string, error) {
+func GetCatalogRouteInfo(rt *rt.PodmanClient) (map[string]string, string, error) { //nolint:revive
+	ctx := context.Background()
 	// Create deployment context to access templates
 	deployCtx, err := deploy.NewDeployContext()
 	if err != nil {
@@ -99,7 +102,7 @@ func GetCatalogRouteInfo(rt *rt.PodmanClient) (map[string]string, string, error)
 	caddyCtx := caddy.NewContext(caddyPodName, "")
 
 	// Use caddy package to get route info
-	return caddy.GetCatalogRouteInfo(caddyCtx, rt, routeInfos)
+	return caddy.GetCatalogRouteInfo(ctx, caddyCtx, rt, routeInfos)
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/info/podman/info.go
+++ b/ai-services/internal/pkg/catalog/cli/info/podman/info.go
@@ -77,7 +77,7 @@ func DisplayCatalogInfo(ctx context.Context) error {
 // GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service.
 // This orchestrates: deployContext gets pod name and route info from templates,
 // caddy.Context queries Caddy for route domains and HTTPS port.
-func GetCatalogRouteInfo(ctx context.Context, rt *rt.PodmanClient) (map[string]string, string, error) { //nolint:revive
+func GetCatalogRouteInfo(ctx context.Context, runtime *rt.PodmanClient) (map[string]string, string, error) {
 	// Create deployment context to access templates
 	deployCtx, err := deploy.NewDeployContext()
 	if err != nil {
@@ -100,7 +100,7 @@ func GetCatalogRouteInfo(ctx context.Context, rt *rt.PodmanClient) (map[string]s
 	caddyCtx := caddy.NewContext(caddyPodName, "")
 
 	// Use caddy package to get route info
-	return caddy.GetCatalogRouteInfo(ctx, caddyCtx, rt, routeInfos)
+	return caddy.GetCatalogRouteInfo(ctx, caddyCtx, runtime, routeInfos)
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/info/podman/info.go
+++ b/ai-services/internal/pkg/catalog/cli/info/podman/info.go
@@ -16,8 +16,7 @@ import (
 )
 
 // DisplayCatalogInfo displays detailed information about the catalog service.
-func DisplayCatalogInfo() error {
-	ctx := context.Background()
+func DisplayCatalogInfo(ctx context.Context) error {
 	// Initialize runtime
 	runtime, err := rt.NewPodmanClient()
 	if err != nil {
@@ -53,11 +52,11 @@ func DisplayCatalogInfo() error {
 
 	// Step 3: Fetch route information
 	tp := templates.NewEmbedTemplateProvider(&assets.CatalogFS, "")
-	routeDomains, httpsPort, err := GetCatalogRouteInfo(runtime)
+	routeDomains, httpsPort, err := GetCatalogRouteInfo(ctx, runtime)
 	if err != nil {
 		logger.Errorf("failed to get route info: %v\n", err)
 		// Continue with basic info display
-		if err := helpers.PrintInfo(tp, runtime, constants.CatalogAppName, catalogTemplate); err != nil {
+		if err := helpers.PrintInfo(ctx, tp, runtime, constants.CatalogAppName, catalogTemplate); err != nil {
 			logger.Errorf("failed to display info: %v\n", err)
 		}
 
@@ -65,7 +64,7 @@ func DisplayCatalogInfo() error {
 	}
 
 	// Step 4: Read and print the info.md file with route information
-	if err := helpers.PrintInfoWithProxy(tp, runtime, constants.CatalogAppName, catalogTemplate, routeDomains, httpsPort); err != nil {
+	if err := helpers.PrintInfoWithProxy(ctx, tp, runtime, constants.CatalogAppName, catalogTemplate, routeDomains, httpsPort); err != nil {
 		// not failing overall info command if we cannot display Info
 		logger.Errorf("failed to display info: %v\n", err)
 
@@ -78,8 +77,7 @@ func DisplayCatalogInfo() error {
 // GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service.
 // This orchestrates: deployContext gets pod name and route info from templates,
 // caddy.Context queries Caddy for route domains and HTTPS port.
-func GetCatalogRouteInfo(rt *rt.PodmanClient) (map[string]string, string, error) { //nolint:revive
-	ctx := context.Background()
+func GetCatalogRouteInfo(ctx context.Context, rt *rt.PodmanClient) (map[string]string, string, error) { //nolint:revive
 	// Create deployment context to access templates
 	deployCtx, err := deploy.NewDeployContext()
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/cli/info/podman/info.go
+++ b/ai-services/internal/pkg/catalog/cli/info/podman/info.go
@@ -11,14 +11,14 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	rt "github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // DisplayCatalogInfo displays detailed information about the catalog service.
 func DisplayCatalogInfo(ctx context.Context) error {
 	// Initialize runtime
-	runtime, err := rt.NewPodmanClient()
+	runtime, err := podman.NewPodmanClient()
 	if err != nil {
 		return fmt.Errorf("failed to initialize podman client: %w", err)
 	}
@@ -77,7 +77,7 @@ func DisplayCatalogInfo(ctx context.Context) error {
 // GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service.
 // This orchestrates: deployContext gets pod name and route info from templates,
 // caddy.Context queries Caddy for route domains and HTTPS port.
-func GetCatalogRouteInfo(ctx context.Context, runtime *rt.PodmanClient) (map[string]string, string, error) {
+func GetCatalogRouteInfo(ctx context.Context, rt *podman.PodmanClient) (map[string]string, string, error) {
 	// Create deployment context to access templates
 	deployCtx, err := deploy.NewDeployContext()
 	if err != nil {
@@ -100,7 +100,7 @@ func GetCatalogRouteInfo(ctx context.Context, runtime *rt.PodmanClient) (map[str
 	caddyCtx := caddy.NewContext(caddyPodName, "")
 
 	// Use caddy package to get route info
-	return caddy.GetCatalogRouteInfo(ctx, caddyCtx, runtime, routeInfos)
+	return caddy.GetCatalogRouteInfo(ctx, caddyCtx, rt, routeInfos)
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/uninstall/common.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/common.go
@@ -11,9 +11,7 @@ import (
 )
 
 // Uninstall removes the catalog service and cleans up resources.
-func Uninstall(opts cliutils.UninstallOptions) error {
-	ctx := context.Background()
-
+func Uninstall(ctx context.Context, opts cliutils.UninstallOptions) error {
 	// Remove catalog service based on runtime
 	switch opts.Runtime {
 	case types.RuntimeTypePodman:

--- a/ai-services/internal/pkg/catalog/cli/uninstall/openshift/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/openshift/uninstall.go
@@ -44,13 +44,13 @@ func UninstallCatalog(ctx context.Context, opts utils.UninstallOptions) error {
 	if !opts.SkipCleanup {
 		logger.DebuglnCtx(ctx, "Delete catalog PVCs...")
 
-		if err := rt.DeletePVCs(fmt.Sprintf("%s=%s", constants.ApplicationAnnotationKey, catalog)); err != nil {
+		if err := rt.DeletePVCs(ctx, fmt.Sprintf("%s=%s", constants.ApplicationAnnotationKey, catalog)); err != nil {
 			s.Fail("failed to delete catalog pvc")
 
 			return fmt.Errorf("failed to delete PVCs: %w", err)
 		}
 
-		if err := rt.DeleteNamespace(namespace); err != nil {
+		if err := rt.DeleteNamespace(ctx, namespace); err != nil {
 			s.Fail("failed to delete catalog namespace")
 
 			return fmt.Errorf("failed to delete '%s' namespace: %w", namespace, err)

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -50,7 +50,7 @@ func performCleanup(rt *podman.PodmanClient, pods []types.Pod, skipCleanup bool)
 
 	// Retrieve the BaseDir from the catalog pod configuration
 	var baseDir string
-	config, _, err := catalogUtils.GetCatalogPodConfig(rt)
+	config, _, err := catalogUtils.GetCatalogPodConfig(context.Background(), rt)
 	if err != nil {
 		logger.Warningf("Failed to retrieve BaseDir from catalog pod: %v. Using default BaseDir.\n", err)
 		baseDir = utils.GetBaseDir()
@@ -104,7 +104,7 @@ func performCleanup(rt *podman.PodmanClient, pods []types.Pod, skipCleanup bool)
 // deleteSecrets removes the specified secrets.
 func deleteSecrets(rt *podman.PodmanClient, secrets []string) error {
 	for _, secret := range secrets {
-		if err := rt.DeleteSecret(secret); err != nil {
+		if err := rt.DeleteSecret(context.Background(), secret); err != nil {
 			return err
 		}
 	}
@@ -136,7 +136,7 @@ func podsDeletion(rt *podman.PodmanClient, pods []types.Pod) error {
 	for _, pod := range pods {
 		logger.Infof("Deleting pod: %s\n", pod.Name)
 
-		if err := rt.DeletePod(pod.ID, utils.BoolPtr(true)); err != nil {
+		if err := rt.DeletePod(context.Background(), pod.ID, utils.BoolPtr(true)); err != nil {
 			errors = append(errors, fmt.Sprintf("pod %s: %v", pod.Name, err))
 
 			continue
@@ -248,7 +248,7 @@ func deleteVolumes(rt *podman.PodmanClient, volumeNames []string) error {
 	for _, volumeName := range volumeNames {
 		logger.Infof("Deleting volume: %s\n", volumeName)
 
-		if err := rt.DeleteVolume(volumeName); err != nil {
+		if err := rt.DeleteVolume(context.Background(), volumeName); err != nil {
 			// Ignore "not found" errors - volume already deleted or never existed
 			if catalogUtils.IsNotFoundError(err) {
 				logger.Infof("Volume %s already deleted or does not exist\n", volumeName)

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -41,16 +41,16 @@ func UninstallCatalog(ctx context.Context, opts cliutils.UninstallOptions) error
 		}
 	}
 
-	return performCleanup(rt, pods, opts.SkipCleanup)
+	return performCleanup(ctx, rt, pods, opts.SkipCleanup)
 }
 
 // performCleanup executes all cleanup operations.
-func performCleanup(rt *podman.PodmanClient, pods []types.Pod, skipCleanup bool) error {
+func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.Pod, skipCleanup bool) error {
 	logger.Infoln("Proceeding with deletion...")
 
 	// Retrieve the BaseDir from the catalog pod configuration
 	var baseDir string
-	config, _, err := catalogUtils.GetCatalogPodConfig(context.Background(), rt)
+	config, _, err := catalogUtils.GetCatalogPodConfig(ctx, rt)
 	if err != nil {
 		logger.Warningf("Failed to retrieve BaseDir from catalog pod: %v. Using default BaseDir.\n", err)
 		baseDir = utils.GetBaseDir()
@@ -65,17 +65,17 @@ func performCleanup(rt *podman.PodmanClient, pods []types.Pod, skipCleanup bool)
 	volumesToDelete, volumesToSkip := fetchVolumesToDelete(pods)
 
 	// Delete catalog pods
-	if err := podsDeletion(rt, pods); err != nil {
+	if err := podsDeletion(ctx, rt, pods); err != nil {
 		return err
 	}
 
 	// Delete catalog secrets
-	if err := deleteSecrets(rt, secretsToDelete); err != nil {
+	if err := deleteSecrets(ctx, rt, secretsToDelete); err != nil {
 		return err
 	}
 
 	// Delete volumes (only those without skip-cleanup label)
-	if err := deleteVolumes(rt, volumesToDelete); err != nil {
+	if err := deleteVolumes(ctx, rt, volumesToDelete); err != nil {
 		return err
 	}
 
@@ -92,7 +92,7 @@ func performCleanup(rt *podman.PodmanClient, pods []types.Pod, skipCleanup bool)
 	}
 
 	// Delete database data and secrets
-	if err := cleanupDatabaseResources(rt, secretsToSkip, volumesToSkip, skipCleanup); err != nil {
+	if err := cleanupDatabaseResources(ctx, rt, secretsToSkip, volumesToSkip, skipCleanup); err != nil {
 		return err
 	}
 
@@ -102,9 +102,9 @@ func performCleanup(rt *podman.PodmanClient, pods []types.Pod, skipCleanup bool)
 }
 
 // deleteSecrets removes the specified secrets.
-func deleteSecrets(rt *podman.PodmanClient, secrets []string) error {
+func deleteSecrets(ctx context.Context, rt *podman.PodmanClient, secrets []string) error {
 	for _, secret := range secrets {
-		if err := rt.DeleteSecret(context.Background(), secret); err != nil {
+		if err := rt.DeleteSecret(ctx, secret); err != nil {
 			return err
 		}
 	}
@@ -113,7 +113,7 @@ func deleteSecrets(rt *podman.PodmanClient, secrets []string) error {
 }
 
 // cleanupDatabaseResources handles database volume and secret cleanup.
-func cleanupDatabaseResources(rt *podman.PodmanClient, secretsToSkip []string, volumesToSkip []string, skipCleanup bool) error {
+func cleanupDatabaseResources(ctx context.Context, rt *podman.PodmanClient, secretsToSkip []string, volumesToSkip []string, skipCleanup bool) error {
 	if skipCleanup {
 		logger.Infoln("Skipping database data cleanup (--skip-cleanup flag set)")
 
@@ -121,22 +121,22 @@ func cleanupDatabaseResources(rt *podman.PodmanClient, secretsToSkip []string, v
 	}
 
 	// Delete catalog secrets
-	if err := deleteSecrets(rt, secretsToSkip); err != nil {
+	if err := deleteSecrets(ctx, rt, secretsToSkip); err != nil {
 		return err
 	}
 
 	// Delete volumes with skip-cleanup label (only when --skip-cleanup is not set)
-	return deleteVolumes(rt, volumesToSkip)
+	return deleteVolumes(ctx, rt, volumesToSkip)
 }
 
 // podsDeletion removes all catalog pods.
-func podsDeletion(rt *podman.PodmanClient, pods []types.Pod) error {
+func podsDeletion(ctx context.Context, rt *podman.PodmanClient, pods []types.Pod) error {
 	var errors []string
 
 	for _, pod := range pods {
 		logger.Infof("Deleting pod: %s\n", pod.Name)
 
-		if err := rt.DeletePod(context.Background(), pod.ID, utils.BoolPtr(true)); err != nil {
+		if err := rt.DeletePod(ctx, pod.ID, utils.BoolPtr(true)); err != nil {
 			errors = append(errors, fmt.Sprintf("pod %s: %v", pod.Name, err))
 
 			continue
@@ -236,7 +236,7 @@ func dataDeletion(dataPath string) error {
 }
 
 // deleteVolumes removes the specified volumes.
-func deleteVolumes(rt *podman.PodmanClient, volumeNames []string) error {
+func deleteVolumes(ctx context.Context, rt *podman.PodmanClient, volumeNames []string) error {
 	if len(volumeNames) == 0 {
 		// Just return if there are no volumes to delete.
 		return nil
@@ -248,7 +248,7 @@ func deleteVolumes(rt *podman.PodmanClient, volumeNames []string) error {
 	for _, volumeName := range volumeNames {
 		logger.Infof("Deleting volume: %s\n", volumeName)
 
-		if err := rt.DeleteVolume(context.Background(), volumeName); err != nil {
+		if err := rt.DeleteVolume(ctx, volumeName); err != nil {
 			// Ignore "not found" errors - volume already deleted or never existed
 			if catalogUtils.IsNotFoundError(err) {
 				logger.Infof("Volume %s already deleted or does not exist\n", volumeName)

--- a/ai-services/internal/pkg/catalog/client/application.go
+++ b/ai-services/internal/pkg/catalog/client/application.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -37,8 +38,8 @@ type ApplicationClient struct {
 }
 
 // NewApplicationClient creates a new ApplicationClient with the given server URL and token.
-func NewApplicationClient() (*ApplicationClient, error) {
-	client, err := New()
+func NewApplicationClient(ctx context.Context) (*ApplicationClient, error) {
+	client, err := New(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize client: %w", err)
 	}
@@ -60,9 +61,10 @@ func NewApplicationClient() (*ApplicationClient, error) {
 //	    DeploymentType: "services",
 //	    CatalogID: "rag",
 //	})
-func (c *ApplicationClient) ListApplications(params *ListApplicationsParams) (*types.ApplicationListResponse, error) {
+func (c *ApplicationClient) ListApplications(ctx context.Context, params *ListApplicationsParams) (*types.ApplicationListResponse, error) {
 	var result types.ApplicationListResponse
 	req := c.client.HTTPClient().R().
+		SetContext(ctx).
 		SetResult(&result)
 
 	if params != nil {
@@ -97,9 +99,10 @@ func (c *ApplicationClient) ListApplications(params *ListApplicationsParams) (*t
 
 // GetApplicationPS retrieves the process status and runtime information for an application.
 // It returns details about pods, containers, and their health status.
-func (c *ApplicationClient) GetApplicationPS(id string) (*types.ApplicationPSResponse, error) {
+func (c *ApplicationClient) GetApplicationPS(ctx context.Context, id string) (*types.ApplicationPSResponse, error) {
 	var result types.ApplicationPSResponse
 	resp, err := c.client.HTTPClient().R().
+		SetContext(ctx).
 		SetResult(&result).
 		Get(fmt.Sprintf(getApplicationPSRoute, id))
 	if err != nil {
@@ -126,8 +129,8 @@ func (c *ApplicationClient) GetApplicationPS(id string) (*types.ApplicationPSRes
 //	err := client.DeleteApplication("rag", &DeleteApplicationParams{
 //	    KeepData: true,
 //	})
-func (c *ApplicationClient) DeleteApplication(id string, params *DeleteApplicationParams) error {
-	req := c.client.HTTPClient().R()
+func (c *ApplicationClient) DeleteApplication(ctx context.Context, id string, params *DeleteApplicationParams) error {
+	req := c.client.HTTPClient().R().SetContext(ctx)
 
 	if params != nil {
 		if params.KeepData {
@@ -151,9 +154,10 @@ func (c *ApplicationClient) DeleteApplication(id string, params *DeleteApplicati
 }
 
 // GetApplication retrieves full details for a specific application by ID.
-func (c *ApplicationClient) GetApplication(id string) (*types.Application, error) {
+func (c *ApplicationClient) GetApplication(ctx context.Context, id string) (*types.Application, error) {
 	var result types.Application
 	resp, err := c.client.HTTPClient().R().
+		SetContext(ctx).
 		SetResult(&result).
 		Get(fmt.Sprintf(getApplicationRoute, id))
 	if err != nil {
@@ -172,16 +176,16 @@ func (c *ApplicationClient) GetApplication(id string) (*types.Application, error
 
 // GetApplicationWithRefresh retrieves full details for a specific application by ID.
 // If the server returns 401 Unauthorized, it refreshes the access token once and retries.
-func (c *ApplicationClient) GetApplicationWithRefresh(id string) (*types.Application, error) {
-	result, err := c.GetApplication(id)
+func (c *ApplicationClient) GetApplicationWithRefresh(ctx context.Context, id string) (*types.Application, error) {
+	result, err := c.GetApplication(ctx, id)
 	if err != nil {
 		var httpErr *HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusUnauthorized {
-			if refreshErr := c.client.RefreshToken(); refreshErr != nil {
+			if refreshErr := c.client.RefreshToken(ctx); refreshErr != nil {
 				return nil, err
 			}
 
-			return c.GetApplication(id)
+			return c.GetApplication(ctx, id)
 		}
 
 		return nil, err
@@ -192,9 +196,10 @@ func (c *ApplicationClient) GetApplicationWithRefresh(id string) (*types.Applica
 
 // CreateApplication creates a new application deployment via catalog API.
 // It accepts a CreateApplicationRequest with catalog ID, name, services, and components configuration.
-func (c *ApplicationClient) CreateApplication(req *models.CreateApplicationRequest) (*models.CreateApplicationResponse, error) {
+func (c *ApplicationClient) CreateApplication(ctx context.Context, req *models.CreateApplicationRequest) (*models.CreateApplicationResponse, error) {
 	var result models.CreateApplicationResponse
 	resp, err := c.client.HTTPClient().R().
+		SetContext(ctx).
 		SetBody(req).
 		SetResult(&result).
 		Post(applicationsRoute)
@@ -213,9 +218,10 @@ func (c *ApplicationClient) CreateApplication(req *models.CreateApplicationReque
 
 // GetServiceDeployOptions retrieves deploy options for a specific service.
 // It returns available providers and dependency rules for the service and its components.
-func (c *ApplicationClient) GetServiceDeployOptions(serviceID string) (*types.DeployOptionsService, error) {
+func (c *ApplicationClient) GetServiceDeployOptions(ctx context.Context, serviceID string) (*types.DeployOptionsService, error) {
 	var result types.DeployOptionsService
 	resp, err := c.client.HTTPClient().R().
+		SetContext(ctx).
 		SetResult(&result).
 		Get(fmt.Sprintf(svcDeployOptionsRoute, serviceID))
 	if err != nil {
@@ -231,9 +237,10 @@ func (c *ApplicationClient) GetServiceDeployOptions(serviceID string) (*types.De
 
 // GetArchitectureDeployOptions retrieves deploy options for an architecture.
 // It returns available providers and dependency rules for all services in the architecture.
-func (c *ApplicationClient) GetArchitectureDeployOptions(architectureID string) (*types.DeployOptionsArchitecture, error) {
+func (c *ApplicationClient) GetArchitectureDeployOptions(ctx context.Context, architectureID string) (*types.DeployOptionsArchitecture, error) {
 	var result types.DeployOptionsArchitecture
 	resp, err := c.client.HTTPClient().R().
+		SetContext(ctx).
 		SetResult(&result).
 		Get(fmt.Sprintf(archDeployOptionsRoute, architectureID))
 	if err != nil {
@@ -248,9 +255,10 @@ func (c *ApplicationClient) GetArchitectureDeployOptions(architectureID string) 
 }
 
 // GetComponentProviderParams retrieves the parameter schema for a specific component provider.
-func (c *ApplicationClient) GetComponentProviderParams(componentType, providerID string) (map[string]any, error) {
+func (c *ApplicationClient) GetComponentProviderParams(ctx context.Context, componentType, providerID string) (map[string]any, error) {
 	var result map[string]any
 	resp, err := c.client.HTTPClient().R().
+		SetContext(ctx).
 		SetResult(&result).
 		Get(fmt.Sprintf(compProviderParamsRoute, componentType, providerID))
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/client/client.go
+++ b/ai-services/internal/pkg/catalog/client/client.go
@@ -3,6 +3,7 @@
 package client
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -46,7 +47,7 @@ type UserInfo struct {
 // It refreshes the access token only when it is about to expire (within
 // tokenRefreshSkew of its expiry time); otherwise the stored token is reused.
 // The insecure flag from stored credentials determines whether TLS verification is performed.
-func New() (*Client, error) {
+func New(ctx context.Context) (*Client, error) {
 	creds, err := config.Load()
 	if err != nil {
 		return nil, err
@@ -70,7 +71,7 @@ func New() (*Client, error) {
 	}
 
 	if c.accessTokenNeedsRefresh() {
-		if err := c.RefreshToken(); err != nil {
+		if err := c.RefreshToken(ctx); err != nil {
 			return nil, fmt.Errorf("refresh token: %w", err)
 		}
 	}
@@ -104,7 +105,7 @@ func (c *Client) accessTokenNeedsRefresh() bool {
 // NewWithLogin creates a Client by performing a fresh login with username/password.
 // The resulting tokens are saved to the local config file.
 // If insecure is true, TLS certificate verification will be skipped.
-func NewWithLogin(serverURL, username, password string, insecure bool) (*Client, error) {
+func NewWithLogin(ctx context.Context, serverURL, username, password string, insecure bool) (*Client, error) {
 	restyClient := resty.New().SetBaseURL(serverURL)
 
 	// Configure TLS settings based on the insecure flag
@@ -119,7 +120,7 @@ func NewWithLogin(serverURL, username, password string, insecure bool) (*Client,
 		httpClient: restyClient,
 	}
 
-	resp, err := c.Login(username, password)
+	resp, err := c.Login(ctx, username, password)
 	if err != nil {
 		return nil, err
 	}
@@ -147,9 +148,10 @@ func NewWithLogin(serverURL, username, password string, insecure bool) (*Client,
 }
 
 // Login calls POST /api/v1/auth/login and returns the token pair.
-func (c *Client) Login(username, password string) (LoginResponse, error) {
+func (c *Client) Login(ctx context.Context, username, password string) (LoginResponse, error) {
 	var resp LoginResponse
 	httpResp, err := c.httpClient.R().
+		SetContext(ctx).
 		SetBody(map[string]string{"username": username, "password": password}).
 		SetResult(&resp).
 		Post("/api/v1/auth/login")
@@ -166,9 +168,10 @@ func (c *Client) Login(username, password string) (LoginResponse, error) {
 
 // LoginWithMIQToken calls POST /api/v1/auth/token, passing the ManageIQ token in
 // the Authorization header. Used by IBM Power Mission Control (Flow B).
-func (c *Client) LoginWithMIQToken(miqToken string) (LoginResponse, error) {
+func (c *Client) LoginWithMIQToken(ctx context.Context, miqToken string) (LoginResponse, error) {
 	var resp LoginResponse
 	httpResp, err := c.httpClient.R().
+		SetContext(ctx).
 		SetHeader("Authorization", "Bearer "+miqToken).
 		SetResult(&resp).
 		Post("/api/v1/auth/token")
@@ -186,7 +189,7 @@ func (c *Client) LoginWithMIQToken(miqToken string) (LoginResponse, error) {
 // NewWithMIQToken creates a Client by exchanging a ManageIQ token for a Catalog API JWT.
 // This is Flow B: used by IBM Power Mission Control which already holds a MIQ token.
 // The resulting tokens are saved to the local config file exactly like NewWithLogin.
-func NewWithMIQToken(serverURL, miqToken string, insecure bool) (*Client, error) {
+func NewWithMIQToken(ctx context.Context, serverURL, miqToken string, insecure bool) (*Client, error) {
 	restyClient := resty.New().SetBaseURL(serverURL)
 	if insecure {
 		restyClient.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}) //nolint:gosec
@@ -197,7 +200,7 @@ func NewWithMIQToken(serverURL, miqToken string, insecure bool) (*Client, error)
 		httpClient: restyClient,
 	}
 
-	resp, err := c.LoginWithMIQToken(miqToken)
+	resp, err := c.LoginWithMIQToken(ctx, miqToken)
 	if err != nil {
 		return nil, err
 	}
@@ -223,9 +226,10 @@ func NewWithMIQToken(serverURL, miqToken string, insecure bool) (*Client, error)
 
 // RefreshToken calls POST /api/v1/auth/refresh using the stored refresh token
 // and updates the in-memory credentials (and persists them to disk).
-func (c *Client) RefreshToken() error {
+func (c *Client) RefreshToken(ctx context.Context) error {
 	var resp LoginResponse
 	httpResp, err := c.httpClient.R().
+		SetContext(ctx).
 		SetBody(map[string]string{"refresh_token": c.creds.RefreshToken}).
 		SetResult(&resp).
 		Post("/api/v1/auth/refresh")
@@ -254,9 +258,10 @@ func (c *Client) RefreshToken() error {
 }
 
 // Me calls GET /api/v1/auth/me and returns the current user info.
-func (c *Client) Me() (UserInfo, error) {
+func (c *Client) Me(ctx context.Context) (UserInfo, error) {
 	var info UserInfo
 	httpResp, err := c.httpClient.R().
+		SetContext(ctx).
 		SetResult(&info).
 		Get("/api/v1/auth/me")
 	if err != nil {
@@ -272,9 +277,10 @@ func (c *Client) Me() (UserInfo, error) {
 
 // Logout calls POST /api/v1/auth/logout to invalidate the access token on the server,
 // then removes the local credentials file.
-func (c *Client) Logout() error {
+func (c *Client) Logout(ctx context.Context) error {
 	// Best-effort server-side logout; ignore errors (token may already be expired).
 	_, _ = c.httpClient.R().
+		SetContext(ctx).
 		SetHeader("X-Refresh-Token", c.creds.RefreshToken).
 		Post("/api/v1/auth/logout")
 

--- a/ai-services/internal/pkg/catalog/client/worker.go
+++ b/ai-services/internal/pkg/catalog/client/worker.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 
 	catalogtypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
@@ -24,9 +25,10 @@ type CreateWorkerResponse struct {
 }
 
 // CreateWorker pre-registers a new worker by name and returns its bootstrap token.
-func (c *Client) CreateWorker(name string) (*CreateWorkerResponse, error) {
+func (c *Client) CreateWorker(ctx context.Context, name string) (*CreateWorkerResponse, error) {
 	var result CreateWorkerResponse
 	resp, err := c.httpClient.R().
+		SetContext(ctx).
 		SetBody(CreateWorkerRequest{WorkerName: name}).
 		SetResult(&result).
 		Post(workersRoute)
@@ -43,9 +45,10 @@ func (c *Client) CreateWorker(name string) (*CreateWorkerResponse, error) {
 }
 
 // ListWorkers returns all registered workers from the catalog.
-func (c *Client) ListWorkers() ([]catalogtypes.Worker, error) {
+func (c *Client) ListWorkers(ctx context.Context) ([]catalogtypes.Worker, error) {
 	var result []catalogtypes.Worker
 	resp, err := c.httpClient.R().
+		SetContext(ctx).
 		SetResult(&result).
 		Get(workersRoute)
 	if err != nil {
@@ -62,15 +65,15 @@ func (c *Client) ListWorkers() ([]catalogtypes.Worker, error) {
 
 // DeleteWorkerByName resolves a worker name to its UUID and permanently removes it.
 // Returns an error if no worker with that name is registered.
-func (c *Client) DeleteWorkerByName(name string) error {
-	workers, err := c.ListWorkers()
+func (c *Client) DeleteWorkerByName(ctx context.Context, name string) error {
+	workers, err := c.ListWorkers(ctx)
 	if err != nil {
 		return err
 	}
 
 	for _, w := range workers {
 		if w.Name == name {
-			return c.deleteWorkerByID(w.ID)
+			return c.deleteWorkerByID(ctx, w.ID)
 		}
 	}
 
@@ -78,8 +81,9 @@ func (c *Client) DeleteWorkerByName(name string) error {
 }
 
 // deleteWorkerByID permanently removes a worker by its UUID string.
-func (c *Client) deleteWorkerByID(id string) error {
+func (c *Client) deleteWorkerByID(ctx context.Context, id string) error {
 	resp, err := c.httpClient.R().
+		SetContext(ctx).
 		Delete(fmt.Sprintf(workerByIDRoute, id))
 	if err != nil {
 		return fmt.Errorf("delete worker: %w", err)

--- a/ai-services/internal/pkg/catalog/utils/common.go
+++ b/ai-services/internal/pkg/catalog/utils/common.go
@@ -43,7 +43,7 @@ type OpenShiftConfigureOptions struct {
 
 // GetCatalogPodConfig retrieves catalog pod configuration by inspecting the running pod and its containers.
 // It extracts environment variables like AI_SERVICES_BASE_DIR, DOMAIN_SUFFIX, and CADDY_HTTPS_PORT.
-func GetCatalogPodConfig(rt runtime.Runtime) (*PodmanConfigureOptions, string, error) {
+func GetCatalogPodConfig(ctx context.Context, rt runtime.Runtime) (*PodmanConfigureOptions, string, error) {
 	// Build filter to find all pods using the catalog secret via label
 	logger.Debugf("Getting catalog pod configuration")
 	filter := map[string][]string{
@@ -55,7 +55,7 @@ func GetCatalogPodConfig(rt runtime.Runtime) (*PodmanConfigureOptions, string, e
 	}
 
 	// List all pods that reference the catalog secret
-	pods, err := rt.ListPods(filter)
+	pods, err := rt.ListPods(ctx, filter)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to list pods: %w", err)
 	}
@@ -65,7 +65,7 @@ func GetCatalogPodConfig(rt runtime.Runtime) (*PodmanConfigureOptions, string, e
 
 	// Inspect catalog pod
 	pod := pods[0]
-	pInfo, err := rt.InspectPod(pod.ID)
+	pInfo, err := rt.InspectPod(ctx, pod.ID)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to inspect pod %s: %w", pod.Name, err)
 	}
@@ -74,7 +74,7 @@ func GetCatalogPodConfig(rt runtime.Runtime) (*PodmanConfigureOptions, string, e
 
 	for _, container := range pInfo.Containers {
 		// Inspect container to get environment variables
-		cInfo, err := rt.InspectContainer(container.ID)
+		cInfo, err := rt.InspectContainer(ctx, container.ID)
 		if err != nil {
 			return nil, "", fmt.Errorf("failed to inspect container %s: %w", container.Name, err)
 		}

--- a/ai-services/internal/pkg/catalog/utils/password.go
+++ b/ai-services/internal/pkg/catalog/utils/password.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
@@ -37,8 +38,8 @@ func HashPasswordPBKDF2(password string, iteration int) (string, error) {
 
 // CollectAndHashPassword collects the password from user and returns the hashed password.
 // Returns empty string if the secret already exists (no password needed).
-func CollectAndHashPassword(rt runtime.Runtime) (string, error) {
-	secretExists, err := rt.SecretExists(catalogConstants.CatalogSecretName)
+func CollectAndHashPassword(ctx context.Context, rt runtime.Runtime) (string, error) {
+	secretExists, err := rt.SecretExists(ctx, catalogConstants.CatalogSecretName)
 	if err != nil {
 		return "", fmt.Errorf("failed to check existing secrets: %w", err)
 	}

--- a/ai-services/internal/pkg/cli/helpers/helper.go
+++ b/ai-services/internal/pkg/cli/helpers/helper.go
@@ -18,7 +18,7 @@ const (
 	inspectPollInterval = 10 * time.Second
 )
 
-func WaitForContainerReadiness(runtime runtime.Runtime, containerNameOrId string, timeout time.Duration) error {
+func WaitForContainerReadiness(ctx context.Context, runtime runtime.Runtime, containerNameOrId string, timeout time.Duration) error {
 	var containerStatus *types.Container
 	var err error
 
@@ -26,7 +26,7 @@ func WaitForContainerReadiness(runtime runtime.Runtime, containerNameOrId string
 
 	for {
 		// fetch the container status
-		containerStatus, err = runtime.InspectContainer(containerNameOrId)
+		containerStatus, err = runtime.InspectContainer(ctx, containerNameOrId)
 		if err != nil {
 			return fmt.Errorf("failed to check container status: %w", err)
 		}
@@ -52,12 +52,12 @@ func WaitForContainerReadiness(runtime runtime.Runtime, containerNameOrId string
 }
 
 // WaitForContainersCreation waits until all the containers in the provided podID are created within the specified timeout.
-func WaitForContainersCreation(runtime runtime.Runtime, podID string, expectedContainerCount int, timeout time.Duration) error {
+func WaitForContainersCreation(ctx context.Context, runtime runtime.Runtime, podID string, expectedContainerCount int, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 
 	for {
 		// fetch the pod info
-		pInfo, err := runtime.InspectPod(podID)
+		pInfo, err := runtime.InspectPod(ctx, podID)
 		if err != nil {
 			return fmt.Errorf("failed to do pod inspect for podID: %s with error: %w", podID, err)
 		}
@@ -78,9 +78,9 @@ func WaitForContainersCreation(runtime runtime.Runtime, podID string, expectedCo
 	}
 }
 
-func FetchContainerStartPeriod(runtime runtime.Runtime, containerNameOrId string) (time.Duration, error) {
+func FetchContainerStartPeriod(ctx context.Context, runtime runtime.Runtime, containerNameOrId string) (time.Duration, error) {
 	// fetch the container stats
-	containerStats, err := runtime.InspectContainer(containerNameOrId)
+	containerStats, err := runtime.InspectContainer(ctx, containerNameOrId)
 	if err != nil {
 		return 0, fmt.Errorf("failed to check container stats: %w", err)
 	}
@@ -140,7 +140,7 @@ func CheckExistingResourcesForApplication(ctx context.Context, runtime runtime.R
 func existingRunningPods(ctx context.Context, runtime runtime.Runtime, appName string) ([]string, error) {
 	//nolint:prealloc // as capacity is unknown and depends on runtime.ListPods response
 	var podsToSkip []string
-	pods, err := runtime.ListPods(map[string][]string{
+	pods, err := runtime.ListPods(ctx, map[string][]string{
 		"label": {fmt.Sprintf("ai-services.io/application=%s", appName)},
 	})
 	if err != nil {
@@ -158,7 +158,7 @@ func existingRunningPods(ctx context.Context, runtime runtime.Runtime, appName s
 		if pod.Status != "Running" {
 			logger.WarningfCtx(ctx, "Pod %q is in %q state — deleting it so it can be redeployed\n", pod.Name, pod.Status)
 
-			if err := runtime.DeletePod(pod.ID, utils.BoolPtr(true)); err != nil {
+			if err := runtime.DeletePod(ctx, pod.ID, utils.BoolPtr(true)); err != nil {
 				return nil, fmt.Errorf("failed to delete non-running pod %q: %w", pod.Name, err)
 			}
 
@@ -173,7 +173,7 @@ func existingRunningPods(ctx context.Context, runtime runtime.Runtime, appName s
 func existingSecrets(ctx context.Context, runtime runtime.Runtime, secretNames []string) ([]string, error) {
 	secretsToSkip := make([]string, 0, len(secretNames))
 	for _, secretName := range secretNames {
-		secret, err := runtime.ListSecrets(map[string][]string{
+		secret, err := runtime.ListSecrets(ctx, map[string][]string{
 			"name": {secretName},
 		})
 		if err != nil && !strings.Contains(err.Error(), constants.ErrSecretNotFound) {

--- a/ai-services/internal/pkg/cli/helpers/models.go
+++ b/ai-services/internal/pkg/cli/helpers/models.go
@@ -47,7 +47,7 @@ func ListModels(template, appName string) ([]string, error) {
 	return modelList, nil
 }
 
-func DownloadModel(model, targetDir string) error {
+func DownloadModel(ctx context.Context, model, targetDir string) error {
 	// check for target model directory
 	fileInfo, err := os.Stat(targetDir)
 	if err != nil {
@@ -73,7 +73,7 @@ func DownloadModel(model, targetDir string) error {
 		return fmt.Errorf("failed to remove test file: %w", err)
 	}
 
-	return DownloadModelContainer(context.Background(), model, targetDir)
+	return DownloadModelContainer(ctx, model, targetDir)
 }
 
 func DownloadModelContainer(ctx context.Context, model, targetDir string) error {

--- a/ai-services/internal/pkg/cli/helpers/steps.go
+++ b/ai-services/internal/pkg/cli/helpers/steps.go
@@ -89,7 +89,7 @@ func PrintInfoWithProxy(tp templates.Template, runtime runtime.Runtime, app, app
 }
 
 // populatePodValues -> populates the host values within the params.
-func populateHostValues(runtime runtime.Runtime, params map[string]string, varsData *templates.Vars) error {
+func populateHostValues(ctx context.Context, runtime runtime.Runtime, params map[string]string, varsData *templates.Vars) error {
 	for _, host := range varsData.Hosts {
 		switch host.Type {
 		case "ip":
@@ -100,7 +100,7 @@ func populateHostValues(runtime runtime.Runtime, params map[string]string, varsD
 			}
 			params["HOST_IP"] = hostIP
 		case "route":
-			route, err := runtime.ListRoutes("")
+			route, err := runtime.ListRoutes(ctx, "")
 			if err != nil {
 				return fmt.Errorf("unable to fetch the route: %w", err)
 			}
@@ -118,9 +118,9 @@ func populateHostValues(runtime runtime.Runtime, params map[string]string, varsD
 	return nil
 }
 
-func populatePodInfo(runtime runtime.Runtime, params map[string]string, varsData *templates.Vars) error {
+func populatePodInfo(ctx context.Context, runtime runtime.Runtime, params map[string]string, varsData *templates.Vars) error {
 	for _, pod := range varsData.Pods {
-		exists, err := runtime.PodExists(pod.Name)
+		exists, err := runtime.PodExists(ctx, pod.Name)
 		if err != nil {
 			return fmt.Errorf("failed to check if pod exists: %w", err)
 		}
@@ -131,7 +131,7 @@ func populatePodInfo(runtime runtime.Runtime, params map[string]string, varsData
 			continue
 		}
 
-		pInfo, err := runtime.InspectPod(pod.Name)
+		pInfo, err := runtime.InspectPod(ctx, pod.Name)
 		if err != nil {
 			return fmt.Errorf("failed to inspect Pod '%s': %w", pod.Name, err)
 		}
@@ -154,9 +154,9 @@ func populatePodInfo(runtime runtime.Runtime, params map[string]string, varsData
 	return nil
 }
 
-func populateContainerInfo(runtime runtime.Runtime, params map[string]string, varsData *templates.Vars) error {
+func populateContainerInfo(ctx context.Context, runtime runtime.Runtime, params map[string]string, varsData *templates.Vars) error {
 	for _, container := range varsData.Containers {
-		exists, err := runtime.ContainerExists(container.Name)
+		exists, err := runtime.ContainerExists(ctx, container.Name)
 		if err != nil {
 			return fmt.Errorf("failed to check if container exists: %w", err)
 		}
@@ -167,7 +167,7 @@ func populateContainerInfo(runtime runtime.Runtime, params map[string]string, va
 			continue
 		}
 
-		cInfo, err := runtime.InspectContainer(container.Name)
+		cInfo, err := runtime.InspectContainer(ctx, container.Name)
 		if err != nil {
 			return fmt.Errorf("failed to inspect Container '%s': %w", container.Name, err)
 		}
@@ -234,18 +234,20 @@ func renderStepsMarkdown(tp templates.Template, runtime runtime.Runtime, appTemp
 		return fmt.Errorf("failed to load vars file: %w", err)
 	}
 
+	ctx := context.Background()
+
 	// populate the host values set in vars file
-	if err := populateHostValues(runtime, params, varsData); err != nil {
+	if err := populateHostValues(ctx, runtime, params, varsData); err != nil {
 		return fmt.Errorf("failed to populate host values: %w", err)
 	}
 
 	// populate the pod info set in vars file
-	if err := populatePodInfo(runtime, params, varsData); err != nil {
+	if err := populatePodInfo(ctx, runtime, params, varsData); err != nil {
 		return fmt.Errorf("failed to populate pod values: %w", err)
 	}
 
 	// populate the container info set in vars file
-	if err := populateContainerInfo(runtime, params, varsData); err != nil {
+	if err := populateContainerInfo(ctx, runtime, params, varsData); err != nil {
 		return fmt.Errorf("failed to populate container values: %w", err)
 	}
 
@@ -254,7 +256,6 @@ func renderStepsMarkdown(tp templates.Template, runtime runtime.Runtime, appTemp
 		return fmt.Errorf("failed to execute info.md: %w", err)
 	}
 
-	ctx := context.Background()
 	logger.InfolnCtx(ctx, title+":")
 	logger.InfolnCtx(ctx, "-------")
 	logger.InfolnCtx(ctx, rendered.String())

--- a/ai-services/internal/pkg/cli/helpers/steps.go
+++ b/ai-services/internal/pkg/cli/helpers/steps.go
@@ -22,10 +22,10 @@ const (
 	infoTitle  = "Info"
 )
 
-func PrintNextSteps(tp templates.Template, runtime runtime.Runtime, app, appTemplate string) error {
+func PrintNextSteps(ctx context.Context, tp templates.Template, runtime runtime.Runtime, app, appTemplate string) error {
 	params := map[string]string{"AppName": app}
-	if err := renderStepsMarkdown(tp, runtime, appTemplate, params, nextStepsMDFile, nextStepsTitle); err != nil {
-		logger.InfofCtx(context.Background(), "Unable to load steps: %v\n", err)
+	if err := renderStepsMarkdown(ctx, tp, runtime, appTemplate, params, nextStepsMDFile, nextStepsTitle); err != nil {
+		logger.InfofCtx(ctx, "Unable to load steps: %v\n", err)
 
 		return nil
 	}
@@ -34,7 +34,7 @@ func PrintNextSteps(tp templates.Template, runtime runtime.Runtime, app, appTemp
 }
 
 // PrintNextStepsWithProxy prints next steps with proxy route information.
-func PrintNextStepsWithProxy(tp templates.Template, runtime runtime.Runtime, app, appTemplate string, routeDomains map[string]string, httpsPort string) error {
+func PrintNextStepsWithProxy(ctx context.Context, tp templates.Template, runtime runtime.Runtime, app, appTemplate string, routeDomains map[string]string, httpsPort string) error {
 	params := map[string]string{"AppName": app}
 
 	// Add route domains to params
@@ -47,8 +47,8 @@ func PrintNextStepsWithProxy(tp templates.Template, runtime runtime.Runtime, app
 		params["HTTPS_PORT"] = httpsPort
 	}
 
-	if err := renderStepsMarkdown(tp, runtime, appTemplate, params, nextStepsMDFile, nextStepsTitle); err != nil {
-		logger.InfofCtx(context.Background(), "Unable to load steps: %v\n", err)
+	if err := renderStepsMarkdown(ctx, tp, runtime, appTemplate, params, nextStepsMDFile, nextStepsTitle); err != nil {
+		logger.InfofCtx(ctx, "Unable to load steps: %v\n", err)
 
 		return nil
 	}
@@ -56,10 +56,10 @@ func PrintNextStepsWithProxy(tp templates.Template, runtime runtime.Runtime, app
 	return nil
 }
 
-func PrintInfo(tp templates.Template, runtime runtime.Runtime, app, appTemplate string) error {
+func PrintInfo(ctx context.Context, tp templates.Template, runtime runtime.Runtime, app, appTemplate string) error {
 	params := map[string]string{"AppName": app}
-	if err := renderStepsMarkdown(tp, runtime, appTemplate, params, infoMDFile, infoTitle); err != nil {
-		logger.InfofCtx(context.Background(), "Unable to load steps: %v\n", err)
+	if err := renderStepsMarkdown(ctx, tp, runtime, appTemplate, params, infoMDFile, infoTitle); err != nil {
+		logger.InfofCtx(ctx, "Unable to load steps: %v\n", err)
 
 		return nil
 	}
@@ -68,7 +68,7 @@ func PrintInfo(tp templates.Template, runtime runtime.Runtime, app, appTemplate 
 }
 
 // PrintInfoWithProxy prints info with proxy route information.
-func PrintInfoWithProxy(tp templates.Template, runtime runtime.Runtime, app, appTemplate string, routeDomains map[string]string, httpsPort string) error {
+func PrintInfoWithProxy(ctx context.Context, tp templates.Template, runtime runtime.Runtime, app, appTemplate string, routeDomains map[string]string, httpsPort string) error {
 	params := map[string]string{"AppName": app}
 
 	// Add route domains to params
@@ -79,8 +79,8 @@ func PrintInfoWithProxy(tp templates.Template, runtime runtime.Runtime, app, app
 		params["HTTPS_PORT"] = httpsPort
 	}
 
-	if err := renderStepsMarkdown(tp, runtime, appTemplate, params, infoMDFile, infoTitle); err != nil {
-		logger.InfofCtx(context.Background(), "Unable to load steps: %v\n", err)
+	if err := renderStepsMarkdown(ctx, tp, runtime, appTemplate, params, infoMDFile, infoTitle); err != nil {
+		logger.InfofCtx(ctx, "Unable to load steps: %v\n", err)
 
 		return nil
 	}
@@ -218,7 +218,7 @@ func fetchDataSpecificInfo(data any, format string, defaultValue *string) (strin
 	return strings.TrimSpace(result.String()), nil
 }
 
-func renderStepsMarkdown(tp templates.Template, runtime runtime.Runtime, appTemplate string, params map[string]string, mdFile, title string) error {
+func renderStepsMarkdown(ctx context.Context, tp templates.Template, runtime runtime.Runtime, appTemplate string, params map[string]string, mdFile, title string) error {
 	tmpls, err := tp.LoadMdFiles(appTemplate)
 	if err != nil {
 		return nil
@@ -233,8 +233,6 @@ func renderStepsMarkdown(tp templates.Template, runtime runtime.Runtime, appTemp
 	if err != nil {
 		return fmt.Errorf("failed to load vars file: %w", err)
 	}
-
-	ctx := context.Background()
 
 	// populate the host values set in vars file
 	if err := populateHostValues(ctx, runtime, params, varsData); err != nil {

--- a/ai-services/internal/pkg/cli/podman/deploy.go
+++ b/ai-services/internal/pkg/cli/podman/deploy.go
@@ -32,7 +32,7 @@ func DeployPodAndReadinessCheck(ctx context.Context, rt runtime.Runtime, podSpec
 
 	// ---- Pod Readiness Checks ----
 	for _, pod := range pods {
-		pInfo, err := rt.InspectPod(pod.ID)
+		pInfo, err := rt.InspectPod(ctx, pod.ID)
 		if err != nil {
 			return fmt.Errorf("failed to do pod inspect for podID: '%s' with error: %w", pod.ID, err)
 		}
@@ -69,7 +69,7 @@ func doContainersCreationCheck(ctx context.Context, rt runtime.Runtime, podSpec 
 
 	logger.InfofCtx(ctx, "'%s', '%s': Waiting for Containers Creation... Timeout set: %s\n", podTemplateName, podName, containerCreationTimeout)
 	// wait for all containers for a given pod are created
-	if err := helpers.WaitForContainersCreation(rt, podID, expectedContainerCount, containerCreationTimeout); err != nil {
+	if err := helpers.WaitForContainersCreation(ctx, rt, podID, expectedContainerCount, containerCreationTimeout); err != nil {
 		return fmt.Errorf("containers creation check failed for pod: '%s' with error: %w", podName, err)
 	}
 
@@ -79,7 +79,7 @@ func doContainersCreationCheck(ctx context.Context, rt runtime.Runtime, podSpec 
 }
 
 func doContainerReadinessCheck(ctx context.Context, rt runtime.Runtime, podTemplateName, podName, containerID string) error {
-	cInfo, err := rt.InspectContainer(containerID)
+	cInfo, err := rt.InspectContainer(ctx, containerID)
 	if err != nil {
 		return fmt.Errorf("failed to do container inspect for containerID: '%s' with error: %w", containerID, err)
 	}
@@ -87,7 +87,7 @@ func doContainerReadinessCheck(ctx context.Context, rt runtime.Runtime, podTempl
 	logger.InfofCtx(ctx, "'%s', '%s', '%s': Performing Container Readiness check...\n", podTemplateName, podName, cInfo.Name)
 
 	// getting the Start Period set for a container
-	startPeriod, err := helpers.FetchContainerStartPeriod(rt, containerID)
+	startPeriod, err := helpers.FetchContainerStartPeriod(ctx, rt, containerID)
 	if err != nil {
 		return fmt.Errorf("fetching container: '%s' start period failed: %w", cInfo.Name, err)
 	}
@@ -103,7 +103,7 @@ func doContainerReadinessCheck(ctx context.Context, rt runtime.Runtime, podTempl
 
 	logger.InfofCtx(ctx, "'%s', '%s', '%s': Waiting for Container Readiness... Timeout set: %s\n", podTemplateName, podName, cInfo.Name, readinessTimeout)
 
-	if err := helpers.WaitForContainerReadiness(rt, containerID, readinessTimeout); err != nil {
+	if err := helpers.WaitForContainerReadiness(ctx, rt, containerID, readinessTimeout); err != nil {
 		return fmt.Errorf("readiness check failed for container: '%s'!: %w", cInfo.Name, err)
 	}
 	logger.InfofCtx(ctx, "'%s', '%s', '%s': Readiness Check for the container is completed!\n", podTemplateName, podName, cInfo.Name)

--- a/ai-services/internal/pkg/cli/utils/application_utils.go
+++ b/ai-services/internal/pkg/cli/utils/application_utils.go
@@ -1,15 +1,16 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 )
 
-func GetAllApps(appClient *catalogClient.ApplicationClient) ([]types.Application, error) {
+func GetAllApps(ctx context.Context, appClient *catalogClient.ApplicationClient) ([]types.Application, error) {
 	// List all applications
-	listResponse, err := appClient.ListApplications(nil)
+	listResponse, err := appClient.ListApplications(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch applications: %w", err)
 	}
@@ -17,8 +18,8 @@ func GetAllApps(appClient *catalogClient.ApplicationClient) ([]types.Application
 	return listResponse.Data, nil
 }
 
-func GetAppByName(appClient *catalogClient.ApplicationClient, appName string) (*types.Application, error) {
-	listResponse, err := appClient.ListApplications(nil)
+func GetAppByName(ctx context.Context, appClient *catalogClient.ApplicationClient, appName string) (*types.Application, error) {
+	listResponse, err := appClient.ListApplications(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -33,20 +34,20 @@ func GetAppByName(appClient *catalogClient.ApplicationClient, appName string) (*
 
 // GetAppDetailsWithComponents retrieves full application details including services and components.
 // It first finds the app by name, then fetches full details by ID.
-func GetAppDetailsWithComponents(appName string) (*types.Application, error) {
-	appClient, err := catalogClient.NewApplicationClient()
+func GetAppDetailsWithComponents(ctx context.Context, appName string) (*types.Application, error) {
+	appClient, err := catalogClient.NewApplicationClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create application client: %w", err)
 	}
 
 	// First, find the application by name to get its ID
-	app, err := GetAppByName(appClient, appName)
+	app, err := GetAppByName(ctx, appClient, appName)
 	if err != nil {
 		return nil, err
 	}
 
 	// Then fetch full details including services and components
-	appDetails, err := appClient.GetApplication(app.ID)
+	appDetails, err := appClient.GetApplication(ctx, app.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get application details: %w", err)
 	}

--- a/ai-services/internal/pkg/cli/utils/common.go
+++ b/ai-services/internal/pkg/cli/utils/common.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -15,10 +16,10 @@ import (
 
 // FetchApplications retrieves either all applications or a specific application by name.
 // If appName is empty, it fetches all applications. Otherwise, it fetches the specified application.
-func FetchApplications(appClient *catalogClient.ApplicationClient, appName string) ([]catalogTypes.Application, error) {
+func FetchApplications(ctx context.Context, appClient *catalogClient.ApplicationClient, appName string) ([]catalogTypes.Application, error) {
 	if appName == "" {
 		// Fetch all applications when no specific name is provided
-		applicationList, err := GetAllApps(appClient)
+		applicationList, err := GetAllApps(ctx, appClient)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch all applications: %w", err)
 		}
@@ -27,7 +28,7 @@ func FetchApplications(appClient *catalogClient.ApplicationClient, appName strin
 	}
 
 	// Fetch specific application by name
-	application, err := GetAppByName(appClient, appName)
+	application, err := GetAppByName(ctx, appClient, appName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch application '%s': %w", appName, err)
 	}
@@ -99,19 +100,19 @@ func getContainerNamesFromAPI(pod catalogTypes.Pod) []string {
 	return containerNames
 }
 
-func GetPodsFromApplicationsPS(appName string) ([]types.Pod, error) {
+func GetPodsFromApplicationsPS(ctx context.Context, appName string) ([]types.Pod, error) {
 	var pods []types.Pod //nolint: prealloc
-	appClient, err := catalogClient.NewApplicationClient()
+	appClient, err := catalogClient.NewApplicationClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create application client: %w", err)
 	}
 
-	app, err := GetAppByName(appClient, appName)
+	app, err := GetAppByName(ctx, appClient, appName)
 	if err != nil {
 		return nil, err
 	}
 
-	psResp, err := appClient.GetApplicationPS(app.ID)
+	psResp, err := appClient.GetApplicationPS(ctx, app.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch application: %w", err)
 	}

--- a/ai-services/internal/pkg/image/helper.go
+++ b/ai-services/internal/pkg/image/helper.go
@@ -25,11 +25,11 @@ func PullImageFromRegistry(ctx context.Context, runtime runtime.Runtime, images 
 }
 
 // FetchImagesNotFound returns list of images which are not present locally.
-func FetchImagesNotFound(runtime runtime.Runtime, reqImages []string) ([]string, error) {
+func FetchImagesNotFound(ctx context.Context, runtime runtime.Runtime, reqImages []string) ([]string, error) {
 	notfoundImages := make([]string, 0, len(reqImages))
 
 	// Verify the images existing locally
-	lImages, err := runtime.ListImages()
+	lImages, err := runtime.ListImages(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list local images: %w", err)
 	}

--- a/ai-services/internal/pkg/image/images.go
+++ b/ai-services/internal/pkg/image/images.go
@@ -101,7 +101,7 @@ func (img *Images) always(ctx context.Context, images []string) error {
 
 // IfNotPresent pulls only the missing images for a given app template.
 func (img *Images) IfNotPresent(ctx context.Context, images []string) error {
-	notFoundImages, err := FetchImagesNotFound(img.Runtime, images)
+	notFoundImages, err := FetchImagesNotFound(ctx, img.Runtime, images)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func (img *Images) IfNotPresent(ctx context.Context, images []string) error {
 // never -> never pulls any image.
 // It checks whether all the images for given appTemplate is present locally, if not then raises an error.
 func (img *Images) never(ctx context.Context, images []string) error {
-	notFoundImages, err := FetchImagesNotFound(img.Runtime, images)
+	notFoundImages, err := FetchImagesNotFound(ctx, img.Runtime, images)
 	if err != nil {
 		return err
 	}

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -162,7 +162,7 @@ func extractDomainFromRoute(rawRoute map[string]any) (string, error) {
 }
 
 // GetRouteByID retrieves a specific route by its ID from Caddy.
-func (c *caddyManager) GetRouteByID(routeID string) (*Route, error) {
+func (c *caddyManager) GetRouteByID(ctx context.Context, routeID string) (*Route, error) {
 	idURL, err := url.JoinPath(c.adminURL, "id", routeID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build route ID URL: %w", err)
@@ -170,6 +170,7 @@ func (c *caddyManager) GetRouteByID(routeID string) (*Route, error) {
 
 	var rawRoute map[string]any
 	resp, err := c.httpClient.R().
+		SetContext(ctx).
 		SetResult(&rawRoute).
 		Get(idURL)
 	if err != nil {
@@ -197,7 +198,7 @@ func (c *caddyManager) GetRouteByID(routeID string) (*Route, error) {
 
 // UnregisterRoute removes a route from Caddy by its ID.
 // Returns ErrRouteNotFound if the route doesn't exist (404), nil if successfully deleted (200).
-func (c *caddyManager) UnregisterRoute(routeID string) error {
+func (c *caddyManager) UnregisterRoute(ctx context.Context, routeID string) error {
 	if routeID == "" {
 		return fmt.Errorf("route ID cannot be empty")
 	}
@@ -207,7 +208,7 @@ func (c *caddyManager) UnregisterRoute(routeID string) error {
 		return err
 	}
 
-	resp, err := c.httpClient.R().Delete(idURL)
+	resp, err := c.httpClient.R().SetContext(ctx).Delete(idURL)
 	if err != nil {
 		return fmt.Errorf("failed to unregister route: %w", err)
 	}
@@ -352,7 +353,7 @@ func unregisterRoutes(ctx context.Context, proxyManager ProxyManager, routeIDs m
 	var failedRoutes []string
 
 	for routeID := range routeIDs {
-		if err := proxyManager.UnregisterRoute(routeID); err == nil {
+		if err := proxyManager.UnregisterRoute(ctx, routeID); err == nil {
 			logger.InfofCtx(ctx, "%s %s: Successfully unregistered route: %s", instanceType, instanceID, routeID)
 		} else if errors.Is(err, ErrRouteNotFound) {
 			logger.InfofCtx(ctx, "%s %s: Route not configured for %s (already unregistered)", instanceType, instanceID, routeID)

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -58,12 +58,12 @@ func GetCaddyProxyManager() (ProxyManager, error) {
 }
 
 // HealthCheck verifies Caddy is running and accessible.
-func (c *caddyManager) HealthCheck() error {
+func (c *caddyManager) HealthCheck(ctx context.Context) error {
 	url, err := url.JoinPath(c.adminURL, "config")
 	if err != nil {
 		return err
 	}
-	resp, err := c.httpClient.R().Get(url)
+	resp, err := c.httpClient.R().SetContext(ctx).Get(url)
 
 	if err != nil {
 		return fmt.Errorf("failed to connect to Caddy admin API: %w", err)
@@ -245,7 +245,7 @@ func RegisterRoutesForAppAndReturn(
 	servicePodName string,
 ) ([]Route, error) {
 	// Step 1: Perform health check on Caddy
-	if err := proxyManager.HealthCheck(); err != nil {
+	if err := proxyManager.HealthCheck(ctx); err != nil {
 		return nil, fmt.Errorf(
 			"caddy health check failed, routes not registered: %w",
 			err,

--- a/ai-services/internal/pkg/proxy/types.go
+++ b/ai-services/internal/pkg/proxy/types.go
@@ -8,13 +8,13 @@ type ProxyManager interface {
 	RegisterRoute(ctx context.Context, route Route) error
 
 	// UnregisterRoute removes a route from the proxy by its ID
-	UnregisterRoute(routeID string) error
+	UnregisterRoute(ctx context.Context, routeID string) error
 
 	// HealthCheck verifies the proxy is available and responding
 	HealthCheck(ctx context.Context) error
 
 	// GetRouteByID retrieves a specific route by its ID from the proxy
-	GetRouteByID(routeID string) (*Route, error)
+	GetRouteByID(ctx context.Context, routeID string) (*Route, error)
 }
 
 // Route represents a reverse proxy route configuration.

--- a/ai-services/internal/pkg/proxy/types.go
+++ b/ai-services/internal/pkg/proxy/types.go
@@ -11,7 +11,7 @@ type ProxyManager interface {
 	UnregisterRoute(routeID string) error
 
 	// HealthCheck verifies the proxy is available and responding
-	HealthCheck() error
+	HealthCheck(ctx context.Context) error
 
 	// GetRouteByID retrieves a specific route by its ID from the proxy
 	GetRouteByID(routeID string) (*Route, error)

--- a/ai-services/internal/pkg/proxy/utils.go
+++ b/ai-services/internal/pkg/proxy/utils.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -9,8 +10,8 @@ import (
 )
 
 // GetCaddyAdminPort retrieves the host port mapped to Caddy's admin API (container port 2019).
-func GetCaddyAdminPort(rt runtime.Runtime, podName string) (string, error) {
-	pod, err := rt.InspectPod(podName)
+func GetCaddyAdminPort(ctx context.Context, rt runtime.Runtime, podName string) (string, error) {
+	pod, err := rt.InspectPod(ctx, podName)
 	if err != nil {
 		return "", fmt.Errorf("failed to inspect Caddy pod: %w", err)
 	}

--- a/ai-services/internal/pkg/runtime/common/common.go
+++ b/ai-services/internal/pkg/runtime/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
@@ -10,13 +11,13 @@ import (
 )
 
 // FetchFilteredPods Fetch all pods for a given app based on label.
-func FetchFilteredPods(r runtime.Runtime, appID string) ([]types.Pod, error) {
+func FetchFilteredPods(ctx context.Context, r runtime.Runtime, appID string) ([]types.Pod, error) {
 	listFilters := map[string][]string{}
 	if appID != "" {
 		listFilters["label"] = []string{fmt.Sprintf("%s=%s", constants.ApplicationTemplateKey, appID)}
 	}
 
-	pods, err := r.ListPods(listFilters)
+	pods, err := r.ListPods(ctx, listFilters)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods: %w", err)
 	}
@@ -24,9 +25,9 @@ func FetchFilteredPods(r runtime.Runtime, appID string) ([]types.Pod, error) {
 	return pods, nil
 }
 
-func ProcessPod(r runtime.Runtime, pod types.Pod) (*types.Pod, error) {
+func ProcessPod(ctx context.Context, r runtime.Runtime, pod types.Pod) (*types.Pod, error) {
 	// do pod inspect
-	pInfo, err := r.InspectPod(pod.ID)
+	pInfo, err := r.InspectPod(ctx, pod.ID)
 	if err != nil {
 		// log and skip pod if inspect failed
 		logger.Errorf("Failed to do pod inspect: '%s' with error: %v", pod.ID, err)
@@ -34,7 +35,7 @@ func ProcessPod(r runtime.Runtime, pod types.Pod) (*types.Pod, error) {
 		return nil, nil
 	}
 	// load pod status
-	pInfo.Status, pInfo.Health = getPodStatus(r, pInfo)
+	pInfo.Status, pInfo.Health = getPodStatus(ctx, r, pInfo)
 
 	// truncate podID to 13 characters
 	const podIDShortLength = 13
@@ -48,12 +49,12 @@ func ProcessPod(r runtime.Runtime, pod types.Pod) (*types.Pod, error) {
 	return pInfo, nil
 }
 
-func getPodStatus(r runtime.Runtime, pInfo *types.Pod) (string, string) {
+func getPodStatus(ctx context.Context, r runtime.Runtime, pInfo *types.Pod) (string, string) {
 	// if the pod Status is running, make sure to check if its healthy or not, otherwise fallback to default pod state
 	if pInfo.State == "Running" {
 		healthyContainers := 0
 		for i, container := range pInfo.Containers {
-			cInfo, err := r.InspectContainer(container.ID)
+			cInfo, err := r.InspectContainer(ctx, container.ID)
 			if err != nil {
 				// skip container if inspect failed
 				logger.Debugf("failed to do container inspect for pod: '%s', containerID: '%s' with error: %v", pInfo.Name, container.ID, err)

--- a/ai-services/internal/pkg/runtime/interface.go
+++ b/ai-services/internal/pkg/runtime/interface.go
@@ -11,53 +11,53 @@ import (
 
 type Runtime interface {
 	// Image operations
-	ListImages() ([]types.Image, error)
+	ListImages(ctx context.Context) ([]types.Image, error)
 	PullImage(ctx context.Context, image string) error
 
 	// Pod operations
-	ListPods(filters map[string][]string) ([]types.Pod, error)
+	ListPods(ctx context.Context, filters map[string][]string) ([]types.Pod, error)
 	CreatePod(ctx context.Context, body io.Reader, opts map[string]string) ([]types.Pod, error)
-	DeletePod(nameOrID string, force *bool) error
-	StopPod(nameOrID string) error
-	StartPod(nameOrID string) error
-	InspectPod(nameOrID string) (*types.Pod, error)
-	PodExists(nameOrID string) (bool, error)
-	PodLogs(nameOrID string) error
-	GetPodResources(nameOrID string) (*types.PodResources, error)
-	GetNamespace() (string, error)
+	DeletePod(ctx context.Context, id string, force *bool) error
+	StopPod(ctx context.Context, id string) error
+	StartPod(ctx context.Context, id string) error
+	InspectPod(ctx context.Context, nameOrId string) (*types.Pod, error)
+	PodExists(ctx context.Context, nameOrID string) (bool, error)
+	PodLogs(ctx context.Context, nameOrID string) error
+	GetPodResources(ctx context.Context, nameOrID string) (*types.PodResources, error)
+	GetNamespace(ctx context.Context) (string, error)
 
 	// Secret operations
-	ListSecrets(filters map[string][]string) ([]string, error)
-	DeleteSecret(name string) error
-	SecretExists(nameOrID string) (bool, error)
-	UpdateSecret(name, deploymentName string, data map[string][]byte) error
+	ListSecrets(ctx context.Context, filters map[string][]string) ([]string, error)
+	DeleteSecret(ctx context.Context, name string) error
+	SecretExists(ctx context.Context, nameOrID string) (bool, error)
+	UpdateSecret(ctx context.Context, name, deploymentName string, data map[string][]byte) error
 
 	// Volume operations
-	DeleteVolume(name string) error
-	VolumeExists(nameOrID string) (bool, error)
+	DeleteVolume(ctx context.Context, name string) error
+	VolumeExists(ctx context.Context, nameOrID string) (bool, error)
 
 	// Container operations
-	// ListContainers(filters map[string][]string) ([]types.Container, error)
-	InspectContainer(nameOrID string) (*types.Container, error)
-	ContainerExists(nameOrID string) (bool, error)
-	ContainerLogs(containerNameOrID string) error
-	ExecInContainerWithCmd(podName, containerName string, command []string) (string, error)
+	// ListContainers(ctx context.Context, filters map[string][]string) ([]types.Container, error)
+	InspectContainer(ctx context.Context, nameOrId string) (*types.Container, error)
+	ContainerExists(ctx context.Context, nameOrID string) (bool, error)
+	ContainerLogs(ctx context.Context, containerNameOrID string) error
+	ExecInContainerWithCmd(ctx context.Context, podName, containerName string, command []string) (string, error)
 
 	// Network operations
-	ListRoutes(labelSelector string) ([]types.Route, error)
+	ListRoutes(ctx context.Context, labelSelector string) ([]types.Route, error)
 
 	// ListCRD populates crd list
 	// resources in the namespace that carry every label key in filters["label"].
-	ListCRD(list *unstructured.UnstructuredList, filters map[string][]string) ([]types.CRDResource, error)
+	ListCRD(ctx context.Context, list *unstructured.UnstructuredList, filters map[string][]string) ([]types.CRDResource, error)
 
 	// Namespace operations
-	DeleteNamespace(name string) error
+	DeleteNamespace(ctx context.Context, name string) error
 
 	// PVC operations
-	DeletePVCs(appLabel string) error
+	DeletePVCs(ctx context.Context, appLabel string) error
 
 	// System information
-	GetSystemInfo() (*models.SystemInfo, error)
+	GetSystemInfo(ctx context.Context) (*models.SystemInfo, error)
 
 	// Runtime type identification
 	Type() types.RuntimeType

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -72,7 +72,6 @@ type OpenshiftClient struct {
 	KubeClient  *kubernetes.Clientset
 	RouteClient *routeclient.Clientset
 	Namespace   string
-	Ctx         context.Context
 }
 
 // NewOpenshiftClient creates and returns an OpenshiftClient instance.
@@ -99,7 +98,6 @@ func NewOpenshiftClientWithNamespace(namespace string) (*OpenshiftClient, error)
 		KubeClient:  kubeClient,
 		RouteClient: routeClient,
 		Namespace:   namespace,
-		Ctx:         context.Background(),
 	}, nil
 }
 
@@ -240,7 +238,7 @@ func (kc *OpenshiftClient) DeletePod(_ context.Context, id string, force *bool) 
 
 // InspectPod inspects a pod and returns detailed information.
 func (kc *OpenshiftClient) InspectPod(ctx context.Context, nameOrID string) (*types.Pod, error) {
-	podName, err := getPodNameWithPrefix(kc, nameOrID)
+	podName, err := getPodNameWithPrefix(ctx, kc, nameOrID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect the pod: %w", err)
 	}
@@ -258,9 +256,9 @@ func (kc *OpenshiftClient) InspectPod(ctx context.Context, nameOrID string) (*ty
 }
 
 // PodExists checks if a pod exists.
-func (kc *OpenshiftClient) PodExists(_ context.Context, nameOrID string) (bool, error) {
+func (kc *OpenshiftClient) PodExists(ctx context.Context, nameOrID string) (bool, error) {
 	// Since OpenShift pod names have a random string added to it we cannot use Get() here.
-	_, err := getPodNameWithPrefix(kc, nameOrID)
+	_, err := getPodNameWithPrefix(ctx, kc, nameOrID)
 	if err != nil {
 		return false, fmt.Errorf("failed to list pods: %w", err)
 	}
@@ -283,8 +281,8 @@ func (kc *OpenshiftClient) StartPod(_ context.Context, id string) error {
 }
 
 // PodLogs retrieves logs from a pod.
-func (kc *OpenshiftClient) PodLogs(_ context.Context, podNameOrID string) error {
-	podName, err := getPodNameWithPrefix(kc, podNameOrID)
+func (kc *OpenshiftClient) PodLogs(ctx context.Context, podNameOrID string) error {
+	podName, err := getPodNameWithPrefix(ctx, kc, podNameOrID)
 	if err != nil {
 		return fmt.Errorf("failed to get the pod: %w", err)
 	}
@@ -294,7 +292,7 @@ func (kc *OpenshiftClient) PodLogs(_ context.Context, podNameOrID string) error 
 		Follow: true,
 	}
 
-	return followLogs(kc, podName, opts)
+	return followLogs(ctx, kc, podName, opts)
 }
 
 // InspectContainer inspects a container.
@@ -357,7 +355,7 @@ func (kc *OpenshiftClient) ContainerLogs(ctx context.Context, containerNameOrID 
 					Follow:    true,
 				}
 
-				return followLogs(kc, pod.Name, opts)
+				return followLogs(ctx, kc, pod.Name, opts)
 			}
 		}
 	}
@@ -432,8 +430,8 @@ func (kc *OpenshiftClient) Type() types.RuntimeType {
 	return types.RuntimeTypeOpenShift
 }
 
-func getPodNameWithPrefix(kc *OpenshiftClient, nameOrID string) (string, error) {
-	pods, err := kc.ListPods(kc.Ctx, nil)
+func getPodNameWithPrefix(ctx context.Context, kc *OpenshiftClient, nameOrID string) (string, error) {
+	pods, err := kc.ListPods(ctx, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to list pods: %w", err)
 	}
@@ -447,9 +445,9 @@ func getPodNameWithPrefix(kc *OpenshiftClient, nameOrID string) (string, error) 
 	return "", fmt.Errorf("cannot find pod: %s", nameOrID)
 }
 
-func followLogs(kc *OpenshiftClient, podName string, opts *corev1.PodLogOptions) error {
-	// Create interrupt-aware context (Ctrl+C)
-	ctx, stop := signal.NotifyContext(kc.Ctx, os.Interrupt, syscall.SIGTERM)
+func followLogs(ctx context.Context, kc *OpenshiftClient, podName string, opts *corev1.PodLogOptions) error {
+	// Create interrupt-aware context (Ctrl+C), child of the caller's context.
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	req := kc.KubeClient.CoreV1().Pods(kc.Namespace).GetLogs(podName, opts)
@@ -525,7 +523,7 @@ func (kc *OpenshiftClient) UpdateSecret(ctx context.Context, name, deploymentNam
 		return fmt.Errorf("failed to update secret: %w", err)
 	}
 
-	if err := kc.rolloutRestartDeployment(deploymentName); err != nil {
+	if err := kc.rolloutRestartDeployment(ctx, deploymentName); err != nil {
 		return fmt.Errorf("failed to restart deployment after secret update: %w", err)
 	}
 
@@ -536,7 +534,7 @@ func (kc *OpenshiftClient) UpdateSecret(ctx context.Context, name, deploymentNam
 
 	deadline := time.Now().Add(pollTimeout)
 	for time.Now().Before(deadline) {
-		ready, err := kc.isDeploymentReady(deploymentName)
+		ready, err := kc.isDeploymentReady(ctx, deploymentName)
 		if err != nil {
 			return fmt.Errorf("failed to check deployment readiness: %w", err)
 		}
@@ -617,7 +615,7 @@ func (kc *OpenshiftClient) GetSystemInfo(ctx context.Context) (*models.SystemInf
 	// --- Spyre cards ---
 	// Read directly from node capacity/allocatable so the count is accurate
 	// even when Thanos has not yet scraped the custom resource metric.
-	spyreInfo, err := kc.getSpyreCardInfo()
+	spyreInfo, err := kc.getSpyreCardInfo(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve Spyre card info: %w", err)
 	}
@@ -630,8 +628,19 @@ func (kc *OpenshiftClient) GetSystemInfo(ctx context.Context) (*models.SystemInf
 
 // getSpyreCardInfo returns the total and available ibm.com/spyre_pf count for
 // the cluster.
-func (kc *OpenshiftClient) getSpyreCardInfo() (*models.AcceleratorInfo, error) {
-	totalSpyre, err := kc.sumSpyreCapacity()
+//
+// Total is read from node.Status.Capacity — the raw hardware count advertised
+// by the Spyre device plugin.
+//
+// Available is computed as:
+//
+//	Total − (Thanos: sum of ibm.com/spyre_pf requests across all non-infra containers)
+//
+// The in-use count is fetched via Thanos using:
+//
+//	sum(kube_pod_container_resource_requests{resource="ibm_com_spyre_pf",container!=""})
+func (kc *OpenshiftClient) getSpyreCardInfo(ctx context.Context) (*models.AcceleratorInfo, error) {
+	totalSpyre, err := kc.sumSpyreCapacity(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -640,7 +649,7 @@ func (kc *OpenshiftClient) getSpyreCardInfo() (*models.AcceleratorInfo, error) {
 		return nil, nil //nolint:nilnil // no Spyre cards present — caller omits the key
 	}
 
-	usedSpyre, err := kc.sumSpyreInUse()
+	usedSpyre, err := kc.sumSpyreInUse(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -657,8 +666,8 @@ func (kc *OpenshiftClient) getSpyreCardInfo() (*models.AcceleratorInfo, error) {
 }
 
 // sumSpyreCapacity sums ibm.com/spyre_pf Capacity across all cluster nodes.
-func (kc *OpenshiftClient) sumSpyreCapacity() (int64, error) {
-	nodeList, err := kc.KubeClient.CoreV1().Nodes().List(kc.Ctx, metav1.ListOptions{})
+func (kc *OpenshiftClient) sumSpyreCapacity(ctx context.Context) (int64, error) {
+	nodeList, err := kc.KubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return 0, fmt.Errorf("failed to list nodes: %w", err)
 	}
@@ -674,9 +683,12 @@ func (kc *OpenshiftClient) sumSpyreCapacity() (int64, error) {
 	return total, nil
 }
 
-// sumSpyreInUse queries Thanos for the total number of ibm.com/spyre_pf units currently requested.
-func (kc *OpenshiftClient) sumSpyreInUse() (int64, error) {
-	used, err := queryThanos(kc.Ctx, `sum(kube_pod_container_resource_requests{resource="ibm_com_spyre_pf",container!=""})`)
+// sumSpyreInUse queries Thanos for the total number of ibm.com/spyre_pf units
+// currently requested by all non-infra containers cluster-wide.
+//
+// PromQL: sum(kube_pod_container_resource_requests{resource="ibm_com_spyre_pf",container!=""}).
+func (kc *OpenshiftClient) sumSpyreInUse(ctx context.Context) (int64, error) {
+	used, err := queryThanos(ctx, `sum(kube_pod_container_resource_requests{resource="ibm_com_spyre_pf",container!=""})`)
 	if err != nil {
 		return 0, fmt.Errorf("failed to query Spyre cards in use: %w", err)
 	}
@@ -692,7 +704,7 @@ func (kc *OpenshiftClient) GetPodResources(ctx context.Context, podName string) 
 	}
 
 	spyreCards := []string{}
-	collectSpyreCardsFromPod(kc, pod, &spyreCards)
+	collectSpyreCardsFromPod(ctx, kc, pod, &spyreCards)
 
 	cpuQuery := fmt.Sprintf(
 		`sum(rate(container_cpu_usage_seconds_total{namespace=%q,pod=%q,container!=""}[5m]))`,
@@ -722,12 +734,21 @@ func (kc *OpenshiftClient) GetPodResources(ctx context.Context, podName string) 
 }
 
 // collectSpyreCardsFromPod reads the PCIDEVICE_IBM_COM_AIU_PF environment variable
-// from the live environment of each non-init container in the pod.
-func collectSpyreCardsFromPod(kc *OpenshiftClient, pod *corev1.Pod, spyreCards *[]string) {
+// from the live environment of each non-init container in the pod by exec-ing
+// into it via the Kubernetes API server's pod/exec subresource.
+//
+// This variable is injected at runtime by the Kubernetes Spyre device plugin and
+// is NOT present in pod.Spec.Containers[].Env (the static pod spec). It is only
+// visible via `oc exec <pod> -- env`, equivalent to what this function does.
+//
+// The value is comma-separated, e.g.:
+//
+//	PCIDEVICE_IBM_COM_AIU_PF=0182:60:00.0,0183:70:00.0,0481:50:00.0,0181:50:00.0
+func collectSpyreCardsFromPod(ctx context.Context, kc *OpenshiftClient, pod *corev1.Pod, spyreCards *[]string) {
 	for i := range pod.Spec.Containers {
 		containerName := pod.Spec.Containers[i].Name
 
-		output, err := kc.ExecInContainerWithCmd(kc.Ctx, pod.Name, containerName, []string{"env"})
+		output, err := kc.ExecInContainerWithCmd(ctx, pod.Name, containerName, []string{"env"})
 		if err != nil {
 			logger.Warningf("collectSpyreCardsFromPod: exec failed for container %s in pod %s/%s: %v", containerName, pod.Namespace, pod.Name, err)
 
@@ -776,8 +797,8 @@ func (kc *OpenshiftClient) ExecInContainerWithCmd(ctx context.Context, podName, 
 }
 
 // isDeploymentReady reports whether a rollout of the named deployment has fully completed.
-func (kc *OpenshiftClient) isDeploymentReady(name string) (bool, error) {
-	deployment, err := kc.KubeClient.AppsV1().Deployments(kc.Namespace).Get(kc.Ctx, name, metav1.GetOptions{})
+func (kc *OpenshiftClient) isDeploymentReady(ctx context.Context, name string) (bool, error) {
+	deployment, err := kc.KubeClient.AppsV1().Deployments(kc.Namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return false, fmt.Errorf("failed to get deployment %q: %w", name, err)
 	}
@@ -798,8 +819,10 @@ func (kc *OpenshiftClient) isDeploymentReady(name string) (bool, error) {
 		s.AvailableReplicas == desired, nil
 }
 
-// rolloutRestartDeployment triggers a rollout restart for the named deployment.
-func (kc *OpenshiftClient) rolloutRestartDeployment(name string) error {
+// rolloutRestartDeployment triggers a rollout restart for the named deployment by
+// patching the pod template annotation "kubectl.kubernetes.io/restartedAt", which is
+// the same mechanism used by `kubectl rollout restart deployment <name>`.
+func (kc *OpenshiftClient) rolloutRestartDeployment(ctx context.Context, name string) error {
 	patch := map[string]interface{}{
 		"spec": map[string]interface{}{
 			"template": map[string]interface{}{
@@ -818,7 +841,7 @@ func (kc *OpenshiftClient) rolloutRestartDeployment(name string) error {
 	}
 
 	_, err = kc.KubeClient.AppsV1().Deployments(kc.Namespace).Patch(
-		kc.Ctx,
+		ctx,
 		name,
 		k8stypes.MergePatchType,
 		data,

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -176,7 +176,7 @@ func getKubeConfig() (*rest.Config, error) {
 }
 
 // ListImages lists container images.
-func (kc *OpenshiftClient) ListImages() ([]types.Image, error) {
+func (kc *OpenshiftClient) ListImages(_ context.Context) ([]types.Image, error) {
 	logger.Warningln("ListImages is not implemented for OpenshiftClient. Returning empty list.")
 
 	return []types.Image{}, nil
@@ -190,8 +190,8 @@ func (kc *OpenshiftClient) PullImage(_ context.Context, image string) error {
 }
 
 // GetNamespace fetches the namespace details.
-func (kc *OpenshiftClient) GetNamespace() (string, error) {
-	ns, err := kc.KubeClient.CoreV1().Namespaces().Get(kc.Ctx, kc.Namespace, metav1.GetOptions{})
+func (kc *OpenshiftClient) GetNamespace(ctx context.Context) (string, error) {
+	ns, err := kc.KubeClient.CoreV1().Namespaces().Get(ctx, kc.Namespace, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return "", fmt.Errorf("%w: %s", ErrNamespaceNotFound, kc.Namespace)
@@ -204,7 +204,7 @@ func (kc *OpenshiftClient) GetNamespace() (string, error) {
 }
 
 // ListPods lists pods with optional filters.
-func (kc *OpenshiftClient) ListPods(filters map[string][]string) ([]types.Pod, error) {
+func (kc *OpenshiftClient) ListPods(ctx context.Context, filters map[string][]string) ([]types.Pod, error) {
 	labels := client.MatchingLabels{}
 	if labelFilters, exists := filters["label"]; exists {
 		for _, lf := range labelFilters {
@@ -216,7 +216,7 @@ func (kc *OpenshiftClient) ListPods(filters map[string][]string) ([]types.Pod, e
 	}
 
 	podList := &corev1.PodList{}
-	err := kc.Client.List(kc.Ctx, podList, client.InNamespace(kc.Namespace), labels)
+	err := kc.Client.List(ctx, podList, client.InNamespace(kc.Namespace), labels)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods: %w", err)
 	}
@@ -232,21 +232,21 @@ func (kc *OpenshiftClient) CreatePod(_ context.Context, body io.Reader, opts map
 }
 
 // DeletePod deletes a pod by ID or name.
-func (kc *OpenshiftClient) DeletePod(nameOrID string, force *bool) error {
+func (kc *OpenshiftClient) DeletePod(_ context.Context, id string, force *bool) error {
 	logger.Warningln("Not implemented")
 
 	return nil
 }
 
 // InspectPod inspects a pod and returns detailed information.
-func (kc *OpenshiftClient) InspectPod(nameOrID string) (*types.Pod, error) {
+func (kc *OpenshiftClient) InspectPod(ctx context.Context, nameOrID string) (*types.Pod, error) {
 	podName, err := getPodNameWithPrefix(kc, nameOrID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect the pod: %w", err)
 	}
 
 	pod := &corev1.Pod{}
-	err = kc.Client.Get(kc.Ctx, client.ObjectKey{
+	err = kc.Client.Get(ctx, client.ObjectKey{
 		Name:      podName,
 		Namespace: kc.Namespace,
 	}, pod)
@@ -258,7 +258,7 @@ func (kc *OpenshiftClient) InspectPod(nameOrID string) (*types.Pod, error) {
 }
 
 // PodExists checks if a pod exists.
-func (kc *OpenshiftClient) PodExists(nameOrID string) (bool, error) {
+func (kc *OpenshiftClient) PodExists(_ context.Context, nameOrID string) (bool, error) {
 	// Since OpenShift pod names have a random string added to it we cannot use Get() here.
 	_, err := getPodNameWithPrefix(kc, nameOrID)
 	if err != nil {
@@ -269,21 +269,21 @@ func (kc *OpenshiftClient) PodExists(nameOrID string) (bool, error) {
 }
 
 // StopPod stops a pod.
-func (kc *OpenshiftClient) StopPod(nameOrID string) error {
+func (kc *OpenshiftClient) StopPod(_ context.Context, id string) error {
 	logger.Warningf("Unsupported for openshift runtime")
 
 	return nil
 }
 
 // StartPod starts a pod.
-func (kc *OpenshiftClient) StartPod(nameOrID string) error {
+func (kc *OpenshiftClient) StartPod(_ context.Context, id string) error {
 	logger.Warningf("Unsupported for openshift runtime")
 
 	return nil
 }
 
 // PodLogs retrieves logs from a pod.
-func (kc *OpenshiftClient) PodLogs(podNameOrID string) error {
+func (kc *OpenshiftClient) PodLogs(_ context.Context, podNameOrID string) error {
 	podName, err := getPodNameWithPrefix(kc, podNameOrID)
 	if err != nil {
 		return fmt.Errorf("failed to get the pod: %w", err)
@@ -298,9 +298,9 @@ func (kc *OpenshiftClient) PodLogs(podNameOrID string) error {
 }
 
 // InspectContainer inspects a container.
-func (kc *OpenshiftClient) InspectContainer(nameOrID string) (*types.Container, error) {
+func (kc *OpenshiftClient) InspectContainer(ctx context.Context, nameOrID string) (*types.Container, error) {
 	pods := &corev1.PodList{}
-	err := kc.Client.List(kc.Ctx, pods, client.InNamespace(kc.Namespace))
+	err := kc.Client.List(ctx, pods, client.InNamespace(kc.Namespace))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods: %w", err)
 	}
@@ -317,10 +317,10 @@ func (kc *OpenshiftClient) InspectContainer(nameOrID string) (*types.Container, 
 }
 
 // ContainerExists checks if a container exists.
-func (kc *OpenshiftClient) ContainerExists(nameOrID string) (bool, error) {
+func (kc *OpenshiftClient) ContainerExists(ctx context.Context, nameOrID string) (bool, error) {
 	// In Openshift, we check if any pod contains this container
 	pods := &corev1.PodList{}
-	err := kc.Client.List(kc.Ctx, pods, client.InNamespace(kc.Namespace))
+	err := kc.Client.List(ctx, pods, client.InNamespace(kc.Namespace))
 	if err != nil {
 		return false, fmt.Errorf("failed to check container: %w", err)
 	}
@@ -337,14 +337,14 @@ func (kc *OpenshiftClient) ContainerExists(nameOrID string) (bool, error) {
 }
 
 // ContainerLogs retrieves logs from a specific container.
-func (kc *OpenshiftClient) ContainerLogs(containerNameOrID string) error {
+func (kc *OpenshiftClient) ContainerLogs(ctx context.Context, containerNameOrID string) error {
 	if containerNameOrID == "" {
 		return fmt.Errorf("container name is required to fetch logs")
 	}
 
 	// In Openshift, we check if any pod contains this container
 	pods := &corev1.PodList{}
-	if err := kc.Client.List(kc.Ctx, pods, client.InNamespace(kc.Namespace)); err != nil {
+	if err := kc.Client.List(ctx, pods, client.InNamespace(kc.Namespace)); err != nil {
 		return fmt.Errorf("failed to check container: %w", err)
 	}
 
@@ -367,7 +367,7 @@ func (kc *OpenshiftClient) ContainerLogs(containerNameOrID string) error {
 
 // ListCRD populates list resources based on input
 // resources in the client namespace that carry every label key in filters["label"].
-func (kc *OpenshiftClient) ListCRD(list *unstructured.UnstructuredList, filters map[string][]string) ([]types.CRDResource, error) {
+func (kc *OpenshiftClient) ListCRD(ctx context.Context, list *unstructured.UnstructuredList, filters map[string][]string) ([]types.CRDResource, error) {
 	labelKeys := []string{}
 	if labelFilters, exists := filters["label"]; exists {
 		labelKeys = append(labelKeys, labelFilters...)
@@ -378,7 +378,7 @@ func (kc *OpenshiftClient) ListCRD(list *unstructured.UnstructuredList, filters 
 		client.HasLabels(labelKeys),
 	}
 
-	if err := kc.Client.List(kc.Ctx, list, opts...); err != nil {
+	if err := kc.Client.List(ctx, list, opts...); err != nil {
 		return nil, fmt.Errorf("failed to list CRD resources : %w", err)
 	}
 
@@ -393,10 +393,9 @@ func (kc *OpenshiftClient) ListCRD(list *unstructured.UnstructuredList, filters 
 	return result, nil
 }
 
-// ListRoutes lists all routes in the namespace.
 // ListRoutes lists routes in the namespace. Pass an empty string to list all routes.
-func (kc *OpenshiftClient) ListRoutes(labelSelector string) ([]types.Route, error) {
-	routeList, err := kc.RouteClient.RouteV1().Routes(kc.Namespace).List(kc.Ctx, metav1.ListOptions{
+func (kc *OpenshiftClient) ListRoutes(ctx context.Context, labelSelector string) ([]types.Route, error) {
+	routeList, err := kc.RouteClient.RouteV1().Routes(kc.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {
@@ -407,8 +406,8 @@ func (kc *OpenshiftClient) ListRoutes(labelSelector string) ([]types.Route, erro
 }
 
 // DeletePVCs deletes all PVCs matching the given application label.
-func (kc *OpenshiftClient) DeletePVCs(appLabel string) error {
-	pvcs, err := kc.KubeClient.CoreV1().PersistentVolumeClaims(kc.Namespace).List(kc.Ctx, metav1.ListOptions{
+func (kc *OpenshiftClient) DeletePVCs(ctx context.Context, appLabel string) error {
+	pvcs, err := kc.KubeClient.CoreV1().PersistentVolumeClaims(kc.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: appLabel,
 	})
 	if err != nil {
@@ -416,7 +415,7 @@ func (kc *OpenshiftClient) DeletePVCs(appLabel string) error {
 	}
 
 	for _, pvc := range pvcs.Items {
-		if err := kc.KubeClient.CoreV1().PersistentVolumeClaims(kc.Namespace).Delete(kc.Ctx, pvc.Name, metav1.DeleteOptions{}); err != nil {
+		if err := kc.KubeClient.CoreV1().PersistentVolumeClaims(kc.Namespace).Delete(ctx, pvc.Name, metav1.DeleteOptions{}); err != nil {
 			logger.Warningf("Failed to delete PVC '%s': %v\n", pvc.Name, err)
 
 			continue
@@ -434,7 +433,7 @@ func (kc *OpenshiftClient) Type() types.RuntimeType {
 }
 
 func getPodNameWithPrefix(kc *OpenshiftClient, nameOrID string) (string, error) {
-	pods, err := kc.ListPods(nil)
+	pods, err := kc.ListPods(kc.Ctx, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to list pods: %w", err)
 	}
@@ -484,20 +483,20 @@ func followLogs(kc *OpenshiftClient, podName string, opts *corev1.PodLogOptions)
 	return nil
 }
 
-func (kc *OpenshiftClient) ListSecrets(filters map[string][]string) ([]string, error) {
+func (kc *OpenshiftClient) ListSecrets(_ context.Context, filters map[string][]string) ([]string, error) {
 	logger.Warningln("Not implemented")
 
 	return nil, nil
 }
 
-func (kc *OpenshiftClient) DeleteSecret(name string) error {
+func (kc *OpenshiftClient) DeleteSecret(_ context.Context, name string) error {
 	logger.Warningln("Not implemented")
 
 	return nil
 }
 
-func (kc *OpenshiftClient) SecretExists(nameOrID string) (bool, error) {
-	_, err := kc.KubeClient.CoreV1().Secrets(kc.Namespace).Get(kc.Ctx, nameOrID, metav1.GetOptions{})
+func (kc *OpenshiftClient) SecretExists(ctx context.Context, nameOrID string) (bool, error) {
+	_, err := kc.KubeClient.CoreV1().Secrets(kc.Namespace).Get(ctx, nameOrID, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return false, nil
@@ -509,10 +508,10 @@ func (kc *OpenshiftClient) SecretExists(nameOrID string) (bool, error) {
 	return true, nil
 }
 
-func (kc *OpenshiftClient) UpdateSecret(name, deploymentName string, data map[string][]byte) error {
+func (kc *OpenshiftClient) UpdateSecret(ctx context.Context, name, deploymentName string, data map[string][]byte) error {
 	secretClient := kc.KubeClient.CoreV1().Secrets(kc.Namespace)
 
-	existing, err := secretClient.Get(kc.Ctx, name, metav1.GetOptions{})
+	existing, err := secretClient.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get existing secret: %w", err)
 	}
@@ -521,7 +520,7 @@ func (kc *OpenshiftClient) UpdateSecret(name, deploymentName string, data map[st
 		existing.Data[k] = v
 	}
 
-	_, err = secretClient.Update(kc.Ctx, existing, metav1.UpdateOptions{})
+	_, err = secretClient.Update(ctx, existing, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to update secret: %w", err)
 	}
@@ -550,14 +549,14 @@ func (kc *OpenshiftClient) UpdateSecret(name, deploymentName string, data map[st
 	return fmt.Errorf("timed out waiting for deployment %q to become ready after secret update", deploymentName)
 }
 
-func (kc *OpenshiftClient) DeleteVolume(name string) error {
+func (kc *OpenshiftClient) DeleteVolume(_ context.Context, name string) error {
 	logger.Warningln("Not implemented")
 
 	return nil
 }
 
-func (kc *OpenshiftClient) VolumeExists(nameOrID string) (bool, error) {
-	_, err := kc.KubeClient.CoreV1().PersistentVolumeClaims(kc.Namespace).Get(kc.Ctx, nameOrID, metav1.GetOptions{})
+func (kc *OpenshiftClient) VolumeExists(ctx context.Context, nameOrID string) (bool, error) {
+	_, err := kc.KubeClient.CoreV1().PersistentVolumeClaims(kc.Namespace).Get(ctx, nameOrID, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return false, nil
@@ -578,18 +577,18 @@ func (kc *OpenshiftClient) VolumeExists(nameOrID string) (bool, error) {
 //   - Available mem : sum(kube_node_status_allocatable{resource="memory"})
 //
 // Spyre card counts are read directly from the Kubernetes API — see getSpyreCardInfo.
-func (kc *OpenshiftClient) GetSystemInfo() (*models.SystemInfo, error) {
+func (kc *OpenshiftClient) GetSystemInfo(ctx context.Context) (*models.SystemInfo, error) {
 	sysInfo := &models.SystemInfo{
 		Accelerators: make(map[string]*models.AcceleratorInfo),
 	}
 
 	// --- CPU ---
-	totalCPU, err := queryThanos(kc.Ctx, `sum(kube_node_status_capacity{resource="cpu"})`)
+	totalCPU, err := queryThanos(ctx, `sum(kube_node_status_capacity{resource="cpu"})`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query total CPU capacity: %w", err)
 	}
 
-	availCPU, err := queryThanos(kc.Ctx, `sum(kube_node_status_allocatable{resource="cpu"})`)
+	availCPU, err := queryThanos(ctx, `sum(kube_node_status_allocatable{resource="cpu"})`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query allocatable CPU: %w", err)
 	}
@@ -600,12 +599,12 @@ func (kc *OpenshiftClient) GetSystemInfo() (*models.SystemInfo, error) {
 	}
 
 	// --- Memory ---
-	totalMem, err := queryThanos(kc.Ctx, `sum(kube_node_status_capacity{resource="memory"})`)
+	totalMem, err := queryThanos(ctx, `sum(kube_node_status_capacity{resource="memory"})`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query total memory capacity: %w", err)
 	}
 
-	availMem, err := queryThanos(kc.Ctx, `sum(kube_node_status_allocatable{resource="memory"})`)
+	availMem, err := queryThanos(ctx, `sum(kube_node_status_allocatable{resource="memory"})`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query allocatable memory: %w", err)
 	}
@@ -631,17 +630,6 @@ func (kc *OpenshiftClient) GetSystemInfo() (*models.SystemInfo, error) {
 
 // getSpyreCardInfo returns the total and available ibm.com/spyre_pf count for
 // the cluster.
-//
-// Total is read from node.Status.Capacity — the raw hardware count advertised
-// by the Spyre device plugin.
-//
-// Available is computed as:
-//
-//	Total − (Thanos: sum of ibm.com/spyre_pf requests across all non-infra containers)
-//
-// The in-use count is fetched via Thanos using:
-//
-//	sum(kube_pod_container_resource_requests{resource="ibm_com_spyre_pf",container!=""})
 func (kc *OpenshiftClient) getSpyreCardInfo() (*models.AcceleratorInfo, error) {
 	totalSpyre, err := kc.sumSpyreCapacity()
 	if err != nil {
@@ -686,10 +674,7 @@ func (kc *OpenshiftClient) sumSpyreCapacity() (int64, error) {
 	return total, nil
 }
 
-// sumSpyreInUse queries Thanos for the total number of ibm.com/spyre_pf units
-// currently requested by all non-infra containers cluster-wide.
-//
-// PromQL: sum(kube_pod_container_resource_requests{resource="ibm_com_spyre_pf",container!=""}).
+// sumSpyreInUse queries Thanos for the total number of ibm.com/spyre_pf units currently requested.
 func (kc *OpenshiftClient) sumSpyreInUse() (int64, error) {
 	used, err := queryThanos(kc.Ctx, `sum(kube_pod_container_resource_requests{resource="ibm_com_spyre_pf",container!=""})`)
 	if err != nil {
@@ -700,43 +685,31 @@ func (kc *OpenshiftClient) sumSpyreInUse() (int64, error) {
 }
 
 // GetPodResources retrieves resource usage and Spyre card assignments for a pod.
-//
-// CPU and memory are fetched from the in-cluster Thanos Querier using PromQL:
-//   - CPU  : rate(container_cpu_usage_seconds_total{pod="<name>",container!=""}[5m])
-//   - Memory: container_memory_working_set_bytes{pod="<name>",container!=""}
-//
-// Spyre card PCI addresses are read from the PCIDEVICE_IBM_COM_AIU_PF environment variable
-// set on each container in the pod spec (same convention as the Podman runtime).
-func (kc *OpenshiftClient) GetPodResources(podName string) (*types.PodResources, error) {
-	// Fetch the full pod spec to read container env vars for Spyre cards.
-	pod, err := kc.KubeClient.CoreV1().Pods(kc.Namespace).Get(kc.Ctx, podName, metav1.GetOptions{})
+func (kc *OpenshiftClient) GetPodResources(ctx context.Context, podName string) (*types.PodResources, error) {
+	pod, err := kc.KubeClient.CoreV1().Pods(kc.Namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pod %s: %w", podName, err)
 	}
 
-	// Collect Spyre card PCI addresses from the pod's live container environment
-	// (injected at runtime by the Spyre device plugin — not in the static pod spec).
 	spyreCards := []string{}
 	collectSpyreCardsFromPod(kc, pod, &spyreCards)
 
-	// Query per-pod CPU usage (sum of all containers, excluding the pause/infra container).
 	cpuQuery := fmt.Sprintf(
 		`sum(rate(container_cpu_usage_seconds_total{namespace=%q,pod=%q,container!=""}[5m]))`,
 		kc.Namespace, podName,
 	)
 
-	cpuCores, err := queryThanos(kc.Ctx, cpuQuery)
+	cpuCores, err := queryThanos(ctx, cpuQuery)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query CPU usage for pod %s: %w", podName, err)
 	}
 
-	// Query per-pod memory working-set usage in bytes.
 	memQuery := fmt.Sprintf(
 		`sum(container_memory_working_set_bytes{namespace=%q,pod=%q,container!=""})`,
 		kc.Namespace, podName,
 	)
 
-	memBytes, err := queryThanos(kc.Ctx, memQuery)
+	memBytes, err := queryThanos(ctx, memQuery)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query memory usage for pod %s: %w", podName, err)
 	}
@@ -749,21 +722,12 @@ func (kc *OpenshiftClient) GetPodResources(podName string) (*types.PodResources,
 }
 
 // collectSpyreCardsFromPod reads the PCIDEVICE_IBM_COM_AIU_PF environment variable
-// from the live environment of each non-init container in the pod by exec-ing
-// into it via the Kubernetes API server's pod/exec subresource.
-//
-// This variable is injected at runtime by the Kubernetes Spyre device plugin and
-// is NOT present in pod.Spec.Containers[].Env (the static pod spec). It is only
-// visible via `oc exec <pod> -- env`, equivalent to what this function does.
-//
-// The value is comma-separated, e.g.:
-//
-//	PCIDEVICE_IBM_COM_AIU_PF=0182:60:00.0,0183:70:00.0,0481:50:00.0,0181:50:00.0
+// from the live environment of each non-init container in the pod.
 func collectSpyreCardsFromPod(kc *OpenshiftClient, pod *corev1.Pod, spyreCards *[]string) {
 	for i := range pod.Spec.Containers {
 		containerName := pod.Spec.Containers[i].Name
 
-		output, err := kc.ExecInContainerWithCmd(pod.Name, containerName, []string{"env"})
+		output, err := kc.ExecInContainerWithCmd(kc.Ctx, pod.Name, containerName, []string{"env"})
 		if err != nil {
 			logger.Warningf("collectSpyreCardsFromPod: exec failed for container %s in pod %s/%s: %v", containerName, pod.Namespace, pod.Name, err)
 
@@ -777,9 +741,7 @@ func collectSpyreCardsFromPod(kc *OpenshiftClient, pod *corev1.Pod, spyreCards *
 
 // ExecInContainerWithCmd runs the given command inside the named container via
 // the Kubernetes API server pod/exec subresource and returns the combined stdout.
-// This works from inside the cluster without requiring the `oc` binary to be
-// present in the catalog-backend pod.
-func (kc *OpenshiftClient) ExecInContainerWithCmd(podName, containerName string, command []string) (string, error) {
+func (kc *OpenshiftClient) ExecInContainerWithCmd(ctx context.Context, podName, containerName string, command []string) (string, error) {
 	req := kc.KubeClient.CoreV1().RESTClient().Post().
 		Resource("pods").
 		Name(podName).
@@ -804,7 +766,7 @@ func (kc *OpenshiftClient) ExecInContainerWithCmd(podName, containerName string,
 
 	var stdout bytes.Buffer
 
-	if err = executor.StreamWithContext(kc.Ctx, remotecommand.StreamOptions{
+	if err = executor.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdout: &stdout,
 	}); err != nil {
 		return "", fmt.Errorf("exec stream failed for %s/%s: %w", podName, containerName, err)
@@ -836,9 +798,7 @@ func (kc *OpenshiftClient) isDeploymentReady(name string) (bool, error) {
 		s.AvailableReplicas == desired, nil
 }
 
-// rolloutRestartDeployment triggers a rollout restart for the named deployment by
-// patching the pod template annotation "kubectl.kubernetes.io/restartedAt", which is
-// the same mechanism used by `kubectl rollout restart deployment <name>`.
+// rolloutRestartDeployment triggers a rollout restart for the named deployment.
 func (kc *OpenshiftClient) rolloutRestartDeployment(name string) error {
 	patch := map[string]interface{}{
 		"spec": map[string]interface{}{
@@ -871,20 +831,20 @@ func (kc *OpenshiftClient) rolloutRestartDeployment(name string) error {
 	return nil
 }
 
-func (kc *OpenshiftClient) DeleteNamespace(name string) error {
+func (kc *OpenshiftClient) DeleteNamespace(ctx context.Context, name string) error {
 	gracePeriod := deleteNamespaceGracePeriod
 	propagation := metav1.DeletePropagationBackground
 
-	ctx, cancel := context.WithTimeout(kc.Ctx, deleteNamespaceTimeout)
+	timeoutCtx, cancel := context.WithTimeout(ctx, deleteNamespaceTimeout)
 	defer cancel()
 
-	err := kc.KubeClient.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{
+	err := kc.KubeClient.CoreV1().Namespaces().Delete(timeoutCtx, name, metav1.DeleteOptions{
 		GracePeriodSeconds: &gracePeriod,
 		PropagationPolicy:  &propagation,
 	})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			logger.DebugfCtx(kc.Ctx, "Ignoring '%s' namespace deletion error: no namespace found\n", name)
+			logger.DebugfCtx(ctx, "Ignoring '%s' namespace deletion error: no namespace found\n", name)
 
 			return nil
 		}

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -283,7 +283,10 @@ func (pc *PodmanClient) streamContainerLogs(ctx context.Context, containerNameOr
 	stdoutChan := make(chan string, logChannelBufferSize)
 	stderrChan := make(chan string, logChannelBufferSize)
 
-	logsCtx, cancelLogs := context.WithCancel(ctx)
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	logsCtx, cancelLogs := context.WithCancel(podCtx)
 	defer cancelLogs()
 
 	// Channel to signal goroutine completion
@@ -294,7 +297,7 @@ func (pc *PodmanClient) streamContainerLogs(ctx context.Context, containerNameOr
 		waitDone := make(chan struct{})
 		go func() {
 			defer close(waitDone)
-			_, err := containers.Wait(ctx, containerNameOrID, nil)
+			_, err := containers.Wait(logsCtx, containerNameOrID, nil)
 			if err == nil {
 				// Container exited, cancel the logs streaming
 				cancelLogs()
@@ -356,7 +359,7 @@ func (pc *PodmanClient) PodLogs(ctx context.Context, podNameOrID string) error {
 	}
 
 	// creating context here that listens for Ctrl+C
-	sigCtx, stop := signal.NotifyContext(pc.Context, os.Interrupt, syscall.SIGTERM)
+	sigCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	for _, container := range podInspect.Containers {
@@ -393,7 +396,7 @@ func (pc *PodmanClient) ContainerLogs(ctx context.Context, containerNameOrID str
 	}
 
 	// Creating context here that listens for Ctrl+C
-	sigCtx, stop := signal.NotifyContext(pc.Context, os.Interrupt, syscall.SIGTERM)
+	sigCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	return pc.streamContainerLogs(sigCtx, containerNameOrID)
@@ -455,14 +458,14 @@ func (pc *PodmanClient) ListRoutes(_ context.Context, _ string) ([]types.Route, 
 	return nil, fmt.Errorf("unsupported method")
 }
 
-func (pc *PodmanClient) ListCRD(_ context.Context, _ *unstructured.UnstructuredList, _ map[string][]string) ([]types.CRDResource, error) {
-	logger.ErrorlnCtx(context.Background(), "unsupported method called!")
+func (pc *PodmanClient) ListCRD(ctx context.Context, _ *unstructured.UnstructuredList, _ map[string][]string) ([]types.CRDResource, error) {
+	logger.ErrorlnCtx(ctx, "unsupported method called!")
 
 	return nil, fmt.Errorf("unsupported method")
 }
 
-func (pc *PodmanClient) DeleteNamespace(_ context.Context, _ string) error {
-	logger.ErrorlnCtx(context.Background(), "unsupported method called!")
+func (pc *PodmanClient) DeleteNamespace(ctx context.Context, _ string) error {
+	logger.ErrorlnCtx(ctx, "unsupported method called!")
 
 	return fmt.Errorf("unsupported method")
 }
@@ -587,7 +590,7 @@ func (pc *PodmanClient) GetSystemInfo(ctx context.Context) (*models.SystemInfo, 
 	}
 
 	// Populate accelerator information (Spyre cards)
-	sysInfo.Accelerators = getAcceleratorInfo(pc.Context)
+	sysInfo.Accelerators = getAcceleratorInfo(ctx)
 
 	return sysInfo, nil
 }
@@ -652,11 +655,14 @@ func (pc *PodmanClient) GetPodResources(ctx context.Context, nameOrID string) (*
 	}
 
 	// Get stats and Spyre cards for all containers in the pod (excluding infra container)
-	return pc.aggregateContainerResourcesWithStats(podInspect)
+	return pc.aggregateContainerResourcesWithStats(ctx, podInspect)
 }
 
 // aggregateContainerResourcesWithStats collects and aggregates resources from all non-infra containers using podman stats.
-func (pc *PodmanClient) aggregateContainerResourcesWithStats(podInspect *entities.PodInspectReport) (*types.PodResources, error) {
+func (pc *PodmanClient) aggregateContainerResourcesWithStats(ctx context.Context, podInspect *entities.PodInspectReport) (*types.PodResources, error) {
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
 	var totalMemUsage uint64
 	var totalCPUs float64
 	spyreCards := []string{}
@@ -668,7 +674,7 @@ func (pc *PodmanClient) aggregateContainerResourcesWithStats(podInspect *entitie
 		}
 
 		// Get container stats for actual CPU and memory usage using podman stats
-		statsChan, err := containers.Stats(pc.Context, []string{container.ID}, &containers.StatsOptions{
+		statsChan, err := containers.Stats(podCtx, []string{container.ID}, &containers.StatsOptions{
 			Stream: utils.BoolPtr(false), // Get a single snapshot, not streaming
 		})
 		if err != nil {
@@ -693,7 +699,7 @@ func (pc *PodmanClient) aggregateContainerResourcesWithStats(podInspect *entitie
 		}
 
 		// Inspect container to get Spyre card annotations
-		containerInspect, err := containers.Inspect(pc.Context, container.ID, nil)
+		containerInspect, err := containers.Inspect(podCtx, container.ID, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to inspect container %s: %w", container.Name, err)
 		}

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -74,13 +74,16 @@ func NewPodmanClient() (*PodmanClient, error) {
 }
 
 // ListImages function to list images (you can expand with more Podman functionalities).
-func (pc *PodmanClient) ListImages() ([]types.Image, error) {
-	images, err := images.List(pc.Context, nil)
+func (pc *PodmanClient) ListImages(ctx context.Context) ([]types.Image, error) {
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	imgs, err := images.List(podCtx, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return toImageList(images), nil
+	return toImageList(imgs), nil
 }
 
 func (pc *PodmanClient) PullImage(ctx context.Context, image string) error {
@@ -107,14 +110,17 @@ func (pc *PodmanClient) PullImage(ctx context.Context, image string) error {
 	return nil
 }
 
-func (pc *PodmanClient) ListPods(filters map[string][]string) ([]types.Pod, error) {
+func (pc *PodmanClient) ListPods(ctx context.Context, filters map[string][]string) ([]types.Pod, error) {
 	var listOpts pods.ListOptions
 
 	if len(filters) >= 1 {
 		listOpts.Filters = filters
 	}
 
-	podList, err := pods.List(pc.Context, &listOpts)
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	podList, err := pods.List(podCtx, &listOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods: %w", err)
 	}
@@ -188,8 +194,11 @@ func (pc *PodmanClient) CreatePod(ctx context.Context, body io.Reader, opts map[
 	return toPodsList(kubeReport), nil
 }
 
-func (pc *PodmanClient) DeletePod(nameOrID string, force *bool) error {
-	_, err := pods.Remove(pc.Context, nameOrID, &pods.RemoveOptions{Force: force})
+func (pc *PodmanClient) DeletePod(ctx context.Context, id string, force *bool) error {
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	_, err := pods.Remove(podCtx, id, &pods.RemoveOptions{Force: force})
 	if err != nil {
 		return fmt.Errorf("failed to delete the pod: %w", err)
 	}
@@ -197,8 +206,11 @@ func (pc *PodmanClient) DeletePod(nameOrID string, force *bool) error {
 	return nil
 }
 
-func (pc *PodmanClient) InspectContainer(nameOrId string) (*types.Container, error) {
-	stats, err := containers.Inspect(pc.Context, nameOrId, nil)
+func (pc *PodmanClient) InspectContainer(ctx context.Context, nameOrId string) (*types.Container, error) {
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	stats, err := containers.Inspect(podCtx, nameOrId, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect container: %w", err)
 	}
@@ -210,22 +222,25 @@ func (pc *PodmanClient) InspectContainer(nameOrId string) (*types.Container, err
 	return toInspectContainer(stats), nil
 }
 
-func (pc *PodmanClient) StopPod(nameOrID string) error {
-	inspectReport, err := pc.InspectPod(nameOrID)
+func (pc *PodmanClient) StopPod(ctx context.Context, id string) error {
+	inspectReport, err := pc.InspectPod(ctx, id)
 	if err != nil {
 		return fmt.Errorf("failed to inspect pod: %w", err)
 	}
 
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
 	for _, container := range inspectReport.Containers {
 		// skipping infra container as it will be stopped when other containers are stopped
 		if container.ID != inspectReport.InfraContainerID {
-			err := containers.Stop(pc.Context, container.ID, nil)
+			err := containers.Stop(podCtx, container.ID, nil)
 			if err != nil {
 				return fmt.Errorf("failed to stop pod container %s; err: %w", container.ID, err)
 			}
 		}
 	}
-	_, err = pods.Stop(pc.Context, nameOrID, &pods.StopOptions{})
+	_, err = pods.Stop(podCtx, id, &pods.StopOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to stop the pod: %w", err)
 	}
@@ -233,8 +248,11 @@ func (pc *PodmanClient) StopPod(nameOrID string) error {
 	return nil
 }
 
-func (pc *PodmanClient) StartPod(nameOrID string) error {
-	_, err := pods.Start(pc.Context, nameOrID, &pods.StartOptions{})
+func (pc *PodmanClient) StartPod(ctx context.Context, id string) error {
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	_, err := pods.Start(podCtx, id, &pods.StartOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to start the pod: %w", err)
 	}
@@ -242,8 +260,11 @@ func (pc *PodmanClient) StartPod(nameOrID string) error {
 	return nil
 }
 
-func (pc *PodmanClient) InspectPod(nameOrID string) (*types.Pod, error) {
-	podInspectReport, err := pods.Inspect(pc.Context, nameOrID, nil)
+func (pc *PodmanClient) InspectPod(ctx context.Context, nameOrID string) (*types.Pod, error) {
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	podInspectReport, err := pods.Inspect(podCtx, nameOrID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect the pod: %w", err)
 	}
@@ -320,12 +341,12 @@ func (pc *PodmanClient) printLogsFromChannels(parentCtx, logsCtx context.Context
 	}
 }
 
-func (pc *PodmanClient) PodLogs(podNameOrID string) error {
+func (pc *PodmanClient) PodLogs(ctx context.Context, podNameOrID string) error {
 	if podNameOrID == "" {
 		return errors.New("pod name or ID cannot be empty")
 	}
 
-	podInspect, err := pc.InspectPod(podNameOrID)
+	podInspect, err := pc.InspectPod(ctx, podNameOrID)
 	if err != nil {
 		return fmt.Errorf("failed to inspect pod: %w", err)
 	}
@@ -335,7 +356,7 @@ func (pc *PodmanClient) PodLogs(podNameOrID string) error {
 	}
 
 	// creating context here that listens for Ctrl+C
-	ctx, stop := signal.NotifyContext(pc.Context, os.Interrupt, syscall.SIGTERM)
+	sigCtx, stop := signal.NotifyContext(pc.Context, os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	for _, container := range podInspect.Containers {
@@ -346,12 +367,12 @@ func (pc *PodmanClient) PodLogs(podNameOrID string) error {
 
 		logger.Infof("Streaming logs for container: %s", container.Name)
 
-		if err := pc.streamContainerLogs(ctx, container.ID); err != nil {
+		if err := pc.streamContainerLogs(sigCtx, container.ID); err != nil {
 			return fmt.Errorf("error reading logs for container %s: %w", container.Name, err)
 		}
 
 		// Check if context was cancelled
-		if ctx.Err() == context.Canceled || ctx.Err() == context.DeadlineExceeded {
+		if sigCtx.Err() == context.Canceled || sigCtx.Err() == context.DeadlineExceeded {
 			return nil
 		}
 	}
@@ -359,24 +380,30 @@ func (pc *PodmanClient) PodLogs(podNameOrID string) error {
 	return nil
 }
 
-func (pc *PodmanClient) PodExists(nameOrID string) (bool, error) {
-	return pods.Exists(pc.Context, nameOrID, nil)
+func (pc *PodmanClient) PodExists(ctx context.Context, nameOrID string) (bool, error) {
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	return pods.Exists(podCtx, nameOrID, nil)
 }
 
-func (pc *PodmanClient) ContainerLogs(containerNameOrID string) error {
+func (pc *PodmanClient) ContainerLogs(ctx context.Context, containerNameOrID string) error {
 	if containerNameOrID == "" {
 		return fmt.Errorf("container name or ID required to fetch logs")
 	}
 
 	// Creating context here that listens for Ctrl+C
-	ctx, stop := signal.NotifyContext(pc.Context, os.Interrupt, syscall.SIGTERM)
+	sigCtx, stop := signal.NotifyContext(pc.Context, os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	return pc.streamContainerLogs(ctx, containerNameOrID)
+	return pc.streamContainerLogs(sigCtx, containerNameOrID)
 }
 
-func (pc *PodmanClient) ContainerExists(nameOrID string) (bool, error) {
-	return containers.Exists(pc.Context, nameOrID, nil)
+func (pc *PodmanClient) ContainerExists(ctx context.Context, nameOrID string) (bool, error) {
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	return containers.Exists(podCtx, nameOrID, nil)
 }
 
 // RunContainerWithSpec creates, starts, waits for, and removes a container with the given spec.
@@ -422,32 +449,35 @@ func (pc *PodmanClient) RunContainerWithSpec(ctx context.Context, s *specgen.Spe
 	}
 }
 
-func (pc *PodmanClient) ListRoutes(_ string) ([]types.Route, error) {
+func (pc *PodmanClient) ListRoutes(_ context.Context, _ string) ([]types.Route, error) {
 	logger.Errorf("unsupported method called!")
 
 	return nil, fmt.Errorf("unsupported method")
 }
 
-func (pc *PodmanClient) ListCRD(_ *unstructured.UnstructuredList, _ map[string][]string) ([]types.CRDResource, error) {
+func (pc *PodmanClient) ListCRD(_ context.Context, _ *unstructured.UnstructuredList, _ map[string][]string) ([]types.CRDResource, error) {
 	logger.ErrorlnCtx(context.Background(), "unsupported method called!")
 
 	return nil, fmt.Errorf("unsupported method")
 }
 
-func (pc *PodmanClient) DeleteNamespace(_ string) error {
+func (pc *PodmanClient) DeleteNamespace(_ context.Context, _ string) error {
 	logger.ErrorlnCtx(context.Background(), "unsupported method called!")
 
 	return fmt.Errorf("unsupported method")
 }
 
-func (pc *PodmanClient) DeletePVCs(appLabel string) error {
+func (pc *PodmanClient) DeletePVCs(_ context.Context, _ string) error {
 	logger.Errorf("unsupported method called!")
 
 	return fmt.Errorf("unsupported method")
 }
 
-func (pc *PodmanClient) DeleteSecret(name string) error {
-	err := secrets.Remove(pc.Context, name)
+func (pc *PodmanClient) DeleteSecret(ctx context.Context, name string) error {
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	err := secrets.Remove(podCtx, name)
 	if err != nil {
 		return fmt.Errorf("failed to remove secret: %w", err)
 	}
@@ -455,8 +485,11 @@ func (pc *PodmanClient) DeleteSecret(name string) error {
 	return nil
 }
 
-func (pc *PodmanClient) DeleteVolume(name string) error {
-	err := volumes.Remove(pc.Context, name, nil)
+func (pc *PodmanClient) DeleteVolume(ctx context.Context, name string) error {
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	err := volumes.Remove(podCtx, name, nil)
 	if err != nil {
 		return fmt.Errorf("failed to remove volume: %w", err)
 	}
@@ -464,17 +497,23 @@ func (pc *PodmanClient) DeleteVolume(name string) error {
 	return nil
 }
 
-func (pc *PodmanClient) VolumeExists(nameOrID string) (bool, error) {
-	return volumes.Exists(pc.Context, nameOrID, nil)
+func (pc *PodmanClient) VolumeExists(ctx context.Context, nameOrID string) (bool, error) {
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	return volumes.Exists(podCtx, nameOrID, nil)
 }
 
-func (pc *PodmanClient) ListSecrets(filters map[string][]string) ([]string, error) {
+func (pc *PodmanClient) ListSecrets(ctx context.Context, filters map[string][]string) ([]string, error) {
 	var listOpts secrets.ListOptions
 	if len(filters) >= 1 {
 		listOpts.Filters = filters
 	}
 
-	secretList, err := secrets.List(pc.Context, &listOpts)
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	secretList, err := secrets.List(podCtx, &listOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list secrets: %w", err)
 	}
@@ -487,17 +526,20 @@ func (pc *PodmanClient) ListSecrets(filters map[string][]string) ([]string, erro
 	return secretIDorNames, nil
 }
 
-func (pc *PodmanClient) SecretExists(nameOrID string) (bool, error) {
-	return secrets.Exists(pc.Context, nameOrID)
+func (pc *PodmanClient) SecretExists(ctx context.Context, nameOrID string) (bool, error) {
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
+	return secrets.Exists(podCtx, nameOrID)
 }
 
-func (pc *PodmanClient) UpdateSecret(name, deploymentName string, data map[string][]byte) error {
+func (pc *PodmanClient) UpdateSecret(_ context.Context, _, _ string, _ map[string][]byte) error {
 	logger.ErrorfCtx(pc.Context, "unsupported method called!")
 
 	return fmt.Errorf("unsupported method")
 }
 
-func (pc *PodmanClient) GetNamespace() (string, error) {
+func (pc *PodmanClient) GetNamespace(_ context.Context) (string, error) {
 	logger.ErrorfCtx(pc.Context, "unsupported method called!")
 
 	return "", fmt.Errorf("unsupported method")
@@ -509,11 +551,14 @@ func (pc *PodmanClient) Type() types.RuntimeType {
 }
 
 // GetSystemInfo retrieves system resource information including CPU, memory, and accelerators.
-func (pc *PodmanClient) GetSystemInfo() (*models.SystemInfo, error) {
+func (pc *PodmanClient) GetSystemInfo(ctx context.Context) (*models.SystemInfo, error) {
 	sysInfo := &models.SystemInfo{}
 
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
 	// Get Podman system info for CPU and memory
-	info, err := system.Info(pc.Context, nil)
+	info, err := system.Info(podCtx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get system info: %w", err)
 	}
@@ -588,9 +633,12 @@ func getAcceleratorInfo(ctx context.Context) map[string]*models.AcceleratorInfo 
 }
 
 // GetPodResources retrieves resource usage and Spyre cards for a pod in a single call.
-func (pc *PodmanClient) GetPodResources(nameOrID string) (*types.PodResources, error) {
+func (pc *PodmanClient) GetPodResources(ctx context.Context, nameOrID string) (*types.PodResources, error) {
+	podCtx, cancel := pc.podmanCtx(ctx)
+	defer cancel()
+
 	// Inspect the pod to get its details
-	podInspect, err := pods.Inspect(pc.Context, nameOrID, nil)
+	podInspect, err := pods.Inspect(podCtx, nameOrID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect pod: %w", err)
 	}
@@ -810,7 +858,7 @@ func (pc *PodmanClient) ManageSidecarLifecycle(podID, sidecarName, image string,
 }
 
 // ExecInContainerWithCmd is not implemented for the Podman runtime.
-func (pc *PodmanClient) ExecInContainerWithCmd(_, _ string, _ []string) (string, error) {
+func (pc *PodmanClient) ExecInContainerWithCmd(_ context.Context, _, _ string, _ []string) (string, error) {
 	logger.Errorf("unsupported method called!")
 
 	return "", fmt.Errorf("unsupported method")

--- a/ai-services/internal/pkg/runtime/remote/runtime.go
+++ b/ai-services/internal/pkg/runtime/remote/runtime.go
@@ -54,8 +54,8 @@ func (r *RemoteRuntime) Type() types.RuntimeType {
 
 // ─── Image operations ─────────────────────────────────────────────────────────
 
-func (r *RemoteRuntime) ListImages() ([]types.Image, error) {
-	res, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_LIST_IMAGES, nil)
+func (r *RemoteRuntime) ListImages(ctx context.Context) ([]types.Image, error) {
+	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_LIST_IMAGES, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -76,8 +76,8 @@ func (r *RemoteRuntime) PullImage(ctx context.Context, image string) error {
 
 // ─── Pod operations ───────────────────────────────────────────────────────────
 
-func (r *RemoteRuntime) ListPods(filters map[string][]string) ([]types.Pod, error) {
-	res, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_LIST_PODS, payload.ListPods{Filters: filters})
+func (r *RemoteRuntime) ListPods(ctx context.Context, filters map[string][]string) ([]types.Pod, error) {
+	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_LIST_PODS, payload.ListPods{Filters: filters})
 	if err != nil {
 		return nil, err
 	}
@@ -109,26 +109,26 @@ func (r *RemoteRuntime) CreatePod(ctx context.Context, body io.Reader, opts map[
 	return pods, nil
 }
 
-func (r *RemoteRuntime) DeletePod(nameOrID string, force *bool) error {
-	_, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_DELETE_POD, payload.DeletePod{ID: nameOrID, Force: force})
+func (r *RemoteRuntime) DeletePod(ctx context.Context, nameOrID string, force *bool) error {
+	_, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_DELETE_POD, payload.DeletePod{ID: nameOrID, Force: force})
 
 	return err
 }
 
-func (r *RemoteRuntime) StopPod(nameOrID string) error {
-	_, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_STOP_POD, payload.NameOrID{NameOrID: nameOrID})
+func (r *RemoteRuntime) StopPod(ctx context.Context, nameOrID string) error {
+	_, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_STOP_POD, payload.NameOrID{NameOrID: nameOrID})
 
 	return err
 }
 
-func (r *RemoteRuntime) StartPod(nameOrID string) error {
-	_, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_START_POD, payload.NameOrID{NameOrID: nameOrID})
+func (r *RemoteRuntime) StartPod(ctx context.Context, nameOrID string) error {
+	_, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_START_POD, payload.NameOrID{NameOrID: nameOrID})
 
 	return err
 }
 
-func (r *RemoteRuntime) InspectPod(nameOrID string) (*types.Pod, error) {
-	res, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_INSPECT_POD, payload.NameOrID{NameOrID: nameOrID})
+func (r *RemoteRuntime) InspectPod(ctx context.Context, nameOrID string) (*types.Pod, error) {
+	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_INSPECT_POD, payload.NameOrID{NameOrID: nameOrID})
 	if err != nil {
 		return nil, err
 	}
@@ -141,8 +141,8 @@ func (r *RemoteRuntime) InspectPod(nameOrID string) (*types.Pod, error) {
 	return &pod, nil
 }
 
-func (r *RemoteRuntime) PodExists(nameOrID string) (bool, error) {
-	res, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_POD_EXISTS, payload.NameOrID{NameOrID: nameOrID})
+func (r *RemoteRuntime) PodExists(ctx context.Context, nameOrID string) (bool, error) {
+	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_POD_EXISTS, payload.NameOrID{NameOrID: nameOrID})
 	if err != nil {
 		return false, err
 	}
@@ -155,14 +155,14 @@ func (r *RemoteRuntime) PodExists(nameOrID string) (bool, error) {
 	return exists, nil
 }
 
-func (r *RemoteRuntime) PodLogs(nameOrID string) error {
-	_, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_POD_LOGS, payload.NameOrID{NameOrID: nameOrID})
+func (r *RemoteRuntime) PodLogs(ctx context.Context, nameOrID string) error {
+	_, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_POD_LOGS, payload.NameOrID{NameOrID: nameOrID})
 
 	return err
 }
 
-func (r *RemoteRuntime) GetPodResources(nameOrID string) (*types.PodResources, error) {
-	res, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_GET_POD_RESOURCES, payload.NameOrID{NameOrID: nameOrID})
+func (r *RemoteRuntime) GetPodResources(ctx context.Context, nameOrID string) (*types.PodResources, error) {
+	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_GET_POD_RESOURCES, payload.NameOrID{NameOrID: nameOrID})
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +175,7 @@ func (r *RemoteRuntime) GetPodResources(nameOrID string) (*types.PodResources, e
 	return &pr, nil
 }
 
-func (r *RemoteRuntime) GetNamespace() (string, error) {
+func (r *RemoteRuntime) GetNamespace(_ context.Context) (string, error) {
 	// Workers are always scoped to the default namespace — the namespace concept
 	// only applies to OpenShift. Return empty string for podman workers.
 	return "", nil
@@ -183,8 +183,8 @@ func (r *RemoteRuntime) GetNamespace() (string, error) {
 
 // ─── Secret operations ────────────────────────────────────────────────────────
 
-func (r *RemoteRuntime) ListSecrets(filters map[string][]string) ([]string, error) {
-	res, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_LIST_SECRETS, payload.ListSecrets{Filters: filters})
+func (r *RemoteRuntime) ListSecrets(ctx context.Context, filters map[string][]string) ([]string, error) {
+	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_LIST_SECRETS, payload.ListSecrets{Filters: filters})
 	if err != nil {
 		return nil, err
 	}
@@ -197,14 +197,14 @@ func (r *RemoteRuntime) ListSecrets(filters map[string][]string) ([]string, erro
 	return names, nil
 }
 
-func (r *RemoteRuntime) DeleteSecret(name string) error {
-	_, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_DELETE_SECRET, payload.Name{Name: name})
+func (r *RemoteRuntime) DeleteSecret(ctx context.Context, name string) error {
+	_, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_DELETE_SECRET, payload.Name{Name: name})
 
 	return err
 }
 
-func (r *RemoteRuntime) SecretExists(nameOrID string) (bool, error) {
-	res, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_SECRET_EXISTS, payload.NameOrID{NameOrID: nameOrID})
+func (r *RemoteRuntime) SecretExists(ctx context.Context, nameOrID string) (bool, error) {
+	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_SECRET_EXISTS, payload.NameOrID{NameOrID: nameOrID})
 	if err != nil {
 		return false, err
 	}
@@ -219,20 +219,20 @@ func (r *RemoteRuntime) SecretExists(nameOrID string) (bool, error) {
 
 // UpdateSecret is not yet supported over the remote worker protocol.
 // TODO: implement when required.
-func (r *RemoteRuntime) UpdateSecret(_, _ string, _ map[string][]byte) error {
+func (r *RemoteRuntime) UpdateSecret(_ context.Context, _, _ string, _ map[string][]byte) error {
 	return fmt.Errorf("remote runtime: UpdateSecret not yet supported on remote workers")
 }
 
 // ─── Volume operations ────────────────────────────────────────────────────────
 
-func (r *RemoteRuntime) DeleteVolume(name string) error {
-	_, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_DELETE_VOLUME, payload.Name{Name: name})
+func (r *RemoteRuntime) DeleteVolume(ctx context.Context, name string) error {
+	_, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_DELETE_VOLUME, payload.Name{Name: name})
 
 	return err
 }
 
-func (r *RemoteRuntime) VolumeExists(nameOrID string) (bool, error) {
-	res, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_VOLUME_EXISTS, payload.NameOrID{NameOrID: nameOrID})
+func (r *RemoteRuntime) VolumeExists(ctx context.Context, nameOrID string) (bool, error) {
+	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_VOLUME_EXISTS, payload.NameOrID{NameOrID: nameOrID})
 	if err != nil {
 		return false, err
 	}
@@ -247,8 +247,8 @@ func (r *RemoteRuntime) VolumeExists(nameOrID string) (bool, error) {
 
 // ─── Container operations ─────────────────────────────────────────────────────
 
-func (r *RemoteRuntime) InspectContainer(nameOrID string) (*types.Container, error) {
-	res, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_INSPECT_CONTAINER, payload.NameOrID{NameOrID: nameOrID})
+func (r *RemoteRuntime) InspectContainer(ctx context.Context, nameOrID string) (*types.Container, error) {
+	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_INSPECT_CONTAINER, payload.NameOrID{NameOrID: nameOrID})
 	if err != nil {
 		return nil, err
 	}
@@ -261,8 +261,8 @@ func (r *RemoteRuntime) InspectContainer(nameOrID string) (*types.Container, err
 	return &c, nil
 }
 
-func (r *RemoteRuntime) ContainerExists(nameOrID string) (bool, error) {
-	res, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_CONTAINER_EXISTS, payload.NameOrID{NameOrID: nameOrID})
+func (r *RemoteRuntime) ContainerExists(ctx context.Context, nameOrID string) (bool, error) {
+	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_CONTAINER_EXISTS, payload.NameOrID{NameOrID: nameOrID})
 	if err != nil {
 		return false, err
 	}
@@ -275,14 +275,14 @@ func (r *RemoteRuntime) ContainerExists(nameOrID string) (bool, error) {
 	return exists, nil
 }
 
-func (r *RemoteRuntime) ContainerLogs(containerNameOrID string) error {
-	_, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_CONTAINER_LOGS, payload.NameOrID{NameOrID: containerNameOrID})
+func (r *RemoteRuntime) ContainerLogs(ctx context.Context, containerNameOrID string) error {
+	_, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_CONTAINER_LOGS, payload.NameOrID{NameOrID: containerNameOrID})
 
 	return err
 }
 
-func (r *RemoteRuntime) ExecInContainerWithCmd(podName, containerName string, command []string) (string, error) {
-	res, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_RUN_EPHEMERAL_CONTAINER,
+func (r *RemoteRuntime) ExecInContainerWithCmd(ctx context.Context, podName, containerName string, command []string) (string, error) {
+	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_RUN_EPHEMERAL_CONTAINER,
 		payload.ExecInContainer{PodName: podName, ContainerName: containerName, Command: command})
 	if err != nil {
 		return "", err
@@ -298,8 +298,8 @@ func (r *RemoteRuntime) ExecInContainerWithCmd(podName, containerName string, co
 
 // ─── Network operations ───────────────────────────────────────────────────────
 
-func (r *RemoteRuntime) ListRoutes(labelSelector string) ([]types.Route, error) {
-	res, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_LIST_ROUTES, payload.ListRoutes{LabelSelector: labelSelector})
+func (r *RemoteRuntime) ListRoutes(ctx context.Context, labelSelector string) ([]types.Route, error) {
+	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_LIST_ROUTES, payload.ListRoutes{LabelSelector: labelSelector})
 	if err != nil {
 		return nil, err
 	}
@@ -315,23 +315,23 @@ func (r *RemoteRuntime) ListRoutes(labelSelector string) ([]types.Route, error) 
 // ─── CRD / namespace / PVC / system operations ────────────────────────────────
 
 // ListCRD is not supported on remote workers (OpenShift-only).
-func (r *RemoteRuntime) ListCRD(_ *unstructured.UnstructuredList, _ map[string][]string) ([]types.CRDResource, error) {
+func (r *RemoteRuntime) ListCRD(_ context.Context, _ *unstructured.UnstructuredList, _ map[string][]string) ([]types.CRDResource, error) {
 	return nil, fmt.Errorf("remote runtime: ListCRD not supported on remote workers")
 }
 
 // DeleteNamespace is not supported on remote workers (OpenShift-only).
-func (r *RemoteRuntime) DeleteNamespace(_ string) error {
+func (r *RemoteRuntime) DeleteNamespace(_ context.Context, _ string) error {
 	return fmt.Errorf("remote runtime: DeleteNamespace not supported on remote workers")
 }
 
-func (r *RemoteRuntime) DeletePVCs(appLabel string) error {
-	_, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_DELETE_PVCS, payload.Name{Name: appLabel})
+func (r *RemoteRuntime) DeletePVCs(ctx context.Context, appLabel string) error {
+	_, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_DELETE_PVCS, payload.Name{Name: appLabel})
 
 	return err
 }
 
-func (r *RemoteRuntime) GetSystemInfo() (*models.SystemInfo, error) {
-	res, err := r.send(context.Background(), workerpb.CommandType_COMMAND_TYPE_GET_SYSTEM_INFO, nil)
+func (r *RemoteRuntime) GetSystemInfo(ctx context.Context) (*models.SystemInfo, error) {
+	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_GET_SYSTEM_INFO, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -1,9 +1,9 @@
 package utils
 
 import (
-	"context"
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"archive/tar"
 	"compress/gzip"
 	"encoding/json"
@@ -415,11 +416,11 @@ func checkParamsInValues(param string, values map[string]any) bool {
 }
 
 // GetExistingCustomResource checks if a single instance resource exists and return the object.
-func GetExistingCustomResource(client *openshift.OpenshiftClient, gvk schema.GroupVersionKind) (*unstructured.Unstructured, bool, error) {
+func GetExistingCustomResource(ctx context.Context, client *openshift.OpenshiftClient, gvk schema.GroupVersionKind) (*unstructured.Unstructured, bool, error) {
 	list := &unstructured.UnstructuredList{}
 	list.SetGroupVersionKind(gvk)
 
-	if err := client.Client.List(client.Ctx, list); err != nil {
+	if err := client.Client.List(ctx, list); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, false, nil
 		}

--- a/ai-services/internal/pkg/validators/openshift/kubeconfig/config.go
+++ b/ai-services/internal/pkg/validators/openshift/kubeconfig/config.go
@@ -25,9 +25,7 @@ func (r *KubeconfigRule) Description() string {
 }
 
 // Verify checks if the kubeconfig can access the OpenShift cluster.
-func (r *KubeconfigRule) Verify() error {
-	ctx := context.Background()
-
+func (r *KubeconfigRule) Verify(ctx context.Context) error {
 	client, err := openshift.NewOpenshiftClient()
 	if err != nil {
 		return fmt.Errorf("failed to create openshift client: %w", err)

--- a/ai-services/internal/pkg/validators/openshift/nodelabels/label.go
+++ b/ai-services/internal/pkg/validators/openshift/nodelabels/label.go
@@ -30,9 +30,7 @@ func (r *NodeLabelsRule) Description() string {
 }
 
 // Verify checks node labels in the cluster.
-func (r *NodeLabelsRule) Verify() error {
-	ctx := context.Background()
-
+func (r *NodeLabelsRule) Verify(ctx context.Context) error {
 	client, err := openshift.NewOpenshiftClient()
 	if err != nil {
 		return fmt.Errorf("failed to create OpenShift client: %w", err)

--- a/ai-services/internal/pkg/validators/openshift/operators/operators.go
+++ b/ai-services/internal/pkg/validators/openshift/operators/operators.go
@@ -1,6 +1,7 @@
 package operators
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -27,7 +28,7 @@ func (r *OperatorRule) Description() string {
 	return "Validates that all operators are installed or not"
 }
 
-func (r *OperatorRule) Verify() error {
+func (r *OperatorRule) Verify(ctx context.Context) error {
 	var failed []string
 
 	client, err := openshift.NewOpenshiftClient()
@@ -37,7 +38,7 @@ func (r *OperatorRule) Verify() error {
 
 	// Prefetch all subscriptions across all namespaces
 	allSubscriptions := &operatorsv1alpha1.SubscriptionList{}
-	if err := client.Client.List(client.Ctx, allSubscriptions); err != nil {
+	if err := client.Client.List(ctx, allSubscriptions); err != nil {
 		return fmt.Errorf("failed to list subscriptions: %w", err)
 	}
 
@@ -46,7 +47,7 @@ func (r *OperatorRule) Verify() error {
 		if opPackage == "" {
 			opPackage = op.Name
 		}
-		if err := validateOperatorByPackage(client, opPackage, op.Namespace, allSubscriptions); err != nil {
+		if err := validateOperatorByPackage(ctx, client, opPackage, op.Namespace, allSubscriptions); err != nil {
 			failed = append(failed, fmt.Sprintf("  - %s: %s", op.Label, err.Error()))
 		} else {
 			r.passed = append(r.passed, fmt.Sprintf("  - %s installed", op.Label))
@@ -72,7 +73,7 @@ func (r *OperatorRule) Hint() string {
 	return "This tool requires certain operators to be up and running, please run `ai-services bootstrap configure --runtime openshift` to install required operators"
 }
 
-func validateOperatorByPackage(c *openshift.OpenshiftClient, packageName, opNamespace string, allSubscriptions *operatorsv1alpha1.SubscriptionList) error {
+func validateOperatorByPackage(ctx context.Context, c *openshift.OpenshiftClient, packageName, opNamespace string, allSubscriptions *operatorsv1alpha1.SubscriptionList) error {
 	// Find subscription with matching package name in the specified namespace
 	var sub *operatorsv1alpha1.Subscription
 	for i := range allSubscriptions.Items {
@@ -94,7 +95,7 @@ func validateOperatorByPackage(c *openshift.OpenshiftClient, packageName, opName
 
 	// Get CSV
 	csv := &operatorsv1alpha1.ClusterServiceVersion{}
-	if err := c.Client.Get(c.Ctx, k8sClient.ObjectKey{
+	if err := c.Client.Get(ctx, k8sClient.ObjectKey{
 		Name:      sub.Status.InstalledCSV,
 		Namespace: opNamespace,
 	}, csv); err != nil {

--- a/ai-services/internal/pkg/validators/openshift/rhods/dsc.go
+++ b/ai-services/internal/pkg/validators/openshift/rhods/dsc.go
@@ -1,6 +1,7 @@
 package rhods
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -30,7 +31,7 @@ func (r *DataScienceCluster) Description() string {
 }
 
 // Verify checks if DataScienceCluster is in ready phase.
-func (r *DataScienceCluster) Verify() error {
+func (r *DataScienceCluster) Verify(ctx context.Context) error {
 	client, err := openshift.NewOpenshiftClient()
 	if err != nil {
 		return fmt.Errorf("failed to create openshift client: %w", err)
@@ -41,7 +42,7 @@ func (r *DataScienceCluster) Verify() error {
 		Kind:    constants.DSCKind,
 	}
 
-	obj, exists, err := utils.GetExistingCustomResource(client, gvk)
+	obj, exists, err := utils.GetExistingCustomResource(ctx, client, gvk)
 	if err != nil {
 		return fmt.Errorf("failed to get existing DataScienceCluster: %w", err)
 	}

--- a/ai-services/internal/pkg/validators/openshift/rhods/dsci.go
+++ b/ai-services/internal/pkg/validators/openshift/rhods/dsci.go
@@ -1,6 +1,7 @@
 package rhods
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -26,7 +27,7 @@ func (r *DSCInitialization) Description() string {
 }
 
 // Verify checks DSCInitialization is in Ready phase.
-func (r *DSCInitialization) Verify() error {
+func (r *DSCInitialization) Verify(ctx context.Context) error {
 	client, err := openshift.NewOpenshiftClient()
 	if err != nil {
 		return fmt.Errorf("failed to create openshift client: %w", err)
@@ -37,7 +38,7 @@ func (r *DSCInitialization) Verify() error {
 		Kind:    constants.DSCIKind,
 	}
 
-	obj, exists, err := utils.GetExistingCustomResource(client, gvk)
+	obj, exists, err := utils.GetExistingCustomResource(ctx, client, gvk)
 	if err != nil {
 		return fmt.Errorf("failed to get existing DSCInitialization: %w", err)
 	}

--- a/ai-services/internal/pkg/validators/openshift/spyreclusterpolicy/spyre.go
+++ b/ai-services/internal/pkg/validators/openshift/spyreclusterpolicy/spyre.go
@@ -1,6 +1,7 @@
 package spyrepolicy
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
@@ -33,7 +34,7 @@ func (r *SpyrePolicyRule) Description() string {
 }
 
 // Verify performs a direct check without polling.
-func (r *SpyrePolicyRule) Verify() error {
+func (r *SpyrePolicyRule) Verify(ctx context.Context) error {
 	client, err := openshift.NewOpenshiftClient()
 	if err != nil {
 		return fmt.Errorf("failed to create openshift client: %w", err)
@@ -46,7 +47,7 @@ func (r *SpyrePolicyRule) Verify() error {
 		Kind:    spyreKind,
 	})
 
-	if err := client.Client.Get(client.Ctx, types.NamespacedName{Name: spyreName}, obj); err != nil {
+	if err := client.Client.Get(ctx, types.NamespacedName{Name: spyreName}, obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			return fmt.Errorf("SpyreClusterPolicy %s not found", spyreName)
 		}

--- a/ai-services/internal/pkg/validators/openshift/storageclass/storage.go
+++ b/ai-services/internal/pkg/validators/openshift/storageclass/storage.go
@@ -29,9 +29,7 @@ func (r *StorageClassRule) Description() string {
 }
 
 // Verify checks if a default StorageClass exists.
-func (r *StorageClassRule) Verify() error {
-	ctx := context.Background()
-
+func (r *StorageClassRule) Verify(ctx context.Context) error {
 	client, err := openshift.NewOpenshiftClient()
 	if err != nil {
 		return fmt.Errorf("failed to create openshift client: %w", err)

--- a/ai-services/internal/pkg/validators/podman/numa/numa.go
+++ b/ai-services/internal/pkg/validators/podman/numa/numa.go
@@ -1,6 +1,7 @@
 package numa
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strconv"
@@ -24,7 +25,7 @@ func (r *NumaRule) Description() string {
 	return "Validates that the NUMA node alignment on LPAR is set to 1 for optimal performance."
 }
 
-func (r *NumaRule) Verify() error {
+func (r *NumaRule) Verify(_ context.Context) error {
 	logger.Debugln("Validating NUMA node alignment on LPAR")
 	cmd := `lscpu | grep -i "NUMA node(s)"`
 	out, err := exec.Command("bash", "-c", cmd).Output()

--- a/ai-services/internal/pkg/validators/podman/platform/platform.go
+++ b/ai-services/internal/pkg/validators/podman/platform/platform.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -24,7 +25,7 @@ func (r *PlatformRule) Description() string {
 	return "Validates that the operating system is RHEL version 9.6 or higher."
 }
 
-func (r *PlatformRule) Verify() error {
+func (r *PlatformRule) Verify(_ context.Context) error {
 	logger.Debugln("Validating operating system...")
 
 	data, err := os.ReadFile("/etc/os-release")

--- a/ai-services/internal/pkg/validators/podman/power/power.go
+++ b/ai-services/internal/pkg/validators/podman/power/power.go
@@ -1,6 +1,7 @@
 package power
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"runtime"
@@ -24,7 +25,7 @@ func (r *PowerRule) Description() string {
 	return "Validates that the system is running on IBM Power11 (ppc64le)"
 }
 
-func (r *PowerRule) Verify() error {
+func (r *PowerRule) Verify(_ context.Context) error {
 	logger.Debugln("Validating IBM Power version...")
 
 	if runtime.GOARCH != "ppc64le" {

--- a/ai-services/internal/pkg/validators/podman/rhn/rhn.go
+++ b/ai-services/internal/pkg/validators/podman/rhn/rhn.go
@@ -1,6 +1,7 @@
 package rhn
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -23,7 +24,7 @@ func (r *RHNRule) Description() string {
 	return "Validates that the system is registered with Red Hat Network (RHN)."
 }
 
-func (r *RHNRule) Verify() error {
+func (r *RHNRule) Verify(_ context.Context) error {
 	logger.Debugln("Validating RHN registration...")
 	cmd := exec.Command("dnf", "repolist")
 	output, err := cmd.CombinedOutput()

--- a/ai-services/internal/pkg/validators/podman/slicelimits/slicelimits.go
+++ b/ai-services/internal/pkg/validators/podman/slicelimits/slicelimits.go
@@ -1,6 +1,7 @@
 package slicelimits
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -26,7 +27,7 @@ func (r *SliceLimitsRule) Description() string {
 	return "Validates that systemd user slice limits are configured for rootless podman."
 }
 
-func (r *SliceLimitsRule) Verify() error {
+func (r *SliceLimitsRule) Verify(_ context.Context) error {
 	logger.Debugln("Validating systemd user slice limits")
 
 	sudoUser := os.Getenv("SUDO_USER")

--- a/ai-services/internal/pkg/validators/podman/spyre/spyre.go
+++ b/ai-services/internal/pkg/validators/podman/spyre/spyre.go
@@ -1,6 +1,7 @@
 package spyre
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -24,7 +25,7 @@ func (r *SpyreRule) Description() string {
 }
 
 // Verify performs comprehensive Spyre validation.
-func (r *SpyreRule) Verify() error {
+func (r *SpyreRule) Verify(_ context.Context) error {
 	logger.Debugln("Running comprehensive Spyre validation...")
 
 	// Check if Spyre cards are present

--- a/ai-services/internal/pkg/validators/podman/ulimits/ulimits.go
+++ b/ai-services/internal/pkg/validators/podman/ulimits/ulimits.go
@@ -1,6 +1,7 @@
 package ulimits
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -25,7 +26,7 @@ func (r *UlimitsRule) Description() string {
 	return "Validates that memlock and nofile ulimits are properly configured for the sentient group."
 }
 
-func (r *UlimitsRule) Verify() error {
+func (r *UlimitsRule) Verify(_ context.Context) error {
 	logger.Debugln("Validating ulimit configurations")
 
 	// Validate memlock configuration

--- a/ai-services/internal/pkg/validators/podman/usergroup/usergroup.go
+++ b/ai-services/internal/pkg/validators/podman/usergroup/usergroup.go
@@ -1,6 +1,7 @@
 package usergroup
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 
@@ -22,7 +23,7 @@ func (r *UsergroupRule) Description() string {
 	return "Validates that the sentient group exists for ulimit configurations."
 }
 
-func (r *UsergroupRule) Verify() error {
+func (r *UsergroupRule) Verify(_ context.Context) error {
 	logger.Debugln("Validating sentient group exists")
 
 	// Check if sentient group exists using getent

--- a/ai-services/internal/pkg/validators/validators.go
+++ b/ai-services/internal/pkg/validators/validators.go
@@ -1,6 +1,7 @@
 package validators
 
 import (
+	"context"
 	"sync"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
@@ -44,7 +45,7 @@ func init() {
 
 // Rule defines the interface for validation rules.
 type Rule interface {
-	Verify() error
+	Verify(ctx context.Context) error
 	Message() string
 	Name() string
 	Level() constants.ValidationLevel

--- a/ai-services/internal/pkg/worker/deploy/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/deploy.go
@@ -69,7 +69,7 @@ type Options struct {
 func Setup(ctx context.Context, rt runtime.Runtime, opts Options) error {
 	logger.InfolnCtx(ctx, "Setting up worker node...")
 
-	pods, err := rt.ListPods(map[string][]string{
+	pods, err := rt.ListPods(ctx, map[string][]string{
 		"label": {workerconstants.WorkerProxyLabel},
 	})
 	if err != nil {

--- a/ai-services/internal/pkg/worker/dispatch/dispatch.go
+++ b/ai-services/internal/pkg/worker/dispatch/dispatch.go
@@ -44,7 +44,7 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 	// ── Images ────────────────────────────────────────────────────────────────
 
 	case workerpb.CommandType_COMMAND_TYPE_LIST_IMAGES:
-		images, err := rt.ListImages()
+		images, err := rt.ListImages(ctx)
 
 		return marshalOr(images, err)
 
@@ -63,7 +63,7 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 		if err := json.Unmarshal(p, &req); err != nil {
 			return nil, fmt.Errorf("decode list_pods payload: %w", err)
 		}
-		pods, err := rt.ListPods(req.Filters)
+		pods, err := rt.ListPods(ctx, req.Filters)
 
 		return marshalOr(pods, err)
 
@@ -82,7 +82,7 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 			return nil, fmt.Errorf("decode delete_pod payload: %w", err)
 		}
 
-		return nil, rt.DeletePod(req.ID, req.Force)
+		return nil, rt.DeletePod(ctx, req.ID, req.Force)
 
 	case workerpb.CommandType_COMMAND_TYPE_STOP_POD:
 		var req payload.NameOrID
@@ -90,7 +90,7 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 			return nil, fmt.Errorf("decode stop_pod payload: %w", err)
 		}
 
-		return nil, rt.StopPod(req.NameOrID)
+		return nil, rt.StopPod(ctx, req.NameOrID)
 
 	case workerpb.CommandType_COMMAND_TYPE_START_POD:
 		var req payload.NameOrID
@@ -98,14 +98,14 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 			return nil, fmt.Errorf("decode start_pod payload: %w", err)
 		}
 
-		return nil, rt.StartPod(req.NameOrID)
+		return nil, rt.StartPod(ctx, req.NameOrID)
 
 	case workerpb.CommandType_COMMAND_TYPE_INSPECT_POD:
 		var req payload.NameOrID
 		if err := json.Unmarshal(p, &req); err != nil {
 			return nil, fmt.Errorf("decode inspect_pod payload: %w", err)
 		}
-		pod, err := rt.InspectPod(req.NameOrID)
+		pod, err := rt.InspectPod(ctx, req.NameOrID)
 
 		return marshalOr(pod, err)
 
@@ -114,7 +114,7 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 		if err := json.Unmarshal(p, &req); err != nil {
 			return nil, fmt.Errorf("decode pod_exists payload: %w", err)
 		}
-		exists, err := rt.PodExists(req.NameOrID)
+		exists, err := rt.PodExists(ctx, req.NameOrID)
 
 		return marshalOr(exists, err)
 
@@ -124,14 +124,14 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 			return nil, fmt.Errorf("decode pod_logs payload: %w", err)
 		}
 
-		return nil, rt.PodLogs(req.NameOrID)
+		return nil, rt.PodLogs(ctx, req.NameOrID)
 
 	case workerpb.CommandType_COMMAND_TYPE_GET_POD_RESOURCES:
 		var req payload.NameOrID
 		if err := json.Unmarshal(p, &req); err != nil {
 			return nil, fmt.Errorf("decode get_pod_resources payload: %w", err)
 		}
-		pr, err := rt.GetPodResources(req.NameOrID)
+		pr, err := rt.GetPodResources(ctx, req.NameOrID)
 
 		return marshalOr(pr, err)
 
@@ -142,7 +142,7 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 		if err := json.Unmarshal(p, &req); err != nil {
 			return nil, fmt.Errorf("decode list_secrets payload: %w", err)
 		}
-		names, err := rt.ListSecrets(req.Filters)
+		names, err := rt.ListSecrets(ctx, req.Filters)
 
 		return marshalOr(names, err)
 
@@ -152,14 +152,14 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 			return nil, fmt.Errorf("decode delete_secret payload: %w", err)
 		}
 
-		return nil, rt.DeleteSecret(req.Name)
+		return nil, rt.DeleteSecret(ctx, req.Name)
 
 	case workerpb.CommandType_COMMAND_TYPE_SECRET_EXISTS:
 		var req payload.NameOrID
 		if err := json.Unmarshal(p, &req); err != nil {
 			return nil, fmt.Errorf("decode secret_exists payload: %w", err)
 		}
-		exists, err := rt.SecretExists(req.NameOrID)
+		exists, err := rt.SecretExists(ctx, req.NameOrID)
 
 		return marshalOr(exists, err)
 
@@ -171,14 +171,14 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 			return nil, fmt.Errorf("decode delete_volume payload: %w", err)
 		}
 
-		return nil, rt.DeleteVolume(req.Name)
+		return nil, rt.DeleteVolume(ctx, req.Name)
 
 	case workerpb.CommandType_COMMAND_TYPE_VOLUME_EXISTS:
 		var req payload.NameOrID
 		if err := json.Unmarshal(p, &req); err != nil {
 			return nil, fmt.Errorf("decode volume_exists payload: %w", err)
 		}
-		exists, err := rt.VolumeExists(req.NameOrID)
+		exists, err := rt.VolumeExists(ctx, req.NameOrID)
 
 		return marshalOr(exists, err)
 
@@ -189,7 +189,7 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 		if err := json.Unmarshal(p, &req); err != nil {
 			return nil, fmt.Errorf("decode inspect_container payload: %w", err)
 		}
-		c, err := rt.InspectContainer(req.NameOrID)
+		c, err := rt.InspectContainer(ctx, req.NameOrID)
 
 		return marshalOr(c, err)
 
@@ -198,7 +198,7 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 		if err := json.Unmarshal(p, &req); err != nil {
 			return nil, fmt.Errorf("decode container_exists payload: %w", err)
 		}
-		exists, err := rt.ContainerExists(req.NameOrID)
+		exists, err := rt.ContainerExists(ctx, req.NameOrID)
 
 		return marshalOr(exists, err)
 
@@ -208,14 +208,14 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 			return nil, fmt.Errorf("decode container_logs payload: %w", err)
 		}
 
-		return nil, rt.ContainerLogs(req.NameOrID)
+		return nil, rt.ContainerLogs(ctx, req.NameOrID)
 
 	case workerpb.CommandType_COMMAND_TYPE_RUN_EPHEMERAL_CONTAINER:
 		var req payload.ExecInContainer
 		if err := json.Unmarshal(p, &req); err != nil {
 			return nil, fmt.Errorf("decode run_ephemeral_container payload: %w", err)
 		}
-		out, err := rt.ExecInContainerWithCmd(req.PodName, req.ContainerName, req.Command)
+		out, err := rt.ExecInContainerWithCmd(ctx, req.PodName, req.ContainerName, req.Command)
 
 		return marshalOr(out, err)
 
@@ -226,7 +226,7 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 		if err := json.Unmarshal(p, &req); err != nil {
 			return nil, fmt.Errorf("decode list_routes payload: %w", err)
 		}
-		routes, err := rt.ListRoutes(req.LabelSelector)
+		routes, err := rt.ListRoutes(ctx, req.LabelSelector)
 
 		return marshalOr(routes, err)
 
@@ -238,10 +238,10 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 			return nil, fmt.Errorf("decode delete_pvcs payload: %w", err)
 		}
 
-		return nil, rt.DeletePVCs(req.Name)
+		return nil, rt.DeletePVCs(ctx, req.Name)
 
 	case workerpb.CommandType_COMMAND_TYPE_GET_SYSTEM_INFO:
-		info, err := rt.GetSystemInfo()
+		info, err := rt.GetSystemInfo(ctx)
 
 		return marshalOr(info, err)
 

--- a/ai-services/internal/pkg/worker/uninstall/uninstall.go
+++ b/ai-services/internal/pkg/worker/uninstall/uninstall.go
@@ -37,7 +37,7 @@ func Uninstall(ctx context.Context, opts Options) error {
 		return fmt.Errorf("worker uninstall: init runtime: %w", err)
 	}
 
-	pods, err := rt.ListPods(map[string][]string{
+	pods, err := rt.ListPods(ctx, map[string][]string{
 		"label": {workerconstants.WorkerProxyLabel},
 	})
 	if err != nil {
@@ -76,7 +76,7 @@ func performCleanup(ctx context.Context, rt runtime.Runtime, pods []types.Pod) e
 
 	var baseDir string
 
-	config, err := getWorkerCaddyPodConfig(rt, pods[0].ID)
+	config, err := getWorkerCaddyPodConfig(ctx, rt, pods[0].ID)
 	if err != nil {
 		logger.WarningfCtx(ctx, "Failed to retrieve BaseDir from worker pod: %v. Using default BaseDir.\n", err)
 		baseDir = utils.GetBaseDir()
@@ -98,8 +98,8 @@ func performCleanup(ctx context.Context, rt runtime.Runtime, pods []types.Pod) e
 // getWorkerCaddyPodConfig retrieves worker Caddy pod configuration by inspecting
 // the running pod and its containers. It extracts the AI_SERVICES_BASE_DIR
 // environment variable injected by caddy.yaml.tmpl at deploy time.
-func getWorkerCaddyPodConfig(rt runtime.Runtime, podID string) (*WorkerCaddyConfig, error) {
-	pInfo, err := rt.InspectPod(podID)
+func getWorkerCaddyPodConfig(ctx context.Context, rt runtime.Runtime, podID string) (*WorkerCaddyConfig, error) {
+	pInfo, err := rt.InspectPod(ctx, podID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect pod %s: %w", podID, err)
 	}
@@ -107,7 +107,7 @@ func getWorkerCaddyPodConfig(rt runtime.Runtime, podID string) (*WorkerCaddyConf
 	config := &WorkerCaddyConfig{}
 
 	for _, container := range pInfo.Containers {
-		cInfo, err := rt.InspectContainer(container.ID)
+		cInfo, err := rt.InspectContainer(ctx, container.ID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to inspect container %s: %w", container.Name, err)
 		}
@@ -157,7 +157,7 @@ func deletePods(ctx context.Context, rt runtime.Runtime, pods []types.Pod) error
 	for _, p := range pods {
 		logger.InfofCtx(ctx, "Deleting pod: %s\n", p.Name)
 
-		if err := rt.DeletePod(p.ID, utils.BoolPtr(true)); err != nil {
+		if err := rt.DeletePod(ctx, p.ID, utils.BoolPtr(true)); err != nil {
 			errs = append(errs, fmt.Sprintf("pod %s: %v", p.Name, err))
 
 			continue

--- a/ai-services/tests/e2e/cli/runner.go
+++ b/ai-services/tests/e2e/cli/runner.go
@@ -257,12 +257,12 @@ func (e AppEndpoints) SimilarityURL() string { return e[catalogSvcSimilarity][en
 
 // CatalogGetApplicationEndpoints fetches endpoint URLs for a named application via the catalog REST API.
 func CatalogGetApplicationEndpoints(appName string) (AppEndpoints, error) {
-	appClient, err := client.NewApplicationClient()
+	appClient, err := client.NewApplicationClient(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("catalog client init: %w", err)
 	}
 
-	list, err := appClient.ListApplications(nil)
+	list, err := appClient.ListApplications(context.Background(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("list applications: %w", err)
 	}

--- a/ai-services/tests/e2e/rag/evaluator.go
+++ b/ai-services/tests/e2e/rag/evaluator.go
@@ -152,7 +152,7 @@ func WaitForSimilarityAPIReady(ctx context.Context, similarityBaseURL string, po
 
 // catalogClientNew wraps catalogClient.New() as a variable to allow test overrides and avoid import cycles.
 var catalogClientNew = func() (interface{ AccessToken() string }, error) {
-	return catalogClient.New()
+	return catalogClient.New(context.Background())
 }
 
 const (

--- a/ai-services/tests/e2e/rag/setup.go
+++ b/ai-services/tests/e2e/rag/setup.go
@@ -81,7 +81,7 @@ func judgeModelAlreadyDownloaded() bool {
 }
 
 // DownloadJudgeModel logs in to the RH registry and downloads the judge model if not already present.
-func DownloadJudgeModel(_ context.Context, _ *config.Config) error {
+func DownloadJudgeModel(ctx context.Context, _ *config.Config) error {
 	if judgeModelAlreadyDownloaded() {
 		logger.Infof("[JUDGE] Judge model already present at %s/%s — skipping download", ModelPath, Model)
 
@@ -98,7 +98,7 @@ func DownloadJudgeModel(_ context.Context, _ *config.Config) error {
 	}
 	logger.Infof("[JUDGE] RH Registry login completed")
 
-	if modelErr := helpers.DownloadModel(Model, ModelPath); modelErr != nil {
+	if modelErr := helpers.DownloadModel(ctx, Model, ModelPath); modelErr != nil {
 		logger.Errorf("error downloading LLM as Judge model %v", modelErr)
 
 		return fmt.Errorf("error downloading LLM as Judge model: %w", modelErr)


### PR DESCRIPTION
Added `ctx context.Context` to all methods on the `Runtime` interface so that cancellation signals propagate correctly through the entire call chain.

**Why each group changed:**

- **`runtime/interface.go` + implementations (Podman, OpenShift)** — core change; every method now accepts `ctx` so callers can cancel in-flight operations
- **`application/podman` & `openshift` (`create.go`, `delete.go`)** — deployment path: `ctx` now cancels image pulls, pod creation, and readiness waits mid-flight
- **`cli/podman/deploy.go`, `cli/helpers/helper.go`** — readiness wait loops; cancellation stops waiting immediately
- **`image/`** — image pull respects cancellation
- **`catalog/apiserver/services/deployment/`, `deletion/`** — API-triggered create/delete path
- **`application/{podman,openshift}` (`info.go`, `logs.go`, `ps.go`, `start.go`, `stop.go`) + `catalog/cli/configure/podman` reset functions + `catalog/apiserver/services/sync`** — accept and propagate `ctx` from the cmd layer (`cmd.Context()`) so the full call chain is consistent

**Validation:**
- Applications deployed and deleted via catalog — no regressions
- Applications created and deleted via CLI — no regressions

**Note:** `cmd.Context()` currently behaves the same as `context.Background()` since OS signal wiring at the root command is not yet in place. This change establishes the correct plumbing so that when signal handling is added (tracked separately), cancellation will propagate end-to-end with no further changes required in the internal packages.