### PR TITLE
Add baseDir, domainSuffix, httpsPort as part of worker metadata

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.266
+TAG?=v0.0.267
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.266
+  image: icr.io/ai-services-cicd/ai-services:v0.0.267
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.266
+  image: icr.io/ai-services-cicd/ai-services:v0.0.267
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -3,7 +3,6 @@ package catalog
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -133,9 +132,9 @@ func runConfigure() error {
 	switch rt {
 	case types.RuntimeTypePodman:
 		// Resolve base directory: fall back to default when not provided.
-		aiServicesDir, err := resolveBaseDir(baseDir)
+		aiServicesDir, err := utils.ValidateBaseDir(baseDir)
 		if err != nil {
-			return err
+			return fmt.Errorf("invalid base directory '%s': %w", baseDir, err)
 		}
 
 		// Create the models directory under the base dir.
@@ -167,19 +166,6 @@ func runConfigure() error {
 	}
 }
 
-// resolveBaseDir returns the validated base directory, falling back to the default.
-func resolveBaseDir(baseDir string) (string, error) {
-	if baseDir == "" {
-		return constants.DefaultBaseDir, nil
-	}
-
-	resolved, err := utils.ValidateBaseDir(baseDir)
-	if err != nil {
-		return "", fmt.Errorf("invalid base directory '%s': %w", baseDir, err)
-	}
-
-	return resolved, nil
-}
 
 func validateResetFlag(cmd *cobra.Command, flagName string) error {
 	// Check that no configuration parameters are provided with reset flag
@@ -202,7 +188,7 @@ func validateResetFlag(cmd *cobra.Command, flagName string) error {
 func validateConfigureFlags() error {
 	// Validate SSL flags
 	if vars.RuntimeFactory.GetRuntimeType() == types.RuntimeTypePodman {
-		if err := validateSSLFlags(); err != nil {
+		if err := utils.ValidateSSLFlags(sslCertPath, sslKeyPath, domainName); err != nil {
 			return err
 		}
 
@@ -220,67 +206,13 @@ func validateConfigureFlags() error {
 	return nil
 }
 
-// validateSSLFlags validates SSL certificate and key flags.
-func validateSSLFlags() error {
-	// If no SSL cert/key provided, validation passes
-	if sslCertPath == "" && sslKeyPath == "" {
-		return nil
-	}
-
-	if err := checkSSLFlagsPaired(); err != nil {
-		return err
-	}
-
-	warnIfBothCertAndDomainProvided()
-
-	return validateSSLCertificates()
-}
-
-// checkSSLFlagsPaired ensures cert and key flags are used together.
-func checkSSLFlagsPaired() error {
-	if (sslCertPath != "" && sslKeyPath == "") || (sslCertPath == "" && sslKeyPath != "") {
-		return fmt.Errorf("--ssl-cert and --ssl-key must be used together")
-	}
-
-	return nil
-}
-
-// warnIfBothCertAndDomainProvided warns user if both certificate and custom domain are provided.
-func warnIfBothCertAndDomainProvided() {
-	if sslCertPath != "" && sslKeyPath != "" && domainName != "" {
-		fmt.Fprintf(os.Stderr, "Warning: Both SSL certificate and --domain-name provided. "+
-			"The domain from the certificate will be used, and --domain-name will be ignored.\n\n")
-	}
-}
-
-// validateSSLCertificates performs comprehensive validation of SSL certificates.
-func validateSSLCertificates() error {
-	// Validate certificate files exist and are readable
-	if err := utils.ValidateCertificateFiles(sslCertPath, sslKeyPath); err != nil {
-		return fmt.Errorf("certificate validation failed: %w", err)
-	}
-
-	// Validate certificate and key match
-	if err := utils.ValidateCertificateKeyPair(sslCertPath, sslKeyPath); err != nil {
-		return fmt.Errorf("certificate and key validation failed: %w", err)
-	}
-
-	// Validate wildcard certificate
-	if err := utils.ValidateWildcardCertificate(sslCertPath); err != nil {
-		return fmt.Errorf("wildcard certificate validation failed: %w", err)
-	}
-
-	return nil
-}
-
 func validateResetCertificateFlags(cmd *cobra.Command, flagName string) error {
 	// Require SSL certificate flags with reset-certificate
 	if sslCertPath == "" || sslKeyPath == "" {
 		return fmt.Errorf("--ssl-cert and --ssl-key are required when using --reset-certificate")
 	}
 
-	// Validate SSL certificate flags
-	if err := validateSSLFlags(); err != nil {
+	if err := utils.ValidateSSLFlags(sslCertPath, sslKeyPath, domainName); err != nil {
 		return err
 	}
 

--- a/ai-services/cmd/ai-services/cmd/catalog/configure.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/configure.go
@@ -166,7 +166,6 @@ func runConfigure() error {
 	}
 }
 
-
 func validateResetFlag(cmd *cobra.Command, flagName string) error {
 	// Check that no configuration parameters are provided with reset flag
 	var invalidFlags []string

--- a/ai-services/cmd/ai-services/cmd/worker/join.go
+++ b/ai-services/cmd/ai-services/cmd/worker/join.go
@@ -2,34 +2,41 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/spf13/cobra"
 
 	cmdcommon "github.com/project-ai-services/ai-services/cmd/ai-services/cmd/common"
+	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	workerdeploy "github.com/project-ai-services/ai-services/internal/pkg/worker/deploy"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/join"
 )
 
-const defaultJoinHTTPSPort = "443"
+const defaultJoinHTTPSPort = 443
 
-func newJoinCmd() *cobra.Command {
-	var (
-		token       string
-		runtimeType string
-		baseDir     string
-		httpsPort   string
-	)
+// Flag variables for the worker join command.
+var (
+	token       string
+	runtimeType string
+	baseDir     string
+	httpsPort   int
+	domainName  string
+	sslCertPath string
+	sslKeyPath  string
+)
 
-	cmd := &cobra.Command{
-		Use:   "join <gateway>",
-		Short: "Join this node to the catalog as a worker",
-		Long: `Deploys the Caddy reverse-proxy on this node, registers with the catalog
+var cmd = &cobra.Command{
+	Use:   "join <gateway>",
+	Short: "Join this node to the catalog as a worker",
+	Long: `Deploys the Caddy reverse-proxy on this node, registers with the catalog
 gRPC worker-gateway using the bootstrap token, and holds the connection open.
 
 <gateway> is the host:port of the catalog gRPC worker-gateway.
@@ -40,68 +47,108 @@ The command runs until interrupted (Ctrl-C). Heartbeats are sent every
 Obtain a token first by running on the catalog node:
 
   ai-services catalog worker register <name>`,
-		Example: `  # Minimal — required argument + flag only
+	Example: `  # Minimal — required argument + flag only
   ai-services worker join catalog.example.com:9090 --token <bootstrap-token>
 
   # Custom base directory and HTTPS port
   ai-services worker join catalog.example.com:9090 \
       --token      <bootstrap-token> \
       --basedir    /data/ai-services \
-      --https-port 8443`,
-		Args:    cobra.ExactArgs(1),
-		PreRunE: joinPreRunE(&runtimeType),
-		RunE:    joinRunE(&token, &runtimeType, &baseDir, &httpsPort),
-	}
+      --https-port 8443
 
-	addJoinFlags(cmd, &token, &runtimeType, &baseDir, &httpsPort)
-
-	return cmd
+  # Custom SSL certificate
+  ai-services worker join catalog.example.com:9090 \
+      --token    <bootstrap-token> \
+      --ssl-cert /path/to/cert.pem \
+      --ssl-key  /path/to/key.pem`,
+	Args:    cobra.ExactArgs(1),
+	PreRunE: joinPreRunE,
+	RunE:    joinRunE,
 }
 
-func joinPreRunE(runtimeType *string) func(*cobra.Command, []string) error {
-	return func(cmd *cobra.Command, _ []string) error {
-		cmd.SilenceUsage = true
+func joinPreRunE(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
 
-		return cmdcommon.InitAndValidateRuntimeFlag(*runtimeType)
+	if err := cmdcommon.InitAndValidateRuntimeFlag(runtimeType); err != nil {
+		return err
 	}
+
+	if httpsPort < 1 || httpsPort > 65535 {
+		return fmt.Errorf("invalid HTTPS port %d: must be between 1 and 65535", httpsPort)
+	}
+
+	return utils.ValidateSSLFlags(sslCertPath, sslKeyPath, domainName)
 }
 
-func joinRunE(token, runtimeType, baseDir, httpsPort *string) func(*cobra.Command, []string) error {
-	return func(_ *cobra.Command, args []string) error {
-		opts := join.Options{
-			GatewayAddr: args[0],
-			Token:       *token,
-			RuntimeType: types.RuntimeType(*runtimeType),
-			Setup: workerdeploy.Options{
-				BaseDir:   *baseDir,
-				HTTPSPort: *httpsPort,
-			},
-		}
-
-		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-		defer stop()
-
-		logger.Infoln("Starting worker join — press Ctrl-C to stop.")
-
-		return join.Run(ctx, opts)
+func joinRunE(_ *cobra.Command, args []string) error {
+	aiServicesDir, err := utils.ValidateBaseDir(baseDir)
+	if err != nil {
+		return fmt.Errorf("invalid base directory %q: %w", baseDir, err)
 	}
+
+	if err := utils.CreateDir(filepath.Join(aiServicesDir, "models")); err != nil {
+		return fmt.Errorf("failed to create model directory: %w", err)
+	}
+
+	opts := join.Options{
+		GatewayAddr: args[0],
+		Token:       token,
+		RuntimeType: types.RuntimeType(runtimeType),
+		Setup: workerdeploy.Options{
+			BaseDir:     aiServicesDir,
+			HTTPSPort:   httpsPort,
+			DomainName:  domainName,
+			SSLCertPath: catalogUtils.SanitizeFilePath(sslCertPath),
+			SSLKeyPath:  catalogUtils.SanitizeFilePath(sslKeyPath),
+		},
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	logger.Infoln("Starting worker join — press Ctrl-C to stop.")
+
+	return join.Run(ctx, opts)
 }
 
-func addJoinFlags(cmd *cobra.Command, token, runtimeType, baseDir, httpsPort *string) {
-	cmd.Flags().StringVar(token, "token", "",
+func newJoinCmd() *cobra.Command {
+	cmd.Flags().StringVar(&token, "token", "",
 		"Single-use bootstrap token issued by 'catalog worker register' (required).\n"+
 			"Example: --token <uuid>\n")
 	_ = cmd.MarkFlagRequired("token")
 
-	cmdcommon.ConfigureRuntimeFlag(cmd, runtimeType)
+	cmdcommon.ConfigureRuntimeFlag(cmd, &runtimeType)
 
-	cmd.Flags().StringVar(baseDir, "basedir", constants.DefaultBaseDir,
+	cmd.Flags().StringVar(&baseDir, "basedir", constants.DefaultBaseDir,
 		"Base directory for AI services data (models, caddy, etc.) on this worker.\n"+
+			"Defaults to "+constants.DefaultBaseDir+" when not specified.\n"+
 			"Note: Supported for podman runtime only.\n"+
 			"Example: --basedir /var/lib/ai-services\n")
 
-	cmd.Flags().StringVar(httpsPort, "https-port", defaultJoinHTTPSPort,
+	cmd.Flags().IntVar(&httpsPort, "https-port", defaultJoinHTTPSPort,
 		"Custom HTTPS port to expose the service endpoints externally.\n"+
 			"Note: Supported for podman runtime only.\n"+
 			"Example: --https-port 8443\n")
+
+	cmd.Flags().StringVar(&domainName, "domain-name", "",
+		"Custom domain name for self-signed certificates.\n"+
+			"If not provided, uses wildcard DNS format: <service>.<ip>.nip.io\n"+
+			"If a custom SSL certificate/key pair is provided, the domain is extracted from the certificate and this flag is ignored.\n"+
+			"Note: Supported for podman runtime only.\n"+
+			"Example: --domain-name example.com\n")
+
+	cmd.Flags().StringVar(&sslCertPath, "ssl-cert", "",
+		"Path to user-provided SSL certificate (optional).\n"+
+			"Must be used together with --ssl-key.\n"+
+			"Certificate must contain wildcard SAN entry (e.g., *.example.com).\n"+
+			"Note: Supported for podman runtime only.\n"+
+			"Example: --ssl-cert /path/to/cert.pem\n")
+
+	cmd.Flags().StringVar(&sslKeyPath, "ssl-key", "",
+		"Path to user-provided SSL private key (optional).\n"+
+			"Must be used together with --ssl-cert.\n"+
+			"Note: Supported for podman runtime only.\n"+
+			"Example: --ssl-key /path/to/key.pem\n")
+
+	return cmd
 }

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
@@ -12,35 +12,7 @@ import (
 	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
-	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
-
-// ComputeDomainConfig computes the domain configuration from SSL certificates and domain name.
-// Priority: certDomain > customDomain > hostIP.nip.io.
-func ComputeDomainConfig(sslCertPath, sslKeyPath, domainName string) (string, error) {
-	var domainSuffix string
-
-	// If SSL certificate is provided, extract domain from it
-	if sslCertPath != "" && sslKeyPath != "" {
-		extractedDomain, err := utils.ExtractDomainFromCertificate(sslCertPath)
-		if err != nil {
-			return "", fmt.Errorf("failed to extract domain from certificate: %w", err)
-		}
-		domainSuffix = extractedDomain
-	} else if domainName != "" {
-		// Use provided domain name
-		domainSuffix = domainName
-	} else {
-		// Default to hostIP.nip.io when no configuration is provided
-		hostIP, err := utils.GetHostIP()
-		if err != nil {
-			return "", fmt.Errorf("failed to get host IP for domain suffix: %w", err)
-		}
-		domainSuffix = fmt.Sprintf("%s.nip.io", hostIP)
-	}
-
-	return domainSuffix, nil
-}
 
 // getCaddyAdminPort retrieves the host port mapped to Caddy's admin API (container port 2019).
 func getCaddyAdminPort(runtime *podman.PodmanClient, podName string) (string, error) {

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -223,7 +223,7 @@ func setupCaddyContext(deployCtx *deploy.DeployContext, opts catalogUtils.Podman
 	}
 
 	// Compute domain configuration (cert domain extraction + domain suffix resolution)
-	domainSuffix, err := caddy.ComputeDomainConfig(opts.SSLCertPath, opts.SSLKeyPath, opts.DomainName)
+	domainSuffix, err := utils.ComputeDomainSuffix(opts.SSLCertPath, opts.SSLKeyPath, opts.DomainName)
 	if err != nil {
 		s.Fail("failed to calculate domain")
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
 	cliutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure/utils"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 const certsDirName = "certs"
@@ -113,7 +113,7 @@ func validateCertificateChanges(opts *catalogUtils.PodmanConfigureOptions) error
 func validateDomainUnchanged(existingOpts *catalogUtils.PodmanConfigureOptions, sslCertPath, sslKeyPath string) error {
 	// Compute the current domain configuration based on the provided SSL certificates
 	// This uses the same logic as initial configuration
-	currentDomainSuffix, err := caddy.ComputeDomainConfig(sslCertPath, sslKeyPath, "")
+	currentDomainSuffix, err := utils.ComputeDomainSuffix(sslCertPath, sslKeyPath, "")
 	if err != nil {
 		return fmt.Errorf("failed to compute current domain: %w", err)
 	}

--- a/ai-services/internal/pkg/utils/cert.go
+++ b/ai-services/internal/pkg/utils/cert.go
@@ -93,11 +93,11 @@ func validateSSLCertificates(certPath, keyPath string) error {
 		return fmt.Errorf("certificate validation failed: %w", err)
 	}
 
-	if err := ValidateCertificateKeyPair(certPath, keyPath); err != nil {
+	if err := validateCertificateKeyPair(certPath, keyPath); err != nil {
 		return fmt.Errorf("certificate and key validation failed: %w", err)
 	}
 
-	if err := ValidateWildcardCertificate(certPath); err != nil {
+	if err := validateWildcardCertificate(certPath); err != nil {
 		return fmt.Errorf("wildcard certificate validation failed: %w", err)
 	}
 
@@ -166,7 +166,7 @@ func LoadCertificate(certPath string) (*x509.Certificate, error) {
 }
 
 // ValidateCertificateKeyPair verifies that a certificate and private key match.
-func ValidateCertificateKeyPair(certPath, keyPath string) error {
+func validateCertificateKeyPair(certPath, keyPath string) error {
 	// Load the certificate and key pair
 	_, err := tls.LoadX509KeyPair(certPath, keyPath)
 	if err != nil {
@@ -177,7 +177,7 @@ func ValidateCertificateKeyPair(certPath, keyPath string) error {
 }
 
 // ValidateWildcardCertificate checks if a certificate contains a wildcard SAN entry.
-func ValidateWildcardCertificate(certPath string) error {
+func validateWildcardCertificate(certPath string) error {
 	cert, err := LoadCertificate(certPath)
 	if err != nil {
 		return err

--- a/ai-services/internal/pkg/utils/cert.go
+++ b/ai-services/internal/pkg/utils/cert.go
@@ -21,8 +21,93 @@ const (
 	caddyAPITimeout = 10 * time.Second
 )
 
-// ValidateCertificateFiles verifies that certificate and key files exist and are readable.
-func ValidateCertificateFiles(certPath, keyPath string) error {
+// ComputeDomainSuffix resolves the domain suffix used for certificate and routing
+// configuration. Priority: cert domain > custom domain name > hostIP.nip.io.
+func ComputeDomainSuffix(sslCertPath, sslKeyPath, domainName string) (string, error) {
+	if sslCertPath != "" && sslKeyPath != "" {
+		extracted, err := ExtractDomainFromCertificate(sslCertPath)
+		if err != nil {
+			return "", fmt.Errorf("failed to extract domain from certificate: %w", err)
+		}
+
+		return extracted, nil
+	}
+
+	if domainName != "" {
+		return domainName, nil
+	}
+
+	hostIP, err := GetHostIP()
+	if err != nil {
+		return "", fmt.Errorf("failed to get host IP for domain suffix: %w", err)
+	}
+
+	return fmt.Sprintf("%s.nip.io", hostIP), nil
+}
+
+
+
+// ValidateSSLFlags is the shared entry-point for SSL flag validation used by
+// commands that accept --ssl-cert, --ssl-key, and --domain-name. It:
+//   - is a no-op when both paths are empty,
+//   - returns an error when only one of the pair is set,
+//   - prints a warning to stderr when a domain name is also supplied (it is
+//     ignored in favour of the domain embedded in the certificate),
+//   - validates file existence, cert/key pair match, and wildcard SAN.
+func ValidateSSLFlags(certPath, keyPath, domainName string) error {
+	if certPath == "" && keyPath == "" {
+		return nil
+	}
+
+	if err := checkSSLFlagsPaired(certPath, keyPath); err != nil {
+		return err
+	}
+
+	warnIfBothCertAndDomainProvided(certPath, keyPath, domainName)
+
+	return validateSSLCertificates(certPath, keyPath)
+}
+
+// checkSSLFlagsPaired returns an error when only one of --ssl-cert / --ssl-key
+// is provided; both must be supplied together or neither.
+func checkSSLFlagsPaired(certPath, keyPath string) error {
+	if (certPath != "" && keyPath == "") || (certPath == "" && keyPath != "") {
+		return fmt.Errorf("--ssl-cert and --ssl-key must be used together")
+	}
+
+	return nil
+}
+
+// warnIfBothCertAndDomainProvided prints a stderr warning when the caller
+// supplies both a certificate and a custom domain name. The domain is ignored
+// because it will be extracted from the certificate instead.
+func warnIfBothCertAndDomainProvided(certPath, keyPath, domainName string) {
+	if certPath != "" && keyPath != "" && domainName != "" {
+		fmt.Fprintf(os.Stderr, "Warning: Both SSL certificate and --domain-name provided. "+
+			"The domain from the certificate will be used, and --domain-name will be ignored.\n\n")
+	}
+}
+
+// validateSSLCertificates runs file-existence, key-pair match, and wildcard-SAN
+// checks against the provided certificate and key paths.
+func validateSSLCertificates(certPath, keyPath string) error {
+	if err := validateCertificateFiles(certPath, keyPath); err != nil {
+		return fmt.Errorf("certificate validation failed: %w", err)
+	}
+
+	if err := ValidateCertificateKeyPair(certPath, keyPath); err != nil {
+		return fmt.Errorf("certificate and key validation failed: %w", err)
+	}
+
+	if err := ValidateWildcardCertificate(certPath); err != nil {
+		return fmt.Errorf("wildcard certificate validation failed: %w", err)
+	}
+
+	return nil
+}
+
+// validateCertificateFiles verifies that certificate and key files exist and are readable.
+func validateCertificateFiles(certPath, keyPath string) error {
 	// Validate paths are not empty (fail-fast)
 	if certPath == "" {
 		return fmt.Errorf("certificate path is empty")

--- a/ai-services/internal/pkg/utils/cert.go
+++ b/ai-services/internal/pkg/utils/cert.go
@@ -45,8 +45,6 @@ func ComputeDomainSuffix(sslCertPath, sslKeyPath, domainName string) (string, er
 	return fmt.Sprintf("%s.nip.io", hostIP), nil
 }
 
-
-
 // ValidateSSLFlags is the shared entry-point for SSL flag validation used by
 // commands that accept --ssl-cert, --ssl-key, and --domain-name. It:
 //   - is a no-op when both paths are empty,

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -530,8 +530,13 @@ func GetModelsPath() string {
 // ValidateBaseDir validates that the base directory exists or can be created.
 // It always appends 'ai-services' subdirectory to the provided base directory for all AI services content.
 func ValidateBaseDir(baseDir string) (string, error) {
+	// Fall back to the default when the flag was not set.
+	if baseDir == "" {
+		return constants.DefaultBaseDir, nil
+	}
+
 	// Resolve relative paths to absolute paths to prevent Podman from mounting
-	//the wrong (or empty) host directory.
+	// the wrong (or empty) host directory.
 	absBase, err := filepath.Abs(baseDir)
 	if err != nil {
 		return "", fmt.Errorf("cannot resolve absolute path: %w", err)

--- a/ai-services/internal/pkg/worker/deploy/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/deploy.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	ttemplate "text/template"
 
 	"github.com/project-ai-services/ai-services/assets"
@@ -47,7 +48,17 @@ type Options struct {
 	BaseDir string
 	// HTTPSPort is the host port Caddy binds for HTTPS traffic, e.g. "443".
 	// Set once at first join; ignored on subsequent runs if already deployed.
-	HTTPSPort string
+	HTTPSPort int
+
+	// DomainName is an optional custom domain suffix for self-signed certificates.
+	// If empty, Caddy uses wildcard DNS format: <service>.<ip>.nip.io.
+	DomainName string
+	// SSLCertPath is the path to a user-provided SSL certificate (PEM).
+	// Must be used together with SSLKeyPath.
+	SSLCertPath string
+	// SSLKeyPath is the path to a user-provided SSL private key (PEM).
+	// Must be used together with SSLCertPath.
+	SSLKeyPath string
 }
 
 // Setup writes prerequisite config files, checks whether the worker proxy
@@ -129,7 +140,7 @@ func deployAll(ctx context.Context, rt runtime.Runtime, opts Options) error {
 	}
 
 	values, err := tp.LoadValues(workerApp, nil, map[string]string{
-		"caddy.httpsPort": opts.HTTPSPort,
+		"caddy.httpsPort": strconv.Itoa(opts.HTTPSPort),
 	})
 	if err != nil {
 		return fmt.Errorf("worker setup: load values: %w", err)

--- a/ai-services/internal/pkg/worker/join/join.go
+++ b/ai-services/internal/pkg/worker/join/join.go
@@ -284,5 +284,4 @@ func isUnauthenticated(err error) bool {
 	return status.Code(err) == codes.Unauthenticated
 }
 
-
 // Made with Bob

--- a/ai-services/internal/pkg/worker/join/join.go
+++ b/ai-services/internal/pkg/worker/join/join.go
@@ -27,15 +27,21 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	workerdeploy "github.com/project-ai-services/ai-services/internal/pkg/worker/deploy"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/dispatch"
 	workerpb "github.com/project-ai-services/ai-services/internal/pkg/worker/proto"
 )
 
 const (
+	// metaKeyBaseDir is the metadata key used to transmit the worker's base
+	// directory to the control plane during registration.
+	metaKeyBaseDir = "basedir"
+
 	// heartbeatInterval is how often the worker sends a keep-alive to the control plane.
 	heartbeatInterval = 30 * time.Second
 
@@ -78,7 +84,7 @@ type Options struct {
 //   - Call Register with the bootstrap token.
 //   - Open CommandStream and hold it, retrying on transient failures.
 func Run(ctx context.Context, opts Options) error {
-	if err := validateOptions(opts); err != nil {
+	if err := validateOptions(&opts); err != nil {
 		return err
 	}
 
@@ -104,7 +110,11 @@ func Run(ctx context.Context, opts Options) error {
 	client := workerpb.NewWorkerGatewayClient(conn)
 
 	// ── Step 3: Register + stream loop ───────────────────────────────────────
-	return runRegistrationLoop(ctx, rt, client, opts.Token)
+	meta := map[string]string{
+		metaKeyBaseDir: opts.Setup.BaseDir,
+	}
+
+	return runRegistrationLoop(ctx, rt, client, opts.Token, meta)
 }
 
 // ─── registration loop ────────────────────────────────────────────────────────
@@ -112,8 +122,8 @@ func Run(ctx context.Context, opts Options) error {
 // runRegistrationLoop calls Register and then enters the CommandStream retry
 // loop.  If the stream comes back with codes.Unauthenticated it re-registers
 // before reconnecting.
-func runRegistrationLoop(ctx context.Context, rt runtime.Runtime, client workerpb.WorkerGatewayClient, token string) error {
-	workerName, err := register(ctx, client, token, rt.Type())
+func runRegistrationLoop(ctx context.Context, rt runtime.Runtime, client workerpb.WorkerGatewayClient, token string, meta map[string]string) error {
+	workerName, err := register(ctx, client, token, rt.Type(), meta)
 	if err != nil {
 		return fmt.Errorf("worker join: register: %w", err)
 	}
@@ -125,12 +135,13 @@ func runRegistrationLoop(ctx context.Context, rt runtime.Runtime, client workerp
 
 // register calls the Register RPC once and returns the worker name bound by
 // the control plane.
-func register(ctx context.Context, client workerpb.WorkerGatewayClient, token string, rt types.RuntimeType) (string, error) {
+func register(ctx context.Context, client workerpb.WorkerGatewayClient, token string, rt types.RuntimeType, meta map[string]string) (string, error) {
 	logger.InfolnCtx(ctx, "Registering worker with catalog control plane...")
 
 	resp, err := client.Register(ctx, &workerpb.RegisterRequest{
 		PreSharedToken: token,
 		RuntimeType:    rt.String(),
+		Metadata:       meta,
 	})
 	if err != nil {
 		return "", fmt.Errorf("register RPC: %w", err)
@@ -262,8 +273,10 @@ func isUnauthenticated(err error) bool {
 	return status.Code(err) == codes.Unauthenticated
 }
 
-// validateOptions performs lightweight up-front validation of join options.
-func validateOptions(opts Options) error {
+// validateOptions performs lightweight up-front validation of join options
+// and resolves opts.Setup.BaseDir to its canonical absolute path, creating
+// the directory if it does not yet exist.
+func validateOptions(opts *Options) error {
 	if opts.GatewayAddr == "" {
 		return fmt.Errorf("worker join: gateway address is required")
 	}
@@ -277,7 +290,30 @@ func validateOptions(opts Options) error {
 			opts.RuntimeType, types.RuntimeTypePodman, types.RuntimeTypeOpenShift)
 	}
 
+	resolved, err := resolveBaseDir(opts.Setup.BaseDir)
+	if err != nil {
+		return err
+	}
+
+	opts.Setup.BaseDir = resolved
+
 	return nil
+}
+
+// resolveBaseDir returns the validated base directory, falling back to the
+// default when the flag was not set. Mirrors the same logic used by
+// `catalog configure` so behaviour is consistent across commands.
+func resolveBaseDir(baseDir string) (string, error) {
+	if baseDir == "" {
+		return constants.DefaultBaseDir, nil
+	}
+
+	resolved, err := utils.ValidateBaseDir(baseDir)
+	if err != nil {
+		return "", fmt.Errorf("invalid base directory %q: %w", baseDir, err)
+	}
+
+	return resolved, nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/worker/join/join.go
+++ b/ai-services/internal/pkg/worker/join/join.go
@@ -20,6 +20,7 @@ package join
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"google.golang.org/grpc"
@@ -27,7 +28,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
-	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
@@ -41,6 +41,14 @@ const (
 	// metaKeyBaseDir is the metadata key used to transmit the worker's base
 	// directory to the control plane during registration.
 	metaKeyBaseDir = "basedir"
+
+	// metaKeyDomainSuffix is the metadata key used to transmit the resolved
+	// domain suffix to the control plane during registration.
+	metaKeyDomainSuffix = "domainSuffix"
+
+	// metaKeyHTTPSPort is the metadata key used to transmit the HTTPS port
+	// the worker's Caddy proxy listens on.
+	metaKeyHTTPSPort = "httpsPort"
 
 	// heartbeatInterval is how often the worker sends a keep-alive to the control plane.
 	heartbeatInterval = 30 * time.Second
@@ -84,7 +92,8 @@ type Options struct {
 //   - Call Register with the bootstrap token.
 //   - Open CommandStream and hold it, retrying on transient failures.
 func Run(ctx context.Context, opts Options) error {
-	if err := validateOptions(&opts); err != nil {
+	domainSuffix, err := utils.ComputeDomainSuffix(opts.Setup.SSLCertPath, opts.Setup.SSLKeyPath, opts.Setup.DomainName)
+	if err != nil {
 		return err
 	}
 
@@ -111,7 +120,9 @@ func Run(ctx context.Context, opts Options) error {
 
 	// ── Step 3: Register + stream loop ───────────────────────────────────────
 	meta := map[string]string{
-		metaKeyBaseDir: opts.Setup.BaseDir,
+		metaKeyBaseDir:      opts.Setup.BaseDir,
+		metaKeyDomainSuffix: domainSuffix,
+		metaKeyHTTPSPort:    strconv.Itoa(opts.Setup.HTTPSPort),
 	}
 
 	return runRegistrationLoop(ctx, rt, client, opts.Token, meta)
@@ -273,47 +284,5 @@ func isUnauthenticated(err error) bool {
 	return status.Code(err) == codes.Unauthenticated
 }
 
-// validateOptions performs lightweight up-front validation of join options
-// and resolves opts.Setup.BaseDir to its canonical absolute path, creating
-// the directory if it does not yet exist.
-func validateOptions(opts *Options) error {
-	if opts.GatewayAddr == "" {
-		return fmt.Errorf("worker join: gateway address is required")
-	}
-
-	if opts.Token == "" {
-		return fmt.Errorf("worker join: bootstrap token is required")
-	}
-
-	if !opts.RuntimeType.Valid() {
-		return fmt.Errorf("worker join: invalid runtime type %q (must be %q or %q)",
-			opts.RuntimeType, types.RuntimeTypePodman, types.RuntimeTypeOpenShift)
-	}
-
-	resolved, err := resolveBaseDir(opts.Setup.BaseDir)
-	if err != nil {
-		return err
-	}
-
-	opts.Setup.BaseDir = resolved
-
-	return nil
-}
-
-// resolveBaseDir returns the validated base directory, falling back to the
-// default when the flag was not set. Mirrors the same logic used by
-// `catalog configure` so behaviour is consistent across commands.
-func resolveBaseDir(baseDir string) (string, error) {
-	if baseDir == "" {
-		return constants.DefaultBaseDir, nil
-	}
-
-	resolved, err := utils.ValidateBaseDir(baseDir)
-	if err != nil {
-		return "", fmt.Errorf("invalid base directory %q: %w", baseDir, err)
-	}
-
-	return resolved, nil
-}
 
 // Made with Bob


### PR DESCRIPTION
1. Added metadata to the worker register flow.
2. Added remaining CLI params for `join` cmd.
3. Refactored common cmd code for `catalog configure` and `worker join`.