### PR TITLE
chore: reduce debug log noise across digitize services

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.260
+TAG?=v0.0.261
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.46
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.47
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.46
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.47
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.46
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.47
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.46
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.47
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.46
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.47
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.260
+  image: icr.io/ai-services-cicd/ai-services:v0.0.261
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.260
+  image: icr.io/ai-services-cicd/ai-services:v0.0.261
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/services/digitize/openshift/values.yaml
+++ b/ai-services/assets/services/digitize/openshift/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.46
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.47
   log_level: "INFO"
   database: "digitize_metadata"
   numShards: 1

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.46
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.47
   log_level: "INFO"
   database: "digitize_metadata"
   # @generate:password length=32, special=false

--- a/services/common/opensearch.py
+++ b/services/common/opensearch.py
@@ -29,8 +29,6 @@ class OpensearchNotReadyError(VectorStoreNotReadyError):
 
 class OpensearchVectorStore(VectorStore):
     def __init__(self):
-        """Initialize the OpenSearch client and create the hybrid search pipeline."""
-        logger.debug("Initializing OpensearchVectorStore")
 
         self.host = settings.vector_store.opensearch_host
         self.port = settings.vector_store.opensearch_port
@@ -42,7 +40,6 @@ class OpensearchVectorStore(VectorStore):
         self.num_shards = settings.vector_store.opensearch_num_shards
         
         logger.debug(f"Connecting to OpenSearch at {self.host}:{self.port}, index: {self.index_name}")
-        logger.debug(f"Index configuration: shards={self.num_shards}")
 
         self.client = OpenSearch(
             hosts=[{'host': self.host, 'port': self.port}],

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.46
+TAG?=v0.0.47
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -69,7 +69,6 @@ class DatabaseManager:
                 )
                 session.add(job)
                 session.flush()  # Ensure job is persisted before returning
-                logger.info(f"Created job in database: {job_id}")
                 return job
         except IntegrityError as e:
             logger.error(f"Job {job_id} already exists in database: {e}")
@@ -103,7 +102,6 @@ class DatabaseManager:
                          job.stats, job.updated_at)
                     # Expunge the object from session to prevent DetachedInstanceError
                     session.expunge(job)
-                    logger.debug(f"Retrieved job from database: {job_id}")
                 else:
                     logger.debug(f"Job not found in database: {job_id}")
                 return job
@@ -158,7 +156,6 @@ class DatabaseManager:
                 # Expunge all jobs from session to prevent DetachedInstanceError
                 for job in jobs:
                     session.expunge(job)
-                logger.debug(f"Retrieved {len(jobs)} jobs from database (total: {total})")
                 return jobs, total
         except SQLAlchemyError as e:
             logger.error(f"Database error retrieving jobs: {e}", exc_info=True)
@@ -208,7 +205,6 @@ class DatabaseManager:
                 result = cast(CursorResult, session.execute(stmt))
                 
                 if result.rowcount > 0:
-                    logger.debug(f"Updated job in database: {job_id}")
                     return True
                 else:
                     logger.warning(f"Job not found for update: {job_id}")
@@ -296,7 +292,6 @@ class DatabaseManager:
                 )
                 session.add(document)
                 session.flush()
-                logger.info(f"Created document in database: {doc_id}")
                 return document
         except IntegrityError as e:
             logger.error(f"Document {doc_id} already exists or invalid job_id: {e}")
@@ -521,7 +516,6 @@ class DatabaseManager:
                          doc.output_format, doc.submitted_at, doc.completed_at,
                          doc.error, doc.doc_metadata, doc.updated_at)
                     session.expunge(doc)
-                logger.debug(f"Retrieved {len(documents)} documents for job {job_id}")
                 return documents
         except SQLAlchemyError as e:
             logger.error(f"Database error retrieving documents for job {job_id}: {e}", exc_info=True)
@@ -571,7 +565,6 @@ class DatabaseManager:
                 result = cast(CursorResult, session.execute(stmt))
                 
                 if result.rowcount > 0:
-                    logger.debug(f"Updated document in database: {doc_id}")
                     return True
                 else:
                     logger.warning(f"Document not found for update: {doc_id}")
@@ -685,8 +678,6 @@ class DatabaseManager:
                 stmt = delete(Document)
                 result = cast(CursorResult, session.execute(stmt))
                 deleted_count = result.rowcount
-
-                logger.info(f"Deleted all documents from database: {deleted_count} documents")
                 return {
                     "deleted_count": deleted_count,
                     "success": True
@@ -721,8 +712,6 @@ class DatabaseManager:
                 stmt = delete(Job)
                 result = cast(CursorResult, session.execute(stmt))
                 deleted_count = result.rowcount
-                
-                logger.info(f"Deleted all jobs from database: {deleted_count} jobs")
                 return {
                     "deleted_count": deleted_count,
                     "success": True

--- a/services/digitize/parsing/converter.py
+++ b/services/digitize/parsing/converter.py
@@ -163,7 +163,6 @@ def get_doc_converter():
         artifacts_path = Path(docling_models_path)
         if artifacts_path.exists():
             pipeline_options.artifacts_path = artifacts_path
-            logger.debug(f"Using docling models from: {artifacts_path}")
         else:
             logger.warning(f"DOCLING_MODELS_PATH set to {artifacts_path} but directory does not exist")
     else:

--- a/services/digitize/parsing/docx.py
+++ b/services/digitize/parsing/docx.py
@@ -33,10 +33,8 @@ def _parse_ref_index(ref: str, prefix: str) -> int | None:
     try:
         expected_prefix = f"#/{prefix}/"
         if not isinstance(ref, str) or not ref.startswith(expected_prefix):
-            logger.debug(f"_parse_ref_index: ref '{ref}' does not match expected prefix '{expected_prefix}'")
             return None
         parsed_idx = int(ref[len(expected_prefix):])
-        logger.debug(f"_parse_ref_index: parsed ref '{ref}' with prefix '{prefix}' to index {parsed_idx}")
         return parsed_idx
     except Exception as e:
         logger.debug(f"_parse_ref_index: failed to parse ref '{ref}' with prefix '{prefix}': {e}")
@@ -50,8 +48,7 @@ def _get_body_children_refs(converted_doc) -> list[str]:
     try:
         children = getattr(converted_doc.body, "children", []) or []
         refs = []
-        logger.debug(f"_get_body_children_refs: found {len(children)} top-level body children")
-        for idx, child in enumerate(children):
+        for child in children:
             if isinstance(child, dict) and "$ref" in child:
                 refs.append(child["$ref"])
             else:
@@ -61,13 +58,8 @@ def _get_body_children_refs(converted_doc) -> list[str]:
                     or getattr(child, "cref", None)
                     or getattr(child, "self_ref", None)
                 )
-                if not child_ref and hasattr(child, "__dict__"):
-                    logger.debug(
-                        f"_get_body_children_refs: child[{idx}] available attrs={list(vars(child).keys())}, type={type(child)}"
-                    )
                 if child_ref:
                     refs.append(child_ref)
-        logger.debug(f"_get_body_children_refs: extracted {len(refs)} refs")
         return refs
     except Exception as e:
         logger.debug(f"_get_body_children_refs: failed to extract body children refs: {e}", exc_info=True)
@@ -80,24 +72,17 @@ def _get_text_value_by_ref(converted_doc, ref: str) -> str:
     """
     idx = _parse_ref_index(ref, "texts")
     if idx is None:
-        logger.debug(f"_get_text_value_by_ref: could not parse text ref '{ref}'")
         return ""
 
     try:
         text_obj = converted_doc.texts[idx]
         text = getattr(text_obj, "text", None)
         if text:
-            resolved_text = str(text).strip()
-            logger.debug(f"_get_text_value_by_ref: resolved '{ref}' from text field -> '{resolved_text}'")
-            return resolved_text
+            return str(text).strip()
 
         orig = getattr(text_obj, "orig", None)
         if orig:
-            resolved_orig = str(orig).strip()
-            logger.debug(f"_get_text_value_by_ref: resolved '{ref}' from orig field -> '{resolved_orig}'")
-            return resolved_orig
-
-        logger.debug(f"_get_text_value_by_ref: ref '{ref}' resolved to empty text/orig")
+            return str(orig).strip()
     except Exception as e:
         logger.debug(f"_get_text_value_by_ref: failed to resolve ref '{ref}': {e}", exc_info=True)
 
@@ -109,12 +94,9 @@ def _looks_like_table_caption(text: str) -> bool:
     'Table 1-1 VIOS release schedule'.
     """
     if not text:
-        logger.debug("_looks_like_table_caption: empty text -> False")
         return False
     text_stripped = text.strip()
-    is_match = bool(TABLE_CAPTION_PATTERN.match(text_stripped))
-    logger.debug(f"_looks_like_table_caption: text='{text_stripped}' match={is_match}")
-    return is_match
+    return bool(TABLE_CAPTION_PATTERN.match(text_stripped))
 
 
 def _get_ref_value(ref_obj) -> str | None:
@@ -146,7 +128,6 @@ def _get_doc_item_by_ref(converted_doc, ref: str):
         except Exception as e:
             logger.debug(f"_get_doc_item_by_ref: failed to resolve '{ref}' in '{prefix}': {e}", exc_info=True)
             return None
-    logger.debug(f"_get_doc_item_by_ref: unsupported or unresolved ref '{ref}'")
     return None
 
 
@@ -158,7 +139,6 @@ def _get_parent_ref_for_table(converted_doc, table_ix: int) -> str:
         table_obj = converted_doc.tables[table_ix]
         parent = getattr(table_obj, "parent", None)
         parent_ref = _get_ref_value(parent) if parent is not None else None
-        logger.debug(f"_get_parent_ref_for_table: table_ix={table_ix}, parent_ref={parent_ref}")
         return parent_ref or ""
     except Exception as e:
         logger.debug(f"_get_parent_ref_for_table: failed for table_ix={table_ix}: {e}", exc_info=True)
@@ -187,38 +167,25 @@ def _find_matching_caption_near_refs(converted_doc, ordered_refs: list[str], tar
     Look for a caption-like text node near the target ref inside an ordered ref list.
     """
     if not ordered_refs:
-        logger.debug("_find_matching_caption_near_refs: ordered_refs empty")
         return ""
 
     try:
         target_pos = ordered_refs.index(target_ref)
-        logger.debug(f"_find_matching_caption_near_refs: found {target_ref} at pos={target_pos}")
     except ValueError:
-        logger.debug(f"_find_matching_caption_near_refs: target_ref {target_ref} not found in ordered refs")
         return ""
 
     candidate_positions = list(range(max(0, target_pos - search_window), target_pos))
     candidate_positions.reverse()
     candidate_positions.extend(range(target_pos + 1, min(len(ordered_refs), target_pos + 1 + search_window)))
 
-    candidate_refs = [(pos, ordered_refs[pos]) for pos in candidate_positions]
-    logger.debug(f"_find_matching_caption_near_refs: candidate positions/refs={candidate_refs}")
-
     for pos in candidate_positions:
         ref = ordered_refs[pos]
-
         if not ref.startswith("#/texts/"):
-            logger.debug(f"_find_matching_caption_near_refs: skipping non-text ref {ref}")
             continue
-
         text = _get_text_value_by_ref(converted_doc, ref)
-        logger.debug(f"_find_matching_caption_near_refs: resolved ref {ref} to text='{text}'")
-
         if _looks_like_table_caption(text):
-            logger.debug(f"_find_matching_caption_near_refs: matched caption '{text}' near {target_ref}")
             return text
 
-    logger.debug(f"_find_matching_caption_near_refs: no caption match found near {target_ref}")
     return ""
 
 def _get_enclosing_section_header_for_table(converted_doc, table_ix: int) -> str:
@@ -228,20 +195,14 @@ def _get_enclosing_section_header_for_table(converted_doc, table_ix: int) -> str
     """
     parent_ref = _get_parent_ref_for_table(converted_doc, table_ix)
     if not parent_ref:
-        logger.debug(f"_get_enclosing_section_header_for_table: no parent ref for table_ix={table_ix}")
         return ""
 
     parent_item = _get_doc_item_by_ref(converted_doc, parent_ref)
     if parent_item is None:
-        logger.debug(f"_get_enclosing_section_header_for_table: could not resolve parent item for {parent_ref}")
         return ""
 
     label = getattr(parent_item, "label", None)
     text = (getattr(parent_item, "text", None) or getattr(parent_item, "orig", None) or "").strip()
-    logger.debug(
-        f"_get_enclosing_section_header_for_table: table_ix={table_ix}, parent_ref={parent_ref}, "
-        f"label={label}, text='{text}'"
-    )
 
     if label == "section_header" and text:
         return text
@@ -256,12 +217,11 @@ def recover_table_caption_from_body_context(converted_doc, table_ix: int, search
     3. enclosing section header text as semantic fallback.
     """
     target_ref = f"#/tables/{table_ix}"
-    logger.debug(f"recover_table_caption_from_body_context: looking for caption near {target_ref} with search_window={search_window}")
 
     body_refs = _get_body_children_refs(converted_doc)
     caption = _find_matching_caption_near_refs(converted_doc, body_refs, target_ref, search_window)
     if caption:
-        logger.debug(f"recover_table_caption_from_body_context: using body-level caption '{caption}' for {target_ref}")
+        logger.debug(f"recover_table_caption_from_body_context: {target_ref} -> body-level caption '{caption}'")
         return caption
 
     parent_ref = _get_parent_ref_for_table(converted_doc, table_ix)
@@ -271,21 +231,15 @@ def recover_table_caption_from_body_context(converted_doc, table_ix: int, search
             parent_child_refs = _get_child_refs(parent_item)
             caption = _find_matching_caption_near_refs(converted_doc, parent_child_refs, target_ref, search_window)
             if caption:
-                logger.debug(
-                    f"recover_table_caption_from_body_context: using parent-level nearby caption '{caption}' "
-                    f"for {target_ref} within parent {parent_ref}"
-                )
+                logger.debug(f"recover_table_caption_from_body_context: {target_ref} -> parent-level caption '{caption}'")
                 return caption
 
     section_header = _get_enclosing_section_header_for_table(converted_doc, table_ix)
     if section_header:
-        logger.debug(
-            f"recover_table_caption_from_body_context: using enclosing section header '{section_header}' "
-            f"as secondary fallback for {target_ref}"
-        )
+        logger.debug(f"recover_table_caption_from_body_context: {target_ref} -> section header fallback '{section_header}'")
         return section_header
 
-    logger.debug(f"recover_table_caption_from_body_context: no caption match found for {target_ref}")
+    logger.debug(f"recover_table_caption_from_body_context: {target_ref} -> no caption found")
     return ""
 
 def estimate_docx_page_count(docx_path: str) -> int:

--- a/services/digitize/processing/orchestrator.py
+++ b/services/digitize/processing/orchestrator.py
@@ -449,7 +449,7 @@ def process_converted_document(converted_json_path, doc_path, out_path, gen_mode
             with open(processed_text_json_path, "r") as f:
                 text_data = json.load(f)
                 document_language = detect_document_language(text_data)
-                logger.info(f"Detected document language: {document_language}")
+                logger.info(f"Detected document language: {document_language} for doc: {doc_path}")
         except Exception as e:
             logger.warning(f"Failed to detect document language, using default {LanguageCodes.ENGLISH}: {e}")
 
@@ -537,7 +537,7 @@ def process_documents(input_paths, out_path, llm_model, llm_endpoint, emb_endpoi
                 future = converter_executor.submit(convert_document, path, out_path, file_name)
                 conversion_futures[future] = path
                 if doc_id is not None:
-                    logger.debug(f"Submitted for conversion: updating job & doc metadata to IN_PROGRESS for document: {doc_id}")
+                    logger.debug(f"Submitted for conversion: {Path(path).name}")
                     status_mgr.update_doc_metadata(doc_id, {"status": DocStatus.IN_PROGRESS})
                     status_mgr.update_job_progress(doc_id, DocStatus.IN_PROGRESS, JobStatus.IN_PROGRESS)
 

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -209,7 +209,6 @@ def create_job(
                 "in_progress": 0
             }
         )
-        logger.info(f"Created job {job_id} in database")
 
     except Exception as e:
         logger.error(f"Failed to create job {job_id} in database: {e}", exc_info=True)
@@ -329,7 +328,6 @@ def get_all_jobs(
             )
             job_dicts.append(job_state.to_dict())
 
-        logger.debug(f"Retrieved {len(job_dicts)} jobs from database (total: {total})")
         return job_dicts, total
     except Exception as e:
         logger.error(f"Failed to get jobs from database: {e}", exc_info=True)
@@ -406,7 +404,6 @@ def create_document(
                 f"db_manager.create_document returned None for doc_id={doc_id} "
                 f"(name={doc_name!r}). Check logs for the underlying DB error."
             )
-        logger.info(f"Created document {doc_id} in database")
 
     except Exception as e:
         logger.error(f"Failed to create document {doc_id} in database: {e}", exc_info=True)
@@ -1049,7 +1046,6 @@ class DatabaseStatusManager:
         if update_params:
             success = db_manager.update_document(doc_id, **update_params)
             if success:
-                logger.debug(f"Updated document {doc_id} in database")
                 # Register the checksum once the document is marked COMPLETED so
                 # that future uploads of the same content are caught via the
                 # document_checksum table.
@@ -1130,12 +1126,7 @@ class DatabaseStatusManager:
             update_params["error"] = error
 
         # Perform database update
-        success = db_manager.update_job(self.job_id, **update_params)
-        if success:
-            logger.debug(f"Updated job {self.job_id} in database")
-        else:
-            logger.warning(f"Job {self.job_id} not found in database for update")
-
+        db_manager.update_job(self.job_id, **update_params)
 
 def get_status_manager(job_id: str) -> DatabaseStatusManager:
     """

--- a/services/digitize/utils/jobs.py
+++ b/services/digitize/utils/jobs.py
@@ -86,7 +86,6 @@ def generate_uuid():
     """
     # Generate a random UUID (uuid4)
     generated_uuid = uuid.uuid4()
-    logger.debug(f"Generated UUID: {generated_uuid}")
     return str(generated_uuid)
 
 
@@ -138,7 +137,6 @@ def initialize_job_state(
     # Now create document metadata in both database and file system
     for doc in documents_info:
         doc_id = doc_id_dict[doc]
-        logger.debug(f"Generated document id {doc_id} for file: {doc}")
         create_document(
             doc_name=doc,
             doc_id=doc_id,
@@ -147,6 +145,7 @@ def initialize_job_state(
             operation=operation,
             submitted_at=submitted_at
         )
+    logger.info(f"Created job {job_id} with {len(documents_info)} document(s) in database")
 
     # Record ALREADY_EXISTS entries for files stripped from the batch.
     # Created AFTER the job row exists (foreign key constraint).

--- a/services/digitize/utils/storage.py
+++ b/services/digitize/utils/storage.py
@@ -61,7 +61,6 @@ class StorageManager:
                     None,
                     partial(self._write_bytes, target, content),
                 )
-                logger.debug(f"Staged file: {filename} for job {job_id}")
             except PermissionError as exc:
                 logger.error(
                     f"Permission denied staging {filename} (job {job_id}): {exc}"
@@ -72,6 +71,7 @@ class StorageManager:
                     f"Unexpected error staging {filename} (job {job_id}): {exc}"
                 )
                 raise
+        logger.debug(f"Staged {len(filenames)} file(s) for job {job_id}")
 
     @staticmethod
     def _write_bytes(path: Path, content: bytes) -> None:


### PR DESCRIPTION
Remove or consolidate low-value debug/info log statements that were generating excessive noise in normal operation:

- db/manager.py: drop per-operation debug logs for create/get/update job and document rows; logging at the caller boundary is sufficient
- utils/db.py: remove redundant "Created job/doc" info logs and the per-item "Updated document" debug log; collapse update_job result check that spuriously warned on no-op updates
- utils/jobs.py: remove per-document-id debug log; emit a single summary info log after all documents are created for the job
- utils/storage.py: replace per-file "Staged file" debug with a single "Staged N file(s)" summary after the loop
- parsing/docx.py: strip trace-level debug logs from internal table-caption helpers (_parse_ref_index, _get_body_children_refs, _get_text_value_by_ref, _looks_like_table_caption, _find_matching_caption_near_refs, _get_enclosing_section_header); condense surviving logs in recover_table_caption_from_body_context to compact "ref -> result" format
- parsing/converter.py: drop docling-models-path debug log
- common/opensearch.py: drop init banner and redundant shard-count log
- processing/orchestrator.py: add doc_path to language-detection info log; shorten conversion-submission debug to filename only