### PR TITLE
Update application assets to use Opensearch image 3.7

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.286
+TAG?=v0.0.287
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -38,7 +38,7 @@ ingest:
 
 opensearch:
   # @hidden
-  image: icr.io/ai-services-private/opensearch:3.7.0-ppc64le
+  image: icr.io/ai-services-cicd/opensearch:3.7.0-ppc64le
   # @description Sets the memory limit for the Opensearch service(Default: 8Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   memoryLimit: 8Gi
   auth:

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -38,7 +38,7 @@ ingest:
 
 opensearch:
   # @hidden
-  image: icr.io/ppc64le-oss/opensearch-ppc64le:3.5.0
+  image: icr.io/ai-services-private/opensearch:3.7.0-ppc64le
   # @description Sets the memory limit for the Opensearch service(Default: 8Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   memoryLimit: 8Gi
   auth:

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -79,7 +79,7 @@ ingest:
 
 opensearch:
   # @hidden
-  image: icr.io/ai-services-private/opensearch:3.7.0-ppc64le
+  image: icr.io/ai-services-cicd/opensearch:3.7.0-ppc64le
   # @description Sets the memory limit for the Opensearch service(Default: 8Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   memoryLimit: 8Gi
   # @description Sets the storage limit for the Opensearch service(Default: 10Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -79,7 +79,7 @@ ingest:
 
 opensearch:
   # @hidden
-  image: icr.io/ppc64le-oss/opensearch-ppc64le:3.5.0
+  image: icr.io/ai-services-private/opensearch:3.7.0-ppc64le
   # @description Sets the memory limit for the Opensearch service(Default: 8Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   memoryLimit: 8Gi
   # @description Sets the storage limit for the Opensearch service(Default: 10Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -38,7 +38,7 @@ ingest:
 
 opensearch:
   # @hidden
-  image: icr.io/ai-services-private/opensearch:3.7.0-ppc64le
+  image: icr.io/ai-services-cicd/opensearch:3.7.0-ppc64le
   # @description Sets the memory limit for the Opensearch service(Default: 8Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   memoryLimit: 8Gi
   auth:

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -38,7 +38,7 @@ ingest:
 
 opensearch:
   # @hidden
-  image: icr.io/ppc64le-oss/opensearch-ppc64le:3.5.0
+  image: icr.io/ai-services-private/opensearch:3.7.0-ppc64le
   # @description Sets the memory limit for the Opensearch service(Default: 8Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   memoryLimit: 8Gi
   auth:

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -79,7 +79,7 @@ ingest:
 
 opensearch:
   # @hidden
-  image: icr.io/ai-services-private/opensearch:3.7.0-ppc64le
+  image: icr.io/ai-services-cicd/opensearch:3.7.0-ppc64le
   # @description Sets the memory limit for the Opensearch service(Default: 8Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   memoryLimit: 8Gi
   # @description Sets the storage limit for the Opensearch service(Default: 10Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -79,7 +79,7 @@ ingest:
 
 opensearch:
   # @hidden
-  image: icr.io/ppc64le-oss/opensearch-ppc64le:3.5.0
+  image: icr.io/ai-services-private/opensearch:3.7.0-ppc64le
   # @description Sets the memory limit for the Opensearch service(Default: 8Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   memoryLimit: 8Gi
   # @description Sets the storage limit for the Opensearch service(Default: 10Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -36,7 +36,7 @@ ingest:
 
 opensearch:
   # @hidden
-  image: icr.io/ppc64le-oss/opensearch-ppc64le:3.5.0
+  image: icr.io/ai-services-private/opensearch:3.7.0-ppc64le
   # @description Sets the memory limit for the Opensearch service(Default: 8Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   memoryLimit: 8Gi
   auth:

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -36,7 +36,7 @@ ingest:
 
 opensearch:
   # @hidden
-  image: icr.io/ai-services-private/opensearch:3.7.0-ppc64le
+  image: icr.io/ai-services-cicd/opensearch:3.7.0-ppc64le
   # @description Sets the memory limit for the Opensearch service(Default: 8Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   memoryLimit: 8Gi
   auth:

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.286
+  image: icr.io/ai-services-cicd/ai-services:v0.0.287
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.286
+  image: icr.io/ai-services-cicd/ai-services:v0.0.287
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/components/vector_db/opensearch/openshift/values.yaml
+++ b/ai-services/assets/components/vector_db/opensearch/openshift/values.yaml
@@ -1,4 +1,4 @@
-image: icr.io/ai-services-private/opensearch:3.7.0-ppc64le
+image: icr.io/ai-services-cicd/opensearch:3.7.0-ppc64le
 memoryLimit: 8Gi
 storage: 10Gi
 replicas: 1

--- a/ai-services/assets/components/vector_db/opensearch/openshift/values.yaml
+++ b/ai-services/assets/components/vector_db/opensearch/openshift/values.yaml
@@ -1,4 +1,4 @@
-image: icr.io/ppc64le-oss/opensearch-ppc64le:3.5.0
+image: icr.io/ai-services-private/opensearch:3.7.0-ppc64le
 memoryLimit: 8Gi
 storage: 10Gi
 replicas: 1

--- a/ai-services/assets/components/vector_db/opensearch/podman/values.yaml
+++ b/ai-services/assets/components/vector_db/opensearch/podman/values.yaml
@@ -1,4 +1,4 @@
-image: icr.io/ai-services-private/opensearch:3.7.0-ppc64le
+image: icr.io/ai-services-cicd/opensearch:3.7.0-ppc64le
 memoryLimit: 8Gi
 auth:
   username: "admin"

--- a/ai-services/assets/components/vector_db/opensearch/podman/values.yaml
+++ b/ai-services/assets/components/vector_db/opensearch/podman/values.yaml
@@ -1,4 +1,4 @@
-image: icr.io/ppc64le-oss/opensearch-ppc64le:3.5.0
+image: icr.io/ai-services-private/opensearch:3.7.0-ppc64le
 memoryLimit: 8Gi
 auth:
   username: "admin"


### PR DESCRIPTION
- This Opensearch image version bump to the 3.7 version is to accomodate latest opensearch features, CVE fixes. 