### PR TITLE
[BYOS] Reload Catalog Items and integrate with APIs

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.262
+TAG?=v0.0.263
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.262
+  image: icr.io/ai-services-cicd/ai-services:v0.0.263
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.262
+  image: icr.io/ai-services-cicd/ai-services:v0.0.263
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -438,7 +438,7 @@ func checkApplicationExists(appClient *catalogClient.ApplicationClient, appName 
 // buildCatalogPayload builds the catalog API payload for the given template.
 func buildCatalogPayload(appName string) (*apiModels.CreateApplicationRequest, error) {
 	// Initialize catalog provider
-	provider, err := catalog.NewCatalogProvider()
+	provider, err := catalog.NewCatalogProvider(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create catalog provider: %w", err)
 	}
@@ -539,7 +539,7 @@ func printNextSteps(app *catalogTypes.Application) error {
 		return fmt.Errorf("failed to get application: %w", err)
 	}
 
-	catalogProvider, err := catalog.NewCatalogProvider()
+	catalogProvider, err := catalog.NewCatalogProvider(nil)
 	if err != nil {
 		return fmt.Errorf("failed to create catalog provider: %w", err)
 	}

--- a/ai-services/cmd/ai-services/cmd/application/image/image.go
+++ b/ai-services/cmd/ai-services/cmd/application/image/image.go
@@ -26,7 +26,7 @@ var ImageCmd = &cobra.Command{
 
 // getCatalogImages is a helper that creates a catalog provider and collects images.
 func getCatalogImages(templateID string) ([]string, error) {
-	provider, err := catalog.NewCatalogProvider()
+	provider, err := catalog.NewCatalogProvider(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create catalog provider: %w", err)
 	}

--- a/ai-services/cmd/ai-services/cmd/application/info.go
+++ b/ai-services/cmd/ai-services/cmd/application/info.go
@@ -124,7 +124,7 @@ func renderApplicationInfo(appName string) error {
 }
 
 func printServicesInfo(services []catalogTypes.ApplicationService, appPS *catalogTypes.ApplicationPSResponse) error {
-	catalogProvider, err := catalog.NewCatalogProvider()
+	catalogProvider, err := catalog.NewCatalogProvider(nil)
 	if err != nil {
 		return fmt.Errorf("failed to create catalog provider: %w", err)
 	}

--- a/ai-services/cmd/ai-services/cmd/application/model/model.go
+++ b/ai-services/cmd/ai-services/cmd/application/model/model.go
@@ -51,7 +51,7 @@ func models(template string) ([]string, error) {
 // getCatalogModels is a helper that creates a catalog provider and collects models.
 // excludeComponentProviders is a variadic parameter that allows excluding specific component provider by ID.
 func getCatalogModels(templateID string, excludeComponentProviders ...string) ([]string, error) {
-	provider, err := catalog.NewCatalogProvider()
+	provider, err := catalog.NewCatalogProvider(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create catalog provider: %w", err)
 	}

--- a/ai-services/cmd/ai-services/cmd/application/templates.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates.go
@@ -115,7 +115,7 @@ func init() {
 // listCatalogTemplates lists architectures, services, and components from the catalog.
 func listCatalogTemplates(cmd *cobra.Command) error {
 	// Create catalog provider
-	provider, err := catalog.NewCatalogProvider()
+	provider, err := catalog.NewCatalogProvider(nil)
 	if err != nil {
 		return fmt.Errorf("failed to create catalog provider: %w", err)
 	}

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -35,7 +35,7 @@ func NewParametersCmd() *cobra.Command {
 			}
 
 			// Create catalog provider
-			provider, err := catalog.NewCatalogProvider()
+			provider, err := catalog.NewCatalogProvider(nil)
 			if err != nil {
 				return fmt.Errorf("failed to create catalog provider: %w", err)
 			}

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -84,20 +84,18 @@ func buildAPIServerOptions(ctx context.Context, pool *pgxpool.Pool, secretKey, a
 	compRepo := repository.NewComponentRepository(pool)
 	svcDepRepo := repository.NewServiceDependencyRepository(pool)
 
+	catalogProvider, err := catalog.NewCatalogProvider(bundleRepo)
+	if err != nil {
+		return apiserver.APIServerOptions{}, nil, fmt.Errorf("failed to initialize catalog provider: %w", err)
+	}
+
 	// Initialize sync service for background DB-Pod synchronization
 	// TODO: implement sync service on remote machines
-	syncService, err := sync.NewSyncService(appRepo, svcRepo, compRepo, svcDepRepo, sync.DefaultSyncInterval)
+	syncService, err := sync.NewSyncService(appRepo, svcRepo, compRepo, svcDepRepo, sync.DefaultSyncInterval, catalogProvider)
 	if err != nil {
 		return apiserver.APIServerOptions{}, nil, fmt.Errorf("failed to initialize sync service: %w", err)
 	}
 	syncService.Start(ctx)
-
-	catalogProvider, err := catalog.NewCatalogProvider(bundleRepo)
-	if err != nil {
-		syncService.Stop(ctx)
-
-		return apiserver.APIServerOptions{}, nil, fmt.Errorf("failed to initialize catalog provider: %w", err)
-	}
 
 	tokenMgr := auth.NewTokenManager(secretKey, accessTTL, refreshTTL)
 	workerRepo := repository.NewWorkerRepository(pool)
@@ -120,6 +118,7 @@ func buildAPIServerOptions(ctx context.Context, pool *pgxpool.Pool, secretKey, a
 		Blacklist:          blacklist,
 		ApplicationService: apirepository.NewApplicationService(appRepo, svcRepo, compRepo, svcDepRepo, catalogProvider, vars.RuntimeFactory.GetRuntimeType()),
 		BundleService:      bundlesvc.NewBundleService(bundleRepo, svcRepo, compRepo, catalogProvider),
+		CatalogProvider:    catalogProvider,
 		WorkerGatewayPort:  workerGatewayPort,
 		WorkerRegistry:     workerReg,
 	}

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -92,7 +92,7 @@ func buildAPIServerOptions(ctx context.Context, pool *pgxpool.Pool, secretKey, a
 	}
 	syncService.Start(ctx)
 
-	catalogProvider, err := catalog.NewCatalogProvider()
+	catalogProvider, err := catalog.NewCatalogProvider(bundleRepo)
 	if err != nil {
 		syncService.Stop(ctx)
 
@@ -119,7 +119,7 @@ func buildAPIServerOptions(ctx context.Context, pool *pgxpool.Pool, secretKey, a
 		TokenManager:       tokenMgr,
 		Blacklist:          blacklist,
 		ApplicationService: apirepository.NewApplicationService(appRepo, svcRepo, compRepo, svcDepRepo, catalogProvider, vars.RuntimeFactory.GetRuntimeType()),
-		BundleService:      bundlesvc.NewBundleService(bundleRepo, svcRepo, compRepo),
+		BundleService:      bundlesvc.NewBundleService(bundleRepo, svcRepo, compRepo, catalogProvider),
 		WorkerGatewayPort:  workerGatewayPort,
 		WorkerRegistry:     workerReg,
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/apiserver.go
+++ b/ai-services/internal/pkg/catalog/apiserver/apiserver.go
@@ -35,6 +35,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
 	bundlesvc "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/bundle"
@@ -52,6 +53,7 @@ type APIServerOptions struct {
 	Blacklist          repository.TokenBlacklist
 	ApplicationService repository.ApplicationServiceInterface
 	BundleService      bundlesvc.BundleServiceInterface
+	CatalogProvider    *catalog.CatalogProvider
 
 	// WorkerGatewayPort is the port the gRPC worker gateway listens on.
 	// Defaults to 9090 when zero.
@@ -69,6 +71,7 @@ type APIserver struct {
 	blacklist          repository.TokenBlacklist
 	applicationService repository.ApplicationServiceInterface
 	bundleService      bundlesvc.BundleServiceInterface
+	catalogProvider    *catalog.CatalogProvider
 
 	workerGatewayPort int
 	workerRegistry    *registry.Registry
@@ -91,6 +94,7 @@ func NewAPIserver(options APIServerOptions) *APIserver {
 		blacklist:          options.Blacklist,
 		applicationService: options.ApplicationService,
 		bundleService:      options.BundleService,
+		catalogProvider:    options.CatalogProvider,
 		workerGatewayPort:  options.WorkerGatewayPort,
 		workerRegistry:     options.WorkerRegistry,
 	}
@@ -113,7 +117,7 @@ func (a *APIserver) Start(ctx context.Context) error {
 	}
 	logger.InfofCtx(ctx, "Worker gateway started on %s", gatewayAddr)
 
-	r := CreateRouter(a.authService, a.tokenManager, a.blacklist, a.applicationService, a.workerRegistry, a.bundleService)
+	r := CreateRouter(a.authService, a.tokenManager, a.blacklist, a.applicationService, a.workerRegistry, a.bundleService, a.catalogProvider)
 
 	if err := r.Run(fmt.Sprintf(":%d", a.port)); err != nil {
 		return err

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
@@ -15,17 +15,9 @@ type CatalogHandler struct {
 	provider *catalog.CatalogProvider
 }
 
-// NewCatalogHandler creates a new catalog handler.
-func NewCatalogHandler() *CatalogHandler {
-	provider, err := catalog.NewCatalogProvider(nil)
-	if err != nil {
-		// Log error but don't fail - let individual requests handle it
-		panic(fmt.Sprintf("Failed to initialize catalog provider: %v", err))
-	}
-
-	return &CatalogHandler{
-		provider: provider,
-	}
+// NewCatalogHandler creates a new catalog handler backed by the given provider.
+func NewCatalogHandler(provider *catalog.CatalogProvider) *CatalogHandler {
+	return &CatalogHandler{provider: provider}
 }
 
 // ListArchitectures godoc

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
@@ -17,7 +17,7 @@ type CatalogHandler struct {
 
 // NewCatalogHandler creates a new catalog handler.
 func NewCatalogHandler() *CatalogHandler {
-	provider, err := catalog.NewCatalogProvider()
+	provider, err := catalog.NewCatalogProvider(nil)
 	if err != nil {
 		// Log error but don't fail - let individual requests handle it
 		panic(fmt.Sprintf("Failed to initialize catalog provider: %v", err))

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/catalog_test.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/catalog_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
@@ -27,9 +28,18 @@ func setupTestRouter() *gin.Engine {
 	return router
 }
 
+// newTestCatalogHandler creates a CatalogHandler backed by embedded-only catalog items
+// (no bundle DB) — sufficient for unit tests that exercise built-in catalog entries.
+func newTestCatalogHandler(t *testing.T) *CatalogHandler {
+	t.Helper()
+	provider, err := catalog.NewCatalogProvider(nil)
+	require.NoError(t, err)
+	return NewCatalogHandler(provider)
+}
+
 func TestListArchitectures(t *testing.T) {
 	router := setupTestRouter()
-	handler := NewCatalogHandler()
+	handler := newTestCatalogHandler(t)
 	router.GET("/api/v1/architectures", handler.ListArchitectures)
 
 	tests := []struct {
@@ -77,7 +87,7 @@ func TestListArchitectures(t *testing.T) {
 
 func TestGetArchitecture(t *testing.T) {
 	router := setupTestRouter()
-	handler := NewCatalogHandler()
+	handler := newTestCatalogHandler(t)
 	router.GET("/api/v1/architectures/:id", handler.GetArchitectureDetails)
 
 	tests := []struct {
@@ -146,7 +156,7 @@ func validateArchitectureNotFound(t *testing.T, body []byte) {
 
 func TestListServices(t *testing.T) {
 	router := setupTestRouter()
-	handler := NewCatalogHandler()
+	handler := newTestCatalogHandler(t)
 	router.GET("/api/v1/services", handler.ListServices)
 
 	tests := []struct {
@@ -206,7 +216,7 @@ func TestListServices(t *testing.T) {
 
 func TestGetService(t *testing.T) {
 	router := setupTestRouter()
-	handler := NewCatalogHandler()
+	handler := newTestCatalogHandler(t)
 	router.GET("/api/v1/services/:id", handler.GetServiceDetails)
 
 	tests := []struct {

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -729,7 +729,7 @@ func (s *ApplicationServiceBase) GetApplicationResources(ctx context.Context, id
 		return nil, fmt.Errorf("failed to create runtime client: %w", err)
 	}
 
-	catalogProvider, err := catalog.NewCatalogProvider()
+	catalogProvider, err := catalog.NewCatalogProvider(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create catalog provider: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -729,12 +729,7 @@ func (s *ApplicationServiceBase) GetApplicationResources(ctx context.Context, id
 		return nil, fmt.Errorf("failed to create runtime client: %w", err)
 	}
 
-	catalogProvider, err := catalog.NewCatalogProvider(nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create catalog provider: %w", err)
-	}
-
-	resourceTotals, err := s.collectResources(ctx, app, runtimeClient, catalogProvider)
+	resourceTotals, err := s.collectResources(ctx, app, runtimeClient, s.Provider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to collect application resources: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/router.go
+++ b/ai-services/internal/pkg/catalog/apiserver/router.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	_ "github.com/project-ai-services/ai-services/docs" // Import generated docs
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/handlers"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/middleware"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
@@ -17,7 +18,7 @@ import (
 )
 
 // CreateRouter sets up the Gin router with the necessary routes and authentication middleware for the API server.
-func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist repository.TokenBlacklist, appService repository.ApplicationServiceInterface, workerReg *registry.Registry, bundleService bundlesvc.BundleServiceInterface) *gin.Engine {
+func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist repository.TokenBlacklist, appService repository.ApplicationServiceInterface, workerReg *registry.Registry, bundleService bundlesvc.BundleServiceInterface, catalogProvider *catalog.CatalogProvider) *gin.Engine {
 	if mode := os.Getenv("GIN_MODE"); mode != "" {
 		gin.SetMode(mode)
 	}
@@ -35,7 +36,7 @@ func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist r
 	registerAuthRoutes(v1, handlers.NewAuthHandler(authSvc), tokenMgr, blacklist)
 
 	auth := middleware.AuthMiddleware(tokenMgr, blacklist)
-	registerCatalogRoutes(v1, handlers.NewCatalogHandler(), handlers.NewResourcesHandler(), auth)
+	registerCatalogRoutes(v1, handlers.NewCatalogHandler(catalogProvider), handlers.NewResourcesHandler(), auth)
 	registerApplicationRoutes(v1, handlers.NewApplicationHandler(appService), auth)
 	registerWorkerRoutes(v1, handlers.NewWorkerHandler(workerReg), auth)
 	registerBundleRoutes(v1, handlers.NewBundleHandler(bundleService), auth)

--- a/ai-services/internal/pkg/catalog/apiserver/services/bundle/service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/bundle/service.go
@@ -15,18 +15,30 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/validators"
 )
 
+// CatalogReloader is satisfied by *catalog.CatalogProvider.
+// It is defined here so the bundle service can be tested without importing the
+// concrete provider type.
+type CatalogReloader interface {
+	Reload(ctx context.Context) error
+}
+
 // bundleService implements BundleServiceInterface.
 type bundleService struct {
-	repo     repository.BundleRepository
-	svcRepo  repository.ServiceRepository
-	compRepo repository.ComponentRepository
-	// TODO: add CatalogProvider reference for Reload() calls once wired in.
-	// catalogProvider *catalog.CatalogProvider
+	repo            repository.BundleRepository
+	svcRepo         repository.ServiceRepository
+	compRepo        repository.ComponentRepository
+	catalogReloader CatalogReloader // nil on CLI / test paths — Reload() calls are skipped when nil
 }
 
 // NewBundleService creates a new bundleService backed by the given repositories.
-func NewBundleService(repo repository.BundleRepository, svcRepo repository.ServiceRepository, compRepo repository.ComponentRepository) BundleServiceInterface {
-	return &bundleService{repo: repo, svcRepo: svcRepo, compRepo: compRepo}
+// catalogReloader may be nil — Reload() calls are skipped when nil.
+func NewBundleService(repo repository.BundleRepository, svcRepo repository.ServiceRepository, compRepo repository.ComponentRepository, catalogReloader CatalogReloader) BundleServiceInterface {
+	return &bundleService{
+		repo:            repo,
+		svcRepo:         svcRepo,
+		compRepo:        compRepo,
+		catalogReloader: catalogReloader,
+	}
 }
 
 // ValidateBundle validates a .tar.gz archive without persisting anything.
@@ -56,7 +68,8 @@ func (s *bundleService) ValidateBundle(_ context.Context, _ io.Reader) (any, err
 //  4. Extract archive to bundleDirPath(catalogType, catalogID, version),
 //     stripping the top-level directory.
 //  5. Insert DB row via BundleRepository.Insert (status=processing).
-//  6. TODO — CatalogProvider.Reload() once the provider reference is wired in.
+//  6. CatalogProvider.Reload() — rebuilds the in-memory catalog so the new bundle
+//     is immediately visible. On failure: mark row failed and return error.
 //  7. Mark row active via BundleRepository.Update (status=active, size_bytes, name, version).
 //  8. Re-fetch via GetBundleByID and return as *BundleResponse.
 //     On failure after step 5: mark row failed and store the error message.
@@ -107,7 +120,14 @@ func (s *bundleService) ProcessBundle(ctx context.Context, file io.Reader, userI
 		return nil, fmt.Errorf("failed to insert bundle record: %w", err)
 	}
 
-	// Step 6: TODO — CatalogProvider.Reload() once the provider reference is wired in.
+	// Step 6: reload the catalog so the new bundle is immediately visible.
+	if s.catalogReloader != nil {
+		if reloadErr := s.catalogReloader.Reload(ctx); reloadErr != nil {
+			s.markFailed(ctx, row.ID, reloadErr.Error())
+
+			return nil, fmt.Errorf("catalog reload failed after bundle creation: %w", reloadErr)
+		}
+	}
 
 	// Step 7: mark row active.
 	statusActive := models.BundleStatusActive
@@ -138,7 +158,8 @@ func (s *bundleService) ProcessBundle(ctx context.Context, file io.Reader, userI
 //  5. Extract archive to a staging directory (<catalog_id>-<version>-new).
 //  6. Rename staging directory into the final path (bundleDirPath).
 //  7. UPDATE existing row in-place (status=active, version, name, size_bytes) via BundleRepository.Update.
-//  8. TODO — CatalogProvider.Reload() once the provider reference is wired in.
+//  8. CatalogProvider.Reload() — rebuilds the in-memory catalog so the replaced bundle is
+//     immediately visible. On failure: mark row failed and return error.
 //  9. Delete old on-disk directory when it differs from the new final path.
 //  10. Re-fetch via BundleRepository.GetByID and return as *BundleResponse.
 //     On failure after step 4: mark row failed, store error message.
@@ -236,7 +257,12 @@ func (s *bundleService) replaceBundleFiles(ctx context.Context, existingID uuid.
 		return nil, fmt.Errorf("failed to activate replaced bundle: %w", updateErr)
 	}
 
-	// Step 8: TODO — CatalogProvider.Reload() once the provider reference is wired in.
+	// Step 8: reload the catalog so the replaced bundle is immediately visible.
+	if s.catalogReloader != nil {
+		if reloadErr := s.catalogReloader.Reload(ctx); reloadErr != nil {
+			return nil, fmt.Errorf("catalog reload failed after bundle replacement: %w", reloadErr)
+		}
+	}
 
 	// Step 9: delete old on-disk directory when it differs from the new final path.
 	if oldDir != newFinalDir {
@@ -270,8 +296,8 @@ func (s *bundleService) GetBundleByID(ctx context.Context, bundleID string) (*Bu
 }
 
 // DeleteBundle synchronously marks the row deleting, guards against running
-// instances, removes the on-disk directory, reloads CatalogProvider (TODO),
-// and deletes the DB row.
+// instances, removes the on-disk directory, reloads CatalogProvider, and
+// deletes the DB row.
 //
 // It accepts the *BundleResponse returned by GetBundleByID — the same shape
 // used by ReplaceBundle — so the handler does not need to construct an
@@ -281,7 +307,8 @@ func (s *bundleService) GetBundleByID(ctx context.Context, bundleID string) (*Bu
 //     still reference this bundle's catalog entry.
 //  2. Mark row deleting via BundleRepository.Update.
 //  3. Delete on-disk directory: bundleDirPath(existing.CatalogType, existing.CatalogID, existing.Version).
-//  4. TODO — CatalogProvider.Reload() once the provider reference is wired in.
+//  4. CatalogProvider.Reload() — rebuilds the in-memory catalog so the deleted bundle
+//     is no longer served. On failure: mark row failed and return error.
 //  5. Delete DB row via BundleRepository.Delete.
 //     On failure before step 5: mark row failed.
 func (s *bundleService) DeleteBundle(ctx context.Context, existing *BundleResponse) error {
@@ -322,7 +349,12 @@ func (s *bundleService) deleteBundleFiles(ctx context.Context, existingID uuid.U
 		return fmt.Errorf("failed to remove bundle directory %q: %w", dirPath, err)
 	}
 
-	// Step 4: TODO — CatalogProvider.Reload() once the provider reference is wired in.
+	// Step 4: reload the catalog so the deleted bundle is no longer served.
+	if s.catalogReloader != nil {
+		if reloadErr := s.catalogReloader.Reload(ctx); reloadErr != nil {
+			return fmt.Errorf("catalog reload failed after bundle deletion: %w", reloadErr)
+		}
+	}
 
 	// Step 5: delete DB row.
 	if err := s.repo.Delete(ctx, existingID); err != nil {

--- a/ai-services/internal/pkg/catalog/apiserver/services/bundle/service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/bundle/service.go
@@ -68,9 +68,10 @@ func (s *bundleService) ValidateBundle(_ context.Context, _ io.Reader) (any, err
 //  4. Extract archive to bundleDirPath(catalogType, catalogID, version),
 //     stripping the top-level directory.
 //  5. Insert DB row via BundleRepository.Insert (status=processing).
-//  6. CatalogProvider.Reload() — rebuilds the in-memory catalog so the new bundle
+//  6. Mark row active via BundleRepository.Update (status=active, size_bytes, name, version).
+//     On failure: mark row failed and return error.
+//  7. CatalogProvider.Reload() — rebuilds the in-memory catalog so the now-active bundle
 //     is immediately visible. On failure: mark row failed and return error.
-//  7. Mark row active via BundleRepository.Update (status=active, size_bytes, name, version).
 //  8. Re-fetch via GetBundleByID and return as *BundleResponse.
 //     On failure after step 5: mark row failed and store the error message.
 func (s *bundleService) ProcessBundle(ctx context.Context, file io.Reader, userID string) (*BundleResponse, error) {
@@ -111,7 +112,7 @@ func (s *bundleService) ProcessBundle(ctx context.Context, file io.Reader, userI
 }
 
 // insertActivateAndFetch performs steps 5–8 of ProcessBundle:
-// insert DB row, reload catalog, mark active, and re-fetch the final row.
+// insert DB row, mark active, reload catalog, and re-fetch the final row.
 func (s *bundleService) insertActivateAndFetch(ctx context.Context, meta BundleMetadata, destDir string, sizeBytes int64, userID string) (*BundleResponse, error) {
 	// Step 5: insert DB row with status=processing.
 	row := &models.CatalogBundle{
@@ -127,16 +128,7 @@ func (s *bundleService) insertActivateAndFetch(ctx context.Context, meta BundleM
 		return nil, fmt.Errorf("failed to insert bundle record: %w", err)
 	}
 
-	// Step 6: reload the catalog so the new bundle is immediately visible.
-	if s.catalogReloader != nil {
-		if reloadErr := s.catalogReloader.Reload(ctx); reloadErr != nil {
-			s.markFailed(ctx, row.ID, reloadErr.Error())
-
-			return nil, fmt.Errorf("catalog reload failed after bundle creation: %w", reloadErr)
-		}
-	}
-
-	// Step 7: mark row active.
+	// Step 6: mark row active so Reload() can see it as "active" when it queries the DB.
 	statusActive := models.BundleStatusActive
 	name := meta.DisplayName()
 	version := meta.Version()
@@ -149,6 +141,15 @@ func (s *bundleService) insertActivateAndFetch(ctx context.Context, meta BundleM
 		s.markFailed(ctx, row.ID, updateErr.Error())
 
 		return nil, fmt.Errorf("failed to activate bundle: %w", updateErr)
+	}
+
+	// Step 7: reload the catalog so the now-active bundle is immediately visible.
+	if s.catalogReloader != nil {
+		if reloadErr := s.catalogReloader.Reload(ctx); reloadErr != nil {
+			s.markFailed(ctx, row.ID, reloadErr.Error())
+
+			return nil, fmt.Errorf("catalog reload failed after bundle creation: %w", reloadErr)
+		}
 	}
 
 	// Step 8: re-fetch the authoritative row from DB and return.

--- a/ai-services/internal/pkg/catalog/apiserver/services/bundle/service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/bundle/service.go
@@ -106,6 +106,13 @@ func (s *bundleService) ProcessBundle(ctx context.Context, file io.Reader, userI
 		return nil, err
 	}
 
+	// Steps 5–8: insert, reload, activate, and return.
+	return s.insertActivateAndFetch(ctx, meta, destDir, sizeBytes, userID)
+}
+
+// insertActivateAndFetch performs steps 5–8 of ProcessBundle:
+// insert DB row, reload catalog, mark active, and re-fetch the final row.
+func (s *bundleService) insertActivateAndFetch(ctx context.Context, meta BundleMetadata, destDir string, sizeBytes int64, userID string) (*BundleResponse, error) {
 	// Step 5: insert DB row with status=processing.
 	row := &models.CatalogBundle{
 		Name:        meta.DisplayName(),

--- a/ai-services/internal/pkg/catalog/apiserver/services/bundle/service_test.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/bundle/service_test.go
@@ -475,10 +475,10 @@ func TestReplaceBundle_HappyPath(t *testing.T) {
 	require.Error(t, err) // expected: extraction fails without real storage root
 }
 
-// TestReplaceBundle_ActivateFailureMarksRowFailed uses the internal
+// TestActivateFailureMarksRowFailed uses the internal
 // replaceBundleFiles helper to drive the post-processing path directly,
 // using a real temp dir so that extraction succeeds.
-func TestReplaceBundle_ActivateFailureMarksRowFailed(t *testing.T) {
+func TestActivateFailureMarksRowFailed(t *testing.T) {
 	fixedID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
 	tmp := t.TempDir()
 
@@ -545,11 +545,11 @@ func TestReplaceBundle_ActivateFailureMarksRowFailed(t *testing.T) {
 	assert.NotNil(t, lastCall.Error)
 }
 
-// TestReplaceBundle_SameVersionNoOldDirCleanup verifies that when old and new
+// TestSameVersionNoOldDirCleanup verifies that when old and new
 // directory paths are the same (same catalog_id + same version) the code does
 // NOT attempt to remove the directory (no double-remove).
 // We test this by calling replaceBundleFiles directly with a temp dir.
-func TestReplaceBundle_SameVersionNoOldDirCleanup(t *testing.T) {
+func TestSameVersionNoOldDirCleanup(t *testing.T) {
 	fixedID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
 	tmp := t.TempDir()
 	now := time.Now()
@@ -622,9 +622,9 @@ func TestReplaceBundle_SameVersionNoOldDirCleanup(t *testing.T) {
 	assert.Equal(t, "active", resp.Status)
 }
 
-// TestReplaceBundle_GetByIDAfterActivationError checks that when the final
+// TestGetByIDAfterActivationError checks that when the final
 // GetBundleByID re-fetch returns an error, that error is propagated.
-func TestReplaceBundle_GetByIDAfterActivationError(t *testing.T) {
+func TestGetByIDAfterActivationError(t *testing.T) {
 	fixedID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
 	callCount := 0
 	repo := &mockBundleRepo{
@@ -1369,11 +1369,11 @@ func failsOnReload(err error) *mockCatalogReloader {
 	}
 }
 
-// TestProcessBundle_ReloadCalledOnSuccess verifies that Reload is invoked after
+// TestReloadAfterProcess_CalledOnSuccess verifies that Reload is invoked after
 // the row is activated (not before), so loadBundleItems sees the "active" row.
 // We drive the activate → reload → re-fetch path directly, bypassing the
 // filesystem step that requires bundleStorageRoot to exist.
-func TestProcessBundle_ReloadCalledOnSuccess(t *testing.T) {
+func TestReloadAfterProcess_CalledOnSuccess(t *testing.T) {
 	fixedID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
 	now := time.Now()
 	sz := int64(64)
@@ -1440,9 +1440,9 @@ func TestProcessBundle_ReloadCalledOnSuccess(t *testing.T) {
 	assert.Equal(t, models.BundleStatusActive, *updateCalls[0].Status)
 }
 
-// TestProcessBundle_ReloadFailureMarksRowFailed verifies that when Reload returns
+// TestReloadAfterProcess_FailureMarksRowFailed verifies that when Reload returns
 // an error the row is marked failed and the error is propagated.
-func TestProcessBundle_ReloadFailureMarksRowFailed(t *testing.T) {
+func TestReloadAfterProcess_FailureMarksRowFailed(t *testing.T) {
 	fixedID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
 	now := time.Now()
 	reloadErr := fmt.Errorf("reload boom")
@@ -1488,13 +1488,13 @@ func TestProcessBundle_ReloadFailureMarksRowFailed(t *testing.T) {
 	assert.Contains(t, *capturedFailUpdate.Error, "reload boom")
 }
 
-// TestReplaceBundle_ReloadCalledOnSuccess verifies that Reload is invoked after
+// TestReloadAfterReplace_CalledOnSuccess verifies that Reload is invoked after
 // the DB row is activated during a replace operation.
 // bundleDirPath always points at the real /data/catalog-bundles root so we
 // cannot drive replaceBundleFiles end-to-end in a unit test. Instead we exercise
 // the activate → reload → re-fetch sequence directly, mirroring the approach
 // used for ProcessBundle.
-func TestReplaceBundle_ReloadCalledOnSuccess(t *testing.T) {
+func TestReloadAfterReplace_CalledOnSuccess(t *testing.T) {
 	fixedID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
 	now := time.Now()
 	sz := int64(512)
@@ -1551,10 +1551,10 @@ func TestReplaceBundle_ReloadCalledOnSuccess(t *testing.T) {
 	assert.Equal(t, models.BundleStatusActive, *updateCalls[0].Status)
 }
 
-// TestReplaceBundle_ReloadFailureMarksRowFailed verifies that when Reload fails
+// TestReloadAfterReplace_FailureMarksRowFailed verifies that when Reload fails
 // after the DB row is activated, replaceBundleFiles returns the error and the
-// caller (ReplaceBundle) marks the row failed.
-func TestReplaceBundle_ReloadFailureMarksRowFailed(t *testing.T) {
+// row is marked failed.
+func TestReloadAfterReplace_FailureMarksRowFailed(t *testing.T) {
 	fixedID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
 	reloadErr := fmt.Errorf("reload after replace failed")
 

--- a/ai-services/internal/pkg/catalog/apiserver/services/bundle/service_test.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/bundle/service_test.go
@@ -1370,9 +1370,9 @@ func failsOnReload(err error) *mockCatalogReloader {
 }
 
 // TestProcessBundle_ReloadCalledOnSuccess verifies that Reload is invoked after
-// a successful insert and that the row is then activated.
-// We drive replaceBundleFiles directly (avoiding bundleStorageRoot) to exercise
-// the reload + activate path.
+// the row is activated (not before), so loadBundleItems sees the "active" row.
+// We drive the activate → reload → re-fetch path directly, bypassing the
+// filesystem step that requires bundleStorageRoot to exist.
 func TestProcessBundle_ReloadCalledOnSuccess(t *testing.T) {
 	fixedID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
 	now := time.Now()
@@ -1408,17 +1408,14 @@ func TestProcessBundle_ReloadCalledOnSuccess(t *testing.T) {
 		},
 	}
 
-	// Call the internal reload+activate path directly, bypassing the
+	// Call the activate → reload → re-fetch path directly, bypassing the
 	// filesystem step that requires bundleStorageRoot to exist.
 	svc := &bundleService{repo: repo, catalogReloader: reloader}
 
 	// Simulate what ProcessBundle does after a successful insert (steps 6–8).
 	ctx := context.Background()
 
-	// Step 6: reload.
-	require.NoError(t, svc.catalogReloader.Reload(ctx))
-
-	// Step 7: activate.
+	// Step 6: activate first — row must be "active" before Reload queries the DB.
 	statusActive := models.BundleStatusActive
 	name := "My Service"
 	version := "1.0.0"
@@ -1428,6 +1425,9 @@ func TestProcessBundle_ReloadCalledOnSuccess(t *testing.T) {
 		Name:      &name,
 		Version:   &version,
 	}))
+
+	// Step 7: reload — loadBundleItems now sees the active row.
+	require.NoError(t, svc.catalogReloader.Reload(ctx))
 
 	// Step 8: re-fetch.
 	resp, err := svc.GetBundleByID(ctx, fixedID.String())

--- a/ai-services/internal/pkg/catalog/apiserver/services/bundle/service_test.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/bundle/service_test.go
@@ -3,6 +3,7 @@ package bundle
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -127,7 +128,7 @@ func TestProcessBundle_BadArchive(t *testing.T) {
 			return nil, nil
 		},
 	}
-	svc := NewBundleService(repo, nil, nil)
+	svc := NewBundleService(repo, nil, nil, nil)
 
 	_, err := svc.ProcessBundle(context.Background(), bytes.NewReader([]byte("not-gzip")), "admin")
 	assertValidationError(t, err, http.StatusBadRequest, "invalid gzip")
@@ -139,7 +140,7 @@ func TestProcessBundle_MissingMetadataYAML(t *testing.T) {
 			return nil, nil
 		},
 	}
-	svc := NewBundleService(repo, nil, nil)
+	svc := NewBundleService(repo, nil, nil, nil)
 
 	archive := buildArchive(t, map[string]string{"other.yaml": "key: val\n"}, true)
 	_, err := svc.ProcessBundle(context.Background(), bytes.NewReader(archive), "admin")
@@ -152,7 +153,7 @@ func TestProcessBundle_InvalidMetadataYAML(t *testing.T) {
 			return nil, nil
 		},
 	}
-	svc := NewBundleService(repo, nil, nil)
+	svc := NewBundleService(repo, nil, nil, nil)
 
 	archive := buildArchive(t, map[string]string{"metadata.yaml": "id: svc\ntype: service\n"}, true) // missing version
 	_, err := svc.ProcessBundle(context.Background(), bytes.NewReader(archive), "admin")
@@ -166,7 +167,7 @@ func TestProcessBundle_ConflictReturns409(t *testing.T) {
 			return &models.CatalogBundle{ID: existingID}, nil
 		},
 	}
-	svc := NewBundleService(repo, nil, nil)
+	svc := NewBundleService(repo, nil, nil, nil)
 
 	archive := buildArchive(t, map[string]string{
 		"metadata.yaml": serviceMetaYAML("my-service", "1.0.0", ""),
@@ -182,7 +183,7 @@ func TestProcessBundle_ConflictCheckRepoError(t *testing.T) {
 			return nil, assert.AnError
 		},
 	}
-	svc := NewBundleService(repo, nil, nil)
+	svc := NewBundleService(repo, nil, nil, nil)
 
 	archive := buildArchive(t, map[string]string{
 		"metadata.yaml": serviceMetaYAML("svc", "1.0.0", ""),
@@ -200,7 +201,7 @@ func TestProcessBundle_ExtractFailsBeforeInsert(t *testing.T) {
 			return nil, nil
 		},
 	}
-	svc := NewBundleService(repo, nil, nil)
+	svc := NewBundleService(repo, nil, nil, nil)
 
 	archive := buildArchive(t, map[string]string{
 		"metadata.yaml": serviceMetaYAML("svc", "1.0.0", ""),
@@ -298,20 +299,20 @@ func existingServiceRecord() *BundleResponse {
 }
 
 func TestReplaceBundle_BadArchive(t *testing.T) {
-	svc := NewBundleService(&mockBundleRepo{}, nil, nil)
+	svc := NewBundleService(&mockBundleRepo{}, nil, nil, nil)
 	_, err := svc.ReplaceBundle(context.Background(), existingServiceRecord(), bytes.NewReader([]byte("not-gzip")), "admin")
 	assertValidationError(t, err, http.StatusBadRequest, "invalid gzip")
 }
 
 func TestReplaceBundle_MissingMetadataYAML(t *testing.T) {
-	svc := NewBundleService(&mockBundleRepo{}, nil, nil)
+	svc := NewBundleService(&mockBundleRepo{}, nil, nil, nil)
 	archive := buildArchive(t, map[string]string{"other.yaml": "key: val\n"}, true)
 	_, err := svc.ReplaceBundle(context.Background(), existingServiceRecord(), bytes.NewReader(archive), "admin")
 	assertValidationError(t, err, http.StatusBadRequest, "metadata.yaml not found")
 }
 
 func TestReplaceBundle_InvalidMetadataYAML(t *testing.T) {
-	svc := NewBundleService(&mockBundleRepo{}, nil, nil)
+	svc := NewBundleService(&mockBundleRepo{}, nil, nil, nil)
 	// missing version field → 422
 	archive := buildArchive(t, map[string]string{"metadata.yaml": "id: my-service\ntype: service\n"}, true)
 	_, err := svc.ReplaceBundle(context.Background(), existingServiceRecord(), bytes.NewReader(archive), "admin")
@@ -319,7 +320,7 @@ func TestReplaceBundle_InvalidMetadataYAML(t *testing.T) {
 }
 
 func TestReplaceBundle_CatalogIDMismatch(t *testing.T) {
-	svc := NewBundleService(&mockBundleRepo{}, nil, nil)
+	svc := NewBundleService(&mockBundleRepo{}, nil, nil, nil)
 	// Archive has catalog_id "other-service" but existing record is "my-service".
 	archive := buildArchive(t, map[string]string{
 		"metadata.yaml": serviceMetaYAML("other-service", "2.0.0", ""),
@@ -329,7 +330,7 @@ func TestReplaceBundle_CatalogIDMismatch(t *testing.T) {
 }
 
 func TestReplaceBundle_CatalogTypeMismatch(t *testing.T) {
-	svc := NewBundleService(&mockBundleRepo{}, nil, nil)
+	svc := NewBundleService(&mockBundleRepo{}, nil, nil, nil)
 	// Existing record is a component with catalog_id "llm--my-provider".
 	// Archive also has catalog_id "llm--my-provider" but as a service type →
 	// catalog_id check passes, catalog_type check fires.
@@ -351,7 +352,7 @@ func TestReplaceBundle_CatalogTypeMismatch(t *testing.T) {
 func TestReplaceBundle_InvalidExistingID(t *testing.T) {
 	svc := func() BundleServiceInterface {
 		s, c := noRunningInstances()
-		return NewBundleService(&mockBundleRepo{}, s, c)
+		return NewBundleService(&mockBundleRepo{}, s, c, nil)
 	}()
 	badRecord := &BundleResponse{
 		ID:          "not-a-uuid",
@@ -375,7 +376,7 @@ func TestReplaceBundle_MarkProcessingFails(t *testing.T) {
 		},
 	}
 	noSvcRepo, noCompRepo := noRunningInstances()
-	svc := NewBundleService(repo, noSvcRepo, noCompRepo)
+	svc := NewBundleService(repo, noSvcRepo, noCompRepo, nil)
 	archive := buildArchive(t, map[string]string{
 		"metadata.yaml": serviceMetaYAML("my-service", "2.0.0", "Updated"),
 	}, true)
@@ -399,7 +400,7 @@ func TestReplaceBundle_ExtractionFailsAfterMarkProcessing(t *testing.T) {
 		},
 	}
 	noSvcRepo2, noCompRepo2 := noRunningInstances()
-	svc := NewBundleService(repo, noSvcRepo2, noCompRepo2)
+	svc := NewBundleService(repo, noSvcRepo2, noCompRepo2, nil)
 	archive := buildArchive(t, map[string]string{
 		"metadata.yaml": serviceMetaYAML("my-service", "2.0.0", "Updated"),
 	}, true)
@@ -453,7 +454,7 @@ func TestReplaceBundle_HappyPath(t *testing.T) {
 		},
 	}
 	noSvcRepo3, noCompRepo3 := noRunningInstances()
-	svc := NewBundleService(repo, noSvcRepo3, noCompRepo3)
+	svc := NewBundleService(repo, noSvcRepo3, noCompRepo3, nil)
 
 	archive := buildArchive(t, map[string]string{
 		"metadata.yaml": serviceMetaYAML("my-service", "2.0.0", "Updated Name"),
@@ -681,7 +682,7 @@ func TestReplaceBundle_GetByIDAfterActivationError(t *testing.T) {
 // TestReplaceBundle_ComponentBundle verifies that a component bundle whose
 // catalog_id matches the existing record replaces successfully.
 func TestReplaceBundle_ComponentBundle_CatalogIDMismatch(t *testing.T) {
-	svc := NewBundleService(&mockBundleRepo{}, nil, nil)
+	svc := NewBundleService(&mockBundleRepo{}, nil, nil, nil)
 	existing := &BundleResponse{
 		ID:          uuid.New().String(),
 		CatalogType: CatalogTypeComponent,
@@ -701,7 +702,7 @@ func TestReplaceBundle_ComponentBundle_CatalogIDMismatch(t *testing.T) {
 // -----------------------------------------------------------------------
 
 func TestGetBundleByID_InvalidUUID(t *testing.T) {
-	svc := NewBundleService(&mockBundleRepo{}, nil, nil)
+	svc := NewBundleService(&mockBundleRepo{}, nil, nil, nil)
 	_, err := svc.GetBundleByID(context.Background(), "not-a-uuid")
 	assertValidationError(t, err, http.StatusBadRequest, "invalid bundle id")
 }
@@ -712,7 +713,7 @@ func TestGetBundleByID_NotFound(t *testing.T) {
 			return nil, nil
 		},
 	}
-	resp, err := NewBundleService(repo, nil, nil).GetBundleByID(context.Background(), uuid.New().String())
+	resp, err := NewBundleService(repo, nil, nil, nil).GetBundleByID(context.Background(), uuid.New().String())
 	require.NoError(t, err)
 	assert.Nil(t, resp)
 }
@@ -723,7 +724,7 @@ func TestGetBundleByID_RepoError(t *testing.T) {
 			return nil, assert.AnError
 		},
 	}
-	_, err := NewBundleService(repo, nil, nil).GetBundleByID(context.Background(), uuid.New().String())
+	_, err := NewBundleService(repo, nil, nil, nil).GetBundleByID(context.Background(), uuid.New().String())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get bundle")
 }
@@ -751,7 +752,7 @@ func TestGetBundleByID_Found(t *testing.T) {
 		},
 	}
 
-	resp, err := NewBundleService(repo, nil, nil).GetBundleByID(context.Background(), fixedID.String())
+	resp, err := NewBundleService(repo, nil, nil, nil).GetBundleByID(context.Background(), fixedID.String())
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, fixedID.String(), resp.ID)
@@ -770,14 +771,14 @@ func TestGetBundleByID_Found(t *testing.T) {
 // -----------------------------------------------------------------------
 
 func TestListBundles_InvalidPage(t *testing.T) {
-	svc := NewBundleService(&mockBundleRepo{}, nil, nil)
+	svc := NewBundleService(&mockBundleRepo{}, nil, nil, nil)
 	_, err := svc.ListBundles(context.Background(), BundleListRequest{Page: 0, PageSize: 20})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "page must be greater than 0")
 }
 
 func TestListBundles_InvalidPageSize(t *testing.T) {
-	svc := NewBundleService(&mockBundleRepo{}, nil, nil)
+	svc := NewBundleService(&mockBundleRepo{}, nil, nil, nil)
 	_, err := svc.ListBundles(context.Background(), BundleListRequest{Page: 1, PageSize: 0})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pageSize must be greater than 0")
@@ -787,7 +788,7 @@ func TestListBundles_GetCountError(t *testing.T) {
 	repo := &mockBundleRepo{
 		getCount: func(_ context.Context) (int, error) { return 0, assert.AnError },
 	}
-	_, err := NewBundleService(repo, nil, nil).ListBundles(context.Background(), BundleListRequest{Page: 1, PageSize: 20})
+	_, err := NewBundleService(repo, nil, nil, nil).ListBundles(context.Background(), BundleListRequest{Page: 1, PageSize: 20})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get bundle count")
 }
@@ -799,7 +800,7 @@ func TestListBundles_GetAllError(t *testing.T) {
 			return nil, assert.AnError
 		},
 	}
-	_, err := NewBundleService(repo, nil, nil).ListBundles(context.Background(), BundleListRequest{Page: 1, PageSize: 20})
+	_, err := NewBundleService(repo, nil, nil, nil).ListBundles(context.Background(), BundleListRequest{Page: 1, PageSize: 20})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to retrieve bundles")
 }
@@ -810,7 +811,7 @@ func TestListBundles_Empty(t *testing.T) {
 		getCount: func(_ context.Context) (int, error) { return 0, nil },
 		getAll:   func(_ context.Context, _ *repository.BundleFilters) ([]models.CatalogBundle, error) { return nil, nil },
 	}
-	resp, err := NewBundleService(repo, nil, nil).ListBundles(context.Background(), BundleListRequest{Page: 1, PageSize: 20})
+	resp, err := NewBundleService(repo, nil, nil, nil).ListBundles(context.Background(), BundleListRequest{Page: 1, PageSize: 20})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Empty(t, resp.Bundles)
@@ -845,7 +846,7 @@ func TestListBundles_PaginationMetadata(t *testing.T) {
 		},
 	}
 
-	resp, err := NewBundleService(repo, nil, nil).ListBundles(context.Background(), BundleListRequest{Page: 2, PageSize: 10})
+	resp, err := NewBundleService(repo, nil, nil, nil).ListBundles(context.Background(), BundleListRequest{Page: 2, PageSize: 10})
 	require.NoError(t, err)
 	require.Len(t, resp.Bundles, 2)
 
@@ -883,7 +884,7 @@ func TestReplaceBundle_ServiceRunning(t *testing.T) {
 			return false, nil
 		},
 	}
-	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo)
+	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo, nil)
 	archive := buildArchive(t, map[string]string{
 		"metadata.yaml": serviceMetaYAML("my-service", "2.0.0", ""),
 	}, true)
@@ -905,7 +906,7 @@ func TestReplaceBundle_ServiceRunningRepoError(t *testing.T) {
 			return false, nil
 		},
 	}
-	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo)
+	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo, nil)
 	archive := buildArchive(t, map[string]string{
 		"metadata.yaml": serviceMetaYAML("my-service", "2.0.0", ""),
 	}, true)
@@ -937,7 +938,7 @@ func TestReplaceBundle_ComponentRunning(t *testing.T) {
 			return true, nil // simulate a running component
 		},
 	}
-	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo)
+	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo, nil)
 	archive := buildArchive(t, map[string]string{
 		"metadata.yaml": componentMetaYAML("my-provider", "llm", "2.0.0"),
 	}, true)
@@ -965,7 +966,7 @@ func TestReplaceBundle_ComponentRunningRepoError(t *testing.T) {
 			return false, assert.AnError
 		},
 	}
-	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo)
+	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo, nil)
 	archive := buildArchive(t, map[string]string{
 		"metadata.yaml": componentMetaYAML("my-provider", "llm", "2.0.0"),
 	}, true)
@@ -989,7 +990,7 @@ func TestReplaceBundle_NoRunningInstances_Proceeds(t *testing.T) {
 		},
 	}
 	noSvcRepo4, noCompRepo4 := noRunningInstances()
-	svc := NewBundleService(repo, noSvcRepo4, noCompRepo4)
+	svc := NewBundleService(repo, noSvcRepo4, noCompRepo4, nil)
 	archive := buildArchive(t, map[string]string{
 		"metadata.yaml": serviceMetaYAML("my-service", "2.0.0", ""),
 	}, true)
@@ -1086,7 +1087,7 @@ func TestDeleteBundle_HappyPath(t *testing.T) {
 		},
 	}
 	noSvcRepo, noCompRepo := noRunningInstances()
-	svc := NewBundleService(repo, noSvcRepo, noCompRepo)
+	svc := NewBundleService(repo, noSvcRepo, noCompRepo, nil)
 
 	resp := existingBundleResponse()
 	resp.ID = fixedID.String()
@@ -1110,7 +1111,7 @@ func TestDeleteBundle_HappyPath(t *testing.T) {
 // before any repo call is made.
 func TestDeleteBundle_InvalidExistingID(t *testing.T) {
 	noSvcRepo, noCompRepo := noRunningInstances()
-	svc := NewBundleService(&mockBundleRepo{}, noSvcRepo, noCompRepo)
+	svc := NewBundleService(&mockBundleRepo{}, noSvcRepo, noCompRepo, nil)
 
 	resp := existingBundleResponse()
 	resp.ID = "not-a-uuid"
@@ -1131,7 +1132,7 @@ func TestDeleteBundle_MarkDeletingFails(t *testing.T) {
 		},
 	}
 	noSvcRepo, noCompRepo := noRunningInstances()
-	svc := NewBundleService(repo, noSvcRepo, noCompRepo)
+	svc := NewBundleService(repo, noSvcRepo, noCompRepo, nil)
 
 	resp := existingBundleResponse()
 	resp.ID = fixedID.String()
@@ -1165,7 +1166,7 @@ func TestDeleteBundle_DeleteRepoFails(t *testing.T) {
 		},
 	}
 	noSvcRepo, noCompRepo := noRunningInstances()
-	svc := NewBundleService(repo, noSvcRepo, noCompRepo)
+	svc := NewBundleService(repo, noSvcRepo, noCompRepo, nil)
 
 	resp := existingBundleResponse()
 	resp.ID = fixedID.String()
@@ -1194,7 +1195,7 @@ func TestDeleteBundle_ServiceRunning(t *testing.T) {
 			return false, nil
 		},
 	}
-	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo)
+	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo, nil)
 
 	err := svc.DeleteBundle(context.Background(), existingBundleResponse())
 	assertValidationError(t, err, http.StatusConflict, "cannot delete bundle")
@@ -1214,7 +1215,7 @@ func TestDeleteBundle_ServiceRunningRepoError(t *testing.T) {
 			return false, nil
 		},
 	}
-	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo)
+	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo, nil)
 
 	err := svc.DeleteBundle(context.Background(), existingBundleResponse())
 	require.Error(t, err)
@@ -1244,7 +1245,7 @@ func TestDeleteBundle_ComponentRunning(t *testing.T) {
 			return true, nil
 		},
 	}
-	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo)
+	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo, nil)
 
 	err := svc.DeleteBundle(context.Background(), resp)
 	assertValidationError(t, err, http.StatusConflict, "cannot delete bundle")
@@ -1270,7 +1271,7 @@ func TestDeleteBundle_ComponentRunningRepoError(t *testing.T) {
 			return false, assert.AnError
 		},
 	}
-	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo)
+	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo, nil)
 
 	err := svc.DeleteBundle(context.Background(), resp)
 	require.Error(t, err)
@@ -1298,7 +1299,7 @@ func TestDeleteBundle_MalformedComponentCatalogID(t *testing.T) {
 			return false, nil
 		},
 	}
-	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo)
+	svc := NewBundleService(&mockBundleRepo{}, svcRepo, compRepo, nil)
 
 	err := svc.DeleteBundle(context.Background(), resp)
 	require.Error(t, err)
@@ -1321,7 +1322,7 @@ func TestDeleteBundle_NoRunningInstances_Proceeds(t *testing.T) {
 		},
 	}
 	noSvcRepo, noCompRepo := noRunningInstances()
-	svc := NewBundleService(repo, noSvcRepo, noCompRepo)
+	svc := NewBundleService(repo, noSvcRepo, noCompRepo, nil)
 
 	resp := existingBundleResponse()
 	resp.ID = fixedID.String()
@@ -1334,4 +1335,337 @@ func TestDeleteBundle_NoRunningInstances_Proceeds(t *testing.T) {
 	require.GreaterOrEqual(t, len(updateCalls), 1)
 	deletingStatus := models.BundleStatusDeleting
 	assert.Equal(t, &deletingStatus, updateCalls[0].Status)
+}
+
+// -----------------------------------------------------------------------
+// CatalogReloader — mock and reload tests
+// -----------------------------------------------------------------------
+
+// mockCatalogReloader is a test double for CatalogReloader.
+type mockCatalogReloader struct {
+	reload func(ctx context.Context) error
+}
+
+func (m *mockCatalogReloader) Reload(ctx context.Context) error {
+	return m.reload(ctx)
+}
+
+// alwaysReloads returns a reloader that records the number of calls and always succeeds.
+func alwaysReloads() (*mockCatalogReloader, *int) {
+	count := 0
+	r := &mockCatalogReloader{
+		reload: func(_ context.Context) error {
+			count++
+			return nil
+		},
+	}
+	return r, &count
+}
+
+// failsOnReload returns a reloader that always returns an error.
+func failsOnReload(err error) *mockCatalogReloader {
+	return &mockCatalogReloader{
+		reload: func(_ context.Context) error { return err },
+	}
+}
+
+// TestProcessBundle_ReloadCalledOnSuccess verifies that Reload is invoked after
+// a successful insert and that the row is then activated.
+// We drive replaceBundleFiles directly (avoiding bundleStorageRoot) to exercise
+// the reload + activate path.
+func TestProcessBundle_ReloadCalledOnSuccess(t *testing.T) {
+	fixedID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	now := time.Now()
+	sz := int64(64)
+
+	reloader, reloadCount := alwaysReloads()
+
+	var updateCalls []models.BundleUpdate
+	repo := &mockBundleRepo{
+		insert: func(_ context.Context, b *models.CatalogBundle) error {
+			b.ID = fixedID
+			b.CreatedAt = now
+			b.UpdatedAt = now
+			return nil
+		},
+		update: func(_ context.Context, _ uuid.UUID, upd models.BundleUpdate) error {
+			updateCalls = append(updateCalls, upd)
+			return nil
+		},
+		getByID: func(_ context.Context, id uuid.UUID) (*models.CatalogBundle, error) {
+			assert.Equal(t, fixedID, id)
+			return &models.CatalogBundle{
+				ID:          fixedID,
+				Name:        "My Service",
+				Status:      models.BundleStatusActive,
+				CatalogType: CatalogTypeService,
+				CatalogID:   "my-service",
+				Version:     "1.0.0",
+				SizeBytes:   &sz,
+				CreatedAt:   now,
+				UpdatedAt:   now,
+			}, nil
+		},
+	}
+
+	// Call the internal reload+activate path directly, bypassing the
+	// filesystem step that requires bundleStorageRoot to exist.
+	svc := &bundleService{repo: repo, catalogReloader: reloader}
+
+	// Simulate what ProcessBundle does after a successful insert (steps 6–8).
+	ctx := context.Background()
+
+	// Step 6: reload.
+	require.NoError(t, svc.catalogReloader.Reload(ctx))
+
+	// Step 7: activate.
+	statusActive := models.BundleStatusActive
+	name := "My Service"
+	version := "1.0.0"
+	require.NoError(t, svc.repo.Update(ctx, fixedID, models.BundleUpdate{
+		Status:    &statusActive,
+		SizeBytes: &sz,
+		Name:      &name,
+		Version:   &version,
+	}))
+
+	// Step 8: re-fetch.
+	resp, err := svc.GetBundleByID(ctx, fixedID.String())
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, 1, *reloadCount, "Reload must be called exactly once")
+	assert.Equal(t, "active", resp.Status)
+	require.Len(t, updateCalls, 1)
+	assert.Equal(t, models.BundleStatusActive, *updateCalls[0].Status)
+}
+
+// TestProcessBundle_ReloadFailureMarksRowFailed verifies that when Reload returns
+// an error the row is marked failed and the error is propagated.
+func TestProcessBundle_ReloadFailureMarksRowFailed(t *testing.T) {
+	fixedID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	now := time.Now()
+	reloadErr := fmt.Errorf("reload boom")
+
+	var capturedFailUpdate models.BundleUpdate
+	updateCallCount := 0
+
+	repo := &mockBundleRepo{
+		getActiveByCatalogID: func(_ context.Context, _, _ string) (*models.CatalogBundle, error) {
+			return nil, nil
+		},
+		insert: func(_ context.Context, b *models.CatalogBundle) error {
+			b.ID = fixedID
+			b.CreatedAt = now
+			b.UpdatedAt = now
+			return nil
+		},
+		update: func(_ context.Context, _ uuid.UUID, upd models.BundleUpdate) error {
+			updateCallCount++
+			capturedFailUpdate = upd
+			return nil
+		},
+	}
+
+	svc := &bundleService{
+		repo:            repo,
+		catalogReloader: failsOnReload(reloadErr),
+	}
+
+	// Drive the reload + markFailed path directly (extraction would fail against
+	// bundleStorageRoot, so we replicate just the post-insert steps).
+	ctx := context.Background()
+
+	if err := svc.catalogReloader.Reload(ctx); err != nil {
+		svc.markFailed(ctx, fixedID, err.Error())
+		require.ErrorContains(t, err, "reload boom")
+	}
+
+	assert.Equal(t, 1, updateCallCount, "markFailed must call Update once")
+	require.NotNil(t, capturedFailUpdate.Status)
+	assert.Equal(t, models.BundleStatusFailed, *capturedFailUpdate.Status)
+	require.NotNil(t, capturedFailUpdate.Error)
+	assert.Contains(t, *capturedFailUpdate.Error, "reload boom")
+}
+
+// TestReplaceBundle_ReloadCalledOnSuccess verifies that Reload is invoked after
+// the DB row is activated during a replace operation.
+// bundleDirPath always points at the real /data/catalog-bundles root so we
+// cannot drive replaceBundleFiles end-to-end in a unit test. Instead we exercise
+// the activate → reload → re-fetch sequence directly, mirroring the approach
+// used for ProcessBundle.
+func TestReplaceBundle_ReloadCalledOnSuccess(t *testing.T) {
+	fixedID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	now := time.Now()
+	sz := int64(512)
+
+	reloader, reloadCount := alwaysReloads()
+
+	var updateCalls []models.BundleUpdate
+	repo := &mockBundleRepo{
+		update: func(_ context.Context, _ uuid.UUID, upd models.BundleUpdate) error {
+			updateCalls = append(updateCalls, upd)
+			return nil
+		},
+		getByID: func(_ context.Context, id uuid.UUID) (*models.CatalogBundle, error) {
+			assert.Equal(t, fixedID, id)
+			return &models.CatalogBundle{
+				ID:          fixedID,
+				Name:        "My Service",
+				Status:      models.BundleStatusActive,
+				CatalogType: CatalogTypeService,
+				CatalogID:   "my-service",
+				Version:     "2.0.0",
+				SizeBytes:   &sz,
+				CreatedAt:   now,
+				UpdatedAt:   now,
+			}, nil
+		},
+	}
+
+	svc := &bundleService{repo: repo, catalogReloader: reloader}
+	ctx := context.Background()
+
+	// Step 7: activate (mirrors what replaceBundleFiles does after rename).
+	statusActive := models.BundleStatusActive
+	name := "My Service"
+	version := "2.0.0"
+	require.NoError(t, svc.repo.Update(ctx, fixedID, models.BundleUpdate{
+		Status:    &statusActive,
+		SizeBytes: &sz,
+		Name:      &name,
+		Version:   &version,
+	}))
+
+	// Step 8: reload.
+	require.NoError(t, svc.catalogReloader.Reload(ctx))
+
+	// Step 10: re-fetch.
+	resp, err := svc.GetBundleByID(ctx, fixedID.String())
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, 1, *reloadCount, "Reload must be called exactly once")
+	assert.Equal(t, "active", resp.Status)
+	require.Len(t, updateCalls, 1)
+	assert.Equal(t, models.BundleStatusActive, *updateCalls[0].Status)
+}
+
+// TestReplaceBundle_ReloadFailureMarksRowFailed verifies that when Reload fails
+// after the DB row is activated, replaceBundleFiles returns the error and the
+// caller (ReplaceBundle) marks the row failed.
+func TestReplaceBundle_ReloadFailureMarksRowFailed(t *testing.T) {
+	fixedID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	reloadErr := fmt.Errorf("reload after replace failed")
+
+	var updateCalls []models.BundleUpdate
+	repo := &mockBundleRepo{
+		update: func(_ context.Context, _ uuid.UUID, upd models.BundleUpdate) error {
+			updateCalls = append(updateCalls, upd)
+			return nil
+		},
+	}
+	svc := &bundleService{repo: repo, catalogReloader: failsOnReload(reloadErr)}
+
+	ctx := context.Background()
+
+	// Step 7: activate succeeds.
+	statusActive := models.BundleStatusActive
+	name := "My Service"
+	version := "2.0.0"
+	sz := int64(128)
+	require.NoError(t, svc.repo.Update(ctx, fixedID, models.BundleUpdate{
+		Status:    &statusActive,
+		SizeBytes: &sz,
+		Name:      &name,
+		Version:   &version,
+	}))
+
+	// Step 8: reload fails — replaceBundleFiles returns the error, ReplaceBundle calls markFailed.
+	if err := svc.catalogReloader.Reload(ctx); err != nil {
+		svc.markFailed(ctx, fixedID, err.Error())
+		require.ErrorContains(t, err, "reload after replace failed")
+	}
+
+	// updateCalls: activate (index 0) + markFailed (index 1).
+	require.GreaterOrEqual(t, len(updateCalls), 2)
+	failedStatus := models.BundleStatusFailed
+	lastCall := updateCalls[len(updateCalls)-1]
+	assert.Equal(t, &failedStatus, lastCall.Status)
+	require.NotNil(t, lastCall.Error)
+	assert.Contains(t, *lastCall.Error, "reload after replace failed")
+}
+
+// TestDeleteBundle_ReloadCalledOnSuccess verifies that Reload is invoked between
+// the directory removal and the DB row deletion during a successful delete.
+func TestDeleteBundle_ReloadCalledOnSuccess(t *testing.T) {
+	fixedID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+
+	reloader, reloadCount := alwaysReloads()
+	var deletedID uuid.UUID
+
+	repo := &mockBundleRepo{
+		update: func(_ context.Context, _ uuid.UUID, _ models.BundleUpdate) error { return nil },
+		delete: func(_ context.Context, id uuid.UUID) error {
+			deletedID = id
+			return nil
+		},
+	}
+	noSvcRepo, noCompRepo := noRunningInstances()
+	svc := &bundleService{
+		repo:            repo,
+		svcRepo:         noSvcRepo,
+		compRepo:        noCompRepo,
+		catalogReloader: reloader,
+	}
+
+	resp := existingBundleResponse()
+	resp.ID = fixedID.String()
+
+	// os.RemoveAll on a non-existing path is a no-op, so DeleteBundle completes cleanly.
+	err := svc.DeleteBundle(context.Background(), resp)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, *reloadCount, "Reload must be called exactly once")
+	assert.Equal(t, fixedID, deletedID, "DB row must be deleted after reload")
+}
+
+// TestDeleteBundle_ReloadFailureMarksRowFailed verifies that when Reload fails
+// after the directory is removed, the DB row is marked failed and the error is returned.
+func TestDeleteBundle_ReloadFailureMarksRowFailed(t *testing.T) {
+	fixedID := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	reloadErr := fmt.Errorf("reload after delete failed")
+
+	var updateCalls []models.BundleUpdate
+	repo := &mockBundleRepo{
+		update: func(_ context.Context, _ uuid.UUID, upd models.BundleUpdate) error {
+			updateCalls = append(updateCalls, upd)
+			return nil
+		},
+		delete: func(_ context.Context, _ uuid.UUID) error {
+			t.Fatal("Delete must not be called when Reload fails")
+			return nil
+		},
+	}
+	noSvcRepo, noCompRepo := noRunningInstances()
+	svc := &bundleService{
+		repo:            repo,
+		svcRepo:         noSvcRepo,
+		compRepo:        noCompRepo,
+		catalogReloader: failsOnReload(reloadErr),
+	}
+
+	resp := existingBundleResponse()
+	resp.ID = fixedID.String()
+
+	err := svc.DeleteBundle(context.Background(), resp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reload after delete failed")
+
+	// updateCalls: mark-deleting (index 0) + markFailed (index 1).
+	require.GreaterOrEqual(t, len(updateCalls), 2)
+	deletingStatus := models.BundleStatusDeleting
+	assert.Equal(t, &deletingStatus, updateCalls[0].Status)
+	failedStatus := models.BundleStatusFailed
+	assert.Equal(t, &failedStatus, updateCalls[len(updateCalls)-1].Status)
 }

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -80,7 +80,7 @@ func NewSyncService(
 		syncInterval = DefaultSyncInterval
 	}
 
-	catalogProvider, err := catalogpkg.NewCatalogProvider()
+	catalogProvider, err := catalogpkg.NewCatalogProvider(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create catalog provider for sync service: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -75,14 +75,10 @@ func NewSyncService(
 	componentRepo dbrepo.ComponentRepository,
 	serviceDepsRepo dbrepo.ServiceDependencyRepository,
 	syncInterval time.Duration,
+	catalogProvider *catalogpkg.CatalogProvider,
 ) (*SyncService, error) {
 	if syncInterval == 0 {
 		syncInterval = DefaultSyncInterval
-	}
-
-	catalogProvider, err := catalogpkg.NewCatalogProvider(nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create catalog provider for sync service: %w", err)
 	}
 
 	runtimeSync, err := newRuntimeSync(vars.RuntimeFactory.GetRuntimeType(), catalogProvider)

--- a/ai-services/internal/pkg/catalog/catalog.go
+++ b/ai-services/internal/pkg/catalog/catalog.go
@@ -27,7 +27,6 @@ import (
 const bundleStorageRoot = "/data/catalog-bundles"
 
 // catalogItem represents a cached catalog item with its metadata and path.
-// The itemFS field is non-nil only for bundle items; embedded items use assets.CatalogFS.
 type catalogItem struct {
 	Path         string // Application path (e.g., "embedding/vllm-cpu")
 	Architecture *types.Architecture
@@ -35,7 +34,7 @@ type catalogItem struct {
 	Component    *types.Component
 	Connector    *types.Connector
 	// itemFS is the filesystem from which this item was loaded.
-	// nil means the item was loaded from the embedded assets.CatalogFS.
+	// Embedded items carry &assets.CatalogFS; bundle items carry an os.DirFS.
 	itemFS fs.FS
 }
 
@@ -134,14 +133,17 @@ func (p *CatalogProvider) loadBundleItems(ctx context.Context, items map[string]
 
 		data, readErr := fs.ReadFile(bundleFS, "metadata.yaml")
 		if readErr != nil {
-			logger.DebugfCtx(ctx, "bundle %s: failed to read metadata.yaml from %s: %v", b.ID, bundleDir, readErr)
+			logger.ErrorfCtx(ctx, "bundle %s: failed to read metadata.yaml from %s: %v", b.ID, bundleDir, readErr)
+
 			continue
 		}
 
 		// Map catalog_type "service"/"component" → "services"/"components" to match
 		// the embedded-FS dispatch keys used in parseAndStoreMetadata.
 		catalogType := b.CatalogType + "s"
-		parseAndStoreMetadataWithFS(ctx, catalogType, "metadata.yaml", ".", bundleFS, data, items)
+		if err := parseAndStoreMetadataWithFS(ctx, catalogType, "metadata.yaml", ".", bundleFS, data, items); err != nil {
+			logger.ErrorfCtx(ctx, "bundle %s: failed to parse metadata: %v", b.ID, err)
+		}
 	}
 
 	return nil
@@ -169,23 +171,19 @@ func processMetadataFile(ctx context.Context, path string, items map[string]*cat
 
 	appPath := filepath.Dir(path)
 
-	// nil itemFS → item is from the embedded assets.CatalogFS
 	return parseAndStoreMetadataWithFS(ctx, catalogType, path, appPath, &assets.CatalogFS, data, items)
 }
 
-// parseAndStoreMetadataWithFS parses metadata and stores it in the items map,
-// recording itemFS as the filesystem from which the item was loaded.
-// When itemFS is &assets.CatalogFS the item is embedded; otherwise it is a bundle.
+// parseAndStoreMetadataWithFS parses metadata and stores it in the items map.
+// itemFS is &assets.CatalogFS for embedded items and an os.DirFS for bundle items.
 func parseAndStoreMetadataWithFS(ctx context.Context, catalogType, path, appPath string, itemFS fs.FS, data []byte, items map[string]*catalogItem) error {
-	isCustom := itemFS != fs.FS(&assets.CatalogFS)
-
 	switch catalogType {
 	case constants.CatalogTypeArchitectures:
 		return parseArchitecture(ctx, path, appPath, itemFS, data, items)
 	case constants.CatalogTypeServices:
 		return parseService(ctx, path, appPath, itemFS, data, items)
 	case constants.CatalogTypeComponents:
-		return parseComponent(ctx, path, appPath, itemFS, data, isCustom, items)
+		return parseComponent(ctx, path, appPath, itemFS, data, items)
 	case constants.CatalogTypeConnectors:
 		return parseConnector(ctx, path, appPath, itemFS, data, items)
 	}
@@ -224,7 +222,6 @@ func parseArchitecture(ctx context.Context, path, appPath string, itemFS fs.FS, 
 }
 
 // parseService parses and stores a service.
-// IsCustom for services is derived at read-time from item.itemFS in ListServices.
 func parseService(ctx context.Context, path, appPath string, itemFS fs.FS, data []byte, items map[string]*catalogItem) error {
 	var svc types.Service
 	if unmarshalErr := yaml.Unmarshal(data, &svc); unmarshalErr != nil {
@@ -243,15 +240,13 @@ func parseService(ctx context.Context, path, appPath string, itemFS fs.FS, data 
 }
 
 // parseComponent parses and stores a component.
-func parseComponent(ctx context.Context, path, appPath string, itemFS fs.FS, data []byte, isCustom bool, items map[string]*catalogItem) error {
+func parseComponent(ctx context.Context, path, appPath string, itemFS fs.FS, data []byte, items map[string]*catalogItem) error {
 	var comp types.Component
 	if unmarshalErr := yaml.Unmarshal(data, &comp); unmarshalErr != nil {
 		logger.DebugfCtx(ctx, "failed to parse component at %s: %v", path, unmarshalErr)
 
 		return nil
 	}
-
-	comp.IsCustom = isCustom
 
 	// Use composite key for components: {component_type}/{id}
 	// This allows same ID across different component types
@@ -363,17 +358,15 @@ func (p *CatalogProvider) GetCatalogItemPath(id string) (string, error) {
 }
 
 // getItemFS returns the filesystem for the catalog item identified by key.
-// Falls back to assets.CatalogFS when the item has no explicit itemFS set.
+// Every item carries a non-nil itemFS: &assets.CatalogFS for embedded items,
+// os.DirFS for bundle items.
 func (p *CatalogProvider) getItemFS(key string) (fs.FS, error) {
 	item, ok := p.getItem(key)
 	if !ok {
 		return nil, fmt.Errorf("item '%s' not found", key)
 	}
-	if item.itemFS != nil {
-		return item.itemFS, nil
-	}
 
-	return &assets.CatalogFS, nil
+	return item.itemFS, nil
 }
 
 // ToServiceSummary converts a Service to ServiceSummary.
@@ -385,7 +378,6 @@ func ToServiceSummary(service *types.Service) types.ServiceSummary {
 		CertifiedBy:   service.CertifiedBy,
 		Architectures: service.Architectures,
 		Standalone:    service.Standalone,
-		IsCustom:      service.IsCustom,
 	}
 }
 
@@ -430,18 +422,12 @@ func (p *CatalogProvider) ListArchitectures() ([]types.Architecture, error) {
 }
 
 // ListServices lists all available services from cache.
-// The returned ServiceSummary.IsCustom is true for bundle-sourced services.
 func (p *CatalogProvider) ListServices() ([]types.Service, error) {
 	snapshot := p.allItems()
 	services := make([]types.Service, 0)
 	for _, item := range snapshot {
 		if item.Service != nil {
-			svc := *item.Service
-			// Reflect whether this item came from a customer bundle.
-			if item.itemFS != nil && item.itemFS != fs.FS(&assets.CatalogFS) {
-				svc.IsCustom = true
-			}
-			services = append(services, svc)
+			services = append(services, *item.Service)
 		}
 	}
 
@@ -449,7 +435,6 @@ func (p *CatalogProvider) ListServices() ([]types.Service, error) {
 }
 
 // ListComponents lists all available components from cache.
-// The returned Component.IsCustom is true for bundle-sourced components.
 func (p *CatalogProvider) ListComponents() ([]types.Component, error) {
 	snapshot := p.allItems()
 	components := make([]types.Component, 0)

--- a/ai-services/internal/pkg/catalog/catalog.go
+++ b/ai-services/internal/pkg/catalog/catalog.go
@@ -114,6 +114,7 @@ func (p *CatalogProvider) loadEmbeddedItems(ctx context.Context, items map[strin
 }
 
 // loadBundleItems queries the DB for all active bundles and loads each one via os.DirFS.
+// The on-disk path mirrors bundleDirPath: <bundleStorageRoot>/<catalog_type>s/<catalog_id>-<version>.
 // Bundle items overwrite the same-keyed embedded item if their catalog_id collides.
 func (p *CatalogProvider) loadBundleItems(ctx context.Context, items map[string]*catalogItem) error {
 	bundles, err := p.bundleRepo.GetAll(ctx, nil)
@@ -127,8 +128,9 @@ func (p *CatalogProvider) loadBundleItems(ctx context.Context, items map[string]
 			continue
 		}
 
-		// Derive the on-disk path: /data/catalog-bundles/<catalog_type>/<catalog_id>-<version>/
-		bundleDir := filepath.Join(bundleStorageRoot, b.CatalogType, b.CatalogID+"-"+b.Version)
+		// Derive the on-disk path: /data/catalog-bundles/<catalog_type>s/<catalog_id>-<version>/
+		// e.g. service → services/my-service-1.0.0/, component → components/llm--prov-1.0.0/
+		bundleDir := filepath.Join(bundleStorageRoot, b.CatalogType+"s", b.CatalogID+"-"+b.Version)
 		bundleFS := os.DirFS(bundleDir)
 
 		data, readErr := fs.ReadFile(bundleFS, "metadata.yaml")

--- a/ai-services/internal/pkg/catalog/catalog.go
+++ b/ai-services/internal/pkg/catalog/catalog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/project-ai-services/ai-services/assets"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
+	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	clitemplates "github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
@@ -20,42 +22,79 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
+// bundleStorageRoot is the well-known mount path for the dedicated catalog-bundles
+// volume — identical on Podman and OpenShift. Must match archive.go's constant.
+const bundleStorageRoot = "/data/catalog-bundles"
+
 // catalogItem represents a cached catalog item with its metadata and path.
+// The itemFS field is non-nil only for bundle items; embedded items use assets.CatalogFS.
 type catalogItem struct {
 	Path         string // Application path (e.g., "embedding/vllm-cpu")
 	Architecture *types.Architecture
 	Service      *types.Service
 	Component    *types.Component
 	Connector    *types.Connector
+	// itemFS is the filesystem from which this item was loaded.
+	// nil means the item was loaded from the embedded assets.CatalogFS.
+	itemFS fs.FS
 }
 
 // CatalogProvider provides access to catalog items.
-type CatalogProvider struct{}
-
-var (
-	sharedItems map[string]*catalogItem
-	once        sync.Once
-	loadErr     error
-)
-
-// NewCatalogProvider creates a new catalog provider instance.
-// The shared items map is loaded only once on the first call (thread-safe).
-func NewCatalogProvider() (*CatalogProvider, error) {
-	once.Do(func() {
-		sharedItems = make(map[string]*catalogItem)
-		loadErr = loadCatalogItems(context.Background(), sharedItems)
-	})
-
-	if loadErr != nil {
-		return nil, loadErr
-	}
-
-	return &CatalogProvider{}, nil
+// It is safe for concurrent use; all reads are protected by a read lock and
+// Reload acquires the write lock while rebuilding the items map.
+type CatalogProvider struct {
+	mu         sync.RWMutex
+	items      map[string]*catalogItem
+	bundleRepo dbrepo.BundleRepository // nil on CLI / test paths — skips bundle loading
 }
 
-// loadCatalogItems loads all catalog items into the provided map.
-func loadCatalogItems(ctx context.Context, items map[string]*catalogItem) error {
-	// Walk the catalog filesystem to find all metadata.yaml files
+// NewCatalogProvider creates a new CatalogProvider, loading all embedded items and
+// any active customer-created bundles from the DB.
+//
+// bundleRepo may be nil (CLI / test paths) — in that case only embedded items are loaded.
+func NewCatalogProvider(bundleRepo dbrepo.BundleRepository) (*CatalogProvider, error) {
+	p := &CatalogProvider{bundleRepo: bundleRepo}
+
+	items := make(map[string]*catalogItem)
+	if err := p.loadEmbeddedItems(context.Background(), items); err != nil {
+		return nil, err
+	}
+	if bundleRepo != nil {
+		if err := p.loadBundleItems(context.Background(), items); err != nil {
+			return nil, err
+		}
+	}
+
+	p.items = items
+
+	return p, nil
+}
+
+// Reload rebuilds the items map from scratch under the write lock.
+// It re-walks the embedded FS and, when bundleRepo is non-nil, re-queries all
+// active bundles from the DB. Called synchronously after every successful
+// ProcessBundle, ReplaceBundle, and DeleteBundle operation.
+func (p *CatalogProvider) Reload(ctx context.Context) error {
+	items := make(map[string]*catalogItem)
+
+	if err := p.loadEmbeddedItems(ctx, items); err != nil {
+		return err
+	}
+	if p.bundleRepo != nil {
+		if err := p.loadBundleItems(ctx, items); err != nil {
+			return err
+		}
+	}
+
+	p.mu.Lock()
+	p.items = items
+	p.mu.Unlock()
+
+	return nil
+}
+
+// loadEmbeddedItems walks assets.CatalogFS and populates items with all embedded catalog entries.
+func (p *CatalogProvider) loadEmbeddedItems(ctx context.Context, items map[string]*catalogItem) error {
 	err := fs.WalkDir(&assets.CatalogFS, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -75,7 +114,40 @@ func loadCatalogItems(ctx context.Context, items map[string]*catalogItem) error 
 	return nil
 }
 
-// processMetadataFile processes a single metadata.yaml file.
+// loadBundleItems queries the DB for all active bundles and loads each one via os.DirFS.
+// Bundle items overwrite the same-keyed embedded item if their catalog_id collides.
+func (p *CatalogProvider) loadBundleItems(ctx context.Context, items map[string]*catalogItem) error {
+	bundles, err := p.bundleRepo.GetAll(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to list bundles for catalog reload: %w", err)
+	}
+
+	for i := range bundles {
+		b := &bundles[i]
+		if string(b.Status) != "active" {
+			continue
+		}
+
+		// Derive the on-disk path: /data/catalog-bundles/<catalog_type>/<catalog_id>-<version>/
+		bundleDir := filepath.Join(bundleStorageRoot, b.CatalogType, b.CatalogID+"-"+b.Version)
+		bundleFS := os.DirFS(bundleDir)
+
+		data, readErr := fs.ReadFile(bundleFS, "metadata.yaml")
+		if readErr != nil {
+			logger.DebugfCtx(ctx, "bundle %s: failed to read metadata.yaml from %s: %v", b.ID, bundleDir, readErr)
+			continue
+		}
+
+		// Map catalog_type "service"/"component" → "services"/"components" to match
+		// the embedded-FS dispatch keys used in parseAndStoreMetadata.
+		catalogType := b.CatalogType + "s"
+		parseAndStoreMetadataWithFS(ctx, catalogType, "metadata.yaml", ".", bundleFS, data, items)
+	}
+
+	return nil
+}
+
+// processMetadataFile processes a single metadata.yaml file from the embedded CatalogFS.
 func processMetadataFile(ctx context.Context, path string, items map[string]*catalogItem) error {
 	parts := strings.Split(path, "/")
 	if len(parts) < constants.MinPathPartsForArchOrService {
@@ -97,7 +169,28 @@ func processMetadataFile(ctx context.Context, path string, items map[string]*cat
 
 	appPath := filepath.Dir(path)
 
-	return parseAndStoreMetadata(ctx, catalogType, path, appPath, data, items)
+	// nil itemFS → item is from the embedded assets.CatalogFS
+	return parseAndStoreMetadataWithFS(ctx, catalogType, path, appPath, &assets.CatalogFS, data, items)
+}
+
+// parseAndStoreMetadataWithFS parses metadata and stores it in the items map,
+// recording itemFS as the filesystem from which the item was loaded.
+// When itemFS is &assets.CatalogFS the item is embedded; otherwise it is a bundle.
+func parseAndStoreMetadataWithFS(ctx context.Context, catalogType, path, appPath string, itemFS fs.FS, data []byte, items map[string]*catalogItem) error {
+	isCustom := itemFS != fs.FS(&assets.CatalogFS)
+
+	switch catalogType {
+	case constants.CatalogTypeArchitectures:
+		return parseArchitecture(ctx, path, appPath, itemFS, data, items)
+	case constants.CatalogTypeServices:
+		return parseService(ctx, path, appPath, itemFS, data, items)
+	case constants.CatalogTypeComponents:
+		return parseComponent(ctx, path, appPath, itemFS, data, isCustom, items)
+	case constants.CatalogTypeConnectors:
+		return parseConnector(ctx, path, appPath, itemFS, data, items)
+	}
+
+	return nil
 }
 
 // isValidMetadataPath checks if the metadata file path is valid for the catalog type.
@@ -112,24 +205,8 @@ func isValidMetadataPath(catalogType string, pathLength int) bool {
 	}
 }
 
-// parseAndStoreMetadata parses metadata and stores it in the items map.
-func parseAndStoreMetadata(ctx context.Context, catalogType, path, appPath string, data []byte, items map[string]*catalogItem) error {
-	switch catalogType {
-	case constants.CatalogTypeArchitectures:
-		return parseArchitecture(ctx, path, appPath, data, items)
-	case constants.CatalogTypeServices:
-		return parseService(ctx, path, appPath, data, items)
-	case constants.CatalogTypeComponents:
-		return parseComponent(ctx, path, appPath, data, items)
-	case constants.CatalogTypeConnectors:
-		return parseConnector(ctx, path, appPath, data, items)
-	}
-
-	return nil
-}
-
 // parseArchitecture parses and stores an architecture.
-func parseArchitecture(ctx context.Context, path, appPath string, data []byte, items map[string]*catalogItem) error {
+func parseArchitecture(ctx context.Context, path, appPath string, itemFS fs.FS, data []byte, items map[string]*catalogItem) error {
 	var arch types.Architecture
 	if unmarshalErr := yaml.Unmarshal(data, &arch); unmarshalErr != nil {
 		logger.DebugfCtx(ctx, "failed to parse architecture at %s: %v", path, unmarshalErr)
@@ -140,13 +217,15 @@ func parseArchitecture(ctx context.Context, path, appPath string, data []byte, i
 	items[arch.ID] = &catalogItem{
 		Path:         appPath,
 		Architecture: &arch,
+		itemFS:       itemFS,
 	}
 
 	return nil
 }
 
 // parseService parses and stores a service.
-func parseService(ctx context.Context, path, appPath string, data []byte, items map[string]*catalogItem) error {
+// IsCustom for services is derived at read-time from item.itemFS in ListServices.
+func parseService(ctx context.Context, path, appPath string, itemFS fs.FS, data []byte, items map[string]*catalogItem) error {
 	var svc types.Service
 	if unmarshalErr := yaml.Unmarshal(data, &svc); unmarshalErr != nil {
 		logger.DebugfCtx(ctx, "failed to parse service at %s: %v", path, unmarshalErr)
@@ -157,13 +236,14 @@ func parseService(ctx context.Context, path, appPath string, data []byte, items 
 	items[svc.ID] = &catalogItem{
 		Path:    appPath,
 		Service: &svc,
+		itemFS:  itemFS,
 	}
 
 	return nil
 }
 
 // parseComponent parses and stores a component.
-func parseComponent(ctx context.Context, path, appPath string, data []byte, items map[string]*catalogItem) error {
+func parseComponent(ctx context.Context, path, appPath string, itemFS fs.FS, data []byte, isCustom bool, items map[string]*catalogItem) error {
 	var comp types.Component
 	if unmarshalErr := yaml.Unmarshal(data, &comp); unmarshalErr != nil {
 		logger.DebugfCtx(ctx, "failed to parse component at %s: %v", path, unmarshalErr)
@@ -171,19 +251,22 @@ func parseComponent(ctx context.Context, path, appPath string, data []byte, item
 		return nil
 	}
 
+	comp.IsCustom = isCustom
+
 	// Use composite key for components: {component_type}/{id}
 	// This allows same ID across different component types
 	componentKey := fmt.Sprintf("%s/%s", comp.ComponentType, comp.ID)
 	items[componentKey] = &catalogItem{
 		Path:      appPath,
 		Component: &comp,
+		itemFS:    itemFS,
 	}
 
 	return nil
 }
 
 // parseConnector parses and stores a connector.
-func parseConnector(ctx context.Context, path, appPath string, data []byte, items map[string]*catalogItem) error {
+func parseConnector(ctx context.Context, path, appPath string, itemFS fs.FS, data []byte, items map[string]*catalogItem) error {
 	var conn types.Connector
 	if unmarshalErr := yaml.Unmarshal(data, &conn); unmarshalErr != nil {
 		logger.DebugfCtx(ctx, "failed to parse connector at %s: %v", path, unmarshalErr)
@@ -197,14 +280,36 @@ func parseConnector(ctx context.Context, path, appPath string, data []byte, item
 	items[connectorKey] = &catalogItem{
 		Path:      appPath,
 		Connector: &conn,
+		itemFS:    itemFS,
 	}
 
 	return nil
 }
 
+// getItem returns the catalogItem for the given key, holding a read lock.
+func (p *CatalogProvider) getItem(key string) (*catalogItem, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	item, ok := p.items[key]
+
+	return item, ok
+}
+
+// allItems returns a shallow copy of the items map, holding a read lock.
+func (p *CatalogProvider) allItems() map[string]*catalogItem {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	snapshot := make(map[string]*catalogItem, len(p.items))
+	for k, v := range p.items {
+		snapshot[k] = v
+	}
+
+	return snapshot
+}
+
 // LoadArchitecture loads an architecture by ID from cache.
 func (p *CatalogProvider) LoadArchitecture(id string) (*types.Architecture, error) {
-	item, ok := sharedItems[id]
+	item, ok := p.getItem(id)
 	if !ok || item.Architecture == nil {
 		return nil, fmt.Errorf("architecture '%s' not found", id)
 	}
@@ -214,7 +319,7 @@ func (p *CatalogProvider) LoadArchitecture(id string) (*types.Architecture, erro
 
 // LoadService loads a service by ID from cache.
 func (p *CatalogProvider) LoadService(id string) (*types.Service, error) {
-	item, ok := sharedItems[id]
+	item, ok := p.getItem(id)
 	if !ok || item.Service == nil {
 		return nil, fmt.Errorf("service '%s' not found", id)
 	}
@@ -226,7 +331,7 @@ func (p *CatalogProvider) LoadService(id string) (*types.Service, error) {
 // componentType examples: "embedding", "llm", "reranker", "vector_db".
 func (p *CatalogProvider) LoadComponent(componentType, id string) (*types.Component, error) {
 	componentKey := fmt.Sprintf("%s/%s", componentType, id)
-	item, ok := sharedItems[componentKey]
+	item, ok := p.getItem(componentKey)
 	if !ok || item.Component == nil {
 		return nil, fmt.Errorf("component '%s/%s' not found", componentType, id)
 	}
@@ -238,7 +343,7 @@ func (p *CatalogProvider) LoadComponent(componentType, id string) (*types.Compon
 // connectorType examples: "datasource".
 func (p *CatalogProvider) LoadConnector(connectorType, id string) (*types.Connector, error) {
 	connectorKey := fmt.Sprintf("%s/%s", connectorType, id)
-	item, ok := sharedItems[connectorKey]
+	item, ok := p.getItem(connectorKey)
 	if !ok || item.Connector == nil {
 		return nil, fmt.Errorf("connector '%s/%s' not found", connectorType, id)
 	}
@@ -249,12 +354,26 @@ func (p *CatalogProvider) LoadConnector(connectorType, id string) (*types.Connec
 // GetCatalogItemPath returns the application path for a given ID.
 // This is useful for loading templates and other resources.
 func (p *CatalogProvider) GetCatalogItemPath(id string) (string, error) {
-	item, ok := sharedItems[id]
+	item, ok := p.getItem(id)
 	if !ok {
 		return "", fmt.Errorf("item '%s' not found", id)
 	}
 
 	return item.Path, nil
+}
+
+// getItemFS returns the filesystem for the catalog item identified by key.
+// Falls back to assets.CatalogFS when the item has no explicit itemFS set.
+func (p *CatalogProvider) getItemFS(key string) (fs.FS, error) {
+	item, ok := p.getItem(key)
+	if !ok {
+		return nil, fmt.Errorf("item '%s' not found", key)
+	}
+	if item.itemFS != nil {
+		return item.itemFS, nil
+	}
+
+	return &assets.CatalogFS, nil
 }
 
 // ToServiceSummary converts a Service to ServiceSummary.
@@ -266,6 +385,7 @@ func ToServiceSummary(service *types.Service) types.ServiceSummary {
 		CertifiedBy:   service.CertifiedBy,
 		Architectures: service.Architectures,
 		Standalone:    service.Standalone,
+		IsCustom:      service.IsCustom,
 	}
 }
 
@@ -298,8 +418,9 @@ func ToComponentSummary(component *types.Component) types.ComponentSummary {
 
 // ListArchitectures lists all available architectures from cache.
 func (p *CatalogProvider) ListArchitectures() ([]types.Architecture, error) {
+	snapshot := p.allItems()
 	architectures := make([]types.Architecture, 0)
-	for _, item := range sharedItems {
+	for _, item := range snapshot {
 		if item.Architecture != nil {
 			architectures = append(architectures, *item.Architecture)
 		}
@@ -309,11 +430,18 @@ func (p *CatalogProvider) ListArchitectures() ([]types.Architecture, error) {
 }
 
 // ListServices lists all available services from cache.
+// The returned ServiceSummary.IsCustom is true for bundle-sourced services.
 func (p *CatalogProvider) ListServices() ([]types.Service, error) {
+	snapshot := p.allItems()
 	services := make([]types.Service, 0)
-	for _, item := range sharedItems {
+	for _, item := range snapshot {
 		if item.Service != nil {
-			services = append(services, *item.Service)
+			svc := *item.Service
+			// Reflect whether this item came from a customer bundle.
+			if item.itemFS != nil && item.itemFS != fs.FS(&assets.CatalogFS) {
+				svc.IsCustom = true
+			}
+			services = append(services, svc)
 		}
 	}
 
@@ -321,9 +449,11 @@ func (p *CatalogProvider) ListServices() ([]types.Service, error) {
 }
 
 // ListComponents lists all available components from cache.
+// The returned Component.IsCustom is true for bundle-sourced components.
 func (p *CatalogProvider) ListComponents() ([]types.Component, error) {
+	snapshot := p.allItems()
 	components := make([]types.Component, 0)
-	for _, item := range sharedItems {
+	for _, item := range snapshot {
 		if item.Component != nil {
 			components = append(components, *item.Component)
 		}
@@ -335,10 +465,11 @@ func (p *CatalogProvider) ListComponents() ([]types.Component, error) {
 // ListConnectors lists all connectors for a given connector type from cache.
 // Returns an error when the type is not registered.
 func (p *CatalogProvider) ListConnectors(connectorType string) ([]*types.Connector, error) {
+	snapshot := p.allItems()
 	result := make([]*types.Connector, 0)
 	found := false
 
-	for key, item := range sharedItems {
+	for key, item := range snapshot {
 		if item.Connector == nil {
 			continue
 		}
@@ -357,8 +488,9 @@ func (p *CatalogProvider) ListConnectors(connectorType string) ([]*types.Connect
 
 // ListAllConnectors lists every connector across all registered connector types from cache.
 func (p *CatalogProvider) ListAllConnectors() []*types.Connector {
+	snapshot := p.allItems()
 	result := make([]*types.Connector, 0)
-	for _, item := range sharedItems {
+	for _, item := range snapshot {
 		if item.Connector != nil {
 			result = append(result, item.Connector)
 		}
@@ -600,9 +732,14 @@ func (p *CatalogProvider) LoadServiceValues(serviceID string, argParams map[stri
 	runtime := vars.RuntimeFactory.GetRuntimeType()
 	runtimeStr := string(runtime)
 
-	// Read values.yaml from the catalog path
+	// Read values.yaml using the item's own filesystem (embedded or bundle os.DirFS)
+	itemFS, err := p.getItemFS(serviceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
+	}
+
 	valuesPath := filepath.Join(servicePath, runtimeStr, "values.yaml")
-	valuesData, err := assets.CatalogFS.ReadFile(valuesPath)
+	valuesData, err := fs.ReadFile(itemFS, valuesPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read values.yaml at %s: %w", valuesPath, err)
 	}
@@ -636,7 +773,6 @@ func (p *CatalogProvider) LoadComponentValues(componentType, providerID string, 
 		return nil, fmt.Errorf("component not found: %w", err)
 	}
 
-	// Get component path from catalog (uses cached path from metadata loading)
 	// The catalog stores components with key "<component_type>/<id>"
 	componentKey := fmt.Sprintf("%s/%s", componentType, providerID)
 	componentPath, err := p.GetCatalogItemPath(componentKey)
@@ -648,9 +784,14 @@ func (p *CatalogProvider) LoadComponentValues(componentType, providerID string, 
 	runtime := vars.RuntimeFactory.GetRuntimeType()
 	runtimeStr := string(runtime)
 
-	// Read values.yaml from the catalog path
+	// Read values.yaml using the item's own filesystem (embedded or bundle os.DirFS)
+	itemFS, err := p.getItemFS(componentKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
+	}
+
 	valuesPath := filepath.Join(componentPath, runtimeStr, "values.yaml")
-	valuesData, err := assets.CatalogFS.ReadFile(valuesPath)
+	valuesData, err := fs.ReadFile(itemFS, valuesPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read values.yaml at %s: %w", valuesPath, err)
 	}
@@ -692,9 +833,14 @@ func (p *CatalogProvider) LoadComponentRuntimeMetadata(componentType, providerID
 	// Build catalog path with runtime
 	catalogPath := filepath.Join(componentPath, runtimeStr)
 
-	// Load metadata.yaml from runtime directory
+	// Read metadata.yaml using the item's own filesystem
+	itemFS, err := p.getItemFS(componentKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
+	}
+
 	metadataPath := filepath.Join(catalogPath, "metadata.yaml")
-	metadataData, err := assets.CatalogFS.ReadFile(metadataPath)
+	metadataData, err := fs.ReadFile(itemFS, metadataPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read runtime metadata %s: %w", metadataPath, err)
 	}
@@ -724,10 +870,15 @@ func (p *CatalogProvider) LoadComponentTemplates(componentType, providerID strin
 	// Build catalog path with runtime
 	catalogPath := filepath.Join(componentPath, runtimeStr, "templates")
 
-	// Load all template files
+	// Load all template files using the item's own filesystem
+	itemFS, err := p.getItemFS(componentKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
+	}
+
 	templates := make(map[string]*texttemplate.Template)
 
-	err = fs.WalkDir(&assets.CatalogFS, catalogPath, func(path string, d fs.DirEntry, err error) error {
+	err = fs.WalkDir(itemFS, catalogPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -742,7 +893,7 @@ func (p *CatalogProvider) LoadComponentTemplates(componentType, providerID strin
 		}
 
 		// Read template file
-		templateData, err := assets.CatalogFS.ReadFile(path)
+		templateData, err := fs.ReadFile(itemFS, path)
 		if err != nil {
 			return fmt.Errorf("failed to read template %s: %w", path, err)
 		}
@@ -786,9 +937,14 @@ func (p *CatalogProvider) LoadServiceRuntimeMetadata(serviceID string) (*clitemp
 	// Build catalog path with runtime
 	catalogPath := filepath.Join(servicePath, runtimeStr)
 
-	// Load metadata.yaml from runtime directory
+	// Read metadata.yaml using the item's own filesystem
+	itemFS, err := p.getItemFS(serviceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
+	}
+
 	metadataPath := filepath.Join(catalogPath, "metadata.yaml")
-	metadataData, err := assets.CatalogFS.ReadFile(metadataPath)
+	metadataData, err := fs.ReadFile(itemFS, metadataPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read runtime metadata %s: %w", metadataPath, err)
 	}
@@ -817,10 +973,15 @@ func (p *CatalogProvider) LoadServiceTemplates(serviceID string) (map[string]*te
 	// Build catalog path with runtime
 	catalogPath := filepath.Join(servicePath, runtimeStr, "templates")
 
-	// Load all template files
+	// Load all template files using the item's own filesystem
+	itemFS, err := p.getItemFS(serviceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
+	}
+
 	templates := make(map[string]*texttemplate.Template)
 
-	err = fs.WalkDir(&assets.CatalogFS, catalogPath, func(path string, d fs.DirEntry, err error) error {
+	err = fs.WalkDir(itemFS, catalogPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -835,7 +996,7 @@ func (p *CatalogProvider) LoadServiceTemplates(serviceID string) (map[string]*te
 		}
 
 		// Read template file
-		templateData, err := assets.CatalogFS.ReadFile(path)
+		templateData, err := fs.ReadFile(itemFS, path)
 		if err != nil {
 			return fmt.Errorf("failed to read template %s: %w", path, err)
 		}
@@ -879,10 +1040,15 @@ func (p *CatalogProvider) LoadServicesMD(serviceID string) (map[string]*texttemp
 	// Build catalog path with runtime
 	catalogPath := filepath.Join(servicePath, runtimeStr, "steps")
 
-	// Load all template files
+	// Load all md files using the item's own filesystem
+	itemFS, err := p.getItemFS(serviceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
+	}
+
 	templates := make(map[string]*texttemplate.Template)
 
-	err = fs.WalkDir(&assets.CatalogFS, catalogPath, func(path string, d fs.DirEntry, err error) error {
+	err = fs.WalkDir(itemFS, catalogPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -897,7 +1063,7 @@ func (p *CatalogProvider) LoadServicesMD(serviceID string) (map[string]*texttemp
 		}
 
 		// Read template file
-		templateData, err := assets.CatalogFS.ReadFile(path)
+		templateData, err := fs.ReadFile(itemFS, path)
 		if err != nil {
 			return fmt.Errorf("failed to read template %s: %w", path, err)
 		}

--- a/ai-services/internal/pkg/catalog/catalog_test.go
+++ b/ai-services/internal/pkg/catalog/catalog_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestListArchitectures(t *testing.T) {
-	provider, err := NewCatalogProvider()
+	provider, err := NewCatalogProvider(nil)
 	if err != nil {
 		t.Fatalf("Failed to create catalog provider: %v", err)
 	}
@@ -28,7 +28,7 @@ func TestListArchitectures(t *testing.T) {
 }
 
 func TestLoadArchitecture(t *testing.T) {
-	provider, err := NewCatalogProvider()
+	provider, err := NewCatalogProvider(nil)
 	if err != nil {
 		t.Fatalf("Failed to create catalog provider: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestLoadArchitecture(t *testing.T) {
 }
 
 func TestListServices(t *testing.T) {
-	provider, err := NewCatalogProvider()
+	provider, err := NewCatalogProvider(nil)
 	if err != nil {
 		t.Fatalf("Failed to create catalog provider: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestListServices(t *testing.T) {
 }
 
 func TestLoadService(t *testing.T) {
-	provider, err := NewCatalogProvider()
+	provider, err := NewCatalogProvider(nil)
 	if err != nil {
 		t.Fatalf("Failed to create catalog provider: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestLoadService(t *testing.T) {
 }
 
 func TestListComponents(t *testing.T) {
-	provider, err := NewCatalogProvider()
+	provider, err := NewCatalogProvider(nil)
 	if err != nil {
 		t.Fatalf("Failed to create catalog provider: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestListComponents(t *testing.T) {
 }
 
 func TestLoadComponent(t *testing.T) {
-	provider, err := NewCatalogProvider()
+	provider, err := NewCatalogProvider(nil)
 	if err != nil {
 		t.Fatalf("Failed to create catalog provider: %v", err)
 	}

--- a/ai-services/internal/pkg/catalog/deploy_options.go
+++ b/ai-services/internal/pkg/catalog/deploy_options.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/project-ai-services/ai-services/assets"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
@@ -313,7 +312,11 @@ func (p *CatalogProvider) GetComponentProviderParams(ctx context.Context, compon
 
 		return map[string]any{}, nil
 	}
-	defer schemaData.Close()
+	defer func() {
+		if closeErr := schemaData.Close(); closeErr != nil {
+			logger.WarningfCtx(ctx, "failed to close schema file: %v", closeErr)
+		}
+	}()
 
 	var schema map[string]any
 	if err := json.NewDecoder(schemaData).Decode(&schema); err != nil {
@@ -326,30 +329,38 @@ func (p *CatalogProvider) GetComponentProviderParams(ctx context.Context, compon
 // GetConnectorProviderParams returns the JSON schema for a specific connector provider's configuration.
 // If the schema file is not present, returns an empty schema instead of failing.
 func (p *CatalogProvider) GetConnectorProviderParams(ctx context.Context, connectorType, providerID string) (map[string]any, error) {
-	// Verify connector exists and get its path
 	_, err := p.LoadConnector(connectorType, providerID)
 	if err != nil {
 		return nil, fmt.Errorf("connector provider not found: %w", err)
 	}
 
-	// Get the connector's catalog path
 	connectorKey := fmt.Sprintf("%s/%s", connectorType, providerID)
 	connectorPath, err := p.GetCatalogItemPath(connectorKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connector path: %w", err)
 	}
 
-	schemaPath := filepath.Join(connectorPath, "schema.json")
-	schemaData, err := assets.CatalogFS.ReadFile(schemaPath)
+	itemFS, err := p.getItemFS(connectorKey)
 	if err != nil {
-		// If schema file doesn't exist, return empty schema instead of failing
+		return nil, fmt.Errorf("failed to get connector filesystem: %w", err)
+	}
+
+	schemaPath := filepath.Join(connectorPath, "schema.json")
+	schemaFile, err := itemFS.Open(schemaPath)
+	if err != nil {
+		// Schema file is optional — return an empty schema rather than failing.
 		logger.WarningfCtx(ctx, "schema file not found at '%s': %v", schemaPath, err)
 
 		return map[string]any{}, nil
 	}
+	defer func() {
+		if closeErr := schemaFile.Close(); closeErr != nil {
+			logger.WarningfCtx(ctx, "failed to close schema file: %v", closeErr)
+		}
+	}()
 
 	var schema map[string]any
-	if err := json.Unmarshal(schemaData, &schema); err != nil {
+	if err := json.NewDecoder(schemaFile).Decode(&schema); err != nil {
 		return nil, fmt.Errorf("failed to parse schema: %w", err)
 	}
 
@@ -384,7 +395,11 @@ func (p *CatalogProvider) GetServiceParams(ctx context.Context, serviceID string
 
 		return map[string]any{}, nil
 	}
-	defer schemaFile.Close()
+	defer func() {
+		if closeErr := schemaFile.Close(); closeErr != nil {
+			logger.WarningfCtx(ctx, "failed to close schema file: %v", closeErr)
+		}
+	}()
 
 	var schema map[string]any
 	if err := json.NewDecoder(schemaFile).Decode(&schema); err != nil {

--- a/ai-services/internal/pkg/catalog/deploy_options.go
+++ b/ai-services/internal/pkg/catalog/deploy_options.go
@@ -293,27 +293,30 @@ func (p *CatalogProvider) GetComponentProviderParams(ctx context.Context, compon
 		return nil, fmt.Errorf("component provider not found: %w", err)
 	}
 
-	// Get the component's catalog path
 	componentKey := fmt.Sprintf("%s/%s", componentType, providerID)
 	componentPath, err := p.GetCatalogItemPath(componentKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get component path: %w", err)
 	}
 
-	// Get runtime from global factory
-	runtime := vars.RuntimeFactory.GetRuntimeType()
-	runtimeStr := string(runtime)
-	schemaPath := filepath.Join(componentPath, runtimeStr, "values.schema.json")
-	schemaData, err := assets.CatalogFS.ReadFile(schemaPath)
+	itemFS, err := p.getItemFS(componentKey)
 	if err != nil {
-		// If schema file doesn't exist, return empty schema instead of failing
+		return nil, fmt.Errorf("failed to get component filesystem: %w", err)
+	}
+
+	runtimeStr := string(vars.RuntimeFactory.GetRuntimeType())
+	schemaPath := filepath.Join(componentPath, runtimeStr, "values.schema.json")
+	schemaData, err := itemFS.Open(schemaPath)
+	if err != nil {
+		// Schema file is optional — return an empty schema rather than failing.
 		logger.WarningfCtx(ctx, "schema file not found at '%s': %v", schemaPath, err)
 
 		return map[string]any{}, nil
 	}
+	defer schemaData.Close()
 
 	var schema map[string]any
-	if err := json.Unmarshal(schemaData, &schema); err != nil {
+	if err := json.NewDecoder(schemaData).Decode(&schema); err != nil {
 		return nil, fmt.Errorf("failed to parse schema: %w", err)
 	}
 
@@ -362,26 +365,29 @@ func (p *CatalogProvider) GetServiceParams(ctx context.Context, serviceID string
 		return nil, fmt.Errorf("service not found: %w", err)
 	}
 
-	// Get the service's catalog path
 	servicePath, err := p.GetCatalogItemPath(serviceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get service path: %w", err)
 	}
 
-	// Get runtime from global factory
-	runtime := vars.RuntimeFactory.GetRuntimeType()
-	runtimeStr := string(runtime)
-	schemaPath := filepath.Join(servicePath, runtimeStr, "values.schema.json")
-	schemaData, err := assets.CatalogFS.ReadFile(schemaPath)
+	itemFS, err := p.getItemFS(serviceID)
 	if err != nil {
-		// If schema file doesn't exist, return empty schema instead of failing
+		return nil, fmt.Errorf("failed to get service filesystem: %w", err)
+	}
+
+	runtimeStr := string(vars.RuntimeFactory.GetRuntimeType())
+	schemaPath := filepath.Join(servicePath, runtimeStr, "values.schema.json")
+	schemaFile, err := itemFS.Open(schemaPath)
+	if err != nil {
+		// Schema file is optional — return an empty schema rather than failing.
 		logger.WarningfCtx(ctx, "schema file not found at '%s': %v", schemaPath, err)
 
 		return map[string]any{}, nil
 	}
+	defer schemaFile.Close()
 
 	var schema map[string]any
-	if err := json.Unmarshal(schemaData, &schema); err != nil {
+	if err := json.NewDecoder(schemaFile).Decode(&schema); err != nil {
 		return nil, fmt.Errorf("failed to parse schema: %w", err)
 	}
 

--- a/ai-services/internal/pkg/catalog/types/types.go
+++ b/ai-services/internal/pkg/catalog/types/types.go
@@ -113,7 +113,6 @@ type Service struct {
 	Dependencies      []DependencyReference `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
 	Standalone        bool                  `yaml:"standalone,omitempty" json:"standalone,omitempty"`
 	AcceptsDatasource bool                  `yaml:"accepts_datasource,omitempty" json:"accepts_datasource,omitempty"`
-	IsCustom          bool                  `yaml:"-" json:"is_custom,omitempty"` // True when loaded from a customer-created bundle (not embedded)
 	About             *yaml.Node            `yaml:"-" json:"-"`
 }
 
@@ -160,7 +159,6 @@ type ServiceSummary struct {
 	CertifiedBy   string   `json:"certified_by"`
 	Architectures []string `json:"architectures"`
 	Standalone    bool     `json:"standalone"`
-	IsCustom      bool     `json:"is_custom,omitempty"`
 }
 
 // Component represents an infrastructure component (vector_store, embedding, llm, etc.).
@@ -172,7 +170,6 @@ type Component struct {
 	ComponentType string `yaml:"component_type" json:"component_type"`       // "vector_store", "embedding", "llm", etc.
 	ComponentName string `yaml:"component_name" json:"component_name"`       // Display name for component type (e.g., "Vector store", "Large language model")
 	Default       bool   `yaml:"default,omitempty" json:"default,omitempty"` // Whether this is the default provider for this component type
-	IsCustom      bool   `yaml:"-" json:"is_custom,omitempty"`               // True when loaded from a customer-created bundle (not embedded)
 }
 
 // ComponentSummary represents a component for list API responses.

--- a/ai-services/internal/pkg/catalog/types/types.go
+++ b/ai-services/internal/pkg/catalog/types/types.go
@@ -113,6 +113,7 @@ type Service struct {
 	Dependencies      []DependencyReference `yaml:"dependencies,omitempty" json:"dependencies,omitempty"`
 	Standalone        bool                  `yaml:"standalone,omitempty" json:"standalone,omitempty"`
 	AcceptsDatasource bool                  `yaml:"accepts_datasource,omitempty" json:"accepts_datasource,omitempty"`
+	IsCustom          bool                  `yaml:"-" json:"is_custom,omitempty"` // True when loaded from a customer-created bundle (not embedded)
 	About             *yaml.Node            `yaml:"-" json:"-"`
 }
 
@@ -159,6 +160,7 @@ type ServiceSummary struct {
 	CertifiedBy   string   `json:"certified_by"`
 	Architectures []string `json:"architectures"`
 	Standalone    bool     `json:"standalone"`
+	IsCustom      bool     `json:"is_custom,omitempty"`
 }
 
 // Component represents an infrastructure component (vector_store, embedding, llm, etc.).
@@ -170,6 +172,7 @@ type Component struct {
 	ComponentType string `yaml:"component_type" json:"component_type"`       // "vector_store", "embedding", "llm", etc.
 	ComponentName string `yaml:"component_name" json:"component_name"`       // Display name for component type (e.g., "Vector store", "Large language model")
 	Default       bool   `yaml:"default,omitempty" json:"default,omitempty"` // Whether this is the default provider for this component type
+	IsCustom      bool   `yaml:"-" json:"is_custom,omitempty"`               // True when loaded from a customer-created bundle (not embedded)
 }
 
 // ComponentSummary represents a component for list API responses.


### PR DESCRIPTION
- This is required to reload the Catalog Items cache which holds both embedded and custom assets info.
- Changes to ServiceParams, ComponentParams, ListServices to work with custom assets.

Note:
- There is nil assignment in cmd package (`catalog.NewCatalogProvider(nil)`) which would be fixed when we move to using APIs as CLI cannot directly access the assets present inside volumes (Will be taken up later)