### PR TITLE
worker uninstall cli

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.270
+TAG?=v0.0.271
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.270
+  image: icr.io/ai-services-cicd/ai-services:v0.0.271
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.270
+  image: icr.io/ai-services-cicd/ai-services:v0.0.271
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
@@ -18,6 +18,10 @@ spec:
           # Bind to all interfaces inside the container so the host-side
           # port mapping (127.0.0.1:<random>:2019) can reach it.
           value: "0.0.0.0:2019"
+        - name: AI_SERVICES_BASE_DIR
+          # Required by 'worker uninstall': inspected at uninstall time to
+          # recover the base directory without requiring --basedir explicitly.
+          value: "{{ .BaseDir }}"
       volumeMounts:
         - name: caddy-data
           mountPath: /data/caddy:z

--- a/ai-services/cmd/ai-services/cmd/worker/join.go
+++ b/ai-services/cmd/ai-services/cmd/worker/join.go
@@ -13,7 +13,6 @@ import (
 	cmdcommon "github.com/project-ai-services/ai-services/cmd/ai-services/cmd/common"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
-	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	workerdeploy "github.com/project-ai-services/ai-services/internal/pkg/worker/deploy"
@@ -106,8 +105,6 @@ func joinRunE(_ *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	logger.Infoln("Starting worker join — press Ctrl-C to stop.")
-
 	return join.Run(ctx, opts)
 }
 
@@ -119,7 +116,7 @@ func newJoinCmd() *cobra.Command {
 
 	cmdcommon.ConfigureRuntimeFlag(cmd, &runtimeType)
 
-	cmd.Flags().StringVar(&baseDir, "basedir", constants.DefaultBaseDir,
+	cmd.Flags().StringVar(&baseDir, "basedir", "",
 		"Base directory for AI services data (models, caddy, etc.) on this worker.\n"+
 			"Defaults to "+constants.DefaultBaseDir+" when not specified.\n"+
 			"Note: Supported for podman runtime only.\n"+

--- a/ai-services/cmd/ai-services/cmd/worker/uninstall.go
+++ b/ai-services/cmd/ai-services/cmd/worker/uninstall.go
@@ -1,0 +1,57 @@
+package worker
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	cmdcommon "github.com/project-ai-services/ai-services/cmd/ai-services/cmd/common"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
+	workeruninstall "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall"
+)
+
+// Flag variables for the worker uninstall command.
+var (
+	uninstallRuntimeType string
+	uninstallAutoYes     bool
+)
+
+func newUninstallCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Remove this node's worker components",
+		Long: `Removes all worker components deployed by 'worker join' on this node.
+
+The uninstall process will:
+  - Delete the Caddy reverse-proxy pod
+  - Remove the worker data directory (<basedir>/worker)
+
+Application pods deployed on this worker by the catalog are not touched.`,
+		Example: `  # Uninstall worker components (prompts for confirmation)
+  ai-services worker uninstall --runtime podman
+
+  # Skip confirmation prompt
+  ai-services worker uninstall --runtime podman --yes
+
+  ai-services worker uninstall --runtime podman --yes`,
+		Args: cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true
+
+			return cmdcommon.InitAndValidateRuntimeFlag(uninstallRuntimeType)
+		},
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return workeruninstall.Uninstall(context.Background(), workeruninstall.Options{
+				RuntimeType: vars.RuntimeFactory.GetRuntimeType(),
+				AutoYes:     uninstallAutoYes,
+			})
+		},
+	}
+
+	cmdcommon.ConfigureRuntimeFlag(cmd, &uninstallRuntimeType)
+
+	cmd.Flags().BoolVarP(&uninstallAutoYes, "yes", "y", false,
+		"Automatically accept all confirmation prompts.")
+
+	return cmd
+}

--- a/ai-services/cmd/ai-services/cmd/worker/worker.go
+++ b/ai-services/cmd/ai-services/cmd/worker/worker.go
@@ -23,6 +23,7 @@ To join this node as a worker:
 	}
 
 	cmd.AddCommand(newJoinCmd())
+	cmd.AddCommand(newUninstallCmd())
 
 	return cmd
 }

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -1,0 +1,19 @@
+// Package constants holds constants shared across the worker sub-packages
+// (deploy, join, uninstall, gateway, etc.) to avoid duplication.
+package constants
+
+const (
+	// WorkerProxyLabel is the pod label set by deploy.Setup; used by deploy (idempotency) and uninstall (lookup).
+	WorkerProxyLabel = "ai-services.io/component=worker-proxy"
+
+	// WorkerDataSubDir is the on-disk subtree written by deploy.Setup; removed by uninstall.
+	WorkerDataSubDir = "worker"
+
+	// BaseDirEnvVar is injected into the Caddy container at deploy time; read back by uninstall.
+	BaseDirEnvVar = "AI_SERVICES_BASE_DIR"
+
+	// MetaKeyBaseDir, MetaKeyDomainSuffix, MetaKeyHTTPSPort are RegisterRequest.Metadata keys sent during join.
+	MetaKeyBaseDir      = "basedir"
+	MetaKeyDomainSuffix = "domainSuffix"
+	MetaKeyHTTPSPort    = "httpsPort"
+)

--- a/ai-services/internal/pkg/worker/deploy/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/deploy.go
@@ -124,7 +124,7 @@ func writeCaddyfile(baseDir string) error {
 // deployAll loads all pod templates from assets/worker/<runtime>/templates and
 // deploys each one in the order defined by metadata.yaml podTemplateExecutions.
 func deployAll(ctx context.Context, rt runtime.Runtime, opts Options) error {
-	tp := templates.NewEmbedTemplateProvider(&assets.WorkerFS, workerApp)
+	tp := templates.NewEmbedTemplateProvider(&assets.WorkerFS, "")
 
 	var appMetadata templates.AppMetadata
 	if err := tp.LoadMetadata(workerApp, true, &appMetadata); err != nil {

--- a/ai-services/internal/pkg/worker/deploy/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/deploy.go
@@ -20,6 +20,7 @@ import (
 	podmodels "github.com/project-ai-services/ai-services/internal/pkg/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/specs"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 
 	k8syaml "sigs.k8s.io/yaml"
 )
@@ -28,10 +29,6 @@ const (
 	// workerApp is the app name passed to the template provider.
 	// Resolves to assets/worker/<runtime>/templates/.
 	workerApp = "worker"
-
-	// workerProxyLabel is the label used to check whether the worker proxy
-	// pod is already running — more resilient than checking by name.
-	workerProxyLabel = "ai-services.io/component=worker-proxy"
 
 	caddyfileSubDir = "worker/caddy"
 	caddyfilePath   = "worker/podman/Caddyfile.tmpl"
@@ -73,7 +70,7 @@ func Setup(ctx context.Context, rt runtime.Runtime, opts Options) error {
 	logger.InfolnCtx(ctx, "Setting up worker node...")
 
 	pods, err := rt.ListPods(map[string][]string{
-		"label": {workerProxyLabel},
+		"label": {workerconstants.WorkerProxyLabel},
 	})
 	if err != nil {
 		return fmt.Errorf("worker setup: list pods: %w", err)

--- a/ai-services/internal/pkg/worker/join/join.go
+++ b/ai-services/internal/pkg/worker/join/join.go
@@ -206,7 +206,7 @@ func runStream(ctx context.Context, rt runtime.Runtime, client workerpb.WorkerGa
 		return fmt.Errorf("initial heartbeat: %w", err)
 	}
 
-	logger.InfofCtx(ctx, "CommandStream open for worker %q.\n", workerName)
+	logger.InfofCtx(ctx, "CommandStream open for worker %q — press Ctrl-C to stop.\n", workerName)
 
 	// Two concurrent activities:
 	//   • recv goroutine: read Commands from the gateway and handle them.

--- a/ai-services/internal/pkg/worker/join/join.go
+++ b/ai-services/internal/pkg/worker/join/join.go
@@ -32,8 +32,8 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
-	workerdeploy "github.com/project-ai-services/ai-services/internal/pkg/worker/deploy"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
+	workerdeploy "github.com/project-ai-services/ai-services/internal/pkg/worker/deploy"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/dispatch"
 	workerpb "github.com/project-ai-services/ai-services/internal/pkg/worker/proto"
 )

--- a/ai-services/internal/pkg/worker/join/join.go
+++ b/ai-services/internal/pkg/worker/join/join.go
@@ -33,23 +33,12 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	workerdeploy "github.com/project-ai-services/ai-services/internal/pkg/worker/deploy"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/dispatch"
 	workerpb "github.com/project-ai-services/ai-services/internal/pkg/worker/proto"
 )
 
 const (
-	// metaKeyBaseDir is the metadata key used to transmit the worker's base
-	// directory to the control plane during registration.
-	metaKeyBaseDir = "basedir"
-
-	// metaKeyDomainSuffix is the metadata key used to transmit the resolved
-	// domain suffix to the control plane during registration.
-	metaKeyDomainSuffix = "domainSuffix"
-
-	// metaKeyHTTPSPort is the metadata key used to transmit the HTTPS port
-	// the worker's Caddy proxy listens on.
-	metaKeyHTTPSPort = "httpsPort"
-
 	// heartbeatInterval is how often the worker sends a keep-alive to the control plane.
 	heartbeatInterval = 30 * time.Second
 
@@ -120,9 +109,9 @@ func Run(ctx context.Context, opts Options) error {
 
 	// ── Step 3: Register + stream loop ───────────────────────────────────────
 	meta := map[string]string{
-		metaKeyBaseDir:      opts.Setup.BaseDir,
-		metaKeyDomainSuffix: domainSuffix,
-		metaKeyHTTPSPort:    strconv.Itoa(opts.Setup.HTTPSPort),
+		workerconstants.MetaKeyBaseDir:      opts.Setup.BaseDir,
+		workerconstants.MetaKeyDomainSuffix: domainSuffix,
+		workerconstants.MetaKeyHTTPSPort:    strconv.Itoa(opts.Setup.HTTPSPort),
 	}
 
 	return runRegistrationLoop(ctx, rt, client, opts.Token, meta)

--- a/ai-services/internal/pkg/worker/uninstall/uninstall.go
+++ b/ai-services/internal/pkg/worker/uninstall/uninstall.go
@@ -1,0 +1,193 @@
+// Package uninstall removes all worker-node components deployed by
+// `worker join`: the Caddy reverse-proxy pod and the on-disk worker data
+// directory (Caddyfile, caddy state, etc.).
+//
+// It is intentionally scoped to what `worker join` created.  Application pods
+// deployed on the worker by the catalog are the operator's responsibility and
+// are not touched here.
+package uninstall
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
+)
+
+// Options carries the parameters needed to uninstall a worker node.
+type Options struct {
+	// RuntimeType is the local runtime (podman / openshift).
+	RuntimeType types.RuntimeType
+
+	// AutoYes skips the interactive confirmation prompt.
+	AutoYes bool
+}
+
+// Uninstall removes all worker components deployed by `worker join`.
+func Uninstall(ctx context.Context, opts Options) error {
+	rt, err := runtime.CreateRuntime(opts.RuntimeType, "")
+	if err != nil {
+		return fmt.Errorf("worker uninstall: init runtime: %w", err)
+	}
+
+	pods, err := rt.ListPods(map[string][]string{
+		"label": {workerconstants.WorkerProxyLabel},
+	})
+	if err != nil {
+		return fmt.Errorf("worker uninstall: list pods: %w", err)
+	}
+
+	if len(pods) == 0 {
+		logger.InfolnCtx(ctx, "No worker pods found — nothing to uninstall.")
+
+		return nil
+	}
+
+	logger.Warningln("Ensure no application pods are running on this worker before uninstalling, as they will become unreachable and will need to be deleted manually.")
+
+	if ok, err := confirmUninstall(ctx, pods, opts.AutoYes); err != nil || !ok {
+		return err
+	}
+
+	return performCleanup(ctx, rt, pods)
+}
+
+// ─── internal ─────────────────────────────────────────────────────────────────
+
+// WorkerCaddyConfig holds configuration recovered from the running Caddy pod.
+type WorkerCaddyConfig struct {
+	// BaseDir is the base directory recovered from the AI_SERVICES_BASE_DIR
+	// env var injected by caddy.yaml.tmpl at deploy time.
+	BaseDir string
+}
+
+// performCleanup executes all cleanup operations after confirmation:
+// retrieves the Caddy pod config, deletes the pods, and removes the worker
+// data directory.
+func performCleanup(ctx context.Context, rt runtime.Runtime, pods []types.Pod) error {
+	logger.InfolnCtx(ctx, "Proceeding with deletion...")
+
+	var baseDir string
+
+	config, err := getWorkerCaddyPodConfig(rt, pods[0].ID)
+	if err != nil {
+		logger.WarningfCtx(ctx, "Failed to retrieve BaseDir from worker pod: %v. Using default BaseDir.\n", err)
+		baseDir = utils.GetBaseDir()
+	} else {
+		baseDir = config.BaseDir
+	}
+
+	logger.InfofCtx(ctx, "Using base directory for cleanup: %s\n", baseDir)
+
+	if err := deletePods(ctx, rt, pods); err != nil {
+		return err
+	}
+
+	workerDataPath := filepath.Join(baseDir, workerconstants.WorkerDataSubDir)
+
+	return removeDataDir(ctx, workerDataPath)
+}
+
+// getWorkerCaddyPodConfig retrieves worker Caddy pod configuration by inspecting
+// the running pod and its containers. It extracts the AI_SERVICES_BASE_DIR
+// environment variable injected by caddy.yaml.tmpl at deploy time.
+func getWorkerCaddyPodConfig(rt runtime.Runtime, podID string) (*WorkerCaddyConfig, error) {
+	pInfo, err := rt.InspectPod(podID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect pod %s: %w", podID, err)
+	}
+
+	config := &WorkerCaddyConfig{}
+
+	for _, container := range pInfo.Containers {
+		cInfo, err := rt.InspectContainer(container.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to inspect container %s: %w", container.Name, err)
+		}
+
+		extractConfigFromEnv(cInfo.Env, config)
+	}
+
+	return config, nil
+}
+
+// extractConfigFromEnv populates config from Caddy container environment variables.
+func extractConfigFromEnv(env map[string]string, config *WorkerCaddyConfig) {
+	if value, ok := env[workerconstants.BaseDirEnvVar]; ok {
+		config.BaseDir = value
+	}
+}
+
+// confirmUninstall prints the pod list and prompts the user when autoYes is false.
+// Returns (false, nil) when the user declines, (true, nil) when confirmed.
+func confirmUninstall(ctx context.Context, pods []types.Pod, autoYes bool) (bool, error) {
+	if autoYes {
+		return true, nil
+	}
+
+	logger.InfolnCtx(ctx, "The following worker pods will be deleted:")
+
+	for _, p := range pods {
+		logger.InfofCtx(ctx, "  -> %s\n", p.Name)
+	}
+
+	confirmed, err := utils.ConfirmAction("\nDo you want to continue?")
+	if err != nil {
+		return false, fmt.Errorf("worker uninstall: confirmation: %w", err)
+	}
+
+	if !confirmed {
+		logger.InfolnCtx(ctx, "Uninstall cancelled.")
+	}
+
+	return confirmed, nil
+}
+
+// deletePods force-deletes every pod in the list and aggregates any errors.
+func deletePods(ctx context.Context, rt runtime.Runtime, pods []types.Pod) error {
+	var errs []string
+
+	for _, p := range pods {
+		logger.InfofCtx(ctx, "Deleting pod: %s\n", p.Name)
+
+		if err := rt.DeletePod(p.ID, utils.BoolPtr(true)); err != nil {
+			errs = append(errs, fmt.Sprintf("pod %s: %v", p.Name, err))
+
+			continue
+		}
+
+		logger.InfofCtx(ctx, "Deleted pod: %s\n", p.Name)
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to delete pods:\n%s", strings.Join(errs, "\n"))
+	}
+
+	return nil
+}
+
+// removeDataDir deletes path if it exists, logging a note when absent.
+func removeDataDir(ctx context.Context, dataPath string) error {
+	if _, err := os.Stat(dataPath); os.IsNotExist(err) {
+		logger.InfofCtx(ctx, "data directory does not exist, skipping: %s\n", dataPath)
+
+		return nil
+	}
+
+	logger.InfofCtx(ctx, "Deleting data at: %s\n", dataPath)
+
+	if err := os.RemoveAll(dataPath); err != nil {
+		return fmt.Errorf("failed to remove data directory %s: %w", dataPath, err)
+	}
+
+	logger.InfofCtx(ctx, "Successfully removed data at: %s\n", dataPath)
+
+	return nil
+}


### PR DESCRIPTION
Add `worker uninstall` command

1. Deletes the Caddy proxy pod and cleans up <baseDir>/worker
2. Recovers base dir from AI_SERVICES_BASE_DIR env via pod inspect.
3. Extracts shared worker constants into worker/constants package.