### PR TITLE
Fix the issue with order for datasource params (raw data approach)

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.275
+TAG?=v0.0.276
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.275
+  image: icr.io/ai-services-cicd/ai-services:v0.0.276
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.275
+  image: icr.io/ai-services-cicd/ai-services:v0.0.276
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
@@ -281,7 +281,7 @@ func (h *CatalogHandler) GetConnectorProviderParams(c *gin.Context) {
 	connectorType := c.Param("connector_type")
 	providerID := c.Param("provider_id")
 
-	schema, err := h.provider.GetConnectorProviderParams(c.Request.Context(), connectorType, providerID)
+	raw, err := h.provider.GetConnectorProviderParams(c.Request.Context(), connectorType, providerID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, ErrorResponse{
 			Error: fmt.Sprintf("Failed to get parameters for provider '%s/%s': %v", connectorType, providerID, err),
@@ -290,7 +290,8 @@ func (h *CatalogHandler) GetConnectorProviderParams(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, schema)
+	// Write the raw JSON bytes directly so the property order defined in schema.json is preserved.
+	c.Data(http.StatusOK, "application/json; charset=utf-8", raw)
 }
 
 // GetServiceParams godoc

--- a/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service/datasource_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service/datasource_service.go
@@ -12,6 +12,7 @@ import (
 	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/validators"
+	pkgutils "github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 const (
@@ -107,7 +108,7 @@ func (s *DatasourceService) CreateDatasource(ctx context.Context, req apimodels.
 		return nil, fmt.Errorf("failed to load schema for provider %q: %w", req.ProviderID, err)
 	}
 
-	schema, err := catalog.ConnectorSchemaToMap(rawSchema)
+	schema, err := pkgutils.ConvertRawJsontoMap(rawSchema)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode schema for provider %q: %w", req.ProviderID, err)
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service/datasource_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service/datasource_service.go
@@ -102,9 +102,14 @@ func (s *DatasourceService) CreateDatasource(ctx context.Context, req apimodels.
 	}
 
 	// Phase 4: derive sensitive fields from the provider's schema.json and encrypt.
-	schema, err := s.catalogProvider.GetConnectorProviderParams(ctx, catalogconstants.ConnectorTypeDatasource, req.ProviderID)
+	rawSchema, err := s.catalogProvider.GetConnectorProviderParams(ctx, catalogconstants.ConnectorTypeDatasource, req.ProviderID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load schema for provider %q: %w", req.ProviderID, err)
+	}
+
+	schema, err := catalog.ConnectorSchemaToMap(rawSchema)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode schema for provider %q: %w", req.ProviderID, err)
 	}
 
 	encryptedParams, err := encryptSensitiveFields(req.Params, sensitiveFieldsFromSchema(schema), s.encryptionKey)

--- a/ai-services/internal/pkg/catalog/deploy_options.go
+++ b/ai-services/internal/pkg/catalog/deploy_options.go
@@ -326,9 +326,10 @@ func (p *CatalogProvider) GetComponentProviderParams(ctx context.Context, compon
 	return schema, nil
 }
 
-// GetConnectorProviderParams returns the JSON schema for a specific connector provider's configuration.
-// If the schema file is not present, returns an empty schema instead of failing.
-func (p *CatalogProvider) GetConnectorProviderParams(ctx context.Context, connectorType, providerID string) (map[string]any, error) {
+// GetConnectorProviderParams returns the raw JSON schema bytes for a specific connector
+// provider's configuration, preserving the property order defined in schema.json.
+// If the schema file is not present, returns an empty JSON object instead of failing.
+func (p *CatalogProvider) GetConnectorProviderParams(ctx context.Context, connectorType, providerID string) (json.RawMessage, error) {
 	_, err := p.LoadConnector(connectorType, providerID)
 	if err != nil {
 		return nil, fmt.Errorf("connector provider not found: %w", err)
@@ -348,10 +349,10 @@ func (p *CatalogProvider) GetConnectorProviderParams(ctx context.Context, connec
 	schemaPath := filepath.Join(connectorPath, "schema.json")
 	schemaFile, err := itemFS.Open(schemaPath)
 	if err != nil {
-		// Schema file is optional — return an empty schema rather than failing.
+		// Schema file is optional — return an empty JSON object rather than failing.
 		logger.WarningfCtx(ctx, "schema file not found at '%s': %v", schemaPath, err)
 
-		return map[string]any{}, nil
+		return json.RawMessage("{}"), nil
 	}
 	defer func() {
 		if closeErr := schemaFile.Close(); closeErr != nil {
@@ -359,9 +360,20 @@ func (p *CatalogProvider) GetConnectorProviderParams(ctx context.Context, connec
 		}
 	}()
 
-	var schema map[string]any
-	if err := json.NewDecoder(schemaFile).Decode(&schema); err != nil {
+	var raw json.RawMessage
+	if err := json.NewDecoder(schemaFile).Decode(&raw); err != nil {
 		return nil, fmt.Errorf("failed to parse schema: %w", err)
+	}
+
+	return raw, nil
+}
+
+// ConnectorSchemaToMap unmarshals a raw connector schema into a map[string]any for
+// internal callers that need to inspect individual properties (validation, encryption).
+func ConnectorSchemaToMap(raw json.RawMessage) (map[string]any, error) {
+	var schema map[string]any
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return nil, fmt.Errorf("failed to decode connector schema: %w", err)
 	}
 
 	return schema, nil

--- a/ai-services/internal/pkg/catalog/deploy_options.go
+++ b/ai-services/internal/pkg/catalog/deploy_options.go
@@ -368,17 +368,6 @@ func (p *CatalogProvider) GetConnectorProviderParams(ctx context.Context, connec
 	return raw, nil
 }
 
-// ConnectorSchemaToMap unmarshals a raw connector schema into a map[string]any for
-// internal callers that need to inspect individual properties (validation, encryption).
-func ConnectorSchemaToMap(raw json.RawMessage) (map[string]any, error) {
-	var schema map[string]any
-	if err := json.Unmarshal(raw, &schema); err != nil {
-		return nil, fmt.Errorf("failed to decode connector schema: %w", err)
-	}
-
-	return schema, nil
-}
-
 // GetServiceParams returns the JSON schema for a specific service's configuration.
 // If the schema file is not present, returns an empty schema instead of failing.
 func (p *CatalogProvider) GetServiceParams(ctx context.Context, serviceID string) (map[string]any, error) {

--- a/ai-services/internal/pkg/catalog/validators/validation.go
+++ b/ai-services/internal/pkg/catalog/validators/validation.go
@@ -471,9 +471,14 @@ func (v *ConnectorValidator) ValidateCreateDatasourceRequest(ctx context.Context
 		}
 	}
 
-	schema, err := v.provider.GetConnectorProviderParams(ctx, catalogconstants.ConnectorTypeDatasource, req.ProviderID)
+	rawSchema, err := v.provider.GetConnectorProviderParams(ctx, catalogconstants.ConnectorTypeDatasource, req.ProviderID)
 	if err != nil {
 		return fmt.Errorf("failed to load param schema for provider %q: %w", req.ProviderID, err)
+	}
+
+	schema, err := catalog.ConnectorSchemaToMap(rawSchema)
+	if err != nil {
+		return fmt.Errorf("failed to decode param schema for provider %q: %w", req.ProviderID, err)
 	}
 
 	if len(schema) == 0 {

--- a/ai-services/internal/pkg/catalog/validators/validation.go
+++ b/ai-services/internal/pkg/catalog/validators/validation.go
@@ -13,6 +13,7 @@ import (
 	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
+	pkgutils "github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 // ValidationError represents a validation error with HTTP status code.
@@ -476,7 +477,7 @@ func (v *ConnectorValidator) ValidateCreateDatasourceRequest(ctx context.Context
 		return fmt.Errorf("failed to load param schema for provider %q: %w", req.ProviderID, err)
 	}
 
-	schema, err := catalog.ConnectorSchemaToMap(rawSchema)
+	schema, err := pkgutils.ConvertRawJsontoMap(rawSchema)
 	if err != nil {
 		return fmt.Errorf("failed to decode param schema for provider %q: %w", req.ProviderID, err)
 	}

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -754,3 +754,13 @@ func DirStats(dir string) (totalBytes int64, fileCount int) {
 
 	return totalBytes, fileCount
 }
+
+// ConvertRawJsontoMap unmarshals a raw JSON message into a map[string]any.
+func ConvertRawJsontoMap(raw json.RawMessage) (map[string]any, error) {
+	var result map[string]any
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("failed to decode JSON: %w", err)
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
UI needs the params in a fixed order. Currently for json it was getting sorted alphabetically even if the file order was fixed, hence it needed the raw data to be sent.
