### PR TITLE
feat(translate): Add synchronous endpoint for translate service

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.277
+TAG?=v0.0.278
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -94,7 +94,7 @@ translate:
   # @description Host port for the Translate API. If unspecified, a random port is assigned.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/translate-service:v0.0.4
+  image: icr.io/ai-services-cicd/translate-service:v0.0.5
   # @hidden
   log_level: "INFO"
   # @description Database name for the TRANSLATE service.

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.277
+  image: icr.io/ai-services-cicd/ai-services:v0.0.278
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.277
+  image: icr.io/ai-services-cicd/ai-services:v0.0.278
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/services/translate/podman/values.yaml
+++ b/ai-services/assets/services/translate/podman/values.yaml
@@ -1,6 +1,6 @@
 translate:
   port: ""
-  image: icr.io/ai-services-cicd/translate-service:v0.0.4
+  image: icr.io/ai-services-cicd/translate-service:v0.0.5
   log_level: "INFO"
   database: "translate_metadata"
 

--- a/services/common/error_utils.py
+++ b/services/common/error_utils.py
@@ -32,6 +32,7 @@ class ErrorCode(str, Enum):
     # Server errors (5xx)
     INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR"
     LLM_ERROR = "LLM_ERROR"
+    LLM_UNAVAILABLE = "LLM_UNAVAILABLE"
     VECTOR_STORE_NOT_READY = "VECTOR_STORE_NOT_READY"
     INSUFFICIENT_STORAGE = "INSUFFICIENT_STORAGE"
 
@@ -241,6 +242,7 @@ class APIError:
         ErrorCode.SERVER_BUSY: (429, "Server is busy. Please try again later"),
         ErrorCode.INTERNAL_SERVER_ERROR: (500, "An unexpected error occurred"),
         ErrorCode.LLM_ERROR: (500, "Failed to generate response. Please try again later"),
+        ErrorCode.LLM_UNAVAILABLE: (503, "LLM service is unavailable. Please try again later"),
         ErrorCode.VECTOR_STORE_NOT_READY: (503, "Vector store not initialized"),
         ErrorCode.INSUFFICIENT_STORAGE: (507, "Insufficient storage space"),
     }

--- a/services/translate/Makefile
+++ b/services/translate/Makefile
@@ -1,5 +1,5 @@
 IMAGE=translate-service
-TAG?=v0.0.4
+TAG?=v0.0.5
 
 run:
 	PORT=$${PORT:-9000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/translate/api/v1/jobs.py
+++ b/services/translate/api/v1/jobs.py
@@ -10,7 +10,7 @@ GET    /v1/translate/jobs/{job_id}/result/download — download translated file
 
 import asyncio
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Optional, Union
 
 from fastapi import APIRouter, File, Form, Query, UploadFile, status
 from fastapi.responses import JSONResponse, PlainTextResponse
@@ -285,7 +285,7 @@ async def get_job(job_id: str) -> JobDetailResponse:
         500: http_error_responses[500],
     },
 )
-async def get_job_result(job_id: str):
+async def get_job_result(job_id: str) -> Union[JobResultResponse, JSONResponse]:
     """Return the completed translation result for a job."""
     job = db_manager.get_job_by_id(job_id)
     if job is None:
@@ -348,7 +348,7 @@ async def get_job_result(job_id: str):
         500: http_error_responses[500],
     },
 )
-async def download_job_result(job_id: str):
+async def download_job_result(job_id: str) -> Union[PlainTextResponse, JSONResponse]:
     """Download the translated output file for a completed job."""
     job = db_manager.get_job_by_id(job_id)
     if job is None:

--- a/services/translate/api/v1/jobs.py
+++ b/services/translate/api/v1/jobs.py
@@ -20,12 +20,11 @@ from common.misc_utils import get_logger, get_utc_timestamp
 from common.validation_utils import validate_file_content, validate_file_extension
 from translate.utils.errors import (
     _raise_file_too_large,
-    _raise_invalid_language,
     _raise_job_failed,
     _raise_job_not_complete,
-    _raise_same_language,
     _raise_unsupported_file_type,
 )
+from translate.utils.language import validate_languages
 from translate.db.manager import db_manager
 from translate.models import (
     JobCreatedResponse,
@@ -53,61 +52,6 @@ router = APIRouter()
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-def _normalise_language(value: Optional[str]) -> str:
-    """Lowercase + strip; treat empty/None as 'auto'."""
-    if not value or not value.strip():
-        return "auto"
-    return value.strip().lower()
-
-
-def _validate_languages(
-    source_language: str,
-    target_language: str,
-) -> tuple[str, str]:
-    """
-    Validate and normalise both language parameters.
-
-    Returns ``(normalised_source, normalised_target)`` on success.
-    Raises ``HTTPException`` on any validation failure.
-    """
-    supported = settings.translate.supported_languages_list
-    supported_display = ", ".join(s.capitalize() for s in sorted(supported))
-
-    norm_source = _normalise_language(source_language)
-    norm_target = _normalise_language(target_language)
-
-    # target must not be "auto"
-    if norm_target == "auto":
-        _raise_invalid_language(
-            f"'auto' is not valid for target_language. "
-            f"Please specify an explicit target language. Supported: {supported_display}."
-        )
-
-    # target must be in allowlist
-    if norm_target not in supported:
-        _raise_invalid_language(
-            f"'{target_language}' is not a supported language. "
-            f"Supported: {supported_display}."
-        )
-
-    # source (if explicit) must be in allowlist
-    if norm_source != "auto" and norm_source not in supported:
-        _raise_invalid_language(
-            f"'{source_language}' is not a supported language. "
-            f"Supported: {supported_display}. "
-            f"Use 'auto' for source_language to auto-detect."
-        )
-
-    # explicit source must differ from target
-    if norm_source != "auto" and norm_source == norm_target:
-        _raise_same_language(
-            f"source_language and target_language must differ "
-            f"(both are '{norm_source}')."
-        )
-
-    return norm_source, norm_target
-
 
 def _job_to_detail(job) -> JobDetailResponse:
     return JobDetailResponse(
@@ -191,7 +135,7 @@ async def create_translation_job(
         _raise_unsupported_file_type(str(exc))
 
     # 3. Validate languages.
-    norm_source, norm_target = _validate_languages(source_language, target_language)
+    norm_source, norm_target = validate_languages(source_language, target_language)
 
     # 4. Check file size (txt/md only — revisit when PDF/Word support is added via digitize integration).
     max_bytes = settings.translate.max_upload_size_mb * 1024 * 1024

--- a/services/translate/api/v1/jobs.py
+++ b/services/translate/api/v1/jobs.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, File, Form, Query, UploadFile, status
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
 
 from common.error_utils import APIError, ErrorCode, http_error_responses
 from common.misc_utils import get_logger, get_utc_timestamp
@@ -21,7 +21,6 @@ from common.validation_utils import validate_file_content, validate_file_extensi
 from translate.utils.errors import (
     _raise_file_too_large,
     _raise_job_failed,
-    _raise_job_not_complete,
     _raise_unsupported_file_type,
 )
 from translate.utils.language import validate_languages
@@ -277,16 +276,16 @@ async def get_job(job_id: str) -> JobDetailResponse:
     summary="Get translation result",
     description=(
         "Retrieve the full translation result as JSON. "
-        "Returns 409 if the job is still running, 410 if it failed."
+        "Returns 202 with current status if the job is still running, 410 if it failed."
     ),
     responses={
+        202: {"description": "Accepted — job is still in progress. Retry after a short delay."},
         404: http_error_responses[404],   # job not found
-        409: http_error_responses[409],   # JOB_NOT_COMPLETE
         410: {"description": "Gone — job failed. Error details on the job resource."},
         500: http_error_responses[500],
     },
 )
-async def get_job_result(job_id: str) -> JobResultResponse:
+async def get_job_result(job_id: str):
     """Return the completed translation result for a job."""
     job = db_manager.get_job_by_id(job_id)
     if job is None:
@@ -296,9 +295,13 @@ async def get_job_result(job_id: str) -> JobResultResponse:
         )
 
     if job.status in (JobStatus.ACCEPTED.value, JobStatus.IN_PROGRESS.value):
-        _raise_job_not_complete(
-            f"Job is still {job.status}. "
-            f"Poll GET /v1/translate/jobs/{job_id} for status."
+        return JSONResponse(
+            status_code=status.HTTP_202_ACCEPTED,
+            content={
+                "job_id": job_id,
+                "status": job.status,
+                "message": f"Job is still {job.status}. Poll GET /v1/translate/jobs/{job_id} for status.",
+            },
         )
 
     if job.status == JobStatus.FAILED.value:
@@ -339,8 +342,8 @@ async def get_job_result(job_id: str) -> JobResultResponse:
         "(.txt → text/plain, .md → text/markdown)."
     ),
     responses={
+        202: {"description": "Accepted — job is still in progress. Retry after a short delay."},
         404: http_error_responses[404],   # job not found
-        409: http_error_responses[409],   # JOB_NOT_COMPLETE
         410: {"description": "Gone — job failed. Error details on the job resource."},
         500: http_error_responses[500],
     },
@@ -355,9 +358,13 @@ async def download_job_result(job_id: str):
         )
 
     if job.status in (JobStatus.ACCEPTED.value, JobStatus.IN_PROGRESS.value):
-        _raise_job_not_complete(
-            f"Job is still {job.status}. "
-            f"Poll GET /v1/translate/jobs/{job_id} for status."
+        return JSONResponse(
+            status_code=status.HTTP_202_ACCEPTED,
+            content={
+                "job_id": job_id,
+                "status": job.status,
+                "message": f"Job is still {job.status}. Poll GET /v1/translate/jobs/{job_id} for status.",
+            },
         )
 
     if job.status == JobStatus.FAILED.value:

--- a/services/translate/api/v1/translate.py
+++ b/services/translate/api/v1/translate.py
@@ -3,11 +3,173 @@ Synchronous translation endpoint.
 
 POST /v1/translate — inline plain-text translation (stateless).
 
-This stub exists so the router is registered and the import tree is stable across all PRs. Business logic will be added in later PRs.
+No DB writes, no staging.  The full pipeline is:
+  1. Validate request fields.
+  2. Acquire concurrency_limiter (vllm_semaphore); 429 if at capacity.
+  3. Tokenize input; run sync context guard; 413 with diagnostics on breach.
+  4. Resolve source language; build messages.
+  5. Call query_vllm_translate (temperature=0.0).
+  6. Return 200 with data / meta / usage.
 """
 
-from fastapi import APIRouter
+import asyncio
+import time
+
+import httpx
+from fastapi import APIRouter, status
+
+from common.error_utils import APIError, ErrorCode, http_error_responses
+from common.llm_utils import tokenize_with_llm
+from common.misc_utils import get_logger
+from translate.models import SyncTranslateRequest, SyncTranslateResponse
+from translate.settings import settings
+from translate.utils.errors import _raise_context_limit_exceeded
+from translate.utils.language import validate_languages
+from translate.utils.llm import get_llm_max_model_len, query_vllm_translate
+from translate.utils.prompt import build_messages, resolve_source_language
+from translate.workers.concurrency import concurrency_manager
+
+logger = get_logger("translate_api")
 
 router = APIRouter()
 
-# Made with Bob
+
+# ---------------------------------------------------------------------------
+# POST /v1/translate
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "",
+    status_code=status.HTTP_200_OK,
+    response_model=SyncTranslateResponse,
+    response_description="Translated text with source/target language and token usage.",
+    summary="Translate plain text (synchronous)",
+    description=(
+        "Translate inline plain text between supported languages. "
+        "Stateless — no file upload, no DB record. "
+        "Source language is auto-detected when omitted or set to 'auto'."
+    ),
+    responses={
+        400: http_error_responses[400],   # INVALID_LANGUAGE / SAME_LANGUAGE
+        413: http_error_responses[413],   # CONTEXT_LIMIT_EXCEEDED
+        429: http_error_responses[429],   # concurrency_limiter at capacity
+        500: http_error_responses[500],
+        503: http_error_responses[503],   # vLLM unreachable
+    },
+)
+async def sync_translate(body: SyncTranslateRequest) -> SyncTranslateResponse:
+    start_time = time.perf_counter()
+
+    # 1. Validate input text.
+    if not body.text or not body.text.strip():
+        APIError.raise_error(ErrorCode.EMPTY_INPUT, "The 'text' field must not be empty.")
+
+    # 2. Validate languages.
+    norm_source, norm_target = validate_languages(body.source_language, body.target_language)
+
+    # 3. Check concurrency_limiter (vllm_semaphore) — non-blocking probe.
+    if concurrency_manager.vllm_semaphore.locked():
+        APIError.raise_error(
+            ErrorCode.RATE_LIMIT_EXCEEDED,
+            "Server is at capacity. Please try again shortly.",
+        )
+
+    # 4. Tokenize and run sync context guard.
+    llm_endpoint = settings.common.llm.endpoint
+    input_tokens: int = await asyncio.to_thread(
+        lambda: len(tokenize_with_llm(body.text, llm_endpoint))
+    )
+
+    max_model_len = get_llm_max_model_len()
+    prompt_overhead = settings.translate.prompt_overhead_tokens
+    available_for_output = max_model_len - input_tokens - prompt_overhead
+
+    if available_for_output < input_tokens:
+        _raise_context_limit_exceeded(
+            "Input text exceeds the model context limit for translation "
+            "(output window must be at least as large as the input).",
+            diagnostics={
+                "input_tokens": input_tokens,
+                "prompt_overhead_tokens": prompt_overhead,
+                "max_model_len": max_model_len,
+                "available_for_output": available_for_output,
+            },
+        )
+
+    # Cap output tokens: 2× input provides generous headroom for most language
+    # pairs (en→de expansion is typically ~20–30 %).
+    max_tokens = min(available_for_output, input_tokens * 2)
+
+    # 5. Resolve source language and build prompt messages.
+    resolved_name, _resolved_code = resolve_source_language(
+        text=body.text,
+        requested_source=norm_source,
+        settings=settings,
+        async_path=False,
+    )
+
+    messages = build_messages(
+        text=body.text,
+        resolved_source_language=resolved_name,
+        target_language=norm_target.capitalize(),
+    )
+
+    # 6. Call vLLM, gated by the shared concurrency semaphore.
+    model = settings.common.llm.model
+    api_key = settings.common.llm.api_key
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    try:
+        async with httpx.AsyncClient(headers=headers, timeout=3600.0) as client:
+            async with concurrency_manager.vllm_semaphore:
+                translation, in_tok, out_tok = await query_vllm_translate(
+                    client=client,
+                    llm_endpoint=llm_endpoint,
+                    messages=messages,
+                    model=model,
+                    max_tokens=max_tokens,
+                    temperature=settings.translate.translation_temperature,
+                )
+    except httpx.RequestError as exc:
+        logger.error(f"vLLM unreachable during sync translate: {exc}", exc_info=True)
+        APIError.raise_error(
+            ErrorCode.VECTOR_STORE_NOT_READY,
+            "Translation service is temporarily unavailable. Please try again later.",
+        )
+    except httpx.HTTPStatusError as exc:
+        logger.error(
+            f"vLLM returned HTTP {exc.response.status_code} during sync translate: {exc}",
+            exc_info=True,
+        )
+        APIError.raise_error(
+            ErrorCode.LLM_ERROR,
+            "Translation model returned an unexpected error. Please try again.",
+        )
+
+    processing_time_ms = round((time.perf_counter() - start_time) * 1000)
+
+    logger.info(
+        f"Sync translate completed: {norm_source}→{norm_target}, "
+        f"{in_tok} in / {out_tok} out tokens, {processing_time_ms}ms"
+    )
+
+    return SyncTranslateResponse(
+        data={
+            "translation": translation,
+            "source_language": resolved_name.lower() if resolved_name else norm_source,
+            "target_language": norm_target,
+        },
+        meta={
+            "model": model,
+            "processing_time_ms": processing_time_ms,
+            "input_type": "text",
+        },
+        usage={
+            "input_tokens": in_tok,
+            "output_tokens": out_tok,
+            "total_tokens": in_tok + out_tok,
+        },
+    )
+

--- a/services/translate/api/v1/translate.py
+++ b/services/translate/api/v1/translate.py
@@ -54,7 +54,7 @@ router = APIRouter()
         413: http_error_responses[413],   # CONTEXT_LIMIT_EXCEEDED
         429: http_error_responses[429],   # concurrency_limiter at capacity
         500: http_error_responses[500],
-        503: http_error_responses[503],   # vLLM unreachable
+        503: {"description": "Service Unavailable — vLLM is unreachable. Retry after a short delay."},
     },
 )
 async def sync_translate(body: SyncTranslateRequest) -> SyncTranslateResponse:
@@ -136,7 +136,7 @@ async def sync_translate(body: SyncTranslateRequest) -> SyncTranslateResponse:
     except httpx.RequestError as exc:
         logger.error(f"vLLM unreachable during sync translate: {exc}", exc_info=True)
         APIError.raise_error(
-            ErrorCode.VECTOR_STORE_NOT_READY,
+            ErrorCode.LLM_UNAVAILABLE,
             "Translation service is temporarily unavailable. Please try again later.",
         )
     except httpx.HTTPStatusError as exc:

--- a/services/translate/api/v1/translate.py
+++ b/services/translate/api/v1/translate.py
@@ -58,6 +58,7 @@ router = APIRouter()
     },
 )
 async def sync_translate(body: SyncTranslateRequest) -> SyncTranslateResponse:
+    """Translate inline plain text synchronously between supported languages."""
     start_time = time.perf_counter()
 
     # 1. Validate input text.

--- a/services/translate/utils/errors.py
+++ b/services/translate/utils/errors.py
@@ -38,13 +38,6 @@ def _raise_file_too_large(detail: str) -> NoReturn:
     )
 
 
-def _raise_job_not_complete(detail: str) -> NoReturn:
-    raise HTTPException(
-        status_code=409,
-        detail={"error": {"code": "JOB_NOT_COMPLETE", "message": detail, "status": 409}},
-    )
-
-
 def _raise_job_failed(detail: str) -> NoReturn:
     raise HTTPException(
         status_code=410,

--- a/services/translate/utils/errors.py
+++ b/services/translate/utils/errors.py
@@ -51,4 +51,18 @@ def _raise_job_failed(detail: str) -> NoReturn:
         detail={"error": {"code": "JOB_FAILED", "message": detail, "status": 410}},
     )
 
+
+def _raise_context_limit_exceeded(detail: str, diagnostics: dict) -> NoReturn:
+    raise HTTPException(
+        status_code=413,
+        detail={
+            "error": {
+                "code": "CONTEXT_LIMIT_EXCEEDED",
+                "message": detail,
+                "status": 413,
+                "diagnostics": diagnostics,
+            }
+        },
+    )
+
 # Made with Bob

--- a/services/translate/utils/language.py
+++ b/services/translate/utils/language.py
@@ -37,6 +37,12 @@ def validate_languages(
     supported = settings.translate.supported_languages_list
     supported_display = ", ".join(s.capitalize() for s in sorted(supported))
 
+    # target must not be empty before normalisation collapses it to "auto"
+    if not target_language or not target_language.strip():
+        _raise_invalid_language(
+            f"target_language must not be empty. Supported: {supported_display}."
+        )
+
     norm_source = normalise_language(source_language)
     norm_target = normalise_language(target_language)
 

--- a/services/translate/utils/language.py
+++ b/services/translate/utils/language.py
@@ -1,0 +1,73 @@
+"""
+Shared language validation helpers for the translate service.
+
+Both the sync endpoint (api/v1/translate.py) and the async jobs endpoint
+(api/v1/jobs.py) need identical language normalisation and validation logic.
+"""
+
+from typing import Optional
+
+from translate.settings import settings
+from translate.utils.errors import _raise_invalid_language, _raise_same_language
+
+
+def normalise_language(value: Optional[str]) -> str:
+    """Lowercase + strip; treat empty/None as 'auto'."""
+    if not value or not value.strip():
+        return "auto"
+    return value.strip().lower()
+
+
+def validate_languages(
+    source_language: str,
+    target_language: str,
+) -> tuple[str, str]:
+    """
+    Validate and normalise both language parameters.
+
+    Returns ``(normalised_source, normalised_target)`` on success.
+    Raises ``HTTPException`` on any validation failure.
+
+    Rules:
+    - ``target`` must be an explicit supported language name (not ``"auto"``).
+    - ``source`` may be ``"auto"`` (triggers lingua / LLM detection) or an
+      explicit supported language name.
+    - When both are explicit they must differ.
+    """
+    supported = settings.translate.supported_languages_list
+    supported_display = ", ".join(s.capitalize() for s in sorted(supported))
+
+    norm_source = normalise_language(source_language)
+    norm_target = normalise_language(target_language)
+
+    # target must not be "auto"
+    if norm_target == "auto":
+        _raise_invalid_language(
+            f"'auto' is not valid for target_language. "
+            f"Please specify an explicit target language. Supported: {supported_display}."
+        )
+
+    # target must be in allowlist
+    if norm_target not in supported:
+        _raise_invalid_language(
+            f"'{target_language}' is not a supported language. "
+            f"Supported: {supported_display}."
+        )
+
+    # source (if explicit) must be in allowlist
+    if norm_source != "auto" and norm_source not in supported:
+        _raise_invalid_language(
+            f"'{source_language}' is not a supported language. "
+            f"Supported: {supported_display}. "
+            f"Use 'auto' for source_language to auto-detect."
+        )
+
+    # explicit source must differ from target
+    if norm_source != "auto" and norm_source == norm_target:
+        _raise_same_language(
+            f"source_language and target_language must differ "
+            f"(both are '{norm_source}')."
+        )
+
+    return norm_source, norm_target
+


### PR DESCRIPTION
- Implements the stateless POST /v1/translate synchronous text translation endpoint (no DB writes, no file staging).
- Adds utils/language.py to consolidate duplicated language validation logic shared by the sync and async job routers.
- Introduces _raise_context_limit_exceeded with a diagnostics payload; tightens the context guard to require available_for_output ≥ input_tokens.
- Covers all expected error codes: 400 (invalid language), 413 (context limit), 429 (concurrency at capacity), 500/503 (vLLM errors).

The PR also includes changes regarding job_not_complete messages in GET /v1/translate/jobs/{job_id}/result  endpoint
