### PR TITLE
Data Connectors: Misc Changes

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.287
+TAG?=v0.0.288
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.49
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.50
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.49
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.50
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.49
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.50
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.49
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.50
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.49
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.50
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.287
+  image: icr.io/ai-services-cicd/ai-services:v0.0.288
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.287
+  image: icr.io/ai-services-cicd/ai-services:v0.0.288
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/services/digitize/openshift/values.yaml
+++ b/ai-services/assets/services/digitize/openshift/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.49
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.50
   log_level: "INFO"
   database: "digitize_metadata"
   numShards: 1

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.49
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.50
   log_level: "INFO"
   database: "digitize_metadata"
   # @generate:password length=32, special=false

--- a/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
+++ b/docs/proposals/data-source-connectors/digitize-connector-processing-proposal.md
@@ -10,8 +10,8 @@ Before any `digitize` connector endpoint is called:
 
 - Catalog has already validated the remote connector configuration.
 - Catalog sends secret material in plaintext via API calls:
-  - `ssh`: `private_key`
-  - `s3`: `secret_access_key`
+  - `file_system`: `private_key`
+  - `object_storage`: `secret_access_key`
 - `digitize` encrypts those secret fields at rest using `/run/secrets/connector_encryption_key` before persisting them in the DB.
 - `/run/secrets/connector_encryption_key` is mounted before pod start.
 - The `document_checksum` table and `DocumentChecksum` ORM model are used exclusively for user-submitted documents. Connector code must never read from or write to it — connector dedup is handled exclusively via `connector_document_checksum` (§2.2).
@@ -49,10 +49,9 @@ CREATE TABLE IF NOT EXISTS connectors (
     attached_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     last_sync_at            TIMESTAMPTZ,
     sync_status             TEXT        NOT NULL DEFAULT 'up to date',
-    last_sync_error         TEXT,
     error                   TEXT,
     total_files             INTEGER     NOT NULL DEFAULT 0,
-    CONSTRAINT chk_connector_type CHECK (type IN ('ssh', 's3'))
+    CONSTRAINT chk_connector_type CHECK (type IN ('file_system', 'object_storage'))
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_connectors_name ON connectors (name);
@@ -88,8 +87,6 @@ CREATE TABLE IF NOT EXISTS connector_sync_logs (
 CREATE INDEX IF NOT EXISTS idx_csl_connector_started ON connector_sync_logs (connector_id, started_at DESC);
 ```
 
-> **Note:** `init_schema.sql` still contains a `failed_files INTEGER` column that is not reflected in the ORM and should be removed in a schema cleanup pass.
-
 ---
 
 ### 2.3 ORM Mapping
@@ -110,12 +107,15 @@ class Connector(Base):
                                 default=lambda: datetime.now(timezone.utc))
     last_sync_at = mapped_column(DateTime(timezone=True), nullable=True)
     sync_status = mapped_column(Text, nullable=False, default=ConnectorStatus.UP_TO_DATE)
-    last_sync_error = mapped_column(Text, nullable=True)
-    error = mapped_column(Text, nullable=True)   # ← teardown error field (no schema equivalent in proposal)
+    error = mapped_column(Text, nullable=True)   # ← teardown error / credential error / last sync error
     total_files = mapped_column(Integer, nullable=False, default=0)
 
     sync_logs = relationship("ConnectorSyncLog", back_populates="connector",
                              cascade="all, delete-orphan")
+
+    __table_args__ = (
+        CheckConstraint("type IN ('file_system', 'object_storage')", name="chk_connector_type"),
+    )
 
 
 class ConnectorDocumentChecksum(Base):
@@ -164,20 +164,20 @@ class ConnectorSyncLog(Base):
 
 ### 3.1 `POST /v1/connectors`
 
-Creates a connector, encrypts secrets at rest, persists configuration. Returns `201 Created` immediately. The scheduler job is registered (with `fire_immediately=True`) before the DB insert so that a scheduler failure aborts the creation cleanly. A `_probe_connector_credentials` background task is also dispatched to test the supplied credentials — on failure the connector row's `error` field is set to the auth-failure sentinel.
+Creates a connector, encrypts secrets at rest, persists configuration. Returns `202 Accepted` immediately. Before any write, two explicit duplicate-check SELECTs are performed (`get_connector_by_id`, `get_connector_by_name`), returning `409 Conflict` if either match. The scheduler job is registered (`fire_immediately=True`) before the DB insert so that a scheduler failure aborts the creation cleanly.
 
 #### Request Parameters
-- Common: `connector_id` (UUID, optional — auto-generated if omitted), `connector_name` (string, unique), `type` (`"ssh"` | `"s3"`), `allowed_extensions` (`array[string]`), `connection_details` (object).
+- Common: `connector_id` (UUID, optional — auto-generated if omitted), `connector_name` (string, unique), `type` (`"file_system"` | `"object_storage"`), `allowed_extensions` (`array[string]`), `connection_details` (object).
 - `sync_interval_seconds`: Read from `CONNECTOR_SYNC_INTERVAL_SECONDS` env var (default `300`). Not settable per-request.
-- SSH `connection_details`: `host`, `username`, `remote_path`, `private_key`. Optional: `port` (default `22`).
-- S3 `connection_details`: `endpoint_url` (full URL with scheme), `bucket_name`, `access_key_id`, `secret_access_key`. Optional: `prefix`, `delimiter`, `download_concurrency`, `verify_ssl`.
+- `file_system` `connection_details`: `host`, `username`, `remote_path`, `private_key`. Optional: `port` (default `22`).
+- `object_storage` `connection_details`: `endpoint_url` (full URL with scheme), `bucket_name`, `access_key_id`, `secret_access_key`. Optional: `prefix`, `delimiter`, `download_concurrency`, `verify_ssl`.
 
 #### Example Payloads
 ```json
 {
   "connector_id": "c7f3a2d1-4e5b-4c6d-8f9a-0b1c2d3e4f5a",
   "connector_name": "prod-sftp-reports",
-  "type": "ssh",
+  "type": "file_system",
   "allowed_extensions": [".pdf", ".docx"],
   "connection_details": {
     "host": "sftp.example.com",
@@ -192,7 +192,7 @@ Creates a connector, encrypts secrets at rest, persists configuration. Returns `
 {
   "connector_id": "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
   "connector_name": "prod-s3-rag-docs",
-  "type": "s3",
+  "type": "object_storage",
   "allowed_extensions": [".pdf", ".docx"],
   "connection_details": {
     "endpoint_url": "https://s3.us-east-1.amazonaws.com",
@@ -206,7 +206,7 @@ Creates a connector, encrypts secrets at rest, persists configuration. Returns `
 ```
 
 #### Responses
-- `201 Created`: Connector created and scheduler job registered immediately (`fire_immediately=True`). Credential probe dispatched as a background task.
+- `202 Accepted`: Connector created and scheduler job registered immediately (`fire_immediately=True`).
 - `409 Conflict`: `connector_id` or `connector_name` already exists.
 
 ---
@@ -218,13 +218,13 @@ Updates connector configuration in place.
 - `connection_details` is merged key-by-key (untouched encrypted keys are preserved via `merge_and_encrypt_partial`).
 - `type` and `sync_interval_seconds` cannot be modified.
 - Does not restart the scheduler — the next scheduled tick reads updated config directly from DB.
-- If `connection_details` is supplied, a `_probe_connector_credentials` background task is dispatched against the merged credentials. On success, any previous auth-failure error is cleared; on failure, the `error` field is set to the credential-error sentinel.
+- If `connection_details` is supplied, `asyncio.create_task(dispatch_sync(connector_id))` is dispatched immediately to validate the new credentials and update the connector/sync-log status.
 - Returns `409 Conflict` if the connector is `DELETE_PENDING`.
 
 #### Responses
 - `200 OK`: Updated successfully.
 - `404 Not Found`: Connector does not exist.
-- `409 Conflict`: Duplicate `connector_name`.
+- `409 Conflict`: Duplicate `connector_name` or connector is `DELETE_PENDING`.
 
 ---
 
@@ -257,15 +257,20 @@ DELETE /v1/connectors/{connector_id} (API Handler)
 ```text
 _run_teardown(connector_id)  (connectors.py — used for BOTH Case A and Case B)
   │
-  ├─ Step 1+2: list_connector_checksums → for each checksum:
-  │              remove_connector_checksum_entry(connector_id, checksum)
+  ├─ Step 1: remove_connector_job(connector_id) — unregister scheduler so no new ticks fire
+  │            on failure → append to deletion_errors (non-fatal; proceed)
+  ├─ Step 2+3: list_connector_checksums → _remove_checksums(connector_id, owned_checksums)
+  │              for each checksum: remove_connector_checksum_entry(connector_id, checksum)
   │              if remaining == 0 and doc_id → _best_effort_delete_document(doc_id)
-  │              on any failure → set_connector_error + return early (connector row kept)
-  ├─ Step 3: delete_active_connector(connector_id) (cascades to sync_logs)
-  └─ Step 4: _sweep_staging_dir(connector_id, staging/connectors)
+  │              on any failure → append to deletion_errors
+  ├─ Step 4: _sweep_staging_dir(connector_id, staging/connectors) — clean residual batch dirs
+  │            on failure → append to deletion_errors
+  ├─ [if deletion_errors] → set_connector_error(connector_id, msg) + return early
+  │                          (connector row kept in 'delete pending' with error message)
+  └─ Step 5: delete_active_connector(connector_id) (cascades to sync_logs)
 ```
 
-> **Note:** There is no separate `_run_delete_teardown` function in `sync_tick.py`. `_handle_interrupt` for `DELETE_CONNECTOR` directly `await`s `_run_teardown` imported from `connectors.py`. The same teardown function is used for both Case A (via the interrupt handler) and Case B (via `asyncio.create_task`).
+> **Note:** `_run_teardown` first removes the scheduler job (Step 1) before any document cleanup, ensuring no new ticks are dispatched after teardown begins. If any step from 2–4 fails, the connector row is kept with an `error` message and the DB row is **not** deleted, allowing operators to retry or inspect. The same `_run_teardown` function handles both Case A (awaited from `_handle_interrupt` in `sync_tick.py`) and Case B (via `asyncio.create_task`).
 
 ![Delete Flow](delete-flow.svg)
 
@@ -273,7 +278,7 @@ _run_teardown(connector_id)  (connectors.py — used for BOTH Case A and Case B)
 
 ### 3.4 `GET /v1/connectors` & `GET /v1/connectors/{connector_id}`
 
-- `GET /v1/connectors`: Returns all connectors ordered by `attached_at` descending. Excludes secret fields. Includes `error` field (teardown error state).
+- `GET /v1/connectors`: Returns all connectors ordered by `attached_at` descending. Excludes secret fields. Includes `error` field (covers teardown errors, credential errors, and last-sync error messages).
 - `GET /v1/connectors/{id}`: Returns full connector detail including `connection_details` (secrets stripped), `allowed_extensions`, `sync_interval_seconds`, and file processing counters (`total_files`).
 
 ---
@@ -288,20 +293,24 @@ Returns a single sync log entry identified by its sequence number. Returns `404`
 
 #### `POST /v1/connectors/{connector_id}/syncs`
 Triggers an immediate manual sync tick. Implemented via the shared `dispatch_sync(connector_id)` helper (also used by the scheduler).
-- Guards: returns `404` if connector not found; raises `SyncLocked` (→ `409`) if connector is `DELETE_PENDING` or if the active sync is already `CANCEL_PENDING`.
+- Guards: returns `404` if connector not found; raises `SyncLocked` (→ `409`) if connector is `DELETE_PENDING` or if the active sync-log row is already `CANCEL_PENDING`.
+- `CANCEL_PENDING` check: reads `get_active_sync_seq()` first; if a row exists, calls `get_sync_log_status(connector_id, active_seq)` — raises `SyncLocked` only if that status is `CANCEL_PENDING`.
 - If lock acquired via `try_acquire_sync_lock`: calls `init_sync_log_and_update_connector` **synchronously in the caller** (no polling), dispatches `asyncio.create_task(run_tick(connector_id, sync_seq))`, and returns `202 Accepted` with `{"sync_seq": <n>}` immediately.
 - If lock unavailable (already syncing): reads `get_active_sync_seq()` and returns `202 Accepted` with the existing seq (idempotent — no duplicate tick started).
 
 ```text
 POST /v1/connectors/{connector_id}/syncs  →  dispatch_sync(connector_id)
   │
-  ├─ 1. get_active_connector() → 404 if not found
+  ├─ 1. get_connector_by_id() → SyncNotFound (404) if not found
   ├─ 2. connector.sync_status == DELETE_PENDING → SyncLocked (409)
-  ├─ 3. get_active_sync_seq() — if CANCEL_PENDING on active row → SyncLocked (409)
+  ├─ 3. get_active_sync_seq()
+  │      └─ if active_seq exists: get_sync_log_status(connector_id, active_seq)
+  │           if CANCEL_PENDING → SyncLocked (409)
   ├─ 4. try_acquire_sync_lock(connector_id)
   │      ├─ Acquired → init_sync_log_and_update_connector() (sync, returns seq immediately)
   │      │             asyncio.create_task(run_tick(connector_id, sync_seq))
   │      └─ Not acquired (already syncing) → get_active_sync_seq()
+  │           None → RuntimeError (should not happen under normal operation)
   └─ 5. Return 202 Accepted { "sync_seq": <seq> }
 ```
 
@@ -315,7 +324,7 @@ Stops the currently running sync tick without deleting the connector.
 ```text
 POST /v1/connectors/{connector_id}/syncs/{sync_seq}/stop
   │
-  ├─ 1. Check existence → 404 if not found
+  ├─ 1. get_connector_by_id() → 404 if not found
   ├─ 2. Check connector.sync_status == 'syncing' → 409 if not syncing
   ├─ 3. get_active_sync_seq() → 409 if None or != sync_seq
   ├─ 4. mark_sync_cancel_pending(connector_id)
@@ -350,9 +359,10 @@ POST /v1/connectors/{connector_id}/syncs/{sync_seq}/stop
 
 | Function (`utils/db.py` wrapper → `manager.py` method) | Purpose / Behavior |
 | --- | --- |
-| `insert_connector()` → `insert_connector()` | Create new connector row. Raises `IntegrityError` on duplicate id. |
-| `upsert_connector()` → `update_connector()` | Partial update: only non-None kwargs written. `connection_details` merged via JSONB `\|\|` operator. Raises `FileNotFoundError` if not found. |
-| `get_active_connector()` → `get_connector_by_id()` | Fetch single connector (eagerly loaded + expunged). Returns `None` if not found. |
+| `insert_connector()` → `insert_connector()` | Create new connector row. Raises `IntegrityError` on duplicate id/name. |
+| `upsert_connector()` → `update_connector()` | Partial update: only non-None kwargs written. Raises `FileNotFoundError` if not found. |
+| `get_connector_by_id()` → `get_connector_by_id()` | Fetch single connector by id. Returns `None` if not found. |
+| `get_connector_by_name()` → `get_connector_by_name()` | Fetch single connector by name. Returns `None` if not found. |
 | `list_connectors()` → `get_all_connectors()` | All connectors ordered by `attached_at` desc. |
 | `delete_active_connector()` → `delete_connector()` | Delete connector row (cascades to `connector_sync_logs`). Returns `bool`. |
 | `get_connector_sync_status()` → `get_connector_sync_status()` | Minimal `SELECT sync_status` query. Returns `None` if not found. |
@@ -365,14 +375,16 @@ POST /v1/connectors/{connector_id}/syncs/{sync_seq}/stop
 | `list_all_checksums()` → `get_all_connector_checksums()` | All distinct checksums across all connectors. |
 | `add_connector_checksum_entry()` → `insert_connector_checksum()` | Insert `(checksum, connector_id, doc_id)` with `ON CONFLICT DO NOTHING`. |
 | `remove_connector_checksum_entry()` → `delete_connector_checksum()` + `count_checksum_owners()` | Delete `(checksum, connector_id)` row; return `(remaining_owner_count, doc_id)`. Two separate DB calls: delete returns `doc_id`; count is a separate query. |
-| `set_connector_error()` → `update_connector()` | Persist error string on connector row (best-effort; logs on failure). |
-| `update_connector_total_files()` → `update_connector()` | Update `total_files` count on connector row. Called after `update_sync_log` in Phase 3b. |
+| `set_connector_error()` → `update_connector()` | Persist or clear error string on connector row (best-effort; logs on failure). Pass `None` to clear. |
+| `update_connector_total_files()` → `update_connector()` | Update `total_files` count on connector row. Called after `_process_new_files` returns, adjusted by `invalid_file_count`. |
 | `init_sync_log_and_update_connector()` → `insert_sync_log()` + `set_connector_sync_status_syncing()` | Insert new log row (seq = `COALESCE(MAX(seq),0)+1`) with `status='started'`; then set connector `sync_status='syncing'`. Returns `seq`. Two separate DB calls. |
 | `update_sync_log()` → `update_sync_log_progress()` | Write `total_files`, `new_files`, `removed_files` before I/O phase. Takes `connector_id` + `seq`. Returns `bool`. |
-| `finalize_sync_log_and_update_connector()` → `finalize_sync_log()` + `update_connector_after_sync()` | Finalize log row (status, finished_at, optional counts/error); then update connector `last_sync_at` and `sync_status`. `CANCELLED`/`FAILED` both map to `OUT_OF_SYNC`. Two separate DB calls. |
+| `finalize_sync_log_and_update_connector()` → `finalize_sync_log()` + `update_connector_after_sync()` | Finalize log row (status, finished_at, optional counts/error); then update connector `last_sync_at`, `sync_status`, and `error`. `CANCELLED`/`FAILED` map to `OUT_OF_SYNC`; `COMPLETED` clears `error` to `NULL`; `FAILED`/`CANCELLED` sets `error = f"Error from last sync: {error}"`. Two separate DB calls. |
 | `get_sync_log()` → `get_sync_log()` | Single sync-log row by `(connector_id, seq)`. |
 | `get_sync_log_status()` → `get_sync_log_status()` | Minimal `SELECT status` for `(connector_id, seq)`. Used by `_check_interrupt_call`. |
 | `list_sync_logs()` → `get_sync_logs()` + `count_sync_logs()` | Paginated log history. Returns `(items, total_count)`. |
+| `reset_syncing_connectors()` → `reset_syncing_connectors()` | Bulk `UPDATE connectors SET sync_status='out of sync' WHERE sync_status='syncing'`. Returns list of affected IDs. Used on startup crash recovery. |
+| `close_open_sync_log()` → `close_open_sync_log()` | Closes the open sync-log row (`started` \| `cancel pending`) to `failed` with error string. Used on startup crash recovery. |
 
 ---
 
@@ -395,6 +407,8 @@ def finalize_sync_log_and_update_connector(
     """
     Two DB calls: finalize log row + update connector.
     CANCELLED/FAILED both map to OUT_OF_SYNC on the connector row.
+    COMPLETED clears the connector's error to NULL.
+    FAILED/CANCELLED stamps connector.error = "Error from last sync: {error}".
     Returns True on success, False if the sync-log row was not found.
     """
     now = finished_at or datetime.now(timezone.utc)
@@ -402,7 +416,10 @@ def finalize_sync_log_and_update_connector(
                                          total_files, new_files, removed_files, error)
     if not found:
         return False
-    db_manager.update_connector_after_sync(connector_id, status=status, last_sync_at=now)
+    connector_error = f"Error from last sync: {error}" if error else error
+    db_manager.update_connector_after_sync(
+        connector_id, status=status, last_sync_at=now, error=connector_error
+    )
     return True
 
 
@@ -485,8 +502,8 @@ class DatabaseManager:
             return row[0] if row else None
 
     @staticmethod
-    def update_connector_after_sync(connector_id, status, last_sync_at=None) -> None:
-        """CANCELLED/FAILED both map to OUT_OF_SYNC; COMPLETED written verbatim."""
+    def update_connector_after_sync(connector_id, status, last_sync_at=None, error=None) -> None:
+        """CANCELLED/FAILED both map to OUT_OF_SYNC; COMPLETED clears error to NULL."""
         connector_sync_status = (
             ConnectorStatus.OUT_OF_SYNC
             if status in (SyncLogStatus.CANCELLED, SyncLogStatus.FAILED)
@@ -495,7 +512,7 @@ class DatabaseManager:
         session.execute(
             update(Connector)
             .where(Connector.id == connector_id)
-            .values(last_sync_at=last_sync_at, sync_status=connector_sync_status)
+            .values(last_sync_at=last_sync_at, sync_status=connector_sync_status, error=error)
         )
 ```
 
@@ -561,16 +578,15 @@ def verify_integrity(self, local_checksum: str, remote_checksum: str) -> bool:
 #### 3. Scanner Factory (`scanner_factory.py`)
 ```python
 _REGISTRY: dict[str, tuple[type[BaseScanner], type]] = {
-    "s3": (S3Scanner, S3ConnectorConfig),
-    "ssh": (SSHScanner, SSHConnectorConfig),
+    "object_storage": (S3Scanner, S3ConnectorConfig),
+    "file_system": (SSHScanner, SSHConnectorConfig),
 }
 
 def build_scanner(connector_row: Any) -> BaseScanner:
     """Decrypt secrets, build config dataclass, return scanner instance."""
     # 1. Decrypt secrets from stored connection_details
-    key_path = settings.digitize.connector.encryption_key_path
-    connection_details = decrypt_secrets(connector_type, connection_details, key_path)
-    # 2. Build typed config
+    connection_details = decrypt_secrets(connector_type, connection_details)
+    # 2. Build typed config (accepts ORM row or dict)
     config = S3ConnectorConfig.from_connection_details(connection_details, allowed_extensions)
     # or SSHConnectorConfig.from_connection_details(...)
     # 3. Return scanner instance
@@ -579,9 +595,9 @@ def build_scanner(connector_row: Any) -> BaseScanner:
 
 #### 4. Config Models (`config.py`)
 
-`S3ConnectorConfig` — fields: `bucket_name`, `access_key_id`, `secret_access_key`, `endpoint_url`, `prefix`, `delimiter`, `download_concurrency`, `verify_ssl`, `allowed_extensions`. Computed properties: `provider`, `is_aws`, `effective_region`. Validators: require scheme on `endpoint_url`; require non-empty credentials for IBM COS.
+`S3ConnectorConfig` — fields: `bucket_name`, `access_key_id`, `secret_access_key`, `endpoint_url`, `prefix`, `delimiter`, `download_concurrency`, `verify_ssl`, `allowed_extensions`. Computed properties: `provider`, `is_aws`, `effective_region`. Validators: require scheme on `endpoint_url`; require non-empty credentials for IBM COS (`_check_credentials` model validator); extensions normalised to lowercase with leading dot (`_normalise_extensions`).
 
-`SSHConnectorConfig` — fields: `host`, `port`, `username`, `private_key`, `remote_path`, `allowed_extensions`. Validators: non-empty host/username/private_key; `"PRIVATE KEY"` substring check on PEM.
+`SSHConnectorConfig` — fields: `host`, `port`, `username`, `private_key`, `remote_path`, `allowed_extensions`. Validators: non-empty host/username/private_key; `"PRIVATE KEY"` substring check on PEM; extensions normalised to lowercase with leading dot (`_normalise_extensions`).
 
 ---
 
@@ -609,6 +625,17 @@ class SyncLogStatus(str, Enum):
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELLED = "cancelled"
+
+
+class ConnectorError(str, Enum):
+    """Well-known error message sentinel written to the connector row."""
+    CREDENTIAL_ERROR_MSG = "Authentication failed: unable to connect with the provided credentials"
+
+
+class ConnectorType(str, Enum):
+    """Allowed connector transport types."""
+    FILE_SYSTEM = "file_system"
+    OBJECT_STORAGE = "object_storage"
 ```
 
 ---
@@ -618,23 +645,28 @@ class SyncLogStatus(str, Enum):
 ![Sync Tick Flow](sync-worker-tick-flow.svg)
 
 - **Phase 0 (Caller — Lock + Log):** `dispatch_sync()` (in `connectors.py`) acquires the lock and opens the sync-log row **before** `run_tick` is called. `init_sync_log_and_update_connector(connector_id)` is called synchronously in the caller; the returned `sync_seq` is passed directly into `run_tick(connector_id, sync_seq)`. This eliminates any need for polling inside the endpoint.
-- **Phase 1b (Interrupt Check):** `_check_interrupt_call(connector_id, sync_seq)` immediately before any remote I/O. If any interrupt detected, raises `asyncio.CancelledError`.
-- **Phase 2 (Scan & State):** Query `known_checksums` and `all_checksums`. Offload blocking calls (`connect`, `scan`) to thread pool via `asyncio.to_thread(...)`.
+- **Phase 1b (Interrupt Check):** `_check_interrupt_call(connector_id, sync_seq)` immediately before `scanner.connect`. If any interrupt detected, raises `asyncio.CancelledError`.
+- **Connection Error Handling:** `scanner.connect()` is wrapped in a `try/except ConnectionError`. On failure, `_fail_tick` is called with `ConnectorError.CREDENTIAL_ERROR_MSG` sentinel and the function returns (no `CancelledError` raised). A `ValidationError` from `build_scanner` (config validation) is also caught in the outer `except Exception` block and calls `_fail_tick` with the same credential sentinel.
+- **Phase 2 (Scan & State):** Offload blocking calls (`connect`, `scan`) to thread pool via `asyncio.to_thread(...)`. Query `known_checksums` and `all_checksums` after scan.
 - **Phase 3 (Classify):** `_classify()` separates `scanned_files` into `ingest_list` and cross-connector duplicates. Cross-connector duplicates execute `add_connector_checksum_entry` inline.
-- **Phase 3b (Count Commit):** `update_sync_log(connector_id, sync_seq, total_files=..., new_files=..., removed_files=...)` + `update_connector_total_files(connector_id, len(scanned_files))`. Both called before any I/O-heavy work.
+- **Phase 3b (Count Commit):** `update_sync_log(connector_id, sync_seq, total_files=..., new_files=..., removed_files=...)` called before any I/O-heavy work.
 - **Phase 4a (Ingest New Files):** Download and ingest `ingest_list` in batches of `_BATCH_SIZE = 10`:
   - Staging directory: `staging/connectors/{connector_id}-{sync_seq}-{batch_number}` (1-based).
   - Interrupt checkpoint **before** each batch starts.
   - Offload download to executor (`asyncio.to_thread(scanner.download_to, ...)`).
   - Files failing `verify_integrity` are **skipped** (warned), not fatal.
+  - Each downloaded file is validated via `validate_document_file(filename, file_bytes)` — files failing validation are removed from the staging dir and counted in `invalid_file_count`; they do not enter the ingest pipeline.
   - Interrupt checkpoint **after** batch downloads complete.
   - Call `initialize_job_state()` with `job_name = f"Connector-{connector_name}-{sync_seq}-{batch_number}"`.
-  - Insert checksum rows (`add_connector_checksum_entry`), call `ingest()`, then `_wait_for_job()`.
+  - Call `ingest(batch_dir, job_id, doc_id_dict)`, then `_wait_for_job(job_id, connector_id, sync_seq)`.
+  - After job completes: `get_job_document_stats(job_id)` is called; `add_connector_checksum_entry` is called **only for `completed_docs`** (not before ingest). If `failed_count > 0`, `batch_failed = True`.
   - `_wait_for_job()` polls every `_JOB_POLL_INTERVAL=10s` and calls `_check_interrupt_call` on each wake-up.
-  - Cleanup staging directory in `finally`; batch failure sets `batch_failed=True`.
-  - After all batches: if `batch_failed`, raises `RuntimeError` → tick closes as `FAILED` → connector set to `OUT_OF_SYNC`.
-- **Phase 4b (Orphan Removal):** After Phase 4a completes. For each checksum in `orphan_checksums = known_checksums − scanned_checksums`: call `remove_connector_checksum_entry`; if `remaining == 0` call `_best_effort_delete_document(doc_id)` via `asyncio.to_thread`.
-- **Phase 5 (Finalize):** Call `finalize_sync_log_and_update_connector` with terminal status. `scanner.close()` in top-level `finally` regardless of outcome.
+  - Cleanup staging directory in `finally`; batch exception sets `batch_failed=True`.
+  - Returns `invalid_file_count` to the caller.
+- **Phase 4a (total_files adjustment):** After `_process_new_files` returns, if `invalid_file_count > 0`, `total_files` is decremented and both `update_connector_total_files` and `update_sync_log(total_files=...)` are called again to reflect the adjusted count. If no invalid files, only `update_connector_total_files` is called.
+- **After all batches:** if `batch_failed`, raises `RuntimeError` (message references the batch job names) → tick closes as `FAILED` → connector set to `OUT_OF_SYNC`.
+- **Phase 4b (Orphan Removal):** After Phase 4a completes. `_delete_orphans` offloads `_remove_checksums(connector_id, orphan_checksums)` via `asyncio.to_thread`. For each checksum in `orphan_checksums = known_checksums − scanned_checksums`: call `remove_connector_checksum_entry`; if `remaining == 0` call `_best_effort_delete_document(doc_id)`. `_delete_orphans` raises `RuntimeError` if any checksum removal or document deletion failures occur.
+- **Phase 5 (Finalize):** Call `finalize_sync_log_and_update_connector` with terminal status. `scanner.close()` in top-level `finally` regardless of outcome (guarded with `if scanner is not None` for the case where `build_scanner` itself raises).
 
 #### Interrupt Handling
 
@@ -642,14 +674,14 @@ class SyncLogStatus(str, Enum):
 
 1. **`connectors.sync_status == DELETE_PENDING`** → `InterruptType.DELETE_CONNECTOR`
    - Triggered when `DELETE /v1/connectors/{id}` arrives (via `mark_connector_delete_pending`).
-   - `_handle_interrupt` calls `_cancel_tick` then `await _run_teardown(connector_id)` (imported from `connectors.py`). Full teardown: remove all checksum ownership rows, delete orphaned docs, delete connector row, sweep staging dirs.
+   - `_handle_interrupt` calls `_cancel_tick` then `await _run_teardown(connector_id)` (imported from `connectors.py`). Full teardown: remove scheduler job, remove all checksum ownership rows, delete orphaned docs, delete connector row, sweep staging dirs.
 
 2. **`connector_sync_logs.status == CANCEL_PENDING`** → `InterruptType.SYNC_CANCEL`
    - Triggered when `POST /syncs/{seq}/stop` arrives (`mark_sync_cancel_pending`).
    - `_handle_interrupt` calls `_cancel_tick` (log → `'cancelled'`, connector → `'out of sync'`) + `_sweep_staging_dir(connector_id, ..., sync_seq=sync_seq)` (only this sync's batch dirs).
    - Connector remains and re-syncs on the next interval.
 
-`_check_interrupt_call()` is invoked at **four checkpoints**: (1) after `init_sync_log_and_update_connector` (Phase 1b), (2) before each batch starts, (3) after batch downloads complete, (4) inside `_wait_for_job` on every poll cycle.
+`_check_interrupt_call()` is invoked at **four checkpoints**: (1) after `build_scanner` / before `scanner.connect` (Phase 1b), (2) before each batch starts, (3) after batch downloads complete, (4) inside `_wait_for_job` on every poll cycle.
 
 ---
 
@@ -683,21 +715,29 @@ async def run_tick(connector_id: str, sync_seq: int) -> None:
       2. Creating the sync-log row via init_sync_log_and_update_connector()
          and passing the returned seq here as sync_seq.
     """
-    config = get_active_connector(connector_id)
+    config = get_connector_by_id(connector_id)
     if config is None:
         logger.error(f"Connector {connector_id!r} not found; tick aborted")
+        _fail_tick(sync_seq, connector_id, RuntimeError(f"Connector {connector_id!r} not found"))
         return
 
-    scanner = build_scanner(config)
-
+    scanner = None
     try:
+        scanner = build_scanner(config)
+
         interrupt = _check_interrupt_call(connector_id, sync_seq)
         if interrupt:
             raise asyncio.CancelledError(
                 f"Connector {connector_id!r} interrupted (type={interrupt.value})"
             )
 
-        await asyncio.to_thread(scanner.connect)
+        try:
+            await asyncio.to_thread(scanner.connect)
+        except ConnectionError as conn_exc:
+            _fail_tick(sync_seq, connector_id, conn_exc,
+                       error_msg=ConnectorError.CREDENTIAL_ERROR_MSG.value)
+            return
+
         scanned_files: list[tuple[str, str]] = await asyncio.to_thread(scanner.scan)
 
         known_checksums: set[str] = set(list_connector_checksums(connector_id))
@@ -707,15 +747,25 @@ async def run_tick(connector_id: str, sync_seq: int) -> None:
             connector_id, scanned_files, known_checksums, all_checksums
         )
 
+        total_files = len(scanned_files)
         update_sync_log(
             connector_id, sync_seq,
-            total_files=len(scanned_files),
+            total_files=total_files,
             new_files=len(ingest_list),
             removed_files=len(orphan_checksums),
         )
-        update_connector_total_files(connector_id, len(scanned_files))
 
-        await _process_new_files(sync_seq, connector_id, config.name, scanner, ingest_list)
+        invalid_count = await _process_new_files(
+            sync_seq, connector_id, config.name, scanner, ingest_list
+        )
+
+        if invalid_count > 0:
+            total_files -= invalid_count
+            update_connector_total_files(connector_id, total_files)
+            update_sync_log(connector_id, sync_seq, total_files=total_files)
+        else:
+            update_connector_total_files(connector_id, total_files)
+
         await _delete_orphans(connector_id, orphan_checksums)
         _complete_tick(sync_seq, connector_id)
 
@@ -726,34 +776,38 @@ async def run_tick(connector_id: str, sync_seq: int) -> None:
         raise
 
     except Exception as exc:
-        logger.error(f"Tick failed for connector {connector_id!r}: {exc}", exc_info=True)
-        _fail_tick(sync_seq, connector_id, exc)
+        if isinstance(exc, ValidationError):
+            _fail_tick(sync_seq, connector_id, exc,
+                       error_msg=ConnectorError.CREDENTIAL_ERROR_MSG.value)
+        else:
+            _fail_tick(sync_seq, connector_id, exc)
 
     finally:
-        await asyncio.to_thread(scanner.close)
+        if scanner is not None:
+            await asyncio.to_thread(scanner.close)
 
 
 _BATCH_SIZE = 10
 _JOB_POLL_INTERVAL = 10  # seconds
 
-async def _process_new_files(sync_seq, connector_id, connector_name, scanner, ingest_list) -> None:
+async def _process_new_files(sync_seq, connector_id, connector_name, scanner, ingest_list) -> int:
+    """Returns invalid_file_count (files rejected by validate_document_file)."""
     staging_base = settings.digitize.staging_dir / "connectors"
     batch_failed = False
+    invalid_file_count = 0
 
     for batch_number, batch_offset in enumerate(range(0, len(ingest_list), _BATCH_SIZE), start=1):
         batch = ingest_list[batch_offset : batch_offset + _BATCH_SIZE]
 
         interrupt = _check_interrupt_call(connector_id, sync_seq)
         if interrupt:
-            raise asyncio.CancelledError(
-                f"Connector {connector_id!r} interrupted (type={interrupt.value})"
-            )
+            raise asyncio.CancelledError(...)
 
         job_id = generate_uuid()
         batch_dir_name = f"{connector_id}-{sync_seq}-{batch_number}"
         batch_dir = staging_base / batch_dir_name
         batch_dir.mkdir(parents=True, exist_ok=True)
-        checksum_to_filename: dict[str, str] = {}
+        filename_to_checksum: dict[str, str] = {}
 
         try:
             for remote_path, checksum in batch:
@@ -762,49 +816,61 @@ async def _process_new_files(sync_seq, connector_id, connector_name, scanner, in
                     scanner.download_to, remote_path, batch_dir / filename
                 )
                 if not scanner.verify_integrity(local_checksum, checksum):
-                    logger.warning(
-                        f"Integrity check failed for {remote_path!r} in connector "
-                        f"{connector_id!r}; skipping file"
-                    )
-                    continue
-                checksum_to_filename[checksum] = filename
+                    continue  # skip — integrity failed
+                try:
+                    validate_document_file(filename, (batch_dir / filename).read_bytes())
+                except ValueError:
+                    (batch_dir / filename).unlink(missing_ok=True)
+                    invalid_file_count += 1
+                    continue  # skip — unsupported file type
+                filename_to_checksum[filename] = checksum
 
             interrupt = _check_interrupt_call(connector_id, sync_seq)
             if interrupt:
-                raise asyncio.CancelledError(
-                    f"Connector {connector_id!r} interrupted (type={interrupt.value})"
-                )
+                raise asyncio.CancelledError(...)
 
-            filenames = list(checksum_to_filename.values())
+            if not filename_to_checksum:
+                continue
+
+            filenames = list(filename_to_checksum.keys())
             job_name = f"Connector-{connector_name}-{sync_seq}-{batch_number}"
             doc_id_dict = initialize_job_state(
                 job_id=job_id, operation=OperationType.INGESTION,
                 output_format=OutputFormat.JSON,
-                documents_info=filenames,
-                job_name=job_name,
+                documents_info=filenames, job_name=job_name,
             )
-            for checksum, filename in checksum_to_filename.items():
-                add_connector_checksum_entry(connector_id, checksum, doc_id_dict[filename])
+            doc_id_to_checksum = {
+                doc_id: filename_to_checksum[filename]
+                for filename, doc_id in doc_id_dict.items()
+                if filename in filename_to_checksum
+            }
 
             await asyncio.to_thread(ingest, batch_dir, job_id, doc_id_dict)
             await _wait_for_job(job_id, connector_id, sync_seq)
 
+            # Register checksum entries only for successfully completed documents.
+            job_stats = get_job_document_stats(job_id)
+            for doc in job_stats["completed_docs"]:
+                checksum = doc_id_to_checksum.get(doc["id"])
+                if checksum is not None:
+                    add_connector_checksum_entry(connector_id, checksum, doc["id"])
+            if job_stats["failed_count"] > 0:
+                batch_failed = True
+
         except asyncio.CancelledError:
             raise
         except Exception as exc:
-            logger.warning(
-                f"Failed to ingest batch {batch_number} for connector {connector_id!r}: {exc}",
-                exc_info=True,
-            )
             batch_failed = True
         finally:
             cleanup_staging_directory(batch_dir_name, staging_base, ignore_errors=True)
 
     if batch_failed:
         raise RuntimeError(
-            f"One or more batches failed to ingest for connector {connector_id!r}; "
-            "connector marked as out of sync"
+            f"One or more documents failed to sync. See more details in digitize jobs "
+            f"Connector-{connector_name}-{sync_seq}-*"
         )
+
+    return invalid_file_count
 
 
 async def _handle_interrupt(sync_seq, connector_id, interrupt_type) -> None:
@@ -859,6 +925,7 @@ async def register_connector_job(
 
     fire_immediately=True fires the first tick at now() instead of waiting
     one full interval.  Used when attaching a new connector.
+    Uses ConflictPolicy.replace so re-registration on lifespan restart is safe.
     """
     from digitize.api.v1.connectors import dispatch_sync
 
@@ -871,6 +938,7 @@ async def register_connector_job(
         trigger=IntervalTrigger(seconds=interval_seconds, start_time=start_time),
         args=[connector_id],
         id=connector_id,
+        conflict_policy=ConflictPolicy.replace,
     )
 
 
@@ -880,7 +948,7 @@ async def remove_connector_job(connector_id: str) -> None:
     try:
         await sched.remove_schedule(connector_id)
     except Exception as exc:
-        logger.debug(f"Could not remove scheduler job for {connector_id!r}: {exc}")
+        logger.warning(f"Could not remove scheduler job for {connector_id!r}: {exc}")
 ```
 
 ---
@@ -895,7 +963,7 @@ Behavior on startup:
 
 Returns number of connectors recovered.
 
-Note: `recover_zombie_jobs()` for regular (non-connector) jobs is also implemented in `recovery.py` and called from `lifespan()`.
+Note: `recover_zombie_jobs()` for regular (non-connector) jobs and `recover_conversion_tasks()` for Docling conversion tasks are also implemented in `recovery.py` and called from `lifespan()`.
 
 ---
 
@@ -913,23 +981,27 @@ async with AsyncScheduler(data_store=data_store) as sched:
     # Connector crash recovery — unlock connectors stuck in 'syncing'.
     recovered = recover_connector_sync_state()
 
-    # Re-register all existing connectors (fire_immediately=False — don't double-fire
-    # connectors that are already up-to-date after crash recovery).
+    # Re-register all existing connectors.
+    # For connectors in DELETE_PENDING: re-trigger _run_teardown instead.
     connectors = list_connectors()
     for connector in connectors:
+        if connector.sync_status == ConnectorStatus.DELETE_PENDING:
+            asyncio.create_task(_run_teardown(connector.id))
+            continue
+
         await scheduler_module.register_connector_job(
             connector.id,
             connector.sync_interval_seconds,
-            fire_immediately=False,
+            fire_immediately=False,  # don't double-fire connectors already up-to-date
         )
 
     await sched.start_in_background()
     yield
 ```
 
-`POST /v1/connectors` calls `register_connector_job(connector_id, sync_interval, fire_immediately=True)` before the DB insert (fail-fast order).
+`POST /v1/connectors` calls `register_connector_job(connector_id, sync_interval, fire_immediately=True)` **before** the DB insert (fail-fast order). If scheduler registration fails, a `RuntimeError` is raised and the connector row is never written.
 
-`DELETE /v1/connectors/{id}` calls `remove_connector_job(connector_id)` after marking the connector `delete_pending`, before dispatching teardown, so no new tick fires after the connector is marked for deletion.
+`_run_teardown` removes the scheduler job as Step 1, ensuring no new tick fires after teardown begins. The `remove_connector_job` call is best-effort (failures are appended to `deletion_errors` and logged, but do not abort teardown).
 
 ---
 
@@ -963,28 +1035,28 @@ Scanners perform synchronous blocking I/O (`boto3` calls, Paramiko SFTP operatio
 
 ### Implemented PRs — All Complete ✅
 
-- **PR 1 — DB Schema + ORM Models + Settings ✅:** `connectors`, `connector_document_checksum`, `connector_sync_logs` tables & ORM models (`db/scripts/init_schema.sql`, `db/models.py`). `connector_sync_logs` uses composite PK `(connector_id, seq)`. `Connector` ORM has an `error` field for teardown errors (in model, not shown in SQL schema). `ConnectorStatus` and `SyncLogStatus` string enums in `connectors/models.py`. Scanner config models (`S3ConnectorConfig`, `SSHConnectorConfig`) in `connectors/scanners/config.py`.
+- **PR 1 — DB Schema + ORM Models + Settings ✅:** `connectors`, `connector_document_checksum`, `connector_sync_logs` tables & ORM models (`db/scripts/init_schema.sql`, `db/models.py`). `connector_sync_logs` uses composite PK `(connector_id, seq)`. `Connector` ORM has an `error` field (used for teardown errors, credential errors, and last-sync error messages). `ConnectorStatus`, `SyncLogStatus`, `ConnectorError`, and `ConnectorType` string enums in `connectors/models.py`. Scanner config models (`S3ConnectorConfig`, `SSHConnectorConfig`) in `connectors/scanners/config.py`. Connector type values are `'file_system'` and `'object_storage'` (not `'ssh'`/`'s3'`).
 
-- **PR 2 — DB Operations Layer ✅:** `manager.py` & `utils/db.py` fully implemented. All checksum helpers (`insert_connector_checksum`, `delete_connector_checksum` returning `doc_id`, `count_checksum_owners`, `find_connector_doc_by_checksum`, `get_connector_checksums`, `get_all_connector_checksums`), sync-lock/signal helpers (`try_acquire_sync_lock`, `mark_sync_cancel_pending`, `mark_connector_delete_pending`), sync-log helpers (`init_sync_log_and_update_connector`, `finalize_sync_log_and_update_connector`, `update_sync_log`, `update_connector_total_files`, `set_connector_error`, `list_sync_logs`, `get_sync_log`, `get_sync_log_status`, `get_active_sync_seq`). Crash-recovery helpers `reset_syncing_connectors` and `close_open_sync_log` also implemented. All tested in `test_connector_db.py`.
+- **PR 2 — DB Operations Layer ✅:** `manager.py` & `utils/db.py` fully implemented. All checksum helpers (`insert_connector_checksum`, `delete_connector_checksum` returning `doc_id`, `count_checksum_owners`, `find_connector_doc_by_checksum`, `get_connector_checksums`, `get_all_connector_checksums`), sync-lock/signal helpers (`try_acquire_sync_lock`, `mark_sync_cancel_pending`, `mark_connector_delete_pending`), sync-log helpers (`init_sync_log_and_update_connector`, `finalize_sync_log_and_update_connector`, `update_sync_log`, `update_connector_total_files`, `set_connector_error`, `list_sync_logs`, `get_sync_log`, `get_sync_log_status`, `get_active_sync_seq`). `get_connector_by_name` added for explicit duplicate-check on `POST`. Crash-recovery helpers `reset_syncing_connectors` and `close_open_sync_log` also implemented. All tested in `test_connector_db.py`.
 
-- **PR 3 — REST API Endpoints ✅:** Full CRUD in `connectors.py` (`POST`, `PUT`, `DELETE`, `GET`, `GET /{id}`, `GET /{id}/syncs`, `GET /{id}/syncs/{seq}`, `POST /{id}/syncs`, `POST /{id}/syncs/{seq}/stop`). Shared `dispatch_sync()` helper used by both the HTTP handler and the APScheduler. Connector visibility filtering in `documents.py` (`is_connector_sourced_document`, `exclude_connector_sourced` in `get_all_documents_paginated`). Credential probe (`_probe_connector_credentials`) dispatched as a background task on `POST` and `PUT`.
+- **PR 3 — REST API Endpoints ✅:** Full CRUD in `connectors.py` (`POST`, `PUT`, `DELETE`, `GET`, `GET /{id}`, `GET /{id}/syncs`, `GET /{id}/syncs/{seq}`, `POST /{id}/syncs`, `POST /{id}/syncs/{seq}/stop`). `POST` returns `202 Accepted` (not `201`). Shared `dispatch_sync()` helper used by both the HTTP handler and APScheduler; raises `SyncNotFound` / `SyncLocked` (not HTTP exceptions) so callers control error mapping. `PUT` dispatches `asyncio.create_task(dispatch_sync(connector_id))` (not a credential probe) when `connection_details` is updated. Connector visibility filtering in `documents.py` (`is_connector_sourced_document`, `exclude_connector_sourced` in `get_all_documents_paginated`). `_remove_checksums` extracted as a standalone helper shared between `_run_teardown` and `_delete_orphans`.
 
-- **PR 4a — Scanner Abstraction ✅:** `BaseScanner` interface (`base_scanner.py`) & `scanner_factory.py` with `_REGISTRY` for `"s3"` and `"ssh"` types. Factory decrypts secrets before building the typed config.
+- **PR 4a — Scanner Abstraction ✅:** `BaseScanner` interface (`base_scanner.py`) & `scanner_factory.py` with `_REGISTRY` for `"object_storage"` and `"file_system"` types. Factory decrypts secrets before building the typed config. Accepts both ORM rows and plain dicts.
 
-- **PR 4b — SSH/SFTP Scanner ✅:** `SSHScanner` implemented in `connectors/scanners/ssh_scanner.py`. Supports RSA, ECDSA, Ed25519 key types. *(Named `ssh_scanner.py` — accepted naming.)*
+- **PR 4b — SSH/SFTP Scanner ✅:** `SSHScanner` implemented in `connectors/scanners/ssh_scanner.py`. Supports RSA, ECDSA, Ed25519 key types.
 
 - **PR 5 — S3 Scanner ✅:** `S3Scanner` implementation with AWS/IBM COS provider auto-detection, cross-region alias resolution, `head_bucket` pre-flight check, `HashingWriter` inline MD5, multi-part ETag integrity bypass.
 
-- **PR 6 — Core Sync Engine ✅:** `sync_tick.py` fully implemented. `run_tick(connector_id, sync_seq)` — `sync_seq` is provided by the caller (`dispatch_sync`), not generated internally. `_classify`, `_process_new_files` (batch download, integrity skip, `batch_failed` flag, 1-based `batch_number`, job named `Connector-{connector_name}-{sync_seq}-{batch_number}`), `_delete_orphans` (uses `asyncio.to_thread` for `_best_effort_delete_document`), `async _handle_interrupt` (awaits `_run_teardown` for DELETE path), `_cancel_tick`, `_fail_tick`, `_complete_tick`. `_check_interrupt_call(connector_id, sync_seq)` reads from both tables using `ConnectorStatus`/`SyncLogStatus`. Tests in `test_sync_tick.py`.
+- **PR 6 — Core Sync Engine ✅:** `sync_tick.py` fully implemented. `run_tick(connector_id, sync_seq)` — `sync_seq` is provided by the caller (`dispatch_sync`), not generated internally. `ConnectionError` from `scanner.connect()` and `ValidationError` from `build_scanner` both call `_fail_tick` with `ConnectorError.CREDENTIAL_ERROR_MSG`. `_classify`, `_process_new_files` (batch download, `validate_document_file` skip, integrity skip, `batch_failed` flag, 1-based `batch_number`, job named `Connector-{connector_name}-{sync_seq}-{batch_number}`, checksum rows inserted post-job-completion from `get_job_document_stats`), `_delete_orphans` (offloads `_remove_checksums` via `asyncio.to_thread`; raises `RuntimeError` on failure), `async _handle_interrupt` (awaits `_run_teardown` for DELETE path), `_cancel_tick`, `_fail_tick`, `_complete_tick`. `_check_interrupt_call(connector_id, sync_seq)` reads from both tables using `ConnectorStatus`/`SyncLogStatus`. Tests in `test_sync_tick.py`.
 
 - **PR 7 — Scheduler + Lifespan + Crash Recovery ✅:**
-  - `connectors/scheduler.py` created: `register_connector_job`, `remove_connector_job`. APScheduler v4 `AsyncScheduler` + `SQLAlchemyDataStore` (schema `"scheduler"`) backed by the shared Postgres engine. `dispatch_sync` registered directly as the scheduler callable (no `_run_tick_wrapped` wrapper). `apscheduler[sqlalchemy]` added to `requirements.txt`.
-  - `recover_connector_sync_state()` added to `utils/recovery.py`: bulk-resets connectors stuck in `'syncing'` → `'out of sync'`; closes open `connector_sync_logs` rows to `'failed'`.
-  - `app.py` `lifespan()` updated via `_connector_scheduler_lifespan()` context manager: starts `AsyncScheduler`, calls `recover_connector_sync_state()`, re-registers all existing connector jobs (`fire_immediately=False`), sizes the default `ThreadPoolExecutor` to `max(N+4, 8)`, and calls `await sched.start_in_background()`.
+  - `connectors/scheduler.py` created: `register_connector_job` (uses `ConflictPolicy.replace`), `remove_connector_job`. APScheduler v4 `AsyncScheduler` + `SQLAlchemyDataStore` (schema `"scheduler"`) backed by the shared Postgres engine. `dispatch_sync` registered directly as the scheduler callable (no `_run_tick_wrapped` wrapper).
+  - `recover_connector_sync_state()` added to `utils/recovery.py`: bulk-resets connectors stuck in `'syncing'` → `'out of sync'`; closes open `connector_sync_logs` rows to `'failed'`. `recover_conversion_tasks()` also added.
+  - `app.py` `lifespan()` updated via `_connector_scheduler_lifespan()` context manager: starts `AsyncScheduler`, calls `recover_connector_sync_state()`, re-registers all existing connector jobs (`fire_immediately=False`); connectors found in `DELETE_PENDING` on startup have `_run_teardown` re-triggered via `asyncio.create_task` instead of being re-registered.
   - `POST /v1/connectors` calls `register_connector_job(connector_id, sync_interval, fire_immediately=True)` **before** the DB insert (fail-fast order).
-  - `DELETE /v1/connectors/{id}` calls `remove_connector_job(connector_id)` after marking `delete_pending` so no new tick fires after the connector is marked for deletion.
-  - Unit tests in `tests/test_connector_scheduler.py` cover `register_connector_job`, `remove_connector_job`, and `recover_connector_sync_state`.
+  - `_run_teardown` calls `remove_connector_job(connector_id)` as Step 1.
+  - Unit tests in `tests/test_connector_scheduler.py`.
 
 - **PR 8 — Cancel Sync Endpoint ✅:** `POST /syncs/{seq}/stop` implemented with `sync_status` pre-check + seq validation + `mark_sync_cancel_pending`. `SyncLogStatus.CANCEL_PENDING` and `InterruptType.SYNC_CANCEL` handle the cancel path. `finalize_sync_log_and_update_connector` maps `CANCELLED` → `OUT_OF_SYNC`.
 
-- **PR 9 — Non-Blocking DELETE ✅:** `DELETE /v1/connectors/{id}` uses `mark_connector_delete_pending` (unconditional) + checks `sync_status` to decide Case A vs B. Case B dispatches `asyncio.create_task(_run_teardown(...))`. Case A tick detects `DELETE_PENDING` via `_check_interrupt_call` → `await _run_teardown` in `_handle_interrupt`. Single `_run_teardown` function in `connectors.py` handles both paths.
+- **PR 9 — Non-Blocking DELETE ✅:** `DELETE /v1/connectors/{id}` uses `mark_connector_delete_pending` (unconditional) + checks `sync_status` to decide Case A vs B. Case B dispatches `asyncio.create_task(_run_teardown(...))`. Case A tick detects `DELETE_PENDING` via `_check_interrupt_call` → `await _run_teardown` in `_handle_interrupt`. Single `_run_teardown` function in `connectors.py` handles both paths. Teardown failures leave the connector row with an `error` message in `DELETE_PENDING` state rather than forcing a partial delete.

--- a/services/common/error_utils.py
+++ b/services/common/error_utils.py
@@ -20,6 +20,7 @@ class ErrorCode(str, Enum):
     INVALID_PARAMETER = "INVALID_PARAMETER"
     AUTHENTICATION_FAILED = "AUTHENTICATION_FAILED"
     RESOURCE_NOT_FOUND = "RESOURCE_NOT_FOUND"
+    METHOD_NOT_ALLOWED = "METHOD_NOT_ALLOWED"
     RESOURCE_LOCKED = "RESOURCE_LOCKED"
     UNSUPPORTED_MEDIA_TYPE = "UNSUPPORTED_MEDIA_TYPE"
     UNSUPPORTED_FILE_TYPE = "UNSUPPORTED_FILE_TYPE"
@@ -94,6 +95,23 @@ class NotFoundErrorResponse(BaseModel):
                     "code": "RESOURCE_NOT_FOUND",
                     "message": "The requested resource was not found",
                     "status": 404
+                }
+            }
+        }
+    }
+
+
+class MethodNotAllowedErrorResponse(BaseModel):
+    """405 Method Not Allowed error response."""
+    error: ErrorDetail
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "error": {
+                    "code": "METHOD_NOT_ALLOWED",
+                    "message": "This operation is not allowed for this resource",
+                    "status": 405
                 }
             }
         }
@@ -207,6 +225,7 @@ http_error_responses: Dict[int | str, Dict[str, Any]] = {
     400: {"description": "Bad Request - Invalid input or validation error", "model": BadRequestErrorResponse},
     401: {"description": "Unauthorized - Authentication failed", "model": UnauthorizedErrorResponse},
     404: {"description": "Not Found - Resource does not exist", "model": NotFoundErrorResponse},
+    405: {"description": "Method Not Allowed - Operation not permitted for this resource", "model": MethodNotAllowedErrorResponse},
     409: {"description": "Conflict - Resource is locked or in use", "model": ConflictErrorResponse},
     413: {"description": "Payload Too Large - Input exceeds size limits", "model": PayloadTooLargeErrorResponse},
     415: {"description": "Unsupported Media Type - Invalid file format", "model": UnsupportedMediaTypeErrorResponse},
@@ -232,6 +251,7 @@ class APIError:
         ErrorCode.INVALID_PARAMETER: (400, "Invalid parameter value"),
         ErrorCode.AUTHENTICATION_FAILED: (401, "Authentication failed"),
         ErrorCode.RESOURCE_NOT_FOUND: (404, "The requested resource was not found"),
+        ErrorCode.METHOD_NOT_ALLOWED: (405, "This operation is not allowed for this resource"),
         ErrorCode.RESOURCE_LOCKED: (409, "Resource is locked by an active operation"),
         ErrorCode.UNSUPPORTED_MEDIA_TYPE: (415, "File format not supported"),
         ErrorCode.UNSUPPORTED_FILE_TYPE: (415, "File type not supported"),

--- a/services/common/misc_utils.py
+++ b/services/common/misc_utils.py
@@ -349,6 +349,18 @@ def validate_document_file(filename: str, content) -> None:
     if not filename:
         raise ValueError("File must have a filename.")
 
+    # Check content is bytes (not an exception from failed read) before any
+    # operation that calls methods on content (e.g. startswith).
+    if isinstance(content, Exception):
+        raise ValueError(f"Failed to read file: {filename}")
+
+    if not isinstance(content, bytes):
+        raise ValueError(f"Invalid file content for: {filename}")
+
+    # Check content is not empty
+    if len(content) == 0:
+        raise ValueError(f"File is empty: {filename}")
+
     # Validate extension and format
     allowed_extensions = {'.pdf', '.docx'}
     file_ext = Path(filename).suffix.lower()
@@ -368,17 +380,6 @@ def validate_document_file(filename: str, content) -> None:
         docx_signature = b'PK\x03\x04'
         if not content.startswith(docx_signature):
             raise ValueError(f"File has .docx extension but invalid DOCX format: {filename}")
-
-    # Check content is bytes (not an exception from failed read)
-    if isinstance(content, Exception):
-        raise ValueError(f"Failed to read file: {filename}")
-
-    if not isinstance(content, bytes):
-        raise ValueError(f"Invalid file content for: {filename}")
-
-    # Check content is not empty
-    if len(content) == 0:
-        raise ValueError(f"File is empty: {filename}")
 
 def get_unprocessed_files(original_files, processed_pdfs):
     """Return the set of files from original_files that have not yet been processed."""

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.49
+TAG?=v0.0.50
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -72,32 +72,26 @@ logger = get_logger("connectors_router")
 async def create_connector(body: ConnectorCreateRequest):
     """Create a new connector and schedule its worker.
 
-    Validates connector settings, encrypts credentials, persists the new connector
-    configuration in the database, and schedules the background worker.
-
-    The DB insert is performed first so that a duplicate id/name is detected
-    (IntegrityError → 409) before any scheduler state is created.  The
-    scheduler job is only registered once the row is safely committed.
+    Checks for duplicate connector id and name via explicit SELECTs before
+    touching the scheduler or writing to the database.  Only once both checks
+    pass is the scheduler job registered and the row inserted.
     """
     connector_id = body.id or str(uuid.uuid4())
     try:
-        encrypted_details = encrypt_secrets(body.type, body.connection_details)
+        # --- Duplicate checks (GET by id, then GET by name) ---
+        if db_ops.get_connector_by_id(connector_id) is not None:
+            msg = f"Connector id {connector_id!r} already exists"
+            logger.error(msg)
+            APIError.raise_error(ErrorCode.RESOURCE_LOCKED, msg)
 
+        if db_ops.get_connector_by_name(body.name) is not None:
+            msg = f"Connector name {body.name!r} already exists"
+            logger.error(msg)
+            APIError.raise_error(ErrorCode.RESOURCE_LOCKED, msg)
+
+        encrypted_details = encrypt_secrets(body.type, body.connection_details)
         sync_interval = settings.digitize.connector.sync_interval_seconds
 
-        # Persist the connector row first — this validates uniqueness.
-        # If a duplicate id or name exists an IntegrityError is raised here
-        # and we return 409 before touching the scheduler.
-        db_ops.insert_connector(
-            connector_id=connector_id,
-            name=body.name,
-            connector_type=body.type,
-            connection_details=encrypted_details,
-            allowed_extensions=body.allowed_extensions,
-            sync_interval_seconds=sync_interval,
-        )
-
-        # Row committed — now it is safe to register the scheduler job.
         try:
             import digitize.connectors.scheduler as _sched
             await _sched.register_connector_job(
@@ -113,6 +107,16 @@ async def create_connector(body: ConnectorCreateRequest):
                 f"during connector creation: {sched_exc}"
             ) from sched_exc
 
+        # Scheduler job registered — persist the row.
+        db_ops.insert_connector(
+            connector_id=connector_id,
+            name=body.name,
+            connector_type=body.type,
+            connection_details=encrypted_details,
+            allowed_extensions=body.allowed_extensions,
+            sync_interval_seconds=sync_interval,
+        )
+
         logger.info(
             f"Connector {connector_id!r} ({body.name!r}) attached "
             f"(type={body.type}, interval={sync_interval}s)"
@@ -124,30 +128,16 @@ async def create_connector(body: ConnectorCreateRequest):
             media_type="application/json",
         )
 
-    except IntegrityError as exc:
-        # Distinguish duplicate id vs duplicate name.
-        # - Duplicate id: the DB layer uses ON CONFLICT DO NOTHING and raises a
-        #   plain IntegrityError whose orig message contains "already exists".
-        # - Duplicate name: PostgreSQL raises a real UniqueViolation (pgcode 23505)
-        #   whose orig.diag.constraint_name references the name unique index.
-        orig = exc.orig
-        name_conflict = (
-            hasattr(orig, "pgcode")
-            and orig.pgcode == "23505"
-            and "name" in (getattr(getattr(orig, "diag", None), "constraint_name", "") or "")
-        )
-        if name_conflict:
-            msg = f"Connector name {body.name!r} already exists"
-        else:
-            msg = f"Connector id {connector_id!r} already exists"
+    except IntegrityError:
+        msg = f"Connector {connector_id!r} already exists"
         logger.error(msg)
         APIError.raise_error(ErrorCode.RESOURCE_LOCKED, msg)
     except RuntimeError as exc:
-        # encryption key not found
-        logger.error(f"Encryption key error: {exc}")
+        # encryption key not found, or scheduler registration failure
+        logger.error(f"Runtime error creating connector: {exc}")
         APIError.raise_error(
             ErrorCode.INTERNAL_SERVER_ERROR,
-            f"Failed to create connector {connector_id!r} (name={body.name!r}): encryption error — {exc}",
+            f"Failed to create connector {connector_id!r} (name={body.name!r}): {exc}",
         )
     except HTTPException as exc:
         message = f"Failed to create connector {connector_id!r}: {extract_http_error_message(exc)}"
@@ -193,7 +183,7 @@ async def update_connector(connector_id: str, body: ConnectorUpdateRequest):
         if body.name is None and body.allowed_extensions is None and body.connection_details is None:
             return Response(status_code=200)
 
-        existing = db_ops.get_active_connector(connector_id)
+        existing = db_ops.get_connector_by_id(connector_id)
         if existing is None:
             APIError.raise_error(
                 ErrorCode.RESOURCE_NOT_FOUND,
@@ -292,7 +282,7 @@ async def delete_connector(connector_id: str):
         return 204 immediately.
     """
     try:
-        connector = db_ops.get_active_connector(connector_id)
+        connector = db_ops.get_connector_by_id(connector_id)
         if connector is None:
             APIError.raise_error(
                 ErrorCode.RESOURCE_NOT_FOUND,
@@ -554,7 +544,7 @@ async def get_connector(connector_id: str):
     Strips out any sensitive/secret connection details from the response.
     """
     try:
-        connector = db_ops.get_active_connector(connector_id)
+        connector = db_ops.get_connector_by_id(connector_id)
         if connector is None:
             APIError.raise_error(
                 ErrorCode.RESOURCE_NOT_FOUND,
@@ -635,7 +625,7 @@ async def dispatch_sync(connector_id: str) -> int:
     """
     from digitize.connectors.sync_tick import run_tick
 
-    connector = db_ops.get_active_connector(connector_id)
+    connector = db_ops.get_connector_by_id(connector_id)
     if connector is None:
         raise SyncNotFound(f"Connector {connector_id!r} not found")
     if connector.sync_status == ConnectorStatus.DELETE_PENDING:
@@ -745,7 +735,7 @@ async def cancel_sync(connector_id: str, sync_seq: int):
     Sends a cancellation signal to the connector worker.
     """
     try:
-        connector = db_ops.get_active_connector(connector_id)
+        connector = db_ops.get_connector_by_id(connector_id)
         if connector is None:
             APIError.raise_error(
                 ErrorCode.RESOURCE_NOT_FOUND,
@@ -808,7 +798,7 @@ async def get_sync_history(
 ):
     """Retrieve a paginated history of sync runs for a specific connector."""
     try:
-        connector = db_ops.get_active_connector(connector_id)
+        connector = db_ops.get_connector_by_id(connector_id)
         if connector is None:
             APIError.raise_error(
                 ErrorCode.RESOURCE_NOT_FOUND,
@@ -866,7 +856,7 @@ async def get_sync_history(
 async def get_sync(connector_id: str, sync_seq: int):
     """Retrieve details of a single sync run by its sequence number."""
     try:
-        connector = db_ops.get_active_connector(connector_id)
+        connector = db_ops.get_connector_by_id(connector_id)
         if connector is None:
             APIError.raise_error(
                 ErrorCode.RESOURCE_NOT_FOUND,

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -26,6 +26,7 @@ from common.misc_utils import cleanup_staging_directory, get_logger, get_utc_tim
 from common.error_utils import APIError, ErrorCode, http_error_responses, extract_http_error_message, build_http_error_detail
 from digitize.connectors.models import (
     ConnectorCreateRequest,
+    ConnectorCreateResponse,
     ConnectorDetailResponse,
     ConnectorListItem,
     ConnectorUpdateRequest,
@@ -54,6 +55,7 @@ logger = get_logger("connectors_router")
 @router.post(
     "",
     status_code=status.HTTP_202_ACCEPTED,
+    response_model=ConnectorCreateResponse,
     responses={
         409: http_error_responses[409],
         500: http_error_responses[500],
@@ -112,7 +114,7 @@ async def create_connector(body: ConnectorCreateRequest):
 
         return Response(
             content=f'{{"id": "{connector_id}"}}',
-            status_code=201,
+            status_code=202,
             media_type="application/json",
         )
 

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -74,6 +74,10 @@ async def create_connector(body: ConnectorCreateRequest):
 
     Validates connector settings, encrypts credentials, persists the new connector
     configuration in the database, and schedules the background worker.
+
+    The DB insert is performed first so that a duplicate id/name is detected
+    (IntegrityError → 409) before any scheduler state is created.  The
+    scheduler job is only registered once the row is safely committed.
     """
     connector_id = body.id or str(uuid.uuid4())
     try:
@@ -81,8 +85,19 @@ async def create_connector(body: ConnectorCreateRequest):
 
         sync_interval = settings.digitize.connector.sync_interval_seconds
 
-        # Register the connector with the scheduler so it starts ticking
-        # immediately (fire_immediately=True for the first-ever sync).
+        # Persist the connector row first — this validates uniqueness.
+        # If a duplicate id or name exists an IntegrityError is raised here
+        # and we return 409 before touching the scheduler.
+        db_ops.insert_connector(
+            connector_id=connector_id,
+            name=body.name,
+            connector_type=body.type,
+            connection_details=encrypted_details,
+            allowed_extensions=body.allowed_extensions,
+            sync_interval_seconds=sync_interval,
+        )
+
+        # Row committed — now it is safe to register the scheduler job.
         try:
             import digitize.connectors.scheduler as _sched
             await _sched.register_connector_job(
@@ -97,15 +112,6 @@ async def create_connector(body: ConnectorCreateRequest):
                 f"Failed to register scheduler job for connector {connector_id!r} "
                 f"during connector creation: {sched_exc}"
             ) from sched_exc
-
-        db_ops.insert_connector(
-            connector_id=connector_id,
-            name=body.name,
-            connector_type=body.type,
-            connection_details=encrypted_details,
-            allowed_extensions=body.allowed_extensions,
-            sync_interval_seconds=sync_interval,
-        )
 
         logger.info(
             f"Connector {connector_id!r} ({body.name!r}) attached "

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -124,13 +124,24 @@ async def create_connector(body: ConnectorCreateRequest):
             media_type="application/json",
         )
 
-    except IntegrityError:
-        # id or name already exists
-        logger.error(f"Connector {connector_id!r} or name {body.name!r} already exists")
-        APIError.raise_error(
-            ErrorCode.RESOURCE_LOCKED,
-            f"Connector {connector_id!r} or name {body.name!r} already exists",
+    except IntegrityError as exc:
+        # Distinguish duplicate id vs duplicate name.
+        # - Duplicate id: the DB layer uses ON CONFLICT DO NOTHING and raises a
+        #   plain IntegrityError whose orig message contains "already exists".
+        # - Duplicate name: PostgreSQL raises a real UniqueViolation (pgcode 23505)
+        #   whose orig.diag.constraint_name references the name unique index.
+        orig = exc.orig
+        name_conflict = (
+            hasattr(orig, "pgcode")
+            and orig.pgcode == "23505"
+            and "name" in (getattr(getattr(orig, "diag", None), "constraint_name", "") or "")
         )
+        if name_conflict:
+            msg = f"Connector name {body.name!r} already exists"
+        else:
+            msg = f"Connector id {connector_id!r} already exists"
+        logger.error(msg)
+        APIError.raise_error(ErrorCode.RESOURCE_LOCKED, msg)
     except RuntimeError as exc:
         # encryption key not found
         logger.error(f"Encryption key error: {exc}")

--- a/services/digitize/api/v1/documents.py
+++ b/services/digitize/api/v1/documents.py
@@ -6,8 +6,8 @@ Extracted from the monolithic app.py following the digitize-api-sample pattern.
 
 Connector visibility rules:
   - GET  /v1/documents        — user-submitted only (connector-sourced excluded)
-  - GET  /v1/documents/{id}   — 404 for connector-sourced docs
-  - DELETE /v1/documents/{id} — 404 for connector-sourced docs
+  - GET  /v1/documents/{id}   — 405 for connector-sourced docs
+  - DELETE /v1/documents/{id} — 405 for connector-sourced docs
   - DELETE /v1/documents      — user-submitted only (connector-sourced skipped)
 """
 
@@ -142,7 +142,7 @@ async def list_documents(
 @router.get(
     "/{doc_id}",
     response_model=models.DocumentDetailResponse,
-    responses={404: http_error_responses[404], 500: http_error_responses[500]},
+    responses={404: http_error_responses[404], 405: http_error_responses[405], 500: http_error_responses[500]},
     summary="Get document metadata",
     description=(
         "Retrieve detailed metadata for a specific document by its ID. "
@@ -163,8 +163,8 @@ async def get_document_metadata(
 
         if is_connector_sourced_document(doc_id):
             APIError.raise_error(
-                ErrorCode.RESOURCE_NOT_FOUND,
-                f"Document with ID '{doc_id}' not found",
+                ErrorCode.METHOD_NOT_ALLOWED,
+                f"Document with ID '{doc_id}' is connector-sourced and cannot be accessed via this endpoint",
             )
 
         return get_document(doc_id, include_details=details)
@@ -225,6 +225,7 @@ async def get_document_content(doc_id: str):
     status_code=status.HTTP_204_NO_CONTENT,
     responses={
         404: http_error_responses[404],
+        405: http_error_responses[405],
         409: http_error_responses[409],
         500: http_error_responses[500],
     },
@@ -238,7 +239,7 @@ async def get_document_content(doc_id: str):
 )
 async def delete_document(doc_id: str):
     """Delete a single document — follows the 'Always-Clean-VDB' strategy.
-    1. Connector guard  — 404 for connector-sourced docs
+    1. Connector guard  — 405 for connector-sourced docs
     2. Fetch metadata
     3. Active-job guard
     4. VDB cleanup (high priority)
@@ -251,8 +252,8 @@ async def delete_document(doc_id: str):
 
         if is_connector_sourced_document(doc_id):
             APIError.raise_error(
-                ErrorCode.RESOURCE_NOT_FOUND,
-                f"Document with ID '{doc_id}' not found",
+                ErrorCode.METHOD_NOT_ALLOWED,
+                f"Document with ID '{doc_id}' is connector-sourced and cannot be deleted via this endpoint",
             )
 
         # 2. Fetch metadata (best-effort).

--- a/services/digitize/api/v1/documents.py
+++ b/services/digitize/api/v1/documents.py
@@ -8,6 +8,7 @@ Connector visibility rules:
   - GET  /v1/documents        — user-submitted only (connector-sourced excluded)
   - GET  /v1/documents/{id}   — 404 for connector-sourced docs
   - DELETE /v1/documents/{id} — 404 for connector-sourced docs
+  - DELETE /v1/documents      — user-submitted only (connector-sourced skipped)
 """
 
 import json

--- a/services/digitize/app.py
+++ b/services/digitize/app.py
@@ -177,21 +177,38 @@ async def _connector_scheduler_lifespan():
             # Re-register all existing connectors (fire_immediately=False so we
             # don't trigger a duplicate tick for connectors that are already
             # up-to-date after crash recovery).
+            # If a connector is in status 'delete pending', trigger the delete
+            # procedure again and do not register a job.
             try:
+                import asyncio
+                from digitize.connectors.models import ConnectorStatus
+                from digitize.api.v1.connectors import _run_teardown
+
                 connectors = list_connectors()
+                registered_count = 0
                 for connector in connectors:
+                    if connector.sync_status == ConnectorStatus.DELETE_PENDING:
+                        logger.info(
+                            f"Connector crash recovery: found connector {connector.id!r} "
+                            "in 'delete pending' status. Re-triggering delete procedure."
+                        )
+                        asyncio.create_task(_run_teardown(connector.id))
+                        continue
+
                     await scheduler_module.register_connector_job(
                         connector.id,
                         connector.sync_interval_seconds,
                         fire_immediately=False,
                     )
-                if connectors:
+                    registered_count += 1
+
+                if registered_count:
                     logger.info(
-                        f"Re-registered {len(connectors)} connector job(s) with scheduler"
+                        f"Re-registered {registered_count} connector job(s) with scheduler"
                     )
             except Exception as exc:
                 logger.error(
-                    f"Error re-registering connector jobs: {exc}", exc_info=True
+                    f"Error recovering/re-registering connector jobs: {exc}", exc_info=True
                 )
 
             await sched.start_in_background()

--- a/services/digitize/app.py
+++ b/services/digitize/app.py
@@ -270,7 +270,7 @@ tags_metadata = [
     },
     {
         "name": "connectors",
-        "description": "Data-source connector lifecycle management (SFTP, S3)",
+        "description": "Data-source connector lifecycle management (file_system, object_storage)",
     },
 ]
 

--- a/services/digitize/connectors/encryption.py
+++ b/services/digitize/connectors/encryption.py
@@ -24,8 +24,8 @@ logger = get_logger("connector_encryption")
 # Secret fields per connector type that must be encrypted before storage
 # and stripped before API responses.
 _SECRET_FIELDS: dict[str, set[str]] = {
-    "ssh": {"private_key"},
-    "s3": {"secret_access_key"},
+    "file_system": {"private_key"},
+    "object_storage": {"secret_access_key"},
 }
 
 _NONCE_SIZE = 12  # 96-bit nonce recommended for GCM

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -137,13 +137,7 @@ class ConnectorCreateRequest(BaseModel):
     @field_validator("allowed_extensions")
     @classmethod
     def validate_allowed_extensions(cls, v: List[str]) -> List[str]:
-        bad_format = [e for e in v if not e.startswith(".")]
-        if bad_format:
-            raise ValueError(
-                f"Each extension must start with '.', got: {bad_format!r}. "
-                f"Use '.pdf' not 'pdf'."
-            )
-        normalised = [e.lower() for e in v]
+        normalised = [e.lower() if e.startswith(".") else f".{e.lower()}" for e in v]
         supported = {".pdf", ".docx"}
         unsupported = [e for e in normalised if e not in supported]
         if unsupported:

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -134,6 +134,25 @@ class ConnectorCreateRequest(BaseModel):
         }
     }
 
+    @field_validator("allowed_extensions")
+    @classmethod
+    def validate_allowed_extensions(cls, v: List[str]) -> List[str]:
+        bad_format = [e for e in v if not e.startswith(".")]
+        if bad_format:
+            raise ValueError(
+                f"Each extension must start with '.', got: {bad_format!r}. "
+                f"Use '.pdf' not 'pdf'."
+            )
+        normalised = [e.lower() for e in v]
+        supported = {".pdf", ".docx"}
+        unsupported = [e for e in normalised if e not in supported]
+        if unsupported:
+            raise ValueError(
+                f"Unsupported extension(s): {unsupported!r}. "
+                f"Supported extensions: {sorted(supported)}"
+            )
+        return normalised
+
     @field_validator("type", mode="before")
     @classmethod
     def validate_type(cls, v: str) -> str:

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -102,6 +102,23 @@ class ConnectorCreateRequest(BaseModel):
     allowed_extensions: List[str] = Field(..., description="File extensions to accept, e.g. ['.pdf', '.docx']")
     connection_details: Dict[str, Any] = Field(..., description="Transport-specific connection parameters")
 
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "name": "prod-sftp-reports",
+                "type": "ssh",
+                "allowed_extensions": [".pdf", ".docx"],
+                "connection_details": {
+                    "host": "sftp.example.com",
+                    "port": 22,
+                    "username": "sync_user",
+                    "password": "secret_password",
+                    "remote_path": "/exports",
+                },
+            }
+        }
+    }
+
     @field_validator("id", mode="before")
     @classmethod
     def validate_id(cls, v: Optional[str]) -> Optional[str]:
@@ -129,10 +146,36 @@ class ConnectorUpdateRequest(BaseModel):
         description="Partial connection details — only supplied keys are overwritten",
     )
 
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "name": "prod-sftp-reports-updated",
+                "allowed_extensions": [".pdf", ".docx"],
+                "connection_details": {
+                    "remote_path": "/exports/v2",
+                },
+            }
+        }
+    }
+
 
 # ---------------------------------------------------------------------------
 # Response models
 # ---------------------------------------------------------------------------
+
+class ConnectorCreateResponse(BaseModel):
+    """Response body for POST /v1/connectors (202 Accepted)."""
+
+    id: str = Field(..., description="Unique identifier of the created connector")
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "id": "c1d2e3f4-a5b6-7890-abcd-ef1234567890"
+            }
+        }
+    }
+
 
 class ConnectorListItem(BaseModel):
     """One connector in GET /v1/connectors list."""
@@ -145,6 +188,21 @@ class ConnectorListItem(BaseModel):
     sync_status: str
     error: Optional[str]
     total_files: int
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "id": "c1d2e3f4-a5b6-7890-abcd-ef1234567890",
+                "name": "prod-sftp-reports",
+                "type": "ssh",
+                "attached_at": "2025-01-15T10:00:00Z",
+                "last_sync_at": "2025-01-15T10:30:00Z",
+                "sync_status": "up to date",
+                "error": None,
+                "total_files": 15,
+            }
+        }
+    }
 
 
 class ConnectorDetailResponse(BaseModel):
@@ -162,6 +220,29 @@ class ConnectorDetailResponse(BaseModel):
     connection_details: Dict[str, Any]
     total_files: int
 
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "id": "c1d2e3f4-a5b6-7890-abcd-ef1234567890",
+                "name": "prod-sftp-reports",
+                "type": "ssh",
+                "allowed_extensions": [".pdf", ".docx"],
+                "sync_interval_seconds": 60,
+                "attached_at": "2025-01-15T10:00:00Z",
+                "last_sync_at": "2025-01-15T10:30:00Z",
+                "sync_status": "up to date",
+                "error": None,
+                "connection_details": {
+                    "host": "sftp.example.com",
+                    "port": 22,
+                    "username": "sync_user",
+                    "remote_path": "/exports",
+                },
+                "total_files": 15,
+            }
+        }
+    }
+
 
 class SyncLogItem(BaseModel):
     """One tick entry in GET /v1/connectors/{connector_id}/syncs."""
@@ -175,6 +256,21 @@ class SyncLogItem(BaseModel):
     status: str
     error: str
 
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "seq": 1,
+                "started_at": "2025-01-15T10:30:00Z",
+                "finished_at": "2025-01-15T10:30:15Z",
+                "total_files": 15,
+                "new_files": 3,
+                "removed_files": 0,
+                "status": "completed",
+                "error": "",
+            }
+        }
+    }
+
 
 class SyncLogResponse(BaseModel):
     """Paginated response for GET /v1/connectors/{connector_id}/syncs."""
@@ -183,6 +279,28 @@ class SyncLogResponse(BaseModel):
     limit: int
     offset: int
     items: List[SyncLogItem]
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "total": 1,
+                "limit": 50,
+                "offset": 0,
+                "items": [
+                    {
+                        "seq": 1,
+                        "started_at": "2025-01-15T10:30:00Z",
+                        "finished_at": "2025-01-15T10:30:15Z",
+                        "total_files": 15,
+                        "new_files": 3,
+                        "removed_files": 0,
+                        "status": "completed",
+                        "error": "",
+                    }
+                ],
+            }
+        }
+    }
 
 
 class SyncLogDetailResponse(BaseModel):
@@ -197,10 +315,33 @@ class SyncLogDetailResponse(BaseModel):
     status: str
     error: str
 
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "seq": 1,
+                "started_at": "2025-01-15T10:30:00Z",
+                "finished_at": "2025-01-15T10:30:15Z",
+                "total_files": 15,
+                "new_files": 3,
+                "removed_files": 0,
+                "status": "completed",
+                "error": "",
+            }
+        }
+    }
+
 
 class SyncTriggerResponse(BaseModel):
     """Response body for POST /v1/connectors/{connector_id}/sync."""
 
     sync_seq: int = Field(..., description="Sequence number of the active or newly-started sync")
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "sync_seq": 1
+            }
+        }
+    }
 
 # Made with Bob

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -84,6 +84,21 @@ class ConnectorError(str, Enum):
     """
 
 # ---------------------------------------------------------------------------
+# Connector type enum
+# ---------------------------------------------------------------------------
+
+class ConnectorType(str, Enum):
+    """Allowed connector transport types.
+
+    Inherits from str so values can be passed directly to SQLAlchemy and
+    compared with raw DB strings without calling .value.
+    """
+
+    SSH = "ssh"
+    S3 = "s3"
+
+
+# ---------------------------------------------------------------------------
 # Request models
 # ---------------------------------------------------------------------------
 
@@ -118,6 +133,16 @@ class ConnectorCreateRequest(BaseModel):
             }
         }
     }
+
+    @field_validator("type", mode="before")
+    @classmethod
+    def validate_type(cls, v: str) -> str:
+        allowed = {t.value for t in ConnectorType}
+        if v not in allowed:
+            raise ValueError(
+                f"Invalid connector type {v!r}. Allowed values: {sorted(allowed)}"
+            )
+        return v
 
     @field_validator("id", mode="before")
     @classmethod

--- a/services/digitize/connectors/models.py
+++ b/services/digitize/connectors/models.py
@@ -94,8 +94,8 @@ class ConnectorType(str, Enum):
     compared with raw DB strings without calling .value.
     """
 
-    SSH = "ssh"
-    S3 = "s3"
+    FILE_SYSTEM = "file_system"
+    OBJECT_STORAGE = "object_storage"
 
 
 # ---------------------------------------------------------------------------
@@ -113,7 +113,7 @@ class ConnectorCreateRequest(BaseModel):
         ),
     )
     name: str = Field(..., description="Human-readable unique name, e.g. 'prod-sftp-reports'")
-    type: str = Field(..., description="Connector transport type: 'ssh' or 's3'")
+    type: str = Field(..., description="Connector transport type: 'file_system' or 'object_storage'")
     allowed_extensions: List[str] = Field(..., description="File extensions to accept, e.g. ['.pdf', '.docx']")
     connection_details: Dict[str, Any] = Field(..., description="Transport-specific connection parameters")
 
@@ -121,7 +121,7 @@ class ConnectorCreateRequest(BaseModel):
         "json_schema_extra": {
             "example": {
                 "name": "prod-sftp-reports",
-                "type": "ssh",
+                "type": "file_system",
                 "allowed_extensions": [".pdf", ".docx"],
                 "connection_details": {
                     "host": "sftp.example.com",
@@ -238,7 +238,7 @@ class ConnectorListItem(BaseModel):
             "example": {
                 "id": "c1d2e3f4-a5b6-7890-abcd-ef1234567890",
                 "name": "prod-sftp-reports",
-                "type": "ssh",
+                "type": "file_system",
                 "attached_at": "2025-01-15T10:00:00Z",
                 "last_sync_at": "2025-01-15T10:30:00Z",
                 "sync_status": "up to date",
@@ -269,7 +269,7 @@ class ConnectorDetailResponse(BaseModel):
             "example": {
                 "id": "c1d2e3f4-a5b6-7890-abcd-ef1234567890",
                 "name": "prod-sftp-reports",
-                "type": "ssh",
+                "type": "file_system",
                 "allowed_extensions": [".pdf", ".docx"],
                 "sync_interval_seconds": 60,
                 "attached_at": "2025-01-15T10:00:00Z",

--- a/services/digitize/connectors/scanners/config.py
+++ b/services/digitize/connectors/scanners/config.py
@@ -189,7 +189,7 @@ class S3ConnectorConfig(BaseModel):
 
     @field_validator("allowed_extensions")
     @classmethod
-    def _check_extensions(cls, v: list[str]) -> list[str]:
+    def _normalise_extensions(cls, v: list[str]) -> list[str]:
         """Normalise extensions to lowercase with a leading dot.
 
         Entries that already have a leading dot are kept as-is;
@@ -276,7 +276,7 @@ class SSHConnectorConfig(BaseModel):
 
     @field_validator("allowed_extensions")
     @classmethod
-    def _check_extensions(cls, v: list[str]) -> list[str]:
+    def _normalise_extensions(cls, v: list[str]) -> list[str]:
         """Normalise extensions to lowercase with a leading dot.
 
         Entries that already have a leading dot are kept as-is;

--- a/services/digitize/connectors/scanners/config.py
+++ b/services/digitize/connectors/scanners/config.py
@@ -190,19 +190,12 @@ class S3ConnectorConfig(BaseModel):
     @field_validator("allowed_extensions")
     @classmethod
     def _check_extensions(cls, v: list[str]) -> list[str]:
-        """Reject extension values that are missing the leading dot.
+        """Normalise extensions to lowercase with a leading dot.
 
-        ``os.path.splitext`` always returns extensions with a leading dot
-        (e.g. ``'.pdf'``).  An entry like ``'pdf'`` would silently match
-        nothing during listing — fail early with a clear message instead.
+        Entries that already have a leading dot are kept as-is;
+        entries without one (e.g. ``'pdf'``) have it prepended automatically.
         """
-        bad = [e for e in v if not e.startswith(".")]
-        if bad:
-            raise ValueError(
-                f"Each allowed_extension must start with '.', got: {bad!r}. "
-                f"Use '.pdf' not 'pdf'."
-            )
-        return [e.lower() for e in v]
+        return [e.lower() if e.startswith(".") else f".{e.lower()}" for e in v]
 
     @model_validator(mode="after")
     def _check_credentials(self) -> "S3ConnectorConfig":
@@ -284,13 +277,12 @@ class SSHConnectorConfig(BaseModel):
     @field_validator("allowed_extensions")
     @classmethod
     def _check_extensions(cls, v: list[str]) -> list[str]:
-        bad = [e for e in v if not e.startswith(".")]
-        if bad:
-            raise ValueError(
-                f"Each allowed_extension must start with '.', got: {bad!r}. "
-                f"Use '.pdf' not 'pdf'."
-            )
-        return [e.lower() for e in v]
+        """Normalise extensions to lowercase with a leading dot.
+
+        Entries that already have a leading dot are kept as-is;
+        entries without one (e.g. ``'pdf'``) have it prepended automatically.
+        """
+        return [e.lower() if e.startswith(".") else f".{e.lower()}" for e in v]
 
     @field_validator("remote_path")
     @classmethod

--- a/services/digitize/connectors/scanners/scanner_factory.py
+++ b/services/digitize/connectors/scanners/scanner_factory.py
@@ -36,8 +36,8 @@ logger = get_logger("scanner_factory")
 # Registry — maps connector type → (scanner class, config class)
 # ---------------------------------------------------------------------------
 _REGISTRY: dict[str, tuple[type[BaseScanner], type]] = {
-    "s3": (S3Scanner, S3ConnectorConfig),
-    "ssh": (SSHScanner, SSHConnectorConfig),
+    "object_storage": (S3Scanner, S3ConnectorConfig),
+    "file_system": (SSHScanner, SSHConnectorConfig),
 }
 
 
@@ -49,7 +49,7 @@ def build_scanner(connector_row: Any) -> BaseScanner:
     ----------
     connector_row:
         Any object (ORM model, dataclass, or dict) that exposes:
-          - ``.type``               → str  (e.g. ``"s3"``, ``"ssh"``)
+          - ``.type``               → str  (e.g. ``"object_storage"``, ``"file_system"``)
           - ``.connection_details`` → dict  (encrypted as stored in the DB)
           - ``.allowed_extensions`` → list[str]  (e.g. ``[".pdf", ".docx"]``)
 

--- a/services/digitize/connectors/scheduler.py
+++ b/services/digitize/connectors/scheduler.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-from apscheduler import AsyncScheduler
+from apscheduler import AsyncScheduler, ConflictPolicy
 from apscheduler.triggers.interval import IntervalTrigger
 
 from common.misc_utils import get_logger
@@ -86,6 +86,7 @@ async def register_connector_job(
         trigger=IntervalTrigger(seconds=interval_seconds, start_time=start_time),
         args=[connector_id],
         id=connector_id,
+        conflict_policy=ConflictPolicy.replace,
     )
     logger.info(
         f"Registered scheduler job for connector {connector_id!r} "

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -48,7 +48,7 @@ from digitize.models import JobStatus, OutputFormat, OperationType
 from digitize.utils.db import (
     add_connector_checksum_entry,
     finalize_sync_log_and_update_connector,
-    get_active_connector,
+    get_connector_by_id,
     get_connector_sync_status,
     get_sync_log_status,
     get_job,
@@ -122,7 +122,7 @@ async def run_tick(connector_id: str, sync_seq: int) -> None:
         responsible for acquiring the sync lock beforehand via
         ``try_acquire_sync_lock()``.
     """
-    config = get_active_connector(connector_id)
+    config = get_connector_by_id(connector_id)
     if config is None:
         logger.error(f"Connector {connector_id!r} not found; tick aborted")
         _fail_tick(sync_seq, connector_id, RuntimeError(f"Connector {connector_id!r} not found"))

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -346,6 +346,9 @@ async def _process_new_files(
                     f"Connector {connector_id!r} interrupted (type={interrupt.value})"
                 )
 
+            if not filename_to_checksum:
+                continue
+
             filenames = list(filename_to_checksum.keys())
             job_name = f"Connector-{connector_name}-{sync_seq}-{batch_number}"
             doc_id_dict = initialize_job_state(

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -169,16 +169,15 @@ async def run_tick(connector_id: str, sync_seq: int) -> None:
 
         invalid_count = await _process_new_files(sync_seq, connector_id, config.name, scanner, ingest_list)
 
-        if invalid_count > 0:
-            total_files -= invalid_count
-            update_connector_total_files(connector_id, total_files)
-            update_sync_log(connector_id, sync_seq, total_files=total_files)
-        else:
-            update_connector_total_files(connector_id, total_files)
+        update_connector_total_files(connector_id, total_files)
 
         await _delete_orphans(connector_id, orphan_checksums)
 
-        _complete_tick(sync_seq, connector_id)
+        if invalid_count > 0:
+            validation_error_msg = f"{invalid_count} file(s) failed due to validation failure"
+            _fail_tick(sync_seq, connector_id, RuntimeError(validation_error_msg), error_msg=validation_error_msg)
+        else:
+            _complete_tick(sync_seq, connector_id)
 
     except asyncio.CancelledError as ce:
         logger.info(f"Tick cancelled for connector {connector_id!r}: {ce}")
@@ -306,8 +305,8 @@ async def _process_new_files(
     -------
     int
         Number of files rejected by ``validate_document_file`` across all
-        batches.  The caller subtracts this from the total_files count so that
-        unsupported files are not included in the connector's reported total.
+        batches.  If non-zero the caller closes the sync log as FAILED with
+        a message indicating how many files failed validation.
     """
     staging_base = settings.digitize.staging_dir / "connectors"
     batch_failed = False

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -37,6 +37,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional
 
+from pydantic import ValidationError
+
 from common.misc_utils import cleanup_staging_directory, get_logger
 from digitize.connectors.scanners.scanner_factory import build_scanner
 from digitize.pipeline.ingest import ingest
@@ -143,7 +145,7 @@ async def run_tick(connector_id: str, sync_seq: int) -> None:
             logger.error(
                 f"Connector {connector_id!r} failed to connect — treating as credential error: {conn_exc}"
             )
-            _fail_tick(sync_seq, connector_id, conn_exc, error_msg=ConnectorError.CREDENTIAL_ERROR_MSG)
+            _fail_tick(sync_seq, connector_id, conn_exc, error_msg=ConnectorError.CREDENTIAL_ERROR_MSG.value)
             return
 
         scanned_files: list[tuple[str, str]] = await asyncio.to_thread(scanner.scan)
@@ -180,7 +182,10 @@ async def run_tick(connector_id: str, sync_seq: int) -> None:
         logger.error(
             f"Tick failed for connector {connector_id!r}: {exc}", exc_info=True
         )
-        _fail_tick(sync_seq, connector_id, exc)
+        if isinstance(exc, ValidationError):
+            _fail_tick(sync_seq, connector_id, exc, error_msg=ConnectorError.CREDENTIAL_ERROR_MSG.value)
+        else:
+            _fail_tick(sync_seq, connector_id, exc)
 
     finally:
         if scanner is not None:

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -126,9 +126,10 @@ async def run_tick(connector_id: str, sync_seq: int) -> None:
         _fail_tick(sync_seq, connector_id, RuntimeError(f"Connector {connector_id!r} not found"))
         return
 
-    scanner = build_scanner(config)
-
+    scanner = None
     try:
+        scanner = build_scanner(config)
+
         # Phase boundary: check for interrupt signals before any remote I/O starts.
         interrupt = _check_interrupt_call(connector_id, sync_seq)
         if interrupt:
@@ -182,12 +183,13 @@ async def run_tick(connector_id: str, sync_seq: int) -> None:
         _fail_tick(sync_seq, connector_id, exc)
 
     finally:
-        try:
-            await asyncio.to_thread(scanner.close)
-        except Exception as close_exc:
-            logger.warning(
-                f"scanner.close() failed for connector {connector_id!r}: {close_exc}"
-            )
+        if scanner is not None:
+            try:
+                await asyncio.to_thread(scanner.close)
+            except Exception as close_exc:
+                logger.warning(
+                    f"scanner.close() failed for connector {connector_id!r}: {close_exc}"
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -39,7 +39,7 @@ from typing import Optional
 
 from pydantic import ValidationError
 
-from common.misc_utils import cleanup_staging_directory, get_logger
+from common.misc_utils import cleanup_staging_directory, get_logger, validate_document_file
 from digitize.connectors.scanners.scanner_factory import build_scanner
 from digitize.pipeline.ingest import ingest
 from digitize.settings import settings
@@ -326,6 +326,16 @@ async def _process_new_files(
                         f"Integrity check failed for {remote_path!r} in connector "
                         f"{connector_id!r}; skipping file"
                     )
+                    continue
+                try:
+                    file_bytes = (batch_dir / filename).read_bytes()
+                    validate_document_file(filename, file_bytes)
+                except ValueError as val_exc:
+                    logger.warning(
+                        f"Invalid file {remote_path!r} in connector "
+                        f"{connector_id!r}; skipping file: {val_exc}"
+                    )
+                    (batch_dir / filename).unlink(missing_ok=True)
                     continue
                 filename_to_checksum[filename] = checksum
 

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -157,16 +157,24 @@ async def run_tick(connector_id: str, sync_seq: int) -> None:
             connector_id, scanned_files, known_checksums, all_checksums
         )
 
+        total_files = len(scanned_files)
+
         update_sync_log(
             connector_id,
             sync_seq,
-            total_files=len(scanned_files),
+            total_files=total_files,
             new_files=len(ingest_list),
             removed_files=len(orphan_checksums),
         )
-        update_connector_total_files(connector_id, len(scanned_files))
 
-        await _process_new_files(sync_seq, connector_id, config.name, scanner, ingest_list)
+        invalid_count = await _process_new_files(sync_seq, connector_id, config.name, scanner, ingest_list)
+
+        if invalid_count > 0:
+            total_files -= invalid_count
+            update_connector_total_files(connector_id, total_files)
+            update_sync_log(connector_id, sync_seq, total_files=total_files)
+        else:
+            update_connector_total_files(connector_id, total_files)
 
         await _delete_orphans(connector_id, orphan_checksums)
 
@@ -283,7 +291,7 @@ async def _process_new_files(
     connector_name: str,
     scanner,
     ingest_list: list[tuple[str, str]],
-) -> None:
+) -> int:
     """Download and ingest *ingest_list* in batches of up to 10 files.
 
     Each batch of up to 10 files is downloaded into a single staging directory,
@@ -293,9 +301,17 @@ async def _process_new_files(
 
     Raises ``RuntimeError`` after processing all batches if any batch failed,
     so the caller can mark the connector as OUT_OF_SYNC.
+
+    Returns
+    -------
+    int
+        Number of files rejected by ``validate_document_file`` across all
+        batches.  The caller subtracts this from the total_files count so that
+        unsupported files are not included in the connector's reported total.
     """
     staging_base = settings.digitize.staging_dir / "connectors"
     batch_failed = False
+    invalid_file_count = 0
 
     for batch_number, batch_offset in enumerate(range(0, len(ingest_list), _BATCH_SIZE), start=1):
         batch = ingest_list[batch_offset : batch_offset + _BATCH_SIZE]
@@ -336,6 +352,7 @@ async def _process_new_files(
                         f"{connector_id!r}; skipping file: {val_exc}"
                     )
                     (batch_dir / filename).unlink(missing_ok=True)
+                    invalid_file_count += 1
                     continue
                 filename_to_checksum[filename] = checksum
 
@@ -402,6 +419,8 @@ async def _process_new_files(
             f"One or more documents failed to sync. See more details in digitize jobs "
             f"Connector-{connector_name}-{sync_seq}-*"
         )
+
+    return invalid_file_count
 
 
 # ---------------------------------------------------------------------------

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -669,77 +669,87 @@ class DatabaseManager:
             logger.error(f"Unexpected error retrieving active jobs: {e}", exc_info=True)
             return []
     @staticmethod
-    def delete_all_documents() -> Dict[str, Any]:
+    def delete_user_documents() -> Dict[str, Any]:
         """
-        Delete all documents from the database.
-        
+        Delete only user-submitted documents (those NOT in connector_document_checksum).
+
+        Connector-sourced documents and their checksum rows are left untouched.
+
         Returns:
-            Dictionary with deletion statistics:
+            Dictionary with:
             - deleted_count: Number of documents deleted
-            - success: Whether operation completed successfully
+            - doc_ids: List of deleted doc_id strings
+            - success: Whether the operation completed successfully
         """
         try:
             with get_db_session() as session:
-                # Wipe the checksum registry so previously-seen hashes are no longer
-                # blocked after a full reset.
-                session.execute(delete(DocumentChecksum))
-                stmt = delete(Document)
-                result = cast(CursorResult, session.execute(stmt))
+                # Collect user-submitted doc IDs first (excludes connector-sourced).
+                user_doc_ids_stmt = (
+                    select(Document.doc_id)
+                    .where(
+                        ~select(ConnectorDocumentChecksum.doc_id)
+                        .where(ConnectorDocumentChecksum.doc_id == Document.doc_id)
+                        .exists()
+                    )
+                )
+                doc_ids = list(session.scalars(user_doc_ids_stmt).all())
+
+                if not doc_ids:
+                    return {"deleted_count": 0, "doc_ids": [], "success": True}
+
+                # Remove checksum registry rows for these docs so hashes can be
+                # re-registered if the same file is ingested again.
+                session.execute(
+                    delete(DocumentChecksum).where(DocumentChecksum.doc_id.in_(doc_ids))
+                )
+
+                # Remove already_exists shadow docs that reference any of these docs.
+                session.execute(
+                    delete(Document).where(
+                        Document.doc_metadata["existing_doc_id"].as_string().in_(doc_ids)
+                    )
+                )
+
+                result = cast(
+                    CursorResult,
+                    session.execute(delete(Document).where(Document.doc_id.in_(doc_ids))),
+                )
                 deleted_count = result.rowcount
-                return {
-                    "deleted_count": deleted_count,
-                    "success": True
-                }
+                logger.info(f"Deleted {deleted_count} user-submitted documents from database")
+                return {"deleted_count": deleted_count, "doc_ids": doc_ids, "success": True}
         except SQLAlchemyError as e:
-            logger.error(f"Database error deleting all documents: {e}", exc_info=True)
-            return {
-                "deleted_count": 0,
-                "success": False,
-                "error": str(e)
-            }
+            logger.error(f"Database error deleting user documents: {e}", exc_info=True)
+            return {"deleted_count": 0, "doc_ids": [], "success": False, "error": str(e)}
         except Exception as e:
-            logger.error(f"Unexpected error deleting all documents: {e}", exc_info=True)
-            return {
-                "deleted_count": 0,
-                "success": False,
-                "error": str(e)
-            }
-    
+            logger.error(f"Unexpected error deleting user documents: {e}", exc_info=True)
+            return {"deleted_count": 0, "doc_ids": [], "success": False, "error": str(e)}
+
     @staticmethod
-    def delete_all_jobs() -> Dict[str, Any]:
+    def delete_user_jobs() -> Dict[str, Any]:
         """
-        Delete all jobs from the database.
-        
+        Delete only user-submitted jobs — those whose job_name does NOT start
+        with the connector-job prefix ``"Connector-"``.
+
         Returns:
-            Dictionary with deletion statistics:
+            Dictionary with:
             - deleted_count: Number of jobs deleted
-            - success: Whether operation completed successfully
+            - success: Whether the operation completed successfully
         """
         try:
             with get_db_session() as session:
-                stmt = delete(Job)
+                stmt = delete(Job).where(
+                    ~Job.job_name.like("Connector-%")
+                )
                 result = cast(CursorResult, session.execute(stmt))
                 deleted_count = result.rowcount
-                return {
-                    "deleted_count": deleted_count,
-                    "success": True
-                }
+                logger.info(f"Deleted {deleted_count} user-submitted jobs from database")
+                return {"deleted_count": deleted_count, "success": True}
         except SQLAlchemyError as e:
-            logger.error(f"Database error deleting all jobs: {e}", exc_info=True)
-            return {
-                "deleted_count": 0,
-                "success": False,
-                "error": str(e)
-            }
+            logger.error(f"Database error deleting user jobs: {e}", exc_info=True)
+            return {"deleted_count": 0, "success": False, "error": str(e)}
         except Exception as e:
-            logger.error(f"Unexpected error deleting all jobs: {e}", exc_info=True)
-            return {
-                "deleted_count": 0,
-                "success": False,
-                "error": str(e)
-            }
-
-
+            logger.error(f"Unexpected error deleting user jobs: {e}", exc_info=True)
+            return {"deleted_count": 0, "success": False, "error": str(e)}
 
     # ========================================================================
     # Connector CRUD

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -884,6 +884,32 @@ class DatabaseManager:
             return None
 
     @staticmethod
+    def get_connector_by_name(name: str) -> "Optional[Connector]":
+        """
+        Fetch a single connector by name, eagerly loaded and expunged.
+
+        Returns None if not found.
+        """
+        try:
+            with get_db_session() as session:
+                stmt = select(Connector).where(Connector.name == name)
+                connector = session.scalars(stmt).one_or_none()
+                if connector is None:
+                    return None
+                _ = (
+                    connector.id, connector.name, connector.type,
+                    connector.connection_details, connector.allowed_extensions,
+                    connector.sync_interval_seconds, connector.attached_at,
+                    connector.last_sync_at, connector.sync_status,
+                    connector.error, connector.total_files,
+                )
+                session.expunge(connector)
+                return connector
+        except SQLAlchemyError as e:
+            logger.error(f"DB error fetching connector by name {name!r}: {e}", exc_info=True)
+            return None
+
+    @staticmethod
     def get_connector_sync_status(connector_id: str) -> Optional[str]:
         """
         Return the current sync_status string for a connector.

--- a/services/digitize/db/models.py
+++ b/services/digitize/db/models.py
@@ -217,7 +217,7 @@ class Connector(Base):
     )
 
     __table_args__ = (
-        CheckConstraint("type IN ('ssh', 's3')", name="chk_connector_type"),
+        CheckConstraint("type IN ('file_system', 'object_storage')", name="chk_connector_type"),
     )
 
     def __repr__(self) -> str:

--- a/services/digitize/db/scripts/init_schema.sql
+++ b/services/digitize/db/scripts/init_schema.sql
@@ -55,7 +55,7 @@ CREATE TABLE IF NOT EXISTS connectors (
     sync_status             TEXT        NOT NULL DEFAULT 'up to date',
     error                   TEXT,
     total_files             INTEGER     NOT NULL DEFAULT 0,
-    CONSTRAINT chk_connector_type CHECK (type IN ('ssh', 's3'))
+    CONSTRAINT chk_connector_type CHECK (type IN ('file_system', 'object_storage'))
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_connectors_name

--- a/services/digitize/pipeline/cleanup.py
+++ b/services/digitize/pipeline/cleanup.py
@@ -1,32 +1,38 @@
 """
 System reset / cleanup pipeline.
 
-Full digitize service reset: VDB reset → PostgreSQL wipe → filesystem cleanup.
+Deletes all user-submitted documents and jobs: VDB reset → PostgreSQL wipe →
+filesystem cleanup.  Connector-sourced documents and connector jobs are left
+untouched.
 """
 import common.db_utils as db
 from common.misc_utils import get_logger
 from digitize.utils.storage import storage_manager
-from digitize.utils.db import get_all_document_ids
+from digitize.utils.db import get_user_document_ids
 from digitize.db.manager import db_manager
 
 logger = get_logger("cleanup")
 
+
 def reset_db():
     """
-    Reset the vector database, PostgreSQL database, and clean up all document files.
+    Reset the vector database, PostgreSQL database, and clean up all
+    user-submitted document files.
 
-    This function performs a complete cleanup:
-    1. Reads all document IDs from metadata files in DOCS_DIR
-    2. Deletes chunks for those documents from the vector database index
-    3. Deletes all jobs and documents from PostgreSQL database
-    4. Deletes all digitized content files from /var/cache/digitized
-    5. Deletes all document metadata files from /var/cache/docs
+    Connector-sourced documents and connector jobs are preserved.
+
+    This function performs the following steps:
+    1. Reads user-submitted document IDs from the database
+    2. Deletes their chunks from the vector database index
+    3. Deletes user-submitted documents from PostgreSQL
+    4. Deletes user-submitted jobs from PostgreSQL
+    5. Deletes the corresponding content files from /var/cache/digitized
 
     Raises:
         Exception: If vector database reset fails or file deletion fails completely
     """
-    # Step 1: Read all document IDs from metadata files
-    doc_ids = get_all_document_ids()
+    # Step 1: Read user-submitted document IDs
+    doc_ids = get_user_document_ids()
 
     # Step 2: Delete chunks from vector database FIRST
     # This ensures documents are removed from search even if file deletion fails
@@ -40,13 +46,12 @@ def reset_db():
     except Exception as e:
         error_msg = f"Failed to reset vector database: {str(e)}"
         logger.error(f"✗ {error_msg}")
-        # Raise error immediately - VDB reset is critical
         raise Exception(error_msg) from e
 
     # Step 3: Delete all records from PostgreSQL database
     try:
-        logger.debug("Deleting all documents from PostgreSQL database...")
-        doc_result = db_manager.delete_all_documents()
+        logger.debug("Deleting user-submitted documents from PostgreSQL database...")
+        doc_result = db_manager.delete_user_documents()
 
         if doc_result["success"]:
             logger.info(f"✓ Deleted {doc_result['deleted_count']} documents from PostgreSQL database")
@@ -55,8 +60,8 @@ def reset_db():
             logger.error(f"✗ {error_msg}")
             raise Exception(error_msg)
 
-        logger.debug("Deleting all jobs from PostgreSQL database...")
-        job_result = db_manager.delete_all_jobs()
+        logger.debug("Deleting user-submitted jobs from PostgreSQL database...")
+        job_result = db_manager.delete_user_jobs()
 
         if job_result["success"]:
             logger.info(f"✓ Deleted {job_result['deleted_count']} jobs from PostgreSQL database")
@@ -72,10 +77,16 @@ def reset_db():
             f"Partial deletion: vector database reset but PostgreSQL deletion failed. {error_msg}"
         ) from e
 
-    # Step 4: Delete all document files LAST
+    # Step 4: Delete content files for user-submitted docs LAST
     try:
-        logger.debug("Deleting all document files...")
-        deletion_stats = storage_manager.delete_all_contents()
+        logger.debug("Deleting document content files...")
+        deletion_stats: dict = {"content_files_deleted": 0, "errors": []}
+        for doc_id in doc_ids:
+            try:
+                storage_manager.delete_document_content_by_id(doc_id)
+                deletion_stats["content_files_deleted"] += 1
+            except Exception as file_exc:
+                deletion_stats["errors"].append(str(file_exc))
 
         total_deleted = deletion_stats["content_files_deleted"]
         logger.info(
@@ -83,9 +94,8 @@ def reset_db():
             f"(metadata is managed in PostgreSQL database)"
         )
 
-        # If there were any file deletion errors, raise an error
         if deletion_stats["errors"]:
-            error_summary = "; ".join(deletion_stats["errors"][:3])  # Limit to first 3 errors
+            error_summary = "; ".join(deletion_stats["errors"][:3])
             logger.error(f"File deletion completed with errors: {error_summary}")
             raise Exception(
                 f"Partial deletion: vector database reset but some files failed to delete. {error_summary}"

--- a/services/digitize/tests/conftest.py
+++ b/services/digitize/tests/conftest.py
@@ -126,7 +126,7 @@ def mock_db_manager():
     mock_manager.update_job = Mock(return_value=True)
     mock_manager.delete_job = Mock(return_value=True)
     mock_manager.get_active_jobs = Mock(return_value=[])
-    mock_manager.delete_all_jobs = Mock(return_value={"deleted_count": 0, "success": True})
+    mock_manager.delete_user_jobs = Mock(return_value={"deleted_count": 0, "success": True})
     
     # Mock document operations
     mock_manager.create_document = Mock(return_value=Mock(
@@ -148,7 +148,7 @@ def mock_db_manager():
     mock_manager.get_documents_by_job_id = Mock(return_value=[])
     mock_manager.update_document = Mock(return_value=True)
     mock_manager.delete_document = Mock(return_value=True)
-    mock_manager.delete_all_documents = Mock(return_value={"deleted_count": 0, "success": True})
+    mock_manager.delete_user_documents = Mock(return_value={"deleted_count": 0, "doc_ids": [], "success": True})
     
     with patch('digitize.db.manager.db_manager', mock_manager):
         with patch('digitize.utils.db.db_manager', mock_manager):

--- a/services/digitize/tests/test_connector_db.py
+++ b/services/digitize/tests/test_connector_db.py
@@ -146,7 +146,7 @@ class TestUpsertActiveConnector:
 
 
 # ===========================================================================
-# get_active_connector
+# get_connector_by_id
 # ===========================================================================
 
 class TestGetConnector:
@@ -169,26 +169,26 @@ class TestGetConnector:
         connector = self._make_connector()
         session = MagicMock()
         session.get.return_value = connector
-        from digitize.utils.db import get_active_connector
+        from digitize.utils.db import get_connector_by_id
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            result = get_active_connector(CONNECTOR_ID)
+            result = get_connector_by_id(CONNECTOR_ID)
         assert result is connector
         session.expunge.assert_called_once_with(connector)
 
     def test_returns_none_when_not_found(self):
         session = MagicMock()
         session.get.return_value = None
-        from digitize.utils.db import get_active_connector
+        from digitize.utils.db import get_connector_by_id
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            result = get_active_connector("nonexistent-id")
+            result = get_connector_by_id("nonexistent-id")
         assert result is None
 
     def test_returns_none_on_db_error(self):
         session = MagicMock()
         session.get.side_effect = SQLAlchemyError("timeout")
-        from digitize.utils.db import get_active_connector
+        from digitize.utils.db import get_connector_by_id
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_cm(session)):
-            result = get_active_connector(CONNECTOR_ID)
+            result = get_connector_by_id(CONNECTOR_ID)
         assert result is None
 
 

--- a/services/digitize/tests/test_connector_encryption.py
+++ b/services/digitize/tests/test_connector_encryption.py
@@ -151,7 +151,7 @@ class TestEncryptSecrets:
     def test_encrypts_ssh_private_key(self, monkeypatch):
         _set_key(monkeypatch)
         details = {"host": "example.com", "username": "user", "private_key": "MY_PRIVATE_KEY"}
-        encrypted = encrypt_secrets("ssh", details)
+        encrypted = encrypt_secrets("file_system", details)
         # The private_key field must be base64-encoded ciphertext, not plain
         assert encrypted["private_key"] != "MY_PRIVATE_KEY"
         assert encrypted["host"] == "example.com"
@@ -160,7 +160,7 @@ class TestEncryptSecrets:
     def test_encrypts_s3_secret_access_key(self, monkeypatch):
         _set_key(monkeypatch)
         details = {"bucket": "my-bucket", "access_key_id": "AKID", "secret_access_key": "MY_SECRET"}
-        encrypted = encrypt_secrets("s3", details)
+        encrypted = encrypt_secrets("object_storage", details)
         assert encrypted["secret_access_key"] != "MY_SECRET"
         assert encrypted["bucket"] == "my-bucket"
         assert encrypted["access_key_id"] == "AKID"
@@ -174,14 +174,14 @@ class TestEncryptSecrets:
     def test_skips_none_valued_secret_fields(self, monkeypatch):
         _set_key(monkeypatch)
         details = {"private_key": None, "username": "admin"}
-        result = encrypt_secrets("ssh", details)
+        result = encrypt_secrets("file_system", details)
         assert result["private_key"] is None
         assert result["username"] == "admin"
 
     def test_does_not_mutate_original_dict(self, monkeypatch):
         _set_key(monkeypatch)
         original = {"private_key": "secret", "host": "ssh.example.com"}
-        _ = encrypt_secrets("ssh", original)
+        _ = encrypt_secrets("file_system", original)
         assert original["private_key"] == "secret"
 
 
@@ -193,15 +193,15 @@ class TestDecryptSecrets:
     def test_decrypts_value_encrypted_by_encrypt_secrets(self, monkeypatch):
         _set_key(monkeypatch)
         details = {"private_key": "-----BEGIN RSA PRIVATE KEY-----\nFAKE\n-----END RSA PRIVATE KEY-----"}
-        encrypted = encrypt_secrets("ssh", details)
-        decrypted = decrypt_secrets("ssh", encrypted)
+        encrypted = encrypt_secrets("file_system", details)
+        decrypted = decrypt_secrets("file_system", encrypted)
         assert decrypted["private_key"] == details["private_key"]
 
     def test_leaves_non_secret_fields_untouched(self, monkeypatch):
         _set_key(monkeypatch)
         details = {"host": "sftp.example.com", "private_key": "KEY_DATA", "port": 22}
-        encrypted = encrypt_secrets("ssh", details)
-        decrypted = decrypt_secrets("ssh", encrypted)
+        encrypted = encrypt_secrets("file_system", details)
+        decrypted = decrypt_secrets("file_system", encrypted)
         assert decrypted["host"] == "sftp.example.com"
         assert decrypted["port"] == 22
 
@@ -209,12 +209,12 @@ class TestDecryptSecrets:
         _set_key(monkeypatch)
         bad_details = {"private_key": "not_valid_base64_ciphertext=="}
         with pytest.raises(Exception):
-            decrypt_secrets("ssh", bad_details)
+            decrypt_secrets("file_system", bad_details)
 
     def test_skips_none_valued_secret_fields(self, monkeypatch):
         _set_key(monkeypatch)
         details = {"private_key": None, "host": "host.example.com"}
-        result = decrypt_secrets("ssh", details)
+        result = decrypt_secrets("file_system", details)
         assert result["private_key"] is None
 
     def test_s3_full_roundtrip(self, monkeypatch):
@@ -224,8 +224,8 @@ class TestDecryptSecrets:
             "access_key_id": "AKID123",
             "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         }
-        encrypted = encrypt_secrets("s3", details)
-        decrypted = decrypt_secrets("s3", encrypted)
+        encrypted = encrypt_secrets("object_storage", details)
+        decrypted = decrypt_secrets("object_storage", encrypted)
         assert decrypted == details
 
 
@@ -236,14 +236,14 @@ class TestDecryptSecrets:
 class TestStripSecrets:
     def test_removes_private_key_from_ssh_details(self):
         details = {"host": "sftp.example.com", "username": "user", "private_key": "SENSITIVE"}
-        result = strip_secrets("ssh", details)
+        result = strip_secrets("file_system", details)
         assert "private_key" not in result
         assert result["host"] == "sftp.example.com"
         assert result["username"] == "user"
 
     def test_removes_secret_access_key_from_s3_details(self):
         details = {"bucket": "b", "access_key_id": "AK", "secret_access_key": "SK"}
-        result = strip_secrets("s3", details)
+        result = strip_secrets("object_storage", details)
         assert "secret_access_key" not in result
         assert result["bucket"] == "b"
         assert result["access_key_id"] == "AK"
@@ -255,13 +255,13 @@ class TestStripSecrets:
 
     def test_does_not_mutate_original_dict(self):
         original = {"private_key": "KEY", "host": "h"}
-        _ = strip_secrets("ssh", original)
+        _ = strip_secrets("file_system", original)
         assert "private_key" in original
 
     def test_field_absent_in_details_is_no_op(self):
         """strip_secrets must not raise if a secret field is simply absent."""
         details = {"host": "sftp.example.com", "username": "bob"}
-        result = strip_secrets("ssh", details)
+        result = strip_secrets("file_system", details)
         assert result == details
 
 
@@ -274,7 +274,7 @@ class TestMergeAndEncryptPartial:
         _set_key(monkeypatch)
         existing = {"private_key": "ENCRYPTED_BLOB", "host": "old.example.com", "port": 22}
         partial = {"host": "new.example.com"}
-        result = merge_and_encrypt_partial("ssh", existing, partial)
+        result = merge_and_encrypt_partial("file_system", existing, partial)
         assert result["host"] == "new.example.com"
         assert result["port"] == 22
 
@@ -282,7 +282,7 @@ class TestMergeAndEncryptPartial:
         _set_key(monkeypatch)
         existing = {"private_key": "OLD_ENCRYPTED", "host": "sftp.example.com"}
         partial = {"private_key": "NEW_PLAINTEXT_KEY"}
-        result = merge_and_encrypt_partial("ssh", existing, partial)
+        result = merge_and_encrypt_partial("file_system", existing, partial)
         # The updated private_key must be a new ciphertext, not plaintext
         assert result["private_key"] != "NEW_PLAINTEXT_KEY"
         assert result["private_key"] != "OLD_ENCRYPTED"
@@ -291,7 +291,7 @@ class TestMergeAndEncryptPartial:
         _set_key(monkeypatch)
         existing = {"private_key": "EXISTING_CIPHERTEXT", "host": "sftp.example.com"}
         partial = {"host": "new-sftp.example.com"}
-        result = merge_and_encrypt_partial("ssh", existing, partial)
+        result = merge_and_encrypt_partial("file_system", existing, partial)
         # Private key blob unchanged — it was not in partial_update
         assert result["private_key"] == "EXISTING_CIPHERTEXT"
 
@@ -299,21 +299,21 @@ class TestMergeAndEncryptPartial:
         _set_key(monkeypatch)
         existing = {"private_key": "CIPHERTEXT", "host": "old.example.com"}
         original_existing = dict(existing)
-        merge_and_encrypt_partial("ssh", existing, {"host": "new.example.com"})
+        merge_and_encrypt_partial("file_system", existing, {"host": "new.example.com"})
         assert existing == original_existing
 
     def test_partial_none_value_for_secret_field_is_passed_through(self, monkeypatch):
         """A None update for a secret field must not be encrypted — passed as None."""
         _set_key(monkeypatch)
         existing = {"private_key": "CIPHERTEXT", "host": "sftp.example.com"}
-        result = merge_and_encrypt_partial("ssh", existing, {"private_key": None})
+        result = merge_and_encrypt_partial("file_system", existing, {"private_key": None})
         assert result["private_key"] is None
 
     def test_s3_partial_update_encrypts_secret_access_key(self, monkeypatch):
         _set_key(monkeypatch)
         existing = {"bucket": "b", "access_key_id": "OLD_AK", "secret_access_key": "OLD_CIPHERTEXT"}
         partial = {"secret_access_key": "NEW_PLAINTEXT_SECRET"}
-        result = merge_and_encrypt_partial("s3", existing, partial)
+        result = merge_and_encrypt_partial("object_storage", existing, partial)
         assert result["secret_access_key"] != "NEW_PLAINTEXT_SECRET"
         assert result["bucket"] == "b"
 

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -222,6 +222,21 @@ class TestPostConnector:
         response = connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
         assert response.status_code == 409
 
+    def test_scheduler_not_called_on_duplicate(self, connector_test_client, monkeypatch):
+        """Scheduler job must NOT be registered when the DB insert fails (duplicate)."""
+        import digitize.connectors.scheduler as scheduler_module
+
+        monkeypatch.setattr(
+            "digitize.api.v1.connectors.db_ops.insert_connector",
+            Mock(side_effect=IntegrityError(None, None, Exception("dup"))),
+        )
+        scheduler_spy = AsyncMock()
+        monkeypatch.setattr(scheduler_module, "register_connector_job", scheduler_spy)
+
+        connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
+
+        scheduler_spy.assert_not_called()
+
     def test_s3_connector_returns_202(self, connector_test_client, monkeypatch):
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())
         response = connector_test_client.post("/v1/connectors", json=S3_PAYLOAD)

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -16,8 +16,8 @@ Coverage:
   - POST   /v1/connectors/{id}/sync                       (202 dispatched, 202 no-op, 404)
   - POST   /v1/connectors/{id}/syncs/{sync_seq}/stop      (204 signalled, 409 stale seq, 409 not running, 404)
   - GET    /v1/documents — excludes connector-sourced docs
-  - GET    /v1/documents/{doc_id} — 404 for connector-sourced
-  - DELETE /v1/documents/{doc_id} — 404 for connector-sourced
+  - GET    /v1/documents/{doc_id} — 405 for connector-sourced
+  - DELETE /v1/documents/{doc_id} — 405 for connector-sourced
 """
 
 from datetime import datetime, timezone
@@ -651,14 +651,14 @@ class TestDocumentListConnectorFilter:
         connector_test_client.get("/v1/documents")
         assert captured.get("exclude_connector_sourced") is True
 
-    def test_get_doc_returns_404_for_connector_sourced(self, connector_test_client, monkeypatch):
+    def test_get_doc_returns_405_for_connector_sourced(self, connector_test_client, monkeypatch):
         """is_connector_sourced_document is imported inside the handler — patch the source."""
         monkeypatch.setattr(
             "digitize.utils.db.is_connector_sourced_document",
             Mock(return_value=True),
         )
         response = connector_test_client.get("/v1/documents/some-connector-doc-id")
-        assert response.status_code == 404
+        assert response.status_code == 405
 
     def test_get_doc_returns_data_for_user_submitted(self, connector_test_client, monkeypatch):
         from digitize.models import DocumentDetailResponse
@@ -681,13 +681,13 @@ class TestDocumentListConnectorFilter:
         response = connector_test_client.get("/v1/documents/doc-001")
         assert response.status_code == 200
 
-    def test_delete_doc_returns_404_for_connector_sourced(self, connector_test_client, monkeypatch):
+    def test_delete_doc_returns_405_for_connector_sourced(self, connector_test_client, monkeypatch):
         monkeypatch.setattr(
             "digitize.utils.db.is_connector_sourced_document",
             Mock(return_value=True),
         )
         response = connector_test_client.delete("/v1/documents/connector-owned-doc")
-        assert response.status_code == 404
+        assert response.status_code == 405
 
 # ===========================================================================
 # dispatch_sync  (core logic — no HTTP)

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -257,7 +257,7 @@ class TestPostConnector:
 class TestPutConnector:
     def test_returns_200_on_success(self, connector_test_client, monkeypatch):
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector()),
         )
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.upsert_connector", Mock())
@@ -269,7 +269,7 @@ class TestPutConnector:
 
     def test_returns_404_when_not_found(self, connector_test_client, monkeypatch):
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector()),
         )
         monkeypatch.setattr(
@@ -285,7 +285,7 @@ class TestPutConnector:
     def test_partial_update_only_overwrites_supplied_keys(self, connector_test_client, monkeypatch):
         """PUT with only name must not touch connection_details."""
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector()),
         )
         upsert_mock = Mock()
@@ -300,7 +300,7 @@ class TestPutConnector:
 
     def test_returns_409_on_name_conflict(self, connector_test_client, monkeypatch):
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector()),
         )
         monkeypatch.setattr(
@@ -315,7 +315,7 @@ class TestPutConnector:
 
     def test_returns_409_when_delete_pending(self, connector_test_client, monkeypatch):
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector(sync_status=ConnectorStatus.DELETE_PENDING)),
         )
         response = connector_test_client.put(
@@ -351,7 +351,7 @@ class TestDeleteConnector:
         """Case B: not syncing → mark DELETE_PENDING, schedule teardown, return 204."""
         mark_mock = self._patch_mark(monkeypatch)
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector()),
         )
         def _consume_coro(coro):
@@ -366,7 +366,7 @@ class TestDeleteConnector:
         """Case A: syncing → mark DELETE_PENDING, return 204; no teardown task created."""
         mark_mock = self._patch_mark(monkeypatch)
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector(sync_status=ConnectorStatus.SYNCING)),
         )
         with patch("digitize.api.v1.connectors.asyncio.create_task") as task_mock:
@@ -377,7 +377,7 @@ class TestDeleteConnector:
 
     def test_returns_404_when_not_found(self, connector_test_client, monkeypatch):
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=None),
         )
         response = connector_test_client.delete(f"/v1/connectors/{CONNECTOR_ID}")
@@ -486,7 +486,7 @@ class TestListConnectors:
 class TestGetConnector:
     def test_returns_200_with_detail(self, connector_test_client, monkeypatch):
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector()),
         )
         response = connector_test_client.get(f"/v1/connectors/{CONNECTOR_ID}")
@@ -502,7 +502,7 @@ class TestGetConnector:
 
     def test_returns_404_when_not_found(self, connector_test_client, monkeypatch):
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=None),
         )
         response = connector_test_client.get(f"/v1/connectors/{CONNECTOR_ID}")
@@ -516,7 +516,7 @@ class TestGetConnector:
             "private_key": "ENCRYPTED_PRIVATE_KEY",
         }
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=c),
         )
         monkeypatch.setattr(
@@ -538,7 +538,7 @@ class TestSyncLog:
     def test_returns_paginated_history(self, connector_test_client, monkeypatch):
         logs = [_make_sync_log(seq=3), _make_sync_log(seq=2)]
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector()),
         )
         monkeypatch.setattr(
@@ -557,7 +557,7 @@ class TestSyncLog:
 
     def test_returns_404_when_connector_not_found(self, connector_test_client, monkeypatch):
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=None),
         )
         response = connector_test_client.get(
@@ -568,7 +568,7 @@ class TestSyncLog:
     def test_limit_capped_at_200(self, connector_test_client, monkeypatch):
         """limit > 200 must be rejected by FastAPI's Query validation."""
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector()),
         )
         monkeypatch.setattr(
@@ -585,7 +585,7 @@ class TestGetSync:
     def test_returns_200_with_sync_detail(self, connector_test_client, monkeypatch):
         log = _make_sync_log(seq=3)
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector()),
         )
         monkeypatch.setattr(
@@ -603,7 +603,7 @@ class TestGetSync:
 
     def test_returns_404_when_sync_not_found(self, connector_test_client, monkeypatch):
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector()),
         )
         monkeypatch.setattr(
@@ -617,7 +617,7 @@ class TestGetSync:
 
     def test_returns_404_when_connector_not_found(self, connector_test_client, monkeypatch):
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=None),
         )
         response = connector_test_client.get(
@@ -706,7 +706,7 @@ class TestDispatchSync:
         from digitize.api.v1.connectors import dispatch_sync
 
         task_mock = Mock(side_effect=lambda coro: coro.close())
-        with patch("digitize.api.v1.connectors.db_ops.get_active_connector",
+        with patch("digitize.api.v1.connectors.db_ops.get_connector_by_id",
                    return_value=_make_connector()), \
              patch("digitize.api.v1.connectors.db_ops.get_active_sync_seq",
                    return_value=None), \
@@ -725,7 +725,7 @@ class TestDispatchSync:
         from digitize.api.v1.connectors import dispatch_sync
 
         task_mock = Mock()
-        with patch("digitize.api.v1.connectors.db_ops.get_active_connector",
+        with patch("digitize.api.v1.connectors.db_ops.get_connector_by_id",
                    return_value=_make_connector()), \
              patch("digitize.api.v1.connectors.db_ops.get_active_sync_seq",
                    return_value=3), \
@@ -742,7 +742,7 @@ class TestDispatchSync:
     def test_raises_sync_not_found_when_connector_missing(self):
         from digitize.api.v1.connectors import dispatch_sync, SyncNotFound
 
-        with patch("digitize.api.v1.connectors.db_ops.get_active_connector",
+        with patch("digitize.api.v1.connectors.db_ops.get_connector_by_id",
                    return_value=None):
             with pytest.raises(SyncNotFound):
                 self._run(dispatch_sync(CONNECTOR_ID))
@@ -750,7 +750,7 @@ class TestDispatchSync:
     def test_raises_sync_locked_when_delete_pending(self):
         from digitize.api.v1.connectors import dispatch_sync, SyncLocked
 
-        with patch("digitize.api.v1.connectors.db_ops.get_active_connector",
+        with patch("digitize.api.v1.connectors.db_ops.get_connector_by_id",
                    return_value=_make_connector(sync_status=ConnectorStatus.DELETE_PENDING)):
             with pytest.raises(SyncLocked):
                 self._run(dispatch_sync(CONNECTOR_ID))
@@ -758,7 +758,7 @@ class TestDispatchSync:
     def test_raises_sync_locked_when_cancel_pending(self):
         from digitize.api.v1.connectors import dispatch_sync, SyncLocked
 
-        with patch("digitize.api.v1.connectors.db_ops.get_active_connector",
+        with patch("digitize.api.v1.connectors.db_ops.get_connector_by_id",
                    return_value=_make_connector()), \
              patch("digitize.api.v1.connectors.db_ops.get_active_sync_seq",
                    return_value=5), \
@@ -840,7 +840,7 @@ class TestStopSync:
     ):
         """Correct sync_seq + mark_sync_cancel_pending True → 204."""
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector(sync_status=ConnectorStatus.SYNCING)),
         )
         monkeypatch.setattr(
@@ -861,7 +861,7 @@ class TestStopSync:
     ):
         """sync_seq older than the active one → 409 without calling mark_sync_cancel_pending."""
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector()),
         )
         monkeypatch.setattr(
@@ -884,7 +884,7 @@ class TestStopSync:
     ):
         """get_active_sync_seq returns None (not syncing) → 409."""
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector()),
         )
         monkeypatch.setattr(
@@ -900,7 +900,7 @@ class TestStopSync:
         self, connector_test_client, monkeypatch
     ):
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=None),
         )
         response = connector_test_client.post(
@@ -922,7 +922,7 @@ class TestPutConnectorTriggersSync:
         from digitize.connectors.models import ConnectorUpdateRequest
 
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector()),
         )
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.upsert_connector", Mock())
@@ -950,7 +950,7 @@ class TestPutConnectorTriggersSync:
         from digitize.connectors.models import ConnectorUpdateRequest
 
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.get_active_connector",
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
             Mock(return_value=_make_connector()),
         )
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.upsert_connector", Mock())

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -41,12 +41,12 @@ _NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
 
 CONNECTOR_ID = "c7f3a2d1-0000-0000-0000-000000000001"
 CONNECTOR_NAME = "prod-sftp-reports"
-CONNECTOR_TYPE = "ssh"
+CONNECTOR_TYPE = "file_system"
 
 SSH_PAYLOAD = {
     "id": CONNECTOR_ID,
     "name": CONNECTOR_NAME,
-    "type": "ssh",
+    "type": "file_system",
     "allowed_extensions": [".pdf", ".docx"],
     "connection_details": {
         "host": "sftp.example.com",
@@ -59,7 +59,7 @@ SSH_PAYLOAD = {
 S3_PAYLOAD = {
     "id": "a1b2c3d4-0000-0000-0000-000000000002",
     "name": "prod-s3-rag-docs",
-    "type": "s3",
+    "type": "object_storage",
     "allowed_extensions": [".pdf"],
     "connection_details": {
         "endpoint_url": "https://s3.us-east-1.amazonaws.com",

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -184,6 +184,10 @@ def connector_test_client(monkeypatch, tmp_path, mock_db_operations):
         },
     )
 
+    # db_ops connector stubs — return None by default (no pre-existing connector)
+    monkeypatch.setattr("digitize.api.v1.connectors.db_ops.get_connector_by_id", Mock(return_value=None))
+    monkeypatch.setattr("digitize.api.v1.connectors.db_ops.get_connector_by_name", Mock(return_value=None))
+
     # Scheduler stubs — prevent RuntimeError from uninitialised _scheduler
     import digitize.connectors.scheduler as scheduler_module
     monkeypatch.setattr(scheduler_module, "register_connector_job", AsyncMock())
@@ -223,12 +227,13 @@ class TestPostConnector:
         assert response.status_code == 409
 
     def test_scheduler_not_called_on_duplicate(self, connector_test_client, monkeypatch):
-        """Scheduler job must NOT be registered when the DB insert fails (duplicate)."""
+        """Scheduler job must NOT be registered when a duplicate is detected by pre-check."""
         import digitize.connectors.scheduler as scheduler_module
 
+        # Simulate pre-check finding an existing connector with the same id.
         monkeypatch.setattr(
-            "digitize.api.v1.connectors.db_ops.insert_connector",
-            Mock(side_effect=IntegrityError(None, None, Exception("dup"))),
+            "digitize.api.v1.connectors.db_ops.get_connector_by_id",
+            Mock(return_value=_make_connector()),
         )
         scheduler_spy = AsyncMock()
         monkeypatch.setattr(scheduler_module, "register_connector_job", scheduler_spy)

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -197,10 +197,10 @@ def connector_test_client(monkeypatch, tmp_path, mock_db_operations):
 # ===========================================================================
 
 class TestPostConnector:
-    def test_returns_201_on_success(self, connector_test_client, monkeypatch):
+    def test_returns_202_on_success(self, connector_test_client, monkeypatch):
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())
         response = connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
-        assert response.status_code == 201
+        assert response.status_code == 202
         assert response.json() == {"id": CONNECTOR_ID}
 
     def test_encrypts_private_key_before_insert(self, connector_test_client, monkeypatch):
@@ -222,10 +222,10 @@ class TestPostConnector:
         response = connector_test_client.post("/v1/connectors", json=SSH_PAYLOAD)
         assert response.status_code == 409
 
-    def test_s3_connector_returns_201(self, connector_test_client, monkeypatch):
+    def test_s3_connector_returns_202(self, connector_test_client, monkeypatch):
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())
         response = connector_test_client.post("/v1/connectors", json=S3_PAYLOAD)
-        assert response.status_code == 201
+        assert response.status_code == 202
 
     def test_secret_not_returned_in_response(self, connector_test_client, monkeypatch):
         monkeypatch.setattr("digitize.api.v1.connectors.db_ops.insert_connector", Mock())

--- a/services/digitize/tests/test_connector_models_extra.py
+++ b/services/digitize/tests/test_connector_models_extra.py
@@ -117,7 +117,7 @@ class TestConnectorCreateRequest:
     def _valid_payload(self, **overrides):
         base = {
             "name": "my-connector",
-            "type": "s3",
+            "type": "file_system",
             "allowed_extensions": [".pdf", ".docx"],
             "connection_details": {"bucket": "my-bucket"},
         }

--- a/services/digitize/tests/test_connector_scanners.py
+++ b/services/digitize/tests/test_connector_scanners.py
@@ -169,9 +169,9 @@ class TestS3ConnectorConfig:
         cfg = _make_config(endpoint_url="")
         assert cfg.endpoint_url == ""
 
-    def test_allowed_extensions_without_dot_raises(self):
-        with pytest.raises(ValueError, match="'.'"):
-            _make_config(allowed_extensions=["pdf", ".docx"])
+    def test_allowed_extensions_without_dot_normalised(self):
+        cfg = _make_config(allowed_extensions=["pdf", ".docx"])
+        assert cfg.allowed_extensions == [".pdf", ".docx"]
 
     def test_allowed_extensions_valid(self):
         cfg = _make_config(allowed_extensions=[".PDF", ".docx"])
@@ -560,9 +560,9 @@ class TestSSHConnectorConfig:
         with pytest.raises(ValueError, match="PRIVATE KEY"):
             _make_sftp_config(private_key="not a pem string")
 
-    def test_allowed_extensions_without_dot_raises(self):
-        with pytest.raises(ValueError, match="'.'"):
-            _make_sftp_config(allowed_extensions=["pdf"])
+    def test_allowed_extensions_without_dot_normalised(self):
+        cfg = _make_sftp_config(allowed_extensions=["pdf"])
+        assert cfg.allowed_extensions == [".pdf"]
 
     def test_allowed_extensions_normalised_to_lowercase(self):
         cfg = _make_sftp_config(allowed_extensions=[".PDF", ".DOCX"])

--- a/services/digitize/tests/test_connector_scanners.py
+++ b/services/digitize/tests/test_connector_scanners.py
@@ -442,7 +442,7 @@ _PATCH_DECRYPT = "digitize.connectors.scanners.scanner_factory.decrypt_secrets"
 
 
 class TestBuildScanner:
-    def _make_connector_dict(self, connector_type: str = "s3") -> dict:
+    def _make_connector_dict(self, connector_type: str = "object_storage") -> dict:
         return {
             "type": connector_type,
             "connection_details": {
@@ -455,13 +455,13 @@ class TestBuildScanner:
         }
 
     def test_s3_type_returns_s3_scanner(self):
-        row = self._make_connector_dict("s3")
+        row = self._make_connector_dict("object_storage")
         with patch(_PATCH_DECRYPT, side_effect=lambda t, d: d):
             scanner = build_scanner(row)
         assert isinstance(scanner, S3Scanner)
 
     def test_s3_scanner_config_populated(self):
-        row = self._make_connector_dict("s3")
+        row = self._make_connector_dict("object_storage")
         with patch(_PATCH_DECRYPT, side_effect=lambda t, d: d):
             scanner = build_scanner(row)
         assert scanner._cfg.bucket_name == "my-bucket"
@@ -469,7 +469,7 @@ class TestBuildScanner:
 
     def test_accepts_orm_like_object(self):
         row = SimpleNamespace(
-            type="s3",
+            type="object_storage",
             connection_details={
                 "bucket_name": "ns-bucket",
                 "access_key_id": "AK",
@@ -1040,7 +1040,7 @@ class TestSFTPLoadPrivateKey:
 class TestBuildScannerSSH:
     def _make_ssh_connector_dict(self) -> dict:
         return {
-            "type": "ssh",
+            "type": "file_system",
             "connection_details": {
                 "host": "sftp.example.com",
                 "username": "user",
@@ -1067,7 +1067,7 @@ class TestBuildScannerSSH:
     def test_ssh_accepts_orm_like_object(self):
         from digitize.connectors.scanners.ssh_scanner import SSHScanner
         row = SimpleNamespace(
-            type="ssh",
+            type="file_system",
             connection_details={
                 "host": "sftp.host",
                 "username": "admin",

--- a/services/digitize/tests/test_connector_scheduler.py
+++ b/services/digitize/tests/test_connector_scheduler.py
@@ -200,3 +200,75 @@ class TestRecoverConnectorSyncState:
             result = recover_connector_sync_state()
             # Both connectors were in the affected list; count reflects that
             assert result == 2
+
+
+# ===========================================================================
+# _connector_scheduler_lifespan with delete_pending recovery
+# ===========================================================================
+
+class TestLifespanRecoveryDeletePending:
+    """Tests for lifespan startup recovery of delete_pending connectors."""
+
+    @pytest.mark.asyncio
+    async def test_lifespan_recovery_delete_pending(self):
+        import asyncio
+        from unittest.mock import MagicMock, AsyncMock, patch
+        from digitize.app import _connector_scheduler_lifespan
+        from digitize.connectors.models import ConnectorStatus
+
+        # Mock connectors list
+        mock_conn_active = MagicMock()
+        mock_conn_active.id = "conn-active"
+        mock_conn_active.sync_status = ConnectorStatus.UP_TO_DATE
+        mock_conn_active.sync_interval_seconds = 300
+
+        mock_conn_delete = MagicMock()
+        mock_conn_delete.id = "conn-delete"
+        mock_conn_delete.sync_status = ConnectorStatus.DELETE_PENDING
+        mock_conn_delete.sync_interval_seconds = 300
+
+        mock_connectors = [mock_conn_active, mock_conn_delete]
+
+        # Mocks for functions/classes used in lifespan
+        mock_recover = MagicMock(return_value=0)
+        mock_list = MagicMock(return_value=mock_connectors)
+        mock_register = AsyncMock()
+        mock_teardown = AsyncMock()
+
+        # Mock scheduler instance
+        mock_sched_instance = AsyncMock()
+        mock_sched_instance.start_in_background = AsyncMock()
+        
+        # We need mock_sched_class to behave as an async context manager
+        mock_sched_class = MagicMock()
+        mock_sched_class.return_value.__aenter__.return_value = mock_sched_instance
+
+        # Mock database datastore and engine
+        mock_datastore = MagicMock()
+        
+        with patch("digitize.app.recover_connector_sync_state", mock_recover), \
+             patch("digitize.utils.db.list_connectors", mock_list), \
+             patch("digitize.connectors.scheduler.register_connector_job", mock_register), \
+             patch("digitize.api.v1.connectors._run_teardown", mock_teardown), \
+             patch("apscheduler.AsyncScheduler", mock_sched_class), \
+             patch("apscheduler.datastores.sqlalchemy.SQLAlchemyDataStore", return_value=mock_datastore), \
+             patch("digitize.db.connection.engine", MagicMock()):
+            
+            # Run the context manager
+            async with _connector_scheduler_lifespan():
+                # Let any background tasks (like the created task for teardown) yield control to execute
+                await asyncio.sleep(0.05)
+
+            # Assertions
+            mock_recover.assert_called_once()
+            mock_list.assert_called_once()
+            
+            # "conn-active" should be registered
+            mock_register.assert_awaited_once_with(
+                "conn-active",
+                300,
+                fire_immediately=False,
+            )
+            
+            # "conn-delete" should not be registered but teardown should be triggered
+            mock_teardown.assert_awaited_once_with("conn-delete")

--- a/services/digitize/tests/test_connector_scheduler.py
+++ b/services/digitize/tests/test_connector_scheduler.py
@@ -99,6 +99,24 @@ class TestRegisterConnectorJob:
         finally:
             sched_mod._scheduler = original
 
+    @pytest.mark.asyncio
+    async def test_uses_replace_conflict_policy(self):
+        """add_schedule must always use ConflictPolicy.replace to handle duplicates."""
+        from apscheduler import ConflictPolicy
+
+        mock_sched = AsyncMock()
+        import digitize.connectors.scheduler as sched_mod
+        original = sched_mod._scheduler
+        sched_mod._scheduler = mock_sched
+        try:
+            from digitize.connectors.scheduler import register_connector_job
+            await register_connector_job("conn-C", 300, fire_immediately=False)
+
+            _, kwargs = mock_sched.add_schedule.await_args
+            assert kwargs["conflict_policy"] == ConflictPolicy.replace
+        finally:
+            sched_mod._scheduler = original
+
 
 # ===========================================================================
 # scheduler.remove_connector_job

--- a/services/digitize/tests/test_connector_scheduler.py
+++ b/services/digitize/tests/test_connector_scheduler.py
@@ -211,7 +211,15 @@ class TestLifespanRecoveryDeletePending:
 
     @pytest.mark.asyncio
     async def test_lifespan_recovery_delete_pending(self):
+        import sys
+        import types
         import asyncio
+        # Ensure the submodule exists in sys.modules so patch() can resolve the
+        # attribute without importing the real package (which requires sniffio).
+        if "apscheduler.datastores.sqlalchemy" not in sys.modules:
+            _stub = types.ModuleType("apscheduler.datastores.sqlalchemy")
+            _stub.SQLAlchemyDataStore = None  # placeholder so patch() finds the attribute
+            sys.modules["apscheduler.datastores.sqlalchemy"] = _stub
         from unittest.mock import MagicMock, AsyncMock, patch
         from digitize.app import _connector_scheduler_lifespan
         from digitize.connectors.models import ConnectorStatus

--- a/services/digitize/tests/test_deduplication.py
+++ b/services/digitize/tests/test_deduplication.py
@@ -30,7 +30,7 @@ Coverage areas
 5. db/manager.py      – upsert_file_checksum (insert + on-conflict update)
                       – find_completed_document_by_hash (match / no-match / DB error)
                       – delete_document removes checksum registry row first
-                      – delete_all_documents wipes checksum registry
+                      – delete_user_documents skips connector docs, wipes user checksum registry
                       – get_all_documents excludes already_exists by default
 """
 
@@ -1026,29 +1026,46 @@ class TestDatabaseManagerDeleteDocumentClearsChecksum:
 
 
 @pytest.mark.unit
-class TestDatabaseManagerDeleteAllDocumentsClearsRegistry:
-    """delete_all_documents must wipe the checksum registry."""
+class TestDatabaseManagerDeleteUserDocuments:
+    """delete_user_documents must skip connector-sourced docs and wipe checksum registry."""
 
-    def test_execute_called_twice(self):
+    def test_returns_early_when_no_user_docs(self):
         session = MagicMock()
-        session.execute.return_value = Mock(rowcount=3)
+        session.scalars.return_value = Mock(all=Mock(return_value=[]))
 
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
             from digitize.db.manager import DatabaseManager
-            DatabaseManager.delete_all_documents()
+            result = DatabaseManager.delete_user_documents()
 
-        # First call: wipe registry. Second call: delete all documents.
-        assert session.execute.call_count == 2
+        # No execute calls — short-circuits when doc_ids is empty.
+        assert session.execute.call_count == 0
+        assert result == {"deleted_count": 0, "doc_ids": [], "success": True}
+
+    def test_execute_called_three_times_when_user_docs_exist(self):
+        session = MagicMock()
+        session.scalars.return_value = Mock(all=Mock(return_value=["doc-1", "doc-2"]))
+        session.execute.return_value = Mock(rowcount=2)
+
+        with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
+            from digitize.db.manager import DatabaseManager
+            DatabaseManager.delete_user_documents()
+
+        # 1st execute: delete checksum registry rows.
+        # 2nd execute: delete shadow already_exists docs.
+        # 3rd execute: delete the documents themselves.
+        assert session.execute.call_count == 3
 
     def test_returns_deleted_count(self):
         session = MagicMock()
-        session.execute.side_effect = [Mock(rowcount=0), Mock(rowcount=5)]
+        session.scalars.return_value = Mock(all=Mock(return_value=["doc-1", "doc-2"]))
+        session.execute.side_effect = [Mock(rowcount=0), Mock(rowcount=0), Mock(rowcount=2)]
 
         with patch("digitize.db.manager.get_db_session", return_value=_make_session_ctx(session)):
             from digitize.db.manager import DatabaseManager
-            result = DatabaseManager.delete_all_documents()
+            result = DatabaseManager.delete_user_documents()
 
-        assert result["deleted_count"] == 5
+        assert result["deleted_count"] == 2
+        assert result["success"] is True
 
 
 @pytest.mark.unit

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -476,7 +476,7 @@ class TestRunTick:
         return scanner
 
     def test_aborts_when_connector_not_found(self):
-        with patch(f"{DB_MODULE}.get_active_connector", return_value=None), \
+        with patch(f"{DB_MODULE}.get_connector_by_id", return_value=None), \
              patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_fail:
             asyncio.run(run_tick("missing", sync_seq=1))
 
@@ -491,7 +491,7 @@ class TestRunTick:
         mock_scanner = self._make_scanner(scan_result=[])
         mock_scanner.close.side_effect = RuntimeError("close boom")
 
-        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+        with patch(f"{DB_MODULE}.get_connector_by_id", return_value=connector), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
@@ -511,7 +511,7 @@ class TestRunTick:
         connector = _connector()
         mock_scanner = self._make_scanner(scan_result=[])
 
-        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+        with patch(f"{DB_MODULE}.get_connector_by_id", return_value=connector), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
@@ -533,7 +533,7 @@ class TestRunTick:
         connector = _connector()
         mock_scanner = self._make_scanner(connect_raises=ConnectionError("refused"))
 
-        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+        with patch(f"{DB_MODULE}.get_connector_by_id", return_value=connector), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
              patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
@@ -550,7 +550,7 @@ class TestRunTick:
         connector = _connector()
         mock_scanner = self._make_scanner(connect_raises=ConnectionError("auth rejected"))
 
-        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+        with patch(f"{DB_MODULE}.get_connector_by_id", return_value=connector), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
              patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
@@ -567,7 +567,7 @@ class TestRunTick:
         connector = _connector()
         mock_scanner = self._make_scanner(scan_raises=RuntimeError("scan exploded"))
 
-        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+        with patch(f"{DB_MODULE}.get_connector_by_id", return_value=connector), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
@@ -582,7 +582,7 @@ class TestRunTick:
         connector = _connector()
         mock_scanner = self._make_scanner(scan_raises=IOError("timeout"))
 
-        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+        with patch(f"{DB_MODULE}.get_connector_by_id", return_value=connector), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.SYNCING), \
@@ -678,7 +678,7 @@ class TestRunTickCancellation:
         connector = _connector()
         mock_scanner = self._make_scanner()
 
-        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+        with patch(f"{DB_MODULE}.get_connector_by_id", return_value=connector), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.DELETE_PENDING), \
              patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close:
@@ -694,7 +694,7 @@ class TestRunTickCancellation:
         connector = _connector()
         mock_scanner = self._make_scanner()
 
-        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+        with patch(f"{DB_MODULE}.get_connector_by_id", return_value=connector), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
@@ -725,7 +725,7 @@ class TestRunTickCancellation:
                 return InterruptType.SYNC_CANCEL
             return None
 
-        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+        with patch(f"{DB_MODULE}.get_connector_by_id", return_value=connector), \
              patch(f"{DB_MODULE}.list_connector_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.list_all_checksums", return_value=[]), \
              patch(f"{DB_MODULE}.update_sync_log"), \
@@ -1108,7 +1108,7 @@ class TestRunTickHandleInterrupt:
         connector = _connector()
         mock_scanner = self._make_scanner()
 
-        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+        with patch(f"{DB_MODULE}.get_connector_by_id", return_value=connector), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.get_connector_sync_status",
                    return_value=ConnectorStatus.DELETE_PENDING), \
@@ -1125,7 +1125,7 @@ class TestRunTickHandleInterrupt:
         connector = _connector()
         mock_scanner = self._make_scanner()
 
-        with patch(f"{DB_MODULE}.get_active_connector", return_value=connector), \
+        with patch(f"{DB_MODULE}.get_connector_by_id", return_value=connector), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.get_connector_sync_status",
                    return_value=ConnectorStatus.DELETE_PENDING), \

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -1038,6 +1038,57 @@ class TestProcessNewFilesExtra:
                 asyncio.run(_process_new_files(1, "conn-1", "name", scanner,
                                                [("a.pdf", "ck1"), ("b.pdf", "ck2")]))
 
+    def test_all_files_invalid_skips_job_creation(self):
+        """When every file in a batch fails validation, no job must be created."""
+        scanner = MagicMock()
+        scanner.download_to.return_value = "local_hash"
+        scanner.verify_integrity.return_value = True
+
+        with self._base_patches():
+            with patch(f"{DB_MODULE}.validate_document_file", side_effect=ValueError("bad")), \
+                 patch(f"{DB_MODULE}.initialize_job_state") as mock_init, \
+                 patch(f"{DB_MODULE}.ingest") as mock_ingest:
+                asyncio.run(_process_new_files(1, "conn-1", "name", scanner,
+                                               [("remote/fake.pdf", "ck1")]))
+
+        mock_init.assert_not_called()
+        mock_ingest.assert_not_called()
+
+    def test_all_files_invalid_does_not_set_batch_failed(self):
+        """A batch where all files are skipped due to invalid format must not raise RuntimeError."""
+        scanner = MagicMock()
+        scanner.download_to.return_value = "local_hash"
+        scanner.verify_integrity.return_value = True
+
+        with self._base_patches():
+            with patch(f"{DB_MODULE}.validate_document_file", side_effect=ValueError("bad")):
+                # must not raise
+                asyncio.run(_process_new_files(1, "conn-1", "name", scanner,
+                                               [("remote/fake.pdf", "ck1")]))
+
+    def test_mixed_batch_only_valid_files_ingested(self):
+        """In a mixed batch, only the valid file reaches ingest; the invalid one is deleted."""
+        scanner = MagicMock()
+        scanner.download_to.return_value = "local_hash"
+        scanner.verify_integrity.return_value = True
+
+        def _validate(filename, _bytes):
+            if filename == "fake.pdf":
+                raise ValueError("bad format")
+
+        with self._base_patches():
+            with patch(f"{DB_MODULE}.validate_document_file", side_effect=_validate), \
+                 patch(f"{DB_MODULE}.initialize_job_state",
+                       return_value={"works.pdf": "doc-1"}) as mock_init:
+                asyncio.run(_process_new_files(1, "conn-1", "name", scanner,
+                                               [("works.pdf", "ck1"), ("fake.pdf", "ck2")]))
+
+        # initialize_job_state must only see the valid file
+        mock_init.assert_called_once()
+        call_args = mock_init.call_args
+        assert call_args is not None
+        assert call_args.kwargs["documents_info"] == ["works.pdf"]
+
 
 # ---------------------------------------------------------------------------
 # run_tick — _handle_interrupt wiring

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -243,6 +243,9 @@ class TestProcessNewFiles:
         stack.enter_context(
             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED)
         )
+        # validate_document_file reads staged bytes from disk; bypass it in unit tests
+        # since the scanner is a MagicMock and no real files are written to disk.
+        stack.enter_context(patch(f"{DB_MODULE}.validate_document_file"))
         return stack
 
     def test_happy_path_completes_without_error(self):
@@ -376,6 +379,7 @@ class TestProcessNewFiles:
             stack.enter_context(
                 patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED)
             )
+            stack.enter_context(patch(f"{DB_MODULE}.validate_document_file"))
             with patch(f"{DB_MODULE}.add_connector_checksum_entry") as mock_add:
                 with pytest.raises(RuntimeError, match="One or more documents failed to sync"):
                     asyncio.run(_process_new_files(1, "conn-1", "conn-name", scanner, ingest_list))
@@ -927,6 +931,7 @@ class TestProcessNewFilesExtra:
         stack.enter_context(
             patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED)
         )
+        stack.enter_context(patch(f"{DB_MODULE}.validate_document_file"))
         return stack
 
     def test_empty_ingest_list_is_noop(self):
@@ -994,6 +999,7 @@ class TestProcessNewFilesExtra:
             stack.enter_context(
                 patch(f"{DB_MODULE}.get_sync_log_status", return_value=SyncLogStatus.STARTED)
             )
+            stack.enter_context(patch(f"{DB_MODULE}.validate_document_file"))
             stack.enter_context(
                 patch(f"{DB_MODULE}._check_interrupt_call", side_effect=_interrupt)
             )

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -501,7 +501,7 @@ class TestRunTick:
              patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector"), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch("digitize.connectors.sync_tick._process_new_files",
-                   new_callable=AsyncMock, return_value=None), \
+                   new_callable=AsyncMock, return_value=0), \
              patch("digitize.connectors.sync_tick._delete_orphans",
                    new_callable=AsyncMock, return_value=0):
             # must not raise despite close() failing
@@ -521,7 +521,7 @@ class TestRunTick:
              patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch("digitize.connectors.sync_tick._process_new_files",
-                   new_callable=AsyncMock, return_value=None), \
+                   new_callable=AsyncMock, return_value=0), \
              patch("digitize.connectors.sync_tick._delete_orphans",
                    new_callable=AsyncMock, return_value=0):
             asyncio.run(run_tick("conn-1", sync_seq=1))
@@ -704,7 +704,7 @@ class TestRunTickCancellation:
              patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close, \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch("digitize.connectors.sync_tick._process_new_files",
-                   new_callable=AsyncMock, return_value=None), \
+                   new_callable=AsyncMock, return_value=0), \
              patch("digitize.connectors.sync_tick._delete_orphans",
                    new_callable=AsyncMock, return_value=0):
             asyncio.run(run_tick("conn-1", sync_seq=11))  # must not raise

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1264,13 +1264,22 @@ def upsert_connector(
     )
 
 
-def get_active_connector(connector_id: str) -> Optional[Connector]:
+def get_connector_by_id(connector_id: str) -> Optional[Connector]:
     """
     Fetch a single connector by id.
 
     Returns the ORM object or None if not found.
     """
     return db_manager.get_connector_by_id(connector_id)
+
+
+def get_connector_by_name(name: str) -> Optional[Connector]:
+    """
+    Fetch a single connector by name.
+
+    Returns the ORM object or None if not found.
+    """
+    return db_manager.get_connector_by_name(name)
 
 
 def get_connector_sync_status(connector_id: str) -> Optional[str]:

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -606,6 +606,42 @@ def get_all_document_ids() -> list[str]:
         raise
 
 
+def get_user_document_ids() -> list[str]:
+    """
+    Read IDs of user-submitted documents only (connector-sourced docs excluded).
+
+    Returns:
+        List of doc_id strings for documents not in connector_document_checksum
+    """
+    if engine is None:
+        raise RuntimeError("Database not available. Cannot retrieve document IDs without database connection.")
+
+    try:
+        logger.debug("Reading user-submitted document IDs from database")
+        all_documents = []
+        offset = 0
+
+        while True:
+            documents, total = db_manager.get_all_documents(
+                limit=IMPORT_EXPORT_DEFAULT_LIMIT,
+                offset=offset,
+                exclude_connector_sourced=True,
+            )
+            if not documents:
+                break
+            all_documents.extend(documents)
+            offset += len(documents)
+            if offset >= total:
+                break
+
+        doc_ids = [doc.doc_id for doc in all_documents]
+        logger.info(f"Found {len(doc_ids)} user-submitted document IDs in database")
+        return doc_ids
+    except Exception as e:
+        logger.error(f"Failed to read user document IDs from database: {e}", exc_info=True)
+        raise
+
+
 IMPORT_EXPORT_DEFAULT_LIMIT = 10000
 IMPORT_EXPORT_BATCH_SIZE = 100
 

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -1233,7 +1233,7 @@ def insert_connector(
     """
     Insert a new connector row on first-time POST /v1/connectors.
 
-    Raises IntegrityError if the id already exists (maps to 409).
+    Raises IntegrityError if the id or name already exists (maps to 409).
     """
     db_manager.insert_connector(
         connector_id=connector_id,

--- a/services/digitize/utils/storage.py
+++ b/services/digitize/utils/storage.py
@@ -184,6 +184,30 @@ class StorageManager:
                 f"Content file not found (may have been deleted already): {content_file}"
             )
 
+    def delete_document_content_by_id(self, doc_id: str) -> None:
+        """
+        Delete all content files for *doc_id* regardless of output format.
+
+        Uses a glob match (``<doc_id>.*``) so the caller does not need to know
+        the output format upfront.  Logs a warning if no files are found.
+
+        Args:
+            doc_id: Unique document identifier.
+        """
+        digitized_dir = settings.digitize.digitized_docs_dir
+        matched = list(digitized_dir.glob(f"{doc_id}.*"))
+        if not matched:
+            logger.warning(
+                f"Content file for document {doc_id} not found (may have been deleted already)"
+            )
+            return
+        for path in matched:
+            try:
+                path.unlink()
+                logger.info(f"Deleted content file for document {doc_id}: {path.name}")
+            except Exception as exc:
+                raise Exception(f"Failed to delete content file {path}: {exc}") from exc
+
     def delete_all_contents(self) -> dict:
         """
         Delete all digitized content files from the cache directory.


### PR DESCRIPTION
[AISERVICES-1672](https://jsw.ibm.com/browse/AISERVICES-1672)

-Bulk delete of docs now deletes only user-submitted docs (not connector sourced docs)
-Fixed Swagger doc examples
-Added validation on Connection type and allowed extensions 
-Ported S3 and SSH to object_storage and file_system (converted to ENUM) on all user-facing APIs
-Connectors stuck in DELETE_PENDING due to restart is cleaned up as part of recovery
-Scanner init exception is caught to show AuthException message
-Reorder validate_document_files to do primitive checks first 
-Reuse validate_document_files in connector flow (without it would accept and mark failed)
-Fixed tests appropriately 
-All exception TCs are attached in the ticket