### PR TITLE
Add unit tests for translation service

### DIFF
--- a/.github/workflows/service-unit-tests.yml
+++ b/.github/workflows/service-unit-tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           # Set PYTHONPATH to include services directory for common module imports
           export PYTHONPATH="${PYTHONPATH}:$(pwd)"
-          pytest common/tests/ digitize/tests/ chatbot/tests/ summarize/tests/ similarity/tests/ extract/tests/ \
+          pytest common/tests/ digitize/tests/ chatbot/tests/ summarize/tests/ similarity/tests/ extract/tests/ translate/tests/ \
             --cov=. \
             --cov-report=html:htmlcov \
             --cov-report=term-missing \

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.314
+TAG?=v0.0.315
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -94,7 +94,7 @@ translate:
   # @description Host port for the Translate API. If unspecified, a random port is assigned.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/translate-service:v0.0.5
+  image: icr.io/ai-services-cicd/translate-service:v0.0.6
   # @hidden
   log_level: "INFO"
   # @description Database name for the TRANSLATE service.

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.314
+  image: icr.io/ai-services-cicd/ai-services:v0.0.315
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.314
+  image: icr.io/ai-services-cicd/ai-services:v0.0.315
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/services/translate/podman/values.yaml
+++ b/ai-services/assets/services/translate/podman/values.yaml
@@ -1,6 +1,6 @@
 translate:
   port: ""
-  image: icr.io/ai-services-cicd/translate-service:v0.0.5
+  image: icr.io/ai-services-cicd/translate-service:v0.0.6
   log_level: "INFO"
   database: "translate_metadata"
 

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.314
+  image: icr.io/ai-services-cicd/ai-services:v0.0.315
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -4,7 +4,7 @@ caddy:
   httpsPort: ""
 
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.314
+  image: icr.io/ai-services-cicd/ai-services:v0.0.315
   runtime: "podman"
   token: ""
   # optionalFlags covers basedir, sslCertPath, sslKeyPath, domainSuffix, and httpsPort flags that are forwarded from the

--- a/services/translate/Makefile
+++ b/services/translate/Makefile
@@ -1,5 +1,5 @@
 IMAGE=translate-service
-TAG?=v0.0.5
+TAG?=v0.0.6
 
 run:
 	PORT=$${PORT:-9000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/translate/api/v1/jobs.py
+++ b/services/translate/api/v1/jobs.py
@@ -334,6 +334,7 @@ async def get_job_result(job_id: str) -> Union[JobResultResponse, JSONResponse]:
 
 @router.get(
     "/{job_id}/result/download",
+    response_class=PlainTextResponse,
     response_description="Translated file stream with Content-Disposition attachment header.",
     summary="Download translated file",
     description=(
@@ -348,7 +349,7 @@ async def get_job_result(job_id: str) -> Union[JobResultResponse, JSONResponse]:
         500: http_error_responses[500],
     },
 )
-async def download_job_result(job_id: str) -> Union[PlainTextResponse, JSONResponse]:
+async def download_job_result(job_id: str):
     """Download the translated output file for a completed job."""
     job = db_manager.get_job_by_id(job_id)
     if job is None:

--- a/services/translate/tests/__init__.py
+++ b/services/translate/tests/__init__.py
@@ -1,0 +1,1 @@
+# Made with Bob

--- a/services/translate/tests/conftest.py
+++ b/services/translate/tests/conftest.py
@@ -1,0 +1,161 @@
+"""
+Pytest configuration and fixtures for translate service tests.
+
+Provides comprehensive mocking to ensure tests run without a real database,
+vLLM endpoint, or file-system dependency.
+"""
+
+import sys
+import types
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Patch the crash-handler BEFORE any app module is imported so that
+# StderrMonitor.start() never replaces pytest's captured stderr fd.
+# ---------------------------------------------------------------------------
+import common.diagnostic_logger as _diag_logger  # noqa: E402
+
+_diag_logger.setup_comprehensive_crash_handler = lambda logger: (
+    MagicMock(),
+    MagicMock(),
+    MagicMock(),
+)
+
+
+# ---------------------------------------------------------------------------
+# Auto-use fixtures: DB engine + session mocked for every test
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def mock_database_engine():
+    """Mock the SQLAlchemy engine to prevent real DB connections."""
+    mock_engine = Mock()
+    mock_engine.dispose = Mock()
+
+    with patch("translate.db.connection.engine", mock_engine):
+        yield mock_engine
+
+
+@pytest.fixture(autouse=True)
+def mock_db_session():
+    """Mock the DB session context-manager used by the DB manager."""
+    mock_session = MagicMock()
+    mock_session.commit = Mock()
+    mock_session.rollback = Mock()
+    mock_session.close = Mock()
+    mock_session.add = Mock()
+    mock_session.flush = Mock()
+    mock_session.scalar = Mock(return_value=None)
+    mock_session.scalars = Mock(return_value=Mock(all=Mock(return_value=[])))
+    mock_session.execute = Mock(return_value=Mock(rowcount=0))
+    mock_session.expunge = Mock()
+
+    with patch("translate.db.connection.get_db_session") as mock_get_session:
+        mock_get_session.return_value.__enter__ = Mock(return_value=mock_session)
+        mock_get_session.return_value.__exit__ = Mock(return_value=None)
+        yield mock_session
+
+
+# ---------------------------------------------------------------------------
+# DB Manager mock
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db_manager():
+    """Mock TranslateDatabaseManager singleton."""
+    mock_manager = Mock()
+
+    mock_manager.create_job = Mock(return_value=_make_db_job())
+    mock_manager.get_job_by_id = Mock(return_value=None)
+    mock_manager.get_all_jobs = Mock(return_value=([], 0))
+    mock_manager.update_job = Mock(return_value=True)
+    mock_manager.get_active_jobs = Mock(return_value=[])
+
+    with patch("translate.db.manager.db_manager", mock_manager), patch(
+        "translate.api.v1.jobs.db_manager", mock_manager
+    ), patch("translate.utils.recovery.db_manager", mock_manager), patch(
+        "translate.workers.translation_worker.db_manager", mock_manager
+    ):
+        yield mock_manager
+
+
+# ---------------------------------------------------------------------------
+# Concurrency manager mock
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def initialized_concurrency_manager():
+    """Return a ConcurrencyManager with semaphores initialized."""
+    import asyncio
+    from translate.workers.concurrency import ConcurrencyManager
+
+    mgr = ConcurrencyManager()
+    # Semaphores must be created inside a running loop.
+    # For sync tests we create them directly.
+    mgr._job_limiter = asyncio.BoundedSemaphore(8)
+    mgr._chunk_semaphore = asyncio.BoundedSemaphore(4)
+    mgr._vllm_semaphore = asyncio.BoundedSemaphore(32)
+    return mgr
+
+
+# ---------------------------------------------------------------------------
+# Sample data helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_db_job(
+    job_id: str = "test-job-123",
+    status: str = "accepted",
+    source_language: str = "german",
+    target_language: str = "english",
+    input_type: str = "txt",
+    document_name: str = "test.txt",
+    job_name: str = None,
+    error: str = None,
+    job_metadata: dict = None,
+) -> Mock:
+    """Build a mock TranslateJob ORM object."""
+    job = Mock()
+    job.job_id = job_id
+    job.job_name = job_name
+    job.status = status
+    job.source_language = source_language
+    job.target_language = target_language
+    job.input_type = input_type
+    job.document_name = document_name
+    job.submitted_at = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    job.completed_at = None
+    job.error = error
+    job.job_metadata = job_metadata or {}
+    job.updated_at = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    return job
+
+
+@pytest.fixture
+def sample_db_job():
+    return _make_db_job()
+
+
+@pytest.fixture
+def completed_db_job():
+    return _make_db_job(
+        status="completed",
+        job_metadata={"phase": "completed"},
+    )
+
+
+@pytest.fixture
+def failed_db_job():
+    return _make_db_job(
+        status="failed",
+        error="Something went wrong",
+        job_metadata={"phase": "failed"},
+    )
+
+# Made with Bob

--- a/services/translate/tests/unit/test_app_endpoints.py
+++ b/services/translate/tests/unit/test_app_endpoints.py
@@ -1,0 +1,682 @@
+"""
+Unit tests for translate app endpoints (FastAPI routes).
+
+Tests cover:
+ - GET /health
+ - GET /  (Swagger UI)
+ - Middleware: X-Request-ID injection
+ - POST /v1/translate    (sync)
+ - POST /v1/translate/jobs  (create job)
+ - GET  /v1/translate/jobs  (list)
+ - GET  /v1/translate/jobs/{id}  (detail)
+ - GET  /v1/translate/jobs/{id}/result
+ - GET  /v1/translate/jobs/{id}/result/download
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_db_job(
+    job_id: str = "job-123",
+    status: str = "completed",
+    source_language: str = "german",
+    target_language: str = "english",
+    input_type: str = "txt",
+    document_name: str = "doc.txt",
+    job_name: str = None,
+    error: str = None,
+    job_metadata: dict = None,
+) -> Mock:
+    job = Mock()
+    job.job_id = job_id
+    job.job_name = job_name
+    job.status = status
+    job.source_language = source_language
+    job.target_language = target_language
+    job.input_type = input_type
+    job.document_name = document_name
+    job.submitted_at = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    job.completed_at = datetime(2024, 1, 1, 1, 0, 0, tzinfo=timezone.utc)
+    job.error = error
+    job.job_metadata = job_metadata or {}
+    job.updated_at = datetime(2024, 1, 1, 1, 0, 0, tzinfo=timezone.utc)
+    return job
+
+
+# ---------------------------------------------------------------------------
+# Fixture: TestClient wired with all required mocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def translate_test_client(monkeypatch, tmp_path):
+    """Build a TestClient for the translate app with all side-effects mocked."""
+    import translate.app as translate_app
+    import translate.api.v1.translate as sync_router_module
+    import translate.api.v1.jobs as jobs_router_module
+
+    staging_dir = tmp_path / "staging"
+    results_dir = tmp_path / "results"
+    staging_dir.mkdir(parents=True)
+    results_dir.mkdir(parents=True)
+
+    # Patch settings used inside the app and routers
+    fake_settings = SimpleNamespace(
+        common=SimpleNamespace(
+            app=SimpleNamespace(log_level="INFO"),
+            llm=SimpleNamespace(
+                endpoint="http://vllm:8000",
+                model="granite",
+                api_key=None,
+                max_model_len=32768,
+                max_batch_size=32,
+            ),
+            language=SimpleNamespace(language_detection_min_confidence=0.9),
+        ),
+        translate=SimpleNamespace(
+            staging_dir=staging_dir,
+            results_dir=results_dir,
+            max_upload_size_mb=10,
+            max_concurrent_jobs=8,
+            chunk_parallelism=4,
+            chunk_token_budget=13107,
+            chunk_budget_ratio=0.40,
+            prompt_overhead_tokens=250,
+            min_output_tokens=50,
+            translation_temperature=0.0,
+            supported_languages="english,german",
+            supported_languages_list=["english", "german"],
+        ),
+    )
+
+    monkeypatch.setattr(translate_app, "settings", fake_settings, raising=False)
+    monkeypatch.setattr(sync_router_module, "settings", fake_settings, raising=False)
+    monkeypatch.setattr(jobs_router_module, "settings", fake_settings, raising=False)
+
+    # Patch configure_uvicorn_logging to avoid stdout capture issues
+    monkeypatch.setattr(translate_app, "configure_uvicorn_logging", Mock())
+
+    # Patch db_manager used in routers
+    mock_db = Mock()
+    mock_db.create_job = Mock(return_value=_make_db_job())
+    mock_db.get_job_by_id = Mock(return_value=None)
+    mock_db.get_all_jobs = Mock(return_value=([], 0))
+    mock_db.update_job = Mock(return_value=True)
+    mock_db.get_active_jobs = Mock(return_value=[])
+
+    monkeypatch.setattr(jobs_router_module, "db_manager", mock_db)
+
+    # Patch concurrency manager (already initialized)
+    import asyncio
+    from translate.workers.concurrency import ConcurrencyManager
+    mock_cm = ConcurrencyManager()
+    mock_cm._job_limiter = asyncio.BoundedSemaphore(8)
+    mock_cm._chunk_semaphore = asyncio.BoundedSemaphore(4)
+    mock_cm._vllm_semaphore = asyncio.BoundedSemaphore(32)
+    monkeypatch.setattr(sync_router_module, "concurrency_manager", mock_cm)
+    monkeypatch.setattr(jobs_router_module, "concurrency_manager", mock_cm)
+
+    # Patch storage_manager to avoid real FS ops in job endpoints
+    mock_storage = Mock()
+    mock_storage.stage_upload_file = AsyncMock(return_value=staging_dir / "job-123" / "doc.txt")
+    mock_storage.cleanup_staging = Mock()
+    mock_storage.write_result = Mock()
+    mock_storage.read_result = Mock()
+    mock_storage.delete_result = Mock()
+    monkeypatch.setattr(jobs_router_module, "storage_manager", mock_storage)
+
+    # Patch run_translation_job so background tasks don't actually run
+    monkeypatch.setattr(jobs_router_module, "run_translation_job", AsyncMock())
+
+    # Patch generate_uuid for deterministic job IDs
+    monkeypatch.setattr(jobs_router_module, "generate_uuid", Mock(return_value="job-123"))
+
+    # Patch stage_uploaded_file to return a fake Path
+    monkeypatch.setattr(
+        jobs_router_module, "stage_uploaded_file",
+        AsyncMock(return_value=staging_dir / "job-123" / "doc.txt")
+    )
+
+    return TestClient(translate_app.app), mock_db, mock_storage
+
+
+# ---------------------------------------------------------------------------
+# Health and Docs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestHealthAndDocs:
+    def test_health_returns_ok(self, translate_test_client):
+        client, _, _ = translate_test_client
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+
+    def test_root_returns_swagger_ui(self, translate_test_client):
+        client, _, _ = translate_test_client
+        response = client.get("/")
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+
+# ---------------------------------------------------------------------------
+# Middleware — X-Request-ID
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRequestIdMiddleware:
+    def test_existing_request_id_is_echoed(self, translate_test_client):
+        client, _, _ = translate_test_client
+        response = client.get("/health", headers={"X-Request-ID": "my-id-123"})
+        assert response.headers.get("x-request-id") == "my-id-123"
+
+    def test_missing_request_id_is_generated(self, translate_test_client):
+        client, _, _ = translate_test_client
+        response = client.get("/health")
+        assert "x-request-id" in response.headers
+        assert len(response.headers["x-request-id"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/translate — sync endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestSyncTranslateEndpoint:
+    def test_successful_translation(self, translate_test_client):
+        client, _, _ = translate_test_client
+
+        with patch("translate.api.v1.translate.tokenize_with_llm", return_value=list(range(10))), \
+             patch("translate.api.v1.translate.get_llm_max_model_len", return_value=32768), \
+             patch("translate.api.v1.translate.resolve_source_language", return_value=("German", "DE")), \
+             patch("translate.api.v1.translate.build_messages", return_value=[]), \
+             patch("translate.api.v1.translate.query_vllm_translate",
+                   new=AsyncMock(return_value=("Hallo Welt", 10, 8))):
+
+            response = client.post(
+                "/v1/translate",
+                json={
+                    "text": "Hello World",
+                    "source_language": "german",
+                    "target_language": "english",
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "data" in data
+        assert "meta" in data
+        assert "usage" in data
+        assert data["data"]["translation"] == "Hallo Welt"
+
+    def test_empty_text_returns_400(self, translate_test_client):
+        client, _, _ = translate_test_client
+        response = client.post(
+            "/v1/translate",
+            json={"text": "   ", "target_language": "english"},
+        )
+        assert response.status_code == 400
+
+    def test_unsupported_target_language_returns_400(self, translate_test_client):
+        client, _, _ = translate_test_client
+        response = client.post(
+            "/v1/translate",
+            json={"text": "Hello", "target_language": "klingon"},
+        )
+        assert response.status_code == 400
+
+    def test_same_source_and_target_returns_400(self, translate_test_client):
+        client, _, _ = translate_test_client
+        response = client.post(
+            "/v1/translate",
+            json={"text": "Hello", "source_language": "english", "target_language": "english"},
+        )
+        assert response.status_code == 400
+
+    def test_context_limit_exceeded_returns_413(self, translate_test_client):
+        client, _, _ = translate_test_client
+
+        # 5000 input tokens, max_model_len=4096, overhead=250 → available=−1154 < input
+        with patch("translate.api.v1.translate.tokenize_with_llm", return_value=list(range(5000))), \
+             patch("translate.api.v1.translate.get_llm_max_model_len", return_value=4096), \
+             patch("translate.api.v1.translate.resolve_source_language", return_value=("German", "DE")):
+
+            response = client.post(
+                "/v1/translate",
+                json={"text": "x" * 100, "target_language": "english"},
+            )
+
+        assert response.status_code == 413
+
+    def test_vllm_request_error_returns_503(self, translate_test_client):
+        import httpx
+        client, _, _ = translate_test_client
+
+        with patch("translate.api.v1.translate.tokenize_with_llm", return_value=list(range(10))), \
+             patch("translate.api.v1.translate.get_llm_max_model_len", return_value=32768), \
+             patch("translate.api.v1.translate.resolve_source_language", return_value=("German", "DE")), \
+             patch("translate.api.v1.translate.build_messages", return_value=[]), \
+             patch("translate.api.v1.translate.query_vllm_translate",
+                   new=AsyncMock(side_effect=httpx.RequestError("connection refused"))):
+
+            response = client.post(
+                "/v1/translate",
+                json={"text": "Hello", "target_language": "english"},
+            )
+
+        assert response.status_code == 503
+
+    def test_vllm_http_status_error_returns_500(self, translate_test_client):
+        import httpx
+        client, _, _ = translate_test_client
+
+        with patch("translate.api.v1.translate.tokenize_with_llm", return_value=list(range(10))), \
+             patch("translate.api.v1.translate.get_llm_max_model_len", return_value=32768), \
+             patch("translate.api.v1.translate.resolve_source_language", return_value=("German", "DE")), \
+             patch("translate.api.v1.translate.build_messages", return_value=[]), \
+             patch("translate.api.v1.translate.query_vllm_translate",
+                   new=AsyncMock(side_effect=httpx.HTTPStatusError(
+                       "500", request=MagicMock(), response=MagicMock()
+                   ))):
+
+            response = client.post(
+                "/v1/translate",
+                json={"text": "Hello", "target_language": "english"},
+            )
+
+        assert response.status_code == 500
+
+    def test_rate_limit_returns_429_when_vllm_semaphore_locked(self, translate_test_client, monkeypatch):
+        client, _, _ = translate_test_client
+        import asyncio
+        import translate.api.v1.translate as sync_mod
+
+        # Lock the single-slot vllm semaphore
+        locked_semaphore = asyncio.BoundedSemaphore(1)
+        locked_semaphore._value = 0  # simulate locked state
+
+        mock_cm = MagicMock()
+        mock_cm.vllm_semaphore = locked_semaphore
+        monkeypatch.setattr(sync_mod, "concurrency_manager", mock_cm)
+
+        with patch("translate.api.v1.translate.tokenize_with_llm", return_value=list(range(5))), \
+             patch("translate.api.v1.translate.get_llm_max_model_len", return_value=32768), \
+             patch("translate.api.v1.translate.validate_languages", return_value=("auto", "english")):
+
+            response = client.post(
+                "/v1/translate",
+                json={"text": "Hello", "target_language": "english"},
+            )
+
+        assert response.status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/translate/jobs — create job
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCreateJobEndpoint:
+    def test_valid_txt_upload_returns_202(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.create_job.return_value = _make_db_job()
+
+        response = client.post(
+            "/v1/translate/jobs",
+            files={"file": ("test.txt", b"Hello World", "text/plain")},
+            data={"target_language": "english"},
+        )
+
+        assert response.status_code == 202
+        assert response.json()["job_id"] == "job-123"
+
+    def test_valid_md_upload_returns_202(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.create_job.return_value = _make_db_job()
+
+        response = client.post(
+            "/v1/translate/jobs",
+            files={"file": ("doc.md", b"# Title\nContent here", "text/markdown")},
+            data={"target_language": "english"},
+        )
+
+        assert response.status_code == 202
+
+    def test_unsupported_extension_returns_415(self, translate_test_client):
+        client, _, _ = translate_test_client
+
+        with patch("translate.api.v1.jobs.validate_file_extension",
+                   side_effect=ValueError("Unsupported extension")):
+            response = client.post(
+                "/v1/translate/jobs",
+                files={"file": ("doc.pdf", b"%PDF content", "application/pdf")},
+                data={"target_language": "english"},
+            )
+
+        assert response.status_code == 415
+
+    def test_invalid_target_language_returns_400(self, translate_test_client):
+        client, _, _ = translate_test_client
+
+        response = client.post(
+            "/v1/translate/jobs",
+            files={"file": ("test.txt", b"Hello", "text/plain")},
+            data={"target_language": "klingon"},
+        )
+
+        assert response.status_code == 400
+
+    def test_same_language_returns_400(self, translate_test_client):
+        client, _, _ = translate_test_client
+
+        response = client.post(
+            "/v1/translate/jobs",
+            files={"file": ("test.txt", b"Hello", "text/plain")},
+            data={"source_language": "english", "target_language": "english"},
+        )
+
+        assert response.status_code == 400
+
+    def test_file_too_large_returns_413(self, translate_test_client, monkeypatch):
+        client, _, _ = translate_test_client
+        import translate.api.v1.jobs as jobs_mod
+
+        # Override settings.translate.max_upload_size_mb = 1 byte (effectively)
+        monkeypatch.setattr(
+            jobs_mod.settings.translate, "max_upload_size_mb", 0, raising=False
+        )
+
+        response = client.post(
+            "/v1/translate/jobs",
+            files={"file": ("test.txt", b"a" * 2000, "text/plain")},
+            data={"target_language": "english"},
+        )
+
+        assert response.status_code == 413
+
+    def test_db_create_failure_returns_500(self, translate_test_client):
+        client, mock_db, mock_storage = translate_test_client
+        mock_db.create_job.return_value = None  # DB failure
+
+        response = client.post(
+            "/v1/translate/jobs",
+            files={"file": ("test.txt", b"Hello World", "text/plain")},
+            data={"target_language": "english"},
+        )
+
+        assert response.status_code == 500
+        # Staging should have been cleaned up
+        mock_storage.cleanup_staging.assert_called()
+
+    def test_job_name_optional_param(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.create_job.return_value = _make_db_job()
+
+        response = client.post(
+            "/v1/translate/jobs",
+            files={"file": ("test.txt", b"Hello", "text/plain")},
+            data={"target_language": "english", "job_name": "My Translation"},
+        )
+
+        assert response.status_code == 202
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/translate/jobs — list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestListJobsEndpoint:
+    def test_empty_list(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_all_jobs.return_value = ([], 0)
+
+        response = client.get("/v1/translate/jobs")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total"] == 0
+        assert data["data"] == []
+
+    def test_pagination_defaults(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_all_jobs.return_value = ([], 0)
+
+        response = client.get("/v1/translate/jobs")
+        data = response.json()
+        assert data["pagination"]["limit"] == 20
+        assert data["pagination"]["offset"] == 0
+
+    def test_custom_pagination(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_all_jobs.return_value = ([], 0)
+
+        response = client.get("/v1/translate/jobs?limit=5&offset=10")
+        data = response.json()
+        assert data["pagination"]["limit"] == 5
+        assert data["pagination"]["offset"] == 10
+
+    def test_valid_status_filter(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_all_jobs.return_value = ([], 0)
+
+        response = client.get("/v1/translate/jobs?status_filter=completed")
+        assert response.status_code == 200
+
+    def test_invalid_status_filter_returns_400(self, translate_test_client):
+        client, _, _ = translate_test_client
+
+        response = client.get("/v1/translate/jobs?status_filter=bogus_status")
+        assert response.status_code == 400
+
+    def test_returns_jobs_in_response(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_all_jobs.return_value = ([_make_db_job()], 1)
+
+        response = client.get("/v1/translate/jobs")
+        data = response.json()
+        assert data["pagination"]["total"] == 1
+        assert len(data["data"]) == 1
+        assert data["data"][0]["job_id"] == "job-123"
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/translate/jobs/{job_id} — detail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetJobEndpoint:
+    def test_existing_job_returns_200(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_job_by_id.return_value = _make_db_job()
+
+        response = client.get("/v1/translate/jobs/job-123")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["job_id"] == "job-123"
+        assert data["status"] == "completed"
+
+    def test_missing_job_returns_404(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_job_by_id.return_value = None
+
+        response = client.get("/v1/translate/jobs/nonexistent")
+        assert response.status_code == 404
+
+    def test_job_detail_fields(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_job_by_id.return_value = _make_db_job(
+            job_name="My Job",
+            input_type="md",
+            document_name="doc.md",
+        )
+
+        response = client.get("/v1/translate/jobs/job-123")
+        data = response.json()
+        assert data["job_name"] == "My Job"
+        assert data["input_type"] == "md"
+        assert data["document_name"] == "doc.md"
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/translate/jobs/{job_id}/result
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGetJobResultEndpoint:
+    def test_completed_job_returns_result(self, translate_test_client):
+        client, mock_db, mock_storage = translate_test_client
+        mock_db.get_job_by_id.return_value = _make_db_job(status="completed")
+        mock_storage.read_result.return_value = {
+            "data": {"translation": "Hallo Welt"},
+            "meta": {"model": "granite"},
+            "usage": {"input_tokens": 10},
+        }
+
+        with patch("translate.api.v1.jobs.read_result_file",
+                   return_value={
+                       "data": {"translation": "Hallo Welt"},
+                       "meta": {"model": "granite"},
+                       "usage": {"input_tokens": 10},
+                   }):
+            response = client.get("/v1/translate/jobs/job-123/result")
+
+        assert response.status_code == 200
+        assert response.json()["data"]["translation"] == "Hallo Welt"
+
+    def test_in_progress_job_returns_202(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_job_by_id.return_value = _make_db_job(status="in_progress")
+
+        response = client.get("/v1/translate/jobs/job-123/result")
+        assert response.status_code == 202
+
+    def test_accepted_job_returns_202(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_job_by_id.return_value = _make_db_job(status="accepted")
+
+        response = client.get("/v1/translate/jobs/job-123/result")
+        assert response.status_code == 202
+
+    def test_failed_job_returns_410(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_job_by_id.return_value = _make_db_job(status="failed", error="disk full")
+
+        response = client.get("/v1/translate/jobs/job-123/result")
+        assert response.status_code == 410
+
+    def test_missing_job_returns_404(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_job_by_id.return_value = None
+
+        response = client.get("/v1/translate/jobs/missing/result")
+        assert response.status_code == 404
+
+    def test_result_file_not_found_returns_500(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_job_by_id.return_value = _make_db_job(status="completed")
+
+        with patch("translate.api.v1.jobs.read_result_file", side_effect=FileNotFoundError()):
+            response = client.get("/v1/translate/jobs/job-123/result")
+
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/translate/jobs/{job_id}/result/download
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDownloadJobResultEndpoint:
+    def test_completed_job_returns_file_content(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_job_by_id.return_value = _make_db_job(
+            status="completed", input_type="txt", document_name="original.txt"
+        )
+
+        with patch("translate.api.v1.jobs.read_result_file",
+                   return_value={"data": {"translation": "Hallo Welt"}, "meta": {}, "usage": {}}):
+            response = client.get("/v1/translate/jobs/job-123/result/download")
+
+        assert response.status_code == 200
+        assert response.text == "Hallo Welt"
+        assert "original_translated.txt" in response.headers["content-disposition"]
+
+    def test_md_file_has_correct_media_type(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_job_by_id.return_value = _make_db_job(
+            status="completed", input_type="md", document_name="original.md"
+        )
+
+        with patch("translate.api.v1.jobs.read_result_file",
+                   return_value={"data": {"translation": "# Hallo"}, "meta": {}, "usage": {}}):
+            response = client.get("/v1/translate/jobs/job-123/result/download")
+
+        assert response.status_code == 200
+        assert "text/markdown" in response.headers["content-type"]
+        assert "original_translated.md" in response.headers["content-disposition"]
+
+    def test_in_progress_returns_202(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_job_by_id.return_value = _make_db_job(status="in_progress")
+
+        response = client.get("/v1/translate/jobs/job-123/result/download")
+        assert response.status_code == 202
+
+    def test_failed_job_returns_410(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_job_by_id.return_value = _make_db_job(status="failed", error="crash")
+
+        response = client.get("/v1/translate/jobs/job-123/result/download")
+        assert response.status_code == 410
+
+    def test_missing_job_returns_404(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_job_by_id.return_value = None
+
+        response = client.get("/v1/translate/jobs/missing/result/download")
+        assert response.status_code == 404
+
+    def test_result_file_not_found_returns_500(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_job_by_id.return_value = _make_db_job(status="completed")
+
+        with patch("translate.api.v1.jobs.read_result_file", side_effect=FileNotFoundError()):
+            response = client.get("/v1/translate/jobs/job-123/result/download")
+
+        assert response.status_code == 500
+
+    def test_document_name_without_extension_uses_job_id(self, translate_test_client):
+        client, mock_db, _ = translate_test_client
+        mock_db.get_job_by_id.return_value = _make_db_job(
+            status="completed", input_type="txt", document_name=None
+        )
+
+        with patch("translate.api.v1.jobs.read_result_file",
+                   return_value={"data": {"translation": "Hi"}, "meta": {}, "usage": {}}):
+            response = client.get("/v1/translate/jobs/job-123/result/download")
+
+        assert response.status_code == 200
+        # Filename derived from job_id when document_name is None
+        assert "_translated.txt" in response.headers["content-disposition"]
+
+# Made with Bob

--- a/services/translate/tests/unit/test_models.py
+++ b/services/translate/tests/unit/test_models.py
@@ -1,0 +1,236 @@
+"""
+Unit tests for translate/models.py — Pydantic models and enums.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from translate.models import (
+    InputType,
+    JobCreatedResponse,
+    JobDetailResponse,
+    JobResultResponse,
+    JobState,
+    JobStatus,
+    JobsListResponse,
+    PaginationInfo,
+    SyncTranslateRequest,
+    SyncTranslateResponse,
+    TranslationChunk,
+)
+
+
+@pytest.mark.unit
+class TestJobStatus:
+    def test_all_expected_values(self):
+        assert JobStatus.ACCEPTED.value == "accepted"
+        assert JobStatus.IN_PROGRESS.value == "in_progress"
+        assert JobStatus.COMPLETED.value == "completed"
+        assert JobStatus.FAILED.value == "failed"
+
+    def test_is_str_enum(self):
+        assert isinstance(JobStatus.ACCEPTED, str)
+
+    def test_construction_from_string(self):
+        assert JobStatus("completed") == JobStatus.COMPLETED
+
+
+@pytest.mark.unit
+class TestInputType:
+    def test_all_expected_values(self):
+        assert InputType.TEXT.value == "text"
+        assert InputType.TXT.value == "txt"
+        assert InputType.MD.value == "md"
+
+    def test_is_str_enum(self):
+        assert isinstance(InputType.TXT, str)
+
+
+@pytest.mark.unit
+class TestSyncTranslateRequest:
+    def test_valid_request(self):
+        req = SyncTranslateRequest(
+            text="Hello world",
+            source_language="German",
+            target_language="English",
+        )
+        assert req.text == "Hello world"
+        assert req.source_language == "German"
+        assert req.target_language == "English"
+
+    def test_source_language_defaults_to_auto(self):
+        req = SyncTranslateRequest(text="Hi", target_language="English")
+        assert req.source_language == "auto"
+
+    def test_missing_text_raises(self):
+        with pytest.raises(ValidationError):
+            SyncTranslateRequest(target_language="English")
+
+    def test_missing_target_language_raises(self):
+        with pytest.raises(ValidationError):
+            SyncTranslateRequest(text="Hello")
+
+
+@pytest.mark.unit
+class TestSyncTranslateResponse:
+    def test_valid_response(self):
+        resp = SyncTranslateResponse(
+            data={"translation": "Hallo", "source_language": "english", "target_language": "german"},
+            meta={"model": "test-model", "processing_time_ms": 500, "input_type": "text"},
+            usage={"input_tokens": 10, "output_tokens": 8, "total_tokens": 18},
+        )
+        assert resp.data["translation"] == "Hallo"
+        assert resp.meta["model"] == "test-model"
+        assert resp.usage["total_tokens"] == 18
+
+
+@pytest.mark.unit
+class TestJobCreatedResponse:
+    def test_valid(self):
+        resp = JobCreatedResponse(job_id="abc-123")
+        assert resp.job_id == "abc-123"
+
+
+@pytest.mark.unit
+class TestPaginationInfo:
+    def test_valid(self):
+        p = PaginationInfo(total=100, limit=20, offset=40)
+        assert p.total == 100
+        assert p.limit == 20
+        assert p.offset == 40
+
+
+@pytest.mark.unit
+class TestJobDetailResponse:
+    def test_valid_with_known_status(self):
+        resp = JobDetailResponse(
+            job_id="job-1",
+            status="completed",
+            source_language="german",
+            target_language="english",
+            input_type="txt",
+            submitted_at="2024-01-01T00:00:00Z",
+        )
+        assert resp.status == "completed"
+        assert resp.job_name is None
+        assert resp.completed_at is None
+
+    def test_status_validator_with_jobstatus_instance(self):
+        resp = JobDetailResponse(
+            job_id="job-1",
+            status=JobStatus.IN_PROGRESS,
+            source_language="german",
+            target_language="english",
+            input_type="txt",
+            submitted_at="2024-01-01T00:00:00Z",
+        )
+        assert resp.status == "in_progress"
+
+    def test_status_validator_falls_back_to_accepted_on_invalid(self):
+        resp = JobDetailResponse(
+            job_id="job-1",
+            status="NOT_A_STATUS",
+            source_language="german",
+            target_language="english",
+            input_type="txt",
+            submitted_at="2024-01-01T00:00:00Z",
+        )
+        assert resp.status == "accepted"
+
+    def test_optional_fields_populated(self):
+        resp = JobDetailResponse(
+            job_id="job-1",
+            job_name="My Job",
+            status="completed",
+            source_language="german",
+            target_language="english",
+            input_type="md",
+            document_name="doc.md",
+            submitted_at="2024-01-01T00:00:00Z",
+            completed_at="2024-01-01T01:00:00Z",
+            error=None,
+            job_metadata={"phase": "completed"},
+        )
+        assert resp.job_name == "My Job"
+        assert resp.document_name == "doc.md"
+        assert resp.job_metadata == {"phase": "completed"}
+
+
+@pytest.mark.unit
+class TestJobState:
+    def test_valid(self):
+        state = JobState(
+            job_id="job-2",
+            status="in_progress",
+            source_language="auto",
+            target_language="english",
+            input_type="md",
+            submitted_at="2024-01-01T00:00:00Z",
+        )
+        assert state.status == "in_progress"
+
+    def test_status_validator_falls_back(self):
+        state = JobState(
+            job_id="job-2",
+            status="GARBAGE",
+            source_language="auto",
+            target_language="english",
+            input_type="md",
+            submitted_at="2024-01-01T00:00:00Z",
+        )
+        assert state.status == "accepted"
+
+
+@pytest.mark.unit
+class TestJobsListResponse:
+    def test_valid(self):
+        jobs_resp = JobsListResponse(
+            pagination=PaginationInfo(total=1, limit=20, offset=0),
+            data=[
+                JobState(
+                    job_id="j1",
+                    status="completed",
+                    source_language="german",
+                    target_language="english",
+                    input_type="txt",
+                    submitted_at="2024-01-01T00:00:00Z",
+                )
+            ],
+        )
+        assert jobs_resp.pagination.total == 1
+        assert len(jobs_resp.data) == 1
+
+
+@pytest.mark.unit
+class TestJobResultResponse:
+    def test_valid(self):
+        resp = JobResultResponse(
+            data={"translation": "Hallo"},
+            meta={"model": "m"},
+            usage={"input_tokens": 5},
+        )
+        assert resp.data["translation"] == "Hallo"
+
+
+@pytest.mark.unit
+class TestTranslationChunk:
+    def test_defaults(self):
+        chunk = TranslationChunk(index=0, text="Hello world")
+        assert chunk.join_after == "paragraph"
+        assert chunk.token_count == 0
+
+    def test_sentence_join(self):
+        chunk = TranslationChunk(index=1, text="Sentence.", join_after="sentence", token_count=5)
+        assert chunk.join_after == "sentence"
+        assert chunk.token_count == 5
+
+    def test_index_ordering(self):
+        chunks = [
+            TranslationChunk(index=2, text="C"),
+            TranslationChunk(index=0, text="A"),
+            TranslationChunk(index=1, text="B"),
+        ]
+        chunks.sort(key=lambda c: c.index)
+        assert [c.text for c in chunks] == ["A", "B", "C"]
+
+# Made with Bob

--- a/services/translate/tests/unit/test_utils_chunking.py
+++ b/services/translate/tests/unit/test_utils_chunking.py
@@ -1,0 +1,295 @@
+"""
+Unit tests for translate/utils/chunking.py — token-based document chunker.
+"""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from translate.models import TranslationChunk
+from translate.utils.chunking import (
+    _is_table_block,
+    _pack_sentences_greedily,
+    build_translation_chunks,
+)
+
+
+# ---------------------------------------------------------------------------
+# _is_table_block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestIsTableBlock:
+    def test_gfm_table_is_detected(self):
+        block = "| Col A | Col B |\n|-------|-------|\n| R1A   | R1B   |"
+        assert _is_table_block(block) is True
+
+    def test_plain_text_is_not_table(self):
+        assert _is_table_block("This is a regular paragraph.") is False
+
+    def test_single_line_starting_with_pipe_is_not_table(self):
+        # Need at least two lines starting with |
+        assert _is_table_block("| Col A |") is False
+
+    def test_empty_string_is_not_table(self):
+        assert _is_table_block("") is False
+
+    def test_blank_lines_only_is_not_table(self):
+        assert _is_table_block("   \n   \n   ") is False
+
+    def test_separator_line_without_header_not_table(self):
+        block = "Some text\n|-------|-------|"
+        assert _is_table_block(block) is False
+
+    def test_table_with_leading_whitespace_detected(self):
+        block = "  | Col A | Col B |\n  |-------|-------|\n  | R1A   | R1B   |"
+        assert _is_table_block(block) is True
+
+
+# ---------------------------------------------------------------------------
+# _pack_sentences_greedily
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPackSentencesGreedily:
+    @pytest.mark.asyncio
+    async def test_single_sentence_fits_in_budget(self):
+        sentences = ["Hello world."]
+
+        with patch("translate.utils.chunking._count_tokens", new=AsyncMock(return_value=3)):
+            chunks = await _pack_sentences_greedily(
+                sentences=sentences,
+                budget=10,
+                llm_endpoint="http://vllm:8000",
+                start_index=0,
+                parent_join_after="paragraph",
+            )
+
+        assert len(chunks) == 1
+        assert chunks[0].text == "Hello world."
+        assert chunks[0].join_after == "paragraph"
+
+    @pytest.mark.asyncio
+    async def test_multiple_sentences_packed_greedily(self):
+        sentences = ["S1.", "S2.", "S3."]
+
+        # Each sentence = 3 tokens, budget = 6 → fits two per chunk
+        call_count = [0]
+
+        async def fake_count_tokens(text, endpoint):
+            call_count[0] += 1
+            return 3
+
+        with patch("translate.utils.chunking._count_tokens", side_effect=fake_count_tokens):
+            chunks = await _pack_sentences_greedily(
+                sentences=sentences,
+                budget=6,
+                llm_endpoint="http://vllm:8000",
+                start_index=0,
+                parent_join_after="paragraph",
+            )
+
+        assert len(chunks) == 2
+        assert "S1" in chunks[0].text and "S2" in chunks[0].text
+        assert "S3" in chunks[1].text
+
+    @pytest.mark.asyncio
+    async def test_last_chunk_inherits_parent_join_after(self):
+        sentences = ["S1.", "S2.", "S3."]
+
+        async def fake_count(text, endpoint):
+            return 3
+
+        with patch("translate.utils.chunking._count_tokens", side_effect=fake_count):
+            chunks = await _pack_sentences_greedily(
+                sentences=sentences,
+                budget=6,
+                llm_endpoint="http://vllm:8000",
+                start_index=0,
+                parent_join_after="paragraph",
+            )
+
+        # Last chunk should have "paragraph", intermediate should have "sentence"
+        assert chunks[-1].join_after == "paragraph"
+        if len(chunks) > 1:
+            assert chunks[0].join_after == "sentence"
+
+    @pytest.mark.asyncio
+    async def test_empty_sentences_list_returns_empty(self):
+        with patch("translate.utils.chunking._count_tokens", new=AsyncMock(return_value=3)):
+            chunks = await _pack_sentences_greedily(
+                sentences=[],
+                budget=10,
+                llm_endpoint="http://vllm:8000",
+                start_index=0,
+                parent_join_after="paragraph",
+            )
+
+        assert chunks == []
+
+    @pytest.mark.asyncio
+    async def test_start_index_increments_correctly(self):
+        sentences = ["A.", "B.", "C.", "D."]
+
+        # Budget = 3 → one sentence per chunk
+        async def fake_count(text, endpoint):
+            return 3
+
+        with patch("translate.utils.chunking._count_tokens", side_effect=fake_count):
+            chunks = await _pack_sentences_greedily(
+                sentences=sentences,
+                budget=3,
+                llm_endpoint="http://vllm:8000",
+                start_index=5,  # offset
+                parent_join_after="sentence",
+            )
+
+        indices = [c.index for c in chunks]
+        assert indices == list(range(5, 5 + len(chunks)))
+
+
+# ---------------------------------------------------------------------------
+# build_translation_chunks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestBuildTranslationChunks:
+    @pytest.mark.asyncio
+    async def test_empty_text_returns_empty(self):
+        with patch("translate.utils.chunking.get_chunk_token_budget", return_value=1000), \
+             patch("translate.utils.chunking.to_sentence_splitter_lang", return_value="en"):
+            chunks = await build_translation_chunks("", llm_endpoint="http://vllm:8000")
+        assert chunks == []
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_text_returns_empty(self):
+        with patch("translate.utils.chunking.get_chunk_token_budget", return_value=1000), \
+             patch("translate.utils.chunking.to_sentence_splitter_lang", return_value="en"):
+            chunks = await build_translation_chunks("   \n\n   ", llm_endpoint="http://vllm:8000")
+        assert chunks == []
+
+    @pytest.mark.asyncio
+    async def test_single_small_block_is_single_chunk(self):
+        text = "This is a short paragraph."
+
+        with patch("translate.utils.chunking.get_chunk_token_budget", return_value=1000), \
+             patch("translate.utils.chunking.to_sentence_splitter_lang", return_value="en"), \
+             patch("translate.utils.chunking._count_tokens", new=AsyncMock(return_value=5)):
+            chunks = await build_translation_chunks(text, llm_endpoint="http://vllm:8000")
+
+        assert len(chunks) == 1
+        assert chunks[0].index == 0
+        assert chunks[0].text == text.strip()
+        assert chunks[0].join_after == "paragraph"
+
+    @pytest.mark.asyncio
+    async def test_two_blocks_packed_into_one_chunk_when_budget_allows(self):
+        text = "Block one.\n\nBlock two."
+
+        # Both blocks together fit inside budget=100
+        with patch("translate.utils.chunking.get_chunk_token_budget", return_value=100), \
+             patch("translate.utils.chunking.to_sentence_splitter_lang", return_value="en"), \
+             patch("translate.utils.chunking._count_tokens", new=AsyncMock(return_value=5)):
+            chunks = await build_translation_chunks(text, llm_endpoint="http://vllm:8000")
+
+        assert len(chunks) == 1
+        assert "Block one." in chunks[0].text
+        assert "Block two." in chunks[0].text
+
+    @pytest.mark.asyncio
+    async def test_oversized_block_forces_new_chunk(self):
+        text = "Short block.\n\nOversized block text."
+
+        # First block = 5 tokens, second = 200 (exceeds budget of 100)
+        token_map = {"Short block.": 5, "Oversized block text.": 200}
+
+        async def fake_count(text, endpoint):
+            return token_map.get(text, 5)
+
+        mock_splitter = MagicMock()
+        mock_splitter.split.return_value = ["Oversized block text."]
+
+        with patch("translate.utils.chunking.get_chunk_token_budget", return_value=100), \
+             patch("translate.utils.chunking.to_sentence_splitter_lang", return_value="en"), \
+             patch("translate.utils.chunking._count_tokens", side_effect=fake_count), \
+             patch("translate.utils.chunking.SentenceSplitter", return_value=mock_splitter), \
+             patch("translate.utils.chunking._pack_sentences_greedily",
+                   new=AsyncMock(return_value=[
+                       TranslationChunk(index=1, text="Oversized block text.", token_count=200)
+                   ])):
+            chunks = await build_translation_chunks(text, llm_endpoint="http://vllm:8000")
+
+        # At least two chunks: one for the normal block, one (or more) for the oversized
+        assert len(chunks) >= 2
+
+    @pytest.mark.asyncio
+    async def test_gfm_table_gets_its_own_chunk(self):
+        table_block = "| H1 | H2 |\n|----|----|\n| A  | B  |"
+        text = f"Intro paragraph.\n\n{table_block}"
+
+        # Intro = 5 tokens, table = 200 tokens (over budget)
+        async def fake_count(text_arg, endpoint):
+            if "|" in text_arg:
+                return 200
+            return 5
+
+        with patch("translate.utils.chunking.get_chunk_token_budget", return_value=100), \
+             patch("translate.utils.chunking.to_sentence_splitter_lang", return_value="en"), \
+             patch("translate.utils.chunking._count_tokens", side_effect=fake_count), \
+             patch("translate.utils.chunking.SentenceSplitter") as mock_ss:
+            chunks = await build_translation_chunks(text, llm_endpoint="http://vllm:8000")
+
+        # Table chunk should be present and NOT sentence-split
+        table_chunks = [c for c in chunks if "|" in c.text]
+        assert len(table_chunks) == 1
+        assert table_chunks[0].join_after == "paragraph"
+
+    @pytest.mark.asyncio
+    async def test_chunk_indices_are_sequential(self):
+        text = "\n\n".join([f"Paragraph {i}." for i in range(5)])
+
+        with patch("translate.utils.chunking.get_chunk_token_budget", return_value=20), \
+             patch("translate.utils.chunking.to_sentence_splitter_lang", return_value="en"), \
+             patch("translate.utils.chunking._count_tokens", new=AsyncMock(return_value=8)), \
+             patch("translate.utils.chunking.SentenceSplitter") as mock_ss:
+            mock_ss.return_value.split.return_value = ["A sentence."]
+            chunks = await build_translation_chunks(text, llm_endpoint="http://vllm:8000")
+
+        indices = [c.index for c in chunks]
+        assert indices == list(range(len(chunks)))
+
+    @pytest.mark.asyncio
+    async def test_source_language_code_passed_to_sentence_splitter(self):
+        text = "Ein einfacher Paragraph."
+
+        with patch("translate.utils.chunking.get_chunk_token_budget", return_value=1000), \
+             patch("translate.utils.chunking.to_sentence_splitter_lang", return_value="de") as mock_lang, \
+             patch("translate.utils.chunking._count_tokens", new=AsyncMock(return_value=5)), \
+             patch("translate.utils.chunking.SentenceSplitter") as mock_ss_cls:
+            mock_ss_cls.return_value = MagicMock()
+            mock_ss_cls.return_value.split.return_value = [text]
+
+            await build_translation_chunks(
+                text, llm_endpoint="http://vllm:8000", source_language_code="DE"
+            )
+
+        mock_lang.assert_called_with("DE")
+
+    @pytest.mark.asyncio
+    async def test_none_source_language_defaults_to_en(self):
+        text = "A simple paragraph."
+
+        with patch("translate.utils.chunking.get_chunk_token_budget", return_value=1000), \
+             patch("translate.utils.chunking.to_sentence_splitter_lang", return_value="en") as mock_lang, \
+             patch("translate.utils.chunking._count_tokens", new=AsyncMock(return_value=5)), \
+             patch("translate.utils.chunking.SentenceSplitter") as mock_ss_cls:
+            mock_ss_cls.return_value = MagicMock()
+
+            await build_translation_chunks(text, llm_endpoint="http://vllm:8000", source_language_code=None)
+
+        mock_lang.assert_called_with("EN")
+
+# Made with Bob

--- a/services/translate/tests/unit/test_utils_errors.py
+++ b/services/translate/tests/unit/test_utils_errors.py
@@ -1,0 +1,117 @@
+"""
+Unit tests for translate/utils/errors.py — HTTP error helper functions.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from translate.utils.errors import (
+    _raise_context_limit_exceeded,
+    _raise_file_too_large,
+    _raise_invalid_language,
+    _raise_job_failed,
+    _raise_same_language,
+    _raise_unsupported_file_type,
+)
+
+
+@pytest.mark.unit
+class TestRaiseInvalidLanguage:
+    def test_raises_http_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_invalid_language("bad language")
+        assert exc_info.value.status_code == 400
+
+    def test_error_code_is_invalid_language(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_invalid_language("bad language")
+        assert exc_info.value.detail["error"]["code"] == "INVALID_LANGUAGE"
+
+    def test_message_is_propagated(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_invalid_language("unsupported: Klingon")
+        assert "Klingon" in exc_info.value.detail["error"]["message"]
+
+
+@pytest.mark.unit
+class TestRaiseSameLanguage:
+    def test_raises_http_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_same_language("both are 'english'")
+        assert exc_info.value.status_code == 400
+
+    def test_error_code_is_same_language(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_same_language("both are 'english'")
+        assert exc_info.value.detail["error"]["code"] == "SAME_LANGUAGE"
+
+
+@pytest.mark.unit
+class TestRaiseUnsupportedFileType:
+    def test_raises_http_415(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_unsupported_file_type("only .txt and .md")
+        assert exc_info.value.status_code == 415
+
+    def test_error_code(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_unsupported_file_type("only .txt and .md")
+        assert exc_info.value.detail["error"]["code"] == "UNSUPPORTED_FILE_TYPE"
+
+
+@pytest.mark.unit
+class TestRaiseFileTooLarge:
+    def test_raises_http_413(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_file_too_large("file exceeds 10 MB")
+        assert exc_info.value.status_code == 413
+
+    def test_error_code(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_file_too_large("file exceeds 10 MB")
+        assert exc_info.value.detail["error"]["code"] == "FILE_TOO_LARGE"
+
+
+@pytest.mark.unit
+class TestRaiseJobFailed:
+    def test_raises_http_410(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_job_failed("job failed: timeout")
+        assert exc_info.value.status_code == 410
+
+    def test_error_code(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_job_failed("job failed: timeout")
+        assert exc_info.value.detail["error"]["code"] == "JOB_FAILED"
+
+
+@pytest.mark.unit
+class TestRaiseContextLimitExceeded:
+    def test_raises_http_413(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_context_limit_exceeded(
+                "Input too large",
+                diagnostics={"input_tokens": 5000, "max_model_len": 4096},
+            )
+        assert exc_info.value.status_code == 413
+
+    def test_error_code(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_context_limit_exceeded(
+                "Input too large",
+                diagnostics={"input_tokens": 5000},
+            )
+        assert exc_info.value.detail["error"]["code"] == "CONTEXT_LIMIT_EXCEEDED"
+
+    def test_diagnostics_attached(self):
+        diag = {"input_tokens": 5000, "max_model_len": 4096, "available_for_output": -904}
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_context_limit_exceeded("Input too large", diagnostics=diag)
+        assert exc_info.value.detail["error"]["diagnostics"] == diag
+
+    def test_message_is_propagated(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _raise_context_limit_exceeded("Custom error message", diagnostics={})
+        assert exc_info.value.detail["error"]["message"] == "Custom error message"
+
+# Made with Bob

--- a/services/translate/tests/unit/test_utils_jobs.py
+++ b/services/translate/tests/unit/test_utils_jobs.py
@@ -1,0 +1,107 @@
+"""
+Unit tests for translate/utils/jobs.py — job lifecycle utilities.
+"""
+
+import pytest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from translate.utils.jobs import (
+    delete_job_files,
+    generate_uuid,
+    read_result_file,
+    stage_uploaded_file,
+)
+
+
+@pytest.mark.unit
+class TestGenerateUuid:
+    def test_returns_string(self):
+        result = generate_uuid()
+        assert isinstance(result, str)
+
+    def test_uuid_format(self):
+        import uuid
+        result = generate_uuid()
+        # Should be parseable as a UUID
+        parsed = uuid.UUID(result)
+        assert str(parsed) == result
+
+    def test_each_call_is_unique(self):
+        ids = {generate_uuid() for _ in range(10)}
+        assert len(ids) == 10
+
+
+@pytest.mark.unit
+class TestStageUploadedFile:
+    @pytest.mark.asyncio
+    async def test_delegates_to_storage_manager(self):
+        mock_path = Path("/tmp/staging/job-1/file.txt")
+        with patch("translate.utils.jobs.storage_manager") as mock_storage:
+            mock_storage.stage_upload_file = AsyncMock(return_value=mock_path)
+            result = await stage_uploaded_file("job-1", "file.txt", b"content")
+
+        mock_storage.stage_upload_file.assert_called_once_with(
+            job_id="job-1",
+            filename="file.txt",
+            content=b"content",
+        )
+        assert result == mock_path
+
+    @pytest.mark.asyncio
+    async def test_returns_path_object(self):
+        mock_path = Path("/tmp/staging/job-abc/doc.md")
+        with patch("translate.utils.jobs.storage_manager") as mock_storage:
+            mock_storage.stage_upload_file = AsyncMock(return_value=mock_path)
+            result = await stage_uploaded_file("job-abc", "doc.md", b"# Title")
+
+        assert isinstance(result, Path)
+
+
+@pytest.mark.unit
+class TestReadResultFile:
+    def test_delegates_to_storage_manager(self):
+        expected = {"data": {"translation": "Hallo"}, "meta": {}, "usage": {}}
+        with patch("translate.utils.jobs.storage_manager") as mock_storage:
+            mock_storage.read_result.return_value = expected
+            result = read_result_file("job-123")
+
+        mock_storage.read_result.assert_called_once_with("job-123")
+        assert result == expected
+
+    def test_file_not_found_propagates(self):
+        with patch("translate.utils.jobs.storage_manager") as mock_storage:
+            mock_storage.read_result.side_effect = FileNotFoundError("not found")
+            with pytest.raises(FileNotFoundError):
+                read_result_file("missing-job")
+
+
+@pytest.mark.unit
+class TestDeleteJobFiles:
+    def test_calls_cleanup_staging_and_delete_result(self):
+        with patch("translate.utils.jobs.storage_manager") as mock_storage:
+            mock_storage.cleanup_staging = MagicMock()
+            mock_storage.delete_result = MagicMock()
+            delete_job_files("job-del")
+
+        mock_storage.cleanup_staging.assert_called_once_with("job-del")
+        mock_storage.delete_result.assert_called_once_with("job-del")
+
+    def test_delete_result_error_is_logged_not_raised(self):
+        with patch("translate.utils.jobs.storage_manager") as mock_storage:
+            mock_storage.cleanup_staging = MagicMock()
+            mock_storage.delete_result.side_effect = OSError("disk error")
+            # Must not raise
+            delete_job_files("job-err")
+
+        mock_storage.cleanup_staging.assert_called_once()
+
+    def test_cleanup_staging_error_propagates(self):
+        """cleanup_staging errors are not swallowed — only delete_result errors are."""
+        with patch("translate.utils.jobs.storage_manager") as mock_storage:
+            mock_storage.cleanup_staging.side_effect = PermissionError("denied")
+            mock_storage.delete_result = MagicMock()
+            with pytest.raises(PermissionError):
+                delete_job_files("job-perm")
+
+# Made with Bob

--- a/services/translate/tests/unit/test_utils_language.py
+++ b/services/translate/tests/unit/test_utils_language.py
@@ -1,0 +1,116 @@
+"""
+Unit tests for translate/utils/language.py — language normalisation and validation.
+"""
+
+import pytest
+from fastapi import HTTPException
+from unittest.mock import patch
+
+from translate.utils.language import normalise_language, validate_languages
+
+
+@pytest.mark.unit
+class TestNormaliseLanguage:
+    def test_none_returns_auto(self):
+        assert normalise_language(None) == "auto"
+
+    def test_empty_string_returns_auto(self):
+        assert normalise_language("") == "auto"
+
+    def test_whitespace_only_returns_auto(self):
+        assert normalise_language("   ") == "auto"
+
+    def test_strips_and_lowercases(self):
+        assert normalise_language("  German  ") == "german"
+
+    def test_already_lowercase_unchanged(self):
+        assert normalise_language("english") == "english"
+
+    def test_uppercase_lowercased(self):
+        assert normalise_language("GERMAN") == "german"
+
+    def test_mixed_case(self):
+        assert normalise_language("English") == "english"
+
+
+@pytest.mark.unit
+class TestValidateLanguages:
+    # ---- target must not be 'auto' ----
+
+    def test_target_auto_raises_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            validate_languages("german", "auto")
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail["error"]["code"] == "INVALID_LANGUAGE"
+
+    # ---- target must be in allowlist ----
+
+    def test_unsupported_target_raises_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            validate_languages("auto", "klingon")
+        assert exc_info.value.status_code == 400
+        assert "klingon" in exc_info.value.detail["error"]["message"].lower()
+
+    # ---- source (if explicit) must be in allowlist ----
+
+    def test_unsupported_explicit_source_raises_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            validate_languages("klingon", "english")
+        assert exc_info.value.status_code == 400
+
+    # ---- explicit source == target must differ ----
+
+    def test_same_explicit_source_and_target_raises_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            validate_languages("english", "english")
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail["error"]["code"] == "SAME_LANGUAGE"
+
+    def test_german_to_german_raises(self):
+        with pytest.raises(HTTPException):
+            validate_languages("german", "german")
+
+    # ---- happy path ----
+
+    def test_valid_auto_to_english(self):
+        src, tgt = validate_languages("auto", "english")
+        assert src == "auto"
+        assert tgt == "english"
+
+    def test_valid_german_to_english(self):
+        src, tgt = validate_languages("german", "english")
+        assert src == "german"
+        assert tgt == "english"
+
+    def test_valid_english_to_german(self):
+        src, tgt = validate_languages("english", "german")
+        assert src == "english"
+        assert tgt == "german"
+
+    def test_case_insensitive_source(self):
+        src, tgt = validate_languages("German", "English")
+        assert src == "german"
+        assert tgt == "english"
+
+    def test_case_insensitive_target(self):
+        src, tgt = validate_languages("auto", "English")
+        assert tgt == "english"
+
+    def test_auto_source_with_whitespace(self):
+        src, tgt = validate_languages("  auto  ", "english")
+        assert src == "auto"
+
+    def test_empty_source_treated_as_auto(self):
+        src, tgt = validate_languages("", "english")
+        assert src == "auto"
+
+    def test_none_source_treated_as_auto(self):
+        src, tgt = validate_languages(None, "english")
+        assert src == "auto"
+
+    def test_returns_normalised_strings(self):
+        src, tgt = validate_languages("  GERMAN  ", "  ENGLISH  ")
+        assert src == "german"
+        assert tgt == "english"
+
+# Made with Bob

--- a/services/translate/tests/unit/test_utils_llm.py
+++ b/services/translate/tests/unit/test_utils_llm.py
@@ -1,0 +1,199 @@
+"""
+Unit tests for translate/utils/llm.py — LLM helpers.
+"""
+
+import pytest
+import httpx
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from translate.utils.llm import (
+    get_chunk_token_budget,
+    get_llm_max_model_len,
+    query_vllm_translate,
+)
+
+
+@pytest.mark.unit
+class TestGetLlmMaxModelLen:
+    def test_delegates_to_resolve_model_max_len(self):
+        with patch("translate.utils.llm.resolve_model_max_len", return_value=32768) as mock_resolve:
+            result = get_llm_max_model_len()
+        assert result == 32768
+        mock_resolve.assert_called_once()
+
+    def test_passes_correct_args(self):
+        with patch("translate.utils.llm.resolve_model_max_len", return_value=16384) as mock_resolve, \
+             patch("translate.utils.llm.settings") as mock_settings:
+            mock_settings.common.llm.endpoint = "http://vllm:8000"
+            mock_settings.common.llm.model = "granite"
+            mock_settings.common.llm.max_model_len = 4096
+            mock_settings.common.llm.api_key = None
+            get_llm_max_model_len()
+        mock_resolve.assert_called_once_with("http://vllm:8000", "granite", 4096, None)
+
+
+@pytest.mark.unit
+class TestGetChunkTokenBudget:
+    def test_budget_is_ratio_of_max_model_len(self):
+        with patch("translate.utils.llm.get_llm_max_model_len", return_value=32768), \
+             patch("translate.utils.llm.settings") as mock_settings:
+            mock_settings.translate.chunk_budget_ratio = 0.40
+            result = get_chunk_token_budget()
+        assert result == int(32768 * 0.40)
+
+    def test_result_is_integer(self):
+        with patch("translate.utils.llm.get_llm_max_model_len", return_value=10000), \
+             patch("translate.utils.llm.settings") as mock_settings:
+            mock_settings.translate.chunk_budget_ratio = 0.40
+            result = get_chunk_token_budget()
+        assert isinstance(result, int)
+
+
+@pytest.mark.unit
+class TestQueryVllmTranslate:
+    def _mock_response(self, content="Hallo Welt", prompt_tokens=10, completion_tokens=8):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": content}}],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+            },
+        }
+        return mock_resp
+
+    @pytest.mark.asyncio
+    async def test_successful_call_returns_translation(self):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=self._mock_response("Hallo Welt"))
+
+        result = await query_vllm_translate(
+            client=mock_client,
+            llm_endpoint="http://vllm:8000",
+            messages=[{"role": "system", "content": "..."}, {"role": "user", "content": "Hello"}],
+            model="granite",
+            max_tokens=200,
+        )
+        text, in_tok, out_tok = result
+        assert text == "Hallo Welt"
+        assert in_tok == 10
+        assert out_tok == 8
+
+    @pytest.mark.asyncio
+    async def test_uses_correct_endpoint_path(self):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=self._mock_response())
+
+        await query_vllm_translate(
+            client=mock_client,
+            llm_endpoint="http://vllm:8000",
+            messages=[],
+            model="m",
+            max_tokens=100,
+        )
+        call_url = mock_client.post.call_args[0][0]
+        assert call_url == "http://vllm:8000/v1/chat/completions"
+
+    @pytest.mark.asyncio
+    async def test_default_temperature_is_zero(self):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=self._mock_response())
+
+        await query_vllm_translate(
+            client=mock_client,
+            llm_endpoint="http://vllm:8000",
+            messages=[],
+            model="m",
+            max_tokens=100,
+        )
+        payload = mock_client.post.call_args[1]["json"]
+        assert payload["temperature"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_custom_temperature_is_passed(self):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=self._mock_response())
+
+        await query_vllm_translate(
+            client=mock_client,
+            llm_endpoint="http://vllm:8000",
+            messages=[],
+            model="m",
+            max_tokens=100,
+            temperature=0.7,
+        )
+        payload = mock_client.post.call_args[1]["json"]
+        assert payload["temperature"] == 0.7
+
+    @pytest.mark.asyncio
+    async def test_raises_on_empty_choices(self):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"choices": [], "usage": {}}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with pytest.raises(ValueError, match="empty 'choices'"):
+            await query_vllm_translate(
+                client=mock_client,
+                llm_endpoint="http://vllm:8000",
+                messages=[],
+                model="m",
+                max_tokens=100,
+            )
+
+    @pytest.mark.asyncio
+    async def test_strips_whitespace_from_content(self):
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=self._mock_response(content="  Hallo  "))
+
+        text, _, _ = await query_vllm_translate(
+            client=mock_client,
+            llm_endpoint="http://vllm:8000",
+            messages=[],
+            model="m",
+            max_tokens=100,
+        )
+        assert text == "Hallo"
+
+    @pytest.mark.asyncio
+    async def test_missing_usage_defaults_to_zero(self):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": "result"}}],
+        }
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        _, in_tok, out_tok = await query_vllm_translate(
+            client=mock_client,
+            llm_endpoint="http://vllm:8000",
+            messages=[],
+            model="m",
+            max_tokens=100,
+        )
+        assert in_tok == 0
+        assert out_tok == 0
+
+    @pytest.mark.asyncio
+    async def test_http_status_error_propagates(self):
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "500", request=MagicMock(), response=MagicMock()
+        )
+        mock_client.post = AsyncMock(return_value=mock_resp)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await query_vllm_translate(
+                client=mock_client,
+                llm_endpoint="http://vllm:8000",
+                messages=[],
+                model="m",
+                max_tokens=100,
+            )
+
+# Made with Bob

--- a/services/translate/tests/unit/test_utils_prompt.py
+++ b/services/translate/tests/unit/test_utils_prompt.py
@@ -1,0 +1,235 @@
+"""
+Unit tests for translate/utils/prompt.py — language resolution and message building.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from translate.utils.prompt import (
+    _detect_majority_vote,
+    build_messages,
+    iso_code_to_language_name,
+    resolve_source_language,
+)
+
+
+@pytest.mark.unit
+class TestIsoCodeToLanguageName:
+    def test_english(self):
+        assert iso_code_to_language_name("EN") == "English"
+
+    def test_german(self):
+        assert iso_code_to_language_name("DE") == "German"
+
+    def test_french(self):
+        assert iso_code_to_language_name("FR") == "French"
+
+    def test_italian(self):
+        assert iso_code_to_language_name("IT") == "Italian"
+
+    def test_lowercase_accepted(self):
+        assert iso_code_to_language_name("en") == "English"
+
+    def test_unknown_returns_none(self):
+        assert iso_code_to_language_name("ZZ") is None
+
+    def test_empty_returns_none(self):
+        # Empty string uppercase is still ""
+        assert iso_code_to_language_name("") is None
+
+
+@pytest.mark.unit
+class TestDetectMajorityVote:
+    def test_empty_text_returns_none(self):
+        result = _detect_majority_vote("", min_confidence=0.9)
+        assert result is None
+
+    def test_majority_with_all_three_same(self):
+        with patch("translate.utils.prompt.detect_language", return_value="DE"):
+            result = _detect_majority_vote("Das ist ein langer deutschsprachiger Text " * 40, min_confidence=0.9)
+        assert result == "DE"
+
+    def test_majority_two_out_of_three(self):
+        # Positions: start=DE, middle=DE, end=EN → DE wins (2/3)
+        side_effects = ["DE", "DE", "EN"]
+        with patch("translate.utils.prompt.detect_language", side_effect=side_effects):
+            result = _detect_majority_vote("x" * 2000, min_confidence=0.9)
+        assert result == "DE"
+
+    def test_no_majority_returns_none(self):
+        # All three positions return different codes (or None for some)
+        side_effects = ["DE", "EN", "FR"]
+        with patch("translate.utils.prompt.detect_language", side_effect=side_effects):
+            result = _detect_majority_vote("x" * 2000, min_confidence=0.9)
+        assert result is None
+
+    def test_all_none_returns_none(self):
+        with patch("translate.utils.prompt.detect_language", return_value=None):
+            result = _detect_majority_vote("x" * 2000, min_confidence=0.9)
+        assert result is None
+
+    def test_short_text_single_sample(self):
+        # Text shorter than 3 × 500 chars — samples may overlap but shouldn't crash
+        with patch("translate.utils.prompt.detect_language", return_value="EN") as mock_detect:
+            result = _detect_majority_vote("Short text.", min_confidence=0.9)
+        assert mock_detect.call_count == 3  # always three samples
+
+
+@pytest.mark.unit
+class TestResolveSourceLanguage:
+    def _settings(self):
+        mock = MagicMock()
+        mock.common.language.language_detection_min_confidence = 0.9
+        return mock
+
+    # ---- Explicit language supplied ----
+
+    def test_explicit_german(self):
+        name, code = resolve_source_language(
+            text="Guten Tag",
+            requested_source="german",
+            settings=self._settings(),
+            async_path=False,
+        )
+        assert name == "German"
+        assert code == "DE"
+
+    def test_explicit_english(self):
+        name, code = resolve_source_language(
+            text="Hello",
+            requested_source="english",
+            settings=self._settings(),
+            async_path=False,
+        )
+        assert name == "English"
+        assert code == "EN"
+
+    def test_explicit_case_insensitive(self):
+        name, code = resolve_source_language(
+            text="Guten Tag",
+            requested_source="GERMAN",
+            settings=self._settings(),
+            async_path=False,
+        )
+        assert name == "German"
+
+    def test_explicit_unknown_language_falls_back_to_none(self):
+        name, code = resolve_source_language(
+            text="xyz",
+            requested_source="klingon",
+            settings=self._settings(),
+            async_path=False,
+        )
+        assert name is None
+        assert code is None
+
+    # ---- Auto-detect sync path ----
+
+    def test_auto_detect_sync_with_high_confidence(self):
+        with patch("translate.utils.prompt.detect_language", return_value="DE"):
+            name, code = resolve_source_language(
+                text="Das ist ein Text",
+                requested_source="auto",
+                settings=self._settings(),
+                async_path=False,
+            )
+        assert name == "German"
+        assert code == "DE"
+
+    def test_auto_detect_sync_low_confidence_returns_none(self):
+        with patch("translate.utils.prompt.detect_language", return_value=None):
+            name, code = resolve_source_language(
+                text="...",
+                requested_source="auto",
+                settings=self._settings(),
+                async_path=False,
+            )
+        assert name is None
+        assert code is None
+
+    def test_auto_detect_sync_unknown_iso_returns_none(self):
+        # detect_language returns a code not in _ISO_TO_NAME
+        with patch("translate.utils.prompt.detect_language", return_value="ZZ"):
+            name, code = resolve_source_language(
+                text="...",
+                requested_source="auto",
+                settings=self._settings(),
+                async_path=False,
+            )
+        assert name is None
+
+    # ---- Async (majority-vote) path ----
+
+    def test_auto_detect_async_with_majority(self):
+        with patch("translate.utils.prompt._detect_majority_vote", return_value="EN"):
+            name, code = resolve_source_language(
+                text="Hello world " * 300,
+                requested_source="auto",
+                settings=self._settings(),
+                async_path=True,
+            )
+        assert name == "English"
+        assert code == "EN"
+
+    def test_auto_detect_async_no_majority(self):
+        with patch("translate.utils.prompt._detect_majority_vote", return_value=None):
+            name, code = resolve_source_language(
+                text="x" * 2000,
+                requested_source="auto",
+                settings=self._settings(),
+                async_path=True,
+            )
+        assert name is None
+        assert code is None
+
+    def test_empty_requested_source_treated_as_auto(self):
+        with patch("translate.utils.prompt.detect_language", return_value="EN"):
+            name, code = resolve_source_language(
+                text="Hello",
+                requested_source="",
+                settings=self._settings(),
+                async_path=False,
+            )
+        assert name == "English"
+
+
+@pytest.mark.unit
+class TestBuildMessages:
+    def test_explicit_source_uses_explicit_template(self):
+        messages = build_messages(
+            text="Guten Tag",
+            resolved_source_language="German",
+            target_language="English",
+        )
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert messages[1]["role"] == "user"
+        assert "German" in messages[1]["content"]
+        assert "English" in messages[1]["content"]
+        assert "Guten Tag" in messages[1]["content"]
+
+    def test_none_source_uses_auto_detect_template(self):
+        messages = build_messages(
+            text="Hello",
+            resolved_source_language=None,
+            target_language="German",
+        )
+        assert "Detect the language" in messages[1]["content"]
+        assert "German" in messages[1]["content"]
+        assert "Hello" in messages[1]["content"]
+
+    def test_system_prompt_is_present(self):
+        messages = build_messages(
+            text="text",
+            resolved_source_language="English",
+            target_language="German",
+        )
+        assert "professional translator" in messages[0]["content"].lower()
+
+    def test_both_templates_include_text(self):
+        text = "unique_marker_text_xyz"
+        for src in ("German", None):
+            messages = build_messages(text=text, resolved_source_language=src, target_language="English")
+            assert text in messages[1]["content"]
+
+# Made with Bob

--- a/services/translate/tests/unit/test_utils_recovery.py
+++ b/services/translate/tests/unit/test_utils_recovery.py
@@ -1,0 +1,142 @@
+"""
+Unit tests for translate/utils/recovery.py — zombie job recovery.
+"""
+
+import pytest
+from datetime import datetime
+from unittest.mock import MagicMock, Mock, patch
+
+from translate.models import JobStatus
+from translate.utils.recovery import recover_zombie_jobs
+
+
+def _make_zombie_job(job_id: str, status: str = "in_progress") -> Mock:
+    job = Mock()
+    job.job_id = job_id
+    job.status = status
+    return job
+
+
+# ---------------------------------------------------------------------------
+# recover_zombie_jobs uses `import translate.settings as config` locally,
+# so the staging_dir is reached via `translate.settings.settings.translate.staging_dir`.
+# We patch that singleton attribute directly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRecoverZombieJobs:
+    def test_no_zombies_returns_zero(self, tmp_path):
+        mock_db = MagicMock()
+        mock_db.get_active_jobs.return_value = []
+
+        with patch("translate.utils.recovery.db_manager", mock_db), \
+             patch("translate.settings.settings") as mock_settings:
+            mock_settings.translate.staging_dir = tmp_path / "staging"
+            result = recover_zombie_jobs()
+
+        assert result == 0
+        mock_db.get_active_jobs.assert_called_once()
+        mock_db.update_job.assert_not_called()
+
+    def test_single_zombie_is_marked_failed(self, tmp_path):
+        zombie = _make_zombie_job("zombie-1", "in_progress")
+        mock_db = MagicMock()
+        mock_db.get_active_jobs.return_value = [zombie]
+        mock_db.update_job.return_value = True
+
+        # No staging directory exists for this job — cleanup is a no-op
+        with patch("translate.utils.recovery.db_manager", mock_db), \
+             patch("translate.settings.settings") as mock_settings:
+            mock_settings.translate.staging_dir = tmp_path / "staging"
+            result = recover_zombie_jobs()
+
+        assert result == 1
+        call_kwargs = mock_db.update_job.call_args.kwargs
+        assert call_kwargs["job_id"] == "zombie-1"
+        assert call_kwargs["status"] == JobStatus.FAILED
+        assert call_kwargs["error"] == "System restarted during processing"
+        assert isinstance(call_kwargs["completed_at"], datetime)
+
+    def test_multiple_zombies_all_marked_failed(self, tmp_path):
+        zombies = [_make_zombie_job(f"zombie-{i}") for i in range(3)]
+        mock_db = MagicMock()
+        mock_db.get_active_jobs.return_value = zombies
+        mock_db.update_job.return_value = True
+
+        with patch("translate.utils.recovery.db_manager", mock_db), \
+             patch("translate.settings.settings") as mock_settings:
+            mock_settings.translate.staging_dir = tmp_path / "staging"
+            result = recover_zombie_jobs()
+
+        assert result == 3
+        assert mock_db.update_job.call_count == 3
+
+    def test_staging_directory_cleaned_up_when_exists(self, tmp_path):
+        zombie = _make_zombie_job("zombie-cleanup", "accepted")
+        mock_db = MagicMock()
+        mock_db.get_active_jobs.return_value = [zombie]
+        mock_db.update_job.return_value = True
+
+        staging_root = tmp_path / "staging"
+        job_staging = staging_root / "zombie-cleanup"
+        job_staging.mkdir(parents=True)
+        (job_staging / "file.txt").write_text("content")
+
+        with patch("translate.utils.recovery.db_manager", mock_db), \
+             patch("translate.settings.settings") as mock_settings:
+            mock_settings.translate.staging_dir = staging_root
+            result = recover_zombie_jobs()
+
+        assert result == 1
+        assert not job_staging.exists()
+
+    def test_get_active_jobs_exception_returns_zero(self, tmp_path):
+        mock_db = MagicMock()
+        mock_db.get_active_jobs.side_effect = RuntimeError("db down")
+
+        with patch("translate.utils.recovery.db_manager", mock_db), \
+             patch("translate.settings.settings") as mock_settings:
+            mock_settings.translate.staging_dir = tmp_path / "staging"
+            result = recover_zombie_jobs()
+
+        assert result == 0
+
+    def test_individual_job_update_failure_continues_loop(self, tmp_path):
+        """One update failure does not stop recovery of remaining zombies."""
+        zombies = [
+            _make_zombie_job("z-fail", "in_progress"),
+            _make_zombie_job("z-ok", "accepted"),
+        ]
+        mock_db = MagicMock()
+        mock_db.get_active_jobs.return_value = zombies
+        mock_db.update_job.side_effect = [RuntimeError("update failed"), True]
+
+        with patch("translate.utils.recovery.db_manager", mock_db), \
+             patch("translate.settings.settings") as mock_settings:
+            mock_settings.translate.staging_dir = tmp_path / "staging"
+            result = recover_zombie_jobs()
+
+        # z-fail fails during update → not counted; z-ok succeeds → counted
+        assert result == 1
+
+    def test_staging_cleanup_error_does_not_abort_recovery(self, tmp_path):
+        """Staging cleanup failures are tolerated."""
+        zombie = _make_zombie_job("zombie-stg-err")
+        mock_db = MagicMock()
+        mock_db.get_active_jobs.return_value = [zombie]
+        mock_db.update_job.return_value = True
+
+        staging_root = tmp_path / "staging"
+        job_dir = staging_root / "zombie-stg-err"
+        job_dir.mkdir(parents=True)
+
+        with patch("translate.utils.recovery.db_manager", mock_db), \
+             patch("translate.settings.settings") as mock_settings, \
+             patch("shutil.rmtree", side_effect=PermissionError("denied")):
+            mock_settings.translate.staging_dir = staging_root
+            result = recover_zombie_jobs()
+
+        assert result == 1
+
+# Made with Bob

--- a/services/translate/tests/unit/test_utils_storage.py
+++ b/services/translate/tests/unit/test_utils_storage.py
@@ -1,0 +1,175 @@
+"""
+Unit tests for translate/utils/storage.py — StorageManager.
+"""
+
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch, AsyncMock
+
+from translate.utils.storage import StorageManager
+
+
+@pytest.fixture
+def manager(tmp_path):
+    """Return a StorageManager with settings pointed at tmp_path."""
+    mgr = StorageManager()
+    with patch("translate.utils.storage.settings") as mock_settings:
+        mock_settings.translate.staging_dir = tmp_path / "staging"
+        mock_settings.translate.results_dir = tmp_path / "results"
+        yield mgr, mock_settings, tmp_path
+
+
+@pytest.mark.unit
+class TestStorageManagerStaging:
+    @pytest.mark.asyncio
+    async def test_stage_upload_file_creates_file(self, tmp_path):
+        mgr = StorageManager()
+        staging_dir = tmp_path / "staging"
+        results_dir = tmp_path / "results"
+
+        with patch("translate.utils.storage.settings") as mock_settings:
+            mock_settings.translate.staging_dir = staging_dir
+            mock_settings.translate.results_dir = results_dir
+
+            job_id = "job-abc"
+            content = b"Hello, world!"
+            path = await mgr.stage_upload_file(job_id=job_id, filename="test.txt", content=content)
+
+        assert path.exists()
+        assert path.read_bytes() == content
+        assert path.name == "test.txt"
+        assert path.parent.name == job_id
+
+    @pytest.mark.asyncio
+    async def test_stage_upload_file_returns_path(self, tmp_path):
+        mgr = StorageManager()
+        with patch("translate.utils.storage.settings") as mock_settings:
+            mock_settings.translate.staging_dir = tmp_path / "staging"
+            job_id = "job-xyz"
+            result = await mgr.stage_upload_file(job_id=job_id, filename="doc.md", content=b"# heading")
+
+        assert isinstance(result, Path)
+        assert result.name == "doc.md"
+
+    def test_cleanup_staging_removes_directory(self, tmp_path):
+        mgr = StorageManager()
+        staging_dir = tmp_path / "staging"
+        job_id = "job-cleanup"
+        job_dir = staging_dir / job_id
+        job_dir.mkdir(parents=True)
+        (job_dir / "file.txt").write_text("content")
+
+        with patch("translate.utils.storage.settings") as mock_settings:
+            mock_settings.translate.staging_dir = staging_dir
+            mgr.cleanup_staging(job_id)
+
+        assert not job_dir.exists()
+
+    def test_cleanup_staging_nonexistent_directory_is_noop(self, tmp_path):
+        mgr = StorageManager()
+        staging_dir = tmp_path / "staging"
+
+        with patch("translate.utils.storage.settings") as mock_settings:
+            mock_settings.translate.staging_dir = staging_dir
+            # Should not raise
+            mgr.cleanup_staging("nonexistent-job")
+
+
+@pytest.mark.unit
+class TestStorageManagerResults:
+    def test_result_path_format(self, tmp_path):
+        mgr = StorageManager()
+        results_dir = tmp_path / "results"
+
+        with patch("translate.utils.storage.settings") as mock_settings:
+            mock_settings.translate.results_dir = results_dir
+            path = mgr.result_path("job-123")
+
+        assert path.name == "job-123_result.json"
+        assert path.parent == results_dir
+
+    def test_write_result_creates_json_file(self, tmp_path):
+        mgr = StorageManager()
+        results_dir = tmp_path / "results"
+        payload = {"data": {"translation": "Hallo"}, "meta": {}, "usage": {}}
+
+        with patch("translate.utils.storage.settings") as mock_settings:
+            mock_settings.translate.results_dir = results_dir
+            mgr.write_result("job-wr", payload)
+
+        result_file = results_dir / "job-wr_result.json"
+        assert result_file.exists()
+        data = json.loads(result_file.read_text(encoding="utf-8"))
+        assert data["data"]["translation"] == "Hallo"
+
+    def test_read_result_returns_deserialized_dict(self, tmp_path):
+        mgr = StorageManager()
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        payload = {"data": {"translation": "Guten Tag"}, "meta": {"model": "m"}, "usage": {}}
+        result_file = results_dir / "job-rr_result.json"
+        result_file.write_text(json.dumps(payload), encoding="utf-8")
+
+        with patch("translate.utils.storage.settings") as mock_settings:
+            mock_settings.translate.results_dir = results_dir
+            data = mgr.read_result("job-rr")
+
+        assert data["data"]["translation"] == "Guten Tag"
+
+    def test_read_result_raises_file_not_found(self, tmp_path):
+        mgr = StorageManager()
+        results_dir = tmp_path / "results"
+
+        with patch("translate.utils.storage.settings") as mock_settings:
+            mock_settings.translate.results_dir = results_dir
+            with pytest.raises(FileNotFoundError):
+                mgr.read_result("nonexistent-job")
+
+    def test_delete_result_removes_file(self, tmp_path):
+        mgr = StorageManager()
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        result_file = results_dir / "job-del_result.json"
+        result_file.write_text("{}", encoding="utf-8")
+
+        with patch("translate.utils.storage.settings") as mock_settings:
+            mock_settings.translate.results_dir = results_dir
+            mgr.delete_result("job-del")
+
+        assert not result_file.exists()
+
+    def test_delete_result_nonexistent_is_noop(self, tmp_path):
+        mgr = StorageManager()
+        results_dir = tmp_path / "results"
+
+        with patch("translate.utils.storage.settings") as mock_settings:
+            mock_settings.translate.results_dir = results_dir
+            # Should not raise
+            mgr.delete_result("no-such-job")
+
+    def test_write_result_creates_parent_dirs(self, tmp_path):
+        mgr = StorageManager()
+        results_dir = tmp_path / "deep" / "nested" / "results"
+
+        with patch("translate.utils.storage.settings") as mock_settings:
+            mock_settings.translate.results_dir = results_dir
+            mgr.write_result("job-nested", {"data": {}, "meta": {}, "usage": {}})
+
+        assert (results_dir / "job-nested_result.json").exists()
+
+    def test_write_result_uses_utf8_encoding(self, tmp_path):
+        mgr = StorageManager()
+        results_dir = tmp_path / "results"
+        payload = {"data": {"translation": "Ä Ö Ü ß é"}}
+
+        with patch("translate.utils.storage.settings") as mock_settings:
+            mock_settings.translate.results_dir = results_dir
+            mgr.write_result("job-utf8", payload)
+
+        result_file = results_dir / "job-utf8_result.json"
+        raw = result_file.read_bytes()
+        decoded = json.loads(raw.decode("utf-8"))
+        assert decoded["data"]["translation"] == "Ä Ö Ü ß é"
+
+# Made with Bob

--- a/services/translate/tests/unit/test_workers_concurrency.py
+++ b/services/translate/tests/unit/test_workers_concurrency.py
@@ -1,0 +1,122 @@
+"""
+Unit tests for translate/workers/concurrency.py — ConcurrencyManager.
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch
+
+from translate.workers.concurrency import ConcurrencyManager
+
+
+@pytest.mark.unit
+class TestConcurrencyManagerInitialize:
+    def test_properties_raise_before_initialize(self):
+        mgr = ConcurrencyManager()
+        with pytest.raises(RuntimeError, match="initialize"):
+            _ = mgr.job_limiter
+
+    def test_chunk_semaphore_raises_before_initialize(self):
+        mgr = ConcurrencyManager()
+        with pytest.raises(RuntimeError, match="initialize"):
+            _ = mgr.chunk_semaphore
+
+    def test_vllm_semaphore_raises_before_initialize(self):
+        mgr = ConcurrencyManager()
+        with pytest.raises(RuntimeError, match="initialize"):
+            _ = mgr.vllm_semaphore
+
+    @pytest.mark.asyncio
+    async def test_initialize_creates_semaphores(self):
+        mgr = ConcurrencyManager()
+        with patch("translate.workers.concurrency.settings") as mock_settings:
+            mock_settings.translate.max_concurrent_jobs = 8
+            mock_settings.translate.chunk_parallelism = 4
+            mock_settings.common.llm.max_batch_size = 32
+            mgr.initialize()
+
+        assert isinstance(mgr.job_limiter, asyncio.BoundedSemaphore)
+        assert isinstance(mgr.chunk_semaphore, asyncio.BoundedSemaphore)
+        assert isinstance(mgr.vllm_semaphore, asyncio.BoundedSemaphore)
+
+    @pytest.mark.asyncio
+    async def test_semaphore_limits_match_settings(self):
+        mgr = ConcurrencyManager()
+        with patch("translate.workers.concurrency.settings") as mock_settings:
+            mock_settings.translate.max_concurrent_jobs = 3
+            mock_settings.translate.chunk_parallelism = 2
+            mock_settings.common.llm.max_batch_size = 10
+            mgr.initialize()
+
+        # BoundedSemaphore._value holds the initial count
+        assert mgr._job_limiter._value == 3
+        assert mgr._chunk_semaphore._value == 2
+        assert mgr._vllm_semaphore._value == 10
+
+
+@pytest.mark.unit
+class TestConcurrencyManagerStats:
+    def test_stats_before_initialize_returns_none_values(self):
+        mgr = ConcurrencyManager()
+        with patch("translate.workers.concurrency.settings") as mock_settings:
+            mock_settings.translate.max_concurrent_jobs = 8
+            mock_settings.translate.chunk_parallelism = 4
+            mock_settings.common.llm.max_batch_size = 32
+            stats = mgr.stats()
+
+        assert stats["job_limiter_locked"] is None
+        assert stats["chunk_semaphore_locked"] is None
+        assert stats["vllm_semaphore_locked"] is None
+
+    @pytest.mark.asyncio
+    async def test_stats_after_initialize_returns_bool_values(self):
+        mgr = ConcurrencyManager()
+        with patch("translate.workers.concurrency.settings") as mock_settings:
+            mock_settings.translate.max_concurrent_jobs = 8
+            mock_settings.translate.chunk_parallelism = 4
+            mock_settings.common.llm.max_batch_size = 32
+            mgr.initialize()
+            stats = mgr.stats()
+
+        assert isinstance(stats["job_limiter_locked"], bool)
+        assert isinstance(stats["chunk_semaphore_locked"], bool)
+        assert isinstance(stats["vllm_semaphore_locked"], bool)
+        assert stats["job_limit"] == 8
+        assert stats["chunk_parallelism"] == 4
+        assert stats["vllm_limit"] == 32
+
+    @pytest.mark.asyncio
+    async def test_stats_shows_locked_when_semaphore_full(self):
+        mgr = ConcurrencyManager()
+        with patch("translate.workers.concurrency.settings") as mock_settings:
+            mock_settings.translate.max_concurrent_jobs = 1
+            mock_settings.translate.chunk_parallelism = 1
+            mock_settings.common.llm.max_batch_size = 1
+            mgr.initialize()
+
+        async def _acquire_and_check():
+            async with mgr.job_limiter:
+                return mgr.job_limiter.locked()
+
+        locked = await _acquire_and_check()
+        # After acquiring the single slot the semaphore is locked
+        assert locked is True
+
+
+@pytest.mark.unit
+class TestConcurrencyManagerSemaphoreUsage:
+    @pytest.mark.asyncio
+    async def test_vllm_semaphore_can_be_acquired_and_released(self):
+        mgr = ConcurrencyManager()
+        with patch("translate.workers.concurrency.settings") as mock_settings:
+            mock_settings.translate.max_concurrent_jobs = 8
+            mock_settings.translate.chunk_parallelism = 4
+            mock_settings.common.llm.max_batch_size = 32
+            mgr.initialize()
+
+        assert not mgr.vllm_semaphore.locked()
+        async with mgr.vllm_semaphore:
+            pass  # acquired and released
+        assert not mgr.vllm_semaphore.locked()
+
+# Made with Bob

--- a/services/translate/tests/unit/test_workers_translation_worker.py
+++ b/services/translate/tests/unit/test_workers_translation_worker.py
@@ -1,0 +1,341 @@
+"""
+Unit tests for translate/workers/translation_worker.py — translation pipeline.
+"""
+
+import asyncio
+import pytest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+from translate.models import JobStatus, TranslationChunk
+from translate.workers.translation_worker import (
+    _assemble_translation,
+    _translate_chunk,
+    run_translation_job,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_chunk(index: int, text: str, join_after: str = "paragraph", token_count: int = 10) -> TranslationChunk:
+    return TranslationChunk(index=index, text=text, join_after=join_after, token_count=token_count)
+
+
+# ---------------------------------------------------------------------------
+# _assemble_translation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAssembleTranslation:
+    def test_single_chunk(self):
+        results = [(_make_chunk(0, "orig"), "Hallo", 5, 4)]
+        text, total_in, total_out = _assemble_translation(results)
+        assert text == "Hallo"
+        assert total_in == 5
+        assert total_out == 4
+
+    def test_two_paragraph_chunks_joined_with_double_newline(self):
+        results = [
+            (_make_chunk(0, "A", join_after="paragraph"), "Eins", 3, 3),
+            (_make_chunk(1, "B", join_after="paragraph"), "Zwei", 3, 3),
+        ]
+        text, _, _ = _assemble_translation(results)
+        assert text == "Eins\n\nZwei"
+
+    def test_two_sentence_chunks_joined_with_space(self):
+        results = [
+            (_make_chunk(0, "S1", join_after="sentence"), "Eins.", 3, 3),
+            (_make_chunk(1, "S2", join_after="sentence"), "Zwei.", 3, 3),
+        ]
+        text, _, _ = _assemble_translation(results)
+        assert text == "Eins. Zwei."
+
+    def test_last_chunk_join_after_not_appended(self):
+        """The separator is determined by join_after of every chunk EXCEPT the last."""
+        results = [
+            (_make_chunk(0, "A", join_after="paragraph"), "Alpha", 2, 2),
+            (_make_chunk(1, "B", join_after="paragraph"), "Beta", 2, 2),
+        ]
+        text, _, _ = _assemble_translation(results)
+        # Should be "Alpha\n\nBeta", NOT "Alpha\n\nBeta\n\n"
+        assert text.endswith("Beta")
+        assert not text.endswith("\n\n")
+
+    def test_mixed_join_modes(self):
+        """Sentence chunk followed by paragraph chunk."""
+        results = [
+            (_make_chunk(0, "S", join_after="sentence"), "Satz.", 2, 2),
+            (_make_chunk(1, "P", join_after="paragraph"), "Absatz.", 2, 2),
+        ]
+        text, _, _ = _assemble_translation(results)
+        # The separator between 0→1 is " " (from chunk 0's join_after="sentence")
+        assert text == "Satz. Absatz."
+
+    def test_out_of_order_results_are_sorted_by_index(self):
+        results = [
+            (_make_chunk(2, "C"), "Drei", 1, 1),
+            (_make_chunk(0, "A"), "Eins", 1, 1),
+            (_make_chunk(1, "B"), "Zwei", 1, 1),
+        ]
+        text, _, _ = _assemble_translation(results)
+        assert text == "Eins\n\nZwei\n\nDrei"
+
+    def test_total_tokens_are_summed(self):
+        results = [
+            (_make_chunk(0, "A"), "T1", 10, 8),
+            (_make_chunk(1, "B"), "T2", 20, 15),
+        ]
+        _, total_in, total_out = _assemble_translation(results)
+        assert total_in == 30
+        assert total_out == 23
+
+    def test_empty_results_list(self):
+        text, total_in, total_out = _assemble_translation([])
+        assert text == ""
+        assert total_in == 0
+        assert total_out == 0
+
+
+# ---------------------------------------------------------------------------
+# _translate_chunk
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTranslateChunk:
+    @pytest.mark.asyncio
+    async def test_returns_tuple_with_chunk(self):
+        chunk = _make_chunk(0, "Hello")
+        mock_client = AsyncMock()
+
+        with patch("translate.workers.translation_worker.build_messages", return_value=[]), \
+             patch("translate.workers.translation_worker.query_vllm_translate",
+                   new=AsyncMock(return_value=("Hallo", 5, 4))), \
+             patch("translate.workers.translation_worker.settings") as mock_settings, \
+             patch("translate.workers.translation_worker.concurrency_manager") as mock_cm:
+
+            mock_settings.common.llm.endpoint = "http://vllm:8000"
+            mock_settings.common.llm.model = "granite"
+            mock_settings.translate.translation_temperature = 0.0
+
+            # Real BoundedSemaphore to satisfy `async with`
+            mock_cm.chunk_semaphore = asyncio.BoundedSemaphore(1)
+            mock_cm.vllm_semaphore = asyncio.BoundedSemaphore(1)
+
+            result = await _translate_chunk(
+                chunk=chunk,
+                resolved_source_language="German",
+                target_language="English",
+                http_client=mock_client,
+                max_tokens=200,
+            )
+
+        returned_chunk, translation, in_tok, out_tok = result
+        assert returned_chunk is chunk
+        assert translation == "Hallo"
+        assert in_tok == 5
+        assert out_tok == 4
+
+
+# ---------------------------------------------------------------------------
+# run_translation_job (integration-style unit test)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestRunTranslationJob:
+    @pytest.mark.asyncio
+    async def test_successful_job_marks_completed(self, tmp_path):
+        staged_file = tmp_path / "job-1" / "doc.txt"
+        staged_file.parent.mkdir(parents=True)
+        staged_file.write_text("Hello world", encoding="utf-8")
+
+        mock_db = MagicMock()
+        mock_db.update_job = MagicMock(return_value=True)
+
+        chunks = [_make_chunk(0, "Hello world", token_count=5)]
+        results = [(chunks[0], "Hallo Welt", 5, 4)]
+
+        with patch("translate.workers.translation_worker.db_manager", mock_db), \
+             patch("translate.workers.translation_worker.resolve_source_language",
+                   return_value=("German", "DE")), \
+             patch("translate.workers.translation_worker.build_translation_chunks",
+                   new=AsyncMock(return_value=chunks)), \
+             patch("translate.workers.translation_worker.get_llm_max_model_len", return_value=32768), \
+             patch("translate.workers.translation_worker.storage_manager") as mock_storage, \
+             patch("translate.workers.translation_worker._translate_chunk",
+                   new=AsyncMock(return_value=(chunks[0], "Hallo Welt", 5, 4))), \
+             patch("translate.workers.translation_worker.settings") as mock_settings, \
+             patch("translate.workers.translation_worker.concurrency_manager") as mock_cm, \
+             patch("httpx.AsyncClient") as mock_http:
+
+            mock_settings.common.llm.endpoint = "http://vllm:8000"
+            mock_settings.common.llm.model = "granite"
+            mock_settings.common.llm.api_key = None
+            mock_settings.translate.prompt_overhead_tokens = 250
+            mock_settings.translate.translation_temperature = 0.0
+            mock_settings.translate.chunk_token_budget = 13107
+
+            # Real semaphore for job_limiter
+            mock_cm.job_limiter = asyncio.BoundedSemaphore(8)
+
+            mock_storage.write_result = MagicMock()
+            mock_storage.cleanup_staging = MagicMock()
+
+            # httpx.AsyncClient context manager
+            mock_http_instance = AsyncMock()
+            mock_http_instance.__aenter__ = AsyncMock(return_value=mock_http_instance)
+            mock_http_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_http.return_value = mock_http_instance
+
+            await run_translation_job(
+                job_id="job-1",
+                staged_file_path=staged_file,
+                source_language="auto",
+                target_language="English",
+                document_name="doc.txt",
+                input_type="txt",
+            )
+
+        # DB should have been updated to completed
+        update_calls = [str(c) for c in mock_db.update_job.call_args_list]
+        assert any("COMPLETED" in c or "completed" in c for c in update_calls)
+        # Staging directory should be cleaned up
+        mock_storage.cleanup_staging.assert_called_once_with("job-1")
+
+    @pytest.mark.asyncio
+    async def test_job_marked_failed_on_exception(self, tmp_path):
+        staged_file = tmp_path / "job-err" / "doc.txt"
+        staged_file.parent.mkdir(parents=True)
+        staged_file.write_text("text", encoding="utf-8")
+
+        mock_db = MagicMock()
+        mock_db.update_job = MagicMock(return_value=True)
+
+        with patch("translate.workers.translation_worker.db_manager", mock_db), \
+             patch("translate.workers.translation_worker.resolve_source_language",
+                   side_effect=RuntimeError("lingua exploded")), \
+             patch("translate.workers.translation_worker.storage_manager") as mock_storage, \
+             patch("translate.workers.translation_worker.settings") as mock_settings, \
+             patch("translate.workers.translation_worker.concurrency_manager") as mock_cm:
+
+            mock_settings.common.llm.endpoint = "http://vllm:8000"
+            mock_settings.common.llm.model = "granite"
+            mock_settings.common.llm.api_key = None
+            mock_settings.translate.prompt_overhead_tokens = 250
+
+            mock_cm.job_limiter = asyncio.BoundedSemaphore(8)
+            mock_storage.cleanup_staging = MagicMock()
+
+            await run_translation_job(
+                job_id="job-err",
+                staged_file_path=staged_file,
+                source_language="auto",
+                target_language="English",
+                document_name="doc.txt",
+                input_type="txt",
+            )
+
+        # Should have been updated to FAILED
+        update_calls = mock_db.update_job.call_args_list
+        failed_calls = [c for c in update_calls if JobStatus.FAILED in c.args or c.kwargs.get("status") == JobStatus.FAILED]
+        assert len(failed_calls) >= 1
+        # Staging always cleaned up
+        mock_storage.cleanup_staging.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_staging_cleanup_always_runs_on_success(self, tmp_path):
+        staged_file = tmp_path / "job-clean" / "doc.txt"
+        staged_file.parent.mkdir(parents=True)
+        staged_file.write_text("text", encoding="utf-8")
+
+        mock_db = MagicMock()
+
+        with patch("translate.workers.translation_worker.db_manager", mock_db), \
+             patch("translate.workers.translation_worker.resolve_source_language",
+                   return_value=(None, None)), \
+             patch("translate.workers.translation_worker.build_translation_chunks",
+                   new=AsyncMock(return_value=[])), \
+             patch("translate.workers.translation_worker.get_llm_max_model_len", return_value=32768), \
+             patch("translate.workers.translation_worker.storage_manager") as mock_storage, \
+             patch("translate.workers.translation_worker.settings") as mock_settings, \
+             patch("translate.workers.translation_worker.concurrency_manager") as mock_cm, \
+             patch("httpx.AsyncClient") as mock_http:
+
+            mock_settings.common.llm.endpoint = "http://vllm:8000"
+            mock_settings.common.llm.model = "granite"
+            mock_settings.common.llm.api_key = None
+            mock_settings.translate.prompt_overhead_tokens = 250
+            mock_settings.translate.translation_temperature = 0.0
+            mock_settings.translate.chunk_token_budget = 13107
+
+            mock_cm.job_limiter = asyncio.BoundedSemaphore(8)
+            mock_storage.write_result = MagicMock()
+            mock_storage.cleanup_staging = MagicMock()
+
+            mock_http_instance = AsyncMock()
+            mock_http_instance.__aenter__ = AsyncMock(return_value=mock_http_instance)
+            mock_http_instance.__aexit__ = AsyncMock(return_value=None)
+            mock_http.return_value = mock_http_instance
+
+            await run_translation_job(
+                job_id="job-clean",
+                staged_file_path=staged_file,
+                source_language="auto",
+                target_language="English",
+                document_name="doc.txt",
+                input_type="txt",
+            )
+
+        mock_storage.cleanup_staging.assert_called_with("job-clean")
+
+    @pytest.mark.asyncio
+    async def test_context_limit_exceeded_marks_failed(self, tmp_path):
+        """If a chunk has too many tokens (leaves no output room), job must fail."""
+        staged_file = tmp_path / "job-ctx" / "doc.txt"
+        staged_file.parent.mkdir(parents=True)
+        staged_file.write_text("text", encoding="utf-8")
+
+        # Chunk with tokens that exceed the model window
+        huge_chunk = _make_chunk(0, "text", token_count=50000)
+
+        mock_db = MagicMock()
+
+        with patch("translate.workers.translation_worker.db_manager", mock_db), \
+             patch("translate.workers.translation_worker.resolve_source_language",
+                   return_value=(None, None)), \
+             patch("translate.workers.translation_worker.build_translation_chunks",
+                   new=AsyncMock(return_value=[huge_chunk])), \
+             patch("translate.workers.translation_worker.get_llm_max_model_len", return_value=4096), \
+             patch("translate.workers.translation_worker.storage_manager") as mock_storage, \
+             patch("translate.workers.translation_worker.settings") as mock_settings, \
+             patch("translate.workers.translation_worker.concurrency_manager") as mock_cm:
+
+            mock_settings.common.llm.endpoint = "http://vllm:8000"
+            mock_settings.common.llm.model = "granite"
+            mock_settings.common.llm.api_key = None
+            mock_settings.translate.prompt_overhead_tokens = 250
+            mock_settings.translate.chunk_token_budget = 13107
+
+            mock_cm.job_limiter = asyncio.BoundedSemaphore(8)
+            mock_storage.cleanup_staging = MagicMock()
+
+            await run_translation_job(
+                job_id="job-ctx",
+                staged_file_path=staged_file,
+                source_language="auto",
+                target_language="English",
+                document_name="doc.txt",
+                input_type="txt",
+            )
+
+        failed_calls = [c for c in mock_db.update_job.call_args_list
+                        if c.kwargs.get("status") == JobStatus.FAILED]
+        assert len(failed_calls) == 1
+
+# Made with Bob


### PR DESCRIPTION
- Adds a comprehensive unit test suite under services/translate/tests/unit/ covering models, language validation, prompt building, LLM utilities, storage, chunking, job lifecycle, zombie recovery, concurrency management, the translation worker pipeline, and all FastAPI endpoints.
- Fixes a FastAPIError in jobs.py caused by an invalid Union[PlainTextResponse, JSONResponse] return annotation on download_job_result by replacing it with response_class=PlainTextResponse on the decorator.
- Wires translate/tests/ into the CI workflow in .github/workflows/service-unit-tests.yml so translate unit tests run on every PR.

<img width="1082" height="820" alt="Screenshot 2026-08-27 at 11 12 41 AM" src="https://github.com/user-attachments/assets/7c15692b-45dd-459f-8bb5-3b2c02f7c793" />

