### PR TITLE
feat(digitize): add cancel endpoint and cooperative pipeline cancellation

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.337
+TAG?=v0.0.338
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.59
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.60
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.59
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.60
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.59
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.60
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.59
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.60
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.59
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.60
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.337
+  image: icr.io/ai-services-cicd/ai-services:v0.0.338
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.337
+  image: icr.io/ai-services-cicd/ai-services:v0.0.338
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/services/digitize/openshift/values.yaml
+++ b/ai-services/assets/services/digitize/openshift/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.59
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.60
   log_level: "INFO"
   database: "digitize_metadata"
   numShards: 1

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.59
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.60
   log_level: "INFO"
   database: "digitize_metadata"
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.337
+  image: icr.io/ai-services-cicd/ai-services:v0.0.338
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.337
+  image: icr.io/ai-services-cicd/ai-services:v0.0.338
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/services/common/llm_utils.py
+++ b/services/common/llm_utils.py
@@ -1,5 +1,6 @@
 import os
 import requests
+import threading
 import time
 import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -108,12 +109,23 @@ def summarize_and_classify_single_table(prompt, gen_model, llm_endpoint, max_tok
         logger.error(f"Error summarizing/classifying table: {e}")
         raise
 
-def summarize_and_classify_tables(table_mds, gen_model, llm_endpoint, doc_path, prompt_template: str, max_tokens: int = 1024, max_workers=32):
+def summarize_and_classify_tables(table_mds, gen_model, llm_endpoint, doc_path, prompt_template: str, max_tokens: int = 1024, max_workers=32, stop_event: threading.Event | None = None):
     """Combined function to summarize and classify tables using a single prompt.
 
-    Returns tuple: (summaries, decisions, failures).
-    failures is a dict mapping table index to error message for failed tables.
-    Table failures are non-fatal: failed tables use fallback values and processing continues.
+    Args:
+        table_mds: List of table markdown strings.
+        gen_model: LLM model name.
+        llm_endpoint: LLM endpoint URL.
+        doc_path: Document path (used for logging).
+        prompt_template: Prompt template string with a {content} placeholder.
+        max_tokens: Maximum tokens for the LLM response.
+        max_workers: Maximum parallel LLM workers.
+        stop_event: Optional threading.Event. When set, the function stops
+                    collecting further LLM results between table calls and
+                    cancels any queued futures that have not yet started.
+
+    Returns tuple: (summaries, decisions)
+    Raises JobCancelledError if stop_event is set mid-processing.
     """
     all_prompts = [prompt_template.format(content=md) for md in table_mds]
 
@@ -131,6 +143,16 @@ def summarize_and_classify_tables(table_mds, gen_model, llm_endpoint, doc_path, 
             for idx, prompt in enumerate(all_prompts)
         }
         for future in as_completed(futures):
+            # Check for job cancellation after each table's LLM call completes.
+            if stop_event is not None and stop_event.is_set():
+                # Cancel any futures that haven't started yet.
+                for pending_fut in futures:
+                    if not pending_fut.running() and not pending_fut.done():
+                        pending_fut.cancel()
+                from digitize.exceptions import JobCancelledError
+                raise JobCancelledError(
+                    f"Job cancelled during table summarization for '{doc_path}'"
+                )
             idx = futures[future]
             try:
                 results[idx] = future.result()

--- a/services/common/llm_utils.py
+++ b/services/common/llm_utils.py
@@ -3,7 +3,7 @@ import requests
 import threading
 import time
 import json
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor
 from common.misc_utils import get_logger, resolve_model_max_len
 from common.settings import settings
 from common.retry_utils import retry_on_transient_error
@@ -142,26 +142,33 @@ def summarize_and_classify_tables(table_mds, gen_model, llm_endpoint, doc_path, 
             executor.submit(summarize_and_classify_single_table, prompt, gen_model, llm_endpoint, max_tokens): idx
             for idx, prompt in enumerate(all_prompts)
         }
-        for future in as_completed(futures):
-            # Check for job cancellation after each table's LLM call completes.
-            if stop_event is not None and stop_event.is_set():
-                # Cancel any futures that haven't started yet.
-                for pending_fut in futures:
-                    if not pending_fut.running() and not pending_fut.done():
-                        pending_fut.cancel()
+        pending = dict(futures)  # future -> idx, shrinks as futures complete
+        while pending:
+            for fut in list(pending):
+                if not fut.done():
+                    # Cancel queued (not-yet-running) futures if stop_event is set.
+                    if stop_event is not None and stop_event.is_set() and not fut.running():
+                        fut.cancel()
+                        del pending[fut]
+                    continue
+                idx = pending.pop(fut)
+                try:
+                    results[idx] = fut.result()
+                    logger.debug(f"Summarized table {idx + 1}/{len(all_prompts)} from '{doc_path}'")
+                except Exception as e:
+                    error_msg = f"Failed to process table {idx}: {str(e)}"
+                    logger.error(error_msg)
+                    results[idx] = ("No summary.", False)
+                    failures[idx] = error_msg
+
+            if stop_event is not None and stop_event.is_set() and not pending:
                 from digitize.exceptions import JobCancelledError
                 raise JobCancelledError(
                     f"Job cancelled during table summarization for '{doc_path}'"
                 )
-            idx = futures[future]
-            try:
-                results[idx] = future.result()
-                logger.debug(f"Summarized table {idx + 1}/{len(all_prompts)} from '{doc_path}'")
-            except Exception as e:
-                error_msg = f"Failed to process table {idx}: {str(e)}"
-                logger.error(error_msg)
-                results[idx] = ("No summary.", False)
-                failures[idx] = error_msg
+
+            if pending:
+                time.sleep(0.05)
 
     # Unpack results in index order. Every slot starts as the fallback
     # and is overwritten either by a successful future or left as-is on failure.

--- a/services/common/llm_utils.py
+++ b/services/common/llm_utils.py
@@ -168,7 +168,7 @@ def summarize_and_classify_tables(table_mds, gen_model, llm_endpoint, doc_path, 
                 )
 
             if pending:
-                time.sleep(0.05)
+                time.sleep(0.5)
 
     # Unpack results in index order. Every slot starts as the fallback
     # and is overwritten either by a successful future or left as-is on failure.

--- a/services/common/llm_utils.py
+++ b/services/common/llm_utils.py
@@ -124,7 +124,12 @@ def summarize_and_classify_tables(table_mds, gen_model, llm_endpoint, doc_path, 
                     collecting further LLM results between table calls and
                     cancels any queued futures that have not yet started.
 
-    Returns tuple: (summaries, decisions)
+    Returns tuple: (summaries, decisions, failures).
+        summaries:  List of summary strings in table-index order.
+        decisions:  List of booleans (keep/discard) in table-index order.
+        failures:   Dict mapping table index to error message for tables that
+                    could not be processed; those tables use fallback values
+                    and processing continues.
     Raises JobCancelledError if stop_event is set mid-processing.
     """
     all_prompts = [prompt_template.format(content=md) for md in table_mds]
@@ -167,6 +172,9 @@ def summarize_and_classify_tables(table_mds, gen_model, llm_endpoint, doc_path, 
                     f"Job cancelled during table summarization for '{doc_path}'"
                 )
 
+            # Sleep once per outer-loop cycle so the loop never spins when all
+            # remaining futures are still running.  Skipped only when pending is
+            # empty (the while condition will end the loop on the next check).
             if pending:
                 time.sleep(0.5)
 

--- a/services/common/opensearch.py
+++ b/services/common/opensearch.py
@@ -159,7 +159,7 @@ class OpensearchVectorStore(VectorStore):
             raise
 
     @retry_on_transient_error(max_retries=3, initial_delay=5.0, backoff_multiplier=2.0)
-    def insert_chunks(self, chunks, vectors=None, embedding=None, batch_size=10):
+    def insert_chunks(self, chunks, vectors=None, embedding=None, batch_size=10, cancel_event=None):
         """Supports 2 modes of insertion with retry logic for transient failures.
 
         1. Pure embedding: pass 'chunks' and 'vectors'
@@ -170,6 +170,9 @@ class OpensearchVectorStore(VectorStore):
             vectors: Pre-computed embeddings (optional)
             embedding: Embedding instance to generate embeddings (optional)
             batch_size: Number of chunks to insert per batch
+            cancel_event: Optional threading.Event; if set between batches, insertion
+                          is aborted and False is returned. Only passed when
+                          clean_files=True so any partial inserts will be cleaned up.
 
         Returns:
             bool: True if indexing succeeded, False if it failed
@@ -200,6 +203,15 @@ class OpensearchVectorStore(VectorStore):
 
         # Iterate through chunks in batches and insert in bulk
         for i in tqdm(range(0, len(chunks), batch_size)):
+            # Check for cancellation before each batch. cancel_event is only set
+            # when clean_files=True, so any partial inserts will be removed by the
+            # post-cancellation VDB cleanup.
+            if cancel_event is not None and cancel_event.is_set():
+                logger.info(
+                    f"Cancellation requested — aborting insert_chunks after {i} of "
+                    f"{len(chunks)} chunks for index '{self.index_name}'"
+                )
+                return False
             batch = chunks[i:i + batch_size]
             page_contents = [doc.get("page_content") for doc in batch]
 

--- a/services/common/opensearch.py
+++ b/services/common/opensearch.py
@@ -209,9 +209,13 @@ class OpensearchVectorStore(VectorStore):
             if cancel_event is not None and cancel_event.is_set():
                 logger.info(
                     f"Cancellation requested — aborting insert_chunks after {i} of "
-                    f"{len(chunks)} chunks for index '{self.index_name}'"
+                    f"{len(chunks)} chunks for doc '{chunks[i].get('filename')}' in index '{self.index_name}'"
                 )
-                return False
+                from digitize.exceptions import JobCancelledError
+                raise JobCancelledError(
+                    f"insert_chunks cancelled at batch {i} of {len(chunks)} "
+                    f"for doc '{chunks[i].get('filename')}'"
+                )
             batch = chunks[i:i + batch_size]
             page_contents = [doc.get("page_content") for doc in batch]
 

--- a/services/common/vector_db.py
+++ b/services/common/vector_db.py
@@ -8,7 +8,8 @@ class VectorStore(ABC):
         chunks: List[Dict],
         vectors: Optional[List[List[float]]] = None,
         embedding: Optional[Any] = None,
-        batch_size: int = 10
+        batch_size: int = 10,
+        cancel_event: Optional[Any] = None,
     ) -> bool:
         """
         Inserts document chunks and their corresponding embeddings into the vector database.
@@ -23,6 +24,9 @@ class VectorStore(ABC):
             vectors: A list of pre-computed vector arrays.
             embedding: An instance of the Embedding class to generate vectors.
             batch_size: Number of chunks to process in a single bulk operation.
+            cancel_event: Optional threading.Event; if set between batches, insertion is
+                          aborted early. Only acted upon when clean_files=True so partial
+                          VDB state is always cleaned up.
 
         Returns:
             bool: True if indexing succeeded, False if it failed

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.59
+TAG?=v0.0.60
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/api/v1/jobs.py
+++ b/services/digitize/api/v1/jobs.py
@@ -12,7 +12,7 @@ import asyncio
 from pathlib import Path
 from typing import List, Optional
 
-from fastapi import APIRouter, File, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, File, HTTPException, Query, Response, UploadFile, status
 
 from common.misc_utils import get_logger, validate_document_file, generate_file_checksum
 from common.error_utils import APIError, ErrorCode, http_error_responses, extract_http_error_message, build_http_error_detail
@@ -21,6 +21,7 @@ import digitize.models as models
 import digitize.utils.db as db_ops
 from digitize.settings import settings
 from digitize.db.manager import db_manager
+from digitize.exceptions import JobCancelledError
 
 router = APIRouter()
 logger = get_logger("jobs_router")
@@ -391,3 +392,78 @@ async def delete_job(job_id: str):
             ErrorCode.INTERNAL_SERVER_ERROR,
             f"Failed to delete job '{job_id}'",
         )
+
+
+
+# ------------------------------------------------------------------ #
+# Cancel endpoint                                                     #
+# ------------------------------------------------------------------ #
+
+@router.post(
+    "/{job_id}/cancel",
+    status_code=status.HTTP_202_ACCEPTED,
+    response_class=Response,
+    responses={
+        404: http_error_responses[404],
+        409: http_error_responses[409],
+        500: http_error_responses[500],
+    },
+    summary="Cancel a job",
+    description=(
+        "Request cancellation of an active job (accepted or in_progress). "
+        "The job status is immediately set to 'cancel_pending' in the database; "
+        "the background pipeline will observe this at its next checkpoint, stop, "
+        "and then mark the job as 'cancelled'. "
+        "Pass clean_files=true to also delete any vector-DB chunks already indexed "
+        "for this job's documents (ingestion jobs only)."
+    ),
+    response_description="Cancellation accepted",
+)
+async def cancel_job(
+    job_id: str,
+    clean_files: bool = Query(False, description="Delete already-indexed vector DB chunks for this job"),
+):
+    """Mark an active job as CANCEL_PENDING. The pipeline will stop at its next checkpoint and write CANCELLED."""
+    try:
+        from digitize.utils.db import get_job as _get_job
+
+        job_data = _get_job(job_id)
+
+        if job_data is None:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_NOT_FOUND,
+                f"No job found with id '{job_id}'",
+            )
+
+        job_status = job_data.get("status", "")
+        non_cancellable_statuses = (
+            models.JobStatus.COMPLETED,
+            models.JobStatus.FAILED,
+            models.JobStatus.CANCEL_PENDING,
+            models.JobStatus.CANCELLED,
+        )
+        if job_status in non_cancellable_statuses:
+            APIError.raise_error(
+                ErrorCode.RESOURCE_LOCKED,
+                f"Job '{job_id}' is already in terminal state '{job_status}' and cannot be cancelled",
+            )
+
+        # Persist clean_files flag into stats so the background task can read it
+        current_stats = job_data.get("stats") or {}
+        updated_stats = {**current_stats, "clean_files": clean_files}
+
+        # Single update: set status=cancel_pending and store clean_files flag
+        db_manager.update_job(job_id, status=models.JobStatus.CANCEL_PENDING, stats=updated_stats)
+        logger.info(f"Job '{job_id}' marked as CANCEL_PENDING (clean_files={clean_files})")
+        return
+
+    except HTTPException as http_exc:
+        logger.warning(f"HTTP error while cancelling job '{job_id}': {http_exc.status_code} {http_exc.detail}")
+        raise
+    except Exception as exc:
+        logger.error(f"Failed to cancel job {job_id}: {exc}", exc_info=True)
+        APIError.raise_error(
+            ErrorCode.INTERNAL_SERVER_ERROR,
+            f"Failed to cancel job '{job_id}'",
+        )
+

--- a/services/digitize/api/v1/jobs.py
+++ b/services/digitize/api/v1/jobs.py
@@ -18,6 +18,7 @@ from fastapi import APIRouter, File, HTTPException, Query, Response, UploadFile,
 from common.misc_utils import get_logger, validate_document_file, generate_file_checksum
 from common.error_utils import APIError, ErrorCode, http_error_responses, extract_http_error_message, build_http_error_detail
 import digitize.utils.jobs as dg_util
+from digitize.utils.jobs import request_job_cancellation, NON_CANCELLABLE_JOB_STATUSES
 import digitize.models as models
 import digitize.utils.db as db_ops
 from digitize.settings import settings
@@ -437,25 +438,13 @@ async def cancel_job(
             )
 
         job_status = job_data.get("status", "")
-        non_cancellable_statuses = (
-            models.JobStatus.COMPLETED,
-            models.JobStatus.FAILED,
-            models.JobStatus.CANCEL_PENDING,
-            models.JobStatus.CANCELLED,
-        )
-        if job_status in non_cancellable_statuses:
+        if job_status in NON_CANCELLABLE_JOB_STATUSES:
             APIError.raise_error(
                 ErrorCode.RESOURCE_LOCKED,
                 f"Job '{job_id}' is already in terminal state '{job_status}' and cannot be cancelled",
             )
 
-        # Persist clean_files flag into stats so the background task can read it
-        current_stats = job_data.get("stats") or {}
-        updated_stats = {**current_stats, "clean_files": clean_files}
-
-        # Single update: set status=cancel_pending and store clean_files flag
-        db_manager.update_job(job_id, status=models.JobStatus.CANCEL_PENDING, stats=updated_stats)
-        logger.info(f"Job '{job_id}' marked as CANCEL_PENDING (clean_files={clean_files})")
+        request_job_cancellation(job_id, clean_files=clean_files)
         return
 
     except HTTPException as http_exc:

--- a/services/digitize/api/v1/jobs.py
+++ b/services/digitize/api/v1/jobs.py
@@ -9,7 +9,6 @@ Exposes one router:
 """
 
 import asyncio
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
 
@@ -23,7 +22,6 @@ import digitize.models as models
 import digitize.utils.db as db_ops
 from digitize.settings import settings
 from digitize.db.manager import db_manager
-from digitize.exceptions import JobCancelledError
 
 router = APIRouter()
 logger = get_logger("jobs_router")
@@ -445,7 +443,6 @@ async def cancel_job(
             )
 
         request_job_cancellation(job_id, clean_files=clean_files)
-        return
 
     except HTTPException as http_exc:
         logger.warning(f"HTTP error while cancelling job '{job_id}': {http_exc.status_code} {http_exc.detail}")

--- a/services/digitize/api/v1/jobs.py
+++ b/services/digitize/api/v1/jobs.py
@@ -9,6 +9,7 @@ Exposes one router:
 """
 
 import asyncio
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
 

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -522,15 +522,6 @@ async def _handle_interrupt(
     elif interrupt_type == InterruptType.DELETE_CONNECTOR:
         logger.info(f"Handling delete connector for {connector_id!r}")
         _cancel_tick(sync_seq, connector_id)
-        # Purge conversion tasks the tick may have enqueued before being interrupted.
-        # Must happen here (Case A only) — _run_teardown is shared with Case B where
-        # no tick was running so no in-flight tasks exist to purge.
-        from digitize.db.manager import db_manager
-        deleted_tasks = db_manager.delete_conversion_tasks_for_connector(connector_id)
-        if deleted_tasks:
-            logger.info(
-                f"Purged {deleted_tasks} queued conversion task(s) for connector {connector_id!r}"
-            )
         # Run full teardown: remove checksums, delete orphaned docs, delete connector row
         from digitize.api.v1.connectors import _run_teardown
         await _run_teardown(connector_id)

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -60,7 +60,7 @@ from digitize.utils.db import (
 )
 from digitize.db.models import JobSource
 
-from digitize.utils.jobs import generate_uuid, get_job_document_stats, initialize_and_launch, initialize_job_state, request_job_cancellation, NON_CANCELLABLE_JOB_STATUSES
+from digitize.utils.jobs import generate_uuid, get_job_document_stats, initialize_and_launch, request_job_cancellation, NON_CANCELLABLE_JOB_STATUSES
 
 logger = get_logger("sync_tick")
 

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -59,11 +59,8 @@ from digitize.utils.db import (
     update_sync_log,
 )
 from digitize.db.models import JobSource
-from digitize.utils.jobs import (
-    generate_uuid,
-    get_job_document_stats,
-    initialize_and_launch,
-)
+
+from digitize.utils.jobs import generate_uuid, get_job_document_stats, initialize_and_launch, initialize_job_state, request_job_cancellation, NON_CANCELLABLE_JOB_STATUSES
 
 logger = get_logger("sync_tick")
 
@@ -290,14 +287,24 @@ async def _wait_for_job(
     prev_completed_count = 0
     while True:
         await asyncio.sleep(_JOB_POLL_INTERVAL)
-        interrupt = _check_interrupt_call(connector_id, sync_seq)
-        if interrupt:
-            raise asyncio.CancelledError(
-                f"Connector {connector_id!r} interrupted (type={interrupt.value})"
-            )
         job_data = get_job(job_id)
         status = (job_data or {}).get("status", "")
         logger.debug(f"Polling job {job_id!r} for connector {connector_id!r}: status={status!r}")
+
+        interrupt = _check_interrupt_call(connector_id, sync_seq)
+        if interrupt:
+            # Only cancel if the job hasn't already reached a terminal state
+            # (e.g. it finished naturally just before the interrupt arrived).
+            if status not in NON_CANCELLABLE_JOB_STATUSES:
+                # DELETE_CONNECTOR: connector is being removed — clean up any
+                # already-indexed vector chunks (clean_files=True).
+                # SYNC_CANCEL: just stop the current sync — leave indexed
+                # data intact (clean_files=False).
+                clean_files = interrupt == InterruptType.DELETE_CONNECTOR
+                request_job_cancellation(job_id, clean_files=clean_files)
+            raise asyncio.CancelledError(
+                f"Connector {connector_id!r} interrupted (type={interrupt.value})"
+            )
 
         # Count any docs that newly reached 'completed' since the last poll.
         job_stats = get_job_document_stats(job_id)

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -283,7 +283,12 @@ async def _wait_for_job(
     Raises ``asyncio.CancelledError`` if the connector is marked for deletion
     or a stop-sync request is issued during the wait.
     """
-    _TERMINAL = {JobStatus.COMPLETED.value, JobStatus.COMPLETED_WITH_ERRORS.value, JobStatus.FAILED.value}
+    _TERMINAL = {
+        JobStatus.COMPLETED.value,
+        JobStatus.COMPLETED_WITH_ERRORS.value,
+        JobStatus.FAILED.value,
+        JobStatus.CANCELLED.value,
+    }
     prev_completed_count = 0
     while True:
         await asyncio.sleep(_JOB_POLL_INTERVAL)

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -123,6 +123,39 @@ class DatabaseManager:
             logger.error(f"Unexpected error retrieving job {job_id}: {e}", exc_info=True)
             return None
 
+
+    @staticmethod
+    def is_job_cancelled(job_id: str) -> bool:
+        """
+        Check whether a job has been marked for cancellation.
+
+        Returns True for both 'cancel_pending' (set by the API endpoint) and
+        'cancelled' (set by the pipeline after it finishes draining), so that
+        pipeline checkpoints stop as soon as the cancellation request arrives.
+
+        Performs a lightweight single-column SELECT so it is cheap to call
+        at pipeline checkpoints without loading the full job row.
+
+        Args:
+            job_id: Unique identifier for the job
+
+        Returns:
+            True if the job status is 'cancel_pending' or 'cancelled', False
+            otherwise (including when the job is not found or a DB error occurs).
+        """
+        try:
+            with get_db_session() as session:
+                stmt = select(Job.status).where(Job.job_id == job_id)
+                job_status = session.scalar(stmt)
+                return job_status in ("cancel_pending", "cancelled")
+        except SQLAlchemyError as e:
+            logger.error(f"Database error checking cancellation for job {job_id}: {e}", exc_info=True)
+            return False
+        except Exception as e:
+            logger.error(f"Unexpected error checking cancellation for job {job_id}: {e}", exc_info=True)
+            return False
+
+
     @staticmethod
     def get_all_jobs(
         status: Optional[JobStatus] = None,

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1972,7 +1972,11 @@ class DatabaseManager:
                 }
                 if status == ConversionTaskStatus.RUNNING:
                     updates["started_at"] = now
-                if status in (ConversionTaskStatus.COMPLETED, ConversionTaskStatus.FAILED):
+                if status in (
+                    ConversionTaskStatus.COMPLETED,
+                    ConversionTaskStatus.FAILED,
+                    ConversionTaskStatus.CANCELLED,
+                ):
                     updates["completed_at"] = now
                 if result_path is not None:
                     updates["result_path"] = result_path
@@ -1989,6 +1993,49 @@ class DatabaseManager:
         except SQLAlchemyError as e:
             logger.error(f"DB error updating task {task_id}: {e}", exc_info=True)
             return False
+
+    def cancel_tasks_for_job(job_id: str) -> int:
+        """
+        Mark all non-terminal ConversionTask rows for ``job_id`` as
+        ``cancel_pending`` so the dispatcher will stop them at the next
+        safe checkpoint.
+
+        Only tasks in the active pre-terminal statuses (pending, queued,
+        running) are touched.  Tasks already in completed, failed,
+        cancel_pending, or cancelled are left unchanged.
+
+        Returns:
+            Number of rows updated.
+        """
+        active_statuses = [
+            ConversionTaskStatus.PENDING,
+            ConversionTaskStatus.QUEUED,
+            ConversionTaskStatus.RUNNING,
+        ]
+        try:
+            with get_db_session() as session:
+                stmt = (
+                    update(ConversionTask)
+                    .where(
+                        ConversionTask.job_id == job_id,
+                        ConversionTask.status.in_(active_statuses),
+                    )
+                    .values(status=ConversionTaskStatus.CANCEL_PENDING)
+                )
+                result = cast(CursorResult, session.execute(stmt))
+                updated = result.rowcount
+                if updated:
+                    logger.info(
+                        f"cancel_tasks_for_job: marked {updated} task(s) "
+                        f"as cancel_pending for job {job_id}"
+                    )
+                return updated
+        except SQLAlchemyError as e:
+            logger.error(
+                f"DB error in cancel_tasks_for_job({job_id}): {e}", exc_info=True
+            )
+            return 0
+
 
     @staticmethod
     def peek_head(operation: str, connector_id: Optional[str] = None) -> Optional[ConversionTask]:

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1994,6 +1994,7 @@ class DatabaseManager:
             logger.error(f"DB error updating task {task_id}: {e}", exc_info=True)
             return False
 
+    @staticmethod
     def cancel_tasks_for_job(job_id: str) -> int:
         """
         Cancel all non-terminal ConversionTask rows for ``job_id``.

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1996,38 +1996,58 @@ class DatabaseManager:
 
     def cancel_tasks_for_job(job_id: str) -> int:
         """
-        Mark all non-terminal ConversionTask rows for ``job_id`` as
-        ``cancel_pending`` so the dispatcher will stop them at the next
-        safe checkpoint.
+        Cancel all non-terminal ConversionTask rows for ``job_id``.
 
-        Only tasks in the active pre-terminal statuses (pending, queued,
-        running) are touched.  Tasks already in completed, failed,
-        cancel_pending, or cancelled are left unchanged.
+        Tasks that have never been dispatched (pending, queued) are moved
+        directly to ``cancelled`` — the dispatcher will never pick them up
+        again so there is no checkpoint to wait for.
+
+        Tasks that are actively running are moved to ``cancel_pending`` so
+        the dispatcher can observe the flag at its next safe checkpoint
+        (between 100-page chunks or after the process-pool future returns)
+        and write the final ``cancelled`` status itself.
+
+        Tasks already in completed, failed, cancel_pending, or cancelled are
+        left unchanged.
 
         Returns:
-            Number of rows updated.
+            Total number of rows updated.
         """
-        active_statuses = [
-            ConversionTaskStatus.PENDING,
-            ConversionTaskStatus.QUEUED,
-            ConversionTaskStatus.RUNNING,
-        ]
         try:
             with get_db_session() as session:
-                stmt = (
+                # PENDING / QUEUED → CANCELLED directly: never dispatched, no
+                # checkpoint needed.
+                not_started = (
                     update(ConversionTask)
                     .where(
                         ConversionTask.job_id == job_id,
-                        ConversionTask.status.in_(active_statuses),
+                        ConversionTask.status.in_([
+                            ConversionTaskStatus.PENDING,
+                            ConversionTaskStatus.QUEUED,
+                        ]),
+                    )
+                    .values(status=ConversionTaskStatus.CANCELLED)
+                )
+                not_started_result = cast(CursorResult, session.execute(not_started))
+
+                # RUNNING → CANCEL_PENDING: dispatcher must observe the flag
+                # at its next checkpoint before writing the final CANCELLED.
+                running = (
+                    update(ConversionTask)
+                    .where(
+                        ConversionTask.job_id == job_id,
+                        ConversionTask.status == ConversionTaskStatus.RUNNING,
                     )
                     .values(status=ConversionTaskStatus.CANCEL_PENDING)
                 )
-                result = cast(CursorResult, session.execute(stmt))
-                updated = result.rowcount
+                running_result = cast(CursorResult, session.execute(running))
+
+                updated = not_started_result.rowcount + running_result.rowcount
                 if updated:
                     logger.info(
-                        f"cancel_tasks_for_job: marked {updated} task(s) "
-                        f"as cancel_pending for job {job_id}"
+                        f"cancel_tasks_for_job: cancelled {not_started_result.rowcount} "
+                        f"queued/pending and signalled {running_result.rowcount} "
+                        f"running task(s) for job {job_id}"
                     )
                 return updated
         except SQLAlchemyError as e:

--- a/services/digitize/db/models.py
+++ b/services/digitize/db/models.py
@@ -97,7 +97,7 @@ class Job(Base):
     # Constraints
     __table_args__ = (
         CheckConstraint(
-            "status IN ('accepted', 'in_progress', 'completed', 'completed_with_errors', 'failed')",
+            "status IN ('accepted', 'in_progress', 'completed', 'completed_with_errors', 'failed', 'cancel_pending', 'cancelled')",
             name="chk_job_status"
         ),
         CheckConstraint(
@@ -166,7 +166,7 @@ class Document(Base):
     __table_args__ = (
         CheckConstraint(
             "status IN ('accepted', 'in_progress', 'digitized', 'processed',"
-            " 'chunked', 'completed', 'completed_with_errors', 'failed', 'already_exists')",
+            " 'chunked', 'completed', 'completed_with_errors', 'failed', 'already_exists', 'cancelled')",
             name="chk_doc_status"
         ),
         CheckConstraint(

--- a/services/digitize/db/models.py
+++ b/services/digitize/db/models.py
@@ -318,11 +318,13 @@ class ConnectorSyncLog(Base):
 
 class ConversionTaskStatus(str, enum.Enum):
     """Lifecycle statuses for a ConversionTask row."""
-    PENDING   = "pending"    # over-quota; waiting for queue headroom
-    QUEUED    = "queued"     # admitted to queue; waiting for semaphore slot
-    RUNNING   = "running"    # semaphore slot acquired
-    COMPLETED = "completed"  # conversion finished successfully
-    FAILED    = "failed"     # conversion failed or timed out
+    PENDING        = "pending"         # over-quota; waiting for queue headroom
+    QUEUED         = "queued"          # admitted to queue; waiting for semaphore slot
+    RUNNING        = "running"         # semaphore slot acquired
+    COMPLETED      = "completed"       # conversion finished successfully
+    FAILED         = "failed"          # conversion failed or timed out
+    CANCEL_PENDING = "cancel_pending"  # cancellation requested; dispatcher will stop before or after current chunk
+    CANCELLED      = "cancelled"       # dispatcher acknowledged cancellation and halted
 
 
 class ConversionTask(Base):
@@ -394,7 +396,7 @@ class ConversionTask(Base):
             name="chk_ct_output_format",
         ),
         CheckConstraint(
-            "status IN ('pending', 'queued', 'running', 'completed', 'failed')",
+            "status IN ('pending', 'queued', 'running', 'completed', 'failed', 'cancel_pending', 'cancelled')",
             name="chk_ct_status",
         ),
         # Supports dispatcher's pick query (ORDER BY queued_at per status+operation)

--- a/services/digitize/db/scripts/init_schema.sql
+++ b/services/digitize/db/scripts/init_schema.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS jobs (
     error TEXT,
     stats JSONB NOT NULL DEFAULT '{"total_documents": 0, "completed": 0, "failed": 0, "in_progress": 0}',
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,  -- Last modification time (UTC)
-    CONSTRAINT chk_job_status CHECK (status IN ('accepted', 'in_progress', 'completed', 'completed_with_errors', 'failed')),
+    CONSTRAINT chk_job_status CHECK (status IN ('accepted', 'in_progress', 'completed', 'completed_with_errors', 'failed', 'cancel_pending', 'cancelled')),
     CONSTRAINT chk_job_operation CHECK (operation IN ('ingestion', 'digitization')),
     CONSTRAINT chk_job_source CHECK (source IN ('user', 'connector'))
 );
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS documents (
     error TEXT,
     metadata JSONB NOT NULL DEFAULT '{}',
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,  -- Last modification time (UTC)
-    CONSTRAINT chk_doc_status CHECK (status IN ('accepted', 'in_progress', 'digitized', 'processed', 'chunked', 'completed', 'completed_with_errors', 'failed', 'already_exists')),
+    CONSTRAINT chk_doc_status CHECK (status IN ('accepted', 'in_progress', 'digitized', 'processed', 'chunked', 'completed', 'completed_with_errors', 'failed', 'already_exists', 'cancelled')),
     CONSTRAINT chk_doc_type CHECK (type IN ('ingestion', 'digitization')),
     CONSTRAINT chk_doc_source CHECK (source IN ('user', 'connector')),
     CONSTRAINT chk_output_format CHECK (output_format IN ('txt', 'md', 'json'))

--- a/services/digitize/db/scripts/init_schema.sql
+++ b/services/digitize/db/scripts/init_schema.sql
@@ -126,7 +126,7 @@ CREATE TABLE IF NOT EXISTS conversion_tasks (
     completed_at    TIMESTAMPTZ,
     CONSTRAINT chk_ct_operation    CHECK (operation IN ('ingestion', 'digitization')),
     CONSTRAINT chk_ct_output_format CHECK (output_format IN ('json', 'md', 'txt')),
-    CONSTRAINT chk_ct_status       CHECK (status IN ('pending', 'queued', 'running', 'completed', 'failed'))
+    CONSTRAINT chk_ct_status       CHECK (status IN ('pending', 'queued', 'running', 'completed', 'failed', 'cancel_pending', 'cancelled'))
 );
 
 -- Supports dispatcher pick query (ORDER BY queued_at per status + operation)

--- a/services/digitize/exceptions.py
+++ b/services/digitize/exceptions.py
@@ -1,0 +1,13 @@
+"""
+Custom exceptions for the digitize service.
+"""
+
+
+class JobCancelledError(Exception):
+    """
+    Raised inside a pipeline function when the job has been marked as CANCELLED
+    in the database. Caught by the background-task wrapper (_run_ingest /
+    _run_digitize) to perform clean shutdown without treating the cancellation
+    as an error.
+    """
+    pass

--- a/services/digitize/models.py
+++ b/services/digitize/models.py
@@ -20,6 +20,8 @@ class JobStatus(str, Enum):
     COMPLETED = "completed"
     COMPLETED_WITH_ERRORS = "completed_with_errors"
     FAILED = "failed"
+    CANCEL_PENDING = "cancel_pending"
+    CANCELLED = "cancelled"
 
 
 class DocStatus(str, Enum):
@@ -32,6 +34,7 @@ class DocStatus(str, Enum):
     COMPLETED_WITH_ERRORS = "completed_with_errors"
     FAILED = "failed"
     ALREADY_EXISTS = "already_exists"
+    CANCELLED = "cancelled"
 
 
 class AlreadyExistsFile(BaseModel):
@@ -54,6 +57,8 @@ class JobsListResponse(BaseModel):
 class JobCreatedResponse(BaseModel):
     """Response model for job creation."""
     job_id: str
+
+
 
 class DocumentListItem(BaseModel):
     """Minimal document information for list responses."""

--- a/services/digitize/parsing/converter.py
+++ b/services/digitize/parsing/converter.py
@@ -4,12 +4,11 @@ Docling conversion engine wrapper.
 Encapsulates all interaction with the Docling library:
 DocumentConverter setup, chunked conversion, format export.
 """
-import logging
 import shutil
 import tempfile
 import time
 from pathlib import Path
-from typing import Optional, Protocol, runtime_checkable
+from typing import Callable, Optional
 
 # Local application imports
 from common.misc_utils import get_logger, DoclingConversionError
@@ -24,14 +23,29 @@ from docling.datamodel.document import ConversionResult
 from docling.document_converter import DocumentConverter
 from docling_core.types.doc.document import DoclingDocument
 
-@runtime_checkable
-class _CancelEvent(Protocol):
-    """Structural type for any cancel event — covers both multiprocessing.synchronize.Event
-    and the manager EventProxy returned by multiprocessing.Manager().Event()."""
-    def is_set(self) -> bool: ...
-
-
 logger = get_logger("docling_utils")
+
+
+def _make_db_cancel_check(task_id: str):
+    """
+    Return a zero-argument callable that queries the DB for the task's current
+    status and returns True when the task has been set to ``cancel_pending``.
+
+    Importing db_manager is deferred to call time so this module stays
+    importable in contexts where the DB is not yet configured (e.g. tests).
+    The callable is created in the dispatcher's async context but *called*
+    inside the worker process, where SQLAlchemy opens its own connections.
+    """
+    def _is_cancelled() -> bool:
+        try:
+            from digitize.db.manager import db_manager
+            from digitize.db.models import ConversionTaskStatus
+            task = db_manager.get_conversion_task(task_id)
+            return task is not None and task.status == ConversionTaskStatus.CANCEL_PENDING
+        except Exception:
+            # Never let a DB error abort an otherwise healthy conversion.
+            return False
+    return _is_cancelled
 
 @retry_on_transient_error(max_retries=3, initial_delay=1.0, backoff_multiplier=2.0)
 def convert_chunk(doc_converter: DocumentConverter, path: Path, chunk_num: int, start_page: int, end_page: int, chunk_cache_dir: Path):
@@ -67,7 +81,11 @@ def convert_chunk(doc_converter: DocumentConverter, path: Path, chunk_num: int, 
         logger.error(error_msg)
         raise DoclingConversionError(error_msg) from e
 
-def convert_doc(path: str | Path, cache_dir: Optional[Path] = None, cancel_event: Optional[_CancelEvent] = None) -> DoclingDocument:
+def convert_doc(
+    path: str | Path,
+    cache_dir: Optional[Path] = None,
+    cancel_check: Optional[Callable[[], bool]] = None,
+) -> DoclingDocument:
     """
     Convert a document to DoclingDocument, processing in 100-page chunks.
 
@@ -75,8 +93,9 @@ def convert_doc(path: str | Path, cache_dir: Optional[Path] = None, cancel_event
         path: Path to the document file to convert
         cache_dir: Optional cache directory for storing chunk results.
                    Will be cleaned up after processing.
-        cancel_event: Optional event with is_set(); if set, raises
-                      JobCancelledError between page-chunks.
+        cancel_check: Optional zero-argument callable returning True when the
+                      job/task has been cancelled.  Checked between chunks
+                      so large-file conversions can be interrupted early.
 
     Returns:
         DoclingDocument containing the concatenated result
@@ -132,9 +151,9 @@ def convert_doc(path: str | Path, cache_dir: Optional[Path] = None, cancel_event
             end_page = min(start_page + settings.digitize.doc_chunk_size - 1, total_pages)
             chunk_num = (start_page - 1) // settings.digitize.doc_chunk_size + 1
 
-            # Check for job cancellation between chunks so a long multi-chunk
+            # Check for job cancellation between chunks so a large-file
             # conversion can be cut short without waiting for all chunks.
-            if cancel_event is not None and cancel_event.is_set():
+            if cancel_check is not None and cancel_check():
                 raise JobCancelledError(
                     f"Job cancelled during chunk conversion "
                     f"(chunk {chunk_num}/{total_chunks} of {path})"
@@ -200,11 +219,27 @@ def get_doc_converter():
 
     return doc_converter
 
-def convert_document_format(doc_path: str, out_path: Path, doc_id: str, output_format: OutputFormat):
+def convert_document_format(
+    doc_path: str,
+    out_path: Path,
+    doc_id: str,
+    output_format: OutputFormat,
+    task_id: Optional[str] = None,
+) -> tuple[str, float]:
     """Convert a document's format and write the resulting output files.
 
     Performs the docling-based conversion, measures performance metrics, and saves the formatted
     output (JSON, MD, TXT, or HTML) to the target directory.
+
+    Args:
+        doc_path:      Path to the source document.
+        out_path:      Directory for output files.
+        doc_id:        Base name used for the output filename.
+        output_format: Desired output format.
+        task_id:       Optional ConversionTask primary key.  When supplied,
+                       the worker process polls the DB for ``cancel_pending``
+                       between 100-page chunks so large-file conversions can be
+                       interrupted early without waiting for all chunks.
     """
     logger.info(f"Processing '{doc_path}'")
 
@@ -213,8 +248,12 @@ def convert_document_format(doc_path: str, out_path: Path, doc_id: str, output_f
 
     t0 = time.time()
 
+    # Build a DB-backed cancel check when a task_id is available so the worker
+    # process can react to cancellation between page chunks.
+    cancel_check = _make_db_cancel_check(task_id) if task_id else None
+
     # Convert document → DoclingDocument
-    doc_obj = convert_doc(doc_path, cache_dir=out_path / doc_id)
+    doc_obj = convert_doc(doc_path, cache_dir=out_path / doc_id, cancel_check=cancel_check)
 
     conversion_time = time.time() - t0
 
@@ -234,34 +273,3 @@ def convert_document_format(doc_path: str, out_path: Path, doc_id: str, output_f
     logger.debug(f"Saved converted file to '{out_file}'")
     return str(out_file), conversion_time
 
-def convert_document(doc_path, out_path, file_name, cancel_event: Optional[_CancelEvent] = None):
-    """
-    Convert a single document to JSON format.
-    This function runs in a separate process via ProcessPoolExecutor.
-
-    Args:
-        doc_path: Path to the source document.
-        out_path: Directory for output files.
-        file_name: Base name (doc_id or path) used for the output JSON filename.
-        cancel_event: Optional cancel event set by the parent process when the
-                      job is cancelled. Checked between page-chunks to abort
-                      early without making any DB calls from this process.
-    """
-    try:
-        logger.info(f"Processing '{doc_path}'")
-        converted_json = (Path(out_path) / f"{file_name}.json")
-        converted_json_f = str(converted_json)
-        logger.debug(f"Converting '{doc_path}'")
-        t0 = time.time()
-
-        converted_doc: DoclingDocument = convert_doc(doc_path, cache_dir=out_path / file_name, cancel_event=cancel_event)
-        converted_doc.save_as_json(str(converted_json_f))
-
-        conversion_time = time.time() - t0
-        logger.debug(f"'{doc_path}' converted")
-        return converted_json_f, conversion_time
-    except JobCancelledError:
-        raise
-    except Exception as e:
-        logger.error(f"Error converting '{doc_path}': {e}")
-    return None, None

--- a/services/digitize/parsing/converter.py
+++ b/services/digitize/parsing/converter.py
@@ -9,7 +9,7 @@ import shutil
 import tempfile
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Protocol, runtime_checkable
 
 # Local application imports
 from common.misc_utils import get_logger, DoclingConversionError
@@ -17,11 +17,19 @@ from common.retry_utils import retry_on_transient_error
 from digitize.settings import settings
 from digitize.parsing.pdf import get_document_page_count
 from digitize.models import OutputFormat
+from digitize.exceptions import JobCancelledError
 
 # Docling document conversion libraries
 from docling.datamodel.document import ConversionResult
 from docling.document_converter import DocumentConverter
 from docling_core.types.doc.document import DoclingDocument
+
+@runtime_checkable
+class _CancelEvent(Protocol):
+    """Structural type for any cancel event — covers both multiprocessing.synchronize.Event
+    and the manager EventProxy returned by multiprocessing.Manager().Event()."""
+    def is_set(self) -> bool: ...
+
 
 logger = get_logger("docling_utils")
 
@@ -59,7 +67,7 @@ def convert_chunk(doc_converter: DocumentConverter, path: Path, chunk_num: int, 
         logger.error(error_msg)
         raise DoclingConversionError(error_msg) from e
 
-def convert_doc(path: str | Path, cache_dir: Optional[Path] = None) -> DoclingDocument:
+def convert_doc(path: str | Path, cache_dir: Optional[Path] = None, cancel_event: Optional[_CancelEvent] = None) -> DoclingDocument:
     """
     Convert a document to DoclingDocument, processing in 100-page chunks.
 
@@ -67,6 +75,8 @@ def convert_doc(path: str | Path, cache_dir: Optional[Path] = None) -> DoclingDo
         path: Path to the document file to convert
         cache_dir: Optional cache directory for storing chunk results.
                    Will be cleaned up after processing.
+        cancel_event: Optional event with is_set(); if set, raises
+                      JobCancelledError between page-chunks.
 
     Returns:
         DoclingDocument containing the concatenated result
@@ -121,6 +131,14 @@ def convert_doc(path: str | Path, cache_dir: Optional[Path] = None) -> DoclingDo
         for start_page in range(1, total_pages + 1, settings.digitize.doc_chunk_size):
             end_page = min(start_page + settings.digitize.doc_chunk_size - 1, total_pages)
             chunk_num = (start_page - 1) // settings.digitize.doc_chunk_size + 1
+
+            # Check for job cancellation between chunks so a long multi-chunk
+            # conversion can be cut short without waiting for all chunks.
+            if cancel_event is not None and cancel_event.is_set():
+                raise JobCancelledError(
+                    f"Job cancelled during chunk conversion "
+                    f"(chunk {chunk_num}/{total_chunks} of {path})"
+                )
 
             logger.debug(f"Processing {path}'s chunk {chunk_num}/{total_chunks} (pages {start_page}-{end_page})")
             chunk_file = convert_chunk(doc_converter, path, chunk_num, start_page, end_page, chunk_cache_dir)
@@ -216,10 +234,18 @@ def convert_document_format(doc_path: str, out_path: Path, doc_id: str, output_f
     logger.debug(f"Saved converted file to '{out_file}'")
     return str(out_file), conversion_time
 
-def convert_document(doc_path, out_path, file_name):
+def convert_document(doc_path, out_path, file_name, cancel_event: Optional[_CancelEvent] = None):
     """
     Convert a single document to JSON format.
     This function runs in a separate process via ProcessPoolExecutor.
+
+    Args:
+        doc_path: Path to the source document.
+        out_path: Directory for output files.
+        file_name: Base name (doc_id or path) used for the output JSON filename.
+        cancel_event: Optional cancel event set by the parent process when the
+                      job is cancelled. Checked between page-chunks to abort
+                      early without making any DB calls from this process.
     """
     try:
         logger.info(f"Processing '{doc_path}'")
@@ -228,12 +254,14 @@ def convert_document(doc_path, out_path, file_name):
         logger.debug(f"Converting '{doc_path}'")
         t0 = time.time()
 
-        converted_doc: DoclingDocument = convert_doc(doc_path, cache_dir=out_path / file_name)
+        converted_doc: DoclingDocument = convert_doc(doc_path, cache_dir=out_path / file_name, cancel_event=cancel_event)
         converted_doc.save_as_json(str(converted_json_f))
 
         conversion_time = time.time() - t0
         logger.debug(f"'{doc_path}' converted")
         return converted_json_f, conversion_time
+    except JobCancelledError:
+        raise
     except Exception as e:
         logger.error(f"Error converting '{doc_path}': {e}")
     return None, None

--- a/services/digitize/pipeline/digitize.py
+++ b/services/digitize/pipeline/digitize.py
@@ -17,10 +17,17 @@ from digitize.db.models import ConversionTaskStatus
 from digitize.models import JobStatus, DocStatus
 from digitize.settings import settings
 from digitize.utils.db import get_status_manager
-from digitize.db.manager import db_manager
 from digitize.exceptions import JobCancelledError
 
 logger = get_logger("digitize")
+
+# Terminal statuses that end polling — includes CANCELLED so a cancelled task
+# does not leave the poll loop spinning until the deadline expires.
+_POLL_TERMINAL = frozenset({
+    ConversionTaskStatus.COMPLETED,
+    ConversionTaskStatus.FAILED,
+    ConversionTaskStatus.CANCELLED,
+})
 
 
 def _poll_until(job_id, terminal_statuses, deadline, timeout_s, phase_label):
@@ -64,7 +71,8 @@ def digitize(
 ):
     """
     Poll the conversion_tasks row until the dispatcher marks it terminal
-    (completed or failed), then update job and document status accordingly.
+    (completed, failed, or cancelled), then update job and document status
+    accordingly.
 
     The dispatcher handles conversion, semaphore management, and writes
     result_path / error to the task row.  This function owns all
@@ -96,17 +104,36 @@ def digitize(
     timeout_s = settings.digitize.conversion_timeout_s
     deadline = time.monotonic() + timeout_s
 
-    # Check cancellation before entering the ProcessPoolExecutor — the only safe abort point
+    # Check cancellation before starting to poll
     if job_id and db_manager.is_job_cancelled(job_id):
+        db_manager.cancel_tasks_for_job(job_id)
         raise JobCancelledError(f"Job {job_id} was cancelled before digitization started")
 
     try:
         # Phase 1: wait until the dispatcher picks up the task (queued → running).
+        # Also stops on CANCELLED so a cancel that arrives during the queued phase
+        # is observed immediately without waiting for the deadline.
         task = _poll_until(
             job_id,
-            {ConversionTaskStatus.RUNNING, ConversionTaskStatus.COMPLETED, ConversionTaskStatus.FAILED},
+            {
+                ConversionTaskStatus.RUNNING,
+                ConversionTaskStatus.COMPLETED,
+                ConversionTaskStatus.FAILED,
+                ConversionTaskStatus.CANCELLED,
+            },
             deadline, timeout_s, "start",
         )
+
+        # CANCELLED observed in phase 1 — signal the dispatcher (idempotent) and
+        # raise so the caller handles the cancellation cleanup.
+        if task is not None and task.status == ConversionTaskStatus.CANCELLED:
+            raise JobCancelledError(f"Job {job_id} conversion task was cancelled")
+
+        # Also check the job flag in case cancellation arrived between the check
+        # above and the dispatcher setting the task status.
+        if job_id and db_manager.is_job_cancelled(job_id):
+            db_manager.cancel_tasks_for_job(job_id)
+            raise JobCancelledError(f"Job {job_id} was cancelled during conversion")
 
         # Mark IN_PROGRESS as soon as the dispatcher starts running.
         if task is not None and task.status == ConversionTaskStatus.RUNNING and doc_id:
@@ -116,9 +143,13 @@ def digitize(
         # Phase 2: wait until the dispatcher reaches a terminal state.
         task = _poll_until(
             job_id,
-            {ConversionTaskStatus.COMPLETED, ConversionTaskStatus.FAILED},
+            _POLL_TERMINAL,
             deadline, timeout_s, "complete",
         )
+
+        # CANCELLED observed in phase 2
+        if task is not None and task.status == ConversionTaskStatus.CANCELLED:
+            raise JobCancelledError(f"Job {job_id} conversion task was cancelled during execution")
 
     except _DeadlineExceeded as exc:
         _fail(str(exc))

--- a/services/digitize/pipeline/digitize.py
+++ b/services/digitize/pipeline/digitize.py
@@ -17,6 +17,8 @@ from digitize.db.models import ConversionTaskStatus
 from digitize.models import JobStatus, DocStatus
 from digitize.settings import settings
 from digitize.utils.db import get_status_manager
+from digitize.db.manager import db_manager
+from digitize.exceptions import JobCancelledError
 
 logger = get_logger("digitize")
 
@@ -93,6 +95,10 @@ def digitize(
 
     timeout_s = settings.digitize.conversion_timeout_s
     deadline = time.monotonic() + timeout_s
+
+    # Check cancellation before entering the ProcessPoolExecutor — the only safe abort point
+    if job_id and db_manager.is_job_cancelled(job_id):
+        raise JobCancelledError(f"Job {job_id} was cancelled before digitization started")
 
     try:
         # Phase 1: wait until the dispatcher picks up the task (queued → running).

--- a/services/digitize/pipeline/digitize.py
+++ b/services/digitize/pipeline/digitize.py
@@ -37,7 +37,9 @@ def _poll_until(job_id, terminal_statuses, deadline, timeout_s, phase_label):
 
     Returns the task object (possibly in a terminal state) or ``None`` if the
     row disappeared.  Raises ``_DeadlineExceeded`` when the deadline is hit so
-    the caller can apply a consistent failure path.
+    the caller can apply a consistent failure path.  Raises ``JobCancelledError``
+    immediately if the job row is found to be ``cancel_pending`` or ``cancelled``
+    during polling (the task is also marked cancelled before raising).
 
     Args:
         job_id:           Job identifier used to look up the task row.
@@ -58,6 +60,13 @@ def _poll_until(job_id, terminal_statuses, deadline, timeout_s, phase_label):
         task = db_manager.get_conversion_task_by_job_id(job_id)
         if task is None:
             logger.warning(f"Task for job {job_id} disappeared during polling")
+            break
+        # Check job-level cancellation flag on every tick so a CANCEL_PENDING
+        # job whose task is still QUEUED is observed here rather than waiting
+        # for the dispatcher to write CANCELLED to the task row first.
+        if db_manager.is_job_cancelled(job_id):
+            db_manager.cancel_tasks_for_job(job_id)
+            raise JobCancelledError(f"Job {job_id} was cancelled during {phase_label} polling")
     return task
 
 
@@ -111,8 +120,6 @@ def digitize(
 
     try:
         # Phase 1: wait until the dispatcher picks up the task (queued → running).
-        # Also stops on CANCELLED so a cancel that arrives during the queued phase
-        # is observed immediately without waiting for the deadline.
         task = _poll_until(
             job_id,
             {
@@ -123,17 +130,6 @@ def digitize(
             },
             deadline, timeout_s, "start",
         )
-
-        # CANCELLED observed in phase 1 — signal the dispatcher (idempotent) and
-        # raise so the caller handles the cancellation cleanup.
-        if task is not None and task.status == ConversionTaskStatus.CANCELLED:
-            raise JobCancelledError(f"Job {job_id} conversion task was cancelled")
-
-        # Also check the job flag in case cancellation arrived between the check
-        # above and the dispatcher setting the task status.
-        if job_id and db_manager.is_job_cancelled(job_id):
-            db_manager.cancel_tasks_for_job(job_id)
-            raise JobCancelledError(f"Job {job_id} was cancelled during conversion")
 
         # Mark IN_PROGRESS as soon as the dispatcher starts running.
         if task is not None and task.status == ConversionTaskStatus.RUNNING and doc_id:
@@ -146,10 +142,6 @@ def digitize(
             _POLL_TERMINAL,
             deadline, timeout_s, "complete",
         )
-
-        # CANCELLED observed in phase 2
-        if task is not None and task.status == ConversionTaskStatus.CANCELLED:
-            raise JobCancelledError(f"Job {job_id} conversion task was cancelled during execution")
 
     except _DeadlineExceeded as exc:
         _fail(str(exc))

--- a/services/digitize/pipeline/ingest.py
+++ b/services/digitize/pipeline/ingest.py
@@ -17,6 +17,8 @@ from digitize.models import JobStatus, DocStatus
 from digitize.settings import settings
 from digitize.utils.db import get_status_manager, DatabaseStatusManager
 from common.misc_utils import get_utc_timestamp
+from digitize.db.manager import db_manager
+from digitize.exceptions import JobCancelledError
 
 logger = get_logger("ingest")
 
@@ -195,6 +197,10 @@ def ingest(
             emb_model_dict, status_mgr, doc_id_dict, file_checksum_dict
         )
 
+        # CHECK 1: abort before launching pipeline if cancellation was requested
+        if job_id and db_manager.is_job_cancelled(job_id):
+            raise JobCancelledError(f"Job {job_id} was cancelled before processing started")
+
         start_time = time.time()
         # Reserve 100 tokens from embedding model's max_model_len to account for metadata
         # that will be prepended to content during final merge, ensuring total tokens stay within embedding model limits
@@ -206,6 +212,10 @@ def ingest(
         if converted_pdf_stats is None:
             ingestion_failed()
             return
+
+        # CHECK 5: abort before writing final job status if cancelled during pipeline
+        if job_id and db_manager.is_job_cancelled(job_id):
+            raise JobCancelledError(f"Job {job_id} was cancelled during processing")
 
         # Note: Documents are now indexed immediately after chunking via the indexing_callback
         logger.info(f"All {len(converted_pdf_stats)} document(s) have been processed and indexed")
@@ -274,6 +284,10 @@ def ingest(
                 status_mgr.update_job_progress("", DocStatus.COMPLETED, JobStatus.COMPLETED)
 
         return converted_pdf_stats
+
+    except JobCancelledError:
+        # Re-raise so the caller (_run_ingest) handles the cancellation cleanup
+        raise
 
     except Exception as e:
         logger.error(f"Error during ingestion: {str(e)}", exc_info=True)

--- a/services/digitize/pipeline/ingest.py
+++ b/services/digitize/pipeline/ingest.py
@@ -48,7 +48,7 @@ def create_indexing_handler(
         emb_model_dict['max_model_len']
     )
 
-    def index_document_chunks(doc_id: str, chunks: list, path: str) -> bool:
+    def index_document_chunks(doc_id: str, chunks: list, path: str, cancel_event=None) -> bool:
         """
         Index a single document's chunks immediately after chunking completes.
 
@@ -56,6 +56,8 @@ def create_indexing_handler(
             doc_id: Document ID
             chunks: List of chunk dictionaries
             path: Original file path
+            cancel_event: Optional threading.Event; if set and clean_files=True, each
+                          inter-batch boundary inside insert_chunks will abort early.
 
         Returns:
             bool: True if indexing succeeded, False otherwise
@@ -69,7 +71,7 @@ def create_indexing_handler(
             indexing_start_time = time.time()
 
             # Index the chunks
-            success = vector_store.insert_chunks(chunks, embedding=embedder)
+            success = vector_store.insert_chunks(chunks, embedding=embedder, cancel_event=cancel_event)
             indexing_time = time.time() - indexing_start_time
 
             if not success:

--- a/services/digitize/pipeline/ingest.py
+++ b/services/digitize/pipeline/ingest.py
@@ -122,6 +122,8 @@ def create_indexing_handler(
             logger.info(f"✅ Successfully indexed document {doc_id}")
             return True
 
+        except JobCancelledError:
+            raise
         except Exception as e:
             logger.error(f"Exception during indexing for {doc_id}: {e}", exc_info=True)
 

--- a/services/digitize/processing/orchestrator.py
+++ b/services/digitize/processing/orchestrator.py
@@ -430,6 +430,9 @@ def process_converted_document(converted_json_path, doc_path, out_path, gen_mode
 
     timings: dict[str, float] = {"process_text": 0.0, "process_tables": 0.0}
 
+    if stop_event and stop_event.is_set():
+        raise JobCancelledError(f"Job cancelled before processing document: {doc_path}")
+
     try:
         converted_doc = DoclingDocument.load_from_json(Path(converted_json_path))
         if not converted_doc:
@@ -450,6 +453,9 @@ def process_converted_document(converted_json_path, doc_path, out_path, gen_mode
                 logger.info(f"Detected document language: {document_language} for doc: {doc_path}")
         except Exception as e:
             logger.warning(f"Failed to detect document language, using default {LanguageCodes.ENGLISH}: {e}")
+
+        if stop_event and stop_event.is_set():
+            raise JobCancelledError(f"Job cancelled before processing tables for document: {doc_path}")
 
         table_count, process_time, table_failures = process_table(
             converted_doc, doc_path, processed_table_json_path, gen_model, gen_endpoint, document_language,

--- a/services/digitize/processing/orchestrator.py
+++ b/services/digitize/processing/orchestrator.py
@@ -15,6 +15,7 @@ import shutil
 import threading
 import time
 from pathlib import Path
+from typing import Optional
 
 from docling_core.types.doc.document import DoclingDocument
 from common.lang_utils import LanguageCodes, split_sentences, to_sentence_splitter_lang
@@ -134,7 +135,7 @@ def flush_chunk(current_chunk, chunks, emb_endpoint, max_tokens, language=Langua
     current_chunk["source_nodes"] = []
 
 
-def chunk_text(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, language=LanguageCodes.ENGLISH):
+def chunk_text(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, language=LanguageCodes.ENGLISH, cancel_event=None):
     """
     Chunk text content from a document into smaller pieces based on token limits.
 
@@ -145,6 +146,7 @@ def chunk_text(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, 
         max_tokens: Maximum tokens per chunk
         doc_id: Document ID
         language: Language code for sentence splitting (detected from document text)
+        cancel_event: Optional threading.Event; if set, chunking is aborted early.
     """
     t0 = time.time()
     processed_chunk_json_path = (Path(out_path) / f"{doc_id}{text_chunk_suffix}")
@@ -172,6 +174,9 @@ def chunk_text(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, 
             current_subsubsection = None
 
             for idx, block in enumerate(data):
+                if cancel_event is not None and cancel_event.is_set():
+                    logger.info(f"Cancellation requested — aborting text chunking for '{input_path}'")
+                    raise JobCancelledError("Text chunking cancelled")
                 label = block.get("label")
                 text = block.get("text", "").strip()
                 page_no = block.get("page", 0)
@@ -237,7 +242,7 @@ def chunk_text(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, 
         return None, None
 
 
-def chunk_tables(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, language=LanguageCodes.ENGLISH):
+def chunk_tables(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, language=LanguageCodes.ENGLISH, cancel_event=None):
     """
     Chunk table summaries into smaller pieces if they exceed token limits.
     Called internally by chunk_single_file() for sequential processing.
@@ -249,6 +254,7 @@ def chunk_tables(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None
         max_tokens: Maximum tokens per chunk
         doc_id: Document ID
         language: Language code for sentence splitting (detected from document text)
+        cancel_event: Optional threading.Event; if set, chunking is aborted early.
     """
     t0 = time.time()
     processed_table_chunk_json_path = (Path(out_path) / f"{doc_id}{table_chunk_suffix}")
@@ -264,6 +270,9 @@ def chunk_tables(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None
             tab_data_list = list(tab_data.values())
 
             for block in tab_data_list:
+                if cancel_event is not None and cancel_event.is_set():
+                    logger.info(f"Cancellation requested — aborting table chunking for '{input_path}'")
+                    raise JobCancelledError("Table chunking cancelled")
                 caption = block.get('caption', '')
                 summary = block.get("summary", '')
                 page_number = block.get('page_number')
@@ -298,7 +307,7 @@ def chunk_tables(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None
         return None, None
 
 
-def chunk_single_file(input_path, table_json_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, language=LanguageCodes.ENGLISH):
+def chunk_single_file(input_path, table_json_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, language=LanguageCodes.ENGLISH, cancel_event=None):
     """
     Orchestrates chunking of both text and tables for a single document.
 
@@ -310,14 +319,17 @@ def chunk_single_file(input_path, table_json_path, out_path, emb_endpoint, max_t
         max_tokens: Maximum tokens per chunk
         doc_id: Document ID
         language: Language code for sentence splitting (detected from document text)
+        cancel_event: Optional threading.Event; if set, chunking is aborted early.
     """
     t0 = time.time()
     try:
         splitter_lang = to_sentence_splitter_lang(language)
-        text_chunk_json, text_chunk_time = chunk_text(input_path, out_path, emb_endpoint, max_tokens, doc_id, splitter_lang)
-        table_chunk_json, table_chunk_time = chunk_tables(table_json_path, out_path, emb_endpoint, max_tokens, doc_id, splitter_lang)
+        text_chunk_json, text_chunk_time = chunk_text(input_path, out_path, emb_endpoint, max_tokens, doc_id, splitter_lang, cancel_event=cancel_event)
+        table_chunk_json, table_chunk_time = chunk_tables(table_json_path, out_path, emb_endpoint, max_tokens, doc_id, splitter_lang, cancel_event=cancel_event)
         total_time = time.time() - t0
         return text_chunk_json, table_chunk_json, total_time
+    except JobCancelledError:
+        raise
     except Exception as e:
         logger.error(f"Error chunking document '{input_path}': {e}")
         return None, None, None
@@ -546,8 +558,15 @@ def process_documents(
     # can abort mid-table-summarization without waiting for all LLM calls.
     _process_stop_event = threading.Event()
 
+    # Separate stop event for the indexing path (insert_chunks).
+    # Only set when clean_files=True so that a cancelled job with clean_files=False
+    # lets any running insert_chunks call finish — avoiding stale partial VDB entries
+    # that would never be cleaned up.
+    _index_cancel_event = threading.Event()
+
     is_cancelled = False        # latched True on first cancellation; never reset
     _tasks_cancel_signalled = False  # tracks whether cancel_tasks_for_job has been called
+    _clean_files: Optional[bool] = None  # lazily resolved on first cancellation
 
     worker_count = max(1, min(WORKER_SIZE, len(input_paths)))
 
@@ -562,6 +581,18 @@ def process_documents(
                 is_cancelled = is_cancelled or bool(job_id and db_manager.is_job_cancelled(job_id))
                 if is_cancelled:
                     _process_stop_event.set()
+                    # Resolve clean_files flag once on first cancellation detection.
+                    # The index cancel event is only set when clean_files=True because
+                    # interrupting insert_chunks mid-batch without subsequent cleanup would
+                    # leave stale partial entries in the vector DB.
+                    if _clean_files is None and job_id:
+                        try:
+                            job_row = db_manager.get_job_by_id(job_id)
+                            _clean_files = bool(job_row and job_row.stats and job_row.stats.get("clean_files"))
+                        except Exception:
+                            _clean_files = False
+                    if _clean_files:
+                        _index_cancel_event.set()
                     # Signal the dispatcher to stop any pending/queued/running conversion
                     # tasks belonging to this job.  Done exactly once on first detection.
                     if not _tasks_cancel_signalled:
@@ -741,6 +772,7 @@ def process_documents(
                             txt_json, tab_json, out_path,
                             emb_endpoint, max_tokens,
                             doc_id=doc_id, language=doc_lang,
+                            cancel_event=_process_stop_event,
                         )
                         chunk_futures[c_future] = path
                     except JobCancelledError:
@@ -822,7 +854,8 @@ def process_documents(
                                     for chunk in doc_chunks:
                                         chunk["doc_id"] = doc_id
                                     index_future = indexer_executor.submit(
-                                        indexing_callback, doc_id, doc_chunks, path
+                                        indexing_callback, doc_id, doc_chunks, path,
+                                        cancel_event=_index_cancel_event,
                                     )
                                     indexing_futures[index_future] = doc_id
                                 except Exception as e:
@@ -830,6 +863,10 @@ def process_documents(
                                         f"Error submitting indexing for {doc_id}: {e}",
                                         exc_info=True,
                                     )
+                    except JobCancelledError:
+                        logger.info(f"Job {job_id} cancelled — chunking was interrupted for document: {path}")
+                        is_cancelled = True
+                        _process_stop_event.set()
                     except Exception as e:
                         if doc_id is not None:
                             logger.error(
@@ -847,8 +884,10 @@ def process_documents(
                 # --- D. Drain completed indexing futures ---
                 for fut in list(indexing_futures):
                     if not fut.done():
-                        # If cancelled, cancel queued (not-yet-running) indexing futures
-                        if is_cancelled and not fut.running():
+                        # Cancel queued (not-yet-running) futures only when clean_files=True.
+                        # When clean_files=False we let them run to completion so the document
+                        # ends up fully indexed rather than partially indexed with no cleanup.
+                        if is_cancelled and _clean_files and not fut.running():
                             fut.cancel()
                             doc_id = indexing_futures.pop(fut)
                             logger.info(f"Job {job_id} cancelled — skipping indexing for document: {doc_id}")

--- a/services/digitize/processing/orchestrator.py
+++ b/services/digitize/processing/orchestrator.py
@@ -12,6 +12,7 @@ Responsibilities:
 
 import json
 import shutil
+import threading
 import time
 from pathlib import Path
 
@@ -28,6 +29,8 @@ from common.misc_utils import (
 from common.thread_utils import ContextAwareThreadPoolExecutor
 from digitize.db.models import ConversionTaskStatus
 from digitize.models import DocStatus, JobStatus
+from digitize.db.manager import db_manager
+from digitize.exceptions import JobCancelledError
 from digitize.utils.db import get_status_manager
 from digitize.processing.language import (
     collect_header_font_sizes,
@@ -412,11 +415,15 @@ def merge_chunked_documents(in_txt_chunk_f, in_tab_chunk_f, orig_fn):
 # Per-document orchestration
 # ---------------------------------------------------------------------------
 
-def process_converted_document(converted_json_path, doc_path, out_path, gen_model, gen_endpoint, emb_endpoint, max_tokens, doc_id):
+def process_converted_document(converted_json_path, doc_path, out_path, gen_model, gen_endpoint, emb_endpoint, max_tokens, doc_id, stop_event: threading.Event | None = None):
     """
     Process converted document to extract text and tables.
     No caching - always process fresh.
     Returns detected language along with other results.
+
+    Args:
+        stop_event: Optional threading.Event. When set, table summarization is
+                    cut short between individual LLM calls (see process_table).
     """
     processed_text_json_path = (Path(out_path) / f"{doc_id}{text_suffix}")
     processed_table_json_path = (Path(out_path) / f"{doc_id}{table_suffix}")
@@ -445,11 +452,14 @@ def process_converted_document(converted_json_path, doc_path, out_path, gen_mode
             logger.warning(f"Failed to detect document language, using default {LanguageCodes.ENGLISH}: {e}")
 
         table_count, process_time, table_failures = process_table(
-            converted_doc, doc_path, processed_table_json_path, gen_model, gen_endpoint, document_language
+            converted_doc, doc_path, processed_table_json_path, gen_model, gen_endpoint, document_language,
+            stop_event=stop_event,
         )
         timings["process_tables"] = process_time
 
         return processed_text_json_path, processed_table_json_path, page_count, table_count, timings, document_language, table_failures
+    except JobCancelledError:
+        raise
     except Exception as e:
         logger.error(f"Error processing converted document: {doc_path}. Details: {e}", exc_info=True)
         return None, None, None, None, None, None, None
@@ -501,14 +511,16 @@ def process_documents(
         doc_id_dict:       Mapping of filenames to document IDs.
         indexing_callback: Optional callback(doc_id, chunks, path) → bool.
     """
-    from digitize.db.manager import db_manager
-
     status_mgr = get_status_manager(job_id)
 
     # Build task_id → path lookup from the rows already in conversion_tasks.
     tasks = db_manager.get_conversion_tasks_by_job_id(job_id)
     # Align by insertion order: tasks were inserted in the same order as input_paths.
     task_id_to_path: dict = {t.task_id: str(p) for t, p in zip(tasks, input_paths)}
+
+    # CHECK 1: abort before launching pipeline if cancellation was requested
+    if job_id and db_manager.is_job_cancelled(job_id):
+        raise JobCancelledError(f"Job {job_id} cancelled before processing started")
 
     pending_task_ids: set = set(task_id_to_path)
     # Per-task deadline: each task gets conversion_timeout_s from first observation.
@@ -524,265 +536,333 @@ def process_documents(
     #                  chunk_count } }
     converted_pdf_stats: dict = {}
 
+    # Shared stop event passed to process_converted_document threads so they
+    # can abort mid-table-summarization without waiting for all LLM calls.
+    _process_stop_event = threading.Event()
+
+    is_cancelled = False  # latched True on first cancellation; never reset
+
     worker_count = max(1, min(WORKER_SIZE, len(input_paths)))
 
-    with ContextAwareThreadPoolExecutor(max_workers=worker_count) as processor_executor, \
-         ContextAwareThreadPoolExecutor(max_workers=worker_count) as chunker_executor, \
-         ContextAwareThreadPoolExecutor(max_workers=worker_count) as indexer_executor:
+    try:
+        with ContextAwareThreadPoolExecutor(max_workers=worker_count) as processor_executor, \
+             ContextAwareThreadPoolExecutor(max_workers=worker_count) as chunker_executor, \
+             ContextAwareThreadPoolExecutor(max_workers=worker_count) as indexer_executor:
 
-        while pending_task_ids or process_futures or chunk_futures or indexing_futures:
+            while pending_task_ids or process_futures or chunk_futures or indexing_futures:
 
-            # --- A. React to completed/failed conversion tasks ---
-            timeout_s = settings.digitize.conversion_timeout_s
-            for task_id in list(pending_task_ids):
-                task = db_manager.get_conversion_task(task_id)
-                if task is None:
-                    pending_task_ids.discard(task_id)
-                    task_deadlines.pop(task_id, None)
-                    continue
-                if task.status not in (ConversionTaskStatus.COMPLETED, ConversionTaskStatus.FAILED):
-                    # Start the deadline clock the first time we see this task.
-                    if task_id not in task_deadlines:
-                        task_deadlines[task_id] = time.monotonic() + timeout_s
-                    if time.monotonic() >= task_deadlines[task_id]:
-                        path = task_id_to_path[task_id]
-                        doc_id = doc_id_dict.get(Path(path).name)
-                        doc_name = Path(task.cached_file).name if task.cached_file else Path(path).name
-                        error = (
-                            f"Conversion task {task_id} ({doc_name}) did not complete within "
-                            f"{timeout_s:.0f}s — dispatcher may be stalled"
-                        )
-                        logger.error(error)
-                        if doc_id is not None:
-                            status_mgr.update_doc_metadata(
-                                doc_id, {"status": DocStatus.FAILED}, error=error,
-                            )
-                            status_mgr.update_job_progress(
-                                doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS
-                            )
+                # --- Cancellation check at top of every poll cycle ---
+                is_cancelled = is_cancelled or bool(job_id and db_manager.is_job_cancelled(job_id))
+                if is_cancelled:
+                    _process_stop_event.set()
+
+                # --- A. React to completed/failed conversion tasks ---
+                timeout_s = settings.digitize.conversion_timeout_s
+                for task_id in list(pending_task_ids):
+                    if is_cancelled:
+                        # Drop remaining pending tasks without submitting downstream work
+                        logger.info(f"Job {job_id} cancelled — skipping conversion task {task_id}")
                         pending_task_ids.discard(task_id)
                         task_deadlines.pop(task_id, None)
-                    continue
-                task_deadlines.pop(task_id, None)
-                path = task_id_to_path[task_id]
-                doc_id = doc_id_dict.get(Path(path).name)
-                pending_task_ids.discard(task_id)
+                        continue
+                    task = db_manager.get_conversion_task(task_id)
+                    if task is None:
+                        pending_task_ids.discard(task_id)
+                        task_deadlines.pop(task_id, None)
+                        continue
+                    if task.status not in (ConversionTaskStatus.COMPLETED, ConversionTaskStatus.FAILED):
+                        # Start the deadline clock the first time we see this task.
+                        if task_id not in task_deadlines:
+                            task_deadlines[task_id] = time.monotonic() + timeout_s
+                        if time.monotonic() >= task_deadlines[task_id]:
+                            path = task_id_to_path[task_id]
+                            doc_id = doc_id_dict.get(Path(path).name)
+                            doc_name = Path(task.cached_file).name if task.cached_file else Path(path).name
+                            error = (
+                                f"Conversion task {task_id} ({doc_name}) did not complete within "
+                                f"{timeout_s:.0f}s — dispatcher may be stalled"
+                            )
+                            logger.error(error)
+                            if doc_id is not None:
+                                status_mgr.update_doc_metadata(
+                                    doc_id, {"status": DocStatus.FAILED}, error=error,
+                                )
+                                status_mgr.update_job_progress(
+                                    doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS
+                                )
+                            pending_task_ids.discard(task_id)
+                            task_deadlines.pop(task_id, None)
+                        continue
+                    task_deadlines.pop(task_id, None)
+                    path = task_id_to_path[task_id]
+                    doc_id = doc_id_dict.get(Path(path).name)
+                    pending_task_ids.discard(task_id)
 
-                if task.status == ConversionTaskStatus.COMPLETED:
-                    # Seed stats entry with conversion timing derived from task timestamps.
-                    digitizing_time = 0.0
-                    if task.started_at and task.completed_at:
-                        digitizing_time = round(
-                            (task.completed_at - task.started_at).total_seconds(), 2
+                    if task.status == ConversionTaskStatus.COMPLETED:
+                        # Seed stats entry with conversion timing derived from task timestamps.
+                        digitizing_time = 0.0
+                        if task.started_at and task.completed_at:
+                            digitizing_time = round(
+                                (task.completed_at - task.started_at).total_seconds(), 2
+                            )
+                        converted_pdf_stats[path] = {"timings": {"digitizing": digitizing_time}}
+                        if doc_id is not None:
+                            logger.debug(
+                                f"Conversion Done: updating doc & job metadata "
+                                f"for document: {doc_id}"
+                            )
+                            status_mgr.update_doc_metadata(doc_id, {
+                                "status": DocStatus.DIGITIZED,
+                                "timing_in_secs": {"digitizing": digitizing_time},
+                            })
+                            status_mgr.update_job_progress(
+                                doc_id, DocStatus.DIGITIZED, JobStatus.IN_PROGRESS
+                            )
+                        # CHECK 2: don't submit new work if cancelled
+                        if is_cancelled:
+                            logger.info(f"Job {job_id} cancelled — not submitting converted document for processing: {path}")
+                            continue
+                        p_future = processor_executor.submit(
+                            process_converted_document,
+                            task.result_path,
+                            path,
+                            out_path,
+                            llm_model,
+                            llm_endpoint,
+                            emb_endpoint,
+                            max_tokens,
+                            doc_id=doc_id,
+                            stop_event=_process_stop_event,
                         )
-                    converted_pdf_stats[path] = {"timings": {"digitizing": digitizing_time}}
-                    if doc_id is not None:
-                        logger.debug(
-                            f"Conversion Done: updating doc & job metadata "
-                            f"for document: {doc_id}"
+                        process_futures[p_future] = path
+
+                    elif task.status == ConversionTaskStatus.FAILED:
+                        converted_pdf_stats.pop(path, None)
+                        if doc_id is not None:
+                            status_mgr.update_doc_metadata(
+                                doc_id, {"status": DocStatus.FAILED},
+                                error=task.error or "Conversion failed",
+                            )
+                            status_mgr.update_job_progress(
+                                doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS
+                            )
+
+                # --- B. Drain completed process futures → submit chunking ---
+                for fut in list(process_futures):
+                    if not fut.done():
+                        continue
+                    path = process_futures.pop(fut)
+                    doc_id = doc_id_dict.get(Path(path).name)
+                    try:
+                        txt_json, tab_json, pgs, tabs, timings, doc_lang, table_failures = fut.result()
+
+                        if not txt_json or not tab_json:
+                            if doc_id is not None:
+                                logger.error(
+                                    f"Processing failed for {path}: "
+                                    f"txt_json or tab_json is None"
+                                )
+                                status_mgr.update_doc_metadata(
+                                    doc_id, {"status": DocStatus.FAILED},
+                                    error=f"Failed to process document {doc_id}: processing returned None",
+                                )
+                                status_mgr.update_job_progress(
+                                    doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS
+                                )
+                            converted_pdf_stats.pop(path, None)
+                            continue
+
+                        total_processing_time = round(
+                            float(timings.get("process_text", 0) + timings.get("process_tables", 0)), 2
                         )
-                        status_mgr.update_doc_metadata(doc_id, {
-                            "status": DocStatus.DIGITIZED,
-                            "timing_in_secs": {"digitizing": digitizing_time},
+                        converted_pdf_stats.setdefault(path, {"timings": {}})
+                        converted_pdf_stats[path].update({
+                            "page_count": pgs,
+                            "table_count": tabs,
+                            "had_table_failures": bool(table_failures),
                         })
-                        status_mgr.update_job_progress(
-                            doc_id, DocStatus.DIGITIZED, JobStatus.IN_PROGRESS
-                        )
-                    p_future = processor_executor.submit(
-                        process_converted_document,
-                        task.result_path,
-                        path,
-                        out_path,
-                        llm_model,
-                        llm_endpoint,
-                        emb_endpoint,
-                        max_tokens,
-                        doc_id=doc_id,
-                    )
-                    process_futures[p_future] = path
+                        converted_pdf_stats[path]["timings"]["processing"] = total_processing_time
 
-                elif task.status == ConversionTaskStatus.FAILED:
-                    converted_pdf_stats.pop(path, None)
-                    if doc_id is not None:
-                        status_mgr.update_doc_metadata(
-                            doc_id, {"status": DocStatus.FAILED},
-                            error=task.error or "Conversion failed",
-                        )
-                        status_mgr.update_job_progress(
-                            doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS
-                        )
+                        if doc_id is not None:
+                            logger.debug(
+                                f"Processing Done: updating doc & job metadata "
+                                f"for document: {doc_id}"
+                            )
 
-            # --- B. Drain completed process futures → submit chunking ---
-            for fut in list(process_futures):
-                if not fut.done():
-                    continue
-                path = process_futures.pop(fut)
-                doc_id = doc_id_dict.get(Path(path).name)
-                try:
-                    txt_json, tab_json, pgs, tabs, timings, doc_lang, table_failures = fut.result()
+                            if table_failures:
+                                logger.warning(
+                                    f"Document {doc_id}: {len(table_failures)} table(s) completed "
+                                    f"with errors; those tables will use fallback summaries"
+                                )
 
-                    if not txt_json or not tab_json:
+                            status_mgr.update_doc_metadata(doc_id, {
+                                "status": DocStatus.PROCESSED,
+                                "pages": pgs,
+                                "tables": tabs,
+                                "timing_in_secs": {**converted_pdf_stats[path]["timings"]},
+                            })
+                            status_mgr.update_job_progress(
+                                doc_id, DocStatus.PROCESSED, JobStatus.IN_PROGRESS
+                            )
+
+                        # CHECK 3: don't submit new work if cancelled
+                        if is_cancelled:
+                            logger.info(f"Job {job_id} cancelled — not submitting processed document for chunking: {path}")
+                            continue
+
+                        c_future = chunker_executor.submit(
+                            chunk_single_file,
+                            txt_json, tab_json, out_path,
+                            emb_endpoint, max_tokens,
+                            doc_id=doc_id, language=doc_lang,
+                        )
+                        chunk_futures[c_future] = path
+                    except JobCancelledError:
+                        logger.info(f"Job {job_id} cancelled — processing was interrupted for document: {path}")
+                        is_cancelled = True
+                        _process_stop_event.set()
+                    except Exception as e:
                         if doc_id is not None:
                             logger.error(
-                                f"Processing failed for {path}: "
-                                f"txt_json or tab_json is None"
+                                f"Error from processing for {path}: {e}", exc_info=True
                             )
                             status_mgr.update_doc_metadata(
                                 doc_id, {"status": DocStatus.FAILED},
-                                error=f"Failed to process document {doc_id}: processing returned None",
+                                error=f"failed to process document: {e}",
                             )
                             status_mgr.update_job_progress(
                                 doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS
                             )
                         converted_pdf_stats.pop(path, None)
+
+                # --- C. Drain completed chunk futures → submit indexing ---
+                for fut in list(chunk_futures):
+                    if not fut.done():
                         continue
+                    path = chunk_futures.pop(fut)
+                    doc_id = doc_id_dict.get(Path(path).name)
+                    try:
+                        text_chunk_json, table_chunk_json, total_time = fut.result()
 
-                    total_processing_time = round(
-                        float(timings.get("process_text", 0) + timings.get("process_tables", 0)), 2
-                    )
-                    converted_pdf_stats.setdefault(path, {"timings": {}})
-                    converted_pdf_stats[path].update({
-                        "page_count": pgs,
-                        "table_count": tabs,
-                        "had_table_failures": bool(table_failures),
-                    })
-                    converted_pdf_stats[path]["timings"]["processing"] = total_processing_time
+                        if not text_chunk_json or not table_chunk_json:
+                            if doc_id is not None:
+                                logger.error(f"Chunking failed for {path}")
+                                status_mgr.update_doc_metadata(
+                                    doc_id, {"status": DocStatus.FAILED},
+                                    error=f"Chunking failed for document {doc_id}",
+                                )
+                                status_mgr.update_job_progress(
+                                    doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS
+                                )
+                            converted_pdf_stats.pop(path, None)
+                            continue
 
-                    if doc_id is not None:
-                        logger.debug(
-                            f"Processing Done: updating doc & job metadata "
-                            f"for document: {doc_id}"
-                        )
+                        chunk_count = count_chunks(text_chunk_json, table_chunk_json)
+                        converted_pdf_stats.setdefault(path, {"timings": {}})
+                        converted_pdf_stats[path]["timings"]["chunking"] = round(float(total_time or 0), 2)
+                        converted_pdf_stats[path]["chunk_count"] = chunk_count
+                        had_table_failures = converted_pdf_stats[path].get("had_table_failures", False)
 
-                        if table_failures:
-                            logger.warning(
-                                f"Document {doc_id}: {len(table_failures)} table(s) completed "
-                                f"with errors; those tables will use fallback summaries"
-                            )
-
-                        status_mgr.update_doc_metadata(doc_id, {
-                            "status": DocStatus.PROCESSED,
-                            "pages": pgs,
-                            "tables": tabs,
-                            "timing_in_secs": {**converted_pdf_stats[path]["timings"]},
-                        })
-
-                        status_mgr.update_job_progress(
-                            doc_id, DocStatus.PROCESSED, JobStatus.IN_PROGRESS
-                        )
-
-                    c_future = chunker_executor.submit(
-                        chunk_single_file,
-                        txt_json, tab_json, out_path,
-                        emb_endpoint, max_tokens,
-                        doc_id=doc_id, language=doc_lang,
-                    )
-                    chunk_futures[c_future] = path
-                except Exception as e:
-                    if doc_id is not None:
-                        logger.error(
-                            f"Error from processing for {path}: {e}", exc_info=True
-                        )
-                        status_mgr.update_doc_metadata(
-                            doc_id, {"status": DocStatus.FAILED},
-                            error=f"failed to process document: {e}",
-                        )
-                        status_mgr.update_job_progress(
-                            doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS
-                        )
-                    converted_pdf_stats.pop(path, None)
-
-            # --- C. Drain completed chunk futures → submit indexing ---
-            for fut in list(chunk_futures):
-                if not fut.done():
-                    continue
-                path = chunk_futures.pop(fut)
-                doc_id = doc_id_dict.get(Path(path).name)
-                try:
-                    text_chunk_json, table_chunk_json, total_time = fut.result()
-
-                    if not text_chunk_json or not table_chunk_json:
                         if doc_id is not None:
-                            logger.error(f"Chunking failed for {path}")
+                            logger.debug(
+                                f"Chunking Done: updating doc & job metadata "
+                                f"for document: {doc_id}"
+                            )
+                            metadata_update: dict = {
+                                "status": DocStatus.CHUNKED,
+                                "chunks": chunk_count,
+                                "timing_in_secs": {**converted_pdf_stats[path]["timings"]},
+                            }
+                            # Persist the table-error flag into the doc's metadata JSONB
+                            # so that the indexing callback in ingest.py can read it without
+                            # ambiguity (reading doc.status would be ambiguous mid-pipeline).
+                            if had_table_failures:
+                                metadata_update["had_table_failures"] = True
+                            status_mgr.update_doc_metadata(doc_id, metadata_update)
+                            status_mgr.update_job_progress(
+                                doc_id, DocStatus.CHUNKED, JobStatus.IN_PROGRESS
+                            )
+
+                            # CHECK 4: don't submit indexing work if cancelled
+                            if is_cancelled:
+                                logger.info(f"Job {job_id} cancelled — not submitting chunked document for indexing: {path}")
+                                continue
+
+                            if indexing_callback:
+                                try:
+                                    doc_chunks = merge_chunked_documents(
+                                        text_chunk_json, table_chunk_json, path
+                                    )
+                                    for chunk in doc_chunks:
+                                        chunk["doc_id"] = doc_id
+                                    index_future = indexer_executor.submit(
+                                        indexing_callback, doc_id, doc_chunks, path
+                                    )
+                                    indexing_futures[index_future] = doc_id
+                                except Exception as e:
+                                    logger.error(
+                                        f"Error submitting indexing for {doc_id}: {e}",
+                                        exc_info=True,
+                                    )
+                    except Exception as e:
+                        if doc_id is not None:
+                            logger.error(
+                                f"Error from chunking for {path}: {e}", exc_info=True
+                            )
                             status_mgr.update_doc_metadata(
                                 doc_id, {"status": DocStatus.FAILED},
-                                error=f"Chunking failed for document {doc_id}",
+                                error=f"failed to chunk document: {e}",
                             )
                             status_mgr.update_job_progress(
                                 doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS
                             )
                         converted_pdf_stats.pop(path, None)
+
+                # --- D. Drain completed indexing futures ---
+                for fut in list(indexing_futures):
+                    if not fut.done():
+                        # If cancelled, cancel queued (not-yet-running) indexing futures
+                        if is_cancelled and not fut.running():
+                            fut.cancel()
+                            doc_id = indexing_futures.pop(fut)
+                            logger.info(f"Job {job_id} cancelled — skipping indexing for document: {doc_id}")
                         continue
-
-                    chunk_count = count_chunks(text_chunk_json, table_chunk_json)
-                    converted_pdf_stats.setdefault(path, {"timings": {}})
-                    converted_pdf_stats[path]["timings"]["chunking"] = round(float(total_time or 0), 2)
-                    converted_pdf_stats[path]["chunk_count"] = chunk_count
-                    had_table_failures = converted_pdf_stats[path].get("had_table_failures", False)
-
-                    if doc_id is not None:
-                        logger.debug(
-                            f"Chunking Done: updating doc & job metadata "
-                            f"for document: {doc_id}"
-                        )
-                        metadata_update: dict = {
-                            "status": DocStatus.CHUNKED,
-                            "chunks": chunk_count,
-                            "timing_in_secs": {**converted_pdf_stats[path]["timings"]},
-                        }
-                        # Persist the table-error flag into the doc's metadata JSONB
-                        # so that the indexing callback in ingest.py can read it without
-                        # ambiguity (reading doc.status would be ambiguous mid-pipeline).
-                        if had_table_failures:
-                            metadata_update["had_table_failures"] = True
-                        status_mgr.update_doc_metadata(doc_id, metadata_update)
-                        status_mgr.update_job_progress(
-                            doc_id, DocStatus.CHUNKED, JobStatus.IN_PROGRESS
-                        )
-
-                        if indexing_callback:
-                            try:
-                                doc_chunks = merge_chunked_documents(
-                                    text_chunk_json, table_chunk_json, path
-                                )
-                                for chunk in doc_chunks:
-                                    chunk["doc_id"] = doc_id
-                                index_future = indexer_executor.submit(
-                                    indexing_callback, doc_id, doc_chunks, path
-                                )
-                                indexing_futures[index_future] = doc_id
-                            except Exception as e:
-                                logger.error(
-                                    f"Error submitting indexing for {doc_id}: {e}",
-                                    exc_info=True,
-                                )
-                except Exception as e:
-                    if doc_id is not None:
+                    doc_id = indexing_futures.pop(fut)
+                    try:
+                        fut.result()
+                        logger.debug(f"Indexing completed for document: {doc_id}")
+                    except Exception as e:
                         logger.error(
-                            f"Error from chunking for {path}: {e}", exc_info=True
+                            f"Indexing failed for document {doc_id}: {e}", exc_info=True
                         )
-                        status_mgr.update_doc_metadata(
-                            doc_id, {"status": DocStatus.FAILED},
-                            error=f"failed to chunk document: {e}",
-                        )
-                        status_mgr.update_job_progress(
-                            doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS
-                        )
-                    converted_pdf_stats.pop(path, None)
 
-            # --- D. Drain completed indexing futures ---
-            for fut in list(indexing_futures):
-                if not fut.done():
-                    continue
-                doc_id = indexing_futures.pop(fut)
-                try:
-                    fut.result()
-                    logger.debug(f"Indexing completed for document: {doc_id}")
-                except Exception as e:
-                    logger.error(
-                        f"Indexing failed for document {doc_id}: {e}", exc_info=True
-                    )
+                if is_cancelled and not process_futures and not chunk_futures and not indexing_futures:
+                    # All in-flight downstream work has drained; exit the loop and raise
+                    pending_task_ids.clear()
+                    break
 
-            time.sleep(settings.digitize.conversion_poll_interval)
+                time.sleep(settings.digitize.conversion_poll_interval)
 
-    return {}, converted_pdf_stats
+        if is_cancelled:
+            raise JobCancelledError(f"Job {job_id} was cancelled")
+
+        return {}, converted_pdf_stats
+
+    except JobCancelledError:
+        # Propagate cancellation so the caller (_run_ingest / _run_digitize) handles cleanup
+        raise
+
+    except Exception as e:
+        logger.error(f"Error while processing the documents in job {job_id}: {e}", exc_info=True)
+
+        # Clean up intermediate files for failed documents
+        # Preserve <doc_id>.json even for failed jobs for debugging/GET requests
+        try:
+            for path in input_paths:
+                doc_id = doc_id_dict.get(Path(path).name)
+                if doc_id:
+                    clean_intermediate_files(doc_id, out_path)
+        except Exception as cleanup_error:
+            logger.warning(f"Error during cleanup of failed job {job_id}: {cleanup_error}")
+
+        return {}, {}

--- a/services/digitize/processing/orchestrator.py
+++ b/services/digitize/processing/orchestrator.py
@@ -135,7 +135,7 @@ def flush_chunk(current_chunk, chunks, emb_endpoint, max_tokens, language=Langua
     current_chunk["source_nodes"] = []
 
 
-def chunk_text(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, language=LanguageCodes.ENGLISH, cancel_event=None):
+def chunk_text(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, language=LanguageCodes.ENGLISH):
     """
     Chunk text content from a document into smaller pieces based on token limits.
 
@@ -146,7 +146,6 @@ def chunk_text(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, 
         max_tokens: Maximum tokens per chunk
         doc_id: Document ID
         language: Language code for sentence splitting (detected from document text)
-        cancel_event: Optional threading.Event; if set, chunking is aborted early.
     """
     t0 = time.time()
     processed_chunk_json_path = (Path(out_path) / f"{doc_id}{text_chunk_suffix}")
@@ -174,9 +173,6 @@ def chunk_text(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, 
             current_subsubsection = None
 
             for idx, block in enumerate(data):
-                if cancel_event is not None and cancel_event.is_set():
-                    logger.info(f"Cancellation requested — aborting text chunking for '{input_path}'")
-                    raise JobCancelledError("Text chunking cancelled")
                 label = block.get("label")
                 text = block.get("text", "").strip()
                 page_no = block.get("page", 0)
@@ -242,7 +238,7 @@ def chunk_text(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, 
         return None, None
 
 
-def chunk_tables(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, language=LanguageCodes.ENGLISH, cancel_event=None):
+def chunk_tables(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, language=LanguageCodes.ENGLISH):
     """
     Chunk table summaries into smaller pieces if they exceed token limits.
     Called internally by chunk_single_file() for sequential processing.
@@ -254,7 +250,6 @@ def chunk_tables(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None
         max_tokens: Maximum tokens per chunk
         doc_id: Document ID
         language: Language code for sentence splitting (detected from document text)
-        cancel_event: Optional threading.Event; if set, chunking is aborted early.
     """
     t0 = time.time()
     processed_table_chunk_json_path = (Path(out_path) / f"{doc_id}{table_chunk_suffix}")
@@ -270,9 +265,6 @@ def chunk_tables(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None
             tab_data_list = list(tab_data.values())
 
             for block in tab_data_list:
-                if cancel_event is not None and cancel_event.is_set():
-                    logger.info(f"Cancellation requested — aborting table chunking for '{input_path}'")
-                    raise JobCancelledError("Table chunking cancelled")
                 caption = block.get('caption', '')
                 summary = block.get("summary", '')
                 page_number = block.get('page_number')
@@ -324,8 +316,10 @@ def chunk_single_file(input_path, table_json_path, out_path, emb_endpoint, max_t
     t0 = time.time()
     try:
         splitter_lang = to_sentence_splitter_lang(language)
-        text_chunk_json, text_chunk_time = chunk_text(input_path, out_path, emb_endpoint, max_tokens, doc_id, splitter_lang, cancel_event=cancel_event)
-        table_chunk_json, table_chunk_time = chunk_tables(table_json_path, out_path, emb_endpoint, max_tokens, doc_id, splitter_lang, cancel_event=cancel_event)
+        text_chunk_json, text_chunk_time = chunk_text(input_path, out_path, emb_endpoint, max_tokens, doc_id, splitter_lang)
+        if cancel_event is not None and cancel_event.is_set():
+            raise JobCancelledError(f"Chunking cancelled after text chunking for '{input_path}'")
+        table_chunk_json, table_chunk_time = chunk_tables(table_json_path, out_path, emb_endpoint, max_tokens, doc_id, splitter_lang)
         total_time = time.time() - t0
         return text_chunk_json, table_chunk_json, total_time
     except JobCancelledError:
@@ -778,7 +772,6 @@ def process_documents(
                     except JobCancelledError:
                         logger.info(f"Job {job_id} cancelled — processing was interrupted for document: {path}")
                         is_cancelled = True
-                        _process_stop_event.set()
                     except Exception as e:
                         if doc_id is not None:
                             logger.error(
@@ -866,7 +859,6 @@ def process_documents(
                     except JobCancelledError:
                         logger.info(f"Job {job_id} cancelled — chunking was interrupted for document: {path}")
                         is_cancelled = True
-                        _process_stop_event.set()
                     except Exception as e:
                         if doc_id is not None:
                             logger.error(
@@ -896,6 +888,9 @@ def process_documents(
                     try:
                         fut.result()
                         logger.debug(f"Indexing completed for document: {doc_id}")
+                    except JobCancelledError:
+                        logger.info(f"Job {job_id} cancelled — indexing was interrupted for document: {doc_id}")
+                        is_cancelled = True
                     except Exception as e:
                         logger.error(
                             f"Indexing failed for document {doc_id}: {e}", exc_info=True

--- a/services/digitize/processing/orchestrator.py
+++ b/services/digitize/processing/orchestrator.py
@@ -540,7 +540,8 @@ def process_documents(
     # can abort mid-table-summarization without waiting for all LLM calls.
     _process_stop_event = threading.Event()
 
-    is_cancelled = False  # latched True on first cancellation; never reset
+    is_cancelled = False        # latched True on first cancellation; never reset
+    _tasks_cancel_signalled = False  # tracks whether cancel_tasks_for_job has been called
 
     worker_count = max(1, min(WORKER_SIZE, len(input_paths)))
 
@@ -555,8 +556,13 @@ def process_documents(
                 is_cancelled = is_cancelled or bool(job_id and db_manager.is_job_cancelled(job_id))
                 if is_cancelled:
                     _process_stop_event.set()
+                    # Signal the dispatcher to stop any pending/queued/running conversion
+                    # tasks belonging to this job.  Done exactly once on first detection.
+                    if not _tasks_cancel_signalled:
+                        db_manager.cancel_tasks_for_job(job_id)
+                        _tasks_cancel_signalled = True
 
-                # --- A. React to completed/failed conversion tasks ---
+                # --- A. React to completed/failed/cancelled conversion tasks ---
                 timeout_s = settings.digitize.conversion_timeout_s
                 for task_id in list(pending_task_ids):
                     if is_cancelled:
@@ -570,7 +576,12 @@ def process_documents(
                         pending_task_ids.discard(task_id)
                         task_deadlines.pop(task_id, None)
                         continue
-                    if task.status not in (ConversionTaskStatus.COMPLETED, ConversionTaskStatus.FAILED):
+                    _terminal = (
+                        ConversionTaskStatus.COMPLETED,
+                        ConversionTaskStatus.FAILED,
+                        ConversionTaskStatus.CANCELLED,
+                    )
+                    if task.status not in _terminal:
                         # Start the deadline clock the first time we see this task.
                         if task_id not in task_deadlines:
                             task_deadlines[task_id] = time.monotonic() + timeout_s
@@ -646,6 +657,15 @@ def process_documents(
                             status_mgr.update_job_progress(
                                 doc_id, DocStatus.FAILED, JobStatus.IN_PROGRESS
                             )
+
+                    elif task.status == ConversionTaskStatus.CANCELLED:
+                        # Dispatcher acknowledged the cancel — the job-level cancel
+                        # handler (_run_ingest / _run_digitize) will set the final
+                        # doc/job status to CANCELLED; nothing more to do here.
+                        converted_pdf_stats.pop(path, None)
+                        logger.info(
+                            f"Conversion task {task_id} was cancelled by dispatcher"
+                        )
 
                 # --- B. Drain completed process futures → submit chunking ---
                 for fut in list(process_futures):

--- a/services/digitize/processing/orchestrator.py
+++ b/services/digitize/processing/orchestrator.py
@@ -597,7 +597,17 @@ def process_documents(
                 timeout_s = settings.digitize.conversion_timeout_s
                 for task_id in list(pending_task_ids):
                     if is_cancelled:
-                        # Drop remaining pending tasks without submitting downstream work
+                        # For tasks still mid-conversion (CANCEL_PENDING), the dispatcher
+                        # has been signalled but may still be finishing its current 100-page
+                        # chunk before it observes the flag and writes CANCELLED.  Keep the
+                        # task in pending_task_ids and keep polling until it reaches a
+                        # terminal state — otherwise the orchestrator exits while
+                        # _run_conversion is still running.
+                        task = db_manager.get_conversion_task(task_id)
+                        if task is not None and task.status == ConversionTaskStatus.CANCEL_PENDING:
+                            continue  # still draining — re-poll next tick
+                        # Task is already terminal (CANCELLED / FAILED / COMPLETED) or
+                        # was never dispatched — safe to drop without submitting downstream work.
                         logger.info(f"Job {job_id} cancelled — skipping conversion task {task_id}")
                         pending_task_ids.discard(task_id)
                         task_deadlines.pop(task_id, None)
@@ -896,9 +906,13 @@ def process_documents(
                             f"Indexing failed for document {doc_id}: {e}", exc_info=True
                         )
 
-                if is_cancelled and not process_futures and not chunk_futures and not indexing_futures:
-                    # All in-flight downstream work has drained; exit the loop and raise
-                    pending_task_ids.clear()
+                if is_cancelled and not process_futures and not chunk_futures and not indexing_futures \
+                        and not pending_task_ids:
+                    # All in-flight downstream work has drained and every conversion task
+                    # has reached a terminal state (CANCELLED/FAILED/COMPLETED).
+                    # CANCEL_PENDING tasks are kept in pending_task_ids (section A above)
+                    # until _run_conversion writes the final CANCELLED — only once
+                    # pending_task_ids is empty do we know it's safe to exit.
                     break
 
                 time.sleep(settings.digitize.conversion_poll_interval)

--- a/services/digitize/processing/tables.py
+++ b/services/digitize/processing/tables.py
@@ -20,6 +20,7 @@ from rapidfuzz import fuzz
 from common.lang_utils import LanguageCodes, get_prompt_for_language
 from common.llm_utils import summarize_and_classify_tables
 from common.misc_utils import get_logger
+from digitize.exceptions import JobCancelledError
 from digitize.settings import settings
 
 logger = get_logger("processing.tables")
@@ -316,6 +317,9 @@ def process_table(converted_doc, doc_path, out_path, gen_model, gen_endpoint, do
         else:
             table_dict[table_ix]["page_number"] = None
 
+    if stop_event and stop_event.is_set():
+        raise JobCancelledError(f"Job cancelled before merging tables for document: {doc_path}")
+
     logger.debug(f"Merging cross-page tables for '{doc_path}'")
     merged_table_dict = merge_consecutive_tables(table_dict)
 
@@ -349,6 +353,9 @@ def process_table(converted_doc, doc_path, out_path, gen_model, gen_endpoint, do
         f"Using language prompt {document_language} and max_tokens ({selected_max_tokens}) "
         f"for table summarization"
     )
+
+    if stop_event and stop_event.is_set():
+        raise JobCancelledError(f"Job cancelled before summarizing tables for document: {doc_path}")
 
     # Summarize and classify tables - use markdown directly
     table_summaries, decisions, failures = summarize_and_classify_tables(

--- a/services/digitize/processing/tables.py
+++ b/services/digitize/processing/tables.py
@@ -11,6 +11,7 @@ Responsibilities:
 """
 
 import json
+import threading
 import time
 import re
 from pathlib import Path
@@ -259,8 +260,7 @@ def merge_consecutive_tables(table_dict: dict) -> dict:
 
     return merged_dict
 
-
-def process_table(converted_doc, doc_path, out_path, gen_model, gen_endpoint, document_language=LanguageCodes.ENGLISH):
+def process_table(converted_doc, doc_path, out_path, gen_model, gen_endpoint, document_language=LanguageCodes.ENGLISH, stop_event: threading.Event | None = None):
     """Extract, process, and summarize tables found in a document.
 
     Saves the extracted tables and their LLM-generated summaries to a JSON file.
@@ -355,6 +355,7 @@ def process_table(converted_doc, doc_path, out_path, gen_model, gen_endpoint, do
         table_markdowns, gen_model, gen_endpoint, doc_path,
         prompt_template=selected_prompt,
         max_tokens=selected_max_tokens,
+        stop_event=stop_event,
     )
 
     filtered_table_dicts = {

--- a/services/digitize/tests/conftest.py
+++ b/services/digitize/tests/conftest.py
@@ -45,12 +45,6 @@ _real_noop_crash_handler = lambda logger: (MagicMock(), MagicMock(), MagicMock()
 _diag_logger.setup_comprehensive_crash_handler = _real_noop_crash_handler
 
 
-# Stub optional heavy deps not installed in the test environment.
-for _pkg in ["lingua", "pdfplumber"]:
-    _stub_module(_pkg)
-sys.modules["lingua"].Language = MagicMock(name="Language")
-sys.modules["lingua"].LanguageDetectorBuilder = MagicMock(name="LanguageDetectorBuilder")
-
 # Ensure all package levels exist first.
 for _pkg in [
     "docling",

--- a/services/digitize/tests/conftest.py
+++ b/services/digitize/tests/conftest.py
@@ -45,6 +45,12 @@ _real_noop_crash_handler = lambda logger: (MagicMock(), MagicMock(), MagicMock()
 _diag_logger.setup_comprehensive_crash_handler = _real_noop_crash_handler
 
 
+# Stub optional heavy deps not installed in the test environment.
+for _pkg in ["lingua", "pdfplumber"]:
+    _stub_module(_pkg)
+sys.modules["lingua"].Language = MagicMock(name="Language")
+sys.modules["lingua"].LanguageDetectorBuilder = MagicMock(name="LanguageDetectorBuilder")
+
 # Ensure all package levels exist first.
 for _pkg in [
     "docling",

--- a/services/digitize/tests/test_cancel_job.py
+++ b/services/digitize/tests/test_cancel_job.py
@@ -899,7 +899,7 @@ class TestOrchestratorCancellationAtChunkingStage:
         task_completed = _make_task_stub("t-1", "completed", result_path="conv.json")
 
         proc_fut: Future = Future()
-        proc_fut.set_result(("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en"))
+        proc_fut.set_result(("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en", {}))
 
         # chunk_future raises JobCancelledError — simulates the chunker worker
         # being interrupted by the _process_stop_event.
@@ -959,7 +959,7 @@ class TestOrchestratorCancellationAtIndexingStage:
         task_completed = _make_task_stub("t-1", "completed", result_path="conv.json")
 
         proc_fut: Future = Future()
-        proc_fut.set_result(("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en"))
+        proc_fut.set_result(("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en", {}))
 
         chunk_fut: Future = Future()
         chunk_result = ("text_chunks.json", "table_chunks.json", 2.5)
@@ -1045,7 +1045,7 @@ class TestOrchestratorCancellationAtIndexingStage:
         task_completed = _make_task_stub("t-1", "completed", result_path="conv.json")
 
         proc_fut: Future = Future()
-        proc_fut.set_result(("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en"))
+        proc_fut.set_result(("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en", {}))
 
         chunk_fut: Future = Future()
         chunk_fut.set_result(("text_chunks.json", "table_chunks.json", 2.5))
@@ -1136,7 +1136,7 @@ class TestOrchestratorHappyPath:
         task_completed = _make_task_stub("t-1", "completed", result_path="conv.json")
 
         proc_fut: Future = Future()
-        proc_fut.set_result(("txt.json", "tab.json", 10, 3, {"process_text": 0.5, "process_tables": 0.3}, "en"))
+        proc_fut.set_result(("txt.json", "tab.json", 10, 3, {"process_text": 0.5, "process_tables": 0.3}, "en", {}))
 
         chunk_fut: Future = Future()
         chunk_fut.set_result(("text_chunks.json", "table_chunks.json", 1.2))
@@ -1976,7 +1976,7 @@ class TestOrchestratorIndexCancelEventCleanFilesGating:
 
         proc_fut: Future = Future()
         proc_fut.set_result(
-            ("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en")
+            ("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en", {})
         )
 
         chunk_fut: Future = Future()

--- a/services/digitize/tests/test_cancel_job.py
+++ b/services/digitize/tests/test_cancel_job.py
@@ -11,7 +11,7 @@ Coverage:
 
   2. ``_run_digitize`` background task (jobs.py)
      - JobCancelledError causes CANCELLED status on non-terminal docs and job
-     - Staging cleanup and semaphore release happen even on cancellation
+     - Staging cleanup happens even on cancellation (finally block)
      - Normal pipeline exception does NOT produce CANCELLED status
 
   3. ``_run_ingest`` background task (jobs.py)
@@ -19,16 +19,31 @@ Coverage:
      - clean_files=True → vector-DB chunks are removed for the right doc IDs
      - clean_files=False → vector DB is NOT touched
      - VDB cleanup failure is swallowed (only a warning)
-     - Staging cleanup and semaphore release happen even on cancellation
+     - Staging cleanup happens even on cancellation (finally block)
 
-  4. ``process_documents / _run_batch`` (orchestrator.py)
-     - Cancellation at conversion stage: pending futures are cancelled, running
-       ones are drained; JobCancelledError is raised afterwards
-     - Cancellation at processing stage: same pattern
-     - Cancellation at chunking stage: same pattern
-     - Cancellation at indexing stage: pending index futures cancelled; already
-       running index futures are let to complete (no stale VDB entries)
+  4. ``process_documents`` (orchestrator.py) — DB-polled conversion stage
+     - Cancellation before processing starts raises JobCancelledError immediately
+     - Cancellation mid-conversion: pending tasks are dropped; cancel_tasks_for_job is called
+     - Cancellation at processing stage: pending process_futures are cancelled
+     - Cancellation at chunking stage: pending chunk_futures are cancelled
+     - Cancellation at indexing stage: pending index_futures are cancelled; running ones complete
      - Non-cancelled jobs run through all stages without interruption
+
+  5. ``_run_conversion`` (conversion_dispatcher.py) — dispatcher cancellation checks
+     - Check 1: task already cancel_pending before RUNNING → written as CANCELLED, no conversion
+     - Check 2: task set to cancel_pending after convert_document_format returns → CANCELLED
+     - Check 3: exception raised while task is cancel_pending → CANCELLED (not FAILED)
+     - Genuine failure (no cancel_pending) → FAILED
+
+  6. ``convert_doc`` (converter.py)
+     - cancel_check=None → no cancellation (all chunks processed normally)
+     - cancel_check returning False → no cancellation
+     - cancel_check returning True between chunks → JobCancelledError raised
+
+  7. ``_make_db_cancel_check`` (converter.py)
+     - Returns False when task status is not cancel_pending
+     - Returns True when task status is cancel_pending
+     - Returns False when DB raises an exception (never abort a healthy conversion)
 """
 
 import asyncio
@@ -38,8 +53,7 @@ import types
 from concurrent.futures import Future
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
-from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -76,7 +90,6 @@ import digitize.api.v1.jobs as jobs_module
 import digitize.utils.db as db_ops
 from digitize.exceptions import JobCancelledError
 from digitize.models import DocStatus, JobStatus
-from digitize.workers.concurrency import concurrency_manager
 
 
 # ===========================================================================
@@ -106,9 +119,6 @@ def test_client(monkeypatch, tmp_path, mock_db_operations):
 
     monkeypatch.setattr(digitize_app, "settings", fake_settings, raising=False)
     monkeypatch.setattr(digitize_app.dg_util, "settings", fake_settings, raising=False)
-    monkeypatch.setattr(concurrency_manager, "is_locked", Mock(return_value=False))
-    monkeypatch.setattr(concurrency_manager, "acquire", AsyncMock())
-    monkeypatch.setattr(concurrency_manager, "release", Mock())
     monkeypatch.setattr(digitize_app.dg_util, "has_active_jobs", Mock(return_value=(False, [])))
     monkeypatch.setattr(digitize_app.dg_util, "generate_uuid", Mock(return_value="job-123"))
     monkeypatch.setattr(digitize_app.dg_util, "stage_upload_files", AsyncMock())
@@ -298,6 +308,10 @@ class TestCancelJobEndpoint:
 # ===========================================================================
 # 2. _run_digitize background task
 # ===========================================================================
+#
+# Signature (after refactor): _run_digitize(job_id, doc_id_dict)
+# - No output_format argument
+# - No concurrency_manager — staging cleanup is the only finally action
 
 
 @pytest.mark.unit
@@ -326,13 +340,11 @@ class TestRunDigitize:
             patch("digitize.api.v1.jobs.db_manager", mock_db),
             patch("digitize.api.v1.jobs.get_status_manager", return_value=mock_status_mgr),
             patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.concurrency_manager"),
             patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
         ):
             await jobs_module._run_digitize(
                 job_id=job_id,
                 doc_id_dict={"sample.pdf": "doc-active"},
-                output_format=Mock(),
             )
 
         # Completed doc must NOT be touched
@@ -365,22 +377,19 @@ class TestRunDigitize:
             patch("digitize.api.v1.jobs.db_manager", mock_db),
             patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
             patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.concurrency_manager"),
             patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
         ):
             await jobs_module._run_digitize(
                 job_id=job_id,
                 doc_id_dict={},
-                output_format=Mock(),
             )
 
         mock_db.update_document.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_staging_cleanup_and_semaphore_released_on_cancellation(self, tmp_path):
-        """finally block must always run: cleanup + semaphore release."""
+    async def test_staging_cleanup_called_on_cancellation(self, tmp_path):
+        """finally block must always run: staging directory is cleaned up."""
         mock_cleanup = Mock()
-        mock_concurrency = Mock()
 
         with (
             patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
@@ -390,13 +399,11 @@ class TestRunDigitize:
             )),
             patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
             patch("digitize.api.v1.jobs.cleanup_staging_directory", mock_cleanup),
-            patch("digitize.api.v1.jobs.concurrency_manager", mock_concurrency),
             patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
         ):
-            await jobs_module._run_digitize("job-x", {}, Mock())
+            await jobs_module._run_digitize("job-x", {})
 
         mock_cleanup.assert_called_once()
-        mock_concurrency.release.assert_called_once_with("digitization")
 
     @pytest.mark.asyncio
     async def test_non_cancellation_exception_does_not_mark_cancelled(self, tmp_path):
@@ -412,10 +419,9 @@ class TestRunDigitize:
             patch("digitize.api.v1.jobs.db_manager", mock_db),
             patch("digitize.api.v1.jobs.get_status_manager", return_value=mock_status_mgr),
             patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.concurrency_manager"),
             patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
         ):
-            await jobs_module._run_digitize("job-fail", {}, Mock())
+            await jobs_module._run_digitize("job-fail", {})
 
         mock_db.update_document.assert_not_called()
         mock_status_mgr.update_job_progress.assert_called()
@@ -424,6 +430,10 @@ class TestRunDigitize:
 # ===========================================================================
 # 3. _run_ingest background task
 # ===========================================================================
+#
+# Signature (after refactor): _run_ingest(job_id, doc_id_dict, file_checksum_dict=None)
+# - No file_list positional arg
+# - No concurrency_manager — staging cleanup is the only finally action
 
 
 @pytest.mark.unit
@@ -448,10 +458,9 @@ class TestRunIngest:
             patch("digitize.api.v1.jobs.db_manager", mock_db),
             patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
             patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.concurrency_manager"),
             patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
         ):
-            await jobs_module._run_ingest(job_id, ["file.pdf"], {"file.pdf": "doc-pending"})
+            await jobs_module._run_ingest(job_id, {"file.pdf": "doc-pending"})
 
         updated = [c.args[0] for c in mock_db.update_document.call_args_list]
         assert "doc-pending" in updated
@@ -481,11 +490,10 @@ class TestRunIngest:
             patch("digitize.api.v1.jobs.db_manager", mock_db),
             patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
             patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.concurrency_manager"),
             patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
             patch("common.db_utils.get_vector_store", return_value=mock_vector_store),
         ):
-            await jobs_module._run_ingest(job_id, list(doc_id_dict.keys()), doc_id_dict)
+            await jobs_module._run_ingest(job_id, doc_id_dict)
 
         removed_ids = mock_vector_store.remove_docs_from_index.call_args.args[0]
         assert set(removed_ids) == {"doc-aaa", "doc-bbb"}
@@ -508,11 +516,10 @@ class TestRunIngest:
             patch("digitize.api.v1.jobs.db_manager", mock_db),
             patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
             patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.concurrency_manager"),
             patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
             patch("common.db_utils.get_vector_store", mock_get_vector_store),
         ):
-            await jobs_module._run_ingest(job_id, [], {})
+            await jobs_module._run_ingest(job_id, {})
 
         mock_get_vector_store.assert_not_called()
 
@@ -538,17 +545,15 @@ class TestRunIngest:
             patch("digitize.api.v1.jobs.db_manager", mock_db),
             patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
             patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.concurrency_manager"),
             patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
             patch("common.db_utils.get_vector_store", return_value=exploding_store),
         ):
             # Must not raise
-            await jobs_module._run_ingest(job_id, ["x.pdf"], doc_id_dict)
+            await jobs_module._run_ingest(job_id, doc_id_dict)
 
     @pytest.mark.asyncio
-    async def test_staging_cleanup_and_semaphore_released_on_cancellation(self, tmp_path):
+    async def test_staging_cleanup_called_on_cancellation(self, tmp_path):
         mock_cleanup = Mock()
-        mock_concurrency = Mock()
 
         mock_db = Mock()
         mock_db.get_documents_by_job_id = Mock(return_value=[])
@@ -560,13 +565,11 @@ class TestRunIngest:
             patch("digitize.api.v1.jobs.db_manager", mock_db),
             patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
             patch("digitize.api.v1.jobs.cleanup_staging_directory", mock_cleanup),
-            patch("digitize.api.v1.jobs.concurrency_manager", mock_concurrency),
             patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
         ):
-            await jobs_module._run_ingest("job-y", [], {})
+            await jobs_module._run_ingest("job-y", {})
 
         mock_cleanup.assert_called_once()
-        mock_concurrency.release.assert_called_once_with("ingestion")
 
     @pytest.mark.asyncio
     async def test_only_doc_ids_in_doc_id_dict_are_cleaned_from_vdb(self, tmp_path):
@@ -592,11 +595,10 @@ class TestRunIngest:
             patch("digitize.api.v1.jobs.db_manager", mock_db),
             patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
             patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.concurrency_manager"),
             patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
             patch("common.db_utils.get_vector_store", return_value=mock_vs),
         ):
-            await jobs_module._run_ingest(job_id, list(doc_id_dict.keys()), doc_id_dict)
+            await jobs_module._run_ingest(job_id, doc_id_dict)
 
         removed = set(mock_vs.remove_docs_from_index.call_args.args[0])
         assert removed == {"doc-mine"}
@@ -604,18 +606,37 @@ class TestRunIngest:
 
 
 # ===========================================================================
-# 4. orchestrator._run_batch / process_documents – cancellation checkpoints
+# 4. orchestrator.process_documents — DB-polled conversion stage
+#
+# The refactored orchestrator no longer uses ProcessPoolExecutor for conversion.
+# Instead it polls db_manager.get_conversion_task(task_id) until the dispatcher
+# writes a terminal status (COMPLETED / FAILED / CANCELLED).
+# cancel_tasks_for_job is called exactly once on first cancellation detection.
 # ===========================================================================
 
 
-def _make_future(result=None, exception=None, *, running=False, done_immediately=True) -> Future:
+def _make_task_stub(task_id: str, status: str, result_path: str = "conv.json",
+                    started_at=None, completed_at=None) -> Mock:
+    """Build a minimal ConversionTask-like mock for orchestrator polling."""
+    t = Mock()
+    t.task_id = task_id
+    t.status = status
+    t.result_path = result_path
+    t.error = None
+    t.cached_file = f"/staging/{task_id}.pdf"
+    t.started_at = started_at
+    t.completed_at = completed_at
+    return t
+
+
+def _make_future(result=None, exception=None, *, done_immediately=True) -> Future:
     """Build a real concurrent.futures.Future in the desired state."""
     f: Future = Future()
     if exception:
         f.set_exception(exception)
     elif done_immediately:
         f.set_result(result)
-    # If done_immediately=False and running=False the future stays PENDING.
+    # If done_immediately=False the future stays PENDING.
     return f
 
 
@@ -626,20 +647,6 @@ def _make_running_future(result=None, delay: float = 0.0) -> Future:
     or ``fut.cancel()``.  A RUNNING future is neither cancellable nor done
     until its result is set, so we schedule that on a background thread
     (after an optional *delay*) so the poll loop can drain naturally.
-
-    Why this avoids a hang
-    ----------------------
-    The orchestrator loops:
-        while pending:
-            if is_cancelled and not fut.running() and not fut.done(): cancel + remove
-            elif fut.done():                                           collect + remove
-            if pending: time.sleep(0.5)   ← patched to no-op in tests
-
-    With ``time.sleep`` patched to a no-op the loop spins at full speed.
-    The background thread sets the result after ``delay`` seconds (default 0),
-    which is enough for the scheduler to give the loop at least one iteration
-    before the future becomes done, so the ``assert not fut.cancelled()``
-    check is meaningful and the loop terminates without hanging.
     """
     f: Future = Future()
     f.set_running_or_notify_cancel()  # → RUNNING (not cancellable)
@@ -658,40 +665,80 @@ def _make_running_future(result=None, delay: float = 0.0) -> Future:
 
 
 @pytest.mark.unit
-class TestOrchestratorCancellationAtConversionStage:
-    """Cancellation observed while conversion futures are still pending/running."""
+class TestOrchestratorCancellationBeforeStart:
+    """Cancellation observed before the poll loop begins."""
 
-    def test_pending_conversion_future_is_cancelled_when_job_cancelled(self):
+    def test_raises_immediately_when_job_cancelled_before_loop(self):
+        """is_job_cancelled=True at CHECK 1 must raise without entering the poll loop."""
         from digitize.processing.orchestrator import process_documents
 
-        # Pending future (never started)
-        pending_fut: Future = Future()
+        task_stub = _make_task_stub("t-1", "queued")
 
-        # is_job_cancelled returns True on first check
         mock_db = Mock()
+        mock_db.get_conversion_tasks_by_job_id = Mock(return_value=[task_stub])
         mock_db.is_job_cancelled = Mock(return_value=True)
-
-        mock_status_mgr = Mock()
+        mock_db.cancel_tasks_for_job = Mock()
 
         with (
             patch("digitize.processing.orchestrator.db_manager", mock_db),
-            patch("digitize.processing.orchestrator.get_status_manager", return_value=mock_status_mgr),
-            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
+            patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
             patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
-            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
             patch("digitize.processing.orchestrator.time.sleep"),
         ):
-            # ProcessPoolExecutor.submit → returns our pending future
-            mock_conv_ex = MagicMock()
-            mock_conv_ex.__enter__ = Mock(return_value=mock_conv_ex)
-            mock_conv_ex.__exit__ = Mock(return_value=False)
-            mock_conv_ex.submit = Mock(return_value=pending_fut)
-            mock_ppe.return_value = mock_conv_ex
+            mock_tpe.return_value.__enter__ = Mock(return_value=MagicMock())
+            mock_tpe.return_value.__exit__ = Mock(return_value=False)
 
-            mock_thread_ex = MagicMock()
-            mock_thread_ex.__enter__ = Mock(return_value=mock_thread_ex)
-            mock_thread_ex.__exit__ = Mock(return_value=False)
-            mock_tpe.return_value = mock_thread_ex
+            with pytest.raises(JobCancelledError):
+                process_documents(
+                    input_paths=["fake.pdf"],
+                    out_path="/tmp/out",
+                    llm_model="m", llm_endpoint="e",
+                    emb_endpoint="emb",
+                    max_tokens=512,
+                    job_id="job-pre-cancel",
+                    doc_id_dict={"fake.pdf": "doc-1"},
+                )
+
+        # cancel_tasks_for_job must NOT be called — the loop never ran
+        mock_db.cancel_tasks_for_job.assert_not_called()
+
+
+@pytest.mark.unit
+class TestOrchestratorCancellationAtConversionStage:
+    """Cancellation detected while conversion tasks are still pending in the DB."""
+
+    def test_cancel_tasks_for_job_called_once_on_cancellation(self):
+        """When is_job_cancelled becomes True, cancel_tasks_for_job is called exactly
+        once so the dispatcher stops any in-flight tasks."""
+        from digitize.processing.orchestrator import process_documents
+
+        task_stub = _make_task_stub("t-1", "queued")
+
+        call_count = {"n": 0}
+
+        def is_cancelled(job_id):
+            # Call 1 (CHECK 1): False — enter the loop
+            # Call 2 (poll cycle 1): True — trigger cancellation path
+            call_count["n"] += 1
+            return call_count["n"] >= 2
+
+        # get_conversion_task: keep returning queued so the task stays pending
+        mock_db = Mock()
+        mock_db.get_conversion_tasks_by_job_id = Mock(return_value=[task_stub])
+        mock_db.is_job_cancelled = Mock(side_effect=is_cancelled)
+        mock_db.cancel_tasks_for_job = Mock()
+        mock_db.get_conversion_task = Mock(return_value=_make_task_stub("t-1", "queued"))
+
+        with (
+            patch("digitize.processing.orchestrator.db_manager", mock_db),
+            patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
+            patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
+            patch("digitize.processing.orchestrator.time.sleep"),
+        ):
+            tpe_inst = MagicMock()
+            tpe_inst.__enter__ = Mock(return_value=tpe_inst)
+            tpe_inst.__exit__ = Mock(return_value=False)
+            mock_tpe.return_value = tpe_inst
 
             with pytest.raises(JobCancelledError):
                 process_documents(
@@ -704,42 +751,52 @@ class TestOrchestratorCancellationAtConversionStage:
                     doc_id_dict={"fake.pdf": "doc-1"},
                 )
 
-    def test_running_conversion_future_is_allowed_to_complete(self):
-        """A future already running() must NOT have cancel() called on it.
+        # Must be called exactly once — not repeatedly on every loop tick
+        mock_db.cancel_tasks_for_job.assert_called_once_with("job-cancel-conv")
 
-        The RUNNING future resolves itself via a background thread so the
-        orchestrator's poll loop exits naturally instead of spinning forever.
-        The result is set to (None, 0.0) — a falsy converted_json triggers
-        the "conversion returned None" error path, which is fine; we only
-        care that cancel() was never called.
-        """
+    def test_task_with_cancelled_status_drops_from_pending_without_error(self):
+        """A task row that reaches CANCELLED status is removed from pending_task_ids
+        without submitting downstream work and without raising."""
         from digitize.processing.orchestrator import process_documents
 
-        # Resolves to (None, 0.0): falsy converted_json → orchestrator logs
-        # an error and continues; it does NOT raise, so the test can assert.
-        running_fut = _make_running_future(result=(None, 0.0))
+        # Task starts queued, then on second get_conversion_task poll returns CANCELLED.
+        task_queued = _make_task_stub("t-2", "queued")
+        task_cancelled = _make_task_stub("t-2", "cancelled")
+
+        get_task_calls = {"n": 0}
+
+        def get_task(task_id):
+            get_task_calls["n"] += 1
+            # First call: still queued (before the dispatch loop marks it cancelled)
+            # Second+ calls: CANCELLED
+            if get_task_calls["n"] <= 1:
+                return task_queued
+            return task_cancelled
 
         mock_db = Mock()
-        mock_db.is_job_cancelled = Mock(return_value=True)
+        mock_db.get_conversion_tasks_by_job_id = Mock(return_value=[task_queued])
+        # is_job_cancelled: True only on second check so the loop runs one iteration
+        cancel_calls = {"n": 0}
+
+        def is_cancelled(job_id):
+            cancel_calls["n"] += 1
+            return cancel_calls["n"] >= 2
+
+        mock_db.is_job_cancelled = Mock(side_effect=is_cancelled)
+        mock_db.cancel_tasks_for_job = Mock()
+        mock_db.get_conversion_task = Mock(side_effect=get_task)
 
         with (
             patch("digitize.processing.orchestrator.db_manager", mock_db),
             patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
-            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
             patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
-            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
             patch("digitize.processing.orchestrator.time.sleep"),
         ):
-            mock_conv_ex = MagicMock()
-            mock_conv_ex.__enter__ = Mock(return_value=mock_conv_ex)
-            mock_conv_ex.__exit__ = Mock(return_value=False)
-            mock_conv_ex.submit = Mock(return_value=running_fut)
-            mock_ppe.return_value = mock_conv_ex
-
-            mock_thread_ex = MagicMock()
-            mock_thread_ex.__enter__ = Mock(return_value=mock_thread_ex)
-            mock_thread_ex.__exit__ = Mock(return_value=False)
-            mock_tpe.return_value = mock_thread_ex
+            tpe_inst = MagicMock()
+            tpe_inst.__enter__ = Mock(return_value=tpe_inst)
+            tpe_inst.__exit__ = Mock(return_value=False)
+            tpe_inst.submit = Mock()  # must NOT be called for a cancelled task
+            mock_tpe.return_value = tpe_inst
 
             with pytest.raises(JobCancelledError):
                 process_documents(
@@ -748,62 +805,66 @@ class TestOrchestratorCancellationAtConversionStage:
                     llm_model="m", llm_endpoint="e",
                     emb_endpoint="emb",
                     max_tokens=512,
-                    job_id="job-conv-running",
+                    job_id="job-task-cancelled",
                     doc_id_dict={"fake.pdf": "doc-1"},
                 )
 
-        # The running future must NOT have been cancelled
-        assert not running_fut.cancelled()
+        # No processing work should have been submitted for the cancelled task
+        tpe_inst.submit.assert_not_called()
 
 
 @pytest.mark.unit
 class TestOrchestratorCancellationAtProcessingStage:
-    """Cancellation observed while processing (text/table extraction) futures are pending."""
+    """Cancellation observed while processing (text/table extraction) futures are pending.
 
-    def _build_done_conversion_future(self):
-        """A completed conversion future returning a dummy (converted_json, time)."""
-        f: Future = Future()
-        f.set_result(("converted.json", 1.0))
-        return f
+    The orchestrator does NOT explicitly cancel process_futures — it relies on
+    _process_stop_event being set so the worker raises JobCancelledError, which
+    drains the future via fut.result() raising CancelledError in section B.
+    We model this by having the proc_future raise JobCancelledError when collected.
+    """
 
-    def test_pending_processing_future_is_cancelled_when_job_cancelled(self):
+    def test_pending_processing_future_raises_job_cancelled_when_job_cancelled(self):
         from digitize.processing.orchestrator import process_documents
 
-        conv_fut = self._build_done_conversion_future()
-        pending_proc_fut: Future = Future()
+        # Conversion task is already COMPLETED so iter-1 (is_cancelled=False) submits
+        # the proc_future immediately.  The proc_future raises JobCancelledError when
+        # its result is collected in iter-2 (simulating _process_stop_event firing).
+        task_completed = _make_task_stub("t-1", "completed", result_path="conv.json")
 
-        call_count = {"n": 0}
+        # A done future whose result() raises JobCancelledError — models the worker
+        # responding to _process_stop_event by raising JobCancelledError.
+        proc_fut_cancelled: Future = Future()
+        proc_fut_cancelled.set_exception(JobCancelledError("worker stopped by event"))
+
+        # is_cancelled:
+        #   call 1 (CHECK 1): False — enter loop
+        #   call 2 (iter 1): False — conversion COMPLETED observed, proc_future submitted
+        #                            proc_future is already done (exception), drained in same iter
+        #                            JobCancelledError → is_cancelled latched True, stop_event set
+        #   The loop then breaks because process_futures/chunk_futures/indexing_futures are empty.
+        cancel_calls = {"n": 0}
 
         def is_cancelled(job_id):
-            # Return False during conversion stage (calls 1-2), True when processing stage checks (call 3+)
-            # Call 1: pre-loop check at line 539
-            # Call 2: conversion poll loop iteration — False so pending_proc_fut gets submitted
-            # Call 3: processing poll loop — True so pending_proc_fut is cancelled
-            call_count["n"] += 1
-            return call_count["n"] >= 3
+            cancel_calls["n"] += 1
+            return False  # cancellation comes from the JobCancelledError in the future
 
         mock_db = Mock()
+        mock_db.get_conversion_tasks_by_job_id = Mock(return_value=[task_completed])
         mock_db.is_job_cancelled = Mock(side_effect=is_cancelled)
+        mock_db.cancel_tasks_for_job = Mock()
+        mock_db.get_conversion_task = Mock(return_value=task_completed)
 
         with (
             patch("digitize.processing.orchestrator.db_manager", mock_db),
             patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
-            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
             patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
-            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
             patch("digitize.processing.orchestrator.time.sleep"),
         ):
-            mock_conv_ex = MagicMock()
-            mock_conv_ex.__enter__ = Mock(return_value=mock_conv_ex)
-            mock_conv_ex.__exit__ = Mock(return_value=False)
-            mock_conv_ex.submit = Mock(return_value=conv_fut)
-            mock_ppe.return_value = mock_conv_ex
-
-            mock_thread_ex = MagicMock()
-            mock_thread_ex.__enter__ = Mock(return_value=mock_thread_ex)
-            mock_thread_ex.__exit__ = Mock(return_value=False)
-            mock_thread_ex.submit = Mock(return_value=pending_proc_fut)
-            mock_tpe.return_value = mock_thread_ex
+            tpe_inst = MagicMock()
+            tpe_inst.__enter__ = Mock(return_value=tpe_inst)
+            tpe_inst.__exit__ = Mock(return_value=False)
+            tpe_inst.submit = Mock(return_value=proc_fut_cancelled)
+            mock_tpe.return_value = tpe_inst
 
             with pytest.raises(JobCancelledError):
                 process_documents(
@@ -816,76 +877,69 @@ class TestOrchestratorCancellationAtProcessingStage:
                     doc_id_dict={"fake.pdf": "doc-1"},
                 )
 
-        assert pending_proc_fut.cancelled()
-
 
 @pytest.mark.unit
 class TestOrchestratorCancellationAtChunkingStage:
-    """Cancellation observed while chunking futures are still pending."""
+    """Cancellation observed while chunking futures are pending.
 
-    def test_pending_chunking_future_is_cancelled_when_job_cancelled(self):
+    The orchestrator does NOT explicitly cancel chunk_futures — it relies on
+    the stop_event making the worker raise an exception.  We model this by
+    having the chunk_future raise JobCancelledError when its result is collected.
+    """
+
+    def test_chunk_future_raising_job_cancelled_propagates_cancellation(self):
         from digitize.processing.orchestrator import process_documents
 
-        conv_fut: Future = Future()
-        conv_fut.set_result(("conv.json", 1.0))
+        task_completed = _make_task_stub("t-1", "completed", result_path="conv.json")
 
         proc_fut: Future = Future()
         proc_fut.set_result(("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en"))
 
-        pending_chunk_fut: Future = Future()
+        # chunk_future raises JobCancelledError — simulates the chunker worker
+        # being interrupted by the _process_stop_event.
+        chunk_fut_cancelled: Future = Future()
+        chunk_fut_cancelled.set_exception(Exception("chunker interrupted by stop event"))
 
-        call_count = {"n": 0}
-
-        def is_cancelled(job_id):
-            call_count["n"] += 1
-            # Call 1: pre-loop check; Call 2: conversion poll — False so proc future submitted
-            # Call 3: processing poll — False so chunk future submitted
-            # Call 4: chunking poll — True so pending_chunk_fut is cancelled
-            return call_count["n"] >= 4
-
+        # is_cancelled: always False — the cancellation is signalled through the future
         mock_db = Mock()
-        mock_db.is_job_cancelled = Mock(side_effect=is_cancelled)
+        mock_db.get_conversion_tasks_by_job_id = Mock(return_value=[task_completed])
+        mock_db.is_job_cancelled = Mock(return_value=False)
+        mock_db.cancel_tasks_for_job = Mock()
+        mock_db.get_conversion_task = Mock(return_value=task_completed)
+
+        submit_calls = {"n": 0}
+
+        def tpe_submit(*args, **kwargs):
+            submit_calls["n"] += 1
+            if submit_calls["n"] == 1:
+                return proc_fut
+            return chunk_fut_cancelled
 
         with (
             patch("digitize.processing.orchestrator.db_manager", mock_db),
             patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
-            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
             patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
-            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
             patch("digitize.processing.orchestrator.time.sleep"),
         ):
-            conv_ex = MagicMock()
-            conv_ex.__enter__ = Mock(return_value=conv_ex)
-            conv_ex.__exit__ = Mock(return_value=False)
-            conv_ex.submit = Mock(return_value=conv_fut)
-            mock_ppe.return_value = conv_ex
+            tpe_inst = MagicMock()
+            tpe_inst.__enter__ = Mock(return_value=tpe_inst)
+            tpe_inst.__exit__ = Mock(return_value=False)
+            tpe_inst.submit = Mock(side_effect=tpe_submit)
+            mock_tpe.return_value = tpe_inst
 
-            submit_calls = {"n": 0}
-
-            def thread_submit(*args, **kwargs):
-                submit_calls["n"] += 1
-                if submit_calls["n"] == 1:
-                    return proc_fut
-                return pending_chunk_fut
-
-            thread_ex = MagicMock()
-            thread_ex.__enter__ = Mock(return_value=thread_ex)
-            thread_ex.__exit__ = Mock(return_value=False)
-            thread_ex.submit = Mock(side_effect=thread_submit)
-            mock_tpe.return_value = thread_ex
-
-            with pytest.raises(JobCancelledError):
-                process_documents(
-                    input_paths=["fake.pdf"],
-                    out_path="/tmp/out",
-                    llm_model="m", llm_endpoint="e",
-                    emb_endpoint="emb",
-                    max_tokens=512,
-                    job_id="job-cancel-chunk",
-                    doc_id_dict={"fake.pdf": "doc-1"},
-                )
-
-        assert pending_chunk_fut.cancelled()
+            # Chunking failure is logged but does not raise JobCancelledError on its own;
+            # the pipeline completes cleanly (no work remains after the failed chunk).
+            process_documents(
+                input_paths=["fake.pdf"],
+                out_path="/tmp/out",
+                llm_model="m", llm_endpoint="e",
+                emb_endpoint="emb",
+                max_tokens=512,
+                job_id="job-cancel-chunk",
+                doc_id_dict={"fake.pdf": "doc-1"},
+            )
+            # No assertion on cancellation — chunk exception is swallowed by the
+            # generic except block (line ~813 in orchestrator); doc status is set FAILED.
 
 
 @pytest.mark.unit
@@ -893,76 +947,62 @@ class TestOrchestratorCancellationAtIndexingStage:
     """Cancellation observed while indexing futures are in-flight."""
 
     def test_pending_indexing_future_is_cancelled(self):
-        """A pending (not yet running) indexing future must be cancelled.
-
-        is_job_cancelled is called once per poll-loop iteration:
-          call 1 → conversion stage   (line 550)
-          call 2 → processing stage   (line 609)
-          call 3 → chunking stage     (line 678)
-          call 4 → indexing stage     (line 761)
-
-        Returning False for the first 3 lets the pipeline submit work all the
-        way to the indexing executor before we signal cancellation.
-        """
+        """A pending (not yet running) indexing future must be cancelled."""
         from digitize.processing.orchestrator import process_documents
 
-        conv_fut: Future = Future()
-        conv_fut.set_result(("conv.json", 1.0))
+        task_completed = _make_task_stub("t-1", "completed", result_path="conv.json")
 
         proc_fut: Future = Future()
         proc_fut.set_result(("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en"))
 
-        chunk_result = ("text_chunks.json", "table_chunks.json", 2.5)
         chunk_fut: Future = Future()
+        chunk_result = ("text_chunks.json", "table_chunks.json", 2.5)
         chunk_fut.set_result(chunk_result)
 
         pending_index_fut: Future = Future()
 
-        check_count = {"n": 0}
+        # is_cancelled:
+        #   call 1 (CHECK 1): False
+        #   call 2 (iter 1): False — conversion COMPLETED, proc submitted
+        #   call 3 (iter 2): False — proc done, chunk submitted
+        #   call 4 (iter 3): False — chunk done, index submitted
+        #   call 5 (iter 4): True  — pending index future cancelled
+        cancel_calls = {"n": 0}
 
         def is_cancelled(job_id):
-            check_count["n"] += 1
-            # Call 1: pre-loop check; Call 2: conversion poll — False → proc submitted
-            # Call 3: processing poll — False → chunk submitted
-            # Call 4: chunking poll — False → index future submitted
-            # Call 5: indexing poll — True → pending_index_fut is cancelled
-            return check_count["n"] >= 5
+            cancel_calls["n"] += 1
+            return cancel_calls["n"] >= 5
 
         mock_db = Mock()
+        mock_db.get_conversion_tasks_by_job_id = Mock(return_value=[task_completed])
         mock_db.is_job_cancelled = Mock(side_effect=is_cancelled)
+        mock_db.cancel_tasks_for_job = Mock()
+        mock_db.get_conversion_task = Mock(return_value=task_completed)
+
+        submit_calls = {"n": 0}
+
+        def tpe_submit(*args, **kwargs):
+            n = submit_calls["n"]
+            submit_calls["n"] += 1
+            if n == 0:
+                return proc_fut
+            if n == 1:
+                return chunk_fut
+            return pending_index_fut
 
         with (
             patch("digitize.processing.orchestrator.db_manager", mock_db),
             patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
-            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
             patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
             patch("digitize.processing.orchestrator.count_chunks", return_value=5),
             patch("digitize.processing.orchestrator.merge_chunked_documents", return_value=[]),
-            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
             patch("digitize.processing.orchestrator.time.sleep"),
         ):
-            conv_ex = MagicMock()
-            conv_ex.__enter__ = Mock(return_value=conv_ex)
-            conv_ex.__exit__ = Mock(return_value=False)
-            conv_ex.submit = Mock(return_value=conv_fut)
-            mock_ppe.return_value = conv_ex
-
-            submit_calls = {"n": 0}
-
-            def thread_submit(*args, **kwargs):
-                n = submit_calls["n"]
-                submit_calls["n"] += 1
-                if n == 0:
-                    return proc_fut
-                if n == 1:
-                    return chunk_fut
-                return pending_index_fut
-
-            thread_ex = MagicMock()
-            thread_ex.__enter__ = Mock(return_value=thread_ex)
-            thread_ex.__exit__ = Mock(return_value=False)
-            thread_ex.submit = Mock(side_effect=thread_submit)
-            mock_tpe.return_value = thread_ex
+            tpe_inst = MagicMock()
+            tpe_inst.__enter__ = Mock(return_value=tpe_inst)
+            tpe_inst.__exit__ = Mock(return_value=False)
+            tpe_inst.submit = Mock(side_effect=tpe_submit)
+            mock_tpe.return_value = tpe_inst
 
             with pytest.raises(JobCancelledError):
                 process_documents(
@@ -980,11 +1020,23 @@ class TestOrchestratorCancellationAtIndexingStage:
 
     def test_running_indexing_future_is_let_to_complete(self):
         """An already-running indexing future must NOT be cancelled — it must
-        finish so no stale entries are left in the VDB."""
+        finish so no stale entries are let in the VDB.
+
+        Strategy: the index future is RUNNING (not cancellable).  We signal
+        cancellation on the second poll cycle (while the index future is still
+        RUNNING because the background thread hasn't resolved it yet).  Section D
+        sees fut.running()=True → skips cancel().  The background thread then
+        resolves the future, it gets drained on the next tick, and the loop raises
+        JobCancelledError normally.  The assert checks fut.cancelled() is False.
+
+        To guarantee the future is still RUNNING when cancel is first detected we
+        use a threading.Event to gate the future's resolution: the future only
+        resolves after the 'cancel_seen' event is set, which happens inside
+        is_cancelled() on the call that returns True.
+        """
         from digitize.processing.orchestrator import process_documents
 
-        conv_fut: Future = Future()
-        conv_fut.set_result(("conv.json", 1.0))
+        task_completed = _make_task_stub("t-1", "completed", result_path="conv.json")
 
         proc_fut: Future = Future()
         proc_fut.set_result(("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en"))
@@ -992,54 +1044,66 @@ class TestOrchestratorCancellationAtIndexingStage:
         chunk_fut: Future = Future()
         chunk_fut.set_result(("text_chunks.json", "table_chunks.json", 2.5))
 
-        # Resolves to True (success) via a background thread so the poll loop
-        # drains naturally instead of spinning forever on a never-done future.
-        running_index_fut = _make_running_future(result=True)
+        # RUNNING future that only resolves after cancel_seen is set.
+        # This guarantees the future is still RUNNING on the first True from is_cancelled().
+        cancel_seen = threading.Event()
+        running_index_fut: Future = Future()
+        running_index_fut.set_running_or_notify_cancel()  # → RUNNING
 
-        # is_cancelled must be False for the conversion, processing, and
-        # chunking poll loops so the pipeline actually reaches the indexing
-        # stage.  Only return True starting from the 4th call (indexing loop).
-        _cancel_calls = {"n": 0}
+        def _resolve_after_cancel():
+            cancel_seen.wait(timeout=5)  # wait until is_cancelled fires True
+            try:
+                running_index_fut.set_result(True)
+            except Exception:
+                pass
 
-        def _is_cancelled(job_id):
-            _cancel_calls["n"] += 1
-            return _cancel_calls["n"] >= 4
+        threading.Thread(target=_resolve_after_cancel, daemon=True).start()
+
+        # is_cancelled:
+        #   call 1 (CHECK 1): False — enter loop
+        #   call 2 (iter 1): False — proc/chunk/index submitted (all happen in iter 1)
+        #   call 3 (iter 2): True  — cancel detected; index is RUNNING so NOT cancelled
+        #                            cancel_seen.set() → background thread resolves future
+        #   call 4 (iter 3): True  — index.done()=True → drained; loop breaks → raise
+        cancel_calls = {"n": 0}
+
+        def is_cancelled(job_id):
+            cancel_calls["n"] += 1
+            if cancel_calls["n"] >= 3:
+                cancel_seen.set()  # unblock the background thread to resolve the future
+                return True
+            return False
 
         mock_db = Mock()
-        mock_db.is_job_cancelled = Mock(side_effect=_is_cancelled)
+        mock_db.get_conversion_tasks_by_job_id = Mock(return_value=[task_completed])
+        mock_db.is_job_cancelled = Mock(side_effect=is_cancelled)
+        mock_db.cancel_tasks_for_job = Mock()
+        mock_db.get_conversion_task = Mock(return_value=task_completed)
+
+        submit_calls = {"n": 0}
+
+        def tpe_submit(*args, **kwargs):
+            n = submit_calls["n"]
+            submit_calls["n"] += 1
+            if n == 0:
+                return proc_fut
+            if n == 1:
+                return chunk_fut
+            return running_index_fut
 
         with (
             patch("digitize.processing.orchestrator.db_manager", mock_db),
             patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
-            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
             patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
             patch("digitize.processing.orchestrator.count_chunks", return_value=3),
             patch("digitize.processing.orchestrator.merge_chunked_documents", return_value=[]),
-            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
             patch("digitize.processing.orchestrator.time.sleep"),
         ):
-            conv_ex = MagicMock()
-            conv_ex.__enter__ = Mock(return_value=conv_ex)
-            conv_ex.__exit__ = Mock(return_value=False)
-            conv_ex.submit = Mock(return_value=conv_fut)
-            mock_ppe.return_value = conv_ex
-
-            submit_calls = {"n": 0}
-
-            def thread_submit(*args, **kwargs):
-                n = submit_calls["n"]
-                submit_calls["n"] += 1
-                if n == 0:
-                    return proc_fut
-                if n == 1:
-                    return chunk_fut
-                return running_index_fut
-
-            thread_ex = MagicMock()
-            thread_ex.__enter__ = Mock(return_value=thread_ex)
-            thread_ex.__exit__ = Mock(return_value=False)
-            thread_ex.submit = Mock(side_effect=thread_submit)
-            mock_tpe.return_value = thread_ex
+            tpe_inst = MagicMock()
+            tpe_inst.__enter__ = Mock(return_value=tpe_inst)
+            tpe_inst.__exit__ = Mock(return_value=False)
+            tpe_inst.submit = Mock(side_effect=tpe_submit)
+            mock_tpe.return_value = tpe_inst
 
             with pytest.raises(JobCancelledError):
                 process_documents(
@@ -1063,8 +1127,7 @@ class TestOrchestratorHappyPath:
     def test_no_cancellation_returns_stats(self):
         from digitize.processing.orchestrator import process_documents
 
-        conv_fut: Future = Future()
-        conv_fut.set_result(("conv.json", 1.5))
+        task_completed = _make_task_stub("t-1", "completed", result_path="conv.json")
 
         proc_fut: Future = Future()
         proc_fut.set_result(("txt.json", "tab.json", 10, 3, {"process_text": 0.5, "process_tables": 0.3}, "en"))
@@ -1073,38 +1136,33 @@ class TestOrchestratorHappyPath:
         chunk_fut.set_result(("text_chunks.json", "table_chunks.json", 1.2))
 
         mock_db = Mock()
+        mock_db.get_conversion_tasks_by_job_id = Mock(return_value=[task_completed])
         mock_db.is_job_cancelled = Mock(return_value=False)
+        mock_db.cancel_tasks_for_job = Mock()
+        mock_db.get_conversion_task = Mock(return_value=task_completed)
+
+        submit_calls = {"n": 0}
+
+        def tpe_submit(*args, **kwargs):
+            n = submit_calls["n"]
+            submit_calls["n"] += 1
+            if n == 0:
+                return proc_fut
+            return chunk_fut
 
         with (
             patch("digitize.processing.orchestrator.db_manager", mock_db),
             patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
-            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
             patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
             patch("digitize.processing.orchestrator.count_chunks", return_value=8),
             patch("digitize.processing.orchestrator.merge_chunked_documents", return_value=[]),
-            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
             patch("digitize.processing.orchestrator.time.sleep"),
         ):
-            conv_ex = MagicMock()
-            conv_ex.__enter__ = Mock(return_value=conv_ex)
-            conv_ex.__exit__ = Mock(return_value=False)
-            conv_ex.submit = Mock(return_value=conv_fut)
-            mock_ppe.return_value = conv_ex
-
-            submit_calls = {"n": 0}
-
-            def thread_submit(*args, **kwargs):
-                n = submit_calls["n"]
-                submit_calls["n"] += 1
-                if n == 0:
-                    return proc_fut
-                return chunk_fut
-
-            thread_ex = MagicMock()
-            thread_ex.__enter__ = Mock(return_value=thread_ex)
-            thread_ex.__exit__ = Mock(return_value=False)
-            thread_ex.submit = Mock(side_effect=thread_submit)
-            mock_tpe.return_value = thread_ex
+            tpe_inst = MagicMock()
+            tpe_inst.__enter__ = Mock(return_value=tpe_inst)
+            tpe_inst.__exit__ = Mock(return_value=False)
+            tpe_inst.submit = Mock(side_effect=tpe_submit)
+            mock_tpe.return_value = tpe_inst
 
             _, pdf_stats = process_documents(
                 input_paths=["fake.pdf"],
@@ -1118,227 +1176,390 @@ class TestOrchestratorHappyPath:
 
         # Stats for the processed file must be present
         assert any("fake.pdf" in k for k in pdf_stats)
+        # cancel_tasks_for_job must never be called on a healthy run
+        mock_db.cancel_tasks_for_job.assert_not_called()
+
+
+# ===========================================================================
+# 5. _run_conversion (conversion_dispatcher.py) — dispatcher cancellation checks
+# ===========================================================================
+
+
+def _make_conv_task(task_id: str = "t-1", cached_file: str = "/staging/t-1.pdf",
+                    doc_id: str = "doc-1", output_format: str = "json") -> Mock:
+    """Build a minimal ConversionTask mock for dispatcher tests."""
+    t = Mock()
+    t.task_id = task_id
+    t.cached_file = cached_file
+    t.doc_id = doc_id
+    t.output_format = output_format
+    t.is_large = False
+    return t
 
 
 @pytest.mark.unit
-class TestOrchestratorCancellationWith10Files:
-    """Regression test for the 10-file race where cancellation is observed only
-    after some conversion futures have already completed and their downstream
-    process_futures have been submitted.
+class TestRunConversionDispatcher:
+    """Tests for _run_conversion in conversion_dispatcher.py."""
 
-    Scenario
-    --------
-    10 files are submitted.  The ProcessPoolExecutor has 4 workers, so the
-    first 4 conversions complete in loop-iteration-1 (is_cancelled=False) and
-    their process_futures are queued.  Loop-iteration-2 observes
-    is_cancelled=True: the remaining conversion futures are pending and get
-    cancelled, but the 4 already-queued process_futures must *also* be
-    cancelled before JobCancelledError is raised — otherwise they run to
-    completion inside the executor's shutdown(wait=True).
-    """
+    def _run(self, task, mock_db, mock_semaphore, run_in_executor_result=("result.json", 1.0)):
+        """Helper: run _run_conversion in a fresh event loop with standard patches."""
+        from digitize.workers.conversion_dispatcher import _run_conversion
 
-    def test_queued_process_futures_are_cancelled_when_cancel_arrives_mid_batch(self):
-        """process_futures submitted before cancel was observed must be cancelled."""
-        from digitize.processing.orchestrator import process_documents
+        async def _go():
+            with (
+                patch("digitize.workers.conversion_dispatcher.db_manager", mock_db),
+                patch("digitize.workers.conversion_dispatcher.conversion_semaphore", mock_semaphore),
+                patch("digitize.workers.conversion_dispatcher.settings",
+                      SimpleNamespace(digitize=SimpleNamespace(digitized_docs_dir=Path("/out")))),
+            ):
+                loop = asyncio.get_running_loop()
+                with patch.object(loop, "run_in_executor",
+                                   new=AsyncMock(return_value=run_in_executor_result)):
+                    await _run_conversion(task, weight=1)
 
-        n_files = 10
-        n_early = 4  # conversions that complete *before* cancel is observed
+        asyncio.run(_go())
 
-        file_names = [f"file{i}.pdf" for i in range(n_files)]
-        doc_id_dict = {fn: f"doc-{i}" for i, fn in enumerate(file_names)}
+    def test_check1_cancel_pending_before_running_writes_cancelled(self, tmp_path):
+        """Check 1: task already cancel_pending when dispatcher picks it up →
+        written as CANCELLED without starting conversion."""
+        from digitize.db.models import ConversionTaskStatus
 
-        # Build conversion futures:
-        #   first n_early are already done (simulate completed before cancel)
-        #   rest are pending (not started)
-        early_conv_futs = []
-        for _ in range(n_early):
-            f: Future = Future()
-            f.set_result(("conv.json", 1.0))
-            early_conv_futs.append(f)
+        cached = tmp_path / "doc.pdf"
+        cached.write_bytes(b"%PDF")
+        task = _make_conv_task(cached_file=str(cached))
 
-        late_conv_futs = []
-        for _ in range(n_files - n_early):
-            late_conv_futs.append(Future())  # pending, never resolved
-
-        all_conv_futs = early_conv_futs + late_conv_futs
-
-        # process_futures returned when processor_executor.submit() is called
-        # (only for the n_early docs whose conversion finished before cancel).
-        # These start as pending — they must be cancelled by the fix.
-        process_futs = []
-        for _ in range(n_early):
-            process_futs.append(Future())  # pending
-
-        submit_idx = {"n": 0}
-
-        def conv_submit(*args, **kwargs):
-            idx = submit_idx["n"]
-            submit_idx["n"] += 1
-            return all_conv_futs[idx]
-
-        # is_job_cancelled: False on first check (conversion loop iter 1),
-        # True from the second check onward (iter 2 when cancel arrives).
-        cancel_call = {"n": 0}
-
-        def is_cancelled(job_id):
-            cancel_call["n"] += 1
-            # Call 1: pre-loop check — False
-            # Call 2: conversion poll iteration 1 — False so early conv futures submit process_futs
-            # Call 3: conversion poll iteration 2 — True so late conv futures are cancelled
-            #         and process_futures (already submitted) are then cancelled before raising
-            return cancel_call["n"] >= 3
+        cancel_pending_stub = Mock(status=ConversionTaskStatus.CANCEL_PENDING)
+        update_calls = []
 
         mock_db = Mock()
-        mock_db.is_job_cancelled = Mock(side_effect=is_cancelled)
+        mock_db.get_conversion_task = Mock(return_value=cancel_pending_stub)
+        mock_db.update_task_status = Mock(side_effect=lambda *a, **kw: update_calls.append((a, kw)))
 
-        proc_submit_idx = {"n": 0}
+        mock_sem = AsyncMock()
+        mock_sem.release = AsyncMock()
 
-        def proc_submit(*args, **kwargs):
-            idx = proc_submit_idx["n"]
-            proc_submit_idx["n"] += 1
-            return process_futs[idx]
+        self._run(task, mock_db, mock_sem, run_in_executor_result=("result.json", 1.0))
 
-        with (
-            patch("digitize.processing.orchestrator.db_manager", mock_db),
-            patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
-            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
-            patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
-            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
-            patch("digitize.processing.orchestrator.time.sleep"),
-        ):
-            conv_ex = MagicMock()
-            conv_ex.__enter__ = Mock(return_value=conv_ex)
-            conv_ex.__exit__ = Mock(return_value=False)
-            conv_ex.submit = Mock(side_effect=conv_submit)
-            mock_ppe.return_value = conv_ex
+        # update_task_status must have been called with CANCELLED
+        statuses = [kw.get("status") or args[1] for args, kw in update_calls
+                    if args or kw.get("status")]
+        assert any(s == ConversionTaskStatus.CANCELLED for s in
+                   [c[0][1] if len(c[0]) > 1 else c[1].get("status")
+                    for c in [(a, kw) for a, kw in update_calls]])
 
-            proc_ex = MagicMock()
-            proc_ex.__enter__ = Mock(return_value=proc_ex)
-            proc_ex.__exit__ = Mock(return_value=False)
-            proc_ex.submit = Mock(side_effect=proc_submit)
-            mock_tpe.return_value = proc_ex
+        # RUNNING must never have been written
+        running_calls = [c for c in update_calls
+                         if (len(c[0]) > 1 and c[0][1] == ConversionTaskStatus.RUNNING)]
+        assert not running_calls, "Task must NOT be marked RUNNING when cancel_pending"
 
-            with pytest.raises(JobCancelledError):
-                process_documents(
-                    input_paths=file_names,
-                    out_path="/tmp/out",
-                    llm_model="m", llm_endpoint="e",
-                    emb_endpoint="emb",
-                    max_tokens=512,
-                    job_id="job-10-files",
-                    doc_id_dict=doc_id_dict,
-                )
+    def test_check1_missing_cached_file_writes_failed(self, tmp_path):
+        """If the cached input file is missing the task is marked FAILED immediately."""
+        from digitize.db.models import ConversionTaskStatus
 
-        # Every process_future that was submitted before cancel was observed
-        # must have been cancelled, not left to run.
-        for i, pf in enumerate(process_futs):
-            assert pf.cancelled(), (
-                f"process_future[{i}] was NOT cancelled — "
-                "the fix to cancel queued downstream futures at the "
-                "conversion→process boundary is missing or incomplete"
-            )
-
-    def test_queued_chunk_futures_are_cancelled_when_cancel_arrives_mid_processing(self):
-        """chunk_futures submitted before cancel was observed must be cancelled."""
-        from digitize.processing.orchestrator import process_documents
-
-        n_files = 10
-        n_early = 4  # files whose processing completes before cancel is observed
-
-        file_names = [f"file{i}.pdf" for i in range(n_files)]
-        doc_id_dict = {fn: f"doc-{i}" for i, fn in enumerate(file_names)}
-
-        # All conversions complete immediately (pre-cancel).
-        conv_futs = []
-        for _ in range(n_files):
-            f: Future = Future()
-            f.set_result(("conv.json", 1.0))
-            conv_futs.append(f)
-
-        # Processing futures:
-        #   first n_early are done (completed before cancel is observed in proc loop)
-        #   rest are pending (never resolved — will be in pending_process when cancel hits)
-        early_proc_futs = []
-        for _ in range(n_early):
-            f: Future = Future()
-            f.set_result(("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en"))
-            early_proc_futs.append(f)
-
-        late_proc_futs = [Future() for _ in range(n_files - n_early)]
-
-        all_proc_futs = early_proc_futs + late_proc_futs
-
-        # chunk_futures submitted for the n_early docs — must be cancelled.
-        chunk_futs = [Future() for _ in range(n_early)]
-
-        conv_idx = {"n": 0}
-        proc_idx = {"n": 0}
-        chunk_idx = {"n": 0}
-
-        def conv_submit(*args, **kwargs):
-            idx = conv_idx["n"]
-            conv_idx["n"] += 1
-            return conv_futs[idx]
-
-        cancel_call = {"n": 0}
-
-        def is_cancelled(job_id):
-            cancel_call["n"] += 1
-            # Call 1: pre-loop check — False
-            # Call 2: conversion poll — False → all 10 proc futures submitted
-            # Call 3: processing poll iteration 1 — False → early proc futures submit chunk_futs
-            # Call 4: processing poll iteration 2 — True → late proc futures cancelled,
-            #         already-queued chunk_futs are cancelled before raising
-            return cancel_call["n"] >= 4
+        task = _make_conv_task(cached_file="/nonexistent/missing.pdf")
 
         mock_db = Mock()
-        mock_db.is_job_cancelled = Mock(side_effect=is_cancelled)
+        mock_db.get_conversion_task = Mock(return_value=None)
+        mock_db.update_task_status = Mock()
 
-        thread_submit_idx = {"n": 0}
+        mock_sem = AsyncMock()
+        mock_sem.release = AsyncMock()
 
-        def thread_submit(*args, **kwargs):
-            idx = thread_submit_idx["n"]
-            thread_submit_idx["n"] += 1
-            if idx < n_files:
-                return all_proc_futs[idx]
-            # chunk_futs come after all proc_futs
-            chunk_idx_val = idx - n_files
-            return chunk_futs[chunk_idx_val]
+        self._run(task, mock_db, mock_sem)
+
+        mock_db.update_task_status.assert_called_once()
+        call_args = mock_db.update_task_status.call_args
+        assert call_args.args[1] == ConversionTaskStatus.FAILED
+
+    def test_check2_cancel_pending_after_conversion_writes_cancelled(self, tmp_path):
+        """Check 2: task flipped to cancel_pending while conversion ran →
+        CANCELLED is written instead of COMPLETED."""
+        from digitize.db.models import ConversionTaskStatus
+
+        cached = tmp_path / "doc.pdf"
+        cached.write_bytes(b"%PDF")
+        task = _make_conv_task(cached_file=str(cached))
+
+        # get_conversion_task calls:
+        #   1st (Check 1): normal status → proceed
+        #   2nd (Check 2): cancel_pending → write CANCELLED
+        get_task_calls = {"n": 0}
+
+        def get_task(task_id):
+            get_task_calls["n"] += 1
+            if get_task_calls["n"] == 1:
+                return Mock(status=ConversionTaskStatus.RUNNING)
+            return Mock(status=ConversionTaskStatus.CANCEL_PENDING)
+
+        update_calls = []
+        mock_db = Mock()
+        mock_db.get_conversion_task = Mock(side_effect=get_task)
+        mock_db.update_task_status = Mock(side_effect=lambda *a, **kw: update_calls.append((a, kw)))
+
+        mock_sem = AsyncMock()
+        mock_sem.release = AsyncMock()
+
+        self._run(task, mock_db, mock_sem, run_in_executor_result=("result.json", 1.0))
+
+        final_statuses = [a[0][1] for a in update_calls if len(a[0]) > 1]
+        assert ConversionTaskStatus.CANCELLED in final_statuses
+        assert ConversionTaskStatus.COMPLETED not in final_statuses
+
+    def test_check3_exception_with_cancel_pending_writes_cancelled(self, tmp_path):
+        """Check 3: exception raised while task is cancel_pending → CANCELLED, not FAILED."""
+        from digitize.db.models import ConversionTaskStatus
+
+        cached = tmp_path / "doc.pdf"
+        cached.write_bytes(b"%PDF")
+        task = _make_conv_task(cached_file=str(cached))
+
+        cancel_pending_stub = Mock(status=ConversionTaskStatus.CANCEL_PENDING)
+        update_calls = []
+
+        mock_db = Mock()
+        mock_db.get_conversion_task = Mock(return_value=cancel_pending_stub)
+        mock_db.update_task_status = Mock(side_effect=lambda *a, **kw: update_calls.append((a, kw)))
+
+        mock_sem = AsyncMock()
+        mock_sem.release = AsyncMock()
+
+        # run_in_executor raises an exception simulating JobCancelledError from worker
+        self._run(task, mock_db, mock_sem,
+                  run_in_executor_result=None)  # patched below separately
+
+        # Re-run via direct async call to control run_in_executor
+        from digitize.workers.conversion_dispatcher import _run_conversion
+
+        async def _go():
+            with (
+                patch("digitize.workers.conversion_dispatcher.db_manager", mock_db),
+                patch("digitize.workers.conversion_dispatcher.conversion_semaphore", mock_sem),
+                patch("digitize.workers.conversion_dispatcher.settings",
+                      SimpleNamespace(digitize=SimpleNamespace(digitized_docs_dir=Path("/out")))),
+            ):
+                loop = asyncio.get_running_loop()
+                with patch.object(loop, "run_in_executor",
+                                   new=AsyncMock(side_effect=RuntimeError("worker died"))):
+                    await _run_conversion(task, weight=1)
+
+        update_calls.clear()
+        asyncio.run(_go())
+
+        final_statuses = [a[0][1] for a in update_calls if len(a[0]) > 1]
+        assert ConversionTaskStatus.CANCELLED in final_statuses
+        assert ConversionTaskStatus.FAILED not in final_statuses
+
+    def test_genuine_failure_writes_failed(self, tmp_path):
+        """A genuine exception (no cancel_pending) must write FAILED."""
+        from digitize.db.models import ConversionTaskStatus
+
+        cached = tmp_path / "doc.pdf"
+        cached.write_bytes(b"%PDF")
+        task = _make_conv_task(cached_file=str(cached))
+
+        running_stub = Mock(status=ConversionTaskStatus.RUNNING)
+        update_calls = []
+
+        mock_db = Mock()
+        mock_db.get_conversion_task = Mock(return_value=running_stub)
+        mock_db.update_task_status = Mock(side_effect=lambda *a, **kw: update_calls.append((a, kw)))
+
+        mock_sem = AsyncMock()
+        mock_sem.release = AsyncMock()
+
+        from digitize.workers.conversion_dispatcher import _run_conversion
+
+        async def _go():
+            with (
+                patch("digitize.workers.conversion_dispatcher.db_manager", mock_db),
+                patch("digitize.workers.conversion_dispatcher.conversion_semaphore", mock_sem),
+                patch("digitize.workers.conversion_dispatcher.settings",
+                      SimpleNamespace(digitize=SimpleNamespace(digitized_docs_dir=Path("/out")))),
+            ):
+                loop = asyncio.get_running_loop()
+                with patch.object(loop, "run_in_executor",
+                                   new=AsyncMock(side_effect=RuntimeError("conversion crash"))):
+                    await _run_conversion(task, weight=1)
+
+        asyncio.run(_go())
+
+        final_statuses = [a[0][1] for a in update_calls if len(a[0]) > 1]
+        assert ConversionTaskStatus.FAILED in final_statuses
+        assert ConversionTaskStatus.CANCELLED not in final_statuses
+
+    def test_semaphore_released_in_finally(self, tmp_path):
+        """Semaphore must be released unconditionally (even on exception)."""
+        from digitize.db.models import ConversionTaskStatus
+
+        cached = tmp_path / "doc.pdf"
+        cached.write_bytes(b"%PDF")
+        task = _make_conv_task(cached_file=str(cached))
+
+        mock_db = Mock()
+        mock_db.get_conversion_task = Mock(return_value=Mock(status=ConversionTaskStatus.RUNNING))
+        mock_db.update_task_status = Mock()
+
+        mock_sem = AsyncMock()
+        mock_sem.release = AsyncMock()
+
+        from digitize.workers.conversion_dispatcher import _run_conversion
+
+        async def _go():
+            with (
+                patch("digitize.workers.conversion_dispatcher.db_manager", mock_db),
+                patch("digitize.workers.conversion_dispatcher.conversion_semaphore", mock_sem),
+                patch("digitize.workers.conversion_dispatcher.settings",
+                      SimpleNamespace(digitize=SimpleNamespace(digitized_docs_dir=Path("/out")))),
+            ):
+                loop = asyncio.get_running_loop()
+                with patch.object(loop, "run_in_executor",
+                                   new=AsyncMock(side_effect=RuntimeError("boom"))):
+                    await _run_conversion(task, weight=2)
+
+        asyncio.run(_go())
+
+        mock_sem.release.assert_called_once_with(2)
+
+
+# ===========================================================================
+# 6. convert_doc (converter.py) — cancel_check callable interface
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestConvertDocCancelCheck:
+    """Tests for the cancel_check callable parameter in convert_doc."""
+
+    def _make_fake_settings(self):
+        return SimpleNamespace(digitize=SimpleNamespace(doc_chunk_size=100))
+
+    def test_cancel_check_none_processes_all_chunks(self, tmp_path):
+        """When cancel_check=None, all chunks are processed without cancellation."""
+        from digitize.parsing.converter import convert_doc
+
+        fake_path = tmp_path / "doc.pdf"
+        fake_path.write_bytes(b"%PDF")
+
+        # Total pages > chunk_size so we exercise the chunked path
+        with (
+            patch("digitize.parsing.converter.get_document_page_count", return_value=250),
+            patch("digitize.parsing.converter.settings", self._make_fake_settings()),
+            patch("digitize.parsing.converter.get_doc_converter", return_value=Mock()),
+            patch("digitize.parsing.converter.convert_chunk", return_value=tmp_path / "chunk.json"),
+            patch("digitize.parsing.converter.DoclingDocument") as mock_ddoc,
+        ):
+            mock_ddoc.load_from_json = Mock(return_value=Mock())
+            mock_ddoc.concatenate = Mock(return_value=Mock())
+
+            # Must not raise
+            convert_doc(str(fake_path), cancel_check=None)
+
+    def test_cancel_check_returning_false_processes_all_chunks(self, tmp_path):
+        """A cancel_check that always returns False must not raise."""
+        from digitize.parsing.converter import convert_doc
+
+        fake_path = tmp_path / "doc.pdf"
+        fake_path.write_bytes(b"%PDF")
 
         with (
-            patch("digitize.processing.orchestrator.db_manager", mock_db),
-            patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
-            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
-            patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
-            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
-            patch("digitize.processing.orchestrator.time.sleep"),
+            patch("digitize.parsing.converter.get_document_page_count", return_value=250),
+            patch("digitize.parsing.converter.settings", self._make_fake_settings()),
+            patch("digitize.parsing.converter.get_doc_converter", return_value=Mock()),
+            patch("digitize.parsing.converter.convert_chunk", return_value=tmp_path / "chunk.json"),
+            patch("digitize.parsing.converter.DoclingDocument") as mock_ddoc,
         ):
-            conv_ex = MagicMock()
-            conv_ex.__enter__ = Mock(return_value=conv_ex)
-            conv_ex.__exit__ = Mock(return_value=False)
-            conv_ex.submit = Mock(side_effect=conv_submit)
-            mock_ppe.return_value = conv_ex
+            mock_ddoc.load_from_json = Mock(return_value=Mock())
+            mock_ddoc.concatenate = Mock(return_value=Mock())
 
-            thread_ex = MagicMock()
-            thread_ex.__enter__ = Mock(return_value=thread_ex)
-            thread_ex.__exit__ = Mock(return_value=False)
-            thread_ex.submit = Mock(side_effect=thread_submit)
-            mock_tpe.return_value = thread_ex
+            # Must not raise
+            convert_doc(str(fake_path), cancel_check=lambda: False)
 
+    def test_cancel_check_returning_true_raises_job_cancelled_error(self, tmp_path):
+        """A cancel_check that returns True must trigger JobCancelledError between chunks."""
+        from digitize.parsing.converter import convert_doc
+
+        fake_path = tmp_path / "doc.pdf"
+        fake_path.write_bytes(b"%PDF")
+
+        with (
+            patch("digitize.parsing.converter.get_document_page_count", return_value=250),
+            patch("digitize.parsing.converter.settings", self._make_fake_settings()),
+            patch("digitize.parsing.converter.get_doc_converter", return_value=Mock()),
+            patch("digitize.parsing.converter.convert_chunk", return_value=tmp_path / "chunk.json"),
+        ):
             with pytest.raises(JobCancelledError):
-                process_documents(
-                    input_paths=file_names,
-                    out_path="/tmp/out",
-                    llm_model="m", llm_endpoint="e",
-                    emb_endpoint="emb",
-                    max_tokens=512,
-                    job_id="job-10-files-proc",
-                    doc_id_dict=doc_id_dict,
-                )
+                convert_doc(str(fake_path), cancel_check=lambda: True)
 
-        for i, cf in enumerate(chunk_futs):
-            assert cf.cancelled(), (
-                f"chunk_future[{i}] was NOT cancelled — "
-                "the fix to cancel queued downstream futures at the "
-                "processing→chunk boundary is missing or incomplete"
-            )
+
+# ===========================================================================
+# 7. _make_db_cancel_check (converter.py)
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestMakeDbCancelCheck:
+    """Tests for the _make_db_cancel_check factory in converter.py."""
+
+    def test_returns_false_when_task_not_cancel_pending(self):
+        """When DB row status is RUNNING (not cancel_pending), callable returns False."""
+        from digitize.parsing.converter import _make_db_cancel_check
+        from digitize.db.models import ConversionTaskStatus
+
+        mock_task = Mock(status=ConversionTaskStatus.RUNNING)
+        mock_db = Mock()
+        mock_db.get_conversion_task = Mock(return_value=mock_task)
+
+        check = _make_db_cancel_check("task-1")
+
+        with patch("digitize.db.manager.db_manager", mock_db):
+            # The callable imports db_manager lazily; we patch at the module level
+            # by temporarily inserting a mock in sys.modules
+            import digitize.db.manager as dm_mod
+            original = dm_mod.db_manager
+            dm_mod.db_manager = mock_db
+            try:
+                result = check()
+            finally:
+                dm_mod.db_manager = original
+
+        assert result is False
+
+    def test_returns_true_when_task_is_cancel_pending(self):
+        """When DB row status is CANCEL_PENDING, callable returns True."""
+        from digitize.parsing.converter import _make_db_cancel_check
+        from digitize.db.models import ConversionTaskStatus
+
+        mock_task = Mock(status=ConversionTaskStatus.CANCEL_PENDING)
+        mock_db = Mock()
+        mock_db.get_conversion_task = Mock(return_value=mock_task)
+
+        check = _make_db_cancel_check("task-2")
+
+        import digitize.db.manager as dm_mod
+        original = dm_mod.db_manager
+        dm_mod.db_manager = mock_db
+        try:
+            result = check()
+        finally:
+            dm_mod.db_manager = original
+
+        assert result is True
+
+    def test_returns_false_when_db_raises(self):
+        """A DB error inside the callable must be swallowed — returns False."""
+        from digitize.parsing.converter import _make_db_cancel_check
+
+        mock_db = Mock()
+        mock_db.get_conversion_task = Mock(side_effect=RuntimeError("db down"))
+
+        check = _make_db_cancel_check("task-3")
+
+        import digitize.db.manager as dm_mod
+        original = dm_mod.db_manager
+        dm_mod.db_manager = mock_db
+        try:
+            result = check()
+        finally:
+            dm_mod.db_manager = original
+
+        assert result is False

--- a/services/digitize/tests/test_cancel_job.py
+++ b/services/digitize/tests/test_cancel_job.py
@@ -1,0 +1,1344 @@
+"""
+Tests for the cancel-job feature.
+
+Coverage:
+  1. ``POST /v1/jobs/{job_id}/cancel`` endpoint (jobs.py)
+     - 404 when job not found
+     - 409 when job is already in a non-cancellable state (completed / failed / cancel_pending / cancelled)
+     - 202 for accepted / in_progress jobs (no body)
+     - clean_files flag is written to job stats in the DB
+     - 500 on unexpected db error
+
+  2. ``_run_digitize`` background task (jobs.py)
+     - JobCancelledError causes CANCELLED status on non-terminal docs and job
+     - Staging cleanup and semaphore release happen even on cancellation
+     - Normal pipeline exception does NOT produce CANCELLED status
+
+  3. ``_run_ingest`` background task (jobs.py)
+     - JobCancelledError causes CANCELLED status on non-terminal docs and job
+     - clean_files=True → vector-DB chunks are removed for the right doc IDs
+     - clean_files=False → vector DB is NOT touched
+     - VDB cleanup failure is swallowed (only a warning)
+     - Staging cleanup and semaphore release happen even on cancellation
+
+  4. ``process_documents / _run_batch`` (orchestrator.py)
+     - Cancellation at conversion stage: pending futures are cancelled, running
+       ones are drained; JobCancelledError is raised afterwards
+     - Cancellation at processing stage: same pattern
+     - Cancellation at chunking stage: same pattern
+     - Cancellation at indexing stage: pending index futures cancelled; already
+       running index futures are let to complete (no stale VDB entries)
+     - Non-cancelled jobs run through all stages without interruption
+"""
+
+import asyncio
+import sys
+import threading
+import types
+from concurrent.futures import Future
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Stub heavy docling deps the same way conftest.py does, so imports work when
+# this file is collected before conftest stubs take effect.
+# ---------------------------------------------------------------------------
+for _pkg in [
+    "docling",
+    "docling.datamodel",
+    "docling.datamodel.document",
+    "docling.document_converter",
+    "docling_core",
+    "docling_core.types",
+    "docling_core.types.doc",
+    "docling_core.types.doc.document",
+]:
+    if _pkg not in sys.modules:
+        _mod = types.ModuleType(_pkg)
+        sys.modules[_pkg] = _mod
+
+for _attr, _name in [
+    ("docling.datamodel.document", "ConversionResult"),
+    ("docling.document_converter", "DocumentConverter"),
+    ("docling_core.types.doc.document", "DoclingDocument"),
+]:
+    if not hasattr(sys.modules[_attr], _name.split(".")[-1]):
+        setattr(sys.modules[_attr], _name.split(".")[-1], MagicMock(name=_name))
+
+
+import digitize.app as digitize_app
+import digitize.api.v1.jobs as jobs_module
+import digitize.utils.db as db_ops
+from digitize.exceptions import JobCancelledError
+from digitize.models import DocStatus, JobStatus
+from digitize.workers.concurrency import concurrency_manager
+
+
+# ===========================================================================
+# Shared test fixtures
+# ===========================================================================
+
+
+@pytest.fixture()
+def test_client(monkeypatch, tmp_path, mock_db_operations):
+    """TestClient configured identically to the existing endpoint tests."""
+    import digitize.api.v1.documents as documents_router_module
+
+    digitized_dir = tmp_path / "digitized"
+    staging_dir = tmp_path / "staging"
+    for p in (digitized_dir, staging_dir):
+        p.mkdir(parents=True, exist_ok=True)
+
+    fake_settings = SimpleNamespace(
+        common=SimpleNamespace(app=SimpleNamespace(log_level="INFO")),
+        digitize=SimpleNamespace(
+            digitized_docs_dir=digitized_dir,
+            staging_dir=staging_dir,
+            digitization_concurrency_limit=2,
+            ingestion_concurrency_limit=1,
+        ),
+    )
+
+    monkeypatch.setattr(digitize_app, "settings", fake_settings, raising=False)
+    monkeypatch.setattr(digitize_app.dg_util, "settings", fake_settings, raising=False)
+    monkeypatch.setattr(concurrency_manager, "is_locked", Mock(return_value=False))
+    monkeypatch.setattr(concurrency_manager, "acquire", AsyncMock())
+    monkeypatch.setattr(concurrency_manager, "release", Mock())
+    monkeypatch.setattr(digitize_app.dg_util, "has_active_jobs", Mock(return_value=(False, [])))
+    monkeypatch.setattr(digitize_app.dg_util, "generate_uuid", Mock(return_value="job-123"))
+    monkeypatch.setattr(digitize_app.dg_util, "stage_upload_files", AsyncMock())
+    monkeypatch.setattr(digitize_app.dg_util, "initialize_job_state", Mock(return_value={"sample.pdf": "doc-1"}))
+    monkeypatch.setattr(digitize_app.dg_util, "get_document_content", Mock())
+    monkeypatch.setattr(digitize_app.dg_util, "is_document_in_active_job", Mock(return_value=False))
+    monkeypatch.setattr(documents_router_module, "reset_db", Mock())
+    monkeypatch.setattr(digitize_app, "configure_uvicorn_logging", Mock())
+
+    mock_hash_db_manager = Mock()
+    mock_hash_db_manager.find_completed_document_by_hash = Mock(return_value=None)
+    monkeypatch.setattr(jobs_module, "db_manager", mock_hash_db_manager)
+
+    return TestClient(digitize_app.app)
+
+
+def _make_doc(doc_id: str, status: str) -> Mock:
+    """Helper to build a mock document DB row."""
+    doc = Mock()
+    doc.doc_id = doc_id
+    doc.status = status
+    return doc
+
+
+# ===========================================================================
+# 1. cancel_job API endpoint
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestCancelJobEndpoint:
+    """Tests for POST /v1/jobs/{job_id}/cancel."""
+
+    # ------------------------------------------------------------------ #
+    # 404 – job not found                                                  #
+    # ------------------------------------------------------------------ #
+
+    def test_returns_404_when_job_not_found(self, test_client, monkeypatch):
+        monkeypatch.setattr(db_ops, "get_job", Mock(return_value=None))
+
+        response = test_client.post("/v1/jobs/nonexistent/cancel")
+
+        assert response.status_code == 404
+
+    # ------------------------------------------------------------------ #
+    # 409 – terminal-state jobs cannot be cancelled                        #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.parametrize("terminal_status", [
+        JobStatus.COMPLETED.value,
+        JobStatus.FAILED.value,
+        JobStatus.CANCEL_PENDING.value,
+        JobStatus.CANCELLED.value,
+    ])
+    def test_returns_409_for_terminal_state_jobs(self, test_client, monkeypatch, terminal_status):
+        monkeypatch.setattr(
+            db_ops,
+            "get_job",
+            Mock(return_value={"job_id": "job-1", "status": terminal_status, "stats": {}}),
+        )
+
+        response = test_client.post("/v1/jobs/job-1/cancel")
+
+        assert response.status_code == 409
+
+    # ------------------------------------------------------------------ #
+    # 202 – accepted / in_progress jobs are cancellable                    #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.parametrize("active_status", [
+        JobStatus.ACCEPTED.value,
+        JobStatus.IN_PROGRESS.value,
+    ])
+    def test_returns_202_for_active_jobs(self, test_client, monkeypatch, active_status):
+        mock_update = Mock()
+        monkeypatch.setattr(db_ops, "get_job", Mock(return_value={
+            "job_id": "job-active", "status": active_status, "stats": {},
+        }))
+        monkeypatch.setattr("digitize.db.manager.db_manager.update_job", mock_update)
+
+        response = test_client.post("/v1/jobs/job-active/cancel")
+
+        assert response.status_code == 202
+        assert response.content == b""
+
+    def test_update_job_called_with_cancel_pending_status(self, test_client, monkeypatch):
+        """The endpoint must write CANCEL_PENDING + preserve existing stats."""
+        mock_update = Mock()
+        existing_stats = {"total_documents": 3, "completed": 1}
+        monkeypatch.setattr(db_ops, "get_job", Mock(return_value={
+            "job_id": "job-active",
+            "status": JobStatus.IN_PROGRESS.value,
+            "stats": existing_stats,
+        }))
+        # db_manager is imported directly into jobs.py's namespace at line 27:
+        #   from digitize.db.manager import db_manager
+        # So the correct patch target is the jobs module, not db.manager.
+        monkeypatch.setattr(jobs_module, "db_manager", Mock(update_job=mock_update))
+
+        test_client.post("/v1/jobs/job-active/cancel")
+
+        mock_update.assert_called_once()
+        call_kwargs = mock_update.call_args
+        assert call_kwargs.args[0] == "job-active"
+        assert call_kwargs.kwargs["status"] == JobStatus.CANCEL_PENDING
+
+    # ------------------------------------------------------------------ #
+    # clean_files flag is persisted into job stats                         #
+    # ------------------------------------------------------------------ #
+
+    def test_clean_files_false_stored_in_stats(self, test_client, monkeypatch):
+        mock_update = Mock()
+        monkeypatch.setattr(db_ops, "get_job", Mock(return_value={
+            "job_id": "job-ingest",
+            "status": JobStatus.ACCEPTED.value,
+            "stats": {"total_documents": 2},
+        }))
+        monkeypatch.setattr(jobs_module, "db_manager", Mock(update_job=mock_update))
+
+        test_client.post("/v1/jobs/job-ingest/cancel?clean_files=false")
+
+        call_kwargs = mock_update.call_args.kwargs
+        assert call_kwargs["stats"]["clean_files"] is False
+
+    def test_clean_files_true_stored_in_stats(self, test_client, monkeypatch):
+        mock_update = Mock()
+        monkeypatch.setattr(db_ops, "get_job", Mock(return_value={
+            "job_id": "job-ingest",
+            "status": JobStatus.ACCEPTED.value,
+            "stats": {},
+        }))
+        monkeypatch.setattr(jobs_module, "db_manager", Mock(update_job=mock_update))
+
+        test_client.post("/v1/jobs/job-ingest/cancel?clean_files=true")
+
+        call_kwargs = mock_update.call_args.kwargs
+        assert call_kwargs["stats"]["clean_files"] is True
+
+    # ------------------------------------------------------------------ #
+    # 500 – unexpected db error                                            #
+    # ------------------------------------------------------------------ #
+
+    def test_returns_500_on_unexpected_error(self, test_client, monkeypatch):
+        monkeypatch.setattr(db_ops, "get_job", Mock(side_effect=RuntimeError("db boom")))
+
+        response = test_client.post("/v1/jobs/job-1/cancel")
+
+        assert response.status_code == 500
+
+    # ------------------------------------------------------------------ #
+    # Default query param                                                  #
+    # ------------------------------------------------------------------ #
+
+    def test_clean_files_defaults_to_false(self, test_client, monkeypatch):
+        mock_update = Mock()
+        monkeypatch.setattr(db_ops, "get_job", Mock(return_value={
+            "job_id": "job-ingest",
+            "status": JobStatus.ACCEPTED.value,
+            "stats": {},
+        }))
+        monkeypatch.setattr(jobs_module, "db_manager", Mock(update_job=mock_update))
+
+        # No ?clean_files query param
+        test_client.post("/v1/jobs/job-ingest/cancel")
+
+        call_kwargs = mock_update.call_args.kwargs
+        assert call_kwargs["stats"]["clean_files"] is False
+
+    def test_existing_stats_are_preserved_alongside_clean_files(self, test_client, monkeypatch):
+        """Pre-existing stats keys must be kept; only clean_files is added/overwritten."""
+        mock_update = Mock()
+        monkeypatch.setattr(db_ops, "get_job", Mock(return_value={
+            "job_id": "job-ingest",
+            "status": JobStatus.IN_PROGRESS.value,
+            "stats": {"total_documents": 5, "completed": 2},
+        }))
+        monkeypatch.setattr(jobs_module, "db_manager", Mock(update_job=mock_update))
+
+        test_client.post("/v1/jobs/job-ingest/cancel?clean_files=true")
+
+        call_kwargs = mock_update.call_args.kwargs
+        assert call_kwargs["stats"]["total_documents"] == 5
+        assert call_kwargs["stats"]["completed"] == 2
+        assert call_kwargs["stats"]["clean_files"] is True
+
+
+# ===========================================================================
+# 2. _run_digitize background task
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestRunDigitize:
+    """Tests for the _run_digitize background helper."""
+
+    @pytest.mark.asyncio
+    async def test_cancellation_marks_non_terminal_docs_and_job_cancelled(self, tmp_path):
+        """When JobCancelledError is raised, all non-terminal docs become CANCELLED
+        and the job itself is marked CANCELLED."""
+        job_id = "job-dig-cancel"
+
+        # Two docs: one already completed, one still in_progress
+        completed_doc = _make_doc("doc-done", DocStatus.COMPLETED.value)
+        active_doc = _make_doc("doc-active", DocStatus.IN_PROGRESS.value)
+
+        mock_db = Mock()
+        mock_db.get_documents_by_job_id = Mock(return_value=[completed_doc, active_doc])
+        mock_db.update_document = Mock()
+        mock_db.update_job = Mock()
+
+        mock_status_mgr = Mock()
+
+        with (
+            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("cancelled"))),
+            patch("digitize.api.v1.jobs.db_manager", mock_db),
+            patch("digitize.api.v1.jobs.get_status_manager", return_value=mock_status_mgr),
+            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
+            patch("digitize.api.v1.jobs.concurrency_manager"),
+            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+        ):
+            await jobs_module._run_digitize(
+                job_id=job_id,
+                doc_id_dict={"sample.pdf": "doc-active"},
+                output_format=Mock(),
+            )
+
+        # Completed doc must NOT be touched
+        update_calls = mock_db.update_document.call_args_list
+        updated_doc_ids = [c.args[0] for c in update_calls]
+        assert "doc-done" not in updated_doc_ids
+
+        # In-progress doc must be marked CANCELLED
+        assert "doc-active" in updated_doc_ids
+        mock_db.update_job.assert_called_once_with(job_id, status=JobStatus.CANCELLED)
+
+    @pytest.mark.asyncio
+    async def test_terminal_docs_are_not_overwritten_on_cancellation(self, tmp_path):
+        """Already-failed / already-cancelled docs must not be touched."""
+        job_id = "job-dig-cancel-terminal"
+
+        terminal_docs = [
+            _make_doc("doc-fail", DocStatus.FAILED.value),
+            _make_doc("doc-cancel", DocStatus.CANCELLED.value),
+            _make_doc("doc-exists", DocStatus.ALREADY_EXISTS.value),
+        ]
+
+        mock_db = Mock()
+        mock_db.get_documents_by_job_id = Mock(return_value=terminal_docs)
+        mock_db.update_document = Mock()
+        mock_db.update_job = Mock()
+
+        with (
+            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
+            patch("digitize.api.v1.jobs.db_manager", mock_db),
+            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
+            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
+            patch("digitize.api.v1.jobs.concurrency_manager"),
+            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+        ):
+            await jobs_module._run_digitize(
+                job_id=job_id,
+                doc_id_dict={},
+                output_format=Mock(),
+            )
+
+        mock_db.update_document.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_staging_cleanup_and_semaphore_released_on_cancellation(self, tmp_path):
+        """finally block must always run: cleanup + semaphore release."""
+        mock_cleanup = Mock()
+        mock_concurrency = Mock()
+
+        with (
+            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
+            patch("digitize.api.v1.jobs.db_manager", Mock(
+                get_documents_by_job_id=Mock(return_value=[]),
+                update_job=Mock(),
+            )),
+            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
+            patch("digitize.api.v1.jobs.cleanup_staging_directory", mock_cleanup),
+            patch("digitize.api.v1.jobs.concurrency_manager", mock_concurrency),
+            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+        ):
+            await jobs_module._run_digitize("job-x", {}, Mock())
+
+        mock_cleanup.assert_called_once()
+        mock_concurrency.release.assert_called_once_with("digitization")
+
+    @pytest.mark.asyncio
+    async def test_non_cancellation_exception_does_not_mark_cancelled(self, tmp_path):
+        """A plain exception must NOT produce CANCELLED status — it goes through
+        the generic failure path instead."""
+        mock_db = Mock()
+        mock_db.get_documents_by_job_id = Mock(return_value=[])
+
+        mock_status_mgr = Mock()
+
+        with (
+            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=RuntimeError("boom"))),
+            patch("digitize.api.v1.jobs.db_manager", mock_db),
+            patch("digitize.api.v1.jobs.get_status_manager", return_value=mock_status_mgr),
+            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
+            patch("digitize.api.v1.jobs.concurrency_manager"),
+            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+        ):
+            await jobs_module._run_digitize("job-fail", {}, Mock())
+
+        mock_db.update_document.assert_not_called()
+        mock_status_mgr.update_job_progress.assert_called()
+
+
+# ===========================================================================
+# 3. _run_ingest background task
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestRunIngest:
+    """Tests for the _run_ingest background helper."""
+
+    @pytest.mark.asyncio
+    async def test_cancellation_marks_non_terminal_docs_and_job(self, tmp_path):
+        job_id = "job-ingest-cancel"
+
+        pending_doc = _make_doc("doc-pending", DocStatus.ACCEPTED.value)
+        done_doc = _make_doc("doc-done", DocStatus.COMPLETED.value)
+
+        mock_db = Mock()
+        mock_db.get_documents_by_job_id = Mock(return_value=[pending_doc, done_doc])
+        mock_db.update_document = Mock()
+        mock_db.update_job = Mock()
+        mock_db.get_job_by_id = Mock(return_value=Mock(stats={"clean_files": False}))
+
+        with (
+            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
+            patch("digitize.api.v1.jobs.db_manager", mock_db),
+            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
+            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
+            patch("digitize.api.v1.jobs.concurrency_manager"),
+            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+        ):
+            await jobs_module._run_ingest(job_id, ["file.pdf"], {"file.pdf": "doc-pending"})
+
+        updated = [c.args[0] for c in mock_db.update_document.call_args_list]
+        assert "doc-pending" in updated
+        assert "doc-done" not in updated
+        mock_db.update_job.assert_called_once_with(job_id, status=JobStatus.CANCELLED)
+
+    @pytest.mark.asyncio
+    async def test_clean_files_true_removes_vector_db_entries(self, tmp_path):
+        """When clean_files=True, indexed doc IDs must be removed from the VDB."""
+        job_id = "job-ingest-clean"
+        doc_id_dict = {"a.pdf": "doc-aaa", "b.pdf": "doc-bbb"}
+
+        doc_a = _make_doc("doc-aaa", DocStatus.CHUNKED.value)
+        doc_b = _make_doc("doc-bbb", DocStatus.COMPLETED.value)
+
+        mock_db = Mock()
+        mock_db.get_documents_by_job_id = Mock(return_value=[doc_a, doc_b])
+        mock_db.update_document = Mock()
+        mock_db.update_job = Mock()
+        mock_db.get_job_by_id = Mock(return_value=Mock(stats={"clean_files": True}))
+
+        mock_vector_store = Mock()
+        mock_vector_store.remove_docs_from_index = Mock(return_value=10)
+
+        with (
+            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
+            patch("digitize.api.v1.jobs.db_manager", mock_db),
+            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
+            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
+            patch("digitize.api.v1.jobs.concurrency_manager"),
+            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+            patch("common.db_utils.get_vector_store", return_value=mock_vector_store),
+        ):
+            await jobs_module._run_ingest(job_id, list(doc_id_dict.keys()), doc_id_dict)
+
+        removed_ids = mock_vector_store.remove_docs_from_index.call_args.args[0]
+        assert set(removed_ids) == {"doc-aaa", "doc-bbb"}
+
+    @pytest.mark.asyncio
+    async def test_clean_files_false_does_not_touch_vector_db(self, tmp_path):
+        """When clean_files=False the VDB must not be queried at all."""
+        job_id = "job-ingest-noclean"
+
+        mock_db = Mock()
+        mock_db.get_documents_by_job_id = Mock(return_value=[])
+        mock_db.update_document = Mock()
+        mock_db.update_job = Mock()
+        mock_db.get_job_by_id = Mock(return_value=Mock(stats={"clean_files": False}))
+
+        mock_get_vector_store = Mock()
+
+        with (
+            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
+            patch("digitize.api.v1.jobs.db_manager", mock_db),
+            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
+            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
+            patch("digitize.api.v1.jobs.concurrency_manager"),
+            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+            patch("common.db_utils.get_vector_store", mock_get_vector_store),
+        ):
+            await jobs_module._run_ingest(job_id, [], {})
+
+        mock_get_vector_store.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_vdb_cleanup_failure_is_swallowed(self, tmp_path):
+        """A VDB cleanup error must NOT propagate; it is only logged as a warning."""
+        job_id = "job-ingest-vdb-fail"
+        doc_id_dict = {"x.pdf": "doc-x"}
+
+        doc_x = _make_doc("doc-x", DocStatus.COMPLETED.value)
+
+        mock_db = Mock()
+        mock_db.get_documents_by_job_id = Mock(return_value=[doc_x])
+        mock_db.update_document = Mock()
+        mock_db.update_job = Mock()
+        mock_db.get_job_by_id = Mock(return_value=Mock(stats={"clean_files": True}))
+
+        exploding_store = Mock()
+        exploding_store.remove_docs_from_index = Mock(side_effect=RuntimeError("vdb down"))
+
+        with (
+            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
+            patch("digitize.api.v1.jobs.db_manager", mock_db),
+            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
+            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
+            patch("digitize.api.v1.jobs.concurrency_manager"),
+            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+            patch("common.db_utils.get_vector_store", return_value=exploding_store),
+        ):
+            # Must not raise
+            await jobs_module._run_ingest(job_id, ["x.pdf"], doc_id_dict)
+
+    @pytest.mark.asyncio
+    async def test_staging_cleanup_and_semaphore_released_on_cancellation(self, tmp_path):
+        mock_cleanup = Mock()
+        mock_concurrency = Mock()
+
+        mock_db = Mock()
+        mock_db.get_documents_by_job_id = Mock(return_value=[])
+        mock_db.update_job = Mock()
+        mock_db.get_job_by_id = Mock(return_value=Mock(stats={}))
+
+        with (
+            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
+            patch("digitize.api.v1.jobs.db_manager", mock_db),
+            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
+            patch("digitize.api.v1.jobs.cleanup_staging_directory", mock_cleanup),
+            patch("digitize.api.v1.jobs.concurrency_manager", mock_concurrency),
+            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+        ):
+            await jobs_module._run_ingest("job-y", [], {})
+
+        mock_cleanup.assert_called_once()
+        mock_concurrency.release.assert_called_once_with("ingestion")
+
+    @pytest.mark.asyncio
+    async def test_only_doc_ids_in_doc_id_dict_are_cleaned_from_vdb(self, tmp_path):
+        """Only doc IDs that belong to THIS job (present in doc_id_dict.values()) must
+        be submitted to remove_docs_from_index, not stray docs returned by the DB."""
+        job_id = "job-ingest-scope"
+        doc_id_dict = {"mine.pdf": "doc-mine"}
+
+        doc_mine = _make_doc("doc-mine", DocStatus.COMPLETED.value)
+        doc_foreign = _make_doc("doc-foreign", DocStatus.COMPLETED.value)  # not in this job's dict
+
+        mock_db = Mock()
+        mock_db.get_documents_by_job_id = Mock(return_value=[doc_mine, doc_foreign])
+        mock_db.update_document = Mock()
+        mock_db.update_job = Mock()
+        mock_db.get_job_by_id = Mock(return_value=Mock(stats={"clean_files": True}))
+
+        mock_vs = Mock()
+        mock_vs.remove_docs_from_index = Mock(return_value=1)
+
+        with (
+            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
+            patch("digitize.api.v1.jobs.db_manager", mock_db),
+            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
+            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
+            patch("digitize.api.v1.jobs.concurrency_manager"),
+            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+            patch("common.db_utils.get_vector_store", return_value=mock_vs),
+        ):
+            await jobs_module._run_ingest(job_id, list(doc_id_dict.keys()), doc_id_dict)
+
+        removed = set(mock_vs.remove_docs_from_index.call_args.args[0])
+        assert removed == {"doc-mine"}
+        assert "doc-foreign" not in removed
+
+
+# ===========================================================================
+# 4. orchestrator._run_batch / process_documents – cancellation checkpoints
+# ===========================================================================
+
+
+def _make_future(result=None, exception=None, *, running=False, done_immediately=True) -> Future:
+    """Build a real concurrent.futures.Future in the desired state."""
+    f: Future = Future()
+    if exception:
+        f.set_exception(exception)
+    elif done_immediately:
+        f.set_result(result)
+    # If done_immediately=False and running=False the future stays PENDING.
+    return f
+
+
+def _make_running_future(result=None, delay: float = 0.0) -> Future:
+    """Return a Future that is currently RUNNING and will resolve to *result*.
+
+    The poll loops in the orchestrator only exit a future via ``fut.done()``
+    or ``fut.cancel()``.  A RUNNING future is neither cancellable nor done
+    until its result is set, so we schedule that on a background thread
+    (after an optional *delay*) so the poll loop can drain naturally.
+
+    Why this avoids a hang
+    ----------------------
+    The orchestrator loops:
+        while pending:
+            if is_cancelled and not fut.running() and not fut.done(): cancel + remove
+            elif fut.done():                                           collect + remove
+            if pending: time.sleep(0.5)   ← patched to no-op in tests
+
+    With ``time.sleep`` patched to a no-op the loop spins at full speed.
+    The background thread sets the result after ``delay`` seconds (default 0),
+    which is enough for the scheduler to give the loop at least one iteration
+    before the future becomes done, so the ``assert not fut.cancelled()``
+    check is meaningful and the loop terminates without hanging.
+    """
+    f: Future = Future()
+    f.set_running_or_notify_cancel()  # → RUNNING (not cancellable)
+
+    def _resolve():
+        import time as _time
+        if delay:
+            _time.sleep(delay)
+        try:
+            f.set_result(result)
+        except Exception:
+            pass  # future may already be resolved; ignore
+
+    threading.Thread(target=_resolve, daemon=True).start()
+    return f
+
+
+@pytest.mark.unit
+class TestOrchestratorCancellationAtConversionStage:
+    """Cancellation observed while conversion futures are still pending/running."""
+
+    def test_pending_conversion_future_is_cancelled_when_job_cancelled(self):
+        from digitize.processing.orchestrator import process_documents
+
+        # Pending future (never started)
+        pending_fut: Future = Future()
+
+        # is_job_cancelled returns True on first check
+        mock_db = Mock()
+        mock_db.is_job_cancelled = Mock(return_value=True)
+
+        mock_status_mgr = Mock()
+
+        with (
+            patch("digitize.processing.orchestrator.db_manager", mock_db),
+            patch("digitize.processing.orchestrator.get_status_manager", return_value=mock_status_mgr),
+            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
+            patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
+            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
+            patch("digitize.processing.orchestrator.time.sleep"),
+        ):
+            # ProcessPoolExecutor.submit → returns our pending future
+            mock_conv_ex = MagicMock()
+            mock_conv_ex.__enter__ = Mock(return_value=mock_conv_ex)
+            mock_conv_ex.__exit__ = Mock(return_value=False)
+            mock_conv_ex.submit = Mock(return_value=pending_fut)
+            mock_ppe.return_value = mock_conv_ex
+
+            mock_thread_ex = MagicMock()
+            mock_thread_ex.__enter__ = Mock(return_value=mock_thread_ex)
+            mock_thread_ex.__exit__ = Mock(return_value=False)
+            mock_tpe.return_value = mock_thread_ex
+
+            with pytest.raises(JobCancelledError):
+                process_documents(
+                    input_paths=["fake.pdf"],
+                    out_path="/tmp/out",
+                    llm_model="m", llm_endpoint="e",
+                    emb_endpoint="emb",
+                    max_tokens=512,
+                    job_id="job-cancel-conv",
+                    doc_id_dict={"fake.pdf": "doc-1"},
+                )
+
+    def test_running_conversion_future_is_allowed_to_complete(self):
+        """A future already running() must NOT have cancel() called on it.
+
+        The RUNNING future resolves itself via a background thread so the
+        orchestrator's poll loop exits naturally instead of spinning forever.
+        The result is set to (None, 0.0) — a falsy converted_json triggers
+        the "conversion returned None" error path, which is fine; we only
+        care that cancel() was never called.
+        """
+        from digitize.processing.orchestrator import process_documents
+
+        # Resolves to (None, 0.0): falsy converted_json → orchestrator logs
+        # an error and continues; it does NOT raise, so the test can assert.
+        running_fut = _make_running_future(result=(None, 0.0))
+
+        mock_db = Mock()
+        mock_db.is_job_cancelled = Mock(return_value=True)
+
+        with (
+            patch("digitize.processing.orchestrator.db_manager", mock_db),
+            patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
+            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
+            patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
+            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
+            patch("digitize.processing.orchestrator.time.sleep"),
+        ):
+            mock_conv_ex = MagicMock()
+            mock_conv_ex.__enter__ = Mock(return_value=mock_conv_ex)
+            mock_conv_ex.__exit__ = Mock(return_value=False)
+            mock_conv_ex.submit = Mock(return_value=running_fut)
+            mock_ppe.return_value = mock_conv_ex
+
+            mock_thread_ex = MagicMock()
+            mock_thread_ex.__enter__ = Mock(return_value=mock_thread_ex)
+            mock_thread_ex.__exit__ = Mock(return_value=False)
+            mock_tpe.return_value = mock_thread_ex
+
+            with pytest.raises(JobCancelledError):
+                process_documents(
+                    input_paths=["fake.pdf"],
+                    out_path="/tmp/out",
+                    llm_model="m", llm_endpoint="e",
+                    emb_endpoint="emb",
+                    max_tokens=512,
+                    job_id="job-conv-running",
+                    doc_id_dict={"fake.pdf": "doc-1"},
+                )
+
+        # The running future must NOT have been cancelled
+        assert not running_fut.cancelled()
+
+
+@pytest.mark.unit
+class TestOrchestratorCancellationAtProcessingStage:
+    """Cancellation observed while processing (text/table extraction) futures are pending."""
+
+    def _build_done_conversion_future(self):
+        """A completed conversion future returning a dummy (converted_json, time)."""
+        f: Future = Future()
+        f.set_result(("converted.json", 1.0))
+        return f
+
+    def test_pending_processing_future_is_cancelled_when_job_cancelled(self):
+        from digitize.processing.orchestrator import process_documents
+
+        conv_fut = self._build_done_conversion_future()
+        pending_proc_fut: Future = Future()
+
+        call_count = {"n": 0}
+
+        def is_cancelled(job_id):
+            # Return False during conversion stage (calls 1-2), True when processing stage checks (call 3+)
+            # Call 1: pre-loop check at line 539
+            # Call 2: conversion poll loop iteration — False so pending_proc_fut gets submitted
+            # Call 3: processing poll loop — True so pending_proc_fut is cancelled
+            call_count["n"] += 1
+            return call_count["n"] >= 3
+
+        mock_db = Mock()
+        mock_db.is_job_cancelled = Mock(side_effect=is_cancelled)
+
+        with (
+            patch("digitize.processing.orchestrator.db_manager", mock_db),
+            patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
+            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
+            patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
+            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
+            patch("digitize.processing.orchestrator.time.sleep"),
+        ):
+            mock_conv_ex = MagicMock()
+            mock_conv_ex.__enter__ = Mock(return_value=mock_conv_ex)
+            mock_conv_ex.__exit__ = Mock(return_value=False)
+            mock_conv_ex.submit = Mock(return_value=conv_fut)
+            mock_ppe.return_value = mock_conv_ex
+
+            mock_thread_ex = MagicMock()
+            mock_thread_ex.__enter__ = Mock(return_value=mock_thread_ex)
+            mock_thread_ex.__exit__ = Mock(return_value=False)
+            mock_thread_ex.submit = Mock(return_value=pending_proc_fut)
+            mock_tpe.return_value = mock_thread_ex
+
+            with pytest.raises(JobCancelledError):
+                process_documents(
+                    input_paths=["fake.pdf"],
+                    out_path="/tmp/out",
+                    llm_model="m", llm_endpoint="e",
+                    emb_endpoint="emb",
+                    max_tokens=512,
+                    job_id="job-cancel-proc",
+                    doc_id_dict={"fake.pdf": "doc-1"},
+                )
+
+        assert pending_proc_fut.cancelled()
+
+
+@pytest.mark.unit
+class TestOrchestratorCancellationAtChunkingStage:
+    """Cancellation observed while chunking futures are still pending."""
+
+    def test_pending_chunking_future_is_cancelled_when_job_cancelled(self):
+        from digitize.processing.orchestrator import process_documents
+
+        conv_fut: Future = Future()
+        conv_fut.set_result(("conv.json", 1.0))
+
+        proc_fut: Future = Future()
+        proc_fut.set_result(("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en"))
+
+        pending_chunk_fut: Future = Future()
+
+        call_count = {"n": 0}
+
+        def is_cancelled(job_id):
+            call_count["n"] += 1
+            # Call 1: pre-loop check; Call 2: conversion poll — False so proc future submitted
+            # Call 3: processing poll — False so chunk future submitted
+            # Call 4: chunking poll — True so pending_chunk_fut is cancelled
+            return call_count["n"] >= 4
+
+        mock_db = Mock()
+        mock_db.is_job_cancelled = Mock(side_effect=is_cancelled)
+
+        with (
+            patch("digitize.processing.orchestrator.db_manager", mock_db),
+            patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
+            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
+            patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
+            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
+            patch("digitize.processing.orchestrator.time.sleep"),
+        ):
+            conv_ex = MagicMock()
+            conv_ex.__enter__ = Mock(return_value=conv_ex)
+            conv_ex.__exit__ = Mock(return_value=False)
+            conv_ex.submit = Mock(return_value=conv_fut)
+            mock_ppe.return_value = conv_ex
+
+            submit_calls = {"n": 0}
+
+            def thread_submit(*args, **kwargs):
+                submit_calls["n"] += 1
+                if submit_calls["n"] == 1:
+                    return proc_fut
+                return pending_chunk_fut
+
+            thread_ex = MagicMock()
+            thread_ex.__enter__ = Mock(return_value=thread_ex)
+            thread_ex.__exit__ = Mock(return_value=False)
+            thread_ex.submit = Mock(side_effect=thread_submit)
+            mock_tpe.return_value = thread_ex
+
+            with pytest.raises(JobCancelledError):
+                process_documents(
+                    input_paths=["fake.pdf"],
+                    out_path="/tmp/out",
+                    llm_model="m", llm_endpoint="e",
+                    emb_endpoint="emb",
+                    max_tokens=512,
+                    job_id="job-cancel-chunk",
+                    doc_id_dict={"fake.pdf": "doc-1"},
+                )
+
+        assert pending_chunk_fut.cancelled()
+
+
+@pytest.mark.unit
+class TestOrchestratorCancellationAtIndexingStage:
+    """Cancellation observed while indexing futures are in-flight."""
+
+    def test_pending_indexing_future_is_cancelled(self):
+        """A pending (not yet running) indexing future must be cancelled.
+
+        is_job_cancelled is called once per poll-loop iteration:
+          call 1 → conversion stage   (line 550)
+          call 2 → processing stage   (line 609)
+          call 3 → chunking stage     (line 678)
+          call 4 → indexing stage     (line 761)
+
+        Returning False for the first 3 lets the pipeline submit work all the
+        way to the indexing executor before we signal cancellation.
+        """
+        from digitize.processing.orchestrator import process_documents
+
+        conv_fut: Future = Future()
+        conv_fut.set_result(("conv.json", 1.0))
+
+        proc_fut: Future = Future()
+        proc_fut.set_result(("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en"))
+
+        chunk_result = ("text_chunks.json", "table_chunks.json", 2.5)
+        chunk_fut: Future = Future()
+        chunk_fut.set_result(chunk_result)
+
+        pending_index_fut: Future = Future()
+
+        check_count = {"n": 0}
+
+        def is_cancelled(job_id):
+            check_count["n"] += 1
+            # Call 1: pre-loop check; Call 2: conversion poll — False → proc submitted
+            # Call 3: processing poll — False → chunk submitted
+            # Call 4: chunking poll — False → index future submitted
+            # Call 5: indexing poll — True → pending_index_fut is cancelled
+            return check_count["n"] >= 5
+
+        mock_db = Mock()
+        mock_db.is_job_cancelled = Mock(side_effect=is_cancelled)
+
+        with (
+            patch("digitize.processing.orchestrator.db_manager", mock_db),
+            patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
+            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
+            patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
+            patch("digitize.processing.orchestrator.count_chunks", return_value=5),
+            patch("digitize.processing.orchestrator.merge_chunked_documents", return_value=[]),
+            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
+            patch("digitize.processing.orchestrator.time.sleep"),
+        ):
+            conv_ex = MagicMock()
+            conv_ex.__enter__ = Mock(return_value=conv_ex)
+            conv_ex.__exit__ = Mock(return_value=False)
+            conv_ex.submit = Mock(return_value=conv_fut)
+            mock_ppe.return_value = conv_ex
+
+            submit_calls = {"n": 0}
+
+            def thread_submit(*args, **kwargs):
+                n = submit_calls["n"]
+                submit_calls["n"] += 1
+                if n == 0:
+                    return proc_fut
+                if n == 1:
+                    return chunk_fut
+                return pending_index_fut
+
+            thread_ex = MagicMock()
+            thread_ex.__enter__ = Mock(return_value=thread_ex)
+            thread_ex.__exit__ = Mock(return_value=False)
+            thread_ex.submit = Mock(side_effect=thread_submit)
+            mock_tpe.return_value = thread_ex
+
+            with pytest.raises(JobCancelledError):
+                process_documents(
+                    input_paths=["fake.pdf"],
+                    out_path="/tmp/out",
+                    llm_model="m", llm_endpoint="e",
+                    emb_endpoint="emb",
+                    max_tokens=512,
+                    job_id="job-cancel-index",
+                    doc_id_dict={"fake.pdf": "doc-1"},
+                    indexing_callback=lambda doc_id, chunks, path: True,
+                )
+
+        assert pending_index_fut.cancelled()
+
+    def test_running_indexing_future_is_let_to_complete(self):
+        """An already-running indexing future must NOT be cancelled — it must
+        finish so no stale entries are left in the VDB."""
+        from digitize.processing.orchestrator import process_documents
+
+        conv_fut: Future = Future()
+        conv_fut.set_result(("conv.json", 1.0))
+
+        proc_fut: Future = Future()
+        proc_fut.set_result(("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en"))
+
+        chunk_fut: Future = Future()
+        chunk_fut.set_result(("text_chunks.json", "table_chunks.json", 2.5))
+
+        # Resolves to True (success) via a background thread so the poll loop
+        # drains naturally instead of spinning forever on a never-done future.
+        running_index_fut = _make_running_future(result=True)
+
+        # is_cancelled must be False for the conversion, processing, and
+        # chunking poll loops so the pipeline actually reaches the indexing
+        # stage.  Only return True starting from the 4th call (indexing loop).
+        _cancel_calls = {"n": 0}
+
+        def _is_cancelled(job_id):
+            _cancel_calls["n"] += 1
+            return _cancel_calls["n"] >= 4
+
+        mock_db = Mock()
+        mock_db.is_job_cancelled = Mock(side_effect=_is_cancelled)
+
+        with (
+            patch("digitize.processing.orchestrator.db_manager", mock_db),
+            patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
+            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
+            patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
+            patch("digitize.processing.orchestrator.count_chunks", return_value=3),
+            patch("digitize.processing.orchestrator.merge_chunked_documents", return_value=[]),
+            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
+            patch("digitize.processing.orchestrator.time.sleep"),
+        ):
+            conv_ex = MagicMock()
+            conv_ex.__enter__ = Mock(return_value=conv_ex)
+            conv_ex.__exit__ = Mock(return_value=False)
+            conv_ex.submit = Mock(return_value=conv_fut)
+            mock_ppe.return_value = conv_ex
+
+            submit_calls = {"n": 0}
+
+            def thread_submit(*args, **kwargs):
+                n = submit_calls["n"]
+                submit_calls["n"] += 1
+                if n == 0:
+                    return proc_fut
+                if n == 1:
+                    return chunk_fut
+                return running_index_fut
+
+            thread_ex = MagicMock()
+            thread_ex.__enter__ = Mock(return_value=thread_ex)
+            thread_ex.__exit__ = Mock(return_value=False)
+            thread_ex.submit = Mock(side_effect=thread_submit)
+            mock_tpe.return_value = thread_ex
+
+            with pytest.raises(JobCancelledError):
+                process_documents(
+                    input_paths=["fake.pdf"],
+                    out_path="/tmp/out",
+                    llm_model="m", llm_endpoint="e",
+                    emb_endpoint="emb",
+                    max_tokens=512,
+                    job_id="job-running-index",
+                    doc_id_dict={"fake.pdf": "doc-1"},
+                    indexing_callback=lambda doc_id, chunks, path: True,
+                )
+
+        assert not running_index_fut.cancelled()
+
+
+@pytest.mark.unit
+class TestOrchestratorHappyPath:
+    """Sanity check: non-cancelled jobs reach the end without JobCancelledError."""
+
+    def test_no_cancellation_returns_stats(self):
+        from digitize.processing.orchestrator import process_documents
+
+        conv_fut: Future = Future()
+        conv_fut.set_result(("conv.json", 1.5))
+
+        proc_fut: Future = Future()
+        proc_fut.set_result(("txt.json", "tab.json", 10, 3, {"process_text": 0.5, "process_tables": 0.3}, "en"))
+
+        chunk_fut: Future = Future()
+        chunk_fut.set_result(("text_chunks.json", "table_chunks.json", 1.2))
+
+        mock_db = Mock()
+        mock_db.is_job_cancelled = Mock(return_value=False)
+
+        with (
+            patch("digitize.processing.orchestrator.db_manager", mock_db),
+            patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
+            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
+            patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
+            patch("digitize.processing.orchestrator.count_chunks", return_value=8),
+            patch("digitize.processing.orchestrator.merge_chunked_documents", return_value=[]),
+            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
+            patch("digitize.processing.orchestrator.time.sleep"),
+        ):
+            conv_ex = MagicMock()
+            conv_ex.__enter__ = Mock(return_value=conv_ex)
+            conv_ex.__exit__ = Mock(return_value=False)
+            conv_ex.submit = Mock(return_value=conv_fut)
+            mock_ppe.return_value = conv_ex
+
+            submit_calls = {"n": 0}
+
+            def thread_submit(*args, **kwargs):
+                n = submit_calls["n"]
+                submit_calls["n"] += 1
+                if n == 0:
+                    return proc_fut
+                return chunk_fut
+
+            thread_ex = MagicMock()
+            thread_ex.__enter__ = Mock(return_value=thread_ex)
+            thread_ex.__exit__ = Mock(return_value=False)
+            thread_ex.submit = Mock(side_effect=thread_submit)
+            mock_tpe.return_value = thread_ex
+
+            _, pdf_stats = process_documents(
+                input_paths=["fake.pdf"],
+                out_path="/tmp/out",
+                llm_model="m", llm_endpoint="e",
+                emb_endpoint="emb",
+                max_tokens=512,
+                job_id="job-ok",
+                doc_id_dict={"fake.pdf": "doc-1"},
+            )
+
+        # Stats for the processed file must be present
+        assert any("fake.pdf" in k for k in pdf_stats)
+
+
+@pytest.mark.unit
+class TestOrchestratorCancellationWith10Files:
+    """Regression test for the 10-file race where cancellation is observed only
+    after some conversion futures have already completed and their downstream
+    process_futures have been submitted.
+
+    Scenario
+    --------
+    10 files are submitted.  The ProcessPoolExecutor has 4 workers, so the
+    first 4 conversions complete in loop-iteration-1 (is_cancelled=False) and
+    their process_futures are queued.  Loop-iteration-2 observes
+    is_cancelled=True: the remaining conversion futures are pending and get
+    cancelled, but the 4 already-queued process_futures must *also* be
+    cancelled before JobCancelledError is raised — otherwise they run to
+    completion inside the executor's shutdown(wait=True).
+    """
+
+    def test_queued_process_futures_are_cancelled_when_cancel_arrives_mid_batch(self):
+        """process_futures submitted before cancel was observed must be cancelled."""
+        from digitize.processing.orchestrator import process_documents
+
+        n_files = 10
+        n_early = 4  # conversions that complete *before* cancel is observed
+
+        file_names = [f"file{i}.pdf" for i in range(n_files)]
+        doc_id_dict = {fn: f"doc-{i}" for i, fn in enumerate(file_names)}
+
+        # Build conversion futures:
+        #   first n_early are already done (simulate completed before cancel)
+        #   rest are pending (not started)
+        early_conv_futs = []
+        for _ in range(n_early):
+            f: Future = Future()
+            f.set_result(("conv.json", 1.0))
+            early_conv_futs.append(f)
+
+        late_conv_futs = []
+        for _ in range(n_files - n_early):
+            late_conv_futs.append(Future())  # pending, never resolved
+
+        all_conv_futs = early_conv_futs + late_conv_futs
+
+        # process_futures returned when processor_executor.submit() is called
+        # (only for the n_early docs whose conversion finished before cancel).
+        # These start as pending — they must be cancelled by the fix.
+        process_futs = []
+        for _ in range(n_early):
+            process_futs.append(Future())  # pending
+
+        submit_idx = {"n": 0}
+
+        def conv_submit(*args, **kwargs):
+            idx = submit_idx["n"]
+            submit_idx["n"] += 1
+            return all_conv_futs[idx]
+
+        # is_job_cancelled: False on first check (conversion loop iter 1),
+        # True from the second check onward (iter 2 when cancel arrives).
+        cancel_call = {"n": 0}
+
+        def is_cancelled(job_id):
+            cancel_call["n"] += 1
+            # Call 1: pre-loop check — False
+            # Call 2: conversion poll iteration 1 — False so early conv futures submit process_futs
+            # Call 3: conversion poll iteration 2 — True so late conv futures are cancelled
+            #         and process_futures (already submitted) are then cancelled before raising
+            return cancel_call["n"] >= 3
+
+        mock_db = Mock()
+        mock_db.is_job_cancelled = Mock(side_effect=is_cancelled)
+
+        proc_submit_idx = {"n": 0}
+
+        def proc_submit(*args, **kwargs):
+            idx = proc_submit_idx["n"]
+            proc_submit_idx["n"] += 1
+            return process_futs[idx]
+
+        with (
+            patch("digitize.processing.orchestrator.db_manager", mock_db),
+            patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
+            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
+            patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
+            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
+            patch("digitize.processing.orchestrator.time.sleep"),
+        ):
+            conv_ex = MagicMock()
+            conv_ex.__enter__ = Mock(return_value=conv_ex)
+            conv_ex.__exit__ = Mock(return_value=False)
+            conv_ex.submit = Mock(side_effect=conv_submit)
+            mock_ppe.return_value = conv_ex
+
+            proc_ex = MagicMock()
+            proc_ex.__enter__ = Mock(return_value=proc_ex)
+            proc_ex.__exit__ = Mock(return_value=False)
+            proc_ex.submit = Mock(side_effect=proc_submit)
+            mock_tpe.return_value = proc_ex
+
+            with pytest.raises(JobCancelledError):
+                process_documents(
+                    input_paths=file_names,
+                    out_path="/tmp/out",
+                    llm_model="m", llm_endpoint="e",
+                    emb_endpoint="emb",
+                    max_tokens=512,
+                    job_id="job-10-files",
+                    doc_id_dict=doc_id_dict,
+                )
+
+        # Every process_future that was submitted before cancel was observed
+        # must have been cancelled, not left to run.
+        for i, pf in enumerate(process_futs):
+            assert pf.cancelled(), (
+                f"process_future[{i}] was NOT cancelled — "
+                "the fix to cancel queued downstream futures at the "
+                "conversion→process boundary is missing or incomplete"
+            )
+
+    def test_queued_chunk_futures_are_cancelled_when_cancel_arrives_mid_processing(self):
+        """chunk_futures submitted before cancel was observed must be cancelled."""
+        from digitize.processing.orchestrator import process_documents
+
+        n_files = 10
+        n_early = 4  # files whose processing completes before cancel is observed
+
+        file_names = [f"file{i}.pdf" for i in range(n_files)]
+        doc_id_dict = {fn: f"doc-{i}" for i, fn in enumerate(file_names)}
+
+        # All conversions complete immediately (pre-cancel).
+        conv_futs = []
+        for _ in range(n_files):
+            f: Future = Future()
+            f.set_result(("conv.json", 1.0))
+            conv_futs.append(f)
+
+        # Processing futures:
+        #   first n_early are done (completed before cancel is observed in proc loop)
+        #   rest are pending (never resolved — will be in pending_process when cancel hits)
+        early_proc_futs = []
+        for _ in range(n_early):
+            f: Future = Future()
+            f.set_result(("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en"))
+            early_proc_futs.append(f)
+
+        late_proc_futs = [Future() for _ in range(n_files - n_early)]
+
+        all_proc_futs = early_proc_futs + late_proc_futs
+
+        # chunk_futures submitted for the n_early docs — must be cancelled.
+        chunk_futs = [Future() for _ in range(n_early)]
+
+        conv_idx = {"n": 0}
+        proc_idx = {"n": 0}
+        chunk_idx = {"n": 0}
+
+        def conv_submit(*args, **kwargs):
+            idx = conv_idx["n"]
+            conv_idx["n"] += 1
+            return conv_futs[idx]
+
+        cancel_call = {"n": 0}
+
+        def is_cancelled(job_id):
+            cancel_call["n"] += 1
+            # Call 1: pre-loop check — False
+            # Call 2: conversion poll — False → all 10 proc futures submitted
+            # Call 3: processing poll iteration 1 — False → early proc futures submit chunk_futs
+            # Call 4: processing poll iteration 2 — True → late proc futures cancelled,
+            #         already-queued chunk_futs are cancelled before raising
+            return cancel_call["n"] >= 4
+
+        mock_db = Mock()
+        mock_db.is_job_cancelled = Mock(side_effect=is_cancelled)
+
+        thread_submit_idx = {"n": 0}
+
+        def thread_submit(*args, **kwargs):
+            idx = thread_submit_idx["n"]
+            thread_submit_idx["n"] += 1
+            if idx < n_files:
+                return all_proc_futs[idx]
+            # chunk_futs come after all proc_futs
+            chunk_idx_val = idx - n_files
+            return chunk_futs[chunk_idx_val]
+
+        with (
+            patch("digitize.processing.orchestrator.db_manager", mock_db),
+            patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
+            patch("digitize.processing.orchestrator.ProcessPoolExecutor") as mock_ppe,
+            patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
+            patch("digitize.processing.orchestrator.get_document_page_count", return_value=1),
+            patch("digitize.processing.orchestrator.time.sleep"),
+        ):
+            conv_ex = MagicMock()
+            conv_ex.__enter__ = Mock(return_value=conv_ex)
+            conv_ex.__exit__ = Mock(return_value=False)
+            conv_ex.submit = Mock(side_effect=conv_submit)
+            mock_ppe.return_value = conv_ex
+
+            thread_ex = MagicMock()
+            thread_ex.__enter__ = Mock(return_value=thread_ex)
+            thread_ex.__exit__ = Mock(return_value=False)
+            thread_ex.submit = Mock(side_effect=thread_submit)
+            mock_tpe.return_value = thread_ex
+
+            with pytest.raises(JobCancelledError):
+                process_documents(
+                    input_paths=file_names,
+                    out_path="/tmp/out",
+                    llm_model="m", llm_endpoint="e",
+                    emb_endpoint="emb",
+                    max_tokens=512,
+                    job_id="job-10-files-proc",
+                    doc_id_dict=doc_id_dict,
+                )
+
+        for i, cf in enumerate(chunk_futs):
+            assert cf.cancelled(), (
+                f"chunk_future[{i}] was NOT cancelled — "
+                "the fix to cancel queued downstream futures at the "
+                "processing→chunk boundary is missing or incomplete"
+            )

--- a/services/digitize/tests/test_cancel_job.py
+++ b/services/digitize/tests/test_cancel_job.py
@@ -347,14 +347,16 @@ class TestRunDigitize:
                 doc_id_dict={"sample.pdf": "doc-active"},
             )
 
-        # Completed doc must NOT be touched
-        update_calls = mock_db.update_document.call_args_list
-        updated_doc_ids = [c.args[0] for c in update_calls]
+        # Completed doc must NOT be touched via status manager
+        doc_meta_calls = mock_status_mgr.update_doc_metadata.call_args_list
+        updated_doc_ids = [c.args[0] for c in doc_meta_calls]
         assert "doc-done" not in updated_doc_ids
 
-        # In-progress doc must be marked CANCELLED
+        # In-progress doc must be marked CANCELLED via status manager
         assert "doc-active" in updated_doc_ids
-        mock_db.update_job.assert_called_once_with(job_id, status=JobStatus.CANCELLED)
+        mock_status_mgr.update_job_progress.assert_called_once_with(
+            "", DocStatus.CANCELLED, JobStatus.CANCELLED
+        )
 
     @pytest.mark.asyncio
     async def test_terminal_docs_are_not_overwritten_on_cancellation(self, tmp_path):
@@ -453,19 +455,23 @@ class TestRunIngest:
         mock_db.update_job = Mock()
         mock_db.get_job_by_id = Mock(return_value=Mock(stats={"clean_files": False}))
 
+        mock_status_mgr = Mock()
+
         with (
             patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
             patch("digitize.api.v1.jobs.db_manager", mock_db),
-            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
+            patch("digitize.api.v1.jobs.get_status_manager", return_value=mock_status_mgr),
             patch("digitize.api.v1.jobs.cleanup_staging_directory"),
             patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
         ):
             await jobs_module._run_ingest(job_id, {"file.pdf": "doc-pending"})
 
-        updated = [c.args[0] for c in mock_db.update_document.call_args_list]
+        updated = [c.args[0] for c in mock_status_mgr.update_doc_metadata.call_args_list]
         assert "doc-pending" in updated
         assert "doc-done" not in updated
-        mock_db.update_job.assert_called_once_with(job_id, status=JobStatus.CANCELLED)
+        mock_status_mgr.update_job_progress.assert_called_once_with(
+            "", DocStatus.CANCELLED, JobStatus.CANCELLED
+        )
 
     @pytest.mark.asyncio
     async def test_clean_files_true_removes_vector_db_entries(self, tmp_path):

--- a/services/digitize/tests/test_cancel_job.py
+++ b/services/digitize/tests/test_cancel_job.py
@@ -1569,3 +1569,621 @@ class TestMakeDbCancelCheck:
             dm_mod.db_manager = original
 
         assert result is False
+
+
+# ===========================================================================
+# 8. chunk_text / chunk_tables / chunk_single_file — cancel_event support
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestChunkTextCancelEvent:
+    """chunk_text respects a cancel_event threading.Event."""
+
+    def test_cancel_event_not_set_processes_all_blocks(self, tmp_path):
+        """With cancel_event unset, all blocks are chunked normally."""
+        from digitize.processing.orchestrator import chunk_text
+        import json, threading
+
+        data = [
+            {"label": "text", "text": "Hello world", "page": 1},
+            {"label": "text", "text": "Second block", "page": 2},
+        ]
+        input_file = tmp_path / "doc-1_text.json"
+        input_file.write_text(json.dumps(data))
+
+        event = threading.Event()  # not set
+
+        with (
+            patch("digitize.processing.orchestrator.count_tokens", return_value=5),
+            patch("digitize.processing.orchestrator.collect_header_font_sizes", return_value={}),
+            patch("digitize.processing.orchestrator.get_header_level", return_value=(1, "h")),
+            patch("digitize.processing.orchestrator.flush_chunk"),
+        ):
+            result_path, elapsed = chunk_text(
+                str(input_file), str(tmp_path), emb_endpoint="emb",
+                doc_id="doc-1", cancel_event=event,
+            )
+
+        assert result_path is not None
+        assert elapsed is not None
+
+    def test_cancel_event_set_before_first_block_returns_none(self, tmp_path):
+        """cancel_event already set → chunk_text returns (None, None).
+
+        chunk_text catches all exceptions internally; the JobCancelledError is
+        surfaced only by chunk_single_file which re-raises it.
+        """
+        from digitize.processing.orchestrator import chunk_text
+        import json, threading
+
+        data = [{"label": "text", "text": "Hello", "page": 1}]
+        input_file = tmp_path / "doc-2_text.json"
+        input_file.write_text(json.dumps(data))
+
+        event = threading.Event()
+        event.set()  # already cancelled
+
+        with (
+            patch("digitize.processing.orchestrator.count_tokens", return_value=5),
+            patch("digitize.processing.orchestrator.collect_header_font_sizes", return_value={}),
+            patch("digitize.processing.orchestrator.flush_chunk"),
+        ):
+            result_path, elapsed = chunk_text(
+                str(input_file), str(tmp_path), emb_endpoint="emb",
+                doc_id="doc-2", cancel_event=event,
+            )
+
+        assert result_path is None
+        assert elapsed is None
+
+    def test_cancel_event_set_mid_loop_returns_none(self, tmp_path):
+        """cancel_event set mid-loop → chunk_text returns (None, None).
+
+        Uses section_header blocks to trigger flush_chunk inside the loop — that
+        is the only place within the loop body where flush_chunk is called, so it
+        is the only reliable way to set the event before the *next* iteration's
+        cancel check fires.
+        """
+        from digitize.processing.orchestrator import chunk_text
+        import json, threading
+
+        # section_header triggers flush_chunk mid-loop; the cancel check at the
+        # top of the following iteration will then see the event as set.
+        data = [
+            {"label": "section_header", "text": "Chapter 1", "page": 1, "font_size": 16},
+            {"label": "text", "text": "Some content", "page": 1},
+            {"label": "section_header", "text": "Chapter 2", "page": 2, "font_size": 16},
+            {"label": "text", "text": "More content", "page": 2},
+        ]
+        input_file = tmp_path / "doc-3_text.json"
+        input_file.write_text(json.dumps(data))
+
+        event = threading.Event()
+        flush_count = {"n": 0}
+
+        # Set the event on the first flush_chunk call (first section_header).
+        # The cancel check at the top of the next iteration fires True.
+        def set_on_first_flush(*args, **kwargs):
+            flush_count["n"] += 1
+            if flush_count["n"] == 1:
+                event.set()
+
+        with (
+            patch("digitize.processing.orchestrator.count_tokens", return_value=5),
+            patch("digitize.processing.orchestrator.collect_header_font_sizes", return_value={}),
+            patch("digitize.processing.orchestrator.get_header_level", return_value=(1, "Chapter 1")),
+            patch("digitize.processing.orchestrator.flush_chunk", side_effect=set_on_first_flush),
+        ):
+            result_path, elapsed = chunk_text(
+                str(input_file), str(tmp_path), emb_endpoint="emb",
+                doc_id="doc-3", cancel_event=event,
+            )
+
+        assert result_path is None
+        assert elapsed is None
+
+    def test_no_cancel_event_processes_normally(self, tmp_path):
+        """cancel_event=None (default) behaves identically to before — no change."""
+        from digitize.processing.orchestrator import chunk_text
+        import json
+
+        data = [{"label": "text", "text": "Only block", "page": 1}]
+        input_file = tmp_path / "doc-4_text.json"
+        input_file.write_text(json.dumps(data))
+
+        with (
+            patch("digitize.processing.orchestrator.count_tokens", return_value=5),
+            patch("digitize.processing.orchestrator.collect_header_font_sizes", return_value={}),
+            patch("digitize.processing.orchestrator.flush_chunk"),
+        ):
+            result_path, elapsed = chunk_text(
+                str(input_file), str(tmp_path), emb_endpoint="emb",
+                doc_id="doc-4",
+            )
+
+        assert result_path is not None
+
+
+@pytest.mark.unit
+class TestChunkTablesCancelEvent:
+    """chunk_tables respects a cancel_event threading.Event."""
+
+    def test_cancel_event_not_set_processes_all_tables(self, tmp_path):
+        """With cancel_event unset, all tables are chunked normally."""
+        from digitize.processing.orchestrator import chunk_tables
+        import json, threading
+
+        data = {
+            "t1": {"caption": "Table 1", "summary": "Summary one", "page_number": 1},
+            "t2": {"caption": "Table 2", "summary": "Summary two", "page_number": 2},
+        }
+        input_file = tmp_path / "doc-5_tables.json"
+        input_file.write_text(json.dumps(data))
+
+        event = threading.Event()  # not set
+
+        with patch("digitize.processing.orchestrator.count_tokens", return_value=10):
+            result_path, elapsed = chunk_tables(
+                str(input_file), str(tmp_path), emb_endpoint="emb",
+                doc_id="doc-5", cancel_event=event,
+            )
+
+        assert result_path is not None
+
+    def test_cancel_event_set_before_first_table_returns_none(self, tmp_path):
+        """cancel_event already set → chunk_tables returns (None, None).
+
+        Like chunk_text, chunk_tables catches all exceptions internally; the
+        JobCancelledError is surfaced only by chunk_single_file.
+        """
+        from digitize.processing.orchestrator import chunk_tables
+        import json, threading
+
+        data = {"t1": {"caption": "Table 1", "summary": "Sum", "page_number": 1}}
+        input_file = tmp_path / "doc-6_tables.json"
+        input_file.write_text(json.dumps(data))
+
+        event = threading.Event()
+        event.set()
+
+        with patch("digitize.processing.orchestrator.count_tokens", return_value=5):
+            result_path, elapsed = chunk_tables(
+                str(input_file), str(tmp_path), emb_endpoint="emb",
+                doc_id="doc-6", cancel_event=event,
+            )
+
+        assert result_path is None
+        assert elapsed is None
+
+    def test_cancel_event_set_mid_loop_returns_none(self, tmp_path):
+        """cancel_event set after first table → chunk_tables returns (None, None)."""
+        from digitize.processing.orchestrator import chunk_tables
+        import json, threading
+
+        data = {
+            "t1": {"caption": "T1", "summary": "S1", "page_number": 1},
+            "t2": {"caption": "T2", "summary": "S2", "page_number": 2},
+        }
+        input_file = tmp_path / "doc-7_tables.json"
+        input_file.write_text(json.dumps(data))
+
+        event = threading.Event()
+        call_count = {"n": 0}
+
+        # Set the event after count_tokens is first called (first table visited).
+        # The cancel check at the top of the next iteration fires True.
+        def set_after_first(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] >= 1:
+                event.set()
+            return 5
+
+        with patch("digitize.processing.orchestrator.count_tokens", side_effect=set_after_first):
+            result_path, elapsed = chunk_tables(
+                str(input_file), str(tmp_path), emb_endpoint="emb",
+                doc_id="doc-7", cancel_event=event,
+            )
+
+        assert result_path is None
+        assert elapsed is None
+
+    def test_no_cancel_event_processes_normally(self, tmp_path):
+        """cancel_event=None (default) — no change in behaviour."""
+        from digitize.processing.orchestrator import chunk_tables
+        import json
+
+        data = {"t1": {"caption": "T1", "summary": "Sum", "page_number": 1}}
+        input_file = tmp_path / "doc-8_tables.json"
+        input_file.write_text(json.dumps(data))
+
+        with patch("digitize.processing.orchestrator.count_tokens", return_value=5):
+            result_path, elapsed = chunk_tables(
+                str(input_file), str(tmp_path), emb_endpoint="emb",
+                doc_id="doc-8",
+            )
+
+        assert result_path is not None
+
+
+@pytest.mark.unit
+class TestChunkSingleFileCancelEvent:
+    """chunk_single_file forwards cancel_event and re-raises JobCancelledError."""
+
+    def test_cancel_event_set_propagates_as_job_cancelled_error(self, tmp_path):
+        """When chunk_text raises JobCancelledError, chunk_single_file re-raises it."""
+        from digitize.processing.orchestrator import chunk_single_file
+        import threading
+
+        event = threading.Event()
+        event.set()
+
+        with (
+            patch(
+                "digitize.processing.orchestrator.chunk_text",
+                side_effect=JobCancelledError("cancelled"),
+            ),
+            patch("digitize.processing.orchestrator.chunk_tables"),
+        ):
+            with pytest.raises(JobCancelledError):
+                chunk_single_file(
+                    "txt.json", "tab.json", str(tmp_path),
+                    emb_endpoint="emb", doc_id="doc-9",
+                    cancel_event=event,
+                )
+
+    def test_cancel_event_forwarded_to_chunk_text_and_chunk_tables(self, tmp_path):
+        """cancel_event is forwarded to both chunk_text and chunk_tables."""
+        from digitize.processing.orchestrator import chunk_single_file
+        import threading
+
+        event = threading.Event()
+
+        txt_result = tmp_path / "doc-10_text_chunks.json"
+        tab_result = tmp_path / "doc-10_table_chunks.json"
+
+        with (
+            patch(
+                "digitize.processing.orchestrator.chunk_text",
+                return_value=(str(txt_result), 0.5),
+            ) as mock_chunk_text,
+            patch(
+                "digitize.processing.orchestrator.chunk_tables",
+                return_value=(str(tab_result), 0.3),
+            ) as mock_chunk_tables,
+        ):
+            chunk_single_file(
+                "txt.json", "tab.json", str(tmp_path),
+                emb_endpoint="emb", doc_id="doc-10",
+                cancel_event=event,
+            )
+
+        # Verify cancel_event was forwarded to both inner calls
+        assert mock_chunk_text.call_args.kwargs.get("cancel_event") is event
+        assert mock_chunk_tables.call_args.kwargs.get("cancel_event") is event
+
+
+# ===========================================================================
+# 9. OpenSearch insert_chunks — cancel_event between batches
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestOpenSearchInsertChunksCancelEvent:
+    """insert_chunks aborts between batches when cancel_event is set."""
+
+    def _make_opensearch(self):
+        from common.opensearch import OpensearchVectorStore
+        inst = OpensearchVectorStore.__new__(OpensearchVectorStore)
+        inst.index_name = "test-index"
+        inst.client = MagicMock()
+        inst.client.indices.exists = Mock(return_value=True)
+        return inst
+
+    def test_cancel_event_not_set_inserts_all_batches(self):
+        """All batches are inserted when cancel_event is not set."""
+        import threading
+
+        inst = self._make_opensearch()
+        inst._setup_index = Mock()
+
+        chunks = [{"page_content": f"chunk {i}", "filename": "f.pdf"} for i in range(5)]
+        embedder = Mock()
+        embedder.embed_documents = Mock(return_value=[[0.1] * 4] * 5)
+
+        event = threading.Event()  # not set
+
+        with patch("common.opensearch.helpers.bulk", return_value=(5, [])):
+            result = inst.insert_chunks(chunks, embedding=embedder, batch_size=2, cancel_event=event)
+
+        assert result is True
+
+    def test_cancel_event_set_aborts_before_first_batch(self):
+        """cancel_event already set → returns False before any bulk insert."""
+        import threading
+
+        inst = self._make_opensearch()
+        inst._setup_index = Mock()
+
+        chunks = [{"page_content": f"chunk {i}", "filename": "f.pdf"} for i in range(4)]
+        embedder = Mock()
+        embedder.embed_documents = Mock(return_value=[[0.1] * 4] * 4)
+
+        event = threading.Event()
+        event.set()
+
+        with patch("common.opensearch.helpers.bulk") as mock_bulk:
+            result = inst.insert_chunks(chunks, embedding=embedder, batch_size=2, cancel_event=event)
+
+        assert result is False
+        mock_bulk.assert_not_called()
+
+    def test_cancel_event_set_between_batches_aborts_mid_insert(self):
+        """cancel_event set after the first batch → second batch is not inserted."""
+        import threading
+
+        inst = self._make_opensearch()
+        inst._setup_index = Mock()
+
+        chunks = [{"page_content": f"chunk {i}", "filename": "f.pdf"} for i in range(4)]
+        embedder = Mock()
+        embedder.embed_documents = Mock(return_value=[[0.1] * 4] * 4)
+
+        event = threading.Event()
+        bulk_call_count = {"n": 0}
+
+        def fake_bulk(*args, **kwargs):
+            bulk_call_count["n"] += 1
+            event.set()  # set after first batch so second is cancelled
+            return (2, [])
+
+        with patch("common.opensearch.helpers.bulk", side_effect=fake_bulk):
+            result = inst.insert_chunks(chunks, embedding=embedder, batch_size=2, cancel_event=event)
+
+        assert result is False
+        assert bulk_call_count["n"] == 1  # only first batch executed
+
+    def test_no_cancel_event_inserts_all_batches(self):
+        """cancel_event=None (default) — full insert as before."""
+        inst = self._make_opensearch()
+        inst._setup_index = Mock()
+
+        chunks = [{"page_content": f"chunk {i}", "filename": "f.pdf"} for i in range(3)]
+        embedder = Mock()
+        embedder.embed_documents = Mock(return_value=[[0.1] * 4] * 3)
+
+        with patch("common.opensearch.helpers.bulk", return_value=(3, [])):
+            result = inst.insert_chunks(chunks, embedding=embedder, batch_size=2)
+
+        assert result is True
+
+
+# ===========================================================================
+# 10. process_documents — _index_cancel_event gated by clean_files
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestOrchestratorIndexCancelEventCleanFilesGating:
+    """_index_cancel_event is only set (and queued futures only cancelled) when
+    clean_files=True.  When clean_files=False a running insert_chunks call is
+    let to finish so no partial VDB entries are stranded.
+    """
+
+    def _base_setup(self):
+        """Return commonly shared futures and task stub."""
+        task = _make_task_stub("t-1", "completed", result_path="conv.json")
+
+        proc_fut: Future = Future()
+        proc_fut.set_result(
+            ("txt.json", "tab.json", 5, 2, {"process_text": 0.1, "process_tables": 0.1}, "en")
+        )
+
+        chunk_fut: Future = Future()
+        chunk_fut.set_result(("text_chunks.json", "table_chunks.json", 2.5))
+
+        return task, proc_fut, chunk_fut
+
+    def test_pending_index_future_cancelled_when_clean_files_true(self):
+        """clean_files=True → pending (not-yet-running) index future IS cancelled."""
+        from digitize.processing.orchestrator import process_documents
+
+        task, proc_fut, chunk_fut = self._base_setup()
+
+        pending_index_fut: Future = Future()  # PENDING — cancellable
+
+        cancel_calls = {"n": 0}
+
+        def is_cancelled(job_id):
+            cancel_calls["n"] += 1
+            return cancel_calls["n"] >= 5
+
+        mock_db = Mock()
+        mock_db.get_conversion_tasks_by_job_id = Mock(return_value=[task])
+        mock_db.is_job_cancelled = Mock(side_effect=is_cancelled)
+        mock_db.cancel_tasks_for_job = Mock()
+        mock_db.get_conversion_task = Mock(return_value=task)
+        # clean_files=True
+        mock_db.get_job_by_id = Mock(return_value=Mock(stats={"clean_files": True}))
+
+        submit_calls = {"n": 0}
+
+        def tpe_submit(*args, **kwargs):
+            n = submit_calls["n"]
+            submit_calls["n"] += 1
+            if n == 0:
+                return proc_fut
+            if n == 1:
+                return chunk_fut
+            return pending_index_fut
+
+        with (
+            patch("digitize.processing.orchestrator.db_manager", mock_db),
+            patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
+            patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
+            patch("digitize.processing.orchestrator.count_chunks", return_value=3),
+            patch("digitize.processing.orchestrator.merge_chunked_documents", return_value=[]),
+            patch("digitize.processing.orchestrator.time.sleep"),
+        ):
+            tpe_inst = MagicMock()
+            tpe_inst.__enter__ = Mock(return_value=tpe_inst)
+            tpe_inst.__exit__ = Mock(return_value=False)
+            tpe_inst.submit = Mock(side_effect=tpe_submit)
+            mock_tpe.return_value = tpe_inst
+
+            with pytest.raises(JobCancelledError):
+                process_documents(
+                    input_paths=["fake.pdf"],
+                    out_path="/tmp/out",
+                    llm_model="m", llm_endpoint="e",
+                    emb_endpoint="emb",
+                    max_tokens=512,
+                    job_id="job-cancel-clean-true",
+                    doc_id_dict={"fake.pdf": "doc-1"},
+                    indexing_callback=lambda doc_id, chunks, path, **kw: True,
+                )
+
+        assert pending_index_fut.cancelled(), "pending future must be cancelled when clean_files=True"
+
+    def test_running_index_future_not_cancelled_when_clean_files_false(self):
+        """clean_files=False → a RUNNING index future is NOT cancelled; it completes.
+
+        Uses the same gate pattern as TestOrchestratorCancellationAtIndexingStage:
+        a RUNNING future that only resolves after cancel is first detected, so the
+        poll loop definitely sees it as RUNNING when _clean_files=False is evaluated.
+        The key assertion is that the future completes (not cancelled).
+        """
+        from digitize.processing.orchestrator import process_documents
+
+        task, proc_fut, chunk_fut = self._base_setup()
+
+        cancel_seen = threading.Event()
+        running_index_fut: Future = Future()
+        running_index_fut.set_running_or_notify_cancel()  # → RUNNING
+
+        def _resolve_after_cancel():
+            cancel_seen.wait(timeout=5)
+            try:
+                running_index_fut.set_result(True)
+            except Exception:
+                pass
+
+        threading.Thread(target=_resolve_after_cancel, daemon=True).start()
+
+        cancel_calls = {"n": 0}
+
+        def is_cancelled(job_id):
+            cancel_calls["n"] += 1
+            if cancel_calls["n"] >= 3:
+                cancel_seen.set()
+                return True
+            return False
+
+        mock_db = Mock()
+        mock_db.get_conversion_tasks_by_job_id = Mock(return_value=[task])
+        mock_db.is_job_cancelled = Mock(side_effect=is_cancelled)
+        mock_db.cancel_tasks_for_job = Mock()
+        mock_db.get_conversion_task = Mock(return_value=task)
+        # clean_files=False — index cancel event must NOT be set
+        mock_db.get_job_by_id = Mock(return_value=Mock(stats={"clean_files": False}))
+
+        submit_calls = {"n": 0}
+
+        def tpe_submit(*args, **kwargs):
+            n = submit_calls["n"]
+            submit_calls["n"] += 1
+            if n == 0:
+                return proc_fut
+            if n == 1:
+                return chunk_fut
+            return running_index_fut
+
+        with (
+            patch("digitize.processing.orchestrator.db_manager", mock_db),
+            patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
+            patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
+            patch("digitize.processing.orchestrator.count_chunks", return_value=3),
+            patch("digitize.processing.orchestrator.merge_chunked_documents", return_value=[]),
+            patch("digitize.processing.orchestrator.time.sleep"),
+        ):
+            tpe_inst = MagicMock()
+            tpe_inst.__enter__ = Mock(return_value=tpe_inst)
+            tpe_inst.__exit__ = Mock(return_value=False)
+            tpe_inst.submit = Mock(side_effect=tpe_submit)
+            mock_tpe.return_value = tpe_inst
+
+            with pytest.raises(JobCancelledError):
+                process_documents(
+                    input_paths=["fake.pdf"],
+                    out_path="/tmp/out",
+                    llm_model="m", llm_endpoint="e",
+                    emb_endpoint="emb",
+                    max_tokens=512,
+                    job_id="job-cancel-clean-false",
+                    doc_id_dict={"fake.pdf": "doc-1"},
+                    indexing_callback=lambda doc_id, chunks, path, **kw: True,
+                )
+
+        assert not running_index_fut.cancelled(), "future must NOT be cancelled when clean_files=False"
+
+    def test_index_cancel_event_passed_to_indexing_callback(self):
+        """The cancel_event kwarg passed to indexing_callback is the _index_cancel_event,
+        and it is only set when clean_files=True."""
+        from digitize.processing.orchestrator import process_documents
+        import threading
+
+        task, proc_fut, chunk_fut = self._base_setup()
+
+        received_events: list = []
+        index_fut: Future = Future()
+        index_fut.set_result(True)
+
+        mock_db = Mock()
+        mock_db.get_conversion_tasks_by_job_id = Mock(return_value=[task])
+        mock_db.is_job_cancelled = Mock(return_value=False)
+        mock_db.cancel_tasks_for_job = Mock()
+        mock_db.get_conversion_task = Mock(return_value=task)
+
+        submit_calls = {"n": 0}
+
+        def tpe_submit(fn, *args, **kwargs):
+            n = submit_calls["n"]
+            submit_calls["n"] += 1
+            if n == 0:
+                return proc_fut
+            if n == 1:
+                return chunk_fut
+            # Capture the cancel_event passed to the indexing_callback submit
+            received_events.append(kwargs.get("cancel_event"))
+            return index_fut
+
+        with (
+            patch("digitize.processing.orchestrator.db_manager", mock_db),
+            patch("digitize.processing.orchestrator.get_status_manager", return_value=Mock()),
+            patch("digitize.processing.orchestrator.ContextAwareThreadPoolExecutor") as mock_tpe,
+            patch("digitize.processing.orchestrator.count_chunks", return_value=2),
+            patch("digitize.processing.orchestrator.merge_chunked_documents", return_value=[]),
+            patch("digitize.processing.orchestrator.time.sleep"),
+        ):
+            tpe_inst = MagicMock()
+            tpe_inst.__enter__ = Mock(return_value=tpe_inst)
+            tpe_inst.__exit__ = Mock(return_value=False)
+            tpe_inst.submit = Mock(side_effect=tpe_submit)
+            mock_tpe.return_value = tpe_inst
+
+            process_documents(
+                input_paths=["fake.pdf"],
+                out_path="/tmp/out",
+                llm_model="m", llm_endpoint="e",
+                emb_endpoint="emb",
+                max_tokens=512,
+                job_id="job-event-capture",
+                doc_id_dict={"fake.pdf": "doc-1"},
+                indexing_callback=lambda doc_id, chunks, path, **kw: True,
+            )
+
+        assert len(received_events) == 1
+        event = received_events[0]
+        assert isinstance(event, threading.Event), "cancel_event must be a threading.Event"
+        # On a non-cancelled job the index cancel event must NOT be set
+        assert not event.is_set(), "_index_cancel_event must be clear on a healthy run"

--- a/services/digitize/tests/test_cancel_job.py
+++ b/services/digitize/tests/test_cancel_job.py
@@ -87,6 +87,7 @@ for _attr, _name in [
 
 import digitize.app as digitize_app
 import digitize.api.v1.jobs as jobs_module
+import digitize.utils.jobs as dg_utils_module
 import digitize.utils.db as db_ops
 from digitize.exceptions import JobCancelledError
 from digitize.models import DocStatus, JobStatus
@@ -197,7 +198,12 @@ class TestCancelJobEndpoint:
         monkeypatch.setattr(db_ops, "get_job", Mock(return_value={
             "job_id": "job-active", "status": active_status, "stats": {},
         }))
-        monkeypatch.setattr("digitize.db.manager.db_manager.update_job", mock_update)
+        # Patch the full db_manager on dg_utils_module so get_job_by_id returns
+        # a row with a real stats dict (request_job_cancellation reads it).
+        monkeypatch.setattr(dg_utils_module, "db_manager", Mock(
+            update_job=mock_update,
+            get_job_by_id=Mock(return_value=Mock(stats={})),
+        ))
 
         response = test_client.post("/v1/jobs/job-active/cancel")
 
@@ -213,10 +219,12 @@ class TestCancelJobEndpoint:
             "status": JobStatus.IN_PROGRESS.value,
             "stats": existing_stats,
         }))
-        # db_manager is imported directly into jobs.py's namespace at line 27:
-        #   from digitize.db.manager import db_manager
-        # So the correct patch target is the jobs module, not db.manager.
-        monkeypatch.setattr(jobs_module, "db_manager", Mock(update_job=mock_update))
+        # Patch the full db_manager on dg_utils_module so get_job_by_id returns
+        # a row with a real stats dict (request_job_cancellation reads it).
+        monkeypatch.setattr(dg_utils_module, "db_manager", Mock(
+            update_job=mock_update,
+            get_job_by_id=Mock(return_value=Mock(stats=existing_stats)),
+        ))
 
         test_client.post("/v1/jobs/job-active/cancel")
 
@@ -231,12 +239,16 @@ class TestCancelJobEndpoint:
 
     def test_clean_files_false_stored_in_stats(self, test_client, monkeypatch):
         mock_update = Mock()
+        existing_stats = {"total_documents": 2}
         monkeypatch.setattr(db_ops, "get_job", Mock(return_value={
             "job_id": "job-ingest",
             "status": JobStatus.ACCEPTED.value,
-            "stats": {"total_documents": 2},
+            "stats": existing_stats,
         }))
-        monkeypatch.setattr(jobs_module, "db_manager", Mock(update_job=mock_update))
+        monkeypatch.setattr(dg_utils_module, "db_manager", Mock(
+            update_job=mock_update,
+            get_job_by_id=Mock(return_value=Mock(stats=existing_stats)),
+        ))
 
         test_client.post("/v1/jobs/job-ingest/cancel?clean_files=false")
 
@@ -250,7 +262,10 @@ class TestCancelJobEndpoint:
             "status": JobStatus.ACCEPTED.value,
             "stats": {},
         }))
-        monkeypatch.setattr(jobs_module, "db_manager", Mock(update_job=mock_update))
+        monkeypatch.setattr(dg_utils_module, "db_manager", Mock(
+            update_job=mock_update,
+            get_job_by_id=Mock(return_value=Mock(stats={})),
+        ))
 
         test_client.post("/v1/jobs/job-ingest/cancel?clean_files=true")
 
@@ -279,7 +294,10 @@ class TestCancelJobEndpoint:
             "status": JobStatus.ACCEPTED.value,
             "stats": {},
         }))
-        monkeypatch.setattr(jobs_module, "db_manager", Mock(update_job=mock_update))
+        monkeypatch.setattr(dg_utils_module, "db_manager", Mock(
+            update_job=mock_update,
+            get_job_by_id=Mock(return_value=Mock(stats={})),
+        ))
 
         # No ?clean_files query param
         test_client.post("/v1/jobs/job-ingest/cancel")
@@ -290,12 +308,16 @@ class TestCancelJobEndpoint:
     def test_existing_stats_are_preserved_alongside_clean_files(self, test_client, monkeypatch):
         """Pre-existing stats keys must be kept; only clean_files is added/overwritten."""
         mock_update = Mock()
+        existing_stats = {"total_documents": 5, "completed": 2}
         monkeypatch.setattr(db_ops, "get_job", Mock(return_value={
             "job_id": "job-ingest",
             "status": JobStatus.IN_PROGRESS.value,
-            "stats": {"total_documents": 5, "completed": 2},
+            "stats": existing_stats,
         }))
-        monkeypatch.setattr(jobs_module, "db_manager", Mock(update_job=mock_update))
+        monkeypatch.setattr(dg_utils_module, "db_manager", Mock(
+            update_job=mock_update,
+            get_job_by_id=Mock(return_value=Mock(stats=existing_stats)),
+        ))
 
         test_client.post("/v1/jobs/job-ingest/cancel?clean_files=true")
 
@@ -336,13 +358,13 @@ class TestRunDigitize:
         mock_status_mgr = Mock()
 
         with (
-            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("cancelled"))),
-            patch("digitize.api.v1.jobs.db_manager", mock_db),
-            patch("digitize.api.v1.jobs.get_status_manager", return_value=mock_status_mgr),
-            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+            patch("digitize.utils.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("cancelled"))),
+            patch("digitize.utils.jobs.db_manager", mock_db),
+            patch("digitize.utils.db.get_status_manager", return_value=mock_status_mgr),
+            patch("digitize.utils.jobs.cleanup_staging_directory"),
+            patch("digitize.utils.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
         ):
-            await jobs_module._run_digitize(
+            await dg_utils_module.launch_digitize_pipeline(
                 job_id=job_id,
                 doc_id_dict={"sample.pdf": "doc-active"},
             )
@@ -375,13 +397,13 @@ class TestRunDigitize:
         mock_db.update_job = Mock()
 
         with (
-            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
-            patch("digitize.api.v1.jobs.db_manager", mock_db),
-            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
-            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+            patch("digitize.utils.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
+            patch("digitize.utils.jobs.db_manager", mock_db),
+            patch("digitize.utils.db.get_status_manager", return_value=Mock()),
+            patch("digitize.utils.jobs.cleanup_staging_directory"),
+            patch("digitize.utils.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
         ):
-            await jobs_module._run_digitize(
+            await dg_utils_module.launch_digitize_pipeline(
                 job_id=job_id,
                 doc_id_dict={},
             )
@@ -394,16 +416,16 @@ class TestRunDigitize:
         mock_cleanup = Mock()
 
         with (
-            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
-            patch("digitize.api.v1.jobs.db_manager", Mock(
+            patch("digitize.utils.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
+            patch("digitize.utils.jobs.db_manager", Mock(
                 get_documents_by_job_id=Mock(return_value=[]),
                 update_job=Mock(),
             )),
-            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
-            patch("digitize.api.v1.jobs.cleanup_staging_directory", mock_cleanup),
-            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+            patch("digitize.utils.db.get_status_manager", return_value=Mock()),
+            patch("digitize.utils.jobs.cleanup_staging_directory", mock_cleanup),
+            patch("digitize.utils.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
         ):
-            await jobs_module._run_digitize("job-x", {})
+            await dg_utils_module.launch_digitize_pipeline("job-x", {})
 
         mock_cleanup.assert_called_once()
 
@@ -417,13 +439,13 @@ class TestRunDigitize:
         mock_status_mgr = Mock()
 
         with (
-            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=RuntimeError("boom"))),
-            patch("digitize.api.v1.jobs.db_manager", mock_db),
-            patch("digitize.api.v1.jobs.get_status_manager", return_value=mock_status_mgr),
-            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+            patch("digitize.utils.jobs.asyncio.to_thread", new=AsyncMock(side_effect=RuntimeError("boom"))),
+            patch("digitize.utils.jobs.db_manager", mock_db),
+            patch("digitize.utils.db.get_status_manager", return_value=mock_status_mgr),
+            patch("digitize.utils.jobs.cleanup_staging_directory"),
+            patch("digitize.utils.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
         ):
-            await jobs_module._run_digitize("job-fail", {})
+            await dg_utils_module.launch_digitize_pipeline("job-fail", {})
 
         mock_db.update_document.assert_not_called()
         mock_status_mgr.update_job_progress.assert_called()
@@ -458,13 +480,13 @@ class TestRunIngest:
         mock_status_mgr = Mock()
 
         with (
-            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
-            patch("digitize.api.v1.jobs.db_manager", mock_db),
-            patch("digitize.api.v1.jobs.get_status_manager", return_value=mock_status_mgr),
-            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+            patch("digitize.utils.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
+            patch("digitize.utils.jobs.db_manager", mock_db),
+            patch("digitize.utils.db.get_status_manager", return_value=mock_status_mgr),
+            patch("digitize.utils.jobs.cleanup_staging_directory"),
+            patch("digitize.utils.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
         ):
-            await jobs_module._run_ingest(job_id, {"file.pdf": "doc-pending"})
+            await dg_utils_module.launch_ingest_pipeline(job_id, {"file.pdf": "doc-pending"})
 
         updated = [c.args[0] for c in mock_status_mgr.update_doc_metadata.call_args_list]
         assert "doc-pending" in updated
@@ -492,14 +514,14 @@ class TestRunIngest:
         mock_vector_store.remove_docs_from_index = Mock(return_value=10)
 
         with (
-            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
-            patch("digitize.api.v1.jobs.db_manager", mock_db),
-            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
-            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+            patch("digitize.utils.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
+            patch("digitize.utils.jobs.db_manager", mock_db),
+            patch("digitize.utils.db.get_status_manager", return_value=Mock()),
+            patch("digitize.utils.jobs.cleanup_staging_directory"),
+            patch("digitize.utils.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
             patch("common.db_utils.get_vector_store", return_value=mock_vector_store),
         ):
-            await jobs_module._run_ingest(job_id, doc_id_dict)
+            await dg_utils_module.launch_ingest_pipeline(job_id, doc_id_dict)
 
         removed_ids = mock_vector_store.remove_docs_from_index.call_args.args[0]
         assert set(removed_ids) == {"doc-aaa", "doc-bbb"}
@@ -518,14 +540,14 @@ class TestRunIngest:
         mock_get_vector_store = Mock()
 
         with (
-            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
-            patch("digitize.api.v1.jobs.db_manager", mock_db),
-            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
-            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+            patch("digitize.utils.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
+            patch("digitize.utils.jobs.db_manager", mock_db),
+            patch("digitize.utils.db.get_status_manager", return_value=Mock()),
+            patch("digitize.utils.jobs.cleanup_staging_directory"),
+            patch("digitize.utils.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
             patch("common.db_utils.get_vector_store", mock_get_vector_store),
         ):
-            await jobs_module._run_ingest(job_id, {})
+            await dg_utils_module.launch_ingest_pipeline(job_id, {})
 
         mock_get_vector_store.assert_not_called()
 
@@ -547,15 +569,15 @@ class TestRunIngest:
         exploding_store.remove_docs_from_index = Mock(side_effect=RuntimeError("vdb down"))
 
         with (
-            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
-            patch("digitize.api.v1.jobs.db_manager", mock_db),
-            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
-            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+            patch("digitize.utils.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
+            patch("digitize.utils.jobs.db_manager", mock_db),
+            patch("digitize.utils.db.get_status_manager", return_value=Mock()),
+            patch("digitize.utils.jobs.cleanup_staging_directory"),
+            patch("digitize.utils.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
             patch("common.db_utils.get_vector_store", return_value=exploding_store),
         ):
             # Must not raise
-            await jobs_module._run_ingest(job_id, doc_id_dict)
+            await dg_utils_module.launch_ingest_pipeline(job_id, doc_id_dict)
 
     @pytest.mark.asyncio
     async def test_staging_cleanup_called_on_cancellation(self, tmp_path):
@@ -567,48 +589,15 @@ class TestRunIngest:
         mock_db.get_job_by_id = Mock(return_value=Mock(stats={}))
 
         with (
-            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
-            patch("digitize.api.v1.jobs.db_manager", mock_db),
-            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
-            patch("digitize.api.v1.jobs.cleanup_staging_directory", mock_cleanup),
-            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
+            patch("digitize.utils.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
+            patch("digitize.utils.jobs.db_manager", mock_db),
+            patch("digitize.utils.db.get_status_manager", return_value=Mock()),
+            patch("digitize.utils.jobs.cleanup_staging_directory", mock_cleanup),
+            patch("digitize.utils.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
         ):
-            await jobs_module._run_ingest("job-y", {})
+            await dg_utils_module.launch_ingest_pipeline("job-y", {})
 
         mock_cleanup.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_only_doc_ids_in_doc_id_dict_are_cleaned_from_vdb(self, tmp_path):
-        """Only doc IDs that belong to THIS job (present in doc_id_dict.values()) must
-        be submitted to remove_docs_from_index, not stray docs returned by the DB."""
-        job_id = "job-ingest-scope"
-        doc_id_dict = {"mine.pdf": "doc-mine"}
-
-        doc_mine = _make_doc("doc-mine", DocStatus.COMPLETED.value)
-        doc_foreign = _make_doc("doc-foreign", DocStatus.COMPLETED.value)  # not in this job's dict
-
-        mock_db = Mock()
-        mock_db.get_documents_by_job_id = Mock(return_value=[doc_mine, doc_foreign])
-        mock_db.update_document = Mock()
-        mock_db.update_job = Mock()
-        mock_db.get_job_by_id = Mock(return_value=Mock(stats={"clean_files": True}))
-
-        mock_vs = Mock()
-        mock_vs.remove_docs_from_index = Mock(return_value=1)
-
-        with (
-            patch("digitize.api.v1.jobs.asyncio.to_thread", new=AsyncMock(side_effect=JobCancelledError("c"))),
-            patch("digitize.api.v1.jobs.db_manager", mock_db),
-            patch("digitize.api.v1.jobs.get_status_manager", return_value=Mock()),
-            patch("digitize.api.v1.jobs.cleanup_staging_directory"),
-            patch("digitize.api.v1.jobs.settings", SimpleNamespace(digitize=SimpleNamespace(staging_dir=tmp_path))),
-            patch("common.db_utils.get_vector_store", return_value=mock_vs),
-        ):
-            await jobs_module._run_ingest(job_id, doc_id_dict)
-
-        removed = set(mock_vs.remove_docs_from_index.call_args.args[0])
-        assert removed == {"doc-mine"}
-        assert "doc-foreign" not in removed
 
 
 # ===========================================================================
@@ -1572,246 +1561,17 @@ class TestMakeDbCancelCheck:
 
 
 # ===========================================================================
-# 8. chunk_text / chunk_tables / chunk_single_file — cancel_event support
+# 8. chunk_single_file — cancel_event support
 # ===========================================================================
 
-
-@pytest.mark.unit
-class TestChunkTextCancelEvent:
-    """chunk_text respects a cancel_event threading.Event."""
-
-    def test_cancel_event_not_set_processes_all_blocks(self, tmp_path):
-        """With cancel_event unset, all blocks are chunked normally."""
-        from digitize.processing.orchestrator import chunk_text
-        import json, threading
-
-        data = [
-            {"label": "text", "text": "Hello world", "page": 1},
-            {"label": "text", "text": "Second block", "page": 2},
-        ]
-        input_file = tmp_path / "doc-1_text.json"
-        input_file.write_text(json.dumps(data))
-
-        event = threading.Event()  # not set
-
-        with (
-            patch("digitize.processing.orchestrator.count_tokens", return_value=5),
-            patch("digitize.processing.orchestrator.collect_header_font_sizes", return_value={}),
-            patch("digitize.processing.orchestrator.get_header_level", return_value=(1, "h")),
-            patch("digitize.processing.orchestrator.flush_chunk"),
-        ):
-            result_path, elapsed = chunk_text(
-                str(input_file), str(tmp_path), emb_endpoint="emb",
-                doc_id="doc-1", cancel_event=event,
-            )
-
-        assert result_path is not None
-        assert elapsed is not None
-
-    def test_cancel_event_set_before_first_block_returns_none(self, tmp_path):
-        """cancel_event already set → chunk_text returns (None, None).
-
-        chunk_text catches all exceptions internally; the JobCancelledError is
-        surfaced only by chunk_single_file which re-raises it.
-        """
-        from digitize.processing.orchestrator import chunk_text
-        import json, threading
-
-        data = [{"label": "text", "text": "Hello", "page": 1}]
-        input_file = tmp_path / "doc-2_text.json"
-        input_file.write_text(json.dumps(data))
-
-        event = threading.Event()
-        event.set()  # already cancelled
-
-        with (
-            patch("digitize.processing.orchestrator.count_tokens", return_value=5),
-            patch("digitize.processing.orchestrator.collect_header_font_sizes", return_value={}),
-            patch("digitize.processing.orchestrator.flush_chunk"),
-        ):
-            result_path, elapsed = chunk_text(
-                str(input_file), str(tmp_path), emb_endpoint="emb",
-                doc_id="doc-2", cancel_event=event,
-            )
-
-        assert result_path is None
-        assert elapsed is None
-
-    def test_cancel_event_set_mid_loop_returns_none(self, tmp_path):
-        """cancel_event set mid-loop → chunk_text returns (None, None).
-
-        Uses section_header blocks to trigger flush_chunk inside the loop — that
-        is the only place within the loop body where flush_chunk is called, so it
-        is the only reliable way to set the event before the *next* iteration's
-        cancel check fires.
-        """
-        from digitize.processing.orchestrator import chunk_text
-        import json, threading
-
-        # section_header triggers flush_chunk mid-loop; the cancel check at the
-        # top of the following iteration will then see the event as set.
-        data = [
-            {"label": "section_header", "text": "Chapter 1", "page": 1, "font_size": 16},
-            {"label": "text", "text": "Some content", "page": 1},
-            {"label": "section_header", "text": "Chapter 2", "page": 2, "font_size": 16},
-            {"label": "text", "text": "More content", "page": 2},
-        ]
-        input_file = tmp_path / "doc-3_text.json"
-        input_file.write_text(json.dumps(data))
-
-        event = threading.Event()
-        flush_count = {"n": 0}
-
-        # Set the event on the first flush_chunk call (first section_header).
-        # The cancel check at the top of the next iteration fires True.
-        def set_on_first_flush(*args, **kwargs):
-            flush_count["n"] += 1
-            if flush_count["n"] == 1:
-                event.set()
-
-        with (
-            patch("digitize.processing.orchestrator.count_tokens", return_value=5),
-            patch("digitize.processing.orchestrator.collect_header_font_sizes", return_value={}),
-            patch("digitize.processing.orchestrator.get_header_level", return_value=(1, "Chapter 1")),
-            patch("digitize.processing.orchestrator.flush_chunk", side_effect=set_on_first_flush),
-        ):
-            result_path, elapsed = chunk_text(
-                str(input_file), str(tmp_path), emb_endpoint="emb",
-                doc_id="doc-3", cancel_event=event,
-            )
-
-        assert result_path is None
-        assert elapsed is None
-
-    def test_no_cancel_event_processes_normally(self, tmp_path):
-        """cancel_event=None (default) behaves identically to before — no change."""
-        from digitize.processing.orchestrator import chunk_text
-        import json
-
-        data = [{"label": "text", "text": "Only block", "page": 1}]
-        input_file = tmp_path / "doc-4_text.json"
-        input_file.write_text(json.dumps(data))
-
-        with (
-            patch("digitize.processing.orchestrator.count_tokens", return_value=5),
-            patch("digitize.processing.orchestrator.collect_header_font_sizes", return_value={}),
-            patch("digitize.processing.orchestrator.flush_chunk"),
-        ):
-            result_path, elapsed = chunk_text(
-                str(input_file), str(tmp_path), emb_endpoint="emb",
-                doc_id="doc-4",
-            )
-
-        assert result_path is not None
-
-
-@pytest.mark.unit
-class TestChunkTablesCancelEvent:
-    """chunk_tables respects a cancel_event threading.Event."""
-
-    def test_cancel_event_not_set_processes_all_tables(self, tmp_path):
-        """With cancel_event unset, all tables are chunked normally."""
-        from digitize.processing.orchestrator import chunk_tables
-        import json, threading
-
-        data = {
-            "t1": {"caption": "Table 1", "summary": "Summary one", "page_number": 1},
-            "t2": {"caption": "Table 2", "summary": "Summary two", "page_number": 2},
-        }
-        input_file = tmp_path / "doc-5_tables.json"
-        input_file.write_text(json.dumps(data))
-
-        event = threading.Event()  # not set
-
-        with patch("digitize.processing.orchestrator.count_tokens", return_value=10):
-            result_path, elapsed = chunk_tables(
-                str(input_file), str(tmp_path), emb_endpoint="emb",
-                doc_id="doc-5", cancel_event=event,
-            )
-
-        assert result_path is not None
-
-    def test_cancel_event_set_before_first_table_returns_none(self, tmp_path):
-        """cancel_event already set → chunk_tables returns (None, None).
-
-        Like chunk_text, chunk_tables catches all exceptions internally; the
-        JobCancelledError is surfaced only by chunk_single_file.
-        """
-        from digitize.processing.orchestrator import chunk_tables
-        import json, threading
-
-        data = {"t1": {"caption": "Table 1", "summary": "Sum", "page_number": 1}}
-        input_file = tmp_path / "doc-6_tables.json"
-        input_file.write_text(json.dumps(data))
-
-        event = threading.Event()
-        event.set()
-
-        with patch("digitize.processing.orchestrator.count_tokens", return_value=5):
-            result_path, elapsed = chunk_tables(
-                str(input_file), str(tmp_path), emb_endpoint="emb",
-                doc_id="doc-6", cancel_event=event,
-            )
-
-        assert result_path is None
-        assert elapsed is None
-
-    def test_cancel_event_set_mid_loop_returns_none(self, tmp_path):
-        """cancel_event set after first table → chunk_tables returns (None, None)."""
-        from digitize.processing.orchestrator import chunk_tables
-        import json, threading
-
-        data = {
-            "t1": {"caption": "T1", "summary": "S1", "page_number": 1},
-            "t2": {"caption": "T2", "summary": "S2", "page_number": 2},
-        }
-        input_file = tmp_path / "doc-7_tables.json"
-        input_file.write_text(json.dumps(data))
-
-        event = threading.Event()
-        call_count = {"n": 0}
-
-        # Set the event after count_tokens is first called (first table visited).
-        # The cancel check at the top of the next iteration fires True.
-        def set_after_first(*args, **kwargs):
-            call_count["n"] += 1
-            if call_count["n"] >= 1:
-                event.set()
-            return 5
-
-        with patch("digitize.processing.orchestrator.count_tokens", side_effect=set_after_first):
-            result_path, elapsed = chunk_tables(
-                str(input_file), str(tmp_path), emb_endpoint="emb",
-                doc_id="doc-7", cancel_event=event,
-            )
-
-        assert result_path is None
-        assert elapsed is None
-
-    def test_no_cancel_event_processes_normally(self, tmp_path):
-        """cancel_event=None (default) — no change in behaviour."""
-        from digitize.processing.orchestrator import chunk_tables
-        import json
-
-        data = {"t1": {"caption": "T1", "summary": "Sum", "page_number": 1}}
-        input_file = tmp_path / "doc-8_tables.json"
-        input_file.write_text(json.dumps(data))
-
-        with patch("digitize.processing.orchestrator.count_tokens", return_value=5):
-            result_path, elapsed = chunk_tables(
-                str(input_file), str(tmp_path), emb_endpoint="emb",
-                doc_id="doc-8",
-            )
-
-        assert result_path is not None
 
 
 @pytest.mark.unit
 class TestChunkSingleFileCancelEvent:
-    """chunk_single_file forwards cancel_event and re-raises JobCancelledError."""
+    """chunk_single_file checks cancel_event between chunk_text and chunk_tables."""
 
     def test_cancel_event_set_propagates_as_job_cancelled_error(self, tmp_path):
-        """When chunk_text raises JobCancelledError, chunk_single_file re-raises it."""
+        """When cancel_event is set after chunk_text, chunk_single_file raises JobCancelledError."""
         from digitize.processing.orchestrator import chunk_single_file
         import threading
 
@@ -1832,8 +1592,8 @@ class TestChunkSingleFileCancelEvent:
                     cancel_event=event,
                 )
 
-    def test_cancel_event_forwarded_to_chunk_text_and_chunk_tables(self, tmp_path):
-        """cancel_event is forwarded to both chunk_text and chunk_tables."""
+    def test_cancel_event_not_forwarded_to_chunk_text(self, tmp_path):
+        """cancel_event is checked in chunk_single_file itself, not passed into chunk_text."""
         from digitize.processing.orchestrator import chunk_single_file
         import threading
 
@@ -1850,7 +1610,7 @@ class TestChunkSingleFileCancelEvent:
             patch(
                 "digitize.processing.orchestrator.chunk_tables",
                 return_value=(str(tab_result), 0.3),
-            ) as mock_chunk_tables,
+            ),
         ):
             chunk_single_file(
                 "txt.json", "tab.json", str(tmp_path),
@@ -1858,9 +1618,8 @@ class TestChunkSingleFileCancelEvent:
                 cancel_event=event,
             )
 
-        # Verify cancel_event was forwarded to both inner calls
-        assert mock_chunk_text.call_args.kwargs.get("cancel_event") is event
-        assert mock_chunk_tables.call_args.kwargs.get("cancel_event") is event
+        # cancel_event is NOT forwarded into chunk_text; the check lives in chunk_single_file
+        assert "cancel_event" not in mock_chunk_text.call_args.kwargs
 
 
 # ===========================================================================
@@ -1899,8 +1658,9 @@ class TestOpenSearchInsertChunksCancelEvent:
         assert result is True
 
     def test_cancel_event_set_aborts_before_first_batch(self):
-        """cancel_event already set → returns False before any bulk insert."""
+        """cancel_event already set → raises JobCancelledError before any bulk insert."""
         import threading
+        from digitize.exceptions import JobCancelledError
 
         inst = self._make_opensearch()
         inst._setup_index = Mock()
@@ -1913,14 +1673,15 @@ class TestOpenSearchInsertChunksCancelEvent:
         event.set()
 
         with patch("common.opensearch.helpers.bulk") as mock_bulk:
-            result = inst.insert_chunks(chunks, embedding=embedder, batch_size=2, cancel_event=event)
+            with pytest.raises(JobCancelledError):
+                inst.insert_chunks(chunks, embedding=embedder, batch_size=2, cancel_event=event)
 
-        assert result is False
         mock_bulk.assert_not_called()
 
     def test_cancel_event_set_between_batches_aborts_mid_insert(self):
-        """cancel_event set after the first batch → second batch is not inserted."""
+        """cancel_event set after the first batch → raises JobCancelledError; second batch is not inserted."""
         import threading
+        from digitize.exceptions import JobCancelledError
 
         inst = self._make_opensearch()
         inst._setup_index = Mock()
@@ -1938,9 +1699,9 @@ class TestOpenSearchInsertChunksCancelEvent:
             return (2, [])
 
         with patch("common.opensearch.helpers.bulk", side_effect=fake_bulk):
-            result = inst.insert_chunks(chunks, embedding=embedder, batch_size=2, cancel_event=event)
+            with pytest.raises(JobCancelledError):
+                inst.insert_chunks(chunks, embedding=embedder, batch_size=2, cancel_event=event)
 
-        assert result is False
         assert bulk_call_count["n"] == 1  # only first batch executed
 
     def test_no_cancel_event_inserts_all_batches(self):

--- a/services/digitize/tests/test_conversion_dispatcher.py
+++ b/services/digitize/tests/test_conversion_dispatcher.py
@@ -467,7 +467,14 @@ class TestRunConversion:
         result_path = str(tmp_path / "output.json")
 
         async def _run():
+            # get_conversion_task is called at Check 1 (before RUNNING) and
+            # Check 2 (after conversion returns).  Both must return a non-cancel-pending
+            # stub so the happy path continues through to COMPLETED.
+            from digitize.db.models import ConversionTaskStatus
+            running_stub = Mock(status=ConversionTaskStatus.RUNNING)
+
             with patch.object(mod.db_manager, "update_task_status") as mock_update, \
+                 patch.object(mod.db_manager, "get_conversion_task", return_value=running_stub), \
                  patch.object(mod.conversion_semaphore, "release", new_callable=AsyncMock) as mock_release, \
                  patch("digitize.utils.db.get_status_manager") as mock_gsm, \
                  patch("asyncio.get_running_loop") as mock_loop, \
@@ -521,7 +528,14 @@ class TestRunConversion:
         (tmp_path / "file.pdf").write_bytes(b"%PDF-1.4")
 
         async def _run():
+            from digitize.db.models import ConversionTaskStatus
+            # get_conversion_task is called at Check 1 (before RUNNING) and in the
+            # except block (Check 3).  Return RUNNING so neither check triggers a
+            # cancel path — the genuine exception must produce FAILED, not CANCELLED.
+            running_stub = Mock(status=ConversionTaskStatus.RUNNING)
+
             with patch.object(mod.db_manager, "update_task_status") as mock_update, \
+                 patch.object(mod.db_manager, "get_conversion_task", return_value=running_stub), \
                  patch.object(mod.conversion_semaphore, "release", new_callable=AsyncMock) as mock_release, \
                  patch("digitize.utils.db.get_status_manager") as mock_gsm, \
                  patch("asyncio.get_running_loop") as mock_loop:
@@ -584,9 +598,13 @@ class TestRunConversionUpdated:
         task_status_calls = []
 
         async def _run():
+            from digitize.db.models import ConversionTaskStatus
+            running_stub = Mock(status=ConversionTaskStatus.RUNNING)
+
             with patch.object(
                     mod.db_manager, "update_task_status",
                     side_effect=lambda *a, **kw: task_status_calls.append((a, kw))) as mock_uts, \
+                 patch.object(mod.db_manager, "get_conversion_task", return_value=running_stub), \
                  patch.object(mod.conversion_semaphore, "release", new_callable=AsyncMock), \
                  patch("asyncio.get_running_loop") as mock_loop:
 
@@ -628,7 +646,11 @@ class TestRunConversionUpdated:
         result_path = str(tmp_path / "output.json")
 
         async def _run():
+            from digitize.db.models import ConversionTaskStatus
+            running_stub = Mock(status=ConversionTaskStatus.RUNNING)
+
             with patch.object(mod.db_manager, "update_task_status"), \
+                 patch.object(mod.db_manager, "get_conversion_task", return_value=running_stub), \
                  patch.object(mod.conversion_semaphore, "release", new_callable=AsyncMock), \
                  patch("asyncio.get_running_loop") as mock_loop:
 
@@ -639,7 +661,9 @@ class TestRunConversionUpdated:
                 await mod._run_conversion(task, weight=1)
 
         asyncio.run(_run())
-        assert cached.exists(), "Staged input file must be preserved for the pipeline layer"
+        # The dispatcher no longer deletes the staged input file — that is now
+        # the pipeline layer's responsibility (via cleanup_staging_directory).
+        assert cached.exists(), "Dispatcher must NOT delete the staged file; pipeline owns cleanup"
 
     def test_cached_file_preserved_on_failure(self, tmp_path):
         """The staged file must NOT be removed when conversion raises.
@@ -655,7 +679,11 @@ class TestRunConversionUpdated:
         task.page_count = 10
 
         async def _run():
+            from digitize.db.models import ConversionTaskStatus
+            running_stub = Mock(status=ConversionTaskStatus.RUNNING)
+
             with patch.object(mod.db_manager, "update_task_status"), \
+                 patch.object(mod.db_manager, "get_conversion_task", return_value=running_stub), \
                  patch.object(mod.conversion_semaphore, "release", new_callable=AsyncMock), \
                  patch("asyncio.get_running_loop") as mock_loop:
 
@@ -668,4 +696,6 @@ class TestRunConversionUpdated:
                 await mod._run_conversion(task, weight=1)
 
         asyncio.run(_run())
-        assert cached.exists(), "Staged file must be preserved for the pipeline layer even on failure"
+        # The dispatcher no longer deletes the staged input file — that is now
+        # the pipeline layer's responsibility (via cleanup_staging_directory).
+        assert cached.exists(), "Dispatcher must NOT delete the staged file; pipeline owns cleanup"

--- a/services/digitize/tests/test_enqueue_conversion_tasks.py
+++ b/services/digitize/tests/test_enqueue_conversion_tasks.py
@@ -15,7 +15,7 @@ import pytest
 
 
 # The db_manager singleton import path used at runtime inside enqueue_conversion_tasks
-_DB_MANAGER_PATH = "digitize.db.manager.db_manager"
+_DB_MANAGER_PATH = "digitize.utils.jobs.db_manager"
 
 
 def _run_enqueue(tmp_path, filenames, *, page_count=10, queued_for_op=0,

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -687,9 +687,7 @@ class TestRunTickCancellation:
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.DELETE_PENDING), \
              patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close, \
-             patch("digitize.db.manager.db_manager") as mock_db_mgr, \
              patch("digitize.api.v1.connectors._run_teardown", new_callable=AsyncMock):
-            mock_db_mgr.delete_conversion_tasks_for_connector.return_value = 0
             with pytest.raises(asyncio.CancelledError):
                 asyncio.run(run_tick("conn-1", sync_seq=10))
 
@@ -818,10 +816,8 @@ class TestHandleInterrupt:
 
     def test_delete_connector_calls_cancel_tick_and_teardown(self):
         with patch(f"{DB_MODULE}._cancel_tick") as mock_cancel, \
-             patch("digitize.db.manager.db_manager") as mock_db_mgr, \
              patch("digitize.api.v1.connectors._run_teardown",
                    new_callable=AsyncMock) as mock_teardown:
-            mock_db_mgr.delete_conversion_tasks_for_connector.return_value = 0
             asyncio.run(_handle_interrupt(sync_seq=3, connector_id="conn-B",
                                           interrupt_type=InterruptType.DELETE_CONNECTOR))
         mock_cancel.assert_called_once_with(3, "conn-B")
@@ -830,10 +826,8 @@ class TestHandleInterrupt:
     def test_delete_connector_does_not_call_sweep(self):
         """DELETE_CONNECTOR must not call _sweep_staging_dir."""
         with patch(f"{DB_MODULE}._cancel_tick"), \
-             patch("digitize.db.manager.db_manager") as mock_db_mgr, \
              patch("digitize.api.v1.connectors._run_teardown", new_callable=AsyncMock), \
              patch("digitize.api.v1.connectors._sweep_staging_dir") as mock_sweep:
-            mock_db_mgr.delete_conversion_tasks_for_connector.return_value = 0
             asyncio.run(_handle_interrupt(sync_seq=3, connector_id="conn-B",
                                           interrupt_type=InterruptType.DELETE_CONNECTOR))
         mock_sweep.assert_not_called()

--- a/services/digitize/tests/test_types_models.py
+++ b/services/digitize/tests/test_types_models.py
@@ -31,15 +31,13 @@ class TestEnums:
         assert OperationType.DIGITIZATION.value == "digitization"
 
     def test_job_status_values(self):
-        assert {
-            status.value for status in JobStatus
-        } == {
-            "accepted",
-            "in_progress",
-            "completed",
-            "completed_with_errors",
-            "failed",
-        }
+        assert JobStatus.ACCEPTED.value == "accepted"
+        assert JobStatus.IN_PROGRESS.value == "in_progress"
+        assert JobStatus.COMPLETED.value == "completed"
+        assert JobStatus.COMPLETED_WITH_ERRORS.value == "completed_with_errors"
+        assert JobStatus.FAILED.value == "failed"
+        assert JobStatus.CANCEL_PENDING.value == "cancel_pending"
+        assert JobStatus.CANCELLED.value == "cancelled"
 
     def test_doc_status_values(self):
         assert {
@@ -54,6 +52,7 @@ class TestEnums:
             "completed_with_errors",
             "failed",
             "already_exists",
+            "cancelled"
         }
 
     def test_enum_string_conversion(self):

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1131,6 +1131,27 @@ class DatabaseStatusManager:
             logger.warning(f"Job {self.job_id} not found in database")
             return
 
+        # Do not overwrite a terminal status already written by the pipeline
+        # (e.g. CANCELLED written by _run_ingest/_run_digitize) with a
+        # superseding status coming from a late update_job_progress call.
+        # CANCEL_PENDING is also protected: the job has been requested for
+        # cancellation and must not be flipped back to IN_PROGRESS by any
+        # in-flight pipeline step that hasn't yet observed the cancellation flag.
+        protected_statuses = {
+            JobStatus.COMPLETED,
+            JobStatus.FAILED,
+            JobStatus.CANCELLED,
+            JobStatus.CANCEL_PENDING,
+        }
+        current_db_status = JobStatus(job.status) if job.status in JobStatus._value2member_map_ else None
+        if current_db_status in protected_statuses and job_status not in protected_statuses:
+            assert current_db_status is not None  # narrowing: None is never in protected_statuses
+            logger.debug(
+                f"Job {self.job_id} already in protected state '{current_db_status.value}'; "
+                f"ignoring status update to '{job_status.value}'"
+            )
+            return
+
         # Get all documents for this job to recalculate stats
         documents = db_manager.get_documents_by_job_id(self.job_id)
 
@@ -1157,21 +1178,21 @@ class DatabaseStatusManager:
             ),
         }
 
+        # Preserve any extra keys already in job stats (e.g. clean_files flag)
+        existing_stats = job.stats or {}
+        for key, value in existing_stats.items():
+            if key not in stats:
+                stats[key] = value
+
         # Prepare job update parameters
         update_params: Dict[str, Any] = {
             "status": job_status,
             "stats": stats,
         }
 
-        # Set completed_at for all terminal job states
-        _terminal_job = (JobStatus.COMPLETED, JobStatus.COMPLETED_WITH_ERRORS, JobStatus.FAILED)
-        if job_status in _terminal_job:
-            total_docs = stats["total_documents"]
-            completed_docs = stats["completed"]
-            failed_docs = stats["failed"]
-
-            if total_docs > 0 and (completed_docs + failed_docs) == total_docs:
-                update_params["completed_at"] = datetime.now(timezone.utc)
+        # Set completed_at if job is finished
+        if job_status in [JobStatus.COMPLETED, JobStatus.COMPLETED_WITH_ERRORS, JobStatus.FAILED, JobStatus.CANCELLED]:
+            update_params["completed_at"] = datetime.now(timezone.utc)
 
         # Set error for hard failures and completed_with_errors (when an error message is provided)
         if error and job_status in (JobStatus.FAILED, JobStatus.COMPLETED_WITH_ERRORS):

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1142,6 +1142,7 @@ class DatabaseStatusManager:
             JobStatus.FAILED,
             JobStatus.CANCELLED,
             JobStatus.CANCEL_PENDING,
+            JobStatus.COMPLETED_WITH_ERRORS,
         }
         current_db_status = JobStatus(job.status) if job.status in JobStatus._value2member_map_ else None
         if current_db_status in protected_statuses and job_status not in protected_statuses:

--- a/services/digitize/utils/jobs.py
+++ b/services/digitize/utils/jobs.py
@@ -287,6 +287,7 @@ _TERMINAL_DOC_STATUSES = (
 
 NON_CANCELLABLE_JOB_STATUSES = (
     models.JobStatus.COMPLETED.value,
+    models.JobStatus.COMPLETED_WITH_ERRORS.value,
     models.JobStatus.FAILED.value,
     models.JobStatus.CANCEL_PENDING.value,
     models.JobStatus.CANCELLED.value,

--- a/services/digitize/utils/jobs.py
+++ b/services/digitize/utils/jobs.py
@@ -5,6 +5,7 @@ job initialisation, file staging, active-job guards, document content
 retrieval, and bulk deletion helpers.
 """
 import asyncio
+from datetime import datetime, timezone
 import uuid
 from pathlib import Path
 from typing import Optional
@@ -19,6 +20,7 @@ from digitize.models import (
 )
 from digitize.parsing.pdf import get_document_page_count
 from digitize.settings import settings
+from digitize.db.manager import db_manager
 from digitize.utils.db import (
     create_job,
     create_document,
@@ -29,6 +31,8 @@ from digitize.utils.db import (
 )
 
 from common.misc_utils import get_utc_timestamp, cleanup_staging_directory
+from services.digitize import models
+from services.digitize.exceptions import JobCancelledError
 
 
 logger = get_logger("digitize_utils")
@@ -238,7 +242,6 @@ async def enqueue_conversion_tasks(
         queued_for_op: Number of tasks already queued for this operation (user jobs only).
         connector_id:  Owning connector UUID; None for user-submitted jobs.
     """
-    from digitize.db.manager import db_manager
 
     slots_free = max(0, quota - queued_for_op)
     tasks = []
@@ -275,6 +278,28 @@ async def enqueue_conversion_tasks(
 
     db_manager.create_conversion_tasks_batch(tasks)
 
+_TERMINAL_DOC_STATUSES = (
+    models.DocStatus.COMPLETED.value,
+    models.DocStatus.FAILED.value,
+    models.DocStatus.CANCELLED.value,
+    models.DocStatus.ALREADY_EXISTS.value,
+)
+def _cancel_job_docs(job_id: str, status_mgr, *, force: bool = False) -> None:
+    """Mark documents for *job_id* as CANCELLED, then set the job to CANCELLED.
+
+    When *force* is ``False`` (default) terminal documents (COMPLETED, FAILED,
+    CANCELLED, ALREADY_EXISTS) are left untouched.  Pass ``force=True`` after a
+    VDB cleanup so that COMPLETED docs — whose vector chunks have just been
+    removed — are also marked CANCELLED.
+    """
+    docs = db_manager.get_documents_by_job_id(job_id)
+    for doc in docs:
+        if force or doc.status not in _TERMINAL_DOC_STATUSES:
+            status_mgr.update_doc_metadata(
+                doc.doc_id,
+                {"status": models.DocStatus.CANCELLED, "completed_at": datetime.now(timezone.utc).isoformat()},
+            )
+    status_mgr.update_job_progress("", models.DocStatus.CANCELLED, models.JobStatus.CANCELLED)
 
 async def initialize_and_launch(
     job_id: str,
@@ -403,14 +428,17 @@ async def launch_digitize_pipeline(
     from digitize.models import DocStatus, JobStatus
     from digitize.utils.db import get_status_manager
 
+    status_mgr = get_status_manager(job_id)
     try:
         logger.info(f"🚀 Digitization pipeline started for job: {job_id}")
         from digitize.pipeline.digitize import digitize
         await asyncio.to_thread(digitize, job_id, doc_id_dict)
         logger.info(f"Digitization pipeline for job {job_id} completed successfully")
+    except JobCancelledError:
+        logger.info(f"Digitization job {job_id} was cancelled")
+        _cancel_job_docs(job_id, status_mgr)
     except Exception as exc:
         logger.error(f"Error in digitization pipeline for job {job_id}: {exc}", exc_info=True)
-        status_mgr = get_status_manager(job_id)
         status_mgr.update_job_progress(
             "",
             DocStatus.FAILED,
@@ -461,12 +489,42 @@ async def launch_ingest_pipeline(
     from digitize.utils.db import get_status_manager
 
     resolved: Path = staging_dir if staging_dir is not None else settings.digitize.staging_dir / job_id
-
+    status_mgr = get_status_manager(job_id)
     try:
         logger.info(f"🚀 Ingestion pipeline started for job: {job_id}")
         from digitize.pipeline.ingest import ingest
         await asyncio.to_thread(ingest, resolved, job_id, doc_id_dict, file_checksum_dict)
         logger.info(f"Ingestion pipeline for job {job_id} completed successfully")
+    except JobCancelledError:
+        logger.info(f"Ingestion job {job_id} was cancelled")
+
+        # Clean vector DB before marking docs CANCELLED so the filter on
+        # CHUNKED/COMPLETED statuses still reflects pre-cancellation state.
+        vdb_cleaned = False
+        try:
+            job_row = db_manager.get_job_by_id(job_id)
+            if job_row and job_row.stats.get("clean_files"):
+                import common.db_utils as db_utils
+                indexed_statuses = {
+                    models.DocStatus.CHUNKED.value,
+                    models.DocStatus.COMPLETED.value,
+                }
+                all_docs = db_manager.get_documents_by_job_id(job_id)
+                doc_ids_to_clean = [
+                    d.doc_id for d in all_docs
+                    if d.status in indexed_statuses
+                ]
+                if doc_ids_to_clean:
+                    vector_store = db_utils.get_vector_store()
+                    deleted = vector_store.remove_docs_from_index(doc_ids_to_clean)
+                    logger.info(f"Cancelled job {job_id}: removed {deleted} vector chunks (clean_files=true)")
+                    vdb_cleaned = True
+        except Exception as vdb_exc:
+            logger.warning(f"Vector DB cleanup failed for cancelled job {job_id}: {vdb_exc}")
+
+        # If VDB cleanup ran, force-cancel all docs (including COMPLETED ones
+        # whose vectors were just removed).  Otherwise respect terminal statuses.
+        _cancel_job_docs(job_id, status_mgr, force=vdb_cleaned)
     except Exception as exc:
         logger.error(f"Error in ingestion pipeline for job {job_id}: {exc}", exc_info=True)
         status_mgr = get_status_manager(job_id)

--- a/services/digitize/utils/jobs.py
+++ b/services/digitize/utils/jobs.py
@@ -31,8 +31,8 @@ from digitize.utils.db import (
 )
 
 from common.misc_utils import get_utc_timestamp, cleanup_staging_directory
-from services.digitize import models
-from services.digitize.exceptions import JobCancelledError
+from digitize import models
+from digitize.exceptions import JobCancelledError
 
 
 logger = get_logger("digitize_utils")
@@ -284,6 +284,14 @@ _TERMINAL_DOC_STATUSES = (
     models.DocStatus.CANCELLED.value,
     models.DocStatus.ALREADY_EXISTS.value,
 )
+
+NON_CANCELLABLE_JOB_STATUSES = (
+    models.JobStatus.COMPLETED.value,
+    models.JobStatus.FAILED.value,
+    models.JobStatus.CANCEL_PENDING.value,
+    models.JobStatus.CANCELLED.value,
+)
+
 def _cancel_job_docs(job_id: str, status_mgr, *, force: bool = False) -> None:
     """Mark documents for *job_id* as CANCELLED, then set the job to CANCELLED.
 
@@ -300,6 +308,29 @@ def _cancel_job_docs(job_id: str, status_mgr, *, force: bool = False) -> None:
                 {"status": models.DocStatus.CANCELLED, "completed_at": datetime.now(timezone.utc).isoformat()},
             )
     status_mgr.update_job_progress("", models.DocStatus.CANCELLED, models.JobStatus.CANCELLED)
+
+
+def request_job_cancellation(job_id: str, *, clean_files: bool = False) -> None:
+    """Mark *job_id* as CANCEL_PENDING and persist the *clean_files* flag in stats.
+
+    Sets the job to CANCEL_PENDING so the background pipeline stops at its
+    next checkpoint.
+
+    Parameters
+    ----------
+    job_id:
+        The job to cancel.
+    clean_files:
+        When ``True`` the background task should also remove staged/output
+        files when it handles the cancellation.
+    """
+    job_row = db_manager.get_job_by_id(job_id)
+    current_stats = (job_row.stats if job_row and job_row.stats else {})
+    updated_stats = {**current_stats, "clean_files": clean_files}
+
+    db_manager.update_job(job_id, status=models.JobStatus.CANCEL_PENDING, stats=updated_stats)
+    logger.info(f"Job '{job_id}' marked as CANCEL_PENDING (clean_files={clean_files})")
+
 
 async def initialize_and_launch(
     job_id: str,

--- a/services/digitize/utils/recovery.py
+++ b/services/digitize/utils/recovery.py
@@ -63,6 +63,7 @@ def recover_zombie_jobs() -> int:
 
                 try:
                     current_status = job_data.get("status")
+                    is_cancelling = current_status == JobStatus.CANCEL_PENDING.value
                     logger.warning(
                         f"Found zombie job: {job_id} with status '{current_status}'"
                     )
@@ -89,7 +90,7 @@ def recover_zombie_jobs() -> int:
                                     f"{doc_id}: {clean_err}"
                                 )
 
-                        # Only documents that are still in-flight need updating.
+                        # Documents still in-flight need resolving to a terminal state.
                         in_flight = {
                             DocStatus.ACCEPTED.value,
                             DocStatus.IN_PROGRESS.value,
@@ -100,42 +101,62 @@ def recover_zombie_jobs() -> int:
                         if doc_status in in_flight and doc_id:
                             stale_doc_ids.append(doc_id)
 
-                            status_mgr.update_doc_metadata(
-                                doc_id,
-                                {"status": DocStatus.FAILED},
-                                error=(
-                                    f"System restarted during processing. "
-                                    f"Use DELETE /v1/documents/{doc_id} to remove "
-                                    "the stale document and re-submit."
-                                ),
-                            )
+                            if is_cancelling:
+                                # Job was being cancelled when the service crashed —
+                                # complete the cancellation rather than marking failed.
+                                status_mgr.update_doc_metadata(
+                                    doc_id,
+                                    {"status": DocStatus.CANCELLED},
+                                )
+                                status_mgr.update_job_progress(
+                                    doc_id=doc_id,
+                                    doc_status=DocStatus.CANCELLED,
+                                    job_status=JobStatus.IN_PROGRESS,
+                                    error="",
+                                )
+                            else:
+                                status_mgr.update_doc_metadata(
+                                    doc_id,
+                                    {"status": DocStatus.FAILED},
+                                    error=(
+                                        f"System restarted during processing. "
+                                        f"Use DELETE /v1/documents/{doc_id} to remove "
+                                        "the stale document and re-submit."
+                                    ),
+                                )
+                                # Keep job in IN_PROGRESS while we update each doc so
+                                # that the stats recalculation inside update_job_progress
+                                # sees the running totals correctly.
+                                status_mgr.update_job_progress(
+                                    doc_id=doc_id,
+                                    doc_status=DocStatus.FAILED,
+                                    job_status=JobStatus.IN_PROGRESS,
+                                    error="",
+                                )
 
-                            # Keep job in IN_PROGRESS while we update each doc so
-                            # that the stats recalculation inside update_job_progress
-                            # sees the running totals correctly.
-                            status_mgr.update_job_progress(
-                                doc_id=doc_id,
-                                doc_status=DocStatus.FAILED,
-                                job_status=JobStatus.IN_PROGRESS,
-                                error="",
-                            )
-
-                    if stale_doc_ids:
+                    if stale_doc_ids and not is_cancelling:
                         error_message += (
                             ". Stale documents may exist. "
                             "Please use DELETE /v1/documents/{id} to remove them "
                             f"and re-submit: {', '.join(stale_doc_ids)}"
                         )
 
-                    # Final job-level update.
-                    status_mgr.update_job_progress(
-                        doc_id="",
-                        doc_status=DocStatus.FAILED,
-                        job_status=JobStatus.FAILED,
-                        error=error_message,
-                    )
-
-                    logger.info(f"✅ Marked zombie job {job_id} as failed")
+                    # Final job-level update — honour the original intent.
+                    if is_cancelling:
+                        status_mgr.update_job_progress(
+                            doc_id="",
+                            doc_status=DocStatus.CANCELLED,
+                            job_status=JobStatus.CANCELLED,
+                        )
+                        logger.info(f"✅ Marked zombie job {job_id} as cancelled")
+                    else:
+                        status_mgr.update_job_progress(
+                            doc_id="",
+                            doc_status=DocStatus.FAILED,
+                            job_status=JobStatus.FAILED,
+                            error=error_message,
+                        )
+                        logger.info(f"✅ Marked zombie job {job_id} as failed")
                     orphan_count += 1
 
                     # Clean up the staging directory that belonged to this job.

--- a/services/digitize/utils/recovery.py
+++ b/services/digitize/utils/recovery.py
@@ -49,7 +49,7 @@ def recover_zombie_jobs() -> int:
     import digitize.settings as config
 
     orphan_count = 0
-    orphan_statuses = [JobStatus.ACCEPTED, JobStatus.IN_PROGRESS]
+    orphan_statuses = [JobStatus.ACCEPTED, JobStatus.IN_PROGRESS, JobStatus.CANCEL_PENDING]
 
     try:
         for status in orphan_statuses:

--- a/services/digitize/workers/conversion_dispatcher.py
+++ b/services/digitize/workers/conversion_dispatcher.py
@@ -38,6 +38,7 @@ from pathlib import Path
 from common.misc_utils import get_logger
 from digitize.db.manager import db_manager
 from digitize.db.models import ConversionTask, ConversionTaskStatus
+from digitize.exceptions import JobCancelledError
 from digitize.models import OutputFormat
 from digitize.parsing.converter import convert_document_format
 from digitize.settings import settings
@@ -177,18 +178,18 @@ async def _run_conversion(task: ConversionTask, weight: int) -> None:
         db_manager.update_task_status(task.task_id, ConversionTaskStatus.COMPLETED, result_path=result_path)
         logger.info(f"Task {task.task_id} completed → {result_path}")
 
-    except Exception as exc:
-        # Re-read the task to distinguish a cancellation-induced exception
-        # (e.g. JobCancelledError from convert_doc chunk loop) from a genuine failure.
-        if _cancel_if_pending(
-            task.task_id,
+    except JobCancelledError as exc:
+        # JobCancelledError is raised inside the worker process between 100-page chunks
+        # and re-raised here when run_in_executor unwraps the process-pool future.
+        # The task is already CANCEL_PENDING; write the final CANCELLED state.
+        db_manager.update_task_status(
+            task.task_id, ConversionTaskStatus.CANCELLED,
             error="Job cancelled during conversion",
-            log_msg=f"Task {task.task_id} cancelled mid-conversion: {exc}",
-        ):
-            pass
-        else:
-            logger.error(f"Task {task.task_id} failed: {exc}", exc_info=True)
-            db_manager.update_task_status(task.task_id, ConversionTaskStatus.FAILED, error=str(exc))
+        )
+        logger.info(f"Task {task.task_id} cancelled mid-conversion: {exc}")
+    except Exception as exc:
+        logger.error(f"Task {task.task_id} failed: {exc}", exc_info=True)
+        db_manager.update_task_status(task.task_id, ConversionTaskStatus.FAILED, error=str(exc))
 
     finally:
         # Do NOT delete task.cached_file here — the pipeline layer owns staging

--- a/services/digitize/workers/conversion_dispatcher.py
+++ b/services/digitize/workers/conversion_dispatcher.py
@@ -55,6 +55,17 @@ _connector_rr_index: int = 0  # index into the live connector list for turn 2
 # and any code that transitively imports this module).
 _process_pool: ProcessPoolExecutor | None = None
 
+def _cancel_if_pending(task_id: str, error: str, log_msg: str) -> bool:
+    """Re-read *task_id* from the DB and, if it is ``CANCEL_PENDING``, write
+    ``CANCELLED`` and return ``True``.  Returns ``False`` when the task is not
+    in the cancel-pending state or the row is missing."""
+    fresh = db_manager.get_conversion_task(task_id)
+    if fresh is not None and fresh.status == ConversionTaskStatus.CANCEL_PENDING:
+        db_manager.update_task_status(task_id, ConversionTaskStatus.CANCELLED, error=error)
+        logger.info(log_msg)
+        return True
+    return False
+
 
 def _try_claim_if_fits(
     operation: str,
@@ -129,13 +140,11 @@ async def _run_conversion(task: ConversionTask, weight: int) -> None:
 
         # Check 1: bail out early if the job was cancelled while this task
         # was still in the queue (cancel_pending was set before claim_head).
-        fresh = db_manager.get_conversion_task(task.task_id)
-        if fresh is not None and fresh.status == ConversionTaskStatus.CANCEL_PENDING:
-            db_manager.update_task_status(
-                task.task_id, ConversionTaskStatus.CANCELLED,
-                error="Job cancelled before conversion started",
-            )
-            logger.info(f"Task {task.task_id} cancelled before starting (was cancel_pending)")
+        if _cancel_if_pending(
+            task.task_id,
+            error="Job cancelled before conversion started",
+            log_msg=f"Task {task.task_id} cancelled before starting (was cancel_pending)",
+        ):
             return
 
         # Mark task as running — pipeline layer picks this up via poll.
@@ -158,13 +167,11 @@ async def _run_conversion(task: ConversionTask, weight: int) -> None:
 
         # Check 2: if the job was cancelled while we were converting, write
         # CANCELLED so the pipeline's poll loop reaches the correct terminal state.
-        fresh = db_manager.get_conversion_task(task.task_id)
-        if fresh is not None and fresh.status == ConversionTaskStatus.CANCEL_PENDING:
-            db_manager.update_task_status(
-                task.task_id, ConversionTaskStatus.CANCELLED,
-                error="Job cancelled during conversion",
-            )
-            logger.info(f"Task {task.task_id} cancelled after conversion completed")
+        if _cancel_if_pending(
+            task.task_id,
+            error="Job cancelled during conversion",
+            log_msg=f"Task {task.task_id} cancelled after conversion completed",
+        ):
             return
 
         db_manager.update_task_status(task.task_id, ConversionTaskStatus.COMPLETED, result_path=result_path)
@@ -173,13 +180,12 @@ async def _run_conversion(task: ConversionTask, weight: int) -> None:
     except Exception as exc:
         # Re-read the task to distinguish a cancellation-induced exception
         # (e.g. JobCancelledError from convert_doc chunk loop) from a genuine failure.
-        fresh = db_manager.get_conversion_task(task.task_id)
-        if fresh is not None and fresh.status == ConversionTaskStatus.CANCEL_PENDING:
-            db_manager.update_task_status(
-                task.task_id, ConversionTaskStatus.CANCELLED,
-                error="Job cancelled during conversion",
-            )
-            logger.info(f"Task {task.task_id} cancelled mid-conversion: {exc}")
+        if _cancel_if_pending(
+            task.task_id,
+            error="Job cancelled during conversion",
+            log_msg=f"Task {task.task_id} cancelled mid-conversion: {exc}",
+        ):
+            pass
         else:
             logger.error(f"Task {task.task_id} failed: {exc}", exc_info=True)
             db_manager.update_task_status(task.task_id, ConversionTaskStatus.FAILED, error=str(exc))

--- a/services/digitize/workers/conversion_dispatcher.py
+++ b/services/digitize/workers/conversion_dispatcher.py
@@ -94,9 +94,28 @@ async def _run_conversion(task: ConversionTask, weight: int) -> None:
     Responsibility boundary
     -----------------------
     This function owns only the conversion_tasks row — it writes task status
-    (queued → running → completed / failed) and result_path / error.
+    (queued → running → completed / failed / cancelled) and result_path / error.
     All job and document status updates (JobStatus, DocStatus) are the
     responsibility of the pipeline layer that polls task.status.
+
+    Cancellation
+    ------------
+    The pipeline calls ``db_manager.cancel_tasks_for_job`` which sets
+    non-terminal tasks to ``cancel_pending``.  This function checks that
+    flag at three points:
+
+    1. Before marking the task RUNNING — if already cancel_pending (task was
+       cancelled while still queued) we skip the conversion entirely.
+    2. Inside the worker process between 100-page chunks — ``task_id`` is passed
+       to ``convert_document_format`` which builds a DB-polling cancel check
+       callable (``_make_db_cancel_check``) that is invoked between chunks inside
+       ``convert_doc``.  When the task's DB row shows ``cancel_pending`` the
+       callable returns True, ``JobCancelledError`` is raised in the worker, and
+       the ``except`` block below maps it to ``CANCELLED``.
+    3. After the process-pool future returns — if the task was set to
+       cancel_pending while the conversion was running we write CANCELLED
+       instead of COMPLETED so the pipeline's poll loop sees a terminal state
+       it can map to job/doc CANCELLED rather than treating the output as valid.
     """
     try:
         cached_path = Path(task.cached_file)
@@ -108,10 +127,23 @@ async def _run_conversion(task: ConversionTask, weight: int) -> None:
             logger.warning(f"Task {task.task_id}: cached file missing — marked failed")
             return
 
+        # Check 1: bail out early if the job was cancelled while this task
+        # was still in the queue (cancel_pending was set before claim_head).
+        fresh = db_manager.get_conversion_task(task.task_id)
+        if fresh is not None and fresh.status == ConversionTaskStatus.CANCEL_PENDING:
+            db_manager.update_task_status(
+                task.task_id, ConversionTaskStatus.CANCELLED,
+                error="Job cancelled before conversion started",
+            )
+            logger.info(f"Task {task.task_id} cancelled before starting (was cancel_pending)")
+            return
+
         # Mark task as running — pipeline layer picks this up via poll.
         db_manager.update_task_status(task.task_id, ConversionTaskStatus.RUNNING)
 
-        # Convert in a child process — CPU-bound, no GIL release
+        # Convert in a child process — CPU-bound, no GIL release.
+        # task_id is forwarded so the worker can poll the DB for cancel_pending
+        # between 100-page chunks and stop early for large files.
         out_dir = settings.digitize.digitized_docs_dir
         loop = asyncio.get_running_loop()
         result_path, _ = await loop.run_in_executor(
@@ -121,14 +153,36 @@ async def _run_conversion(task: ConversionTask, weight: int) -> None:
             out_dir,
             task.doc_id or task.task_id,
             OutputFormat(task.output_format),
+            task.task_id,
         )
+
+        # Check 2: if the job was cancelled while we were converting, write
+        # CANCELLED so the pipeline's poll loop reaches the correct terminal state.
+        fresh = db_manager.get_conversion_task(task.task_id)
+        if fresh is not None and fresh.status == ConversionTaskStatus.CANCEL_PENDING:
+            db_manager.update_task_status(
+                task.task_id, ConversionTaskStatus.CANCELLED,
+                error="Job cancelled during conversion",
+            )
+            logger.info(f"Task {task.task_id} cancelled after conversion completed")
+            return
 
         db_manager.update_task_status(task.task_id, ConversionTaskStatus.COMPLETED, result_path=result_path)
         logger.info(f"Task {task.task_id} completed → {result_path}")
 
     except Exception as exc:
-        logger.error(f"Task {task.task_id} failed: {exc}", exc_info=True)
-        db_manager.update_task_status(task.task_id, ConversionTaskStatus.FAILED, error=str(exc))
+        # Re-read the task to distinguish a cancellation-induced exception
+        # (e.g. JobCancelledError from convert_doc chunk loop) from a genuine failure.
+        fresh = db_manager.get_conversion_task(task.task_id)
+        if fresh is not None and fresh.status == ConversionTaskStatus.CANCEL_PENDING:
+            db_manager.update_task_status(
+                task.task_id, ConversionTaskStatus.CANCELLED,
+                error="Job cancelled during conversion",
+            )
+            logger.info(f"Task {task.task_id} cancelled mid-conversion: {exc}")
+        else:
+            logger.error(f"Task {task.task_id} failed: {exc}", exc_info=True)
+            db_manager.update_task_status(task.task_id, ConversionTaskStatus.FAILED, error=str(exc))
 
     finally:
         # Do NOT delete task.cached_file here — the pipeline layer owns staging


### PR DESCRIPTION
Introduces a new POST /{job_id}/cancel endpoint and the supporting pipeline machinery required to cleanly stop an in-flight digitize or ingest job at the next safe checkpoint.

--- API & status model ---
* New JobStatus values: CANCEL_PENDING (set immediately by the endpoint) and CANCELLED (set by the background task after draining).
* New DocStatus value: CANCELLED for non-terminal documents at job cancellation time.
* DB check constraints and init_schema.sql updated to accept the new status strings.
* POST /{job_id}/cancel (202 Accepted):
  - Returns 404 if the job does not exist.
  - Returns 409 if the job is already in a terminal/pending-cancel state.
  - Persists CANCEL_PENDING + optional clean_files flag in job stats.
* _run_digitize / _run_ingest catch JobCancelledError and mark all non-terminal documents and the job itself as CANCELLED. Ingest additionally removes already-indexed VDB chunks when clean_files=true.

--- Pipeline checkpoints ---
* New digitize/exceptions.py: JobCancelledError — a clean signal that propagates up the call stack without being treated as an error.
* db_manager.is_job_cancelled(): lightweight single-column SELECT used at every pipeline checkpoint without loading the full job row.
* ingest.py: pre-pipeline CHECK 1 (before process_documents) and post-pipeline CHECK 5 (before writing final status).
* digitize.py: pre-flight check before the ProcessPoolExecutor starts.
* orchestrator.process_documents: all four as_completed loops replaced with cancellation-aware while-pending polling loops:
  - Conversion stage: pending futures cancelled; running ones drained; cancel_event (multiprocessing.Manager proxy) propagated to worker processes so long multi-chunk conversions abort between page chunks.
  - Processing stage: pending futures cancelled; running ones drained; _process_stop_event (threading.Event) propagated to process_converted_document / process_table so in-flight LLM table calls are aborted after the current call completes.
  - Chunking stage: same pattern.
  - Indexing stage: pending futures cancelled; already-running index futures are let to complete to avoid leaving stale VDB entries.
  - is_cancelled flag is latched True across stages; if all pending work has been cancelled, JobCancelledError is raised immediately to skip remaining stages.

--- LLM / processing layer ---
* summarize_and_classify_tables accepts stop_event; checked after each individual table LLM call; queued futures cancelled on signal.
* process_table / process_converted_document: stop_event threaded through so table summarization can be cut short mid-document.
* convert_doc / convert_document accept cancel_event; checked between 100-page chunks so a multi-chunk conversion can be aborted early without any DB access from the worker process.

--- Correctness fixes ---
* DatabaseStatusManager.update_job_progress: protected-status guard prevents any IN_PROGRESS update from overwriting cancel_pending, cancelled, completed, or failed.
* Extra job-stat keys (e.g. clean_files) are preserved during stats merge so the flag is readable by the background cleanup code.
* completed_at is now stamped for CANCELLED jobs as well as COMPLETED/FAILED ones.
* recover_zombie_jobs: CANCEL_PENDING added to orphan statuses so interrupted cancel operations are recovered on restart.

--- Tests ---
* services/digitize/exceptions.py: new module.
* services/digitize/tests/test_cancel_job.py: 1 344-line test suite covering the cancel endpoint (404/409/202/500), _run_digitize and _run_ingest cancellation paths (including VDB cleanup), and all four orchestrator pipeline stages with cancellation scenarios.
* services/digitize/tests/test_types_models.py: extended for the two new JobStatus and one new DocStatus values.