### PR TITLE
AISERVICES-1649: Making use of volumes for worker caddy

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.336
+TAG?=v0.0.337
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.336
+  image: icr.io/ai-services-cicd/ai-services:v0.0.337
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
@@ -45,7 +45,7 @@ spec:
         - name: caddy-data
           mountPath: /config:z
         {{- if and .Values.caddy.sslCertContent .Values.caddy.sslKeyContent }}
-        - name: caddy-cert-certs
+        - name: caddy-certs
           mountPath: /etc/secret/ssl
           readOnly: true
         {{- end }}
@@ -68,7 +68,7 @@ spec:
       persistentVolumeClaim:
         claimName: "caddy-catalog"
     {{- if and .Values.caddy.sslCertContent .Values.caddy.sslKeyContent }}
-    - name: caddy-cert-certs
+    - name: caddy-certs
       secret:
         secretName: catalog-caddy-cert-secret
     {{- end }}

--- a/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/caddy.yaml.tmpl
@@ -7,7 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/component: "proxy"
-    ai-services.io/volume: "caddy-catalog"
+    ai-services.io/volume: "caddy-catalog,catalog-caddy-cert-secret"
     ai-services.io/volume-skip-cleanup: "true"
   annotations:
     ai-services.io/ports: "127.0.0.1:{{ .Values.caddy.adminPort }}:2019, {{ .Values.caddy.httpsPort }}:443"

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -7,7 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/secret: "catalog-secret"
-    ai-services.io/volume: "podman-auth-secret,catalog-secret,catalog-db-encryption-secret,catalog-bundles,catalog-caddy-cert-secret,gateway-pki"
+    ai-services.io/volume: "podman-auth-secret,catalog-secret,catalog-db-encryption-secret,catalog-bundles,gateway-pki"
     ai-services.io/volume-skip-cleanup: "true"
   annotations:
     run.oci.keep_original_groups: "1"

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.336
+  image: icr.io/ai-services-cicd/ai-services:v0.0.337
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.336
+  image: icr.io/ai-services-cicd/ai-services:v0.0.337
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/metadata.yaml
+++ b/ai-services/assets/worker/podman/metadata.yaml
@@ -2,5 +2,5 @@ name: ai-services-worker
 version: 0.0.1
 description: "Worker node services for Project AI-Services"
 podTemplateExecutions:
-  - [auth-secret.yaml.tmpl, caddy.yaml.tmpl]
+  - [auth-secret.yaml.tmpl, caddy-cert-secret.yaml.tmpl, caddy.yaml.tmpl]
   - [worker.yaml.tmpl]

--- a/ai-services/assets/worker/podman/templates/caddy-cert-secret.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/caddy-cert-secret.yaml.tmpl
@@ -1,0 +1,15 @@
+{{- if and .Values.caddy.sslCertContent .Values.caddy.sslKeyContent }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: caddy-cert-secret
+  labels:
+    ai-services.io/application: "{{ .AppName }}"
+    ai-services.io/template: "{{ .AppTemplateName }}"
+    ai-services.io/version: "{{ .Version }}"
+stringData:
+  tls.crt: |-
+{{ .Values.caddy.sslCertContent }}
+  tls.key: |-
+{{ .Values.caddy.sslKeyContent }}
+{{- end }}

--- a/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
@@ -7,10 +7,29 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/component: "proxy"
+    ai-services.io/volume: "caddy-worker"
   annotations:
     ai-services.io/ports: "127.0.0.1:{{ .Values.caddy.adminPort }}:2019, {{ .Values.caddy.httpsPort }}:443"
 spec:
   restartPolicy: always
+  initContainers:
+    - name: generate-caddyfile
+      image: "{{ .Values.caddy.image }}"
+      imagePullPolicy: IfNotPresent
+      command:
+        - "sh"
+        - "-c"
+        - |
+          cat << 'EOF' > /data/caddy/Caddyfile
+          {{- if .Values.caddy.caddyFileContent }}
+{{ .Values.caddy.caddyFileContent }}
+          {{- else }}
+          # No Caddyfile
+          {{- end }}
+          EOF
+      volumeMounts:
+        - name: caddy-data
+          mountPath: /data:z
   containers:
     - name: caddy
       image: "{{ .Values.caddy.image }}"
@@ -27,9 +46,14 @@ spec:
           value: "{{ .BaseDir }}"
       volumeMounts:
         - name: caddy-data
-          mountPath: /data/caddy:z
-        - name: caddy-config
+          mountPath: /data:z
+        - name: caddy-data
           mountPath: /config:z
+        {{- if and .Values.caddy.sslCertContent .Values.caddy.sslKeyContent }}
+        - name: caddy-certs
+          mountPath: /etc/secret/ssl
+          readOnly: true
+        {{- end }}
       resources:
         requests:
           memory: "256Mi"
@@ -46,10 +70,10 @@ spec:
         failureThreshold: 3
   volumes:
     - name: caddy-data
-      hostPath:
-        path: {{ .BaseDir }}/worker/caddy
-        type: DirectoryOrCreate
-    - name: caddy-config
-      hostPath:
-        path: {{ .BaseDir }}/worker/caddy-config
-        type: DirectoryOrCreate
+      persistentVolumeClaim:
+        claimName: "caddy-worker"
+    {{- if and .Values.caddy.sslCertContent .Values.caddy.sslKeyContent }}
+    - name: caddy-certs
+      secret:
+        secretName: caddy-cert-secret
+    {{- end }}

--- a/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
@@ -21,6 +21,7 @@ spec:
         - "sh"
         - "-c"
         - |
+          mkdir -p /data/caddy /config
           cat << 'EOF' > /data/caddy/Caddyfile
           {{- if .Values.caddy.caddyFileContent }}
 {{ .Values.caddy.caddyFileContent }}
@@ -31,6 +32,10 @@ spec:
       volumeMounts:
         - name: caddy-data
           mountPath: /data
+          subPath: data
+        - name: caddy-data
+          mountPath: /config
+          subPath: config
   containers:
     - name: caddy
       image: "{{ .Values.caddy.image }}"

--- a/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
@@ -47,9 +47,9 @@ spec:
           value: "{{ .BaseDir }}"
       volumeMounts:
         - name: caddy-data
-          mountPath: /data
+          mountPath: /data:z
         - name: caddy-data
-          mountPath: /config
+          mountPath: /config:z
         {{- if and .Values.caddy.sslCertContent .Values.caddy.sslKeyContent }}
         - name: caddy-certs
           mountPath: /etc/secret/ssl

--- a/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
@@ -48,8 +48,10 @@ spec:
       volumeMounts:
         - name: caddy-data
           mountPath: /data:z
+          subPath: data
         - name: caddy-data
           mountPath: /config:z
+          subPath: config
         {{- if and .Values.caddy.sslCertContent .Values.caddy.sslKeyContent }}
         - name: caddy-certs
           mountPath: /etc/secret/ssl

--- a/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
@@ -7,7 +7,8 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/component: "proxy"
-    ai-services.io/volume: "caddy-worker"
+    ai-services.io/volume: "caddy-worker,caddy-cert-secret"
+    ai-services.io/volume-skip-cleanup: "true"
   annotations:
     ai-services.io/ports: "127.0.0.1:{{ .Values.caddy.adminPort }}:2019, {{ .Values.caddy.httpsPort }}:443"
 spec:

--- a/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
@@ -21,7 +21,6 @@ spec:
         - "sh"
         - "-c"
         - |
-          mkdir -p /data/caddy /config
           cat << 'EOF' > /data/caddy/Caddyfile
           {{- if .Values.caddy.caddyFileContent }}
 {{ .Values.caddy.caddyFileContent }}
@@ -32,10 +31,6 @@ spec:
       volumeMounts:
         - name: caddy-data
           mountPath: /data
-          subPath: data
-        - name: caddy-data
-          mountPath: /config
-          subPath: config
   containers:
     - name: caddy
       image: "{{ .Values.caddy.image }}"
@@ -53,10 +48,8 @@ spec:
       volumeMounts:
         - name: caddy-data
           mountPath: /data
-          subPath: data
         - name: caddy-data
           mountPath: /config
-          subPath: config
         {{- if and .Values.caddy.sslCertContent .Values.caddy.sslKeyContent }}
         - name: caddy-certs
           mountPath: /etc/secret/ssl

--- a/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
@@ -30,7 +30,7 @@ spec:
           EOF
       volumeMounts:
         - name: caddy-data
-          mountPath: /data:z
+          mountPath: /data
   containers:
     - name: caddy
       image: "{{ .Values.caddy.image }}"
@@ -47,10 +47,10 @@ spec:
           value: "{{ .BaseDir }}"
       volumeMounts:
         - name: caddy-data
-          mountPath: /data:z
+          mountPath: /data
           subPath: data
         - name: caddy-data
-          mountPath: /config:z
+          mountPath: /config
           subPath: config
         {{- if and .Values.caddy.sslCertContent .Values.caddy.sslKeyContent }}
         - name: caddy-certs

--- a/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/caddy.yaml.tmpl
@@ -30,7 +30,7 @@ spec:
           EOF
       volumeMounts:
         - name: caddy-data
-          mountPath: /data
+          mountPath: /data:z
   containers:
     - name: caddy
       image: "{{ .Values.caddy.image }}"

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -11,3 +11,9 @@ caddy:
   image: icr.io/ai-services-cicd/caddy:v2.11.4-2
   adminPort: ""
   httpsPort: ""
+  # caddyFileContent: Generated from the 'Caddyfile.tmpl' template
+  caddyFileContent: ""
+  # Populated from the certificate content specified via '--ssl-cert' during worker configuration
+  sslCertContent: ""
+  # Populated from the private key content specified via '--ssl-key' during worker configuration
+  sslKeyContent: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.336
+  image: icr.io/ai-services-cicd/ai-services:v0.0.337
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/internal/pkg/catalog/cli/configure/common.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/common.go
@@ -16,5 +16,4 @@ const (
 	ArgParamCaddyFileContent      = "caddy.caddyFileContent"
 	ArgParamSSLCertFileContent    = "caddy.sslCertContent"
 	ArgParamSSLKeyFileContent     = "caddy.sslKeyContent"
-	ArgParamWorkerGatewayPort     = "backend.workerGatewayPort"
 )

--- a/ai-services/internal/pkg/catalog/cli/configure/common.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/common.go
@@ -16,4 +16,5 @@ const (
 	ArgParamCaddyFileContent      = "caddy.caddyFileContent"
 	ArgParamSSLCertFileContent    = "caddy.sslCertContent"
 	ArgParamSSLKeyFileContent     = "caddy.sslKeyContent"
+	ArgParamWorkerGatewayPort     = "backend.workerGatewayPort"
 )

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -13,14 +13,10 @@ import (
 	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/spinner"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
-)
-
-const (
-	caddyFileIndent   = 10
-	certContentIndent = 4
 )
 
 // DeployCatalog deploys the catalog service using the assets/catalog template for podman runtime.
@@ -216,11 +212,11 @@ func generateArgParams(passwordHash, sslCertPath, sslKeyPath string, httpsPort, 
 	argParams[configure.ArgParamPodmanAuthFileContent] = authFileBase64
 	argParams[configure.ArgParamPodmanURI] = podmanSocketPath
 	argParams[configure.ArgParamDBPassword] = dbPassword
-	argParams[configure.ArgParamCaddyHTTPSPort] = fmt.Sprintf("%d", httpsPort)
+	argParams[constants.ArgParamCaddyHTTPSPort] = fmt.Sprintf("%d", httpsPort)
 	argParams[configure.ArgParamWorkerGatewayPort] = fmt.Sprintf("%d", workerGatewayPort)
-	argParams[configure.ArgParamCaddyFileContent] = utils.IndentString(caddyFileContent, caddyFileIndent)
-	argParams[configure.ArgParamSSLCertFileContent] = utils.IndentString(sslCertContent, certContentIndent)
-	argParams[configure.ArgParamSSLKeyFileContent] = utils.IndentString(sslKeyContent, certContentIndent)
+	argParams[constants.ArgParamCaddyFileContent] = utils.IndentString(caddyFileContent, utils.CaddyFileIndent)
+	argParams[constants.ArgParamSSLCertFileContent] = utils.IndentString(sslCertContent, utils.CertContentIndent)
+	argParams[constants.ArgParamSSLKeyFileContent] = utils.IndentString(sslKeyContent, utils.CertContentIndent)
 
 	return argParams, nil
 }

--- a/ai-services/internal/pkg/constants/common.go
+++ b/ai-services/internal/pkg/constants/common.go
@@ -124,3 +124,10 @@ const (
 	// SecretSkipLabel represents if secret associated with pod should be skipped while deletion.
 	SecretSkipLabel = "ai-services.io/secret-skip-cleanup"
 )
+
+const (
+	ArgParamCaddyHTTPSPort     = "caddy.httpsPort"
+	ArgParamCaddyFileContent   = "caddy.caddyFileContent"
+	ArgParamSSLCertFileContent = "caddy.sslCertContent"
+	ArgParamSSLKeyFileContent  = "caddy.sslKeyContent"
+)

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -28,6 +28,9 @@ import (
 const (
 	maxKeyValueParts  = 2
 	maxHostnameLength = 63
+
+	CaddyFileIndent   = 10
+	CertContentIndent = 4
 )
 
 // IsTransientK8sError checks if a Kubernetes API error is transient and should be retried.

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -45,7 +45,7 @@ const (
 	// WorkerGatewayPort is the default port used by the catalog gRPC worker gateway.
 	WorkerGatewayPort = 9090
 
-	// ArgParamCaddyHTTPSPort, ArgParamWorkerToken, ArgParamWorkerGatewayAddr,
+	// ArgParamWorkerToken, ArgParamWorkerGatewayAddr,
 	// ArgParamWorkerPodmanURI, and ArgParamWorkerAuthFile are template
 	// value-override keys used when deploying worker pods.
 	ArgParamWorkerToken       = "worker.token"

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -48,7 +48,6 @@ const (
 	// ArgParamCaddyHTTPSPort, ArgParamWorkerToken, ArgParamWorkerGatewayAddr,
 	// ArgParamWorkerPodmanURI, and ArgParamWorkerAuthFile are template
 	// value-override keys used when deploying worker pods.
-	ArgParamCaddyHTTPSPort    = "caddy.httpsPort"
 	ArgParamWorkerToken       = "worker.token"
 	ArgParamWorkerGatewayAddr = "worker.gatewayAddr"
 	ArgParamWorkerPodmanURI   = "worker.podman.uri"

--- a/ai-services/internal/pkg/worker/deploy/podman/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/podman/deploy.go
@@ -10,15 +10,16 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
-	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
 	ttemplate "text/template"
 
 	"github.com/project-ai-services/ai-services/assets"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
 	clipodman "github.com/project-ai-services/ai-services/internal/pkg/cli/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	podmodels "github.com/project-ai-services/ai-services/internal/pkg/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
@@ -32,11 +33,7 @@ import (
 )
 
 const (
-	caddyfileSubDir = "worker/caddy"
-	caddyfilePath   = "worker/podman/Caddyfile.tmpl"
-
-	dirPerm  = 0o750
-	filePerm = 0o644
+	caddyfilePath = "worker/podman/Caddyfile.tmpl"
 )
 
 // Options carries the parameters needed to set up the worker node.
@@ -89,11 +86,22 @@ func DeployWorker(ctx context.Context, opts workertypes.PodmanWorkerOptions) err
 		return nil
 	}
 
-	if err := writeCaddyfile(opts.Setup.BaseDir); err != nil {
-		return fmt.Errorf("worker setup: write Caddyfile: %w", err)
+	domainSuffix, err := utils.ComputeDomainSuffix(opts.Setup.SSLCertPath, opts.Setup.SSLKeyPath, opts.Setup.DomainName)
+	if err != nil {
+		return fmt.Errorf("worker join: compute domain suffix: %w", err)
 	}
 
-	if err := deployAll(ctx, rt, tp, opts, existingResource); err != nil {
+	if err := deployAll(ctx, rt, tp, opts, existingResource, domainSuffix); err != nil {
+		return err
+	}
+
+	logger.DebugfCtx(ctx, "Using domain suffix: %s\n", domainSuffix)
+
+	// Create Caddy context with pod name and domain suffix (NO template dependencies)
+	caddyCtx := caddy.NewContext(workerconstants.WorkerCaddyPodName, domainSuffix)
+
+	// Load SSL certificates if provided
+	if err := caddyCtx.LoadSSLCertificates(ctx, opts.Setup.BaseDir, opts.Setup.SSLCertPath, opts.Setup.SSLKeyPath); err != nil {
 		return err
 	}
 
@@ -132,33 +140,28 @@ func CheckStatus(ctx context.Context, rt runtime.Runtime, tp templates.Template)
 
 // ─── internal ────────────────────────────────────────────────────────────────
 
-// writeCaddyfile writes the static worker Caddyfile to
-// <baseDir>/worker/caddy/Caddyfile. The Caddyfile has no template variables —
-// it is written verbatim. Caddy must find it at container start.
-func writeCaddyfile(baseDir string) error {
+func readCaddyConfig(sslCertPath, sslKeyPath string) (string, string, string, error) {
 	raw, err := assets.WorkerFS.ReadFile(caddyfilePath)
 	if err != nil {
-		return fmt.Errorf("read Caddyfile: %w", err)
+		return "", "", "", fmt.Errorf("read Caddyfile: %w", err)
 	}
 
-	dir := filepath.Join(baseDir, caddyfileSubDir)
-	if err := os.MkdirAll(dir, dirPerm); err != nil {
-		return fmt.Errorf("create dir %s: %w", dir, err)
+	var sslCertContent, sslKeyContent string
+	if sslCertPath != "" && sslKeyPath != "" {
+		certbyte, keyBytes, _, err := utils.ReadAndParseCertificates(sslCertPath, sslKeyPath)
+		if err != nil {
+			return "", "", "", fmt.Errorf("failed to load ssl certs: %w", err)
+		}
+		sslCertContent = string(certbyte)
+		sslKeyContent = string(keyBytes)
 	}
 
-	dst := filepath.Join(dir, "Caddyfile")
-	if err := os.WriteFile(dst, raw, filePerm); err != nil {
-		return fmt.Errorf("write Caddyfile to %s: %w", dst, err)
-	}
-
-	logger.Infof("worker setup: Caddyfile written to %s\n", dst)
-
-	return nil
+	return string(raw), sslCertContent, sslKeyContent, nil
 }
 
 // deployAll loads all pod templates from assets/worker/<runtime>/templates and
 // deploys each one in the order defined by metadata.yaml podTemplateExecutions.
-func deployAll(ctx context.Context, rt runtime.Runtime, tp templates.Template, opts workertypes.PodmanWorkerOptions, existingResources []string) error {
+func deployAll(ctx context.Context, rt runtime.Runtime, tp templates.Template, opts workertypes.PodmanWorkerOptions, existingResources []string, domainSuffix string) error {
 	var appMetadata templates.AppMetadata
 	if err := tp.LoadMetadata(workerconstants.WorkerAppTemplate, true, &appMetadata); err != nil {
 		return fmt.Errorf("worker setup: load metadata: %w", err)
@@ -167,11 +170,6 @@ func deployAll(ctx context.Context, rt runtime.Runtime, tp templates.Template, o
 	tmpls, err := tp.LoadAllTemplates(workerconstants.WorkerAppTemplate)
 	if err != nil {
 		return fmt.Errorf("worker setup: load templates: %w", err)
-	}
-
-	domainSuffix, err := utils.ComputeDomainSuffix(opts.Setup.SSLCertPath, opts.Setup.SSLKeyPath, opts.Setup.DomainName)
-	if err != nil {
-		return fmt.Errorf("worker setup: compute domain suffix: %w", err)
 	}
 
 	argParams, err := buildArgParams(opts)
@@ -222,8 +220,16 @@ func buildArgParams(opts workertypes.PodmanWorkerOptions) (map[string]string, er
 		return nil, err
 	}
 
+	caddyFileContent, sslCertContent, sslKeyContent, err := readCaddyConfig(opts.Setup.SSLCertPath, opts.Setup.SSLKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("worker setup: read Caddyfile: %w", err)
+	}
+
 	return map[string]string{
-		workerconstants.ArgParamCaddyHTTPSPort:    strconv.Itoa(opts.Setup.HTTPSPort),
+		constants.ArgParamCaddyHTTPSPort:          strconv.Itoa(opts.Setup.HTTPSPort),
+		constants.ArgParamCaddyFileContent:        utils.IndentString(caddyFileContent, utils.CaddyFileIndent),
+		constants.ArgParamSSLCertFileContent:      utils.IndentString(sslCertContent, utils.CertContentIndent),
+		constants.ArgParamSSLKeyFileContent:       utils.IndentString(sslKeyContent, utils.CertContentIndent),
 		workerconstants.ArgParamWorkerToken:       opts.Token,
 		workerconstants.ArgParamWorkerGatewayAddr: opts.GatewayAddr,
 		workerconstants.ArgParamWorkerPodmanURI:   strings.TrimPrefix(podmanURI, "unix://"),

--- a/ai-services/internal/pkg/worker/deploy/podman/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/podman/deploy.go
@@ -275,6 +275,13 @@ func renderAndDeploy(ctx context.Context, rt runtime.Runtime, tmpls map[string]*
 		return fmt.Errorf("worker setup: render %s: %w", tmplName, err)
 	}
 
+	// If the rendered template is empty, skip deploying it
+	if strings.TrimSpace(rendered.String()) == "" {
+		logger.Infof("%s: Skipping resource deploy as it rendered empty", tmplName)
+
+		return nil
+	}
+	
 	var podSpec podmodels.PodSpec
 	if err := k8syaml.Unmarshal(rendered.Bytes(), &podSpec); err != nil {
 		return fmt.Errorf("worker setup: parse pod spec %s: %w", tmplName, err)

--- a/ai-services/internal/pkg/worker/deploy/podman/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/podman/deploy.go
@@ -281,7 +281,7 @@ func renderAndDeploy(ctx context.Context, rt runtime.Runtime, tmpls map[string]*
 
 		return nil
 	}
-	
+
 	var podSpec podmodels.PodSpec
 	if err := k8syaml.Unmarshal(rendered.Bytes(), &podSpec); err != nil {
 		return fmt.Errorf("worker setup: parse pod spec %s: %w", tmplName, err)


### PR DESCRIPTION
Making use of volume instead of hostpath to mount caddyfile and ssl-certs for worker caddy pod.