### PR TITLE
Implement httpproxy worker grpc command

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.276
+TAG?=v0.0.277
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.276
+  image: icr.io/ai-services-cicd/ai-services:v0.0.277
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.276
+  image: icr.io/ai-services-cicd/ai-services:v0.0.277
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/internal/pkg/runtime/interface.go
+++ b/ai-services/internal/pkg/runtime/interface.go
@@ -59,6 +59,14 @@ type Runtime interface {
 	// System information
 	GetSystemInfo(ctx context.Context) (*models.SystemInfo, error)
 
+	// HTTPProxy tunnels an HTTP request through the gRPC stream to a worker
+	// pod endpoint and returns the response.
+	// method is the HTTP verb (GET, POST, …), targetURL is the full URL of the
+	// pod endpoint on the worker, headers are optional extra request headers,
+	// and body is the request body (may be nil). Returns the HTTP status code,
+	// response headers, and body.
+	HTTPProxy(ctx context.Context, method, targetURL string, headers map[string]string, body []byte) (*types.HTTPProxyResponse, error)
+
 	// Runtime type identification
 	Type() types.RuntimeType
 }

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -877,3 +877,9 @@ func (kc *OpenshiftClient) DeleteNamespace(ctx context.Context, name string) err
 
 	return nil
 }
+
+// HTTPProxy is not implemented on OpenShift — the control plane manages
+// OpenShift pods directly via the Kubernetes API without needing a tunnel.
+func (kc *OpenshiftClient) HTTPProxy(_ context.Context, _, _ string, _ map[string]string, _ []byte) (*types.HTTPProxyResponse, error) {
+	return nil, fmt.Errorf("HTTPProxy not implemented on OpenShift runtime")
+}

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -1,10 +1,14 @@
 package podman
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -868,4 +872,132 @@ func (pc *PodmanClient) ExecInContainerWithCmd(_ context.Context, _, _ string, _
 	logger.Errorf("unsupported method called!")
 
 	return "", fmt.Errorf("unsupported method")
+}
+
+// ─── HTTP proxy tunnel ────────────────────────────────────────────────────────
+
+// HTTPProxy makes an HTTP request to targetURL from the worker node and returns
+// the response to the control plane. The request executes against a local pod
+// endpoint so the control plane can reach pods that are not externally routed.
+//
+// The targetURL hostname may be a Podman pod name (e.g. "my-app--chat-bot").
+// Pod name DNS resolution only works inside Podman-networked containers, not
+// from the host OS. So if the hostname is not already an IP address we
+// resolve it to the pod's infra-container IP before making the request.
+func (pc *PodmanClient) HTTPProxy(ctx context.Context, method, targetURL string, headers map[string]string, body []byte) (*types.HTTPProxyResponse, error) {
+	resolvedURL, err := pc.resolvePodNameInURL(targetURL)
+	if err != nil {
+		return nil, fmt.Errorf("HTTPProxy: resolve pod IP: %w", err)
+	}
+
+	var reqBody io.Reader
+	if len(body) > 0 {
+		reqBody = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, resolvedURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("HTTPProxy: build request: %w", err)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTPProxy: execute request: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			logger.Warningf("HTTPProxy: close response body: %v", closeErr)
+		}
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("HTTPProxy: read response body: %w", err)
+	}
+
+	respHeaders := make(map[string]string, len(resp.Header))
+	for k := range resp.Header {
+		respHeaders[k] = resp.Header.Get(k)
+	}
+
+	return &types.HTTPProxyResponse{
+		StatusCode: resp.StatusCode,
+		Headers:    respHeaders,
+		Body:       respBody,
+	}, nil
+}
+
+// resolvePodNameInURL rewrites the hostname in rawURL from a Podman pod name
+// to the pod's IP address. Pod name DNS is only available inside Podman
+// network namespaces; the host OS resolver cannot use it.
+//
+// If the hostname is already an IP address (or localhost) it is returned
+// unchanged.
+func (pc *PodmanClient) resolvePodNameInURL(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse URL %q: %w", rawURL, err)
+	}
+
+	host := u.Hostname() // strips port if present
+
+	// Already an IP or localhost — nothing to do.
+	if host == "localhost" || net.ParseIP(host) != nil {
+		return rawURL, nil
+	}
+
+	// Treat the hostname as a pod name and resolve it to the pod's IP.
+	podIP, err := pc.podNameToIP(host)
+	if err != nil {
+		return "", fmt.Errorf("resolve pod %q to IP: %w", host, err)
+	}
+
+	// Rebuild the URL with the IP in place of the pod name.
+	if port := u.Port(); port != "" {
+		u.Host = net.JoinHostPort(podIP, port)
+	} else {
+		u.Host = podIP
+	}
+
+	return u.String(), nil
+}
+
+// podNameToIP inspects the named pod and returns its infra-container IP address.
+func (pc *PodmanClient) podNameToIP(podName string) (string, error) {
+	podReport, err := pods.Inspect(pc.Context, podName, nil)
+	if err != nil {
+		return "", fmt.Errorf("inspect pod %q: %w", podName, err)
+	}
+
+	infraID := podReport.InfraContainerID
+	if infraID == "" {
+		return "", fmt.Errorf("pod %q has no infra container", podName)
+	}
+
+	ctr, err := containers.Inspect(pc.Context, infraID, nil)
+	if err != nil {
+		return "", fmt.Errorf("inspect infra container of pod %q: %w", podName, err)
+	}
+
+	if ctr.NetworkSettings == nil {
+		return "", fmt.Errorf("pod %q infra container has no network settings", podName)
+	}
+
+	ip := ctr.NetworkSettings.IPAddress
+	if ip == "" {
+		// Fall back to the first network if the top-level IPAddress is empty
+		// (common in rootless Podman with named networks).
+		for _, n := range ctr.NetworkSettings.Networks {
+			if n.IPAddress != "" {
+				return n.IPAddress, nil
+			}
+		}
+
+		return "", fmt.Errorf("pod %q: no IP address found in network settings", podName)
+	}
+
+	return ip, nil
 }

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -1,19 +1,19 @@
 package podman
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
 	"strings"
 	"syscall"
+
+	"github.com/go-resty/resty/v2"
 
 	"github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/pkg/bindings"
@@ -877,65 +877,50 @@ func (pc *PodmanClient) ExecInContainerWithCmd(_ context.Context, _, _ string, _
 // ─── HTTP proxy tunnel ────────────────────────────────────────────────────────
 
 // HTTPProxy makes an HTTP request to targetURL from the worker node and returns
-// the response to the control plane. The request executes against a local pod
-// endpoint so the control plane can reach pods that are not externally routed.
+// the response to the control plane. The targetURL hostname may be a Podman
+// pod name — it is resolved to the pod's infra-container IP via the Podman
+// socket before the request is made.
 //
-// The targetURL hostname may be a Podman pod name (e.g. "my-app--chat-bot").
-// Pod name DNS resolution only works inside Podman-networked containers, not
-// from the host OS. So if the hostname is not already an IP address we
-// resolve it to the pod's infra-container IP before making the request.
+// TODO: pod IP resolution works for rootful Podman where the pod network bridge
+// is visible on the host. For rootless Podman the resolved IP lives inside a
+// private network namespace and is unreachable from the host process; use a
+// Caddy-proxied URL or a hostPort mapping in that case.
 func (pc *PodmanClient) HTTPProxy(ctx context.Context, method, targetURL string, headers map[string]string, body []byte) (*types.HTTPProxyResponse, error) {
 	resolvedURL, err := pc.resolvePodNameInURL(targetURL)
 	if err != nil {
 		return nil, fmt.Errorf("HTTPProxy: resolve pod IP: %w", err)
 	}
 
-	var reqBody io.Reader
-	if len(body) > 0 {
-		reqBody = bytes.NewReader(body)
-	}
+	client := resty.New()
 
-	req, err := http.NewRequestWithContext(ctx, method, resolvedURL, reqBody)
-	if err != nil {
-		return nil, fmt.Errorf("HTTPProxy: build request: %w", err)
-	}
+	req := client.R().SetContext(ctx)
 	for k, v := range headers {
-		req.Header.Set(k, v)
+		req.SetHeader(k, v)
+	}
+	if len(body) > 0 {
+		req.SetBody(body)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := req.Execute(method, resolvedURL)
 	if err != nil {
 		return nil, fmt.Errorf("HTTPProxy: execute request: %w", err)
 	}
-	defer func() {
-		if closeErr := resp.Body.Close(); closeErr != nil {
-			logger.Warningf("HTTPProxy: close response body: %v", closeErr)
-		}
-	}()
 
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("HTTPProxy: read response body: %w", err)
-	}
-
-	respHeaders := make(map[string]string, len(resp.Header))
-	for k := range resp.Header {
-		respHeaders[k] = resp.Header.Get(k)
+	respHeaders := make(map[string]string, len(resp.Header()))
+	for k := range resp.Header() {
+		respHeaders[k] = resp.Header().Get(k)
 	}
 
 	return &types.HTTPProxyResponse{
-		StatusCode: resp.StatusCode,
+		StatusCode: resp.StatusCode(),
 		Headers:    respHeaders,
-		Body:       respBody,
+		Body:       resp.Body(),
 	}, nil
 }
 
 // resolvePodNameInURL rewrites the hostname in rawURL from a Podman pod name
-// to the pod's IP address. Pod name DNS is only available inside Podman
-// network namespaces; the host OS resolver cannot use it.
-//
-// If the hostname is already an IP address (or localhost) it is returned
-// unchanged.
+// to the pod's infra-container IP address. If the hostname is already an IP
+// or localhost it is returned unchanged.
 func (pc *PodmanClient) resolvePodNameInURL(rawURL string) (string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {

--- a/ai-services/internal/pkg/runtime/remote/runtime.go
+++ b/ai-services/internal/pkg/runtime/remote/runtime.go
@@ -296,6 +296,31 @@ func (r *RemoteRuntime) ExecInContainerWithCmd(ctx context.Context, podName, con
 	return output, nil
 }
 
+// ─── HTTP proxy tunnel ────────────────────────────────────────────────────────
+
+// HTTPProxy tunnels an HTTP request to the worker via the gRPC stream.
+// The worker executes the request locally (inside the Podman network) and
+// returns the status, headers, and body as a single CommandResult.
+func (r *RemoteRuntime) HTTPProxy(ctx context.Context, method, targetURL string, headers map[string]string, body []byte) (*types.HTTPProxyResponse, error) {
+	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_HTTP_PROXY,
+		payload.HTTPProxy{
+			Method:    method,
+			TargetURL: targetURL,
+			Headers:   headers,
+			Body:      body,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	var result types.HTTPProxyResponse
+	if err := unmarshalData(res, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
 // ─── Network operations ───────────────────────────────────────────────────────
 
 func (r *RemoteRuntime) ListRoutes(ctx context.Context, labelSelector string) ([]types.Route, error) {

--- a/ai-services/internal/pkg/runtime/types/types.go
+++ b/ai-services/internal/pkg/runtime/types/types.go
@@ -72,3 +72,11 @@ type CRDResource struct {
 	Name   string
 	Labels map[string]string
 }
+
+// HTTPProxyResponse carries the result of an HTTP request executed on the
+// worker node and returned to the control plane via the gRPC stream.
+type HTTPProxyResponse struct {
+	StatusCode int
+	Headers    map[string]string
+	Body       []byte
+}

--- a/ai-services/internal/pkg/worker/dispatch/dispatch.go
+++ b/ai-services/internal/pkg/worker/dispatch/dispatch.go
@@ -219,6 +219,20 @@ func handle(ctx context.Context, rt runtime.Runtime, cmd *workerpb.Command) ([]b
 
 		return marshalOr(out, err)
 
+	// ── HTTP proxy tunnel ──────────────────────────────────────────────────────
+
+	case workerpb.CommandType_COMMAND_TYPE_HTTP_PROXY:
+		var req payload.HTTPProxy
+		if err := json.Unmarshal(p, &req); err != nil {
+			return nil, fmt.Errorf("decode http_proxy payload: %w", err)
+		}
+		result, err := rt.HTTPProxy(ctx, req.Method, req.TargetURL, req.Headers, req.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		return marshalOr(*result, nil)
+
 	// ── Network ───────────────────────────────────────────────────────────────
 
 	case workerpb.CommandType_COMMAND_TYPE_LIST_ROUTES:

--- a/ai-services/internal/pkg/worker/payload/payload.go
+++ b/ai-services/internal/pkg/worker/payload/payload.go
@@ -62,3 +62,15 @@ type ExecInContainer struct {
 type ListRoutes struct {
 	LabelSelector string `json:"labelSelector"`
 }
+
+// ─── HTTP proxy ───────────────────────────────────────────────────────────────
+
+// HTTPProxy is the request payload for COMMAND_TYPE_HTTP_PROXY.
+// The control plane sends this; the worker executes the HTTP request locally
+// against a pod endpoint and returns a runtimetypes.HTTPProxyResponse.
+type HTTPProxy struct {
+	Method    string            `json:"method"`
+	TargetURL string            `json:"target_url"`
+	Headers   map[string]string `json:"headers,omitempty"`
+	Body      []byte            `json:"body,omitempty"`
+}


### PR DESCRIPTION
`HTTPProxy` command implementation.
This is just for forwarding HTTP requests to the worker node and returning the response.