### PR TITLE
Add summarization ft

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.290
+TAG?=v0.0.291
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.290
+  image: icr.io/ai-services-cicd/ai-services:v0.0.291
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.290
+  image: icr.io/ai-services-cicd/ai-services:v0.0.291
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/tests/e2e/README.md
+++ b/ai-services/tests/e2e/README.md
@@ -120,7 +120,7 @@ Use Ginkgo label filters to run only the part of the suite you need.
 | `golden-dataset-validation` | RAG golden dataset validation against an existing application |
 | `digitization-tests` | Digitization API coverage against an existing or suite-created application |
 | `similarity-tests` | Similarity API health and `/v1/similarity-search` behavior |
-| `summarization-tests` | Asynchronous and synchronous summarization API coverage (requires `--template=summarize`) |
+| `summarization-tests` | Asynchronous and synchronous summarization API coverage, including input-validation failure paths and connectivity failure (requires `--template=summarize`) |
 | `app-backup-restore` | Application backup and restore validation for OpenSearch and digitize data |
 | `failure-test` | **Umbrella label** — all negative-path tests across bootstrap, catalog, and similarity. **Skipped by default** unless `--run-failure-tests` is passed; use `--label-filter="failure-test"` to further narrow once unlocked |
 | `bootstrap-failure` | Bootstrap domain failure tests only (`bootstrap_failure_test.go`) — requires `--run-failure-tests` |
@@ -742,5 +742,7 @@ ai-services/tests/e2e/
    │   └─ setup.go
    ├─ similarity/                    # similarity API request/response helpers
    │   └─ similarity.go
+   ├─ summarization/                 # summarization API request/response helpers
+   │   └─ summarize.go
    └─ <other_test_files>             # add your `_test.go` files here (package `e2e`)
 ```

--- a/ai-services/tests/e2e/e2e_suite_test.go
+++ b/ai-services/tests/e2e/e2e_suite_test.go
@@ -2629,7 +2629,7 @@ var _ = ginkgo.Describe("AI Services End-to-End Tests", ginkgo.Ordered, func() {
 			logger.Infof("[TEST] ✓ binary TXT rejected (status=%d, msg=%s)", statusCode, errResp.Error.Message)
 		})
 
-		// ── TC-2: Invalid level via JSON body ─────────────────────────────────
+		// ──  Invalid level via JSON body ─────────────────────────────────
 		//
 		// Rationale: The existing test "returns 400 for invalid level parameter
 		// via multipart form" only covers the multipart/form-data code path.
@@ -2653,7 +2653,7 @@ var _ = ginkgo.Describe("AI Services End-to-End Tests", ginkgo.Ordered, func() {
 			logger.Infof("[TEST] ✓ invalid level via JSON body rejected (status=%d, msg=%s)", statusCode, errResp.Error.Message)
 		})
 
-		// ── TC-3: Both level and length supplied ──────────────────────────────
+		// ──  Both level and length supplied ──────────────────────────────
 		//
 		// Rationale: "level" (abstraction-based) and "length" (legacy word-count)
 		// are mutually exclusive.  Providing both in the same JSON body is
@@ -2677,7 +2677,7 @@ var _ = ginkgo.Describe("AI Services End-to-End Tests", ginkgo.Ordered, func() {
 			logger.Infof("[TEST] ✓ level+length conflict rejected (status=%d)", statusCode)
 		})
 
-		// ── TC-5: Connectivity failure — unreachable summarize API ────────────
+		// ──  Connectivity failure — unreachable summarize API ────────────
 		//
 		// Rationale: When the summarization service is completely absent (not
 		// deployed, wrong namespace, network partition) callers must receive an

--- a/ai-services/tests/e2e/e2e_suite_test.go
+++ b/ai-services/tests/e2e/e2e_suite_test.go
@@ -240,6 +240,12 @@ func catalogLoginWithDiscovery(loginCtx context.Context, fatal bool) {
 const (
 	invalidJobID = "invalid-job-id-123"
 	invalidDocID = "invalid-doc-id-123"
+
+	// unreachableSummarizeURL points to a host that will never accept TCP
+	// connections, used in the connectivity failure test to exercise
+	// transport-level error handling.  The .invalid TLD is guaranteed by
+	// RFC 2606 to never resolve in DNS.
+	unreachableSummarizeURL = "http://summarize.invalid.ais-failure-test.example.com:9999"
 )
 
 // jobStartDelay lets the service begin processing before asserting in-progress state.
@@ -2621,6 +2627,82 @@ var _ = ginkgo.Describe("AI Services End-to-End Tests", ginkgo.Ordered, func() {
 			gomega.Expect(statusCode).To(gomega.Equal(http.StatusUnsupportedMediaType))
 			gomega.Expect(errResp.Error.Code).To(gomega.Equal(415))
 			logger.Infof("[TEST] ✓ binary TXT rejected (status=%d, msg=%s)", statusCode, errResp.Error.Message)
+		})
+
+		// ── TC-2: Invalid level via JSON body ─────────────────────────────────
+		//
+		// Rationale: The existing test "returns 400 for invalid level parameter
+		// via multipart form" only covers the multipart/form-data code path.
+		// The JSON body path through app.py → summ_utils.validate_summary_level()
+		// is a separate dispatch branch and must be tested independently.
+		//
+		// Expected: HTTP 400, errResp.Error.Code == 400.
+		ginkgo.It("returns 400 for invalid level value via JSON body", func() {
+			ctx, cancel := withTimeout(30 * time.Second)
+			defer cancel()
+
+			errResp, statusCode, err := summarization.SummarizeTextExpectingError(
+				ctx, syncSummarizeBaseURL,
+				"IBM Power Systems are designed for enterprise AI workloads.",
+				"ultra-brief",
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(errResp).NotTo(gomega.BeNil())
+			gomega.Expect(statusCode).To(gomega.Equal(http.StatusBadRequest))
+			gomega.Expect(errResp.Error.Code).To(gomega.Equal(400))
+			logger.Infof("[TEST] ✓ invalid level via JSON body rejected (status=%d, msg=%s)", statusCode, errResp.Error.Message)
+		})
+
+		// ── TC-3: Both level and length supplied ──────────────────────────────
+		//
+		// Rationale: "level" (abstraction-based) and "length" (legacy word-count)
+		// are mutually exclusive.  Providing both in the same JSON body is
+		// ambiguous and must be rejected before any LLM call is made.
+		// This code path (app.py: if summary_level is not None and
+		// summary_length is not None) has no existing test coverage.
+		//
+		// Expected: HTTP 400, response body contains "error".
+		ginkgo.It("returns 400 when both level and length are supplied in JSON body", func() {
+			ctx, cancel := withTimeout(30 * time.Second)
+			defer cancel()
+
+			rawBody, statusCode, err := summarization.SummarizeRawBody(
+				ctx, syncSummarizeBaseURL,
+				bytes.NewBufferString(`{"text":"IBM Power Systems are designed for enterprise AI workloads.","level":"brief","length":10}`),
+				"application/json",
+			)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(statusCode).To(gomega.Equal(http.StatusBadRequest))
+			gomega.Expect(string(rawBody)).To(gomega.ContainSubstring("error"))
+			logger.Infof("[TEST] ✓ level+length conflict rejected (status=%d)", statusCode)
+		})
+
+		// ── TC-5: Connectivity failure — unreachable summarize API ────────────
+		//
+		// Rationale: When the summarization service is completely absent (not
+		// deployed, wrong namespace, network partition) callers must receive an
+		// immediate transport-level error — not a hang or silent empty result.
+		// The context timeout (30 s) is shorter than the HTTP client default,
+		// guaranteeing DNS / TCP failure causes a rapid error rather than a hang.
+		// This is the only test that guards against a dead-endpoint condition.
+		//
+		// Expected: err is non-nil (transport-level failure).
+		ginkgo.It("returns a transport error when the summarize API is unreachable", func() {
+			ctx, cancel := withTimeout(30 * time.Second)
+			defer cancel()
+
+			logger.Infof("[TEST] Attempting request to unreachable summarize URL: %s", unreachableSummarizeURL)
+
+			_, _, transportErr := summarization.SummarizeRawBody(
+				ctx, unreachableSummarizeURL,
+				bytes.NewBufferString(`{"text":"what is IBM Power?"}`),
+				"application/json",
+			)
+			gomega.Expect(transportErr).To(
+				gomega.HaveOccurred(),
+				"Expected a transport error for an unreachable summarize API, but got nil",
+			)
+			logger.Infof("[TEST] ✓ transport error correctly received for unreachable URL: %v", transportErr)
 		})
 
 		// ── Concurrency ───────────────────────────────────────────────────────


### PR DESCRIPTION
Add three Summarization Failure testcases on top of the existing ones
1) Invalid level via JSON body
2) Both level and length supplied
3) Connectivity failure — unreachable summarize API

Test results were added in the Jira ticket, 
https://jsw.ibm.com/browse/AISERVICES-1442
