### PR TITLE
AISERVICES-1573: Adding service base lite image support

### DIFF
--- a/.github/workflows/service-base-lite.yml
+++ b/.github/workflows/service-base-lite.yml
@@ -1,0 +1,33 @@
+name: Service Base Lite
+on:
+  push:
+    paths:
+      - 'images/service-base-lite/**'
+    branches:
+      - main
+      - 'release-*'
+  pull_request:
+    paths:
+      - 'images/service-base-lite/**'
+      - .github/workflows/service-base-lite.yml
+    branches:
+      - main
+      - 'release-*'
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build-publish-image:
+    name: Build and Publish Image
+    uses: ./.github/workflows/build-and-publish-image.yml
+    with:
+      working-directory: 'images/service-base-lite'
+    secrets: inherit
+
+  scan:
+    uses: ./.github/workflows/scanner.yml
+    with:
+      path: 'images/service-base-lite'
+      image: 'service-base-lite'

--- a/images/service-base-lite/Containerfile
+++ b/images/service-base-lite/Containerfile
@@ -6,13 +6,14 @@ RUN microdnf install -y python3.12-devel && \
     rm -f /tmp/epel-release.rpm && \
     microdnf clean all && \
     curl -sSL https://bootstrap.pypa.io/get-pip.py | python3.12 - && \
+    pip install --upgrade pip setuptools wheel msgpack && \
     rm -rf /usr/bin/python && rm -rf /usr/bin/python3 && \
     ln -s /usr/bin/python3.12 /usr/bin/python && ln -s /usr/bin/python3.12 /usr/bin/python3
 
 COPY requirements.txt .
 
 RUN python -m venv /var/venv && source /var/venv/bin/activate && \
-    pip install --upgrade pip setuptools wheel && \
+    pip install --upgrade pip setuptools wheel msgpack && \
     pip install -r requirements.txt \
         --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux \
         --prefer-binary && \

--- a/images/service-base-lite/Containerfile
+++ b/images/service-base-lite/Containerfile
@@ -1,0 +1,29 @@
+FROM localhost/prebuilder as prebuilder
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8
+
+RUN microdnf install -y python3.12-devel \
+        lcms2-devel openblas-devel freetype libicu libjpeg-turbo && \
+    curl -o /tmp/epel-release.rpm https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+    rpm -ivh /tmp/epel-release.rpm && \
+    rm -f /tmp/epel-release.rpm && \
+    microdnf install -y spatialindex-devel && \
+    microdnf clean all && \
+    curl -sSL https://bootstrap.pypa.io/get-pip.py | python3.12 - && \
+    rm -rf /usr/bin/python && rm -rf /usr/bin/python3 && \
+    ln -s /usr/bin/python3.12 /usr/bin/python && ln -s /usr/bin/python3.12 /usr/bin/python3
+
+ENV DOCLING_MODELS_PATH=/var/docling-models
+
+COPY requirements.txt .
+COPY download_docling_models.py .
+
+RUN --mount=type=bind,from=prebuilder,source=/wheels,target=/wheels,ro \
+    python -m venv /var/venv && source /var/venv/bin/activate && \
+    pip install --upgrade pip && \
+    pip install /wheels/*.whl -r requirements.txt \
+        --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux \
+        --prefer-binary && \
+    pip cache purge && \
+    python download_docling_models.py && \
+    rm -rf ~/.cache/huggingface

--- a/images/service-base-lite/Containerfile
+++ b/images/service-base-lite/Containerfile
@@ -12,7 +12,7 @@ RUN microdnf install -y python3.12-devel && \
 COPY requirements.txt .
 
 RUN python -m venv /var/venv && source /var/venv/bin/activate && \
-    pip install --upgrade pip && \
+    pip install --upgrade pip setuptools wheel && \
     pip install -r requirements.txt \
         --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux \
         --prefer-binary && \

--- a/images/service-base-lite/Containerfile
+++ b/images/service-base-lite/Containerfile
@@ -1,29 +1,19 @@
-FROM localhost/prebuilder as prebuilder
-
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8
 
-RUN microdnf install -y python3.12-devel \
-        lcms2-devel openblas-devel freetype libicu libjpeg-turbo && \
+RUN microdnf install -y python3.12-devel && \
     curl -o /tmp/epel-release.rpm https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
     rpm -ivh /tmp/epel-release.rpm && \
     rm -f /tmp/epel-release.rpm && \
-    microdnf install -y spatialindex-devel && \
     microdnf clean all && \
     curl -sSL https://bootstrap.pypa.io/get-pip.py | python3.12 - && \
     rm -rf /usr/bin/python && rm -rf /usr/bin/python3 && \
     ln -s /usr/bin/python3.12 /usr/bin/python && ln -s /usr/bin/python3.12 /usr/bin/python3
 
-ENV DOCLING_MODELS_PATH=/var/docling-models
-
 COPY requirements.txt .
-COPY download_docling_models.py .
 
-RUN --mount=type=bind,from=prebuilder,source=/wheels,target=/wheels,ro \
-    python -m venv /var/venv && source /var/venv/bin/activate && \
+RUN python -m venv /var/venv && source /var/venv/bin/activate && \
     pip install --upgrade pip && \
-    pip install /wheels/*.whl -r requirements.txt \
+    pip install -r requirements.txt \
         --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux \
         --prefer-binary && \
-    pip cache purge && \
-    python download_docling_models.py && \
-    rm -rf ~/.cache/huggingface
+    pip cache purge

--- a/images/service-base-lite/Containerfile
+++ b/images/service-base-lite/Containerfile
@@ -6,14 +6,13 @@ RUN microdnf install -y python3.12-devel && \
     rm -f /tmp/epel-release.rpm && \
     microdnf clean all && \
     curl -sSL https://bootstrap.pypa.io/get-pip.py | python3.12 - && \
-    pip install --upgrade pip setuptools wheel msgpack && \
     rm -rf /usr/bin/python && rm -rf /usr/bin/python3 && \
     ln -s /usr/bin/python3.12 /usr/bin/python && ln -s /usr/bin/python3.12 /usr/bin/python3
 
 COPY requirements.txt .
 
 RUN python -m venv /var/venv && source /var/venv/bin/activate && \
-    pip install --upgrade pip setuptools wheel msgpack && \
+    pip install --upgrade pip setuptools wheel && \
     pip install -r requirements.txt \
         --extra-index-url https://wheels.developerfirst.ibm.com/ppc64le/linux \
         --prefer-binary && \

--- a/images/service-base-lite/Makefile
+++ b/images/service-base-lite/Makefile
@@ -1,0 +1,18 @@
+REGISTRY?=icr.io/ai-services-private
+IMAGE=service-base-lite
+TAG?=v0.0.1
+CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
+
+CONTAINER_BUILDER?=podman
+build:
+	cd prebuilder && $(CONTAINER_BUILDER) build -t prebuilder . && cd -
+	$(CONTAINER_BUILDER) build -t $(REGISTRY)/$(IMAGE):$(TAG) .
+.PHONY: build
+
+push:
+	$(CONTAINER_BUILDER) push $(CREDS_ARG) $(REGISTRY)/$(IMAGE):$(TAG)
+.PHONY: push
+
+image-tag:
+	@echo $(TAG)
+.PHONY: image-tag

--- a/images/service-base-lite/Makefile
+++ b/images/service-base-lite/Makefile
@@ -5,7 +5,6 @@ CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGIST
 
 CONTAINER_BUILDER?=podman
 build:
-	cd prebuilder && $(CONTAINER_BUILDER) build -t prebuilder . && cd -
 	$(CONTAINER_BUILDER) build -t $(REGISTRY)/$(IMAGE):$(TAG) .
 .PHONY: build
 

--- a/images/service-base-lite/requirements.txt
+++ b/images/service-base-lite/requirements.txt
@@ -1,0 +1,17 @@
+fastapi==0.135.3
+httpx==0.28.1
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
+lingua-language-detector==2.2.0
+psycopg2==2.9.11
+pydantic==2.13.4
+pydantic-settings==2.14.2
+pypdfium2==5.9.0
+python-dotenv==1.2.2
+python-multipart==0.0.32
+requests==2.34.2
+sentence-splitter==1.4
+SQLAlchemy==2.0.49
+starlette==1.3.1
+uvicorn==0.44.0
+uvloop==0.22.1


### PR DESCRIPTION
Introduce `service-base-lite` a lightweight base image for services that do not require `Docling`.

The existing `service-base` image bundles Docling packages and its associated models, making it unnecessarily heavy for services that never use document parsing. This PR introduces a new `service-base-lite` base image as a leaner alternative.

All direct third-party dependencies were audited across the following services by scanning every Python source file for external imports:
- chatbot
- summarize
- extract
- translate
- similarity

The identified packages have been pinned and added to `images/service-base-lite/requirements.txt`, keeping the dependency footprint minimal (17 packages vs 144 in service-base). Services that do not rely on Docling can now use this lighter base image, reducing build times and image size