### PR TITLE
fix: wait for inferenceService to be active before proceeding

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.279
+TAG?=v0.0.280
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.279
+  image: icr.io/ai-services-cicd/ai-services:v0.0.280
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.279
+  image: icr.io/ai-services-cicd/ai-services:v0.0.280
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/openshift/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/openshift/deployer.go
@@ -19,10 +19,13 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/helm"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	openshiftRuntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/openshift"
 )
 
 const (
-	defaultHelmTimeout = 10 * time.Minute
+	defaultHelmTimeout    = 10 * time.Minute
+	predictorPollInterval = 15 * time.Second
+	predictorWaitTimeout  = 10 * time.Minute
 )
 
 // Type aliases for deployment plan types.
@@ -167,6 +170,22 @@ func (d *OpenShiftDeployer) deployComponentsConcurrently(ctx context.Context, ns
 func (d *OpenShiftDeployer) deployComponent(ctx context.Context, ns string, plan *DeploymentPlan, comp *ComponentPlan) error {
 	if err := helmInstallOrUpgrade(ctx, ns, catalogutils.HelmReleaseName(plan.ApplicationID, strings.ReplaceAll(comp.ComponentType, "_", "-")), comp.CatalogPath, comp.Values, comp.DatabaseID.String()); err != nil {
 		return err
+	}
+
+	// KServe marks an InferenceService "Ready=True" only once the predictor pod is fully up.
+	// Helm considers the InferenceService "Current" as soon as the CRD is accepted,
+	// so we must poll the InferenceService status directly.
+	if oc, ok := d.runtime.(*openshiftRuntime.OpenshiftClient); ok {
+		isvcName := comp.ComponentType
+
+		logger.InfofCtx(ctx, "Waiting for InferenceService '%s' to become ready\n", isvcName)
+
+		waitCtx, cancel := context.WithTimeout(ctx, predictorWaitTimeout)
+		defer cancel()
+
+		if err := oc.WaitForInferenceServiceReady(waitCtx, isvcName, predictorPollInterval); err != nil {
+			return fmt.Errorf("InferenceService %q is not ready yet: %w", isvcName, err)
+		}
 	}
 
 	if err := d.updateComponentEndpoint(ctx, ns, comp); err != nil {

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -819,14 +820,62 @@ func (kc *OpenshiftClient) isDeploymentReady(ctx context.Context, name string) (
 		s.AvailableReplicas == desired, nil
 }
 
+// WaitForInferenceServiceReady polls the KServe InferenceService with the given name in the
+// client's namespace until its Ready condition is True, or the context is cancelled.
+func (kc *OpenshiftClient) WaitForInferenceServiceReady(ctx context.Context, isvcName string, pollInterval time.Duration) error {
+	isvc := &unstructured.Unstructured{}
+	isvc.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "serving.kserve.io",
+		Version: "v1beta1",
+		Kind:    "InferenceService",
+	})
+
+	for {
+		err := kc.Client.Get(ctx, client.ObjectKey{Namespace: kc.Namespace, Name: isvcName}, isvc)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
+
+			return fmt.Errorf("failed to get InferenceService %q: %w", isvcName, err)
+		}
+
+		conditions, _, _ := unstructured.NestedSlice(isvc.Object, "status", "conditions")
+		for _, c := range conditions {
+			cond, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			if cond["type"] == "Ready" {
+				if fmt.Sprint(cond["status"]) == "True" {
+					logger.InfofCtx(ctx, "InferenceService %q is ready\n", isvcName)
+
+					return nil
+				}
+
+				break
+			}
+		}
+
+		logger.InfofCtx(ctx, "InferenceService %q not ready yet, retrying in %s\n", isvcName, pollInterval)
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for InferenceService %q to become ready: %w", isvcName, ctx.Err())
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
 // rolloutRestartDeployment triggers a rollout restart for the named deployment by
 // patching the pod template annotation "kubectl.kubernetes.io/restartedAt", which is
 // the same mechanism used by `kubectl rollout restart deployment <name>`.
 func (kc *OpenshiftClient) rolloutRestartDeployment(ctx context.Context, name string) error {
-	patch := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"template": map[string]interface{}{
-				"metadata": map[string]interface{}{
+	patch := map[string]any{
+		"spec": map[string]any{
+			"template": map[string]any{
+				"metadata": map[string]any{
 					"annotations": map[string]string{
 						"kubectl.kubernetes.io/restartedAt": time.Now().UTC().Format(time.RFC3339),
 					},


### PR DESCRIPTION
## Problem
On OpenShift, component deployment was completing before the KServe predictor pods were actually running.
This caused Phase 1 (deployComponentsConcurrently) to return immediately with predictors still in Init:0/1, Phase 2 services to deploy against unavailable backends, and the sync service to subsequently mark the application as Error because the LLM/embedding/reranker components weren't actually ready.

A deployment should not be considered ready if its underlying workloads aren't running, but Helm has no awareness of the secondary Deployment that KServe asynchronously creates from an InferenceService.

## Solution
After helmInstallOrUpgrade returns for each component, explicitly poll the InferenceService object `.status.conditions[type=Ready].status` until it is "True" before returning from deployComponent.