### PR TITLE
Deploy remote application code with create cli

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.290
+TAG?=v0.0.291
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.290
+  image: icr.io/ai-services-cicd/ai-services:v0.0.291
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.290
+  image: icr.io/ai-services-cicd/ai-services:v0.0.291
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/podman/Caddyfile.tmpl
+++ b/ai-services/assets/worker/podman/Caddyfile.tmpl
@@ -2,7 +2,7 @@
 	admin 0.0.0.0:2019
 
 	servers :443 {
-		name ai_services_worker
+		name ai_services
 	}
 }
 

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -29,6 +29,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 )
 
 const (
@@ -46,6 +47,7 @@ var (
 	rawArgParams []string
 	argParams    map[string]string
 	legacyCreate bool
+	workerName   string
 
 	// podman flags.
 	skipModelDownload     bool
@@ -171,6 +173,11 @@ func initCreateCommonFlags() {
 
 	createCmd.Flags().StringVarP(&templateName, appFlags.Create.Template, "t", "", "Application template to use (required)")
 	_ = createCmd.MarkFlagRequired(appFlags.Create.Template)
+
+	createCmd.Flags().StringVar(&workerName, appFlags.Create.WorkerName, workerconstants.LocalWorkerName,
+		"Name of a connected remote worker to deploy to.\n"+
+			fmt.Sprintf("Defaults to %q (local deployment).\n", workerconstants.LocalWorkerName)+
+			"Example: --worker node-1\n")
 
 	createCmd.Flags().StringSliceVar(
 		&rawArgParams,
@@ -647,10 +654,11 @@ func buildArchitecturePayload(ctx context.Context, provider *catalog.CatalogProv
 	}
 
 	return &apiModels.CreateApplicationRequest{
-		CatalogID: archID,
-		Name:      appName,
-		Services:  services,
-		Version:   arch.Version,
+		CatalogID:  archID,
+		Name:       appName,
+		Services:   services,
+		Version:    arch.Version,
+		WorkerName: workerName,
 	}, nil
 }
 
@@ -674,10 +682,11 @@ func buildServicePayload(ctx context.Context, serviceID, appName string) (*apiMo
 	}
 
 	return &apiModels.CreateApplicationRequest{
-		CatalogID: serviceID,
-		Name:      appName,
-		Services:  []apiModels.Service{svc},
-		Version:   svc.Version,
+		CatalogID:  serviceID,
+		Name:       appName,
+		Services:   []apiModels.Service{svc},
+		Version:    svc.Version,
+		WorkerName: workerName,
 	}, nil
 }
 

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -174,7 +174,9 @@ func initCreateCommonFlags() {
 	createCmd.Flags().StringVarP(&templateName, appFlags.Create.Template, "t", "", "Application template to use (required)")
 	_ = createCmd.MarkFlagRequired(appFlags.Create.Template)
 
-	createCmd.Flags().StringVar(&workerName, appFlags.Create.WorkerName, workerconstants.LocalWorkerName,
+	// TODO: Once runtime deployment is enabled, use default value as workerconstants.LocalWorkerName
+	// createCmd.Flags().StringVar(&workerName, appFlags.Create.WorkerName, workerconstants.LocalWorkerName,
+	createCmd.Flags().StringVar(&workerName, appFlags.Create.WorkerName, "",
 		"Name of a connected remote worker to deploy to.\n"+
 			fmt.Sprintf("Defaults to %q (local deployment).\n", workerconstants.LocalWorkerName)+
 			"Example: --worker node-1\n")

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -124,7 +124,7 @@ func buildAPIServerOptions(ctx context.Context, pool *pgxpool.Pool, secretKey, a
 		AuthService:        authSvc,
 		TokenManager:       tokenMgr,
 		Blacklist:          blacklist,
-		ApplicationService: apirepository.NewApplicationService(appRepo, svcRepo, compRepo, svcDepRepo, catalogProvider, vars.RuntimeFactory.GetRuntimeType()),
+		ApplicationService: apirepository.NewApplicationService(appRepo, svcRepo, compRepo, svcDepRepo, catalogProvider, vars.RuntimeFactory.GetRuntimeType(), workerReg),
 		DatasourceService:  datasourceSvc,
 		BundleService:      bundlesvc.NewBundleService(bundleRepo, svcRepo, compRepo, catalogProvider),
 		CatalogProvider:    catalogProvider,

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -2099,6 +2099,10 @@ const docTemplate = `{
                 },
                 "version": {
                     "type": "string"
+                },
+                "worker_name": {
+                    "description": "WorkerName is the name of a connected remote worker to deploy to.\nWhen empty the application is deployed locally.",
+                    "type": "string"
                 }
             }
         },

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -2093,6 +2093,10 @@
                 },
                 "version": {
                     "type": "string"
+                },
+                "worker_name": {
+                    "description": "WorkerName is the name of a connected remote worker to deploy to.\nWhen empty the application is deployed locally.",
+                    "type": "string"
                 }
             }
         },

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -66,6 +66,11 @@ definitions:
         type: array
       version:
         type: string
+      worker_name:
+        description: |-
+          WorkerName is the name of a connected remote worker to deploy to.
+          When empty the application is deployed locally.
+        type: string
     required:
     - catalog_id
     - name

--- a/ai-services/internal/pkg/catalog/apiserver/models/create_application.go
+++ b/ai-services/internal/pkg/catalog/apiserver/models/create_application.go
@@ -7,6 +7,9 @@ type CreateApplicationRequest struct {
 	Version   string    `json:"version" binding:"required"`
 	Services  []Service `json:"services" binding:"required,dive"`
 	CreatedBy string    `json:"-"` // Set from auth context, not from request body
+	// WorkerName is the name of a connected remote worker to deploy to.
+	// When empty the application is deployed locally.
+	WorkerName string `json:"worker_name,omitempty"`
 }
 
 // Service represents a service configuration in the application.

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -10,6 +10,7 @@ import (
 	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/validators"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/worker/stream"
 )
 
 // ValidationError represents a validation error with HTTP status code.
@@ -29,6 +30,10 @@ func ValidatePaginationParams(page, pageSize int) (int, int, error) {
 
 // NewApplicationService creates the appropriate ApplicationServiceInterface implementation
 // based on the runtime type. It is the single construction point for the apiserver.
+//
+// reg wires the worker registry into the deployment executor so that requests
+// carrying a non-empty WorkerName are routed to the named remote worker over the
+// gRPC CommandStream. This applies to both Podman and OpenShift local runtimes.
 func NewApplicationService(
 	appRepo dbrepo.ApplicationRepository,
 	serviceRepo dbrepo.ServiceRepository,
@@ -36,6 +41,7 @@ func NewApplicationService(
 	serviceDependencyRepo dbrepo.ServiceDependencyRepository,
 	provider *catalog.CatalogProvider,
 	runtimeType runtimeTypes.RuntimeType,
+	reg stream.WorkerRegistry,
 ) ApplicationServiceInterface {
 	base := appservice.ApplicationServiceBase{
 		AppRepo:               appRepo,
@@ -44,7 +50,7 @@ func NewApplicationService(
 		ServiceDependencyRepo: serviceDependencyRepo,
 		Provider:              provider,
 		DeploymentPlanner:     deployment.NewDeploymentPlanner(provider, componentRepo),
-		DeploymentExecutor:    deployment.NewDeploymentExecutor(provider, appRepo, serviceRepo, componentRepo),
+		DeploymentExecutor:    deployment.NewDeploymentExecutor(provider, appRepo, serviceRepo, componentRepo).WithWorkerRegistry(reg),
 		DeletionExecutor:      deletion.NewDeletionExecutor(appRepo, serviceRepo, componentRepo, serviceDependencyRepo),
 		Validator:             validators.NewApplicationValidator(provider),
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -49,7 +49,7 @@ func NewApplicationService(
 		ComponentRepo:         componentRepo,
 		ServiceDependencyRepo: serviceDependencyRepo,
 		Provider:              provider,
-		DeploymentPlanner:     deployment.NewDeploymentPlanner(provider, componentRepo),
+		DeploymentPlanner:     deployment.NewDeploymentPlanner(provider, componentRepo).WithWorkerRegistry(reg),
 		DeploymentExecutor:    deployment.NewDeploymentExecutor(provider, appRepo, serviceRepo, componentRepo).WithWorkerRegistry(reg),
 		DeletionExecutor:      deletion.NewDeletionExecutor(appRepo, serviceRepo, componentRepo, serviceDependencyRepo),
 		Validator:             validators.NewApplicationValidator(provider),

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -25,7 +25,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/common"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
-	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 )
 
 // ValidationError represents a validation error with HTTP status code.
@@ -622,16 +621,6 @@ func (s *ApplicationServiceBase) ListApplications(ctx context.Context, req ListA
 // CreateApplication validates, plans, persists, and asynchronously deploys a new application
 // for the given runtime type.
 func (s *ApplicationServiceBase) CreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest, runtimeType runtimeTypes.RuntimeType) (*apimodels.CreateApplicationResponse, error) {
-	// Default to local worker when none specified.
-	if req.WorkerName == "" {
-		req.WorkerName = workerconstants.LocalWorkerName
-	}
-
-	// Phase 0: verify the worker is ready before touching the database,
-	// so callers get an immediate 400 error.
-	if err := s.DeploymentExecutor.ValidateWorker(ctx, req.WorkerName); err != nil {
-		return nil, &ValidationError{Code: http.StatusBadRequest, Message: err.Error()}
-	}
 
 	// Phase 1: check for duplicate name
 	existingApp, err := s.AppRepo.GetByName(ctx, req.Name)

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -25,6 +25,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/common"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 )
 
 // ValidationError represents a validation error with HTTP status code.
@@ -621,6 +622,17 @@ func (s *ApplicationServiceBase) ListApplications(ctx context.Context, req ListA
 // CreateApplication validates, plans, persists, and asynchronously deploys a new application
 // for the given runtime type.
 func (s *ApplicationServiceBase) CreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest, runtimeType runtimeTypes.RuntimeType) (*apimodels.CreateApplicationResponse, error) {
+	// Default to local worker when none specified.
+	if req.WorkerName == "" {
+		req.WorkerName = workerconstants.LocalWorkerName
+	}
+
+	// Phase 0: verify the worker is ready before touching the database,
+	// so callers get an immediate 400 error.
+	if err := s.DeploymentExecutor.ValidateWorker(ctx, req.WorkerName); err != nil {
+		return nil, &ValidationError{Code: http.StatusBadRequest, Message: err.Error()}
+	}
+
 	// Phase 1: check for duplicate name
 	existingApp, err := s.AppRepo.GetByName(ctx, req.Name)
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -621,7 +621,6 @@ func (s *ApplicationServiceBase) ListApplications(ctx context.Context, req ListA
 // CreateApplication validates, plans, persists, and asynchronously deploys a new application
 // for the given runtime type.
 func (s *ApplicationServiceBase) CreateApplication(ctx context.Context, req apimodels.CreateApplicationRequest, runtimeType runtimeTypes.RuntimeType) (*apimodels.CreateApplicationResponse, error) {
-
 	// Phase 1: check for duplicate name
 	existingApp, err := s.AppRepo.GetByName(ctx, req.Name)
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/executor.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/executor.go
@@ -18,11 +18,9 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/stream"
 )
 
-// DeploymentExecutor orchestrates the complete deployment process.
-// It uses the DeploymentPlanner to create a plan and then executes it
-// using the appropriate runtime-specific deployer.
+// DeploymentExecutor orchestrates the execution of an already-planned
+// deployment, routing to the correct runtime-specific deployer.
 type DeploymentExecutor struct {
-	planner         *DeploymentPlanner
 	catalogProvider *catalog.CatalogProvider
 	appRepo         repository.ApplicationRepository
 	serviceRepo     repository.ServiceRepository
@@ -39,7 +37,6 @@ func NewDeploymentExecutor(
 	componentRepo repository.ComponentRepository,
 ) *DeploymentExecutor {
 	return &DeploymentExecutor{
-		planner:         NewDeploymentPlanner(catalogProvider, componentRepo),
 		catalogProvider: catalogProvider,
 		appRepo:         appRepo,
 		serviceRepo:     serviceRepo,
@@ -48,20 +45,20 @@ func NewDeploymentExecutor(
 }
 
 // WithWorkerRegistry wires the worker registry into the executor so it can
-// validate workers, read their metadata, and create RemoteRuntime instances.
-// Must be called before any deployment that targets a non-local worker.
+// resolve a RemoteRuntime for worker deployments. Must be called before any
+// deployment that targets a non-local worker.
 func (e *DeploymentExecutor) WithWorkerRegistry(reg stream.WorkerRegistry) *DeploymentExecutor {
 	e.workerRegistry = reg
 
 	return e
 }
 
-// ValidateWorker checks that workerName is non-empty and that the named worker
-// is currently connected with status=ready (cache + DB check). Called before
-// any DB records are written so the API can return 400 immediately.
+// ValidateWorker confirms the named worker is ready before any DB records are
+// written so the API can return 400 immediately.
 func (e *DeploymentExecutor) ValidateWorker(ctx context.Context, workerName string) error {
+	// TODO: Remove when remote deployment is by default
 	if workerName == "" {
-		return fmt.Errorf("worker name must not be empty")
+		return nil
 	}
 
 	if e.workerRegistry == nil {
@@ -91,9 +88,7 @@ func (e *DeploymentExecutor) ExecuteWithPlan(
 }
 
 // executeDeployment routes to the correct deployer based on plan.WorkerName.
-// Any name other than LocalWorkerName is treated as a remote worker and
-// dispatched over the gRPC CommandStream. LocalWorkerName falls back to the
-// local runtime determined by runtimeType.
+// WorkerName is always set by PlanDeployment.
 func (e *DeploymentExecutor) executeDeployment(
 	ctx context.Context,
 	plan *DeploymentPlan,
@@ -101,7 +96,9 @@ func (e *DeploymentExecutor) executeDeployment(
 	runtimeType types.RuntimeType,
 ) error {
 	// ── Remote worker deployment ──────────────────────────────────────────────
-	if plan.WorkerName != "" && plan.WorkerName != workerconstants.LocalWorkerName {
+	// TODO Remove the check when remote deployment is by default
+	// and the remaining code will be dead
+	if plan.WorkerName != "" {
 		return e.executeWorkerDeployment(ctx, plan, req)
 	}
 

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/executor.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/executor.go
@@ -53,25 +53,6 @@ func (e *DeploymentExecutor) WithWorkerRegistry(reg stream.WorkerRegistry) *Depl
 	return e
 }
 
-// ValidateWorker confirms the named worker is ready before any DB records are
-// written so the API can return 400 immediately.
-func (e *DeploymentExecutor) ValidateWorker(ctx context.Context, workerName string) error {
-	// TODO: Remove when remote deployment is by default
-	if workerName == "" {
-		return nil
-	}
-
-	if e.workerRegistry == nil {
-		return fmt.Errorf("worker deployment is not configured on this server")
-	}
-
-	if !e.workerRegistry.IsWorkerConnected(ctx, workerName) {
-		return fmt.Errorf("worker %q is not connected", workerName)
-	}
-
-	return nil
-}
-
 // ExecuteWithPlan runs the deployment described by plan. DB records have
 // already been written by the caller before this is invoked.
 func (e *DeploymentExecutor) ExecuteWithPlan(

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/executor.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/executor.go
@@ -10,9 +10,12 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	openshiftRuntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/openshift"
 	podmanRuntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/worker/stream"
 )
 
 // DeploymentExecutor orchestrates the complete deployment process.
@@ -24,6 +27,8 @@ type DeploymentExecutor struct {
 	appRepo         repository.ApplicationRepository
 	serviceRepo     repository.ServiceRepository
 	componentRepo   repository.ComponentRepository
+	// workerRegistry is used to resolve a RemoteRuntime for worker deployments.
+	workerRegistry stream.WorkerRegistry
 }
 
 // NewDeploymentExecutor creates a new DeploymentExecutor instance.
@@ -42,15 +47,42 @@ func NewDeploymentExecutor(
 	}
 }
 
-// ExecuteWithPlan executes deployment using an existing plan.
-// This is used when the plan has already been created and database records inserted.
+// WithWorkerRegistry wires the worker registry into the executor so it can
+// validate workers, read their metadata, and create RemoteRuntime instances.
+// Must be called before any deployment that targets a non-local worker.
+func (e *DeploymentExecutor) WithWorkerRegistry(reg stream.WorkerRegistry) *DeploymentExecutor {
+	e.workerRegistry = reg
+
+	return e
+}
+
+// ValidateWorker checks that workerName is non-empty and that the named worker
+// is currently connected with status=ready (cache + DB check). Called before
+// any DB records are written so the API can return 400 immediately.
+func (e *DeploymentExecutor) ValidateWorker(ctx context.Context, workerName string) error {
+	if workerName == "" {
+		return fmt.Errorf("worker name must not be empty")
+	}
+
+	if e.workerRegistry == nil {
+		return fmt.Errorf("worker deployment is not configured on this server")
+	}
+
+	if !e.workerRegistry.IsWorkerConnected(ctx, workerName) {
+		return fmt.Errorf("worker %q is not connected", workerName)
+	}
+
+	return nil
+}
+
+// ExecuteWithPlan runs the deployment described by plan. DB records have
+// already been written by the caller before this is invoked.
 func (e *DeploymentExecutor) ExecuteWithPlan(
 	ctx context.Context,
 	plan *DeploymentPlan,
 	req apimodels.CreateApplicationRequest,
 	runtimeType types.RuntimeType,
 ) error {
-	// Execute deployment based on runtime type using the provided plan
 	if err := e.executeDeployment(ctx, plan, req, runtimeType); err != nil {
 		return fmt.Errorf("failed to execute deployment: %w", err)
 	}
@@ -58,13 +90,22 @@ func (e *DeploymentExecutor) ExecuteWithPlan(
 	return nil
 }
 
-// executeDeployment executes the deployment plan using the appropriate runtime deployer.
+// executeDeployment routes to the correct deployer based on plan.WorkerName.
+// Any name other than LocalWorkerName is treated as a remote worker and
+// dispatched over the gRPC CommandStream. LocalWorkerName falls back to the
+// local runtime determined by runtimeType.
 func (e *DeploymentExecutor) executeDeployment(
 	ctx context.Context,
 	plan *DeploymentPlan,
 	req apimodels.CreateApplicationRequest,
 	runtimeType types.RuntimeType,
 ) error {
+	// ── Remote worker deployment ──────────────────────────────────────────────
+	if plan.WorkerName != "" && plan.WorkerName != workerconstants.LocalWorkerName {
+		return e.executeWorkerDeployment(ctx, plan, req)
+	}
+
+	// ── Local deployment ──────────────────────────────────────────────────────
 	switch runtimeType {
 	case types.RuntimeTypePodman:
 		return e.executePodmanDeployment(ctx, plan, req)
@@ -75,8 +116,73 @@ func (e *DeploymentExecutor) executeDeployment(
 	}
 }
 
-// executePodmanDeployment executes deployment for Podman runtime.
-// Handles both architecture and standalone service deployments.
+// executeWorkerDeployment dispatches a deployment to a named remote worker.
+// Resolves the worker's runtime type from the registry, builds a RemoteRuntime
+// that forwards all calls over the gRPC CommandStream, then delegates to the
+// appropriate deployer (Podman or OpenShift).
+func (e *DeploymentExecutor) executeWorkerDeployment(
+	ctx context.Context,
+	plan *DeploymentPlan,
+	req apimodels.CreateApplicationRequest,
+) error {
+	// Connectivity was already confirmed by ValidateWorker; just read the type.
+	rtStr, _ := e.workerRegistry.WorkerRuntimeType(plan.WorkerName)
+	workerType := types.RuntimeType(rtStr)
+
+	// RemoteRuntime forwards every call over the gRPC CommandStream — the
+	// deployer does not need to know it is talking to a remote machine.
+	rt, err := runtime.NewRuntimeFactory(workerType).CreateRemote(plan.WorkerName, e.workerRegistry)
+	if err != nil {
+		return fmt.Errorf("create remote runtime for worker %q: %w", plan.WorkerName, err)
+	}
+
+	switch workerType {
+	case types.RuntimeTypePodman:
+		return e.runPodmanDeployer(ctx, plan, req, rt)
+	case types.RuntimeTypeOpenShift:
+		return e.runOpenShiftDeployer(ctx, plan, req, rt)
+	default:
+		return fmt.Errorf("worker %q has unsupported runtime type %q", plan.WorkerName, workerType)
+	}
+}
+
+// runPodmanDeployer creates a PodmanDeployer backed by the RemoteRuntime and
+// injects the worker's registration metadata (domain suffix, HTTPS port, base
+// dir) via SetPodmanWorkerConfig so the deployer uses the correct values
+// instead of local environment variables.
+func (e *DeploymentExecutor) runPodmanDeployer(
+	ctx context.Context,
+	plan *DeploymentPlan,
+	req apimodels.CreateApplicationRequest,
+	rt runtime.Runtime,
+) error {
+	deployer := podman.NewPodmanDeployer(rt, e.catalogProvider, e.appRepo, e.serviceRepo, e.componentRepo)
+
+	meta, _ := e.workerRegistry.WorkerMetadata(plan.WorkerName)
+	deployer.SetPodmanWorkerConfig(podman.PodmanWorkerConfig{
+		DomainSuffix: meta[workerconstants.MetaKeyDomainSuffix],
+		HTTPSPort:    meta[workerconstants.MetaKeyHTTPSPort],
+		BaseDir:      meta[workerconstants.MetaKeyBaseDir],
+	})
+
+	return deployer.ExecuteDeployment(ctx, plan, req)
+}
+
+// runOpenShiftDeployer creates an OpenShiftDeployer backed by the RemoteRuntime
+// and runs the deployment. OpenShift workers manage routes natively via the
+// Kubernetes API so no config is needed.
+func (e *DeploymentExecutor) runOpenShiftDeployer(
+	ctx context.Context,
+	plan *DeploymentPlan,
+	req apimodels.CreateApplicationRequest,
+	rt runtime.Runtime,
+) error {
+	deployer := openshift.NewOpenShiftDeployer(rt, e.catalogProvider, e.appRepo, e.serviceRepo, e.componentRepo)
+
+	return deployer.ExecuteDeployment(ctx, plan, req)
+}
+
+// executePodmanDeployment executes deployment for local Podman runtime.
 func (e *DeploymentExecutor) executePodmanDeployment(
 	ctx context.Context,
 	plan *DeploymentPlan,

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
@@ -73,6 +73,7 @@ func (p *DeploymentPlanner) PlanDeployment(
 		IsArchitecture:  isArchitecture,
 		Components:      make(map[string]*ComponentPlan),
 		Services:        make(map[string]*ServicePlan),
+		WorkerName:      req.WorkerName,
 	}
 
 	// Process each service from request

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
@@ -14,6 +14,8 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/worker/stream"
 )
 
 // DeploymentPlanner plans the deployment of applications by:
@@ -24,6 +26,9 @@ type DeploymentPlanner struct {
 	catalogProvider *catalog.CatalogProvider
 	componentRepo   repository.ComponentRepository
 	paramBuilder    *params.ParamBuilder
+	// workerRegistry is optional; when set, PlanDeployment validates remote
+	// worker metadata (e.g. Caddy config) before any DB records are written.
+	workerRegistry stream.WorkerRegistry
 }
 
 // NewDeploymentPlanner creates a new deployment planner.
@@ -36,6 +41,15 @@ func NewDeploymentPlanner(
 		componentRepo:   componentRepo,
 		paramBuilder:    params.NewParamBuilder(provider),
 	}
+}
+
+// WithWorkerRegistry wires the worker registry into the planner so it can
+// validate remote worker metadata during PlanDeployment and fail early before
+// any DB records are written.
+func (p *DeploymentPlanner) WithWorkerRegistry(reg stream.WorkerRegistry) *DeploymentPlanner {
+	p.workerRegistry = reg
+
+	return p
 }
 
 // Type aliases for deployment plan types.
@@ -51,6 +65,19 @@ func (p *DeploymentPlanner) PlanDeployment(
 	req apimodels.CreateApplicationRequest,
 	runtimeType string,
 ) (*DeploymentPlan, error) {
+	// Default to local when the caller did not specify a worker so that
+	// WorkerName is always set and no downstream code needs to treat "" as local.
+	// TODO: Enable this to test local worker by default
+	// if req.WorkerName == "" {
+	// 	req.WorkerName = workerconstants.LocalWorkerName
+	// }
+
+	// For remote workers, validate connectivity and Caddy metadata before
+	// touching the DB so the Create API returns an immediate error on failure.
+	if err := p.ValidateWorker(ctx, req.WorkerName, runtimeType); err != nil {
+		return nil, err
+	}
+
 	// First, determine if this is an architecture or standalone service
 	isArchitecture := false
 	_, archErr := p.catalogProvider.LoadArchitecture(req.CatalogID)
@@ -258,6 +285,42 @@ func (p *DeploymentPlanner) getRequiredSpyreCardsForComponent(ctx context.Contex
 	}
 
 	return totalSpyreCards, nil
+}
+
+// ValidateWorker confirms the named remote worker is connected and, for Podman
+// workers, that the required Caddy metadata (domainSuffix, httpsPort) is
+// present. Called from PlanDeployment before any DB records are written so the
+// Create API can return an error immediately on failure.
+func (p *DeploymentPlanner) ValidateWorker(ctx context.Context, workerName, runtimeType string) error {
+	if p.workerRegistry == nil {
+		return fmt.Errorf("worker deployment is not configured on this server")
+	}
+
+	if !p.workerRegistry.IsWorkerConnected(ctx, workerName) {
+		return fmt.Errorf("worker %q is not connected", workerName)
+	}
+
+	// Validate all the metadata for deployment is present
+	if runtimeType == runtimeTypes.RuntimeTypePodman.String() {
+		meta, ok := p.workerRegistry.WorkerMetadata(workerName)
+		if !ok {
+			return fmt.Errorf("worker %q metadata not available", workerName)
+		}
+
+		if meta[workerconstants.MetaKeyDomainSuffix] == "" {
+			return fmt.Errorf("worker %q metadata missing %q", workerName, workerconstants.MetaKeyDomainSuffix)
+		}
+
+		if meta[workerconstants.MetaKeyHTTPSPort] == "" {
+			return fmt.Errorf("worker %q metadata missing %q", workerName, workerconstants.MetaKeyHTTPSPort)
+		}
+
+		if meta[workerconstants.MetaKeyBaseDir] == "" {
+			return fmt.Errorf("worker %q metadata missing %q", workerName, workerconstants.MetaKeyBaseDir)
+		}
+	}
+
+	return nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
@@ -296,6 +296,11 @@ func (p *DeploymentPlanner) ValidateWorker(ctx context.Context, workerName, runt
 		return fmt.Errorf("worker deployment is not configured on this server")
 	}
 
+	// TODO: Remove this when remote deployment is by default
+	if workerName == "" {
+		return nil
+	}
+
 	if !p.workerRegistry.IsWorkerConnected(ctx, workerName) {
 		return fmt.Errorf("worker %q is not connected", workerName)
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -254,6 +254,7 @@ func (d *PodmanDeployer) downloadModels(ctx context.Context, modelSet map[string
 				return fmt.Errorf("failed to download model %s: %w", modelName, err)
 			}
 		}
+
 		return nil
 	}
 
@@ -1147,6 +1148,7 @@ func (d *PodmanDeployer) registerApplicationRoutes(ctx context.Context, plan *De
 func (d *PodmanDeployer) getCaddyConfiguration() (string, string, proxy.ProxyManager, error) {
 	if rt, ok := d.runtime.(*remoteruntime.RemoteRuntime); ok {
 		pm := proxy.NewRemoteProxyManager(rt.Sender)
+
 		return d.workerConfig.DomainSuffix, d.workerConfig.HTTPSPort, pm, nil
 	}
 

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -33,6 +33,9 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/specs"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/worker/payload"
+	workerpb "github.com/project-ai-services/ai-services/internal/pkg/worker/proto"
 	k8syaml "sigs.k8s.io/yaml"
 )
 
@@ -52,6 +55,14 @@ type (
 	SpyreCardPool  = deploymenttypes.SpyreCardPool
 )
 
+// PodmanWorkerConfig holds configuration sourced from a remote worker's
+// registration metadata.
+type PodmanWorkerConfig struct {
+	DomainSuffix string
+	HTTPSPort    string
+	BaseDir      string
+}
+
 // PodmanDeployer implements deployment execution for Podman runtime.
 type PodmanDeployer struct {
 	runtime         runtime.Runtime
@@ -59,6 +70,9 @@ type PodmanDeployer struct {
 	appRepo         repository.ApplicationRepository
 	serviceRepo     repository.ServiceRepository
 	componentRepo   repository.ComponentRepository
+	// workerConfig is non-nil for remote worker deployments. When set,
+	// getCaddyConfiguration uses its values instead of local env vars.
+	workerConfig *PodmanWorkerConfig
 }
 
 // NewPodmanDeployer creates a new PodmanDeployer instance.
@@ -76,6 +90,13 @@ func NewPodmanDeployer(
 		serviceRepo:     serviceRepo,
 		componentRepo:   componentRepo,
 	}
+}
+
+// SetPodmanWorkerConfig injects the Caddy configuration for a remote worker
+// deployment. When set, getCaddyConfiguration uses these values instead of
+// local env vars.
+func (d *PodmanDeployer) SetPodmanWorkerConfig(cfg PodmanWorkerConfig) {
+	d.workerConfig = &cfg
 }
 
 // ExecuteDeployment executes the deployment plan for an application or standalone service.
@@ -218,7 +239,25 @@ func (d *PodmanDeployer) extractModelsFromParams(params map[string]any, modelSet
 }
 
 // downloadModels downloads all models in the provided set.
+// For remote workers the command is forwarded to the worker node via the gRPC
+// stream so the download runs where the models directory lives; for local
+// workers helpers.DownloadModelContainer is called directly.
 func (d *PodmanDeployer) downloadModels(ctx context.Context, modelSet map[string]bool) error {
+	if rt, ok := d.runtime.(*remoteruntime.RemoteRuntime); ok {
+		modelsPath := d.workerConfig.BaseDir + "/models"
+		for modelName := range modelSet {
+			logger.InfofCtx(ctx, "Downloading model: %s\n", modelName)
+			_, err := rt.Send(ctx, workerpb.CommandType_COMMAND_TYPE_DOWNLOAD_MODEL, payload.DownloadModel{
+				Model:     modelName,
+				TargetDir: modelsPath,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to download model %s: %w", modelName, err)
+			}
+		}
+		return nil
+	}
+
 	modelsPath := utils.GetModelsPath()
 
 	for modelName := range modelSet {
@@ -1102,22 +1141,35 @@ func (d *PodmanDeployer) registerApplicationRoutes(ctx context.Context, plan *De
 }
 
 // getCaddyConfiguration retrieves Caddy configuration and creates a ProxyManager.
-// For a local runtime it reads CADDY_ADMIN_URL from the environment.
-// For a remote runtime it returns a RemoteProxyManager that sends route commands
-// over the gRPC CommandStream to the worker.
+// For a remote runtime the domain/port come from the worker's registration
+// metadata (via workerConfig) and a RemoteProxyManager is returned.
+// For a local runtime both values are read from environment variables and a
+// local Caddy ProxyManager is returned.
 func (d *PodmanDeployer) getCaddyConfiguration() (string, string, proxy.ProxyManager, error) {
+	if rt, ok := d.runtime.(*remoteruntime.RemoteRuntime); ok {
+		if d.workerConfig == nil {
+			return "", "", nil, fmt.Errorf("remote runtime requires worker config with domain suffix and HTTPS port")
+		}
+
+		if d.workerConfig.DomainSuffix == "" {
+			return "", "", nil, fmt.Errorf("worker metadata missing %q", workerconstants.MetaKeyDomainSuffix)
+		}
+
+		if d.workerConfig.HTTPSPort == "" {
+			return "", "", nil, fmt.Errorf("worker metadata missing %q", workerconstants.MetaKeyHTTPSPort)
+		}
+
+		pm := proxy.NewRemoteProxyManager(rt.Sender)
+
+		return d.workerConfig.DomainSuffix, d.workerConfig.HTTPSPort, pm, nil
+	}
+
 	domainSuffix := utils.GetEnv("DOMAIN_SUFFIX", "")
 	if domainSuffix == "" {
 		return "", "", nil, fmt.Errorf("DOMAIN_SUFFIX environment variable not set")
 	}
 
 	httpsPort := utils.GetEnv("CADDY_HTTPS_PORT", catalogconstants.DefaultHTTPSPort)
-
-	if rt, ok := d.runtime.(*remoteruntime.RemoteRuntime); ok {
-		pm := proxy.NewRemoteProxyManager(rt.Sender)
-
-		return domainSuffix, httpsPort, pm, nil
-	}
 
 	proxyManager, err := proxy.GetCaddyProxyManager()
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -33,7 +33,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/specs"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
-	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/payload"
 	workerpb "github.com/project-ai-services/ai-services/internal/pkg/worker/proto"
 	k8syaml "sigs.k8s.io/yaml"
@@ -239,9 +238,9 @@ func (d *PodmanDeployer) extractModelsFromParams(params map[string]any, modelSet
 }
 
 // downloadModels downloads all models in the provided set.
-// For remote workers the command is forwarded to the worker node via the gRPC
-// stream so the download runs where the models directory lives; for local
-// workers helpers.DownloadModelContainer is called directly.
+// For remote workers the command is sent over the gRPC stream so the download
+// runs on the worker node where the models directory lives; for local workers
+// helpers.DownloadModelContainer is called directly.
 func (d *PodmanDeployer) downloadModels(ctx context.Context, modelSet map[string]bool) error {
 	if rt, ok := d.runtime.(*remoteruntime.RemoteRuntime); ok {
 		modelsPath := d.workerConfig.BaseDir + "/models"
@@ -1147,20 +1146,7 @@ func (d *PodmanDeployer) registerApplicationRoutes(ctx context.Context, plan *De
 // local Caddy ProxyManager is returned.
 func (d *PodmanDeployer) getCaddyConfiguration() (string, string, proxy.ProxyManager, error) {
 	if rt, ok := d.runtime.(*remoteruntime.RemoteRuntime); ok {
-		if d.workerConfig == nil {
-			return "", "", nil, fmt.Errorf("remote runtime requires worker config with domain suffix and HTTPS port")
-		}
-
-		if d.workerConfig.DomainSuffix == "" {
-			return "", "", nil, fmt.Errorf("worker metadata missing %q", workerconstants.MetaKeyDomainSuffix)
-		}
-
-		if d.workerConfig.HTTPSPort == "" {
-			return "", "", nil, fmt.Errorf("worker metadata missing %q", workerconstants.MetaKeyHTTPSPort)
-		}
-
 		pm := proxy.NewRemoteProxyManager(rt.Sender)
-
 		return d.workerConfig.DomainSuffix, d.workerConfig.HTTPSPort, pm, nil
 	}
 

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/types/plan.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/types/plan.go
@@ -17,6 +17,9 @@ type DeploymentPlan struct {
 	Components      map[string]*ComponentPlan // Key: component hash, Value: component plan
 	Services        map[string]*ServicePlan   // Key: service ID, Value: service plan
 	SpyreCardPool   *SpyreCardPool            // Allocated Spyre card pool (set after allocation)
+	// WorkerName is set when the deployment targets a remote worker node.
+	// Empty means local deployment.
+	WorkerName string
 }
 
 // ComponentPlan represents a single component deployment.

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/types/plan.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/types/plan.go
@@ -17,8 +17,9 @@ type DeploymentPlan struct {
 	Components      map[string]*ComponentPlan // Key: component hash, Value: component plan
 	Services        map[string]*ServicePlan   // Key: service ID, Value: service plan
 	SpyreCardPool   *SpyreCardPool            // Allocated Spyre card pool (set after allocation)
-	// WorkerName is set when the deployment targets a remote worker node.
-	// Empty means local deployment.
+	// WorkerName identifies the target worker. Always set by PlanDeployment:
+	// workerconstants.LocalWorkerName for local deployments, or the actual
+	// worker name for remote ones.
 	WorkerName string
 }
 

--- a/ai-services/internal/pkg/catalog/db/repository/worker_repo.go
+++ b/ai-services/internal/pkg/catalog/db/repository/worker_repo.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
 )
@@ -29,6 +31,8 @@ type WorkerRepository interface {
 	Delete(ctx context.Context, id uuid.UUID) (bool, error)
 	// GetAll returns all worker rows ordered by registered_at ascending.
 	GetAll(ctx context.Context) ([]models.Worker, error)
+	// GetByName returns the worker with the given name, or (nil, nil) if not found.
+	GetByName(ctx context.Context, name string) (*models.Worker, error)
 }
 
 // workerRepo implements WorkerRepository using pgx.
@@ -167,6 +171,45 @@ func (r *workerRepo) GetAll(ctx context.Context) ([]models.Worker, error) {
 	}
 
 	return workers, nil
+}
+
+// GetByName returns the worker with the given name, or (nil, nil) if not found.
+func (r *workerRepo) GetByName(ctx context.Context, name string) (*models.Worker, error) {
+	query := `
+		SELECT id, name, runtime_type, status, last_heartbeat, metadata, registered_at, updated_at
+		FROM workers
+		WHERE name = $1
+	`
+
+	var (
+		w            models.Worker
+		hb           sql.NullTime
+		metadataJSON []byte
+	)
+
+	err := r.pool.QueryRow(ctx, query, name).Scan(
+		&w.ID, &w.Name, &w.RuntimeType, &w.Status,
+		&hb, &metadataJSON, &w.RegisteredAt, &w.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("failed to get worker %q: %w", name, err)
+	}
+
+	if hb.Valid {
+		w.LastHeartbeat = &hb.Time
+	}
+
+	if len(metadataJSON) > 0 {
+		if err := json.Unmarshal(metadataJSON, &w.Metadata); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal worker metadata: %w", err)
+		}
+	}
+
+	return &w, nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/cli/constants/application/flags.go
+++ b/ai-services/internal/pkg/cli/constants/application/flags.go
@@ -8,6 +8,7 @@ type CreateFlags struct {
 	Params         string
 	Values         string
 	Legacy         string
+	WorkerName     string
 
 	// Podman-specific flags
 	SkipImageDownload string
@@ -26,6 +27,7 @@ var Create = CreateFlags{
 	Params:         "params",
 	Values:         "values",
 	Legacy:         "legacy",
+	WorkerName:     "worker",
 
 	// Podman-specific flags
 	SkipImageDownload: "skip-image-download",

--- a/ai-services/internal/pkg/runtime/remote/runtime.go
+++ b/ai-services/internal/pkg/runtime/remote/runtime.go
@@ -272,7 +272,7 @@ func (r *RemoteRuntime) ContainerLogs(ctx context.Context, containerNameOrID str
 }
 
 func (r *RemoteRuntime) ExecInContainerWithCmd(ctx context.Context, podName, containerName string, command []string) (string, error) {
-	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_RUN_EPHEMERAL_CONTAINER,
+	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_EXEC_IN_CONTAINER,
 		payload.ExecInContainer{PodName: podName, ContainerName: containerName, Command: command})
 	if err != nil {
 		return "", err

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -3,6 +3,10 @@
 package constants
 
 const (
+	// LocalWorkerName is the sentinel value used when no remote worker is specified.
+	// It means "deploy on this machine using the local runtime".
+	LocalWorkerName = "Local"
+
 	// WorkerProxyLabel is the pod label set by deploy.Setup; used by deploy (idempotency) and uninstall (lookup).
 	WorkerProxyLabel = "ai-services.io/component=worker-proxy"
 

--- a/ai-services/internal/pkg/worker/dispatch/dispatch.go
+++ b/ai-services/internal/pkg/worker/dispatch/dispatch.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	workercaddy "github.com/project-ai-services/ai-services/internal/pkg/worker/caddy"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/payload"
@@ -212,14 +213,21 @@ func handle(ctx context.Context, rt runtime.Runtime, pr *workercaddy.ProxyRouter
 
 		return nil, rt.ContainerLogs(ctx, req.NameOrID)
 
-	case workerpb.CommandType_COMMAND_TYPE_RUN_EPHEMERAL_CONTAINER:
+	case workerpb.CommandType_COMMAND_TYPE_EXEC_IN_CONTAINER:
 		var req payload.ExecInContainer
 		if err := json.Unmarshal(p, &req); err != nil {
-			return nil, fmt.Errorf("decode run_ephemeral_container payload: %w", err)
+			return nil, fmt.Errorf("decode exec_in_container payload: %w", err)
 		}
 		out, err := rt.ExecInContainerWithCmd(ctx, req.PodName, req.ContainerName, req.Command)
 
 		return marshalOr(out, err)
+
+	case workerpb.CommandType_COMMAND_TYPE_DOWNLOAD_MODEL:
+		var req payload.DownloadModel
+		if err := json.Unmarshal(p, &req); err != nil {
+			return nil, fmt.Errorf("decode download_model payload: %w", err)
+		}
+		return nil, helpers.DownloadModelContainer(ctx, req.Model, req.TargetDir)
 
 	// ── Caddy proxy management ────────────────────────────────────────────────
 

--- a/ai-services/internal/pkg/worker/dispatch/dispatch.go
+++ b/ai-services/internal/pkg/worker/dispatch/dispatch.go
@@ -227,6 +227,7 @@ func handle(ctx context.Context, rt runtime.Runtime, pr *workercaddy.ProxyRouter
 		if err := json.Unmarshal(p, &req); err != nil {
 			return nil, fmt.Errorf("decode download_model payload: %w", err)
 		}
+
 		return nil, helpers.DownloadModelContainer(ctx, req.Model, req.TargetDir)
 
 	// ── Caddy proxy management ────────────────────────────────────────────────

--- a/ai-services/internal/pkg/worker/gateway/gateway_test.go
+++ b/ai-services/internal/pkg/worker/gateway/gateway_test.go
@@ -80,6 +80,15 @@ func (r *fakeWorkerRepo) GetAll(_ context.Context) ([]models.Worker, error) {
 	return out, nil
 }
 
+func (r *fakeWorkerRepo) GetByName(_ context.Context, name string) (*models.Worker, error) {
+	w, ok := r.workers[name]
+	if !ok {
+		return nil, nil
+	}
+	cp := *w
+	return &cp, nil
+}
+
 var _ repository.WorkerRepository = (*fakeWorkerRepo)(nil)
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/ai-services/internal/pkg/worker/payload/payload.go
+++ b/ai-services/internal/pkg/worker/payload/payload.go
@@ -57,6 +57,11 @@ type ExecInContainer struct {
 	Command       []string `json:"command"`
 }
 
+type DownloadModel struct {
+	Model     string `json:"model"`
+	TargetDir string `json:"targetDir"`
+}
+
 // ─── Network ──────────────────────────────────────────────────────────────────
 
 type ListRoutes struct {

--- a/ai-services/internal/pkg/worker/proto/worker.pb.go
+++ b/ai-services/internal/pkg/worker/proto/worker.pb.go
@@ -5,7 +5,7 @@
 // versions:
 // 	protoc-gen-go v1.36.11
 // 	protoc        v7.35.1
-// source: internal/pkg/worker/proto/worker.proto
+// source: worker.proto
 
 package proto
 
@@ -28,34 +28,35 @@ const (
 type CommandType int32
 
 const (
-	CommandType_COMMAND_TYPE_UNSPECIFIED             CommandType = 0
-	CommandType_COMMAND_TYPE_LIST_IMAGES             CommandType = 1
-	CommandType_COMMAND_TYPE_PULL_IMAGE              CommandType = 2
-	CommandType_COMMAND_TYPE_LIST_PODS               CommandType = 3
-	CommandType_COMMAND_TYPE_CREATE_POD              CommandType = 4
-	CommandType_COMMAND_TYPE_DELETE_POD              CommandType = 5
-	CommandType_COMMAND_TYPE_STOP_POD                CommandType = 6
-	CommandType_COMMAND_TYPE_START_POD               CommandType = 7
-	CommandType_COMMAND_TYPE_INSPECT_POD             CommandType = 8
-	CommandType_COMMAND_TYPE_POD_EXISTS              CommandType = 9
-	CommandType_COMMAND_TYPE_POD_LOGS                CommandType = 10
-	CommandType_COMMAND_TYPE_GET_POD_RESOURCES       CommandType = 11
-	CommandType_COMMAND_TYPE_LIST_SECRETS            CommandType = 12
-	CommandType_COMMAND_TYPE_DELETE_SECRET           CommandType = 13
-	CommandType_COMMAND_TYPE_SECRET_EXISTS           CommandType = 14
-	CommandType_COMMAND_TYPE_DELETE_VOLUME           CommandType = 15
-	CommandType_COMMAND_TYPE_VOLUME_EXISTS           CommandType = 16
-	CommandType_COMMAND_TYPE_INSPECT_CONTAINER       CommandType = 17
-	CommandType_COMMAND_TYPE_CONTAINER_EXISTS        CommandType = 18
-	CommandType_COMMAND_TYPE_CONTAINER_LOGS          CommandType = 19
-	CommandType_COMMAND_TYPE_LIST_ROUTES             CommandType = 20
-	CommandType_COMMAND_TYPE_DELETE_PVCS             CommandType = 21
-	CommandType_COMMAND_TYPE_GET_SYSTEM_INFO         CommandType = 22
-	CommandType_COMMAND_TYPE_RUNTIME_TYPE            CommandType = 23
-	CommandType_COMMAND_TYPE_RUN_EPHEMERAL_CONTAINER CommandType = 24
+	CommandType_COMMAND_TYPE_UNSPECIFIED       CommandType = 0
+	CommandType_COMMAND_TYPE_LIST_IMAGES       CommandType = 1
+	CommandType_COMMAND_TYPE_PULL_IMAGE        CommandType = 2
+	CommandType_COMMAND_TYPE_LIST_PODS         CommandType = 3
+	CommandType_COMMAND_TYPE_CREATE_POD        CommandType = 4
+	CommandType_COMMAND_TYPE_DELETE_POD        CommandType = 5
+	CommandType_COMMAND_TYPE_STOP_POD          CommandType = 6
+	CommandType_COMMAND_TYPE_START_POD         CommandType = 7
+	CommandType_COMMAND_TYPE_INSPECT_POD       CommandType = 8
+	CommandType_COMMAND_TYPE_POD_EXISTS        CommandType = 9
+	CommandType_COMMAND_TYPE_POD_LOGS          CommandType = 10
+	CommandType_COMMAND_TYPE_GET_POD_RESOURCES CommandType = 11
+	CommandType_COMMAND_TYPE_LIST_SECRETS      CommandType = 12
+	CommandType_COMMAND_TYPE_DELETE_SECRET     CommandType = 13
+	CommandType_COMMAND_TYPE_SECRET_EXISTS     CommandType = 14
+	CommandType_COMMAND_TYPE_DELETE_VOLUME     CommandType = 15
+	CommandType_COMMAND_TYPE_VOLUME_EXISTS     CommandType = 16
+	CommandType_COMMAND_TYPE_INSPECT_CONTAINER CommandType = 17
+	CommandType_COMMAND_TYPE_CONTAINER_EXISTS  CommandType = 18
+	CommandType_COMMAND_TYPE_CONTAINER_LOGS    CommandType = 19
+	CommandType_COMMAND_TYPE_LIST_ROUTES       CommandType = 20
+	CommandType_COMMAND_TYPE_DELETE_PVCS       CommandType = 21
+	CommandType_COMMAND_TYPE_GET_SYSTEM_INFO   CommandType = 22
+	CommandType_COMMAND_TYPE_RUNTIME_TYPE      CommandType = 23
+	CommandType_COMMAND_TYPE_EXEC_IN_CONTAINER CommandType = 24
 	// Caddy proxy management on the worker node.
 	// A single command covers all route operations; the op is encoded in the payload.
-	CommandType_COMMAND_TYPE_PROXY_ROUTE CommandType = 25
+	CommandType_COMMAND_TYPE_PROXY_ROUTE    CommandType = 25
+	CommandType_COMMAND_TYPE_DOWNLOAD_MODEL CommandType = 27
 	// HTTP proxy tunnel through the gRPC stream.
 	// The control plane sends an HTTP request; the worker executes it locally
 	// against a pod endpoint and returns the response.
@@ -89,38 +90,40 @@ var (
 		21: "COMMAND_TYPE_DELETE_PVCS",
 		22: "COMMAND_TYPE_GET_SYSTEM_INFO",
 		23: "COMMAND_TYPE_RUNTIME_TYPE",
-		24: "COMMAND_TYPE_RUN_EPHEMERAL_CONTAINER",
+		24: "COMMAND_TYPE_EXEC_IN_CONTAINER",
 		25: "COMMAND_TYPE_PROXY_ROUTE",
+		27: "COMMAND_TYPE_DOWNLOAD_MODEL",
 		26: "COMMAND_TYPE_HTTP_PROXY",
 	}
 	CommandType_value = map[string]int32{
-		"COMMAND_TYPE_UNSPECIFIED":             0,
-		"COMMAND_TYPE_LIST_IMAGES":             1,
-		"COMMAND_TYPE_PULL_IMAGE":              2,
-		"COMMAND_TYPE_LIST_PODS":               3,
-		"COMMAND_TYPE_CREATE_POD":              4,
-		"COMMAND_TYPE_DELETE_POD":              5,
-		"COMMAND_TYPE_STOP_POD":                6,
-		"COMMAND_TYPE_START_POD":               7,
-		"COMMAND_TYPE_INSPECT_POD":             8,
-		"COMMAND_TYPE_POD_EXISTS":              9,
-		"COMMAND_TYPE_POD_LOGS":                10,
-		"COMMAND_TYPE_GET_POD_RESOURCES":       11,
-		"COMMAND_TYPE_LIST_SECRETS":            12,
-		"COMMAND_TYPE_DELETE_SECRET":           13,
-		"COMMAND_TYPE_SECRET_EXISTS":           14,
-		"COMMAND_TYPE_DELETE_VOLUME":           15,
-		"COMMAND_TYPE_VOLUME_EXISTS":           16,
-		"COMMAND_TYPE_INSPECT_CONTAINER":       17,
-		"COMMAND_TYPE_CONTAINER_EXISTS":        18,
-		"COMMAND_TYPE_CONTAINER_LOGS":          19,
-		"COMMAND_TYPE_LIST_ROUTES":             20,
-		"COMMAND_TYPE_DELETE_PVCS":             21,
-		"COMMAND_TYPE_GET_SYSTEM_INFO":         22,
-		"COMMAND_TYPE_RUNTIME_TYPE":            23,
-		"COMMAND_TYPE_RUN_EPHEMERAL_CONTAINER": 24,
-		"COMMAND_TYPE_PROXY_ROUTE":             25,
-		"COMMAND_TYPE_HTTP_PROXY":              26,
+		"COMMAND_TYPE_UNSPECIFIED":       0,
+		"COMMAND_TYPE_LIST_IMAGES":       1,
+		"COMMAND_TYPE_PULL_IMAGE":        2,
+		"COMMAND_TYPE_LIST_PODS":         3,
+		"COMMAND_TYPE_CREATE_POD":        4,
+		"COMMAND_TYPE_DELETE_POD":        5,
+		"COMMAND_TYPE_STOP_POD":          6,
+		"COMMAND_TYPE_START_POD":         7,
+		"COMMAND_TYPE_INSPECT_POD":       8,
+		"COMMAND_TYPE_POD_EXISTS":        9,
+		"COMMAND_TYPE_POD_LOGS":          10,
+		"COMMAND_TYPE_GET_POD_RESOURCES": 11,
+		"COMMAND_TYPE_LIST_SECRETS":      12,
+		"COMMAND_TYPE_DELETE_SECRET":     13,
+		"COMMAND_TYPE_SECRET_EXISTS":     14,
+		"COMMAND_TYPE_DELETE_VOLUME":     15,
+		"COMMAND_TYPE_VOLUME_EXISTS":     16,
+		"COMMAND_TYPE_INSPECT_CONTAINER": 17,
+		"COMMAND_TYPE_CONTAINER_EXISTS":  18,
+		"COMMAND_TYPE_CONTAINER_LOGS":    19,
+		"COMMAND_TYPE_LIST_ROUTES":       20,
+		"COMMAND_TYPE_DELETE_PVCS":       21,
+		"COMMAND_TYPE_GET_SYSTEM_INFO":   22,
+		"COMMAND_TYPE_RUNTIME_TYPE":      23,
+		"COMMAND_TYPE_EXEC_IN_CONTAINER": 24,
+		"COMMAND_TYPE_PROXY_ROUTE":       25,
+		"COMMAND_TYPE_DOWNLOAD_MODEL":    27,
+		"COMMAND_TYPE_HTTP_PROXY":        26,
 	}
 )
 
@@ -135,11 +138,11 @@ func (x CommandType) String() string {
 }
 
 func (CommandType) Descriptor() protoreflect.EnumDescriptor {
-	return file_internal_pkg_worker_proto_worker_proto_enumTypes[0].Descriptor()
+	return file_worker_proto_enumTypes[0].Descriptor()
 }
 
 func (CommandType) Type() protoreflect.EnumType {
-	return &file_internal_pkg_worker_proto_worker_proto_enumTypes[0]
+	return &file_worker_proto_enumTypes[0]
 }
 
 func (x CommandType) Number() protoreflect.EnumNumber {
@@ -148,7 +151,7 @@ func (x CommandType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CommandType.Descriptor instead.
 func (CommandType) EnumDescriptor() ([]byte, []int) {
-	return file_internal_pkg_worker_proto_worker_proto_rawDescGZIP(), []int{0}
+	return file_worker_proto_rawDescGZIP(), []int{0}
 }
 
 type RegisterRequest struct {
@@ -165,7 +168,7 @@ type RegisterRequest struct {
 
 func (x *RegisterRequest) Reset() {
 	*x = RegisterRequest{}
-	mi := &file_internal_pkg_worker_proto_worker_proto_msgTypes[0]
+	mi := &file_worker_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -177,7 +180,7 @@ func (x *RegisterRequest) String() string {
 func (*RegisterRequest) ProtoMessage() {}
 
 func (x *RegisterRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pkg_worker_proto_worker_proto_msgTypes[0]
+	mi := &file_worker_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -190,7 +193,7 @@ func (x *RegisterRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegisterRequest.ProtoReflect.Descriptor instead.
 func (*RegisterRequest) Descriptor() ([]byte, []int) {
-	return file_internal_pkg_worker_proto_worker_proto_rawDescGZIP(), []int{0}
+	return file_worker_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *RegisterRequest) GetWorkerName() string {
@@ -233,7 +236,7 @@ type RegisterResponse struct {
 
 func (x *RegisterResponse) Reset() {
 	*x = RegisterResponse{}
-	mi := &file_internal_pkg_worker_proto_worker_proto_msgTypes[1]
+	mi := &file_worker_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -245,7 +248,7 @@ func (x *RegisterResponse) String() string {
 func (*RegisterResponse) ProtoMessage() {}
 
 func (x *RegisterResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pkg_worker_proto_worker_proto_msgTypes[1]
+	mi := &file_worker_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -258,7 +261,7 @@ func (x *RegisterResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegisterResponse.ProtoReflect.Descriptor instead.
 func (*RegisterResponse) Descriptor() ([]byte, []int) {
-	return file_internal_pkg_worker_proto_worker_proto_rawDescGZIP(), []int{1}
+	return file_worker_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *RegisterResponse) GetWorkerName() string {
@@ -293,7 +296,7 @@ type Command struct {
 
 func (x *Command) Reset() {
 	*x = Command{}
-	mi := &file_internal_pkg_worker_proto_worker_proto_msgTypes[2]
+	mi := &file_worker_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -305,7 +308,7 @@ func (x *Command) String() string {
 func (*Command) ProtoMessage() {}
 
 func (x *Command) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pkg_worker_proto_worker_proto_msgTypes[2]
+	mi := &file_worker_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -318,7 +321,7 @@ func (x *Command) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Command.ProtoReflect.Descriptor instead.
 func (*Command) Descriptor() ([]byte, []int) {
-	return file_internal_pkg_worker_proto_worker_proto_rawDescGZIP(), []int{2}
+	return file_worker_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *Command) GetCommandId() string {
@@ -356,7 +359,7 @@ type CommandResult struct {
 
 func (x *CommandResult) Reset() {
 	*x = CommandResult{}
-	mi := &file_internal_pkg_worker_proto_worker_proto_msgTypes[3]
+	mi := &file_worker_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -368,7 +371,7 @@ func (x *CommandResult) String() string {
 func (*CommandResult) ProtoMessage() {}
 
 func (x *CommandResult) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pkg_worker_proto_worker_proto_msgTypes[3]
+	mi := &file_worker_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -381,7 +384,7 @@ func (x *CommandResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CommandResult.ProtoReflect.Descriptor instead.
 func (*CommandResult) Descriptor() ([]byte, []int) {
-	return file_internal_pkg_worker_proto_worker_proto_rawDescGZIP(), []int{3}
+	return file_worker_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *CommandResult) GetCommandId() string {
@@ -426,11 +429,11 @@ func (x *CommandResult) GetWorkerName() string {
 	return ""
 }
 
-var File_internal_pkg_worker_proto_worker_proto protoreflect.FileDescriptor
+var File_worker_proto protoreflect.FileDescriptor
 
-const file_internal_pkg_worker_proto_worker_proto_rawDesc = "" +
+const file_worker_proto_rawDesc = "" +
 	"\n" +
-	"&internal/pkg/worker/proto/worker.proto\x12\tworker.v1\"\x82\x02\n" +
+	"\fworker.proto\x12\tworker.v1\"\x82\x02\n" +
 	"\x0fRegisterRequest\x12\x1f\n" +
 	"\vworker_name\x18\x01 \x01(\tR\n" +
 	"workerName\x12(\n" +
@@ -459,7 +462,7 @@ const file_internal_pkg_worker_proto_worker_proto_rawDesc = "" +
 	"\x05error\x18\x04 \x01(\tR\x05error\x12!\n" +
 	"\fis_heartbeat\x18\x05 \x01(\bR\visHeartbeat\x12\x1f\n" +
 	"\vworker_name\x18\x06 \x01(\tR\n" +
-	"workerName*\xd6\x06\n" +
+	"workerName*\xf1\x06\n" +
 	"\vCommandType\x12\x1c\n" +
 	"\x18COMMAND_TYPE_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18COMMAND_TYPE_LIST_IMAGES\x10\x01\x12\x1b\n" +
@@ -485,29 +488,30 @@ const file_internal_pkg_worker_proto_worker_proto_rawDesc = "" +
 	"\x18COMMAND_TYPE_LIST_ROUTES\x10\x14\x12\x1c\n" +
 	"\x18COMMAND_TYPE_DELETE_PVCS\x10\x15\x12 \n" +
 	"\x1cCOMMAND_TYPE_GET_SYSTEM_INFO\x10\x16\x12\x1d\n" +
-	"\x19COMMAND_TYPE_RUNTIME_TYPE\x10\x17\x12(\n" +
-	"$COMMAND_TYPE_RUN_EPHEMERAL_CONTAINER\x10\x18\x12\x1c\n" +
-	"\x18COMMAND_TYPE_PROXY_ROUTE\x10\x19\x12\x1b\n" +
+	"\x19COMMAND_TYPE_RUNTIME_TYPE\x10\x17\x12\"\n" +
+	"\x1eCOMMAND_TYPE_EXEC_IN_CONTAINER\x10\x18\x12\x1c\n" +
+	"\x18COMMAND_TYPE_PROXY_ROUTE\x10\x19\x12\x1f\n" +
+	"\x1bCOMMAND_TYPE_DOWNLOAD_MODEL\x10\x1b\x12\x1b\n" +
 	"\x17COMMAND_TYPE_HTTP_PROXY\x10\x1a2\x97\x01\n" +
 	"\rWorkerGateway\x12C\n" +
 	"\bRegister\x12\x1a.worker.v1.RegisterRequest\x1a\x1b.worker.v1.RegisterResponse\x12A\n" +
 	"\rCommandStream\x12\x18.worker.v1.CommandResult\x1a\x12.worker.v1.Command(\x010\x01BFZDgithub.com/project-ai-services/ai-services/internal/pkg/worker/protob\x06proto3"
 
 var (
-	file_internal_pkg_worker_proto_worker_proto_rawDescOnce sync.Once
-	file_internal_pkg_worker_proto_worker_proto_rawDescData []byte
+	file_worker_proto_rawDescOnce sync.Once
+	file_worker_proto_rawDescData []byte
 )
 
-func file_internal_pkg_worker_proto_worker_proto_rawDescGZIP() []byte {
-	file_internal_pkg_worker_proto_worker_proto_rawDescOnce.Do(func() {
-		file_internal_pkg_worker_proto_worker_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_internal_pkg_worker_proto_worker_proto_rawDesc), len(file_internal_pkg_worker_proto_worker_proto_rawDesc)))
+func file_worker_proto_rawDescGZIP() []byte {
+	file_worker_proto_rawDescOnce.Do(func() {
+		file_worker_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_worker_proto_rawDesc), len(file_worker_proto_rawDesc)))
 	})
-	return file_internal_pkg_worker_proto_worker_proto_rawDescData
+	return file_worker_proto_rawDescData
 }
 
-var file_internal_pkg_worker_proto_worker_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_internal_pkg_worker_proto_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
-var file_internal_pkg_worker_proto_worker_proto_goTypes = []any{
+var file_worker_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_worker_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_worker_proto_goTypes = []any{
 	(CommandType)(0),         // 0: worker.v1.CommandType
 	(*RegisterRequest)(nil),  // 1: worker.v1.RegisterRequest
 	(*RegisterResponse)(nil), // 2: worker.v1.RegisterResponse
@@ -515,7 +519,7 @@ var file_internal_pkg_worker_proto_worker_proto_goTypes = []any{
 	(*CommandResult)(nil),    // 4: worker.v1.CommandResult
 	nil,                      // 5: worker.v1.RegisterRequest.MetadataEntry
 }
-var file_internal_pkg_worker_proto_worker_proto_depIdxs = []int32{
+var file_worker_proto_depIdxs = []int32{
 	5, // 0: worker.v1.RegisterRequest.metadata:type_name -> worker.v1.RegisterRequest.MetadataEntry
 	0, // 1: worker.v1.Command.type:type_name -> worker.v1.CommandType
 	1, // 2: worker.v1.WorkerGateway.Register:input_type -> worker.v1.RegisterRequest
@@ -529,27 +533,27 @@ var file_internal_pkg_worker_proto_worker_proto_depIdxs = []int32{
 	0, // [0:2] is the sub-list for field type_name
 }
 
-func init() { file_internal_pkg_worker_proto_worker_proto_init() }
-func file_internal_pkg_worker_proto_worker_proto_init() {
-	if File_internal_pkg_worker_proto_worker_proto != nil {
+func init() { file_worker_proto_init() }
+func file_worker_proto_init() {
+	if File_worker_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_pkg_worker_proto_worker_proto_rawDesc), len(file_internal_pkg_worker_proto_worker_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_worker_proto_rawDesc), len(file_worker_proto_rawDesc)),
 			NumEnums:      1,
 			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
-		GoTypes:           file_internal_pkg_worker_proto_worker_proto_goTypes,
-		DependencyIndexes: file_internal_pkg_worker_proto_worker_proto_depIdxs,
-		EnumInfos:         file_internal_pkg_worker_proto_worker_proto_enumTypes,
-		MessageInfos:      file_internal_pkg_worker_proto_worker_proto_msgTypes,
+		GoTypes:           file_worker_proto_goTypes,
+		DependencyIndexes: file_worker_proto_depIdxs,
+		EnumInfos:         file_worker_proto_enumTypes,
+		MessageInfos:      file_worker_proto_msgTypes,
 	}.Build()
-	File_internal_pkg_worker_proto_worker_proto = out.File
-	file_internal_pkg_worker_proto_worker_proto_goTypes = nil
-	file_internal_pkg_worker_proto_worker_proto_depIdxs = nil
+	File_worker_proto = out.File
+	file_worker_proto_goTypes = nil
+	file_worker_proto_depIdxs = nil
 }

--- a/ai-services/internal/pkg/worker/proto/worker.proto
+++ b/ai-services/internal/pkg/worker/proto/worker.proto
@@ -84,7 +84,7 @@ enum CommandType {
   COMMAND_TYPE_DELETE_PVCS        = 21;
   COMMAND_TYPE_GET_SYSTEM_INFO    = 22;
   COMMAND_TYPE_RUNTIME_TYPE              = 23;
-  COMMAND_TYPE_RUN_EPHEMERAL_CONTAINER   = 24;
+  COMMAND_TYPE_EXEC_IN_CONTAINER         = 24;
 
   // Caddy proxy management on the worker node.
   // A single command covers all route operations; the op is encoded in the payload.
@@ -94,4 +94,6 @@ enum CommandType {
   // The control plane sends an HTTP request; the worker executes it locally
   // against a pod endpoint and returns the response.
   COMMAND_TYPE_HTTP_PROXY                = 26;
+
+  COMMAND_TYPE_DOWNLOAD_MODEL            = 27;
 }

--- a/ai-services/internal/pkg/worker/proto/worker_grpc.pb.go
+++ b/ai-services/internal/pkg/worker/proto/worker_grpc.pb.go
@@ -5,7 +5,7 @@
 // versions:
 // - protoc-gen-go-grpc v1.6.2
 // - protoc             v7.35.1
-// source: internal/pkg/worker/proto/worker.proto
+// source: worker.proto
 
 package proto
 
@@ -162,5 +162,5 @@ var WorkerGateway_ServiceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: "internal/pkg/worker/proto/worker.proto",
+	Metadata: "worker.proto",
 }

--- a/ai-services/internal/pkg/worker/registry/registry.go
+++ b/ai-services/internal/pkg/worker/registry/registry.go
@@ -52,6 +52,7 @@ type WorkerEntry struct {
 
 	WorkerName  string
 	RuntimeType string
+	Metadata    map[string]string
 
 	// CommandCh is written by RemoteRuntime to send commands to this worker.
 	// The gateway goroutine reads from it and writes to the gRPC stream.
@@ -125,6 +126,7 @@ func (r *Registry) Register(ctx context.Context, workerName, runtimeType string,
 	entry := &WorkerEntry{
 		WorkerName:  workerName,
 		RuntimeType: runtimeType,
+		Metadata:    metadata,
 		CommandCh:   make(chan *workerpb.Command, commandChannelSize),
 		results:     make(map[string]chan *workerpb.CommandResult),
 	}
@@ -331,6 +333,46 @@ func (r *Registry) WorkerRuntimeType(workerName string) (string, bool) {
 	}
 
 	return entry.RuntimeType, true
+}
+
+// WorkerMetadata returns the metadata map for the named worker.
+// It satisfies the stream.WorkerRegistry interface.
+func (r *Registry) WorkerMetadata(workerName string) (map[string]string, bool) {
+	r.mu.RLock()
+	entry, ok := r.workers[workerName]
+	r.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+
+	return entry.Metadata, true
+}
+
+// IsWorkerConnected checks the in-memory cache first, then confirms status=ready
+// in the DB. Returns false if the worker is absent from the cache, not found in
+// the DB, or has any status other than ready.
+// When repo is nil (New was called without a DB — tests only) the cache check
+// is the sole authority.
+// It satisfies the stream.WorkerRegistry interface.
+func (r *Registry) IsWorkerConnected(ctx context.Context, workerName string) bool {
+	r.mu.RLock()
+	_, inCache := r.workers[workerName]
+	r.mu.RUnlock()
+
+	if !inCache {
+		return false
+	}
+
+	if r.repo == nil {
+		return true
+	}
+
+	w, err := r.repo.GetByName(ctx, workerName)
+	if err != nil || w == nil {
+		return false
+	}
+
+	return w.Status == models.WorkerStatusReady
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/ai-services/internal/pkg/worker/registry/registry_test.go
+++ b/ai-services/internal/pkg/worker/registry/registry_test.go
@@ -73,6 +73,15 @@ func (r *fakeWorkerRepo) GetAll(_ context.Context) ([]models.Worker, error) {
 	return out, nil
 }
 
+func (r *fakeWorkerRepo) GetByName(_ context.Context, name string) (*models.Worker, error) {
+	w, ok := r.workers[name]
+	if !ok {
+		return nil, nil
+	}
+	cp := *w
+	return &cp, nil
+}
+
 var _ repository.WorkerRepository = (*fakeWorkerRepo)(nil)
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -380,5 +389,155 @@ func TestRegistry_SweepStale_StaleReadyWorkerSwept(t *testing.T) {
 	workers, _ := repo.GetAll(context.Background())
 	if workers[0].Status != models.WorkerStatusDisconnected {
 		t.Errorf("expected status %q, got %q", models.WorkerStatusDisconnected, workers[0].Status)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// IsWorkerConnected tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestRegistry_IsWorkerConnected_NotInCache(t *testing.T) {
+	reg := New(nil)
+
+	if reg.IsWorkerConnected(context.Background(), "ghost") {
+		t.Error("expected false for worker not in cache")
+	}
+}
+
+func TestRegistry_IsWorkerConnected_CacheHitNoRepo(t *testing.T) {
+	reg := New(nil)
+	reg.Register(context.Background(), "worker-1", "podman", nil) //nolint:errcheck
+
+	if !reg.IsWorkerConnected(context.Background(), "worker-1") {
+		t.Error("expected true: worker is in cache and no repo to check")
+	}
+}
+
+func TestRegistry_IsWorkerConnected_CacheHitDBReady(t *testing.T) {
+	repo := newFakeWorkerRepo()
+	reg := New(repo)
+
+	if _, err := reg.Preregister(context.Background(), "worker-1"); err != nil {
+		t.Fatalf("Preregister: %v", err)
+	}
+
+	if _, err := reg.Register(context.Background(), "worker-1", "podman", nil); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// DB row has status=ready after Register.
+	if !reg.IsWorkerConnected(context.Background(), "worker-1") {
+		t.Error("expected true: in cache and DB status=ready")
+	}
+}
+
+func TestRegistry_IsWorkerConnected_CacheHitDBNotReady(t *testing.T) {
+	repo := newFakeWorkerRepo()
+	reg := New(repo)
+
+	if _, err := reg.Preregister(context.Background(), "worker-1"); err != nil {
+		t.Fatalf("Preregister: %v", err)
+	}
+
+	if _, err := reg.Register(context.Background(), "worker-1", "podman", nil); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Force DB status to disconnected.
+	w := repo.workers["worker-1"]
+	disc := models.WorkerStatusDisconnected
+	if err := repo.Update(context.Background(), w.ID, repository.WorkerUpdate{Status: &disc}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if reg.IsWorkerConnected(context.Background(), "worker-1") {
+		t.Error("expected false: DB status is disconnected")
+	}
+}
+
+func TestRegistry_IsWorkerConnected_DisconnectedRemovedFromCache(t *testing.T) {
+	reg := New(nil)
+	reg.Register(context.Background(), "worker-1", "podman", nil) //nolint:errcheck
+	reg.Disconnect(context.Background(), "worker-1")
+
+	if reg.IsWorkerConnected(context.Background(), "worker-1") {
+		t.Error("expected false: worker was disconnected")
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// WorkerRuntimeType / WorkerMetadata / WorkerCommandChannel tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestRegistry_WorkerRuntimeType_Connected(t *testing.T) {
+	reg := New(nil)
+	reg.Register(context.Background(), "worker-1", "podman", nil) //nolint:errcheck
+
+	rt, ok := reg.WorkerRuntimeType("worker-1")
+	if !ok {
+		t.Fatal("expected ok=true for connected worker")
+	}
+	if rt != "podman" {
+		t.Errorf("expected runtime type %q, got %q", "podman", rt)
+	}
+}
+
+func TestRegistry_WorkerRuntimeType_NotConnected(t *testing.T) {
+	reg := New(nil)
+
+	_, ok := reg.WorkerRuntimeType("ghost")
+	if ok {
+		t.Error("expected ok=false for unknown worker")
+	}
+}
+
+func TestRegistry_WorkerMetadata_Connected(t *testing.T) {
+	reg := New(nil)
+	meta := map[string]string{"domainSuffix": "example.com", "httpsPort": "443"}
+	reg.Register(context.Background(), "worker-1", "podman", meta) //nolint:errcheck
+
+	got, ok := reg.WorkerMetadata("worker-1")
+	if !ok {
+		t.Fatal("expected ok=true for connected worker")
+	}
+	if got["domainSuffix"] != "example.com" {
+		t.Errorf("expected domainSuffix %q, got %q", "example.com", got["domainSuffix"])
+	}
+	if got["httpsPort"] != "443" {
+		t.Errorf("expected httpsPort %q, got %q", "443", got["httpsPort"])
+	}
+}
+
+func TestRegistry_WorkerMetadata_NotConnected(t *testing.T) {
+	reg := New(nil)
+
+	_, ok := reg.WorkerMetadata("ghost")
+	if ok {
+		t.Error("expected ok=false for unknown worker")
+	}
+}
+
+func TestRegistry_WorkerCommandChannel_Connected(t *testing.T) {
+	reg := New(nil)
+	reg.Register(context.Background(), "worker-1", "podman", nil) //nolint:errcheck
+
+	ch, ok := reg.WorkerCommandChannel("worker-1")
+	if !ok {
+		t.Fatal("expected ok=true for connected worker")
+	}
+	if ch == nil {
+		t.Error("expected non-nil command channel")
+	}
+}
+
+func TestRegistry_WorkerCommandChannel_NotConnected(t *testing.T) {
+	reg := New(nil)
+
+	ch, ok := reg.WorkerCommandChannel("ghost")
+	if ok {
+		t.Error("expected ok=false for unknown worker")
+	}
+	if ch != nil {
+		t.Error("expected nil channel for unknown worker")
 	}
 }

--- a/ai-services/internal/pkg/worker/stream/registry.go
+++ b/ai-services/internal/pkg/worker/stream/registry.go
@@ -1,6 +1,10 @@
 package stream
 
-import workerpb "github.com/project-ai-services/ai-services/internal/pkg/worker/proto"
+import (
+	"context"
+
+	workerpb "github.com/project-ai-services/ai-services/internal/pkg/worker/proto"
+)
 
 // WorkerRegistry is the interface both Sender and RemoteRuntime require.
 // *worker/registry.Registry satisfies it automatically.
@@ -16,4 +20,11 @@ type WorkerRegistry interface {
 	// WorkerRuntimeType returns the runtime type string declared by the worker at
 	// registration time, or ("", false) if the worker is not connected.
 	WorkerRuntimeType(workerName string) (string, bool)
+
+	// WorkerMetadata returns the registration metadata for the named worker, or
+	// (nil, false) if the worker is not connected.
+	WorkerMetadata(workerName string) (map[string]string, bool)
+
+	// IsWorkerConnected reports whether the named worker has status=ready in the DB.
+	IsWorkerConnected(ctx context.Context, workerName string) bool
 }


### PR DESCRIPTION
**Remote worker deployment support**

- **Worker targeting** — `ai-services create --worker <name>` deploys an application to a named remote worker node instead of the local machine. Defaults to `"local"` (existing behaviour unchanged).

- **Worker validation** — before any DB records are written, `ValidateWorker` confirms the named worker is connected and ready (registry cache + DB check), returning HTTP 400 immediately on failure.

- **Remote runtime routing** — `DeploymentExecutor` resolves the worker's runtime type from the registry, constructs a `RemoteRuntime` backed by the gRPC `CommandStream`, and delegates to the standard Podman or OpenShift deployer — no deployer code needed to know it's talking to a remote machine.

- **Worker metadata injection** — for remote Podman workers, `PodmanWorkerConfig` is populated from the worker's registration metadata (`domain-suffix`, `https-port`, `base-dir`) so Caddy configuration and model paths use the worker's values rather than local environment variables.

- **Model download** — `downloadModels` sends `COMMAND_TYPE_DOWNLOAD_MODEL` over the gRPC stream for remote workers; calls `helpers.DownloadModelContainer` directly for local.

- **Proto cleanup** — `COMMAND_TYPE_RUN_EPHEMERAL_CONTAINER` renamed to `COMMAND_TYPE_EXEC_IN_CONTAINER` (wire value `24` unchanged); `COMMAND_TYPE_DOWNLOAD_MODEL = 27` added.

- **`GetByName` on worker repo** — new DB query to look up a worker by name, used by `IsWorkerConnected`.