### PR TITLE
Extend the global conversion queue mechanism to connectors

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.329
+TAG?=v0.0.330
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.56
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.57
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.56
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.57
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.56
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.57
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.56
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.57
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.56
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.57
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.329
+  image: icr.io/ai-services-cicd/ai-services:v0.0.330
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.329
+  image: icr.io/ai-services-cicd/ai-services:v0.0.330
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/services/digitize/openshift/values.yaml
+++ b/ai-services/assets/services/digitize/openshift/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.56
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.57
   log_level: "INFO"
   database: "digitize_metadata"
   numShards: 1

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.56
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.57
   log_level: "INFO"
   database: "digitize_metadata"
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.329
+  image: icr.io/ai-services-cicd/ai-services:v0.0.330
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.329
+  image: icr.io/ai-services-cicd/ai-services:v0.0.330
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.56
+TAG?=v0.0.57
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -317,6 +317,7 @@ async def _run_teardown(connector_id: str) -> None:
     and awaited directly from _handle_interrupt in sync_tick (Case A).
 
     Steps:
+      0. Purge queued conversion tasks so the dispatcher never picks them up
       1. Remove the scheduled job so no new ticks fire
       2. Snapshot checksums owned by this connector
       3. Remove ownership rows; delete documents when last owner
@@ -326,6 +327,15 @@ async def _run_teardown(connector_id: str) -> None:
     logger.info(f"Starting teardown for connector {connector_id!r}")
     deletion_errors: list[str] = []
     try:
+        # Step 0: Purge any queued conversion tasks before anything else so the
+        # dispatcher cannot pick up tasks that belong to a connector being deleted.
+        from digitize.db.manager import db_manager
+        deleted_tasks = db_manager.delete_conversion_tasks_for_connector(connector_id)
+        if deleted_tasks:
+            logger.info(
+                f"Purged {deleted_tasks} queued conversion task(s) for connector {connector_id!r}"
+            )
+
         # Step 1: Remove the scheduled job so no new ticks fire after this point.
         try:
             import digitize.connectors.scheduler as _sched

--- a/services/digitize/api/v1/connectors.py
+++ b/services/digitize/api/v1/connectors.py
@@ -313,11 +313,13 @@ async def _run_teardown(connector_id: str) -> None:
     """
     Teardown for connector deletion.
 
-    Scheduled via asyncio.create_task from the delete endpoint (Case B),
-    and awaited directly from _handle_interrupt in sync_tick (Case A).
+    Scheduled via asyncio.create_task from the delete endpoint (Case B — no
+    tick running). Awaited directly from _handle_interrupt in sync_tick
+    (Case A — tick interrupted). In Case A the caller is responsible for
+    purging in-flight conversion tasks *before* calling this function, since
+    no tick is running when _run_teardown executes in Case B.
 
     Steps:
-      0. Purge queued conversion tasks so the dispatcher never picks them up
       1. Remove the scheduled job so no new ticks fire
       2. Snapshot checksums owned by this connector
       3. Remove ownership rows; delete documents when last owner
@@ -327,15 +329,6 @@ async def _run_teardown(connector_id: str) -> None:
     logger.info(f"Starting teardown for connector {connector_id!r}")
     deletion_errors: list[str] = []
     try:
-        # Step 0: Purge any queued conversion tasks before anything else so the
-        # dispatcher cannot pick up tasks that belong to a connector being deleted.
-        from digitize.db.manager import db_manager
-        deleted_tasks = db_manager.delete_conversion_tasks_for_connector(connector_id)
-        if deleted_tasks:
-            logger.info(
-                f"Purged {deleted_tasks} queued conversion task(s) for connector {connector_id!r}"
-            )
-
         # Step 1: Remove the scheduled job so no new ticks fire after this point.
         try:
             import digitize.connectors.scheduler as _sched

--- a/services/digitize/api/v1/jobs.py
+++ b/services/digitize/api/v1/jobs.py
@@ -58,35 +58,6 @@ async def _run_digitize(
         cleanup_staging_directory(job_id, settings.digitize.staging_dir)
 
 
-async def _run_ingest(
-    job_id: str,
-    doc_id_dict: dict,
-    file_checksum_dict: Optional[dict] = None,  # filename -> md5 hex
-) -> None:
-    """
-    Run the ingestion pipeline for this job.  Polls conversion_tasks rows
-    reactively and drives process → chunk → index for each completed file.
-
-    Runs the blocking pipeline call in a thread so the event loop stays free.
-    """
-    job_staging_path = settings.digitize.staging_dir / job_id
-    try:
-        logger.info(f"🚀 Ingestion started for job: {job_id}")
-        from digitize.pipeline.ingest import ingest
-        await asyncio.to_thread(ingest, job_staging_path, job_id, doc_id_dict, file_checksum_dict)
-        logger.info(f"Ingestion for job {job_id} completed successfully")
-    except Exception as exc:
-        logger.error(f"Error in ingestion job {job_id}: {exc}", exc_info=True)
-        status_mgr = get_status_manager(job_id)
-        status_mgr.update_job_progress(
-            "",
-            models.DocStatus.FAILED,
-            models.JobStatus.FAILED,
-            error=f"Error occurred while processing ingestion pipeline: {exc}",
-        )
-    finally:
-        cleanup_staging_directory(job_id, settings.digitize.staging_dir)
-
 
 # ------------------------------------------------------------------ #
 # File validation helper                                              #
@@ -327,7 +298,7 @@ async def create_job(
         if operation == models.OperationType.DIGITIZATION:
             asyncio.create_task(_run_digitize(job_id, doc_id_dict))
         else:
-            asyncio.create_task(_run_ingest(job_id, doc_id_dict, file_checksum_dict))
+            asyncio.create_task(dg_util.launch_ingest_pipeline(job_id, doc_id_dict, file_checksum_dict))
 
         logger.info(
             f"Job {job_id} accepted — {len(filenames)} file(s), "

--- a/services/digitize/api/v1/jobs.py
+++ b/services/digitize/api/v1/jobs.py
@@ -266,39 +266,23 @@ async def create_job(
             file_contents,
         )
 
-        # 7 & 8. Create DB rows and enqueue conversion tasks.
-        # If either step fails the staged files must be removed — the pipeline
-        # will never run to clean them up because no asyncio task is created yet.
-        try:
-            doc_id_dict = dg_util.initialize_job_state(
-                job_id, operation, output_format, filenames, job_name,
-                already_exists_files=already_exists_files,
-            )
+        # 7, 8 & 9. Create DB rows, enqueue conversion tasks, launch pipeline.
+        doc_id_dict = await dg_util.initialize_and_launch(
+            job_id=job_id,
+            operation=operation,
+            output_format=output_format,
+            filenames=filenames,
+            staging_dir=settings.digitize.staging_dir / job_id,
+            quota=quota,
+            queued_for_op=queued_for_op,
+            job_name=job_name,
+            already_exists_files=already_exists_files,
+            file_checksum_dict=file_checksum_dict,
+        )
 
-            await dg_util.enqueue_conversion_tasks(
-                job_id=job_id,
-                op_key=op_key,
-                filenames=filenames,
-                doc_id_dict=doc_id_dict,
-                staging_dir=settings.digitize.staging_dir / job_id,
-                output_format=output_format,
-                quota=quota,
-                queued_for_op=queued_for_op,
-            )
-        except Exception:
-            logger.error(
-                f"Job {job_id}: DB initialisation or enqueue failed — "
-                f"removing {len(filenames)} staged file(s)",
-            )
-            cleanup_staging_directory(job_id, settings.digitize.staging_dir)
-            raise
-
-        # 9. Launch the pipeline as a fire-and-forget asyncio task.
-        #    The pipeline polls conversion_tasks and drives post-conversion work.
+        # Digitization jobs need a separate pipeline task (not launch_ingest_pipeline).
         if operation == models.OperationType.DIGITIZATION:
             asyncio.create_task(_run_digitize(job_id, doc_id_dict))
-        else:
-            asyncio.create_task(dg_util.launch_ingest_pipeline(job_id, doc_id_dict, file_checksum_dict))
 
         logger.info(
             f"Job {job_id} accepted — {len(filenames)} file(s), "

--- a/services/digitize/api/v1/jobs.py
+++ b/services/digitize/api/v1/jobs.py
@@ -14,49 +14,16 @@ from typing import List, Optional
 
 from fastapi import APIRouter, File, HTTPException, Query, UploadFile, status
 
-from common.misc_utils import get_logger, validate_document_file, cleanup_staging_directory, generate_file_checksum
+from common.misc_utils import get_logger, validate_document_file, generate_file_checksum
 from common.error_utils import APIError, ErrorCode, http_error_responses, extract_http_error_message, build_http_error_detail
 import digitize.utils.jobs as dg_util
 import digitize.models as models
-from digitize.utils.db import get_status_manager
 import digitize.utils.db as db_ops
 from digitize.settings import settings
 from digitize.db.manager import db_manager
 
 router = APIRouter()
 logger = get_logger("jobs_router")
-
-# ------------------------------------------------------------------ #
-# Background pipeline helpers                                         #
-# ------------------------------------------------------------------ #
-
-async def _run_digitize(
-    job_id: str,
-    doc_id_dict: dict,
-) -> None:
-    """
-    Poll the conversion_tasks row for this digitization job until the
-    dispatcher marks it terminal, then surface the result.
-
-    Runs the blocking pipeline call in a thread so the event loop stays free.
-    """
-    try:
-        logger.info(f"🚀 Digitization started for job: {job_id}")
-        from digitize.pipeline.digitize import digitize
-        await asyncio.to_thread(digitize, job_id, doc_id_dict)
-        logger.info(f"Digitization for job {job_id} completed successfully")
-    except Exception as exc:
-        logger.error(f"Error in digitization job {job_id}: {exc}", exc_info=True)
-        status_mgr = get_status_manager(job_id)
-        status_mgr.update_job_progress(
-            "",
-            models.DocStatus.FAILED,
-            models.JobStatus.FAILED,
-            error=f"Error occurred while processing digitization pipeline: {exc}",
-        )
-    finally:
-        cleanup_staging_directory(job_id, settings.digitize.staging_dir)
-
 
 
 # ------------------------------------------------------------------ #
@@ -267,7 +234,7 @@ async def create_job(
         )
 
         # 7, 8 & 9. Create DB rows, enqueue conversion tasks, launch pipeline.
-        doc_id_dict = await dg_util.initialize_and_launch(
+        await dg_util.initialize_and_launch(
             job_id=job_id,
             operation=operation,
             output_format=output_format,
@@ -279,10 +246,6 @@ async def create_job(
             already_exists_files=already_exists_files,
             file_checksum_dict=file_checksum_dict,
         )
-
-        # Digitization jobs need a separate pipeline task (not launch_ingest_pipeline).
-        if operation == models.OperationType.DIGITIZATION:
-            asyncio.create_task(_run_digitize(job_id, doc_id_dict))
 
         logger.info(
             f"Job {job_id} accepted — {len(filenames)} file(s), "

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -41,7 +41,6 @@ from pydantic import ValidationError
 
 from common.misc_utils import cleanup_staging_directory, get_logger, validate_document_file
 from digitize.connectors.scanners.scanner_factory import build_scanner
-from digitize.pipeline.ingest import ingest
 from digitize.settings import settings
 from digitize.connectors.models import ConnectorError, ConnectorStatus, SyncLogStatus
 from digitize.models import JobStatus, OutputFormat, OperationType
@@ -60,7 +59,12 @@ from digitize.utils.db import (
     update_sync_log,
 )
 from digitize.db.models import JobSource
-from digitize.utils.jobs import generate_uuid, get_job_document_stats, initialize_job_state
+from digitize.utils.jobs import (
+    enqueue_conversion_tasks,
+    generate_uuid,
+    get_job_document_stats,
+    initialize_job_state,
+)
 
 logger = get_logger("sync_tick")
 
@@ -407,7 +411,19 @@ async def _process_new_files(
                 if filename in filename_to_checksum
             }
 
-            await asyncio.to_thread(ingest, batch_dir, job_id, doc_id_dict)
+            # Enqueue all files into conversion_tasks as 'queued' (connector path —
+            # no pending phase, no quota). The dispatcher's C-ING turn picks them up.
+            await enqueue_conversion_tasks(
+                job_id=job_id,
+                op_key=OperationType.INGESTION,
+                filenames=filenames,
+                doc_id_dict=doc_id_dict,
+                staging_dir=batch_dir,
+                output_format=OutputFormat.JSON,
+                quota=0,          # unused for connector tasks
+                queued_for_op=0,  # unused for connector tasks
+                connector_id=connector_id,
+            )
 
             await _wait_for_job(job_id, connector_id, sync_seq)
 

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -64,6 +64,7 @@ from digitize.utils.jobs import (
     generate_uuid,
     get_job_document_stats,
     initialize_job_state,
+    launch_ingest_pipeline,
 )
 
 logger = get_logger("sync_tick")
@@ -423,6 +424,18 @@ async def _process_new_files(
                 quota=0,          # unused for connector tasks
                 queued_for_op=0,  # unused for connector tasks
                 connector_id=connector_id,
+            )
+
+            # Launch the ingestion pipeline as a background task so it drives
+            # process → chunk → index after the dispatcher completes each file.
+            # Pass batch_dir as staging_dir so cleanup targets the correct subtree.
+            asyncio.create_task(
+                launch_ingest_pipeline(
+                    job_id=job_id,
+                    doc_id_dict=doc_id_dict,
+                    file_checksum_dict=filename_to_checksum,
+                    staging_dir=batch_dir,
+                )
             )
 
             await _wait_for_job(job_id, connector_id, sync_seq)

--- a/services/digitize/connectors/sync_tick.py
+++ b/services/digitize/connectors/sync_tick.py
@@ -60,11 +60,9 @@ from digitize.utils.db import (
 )
 from digitize.db.models import JobSource
 from digitize.utils.jobs import (
-    enqueue_conversion_tasks,
     generate_uuid,
     get_job_document_stats,
-    initialize_job_state,
-    launch_ingest_pipeline,
+    initialize_and_launch,
 )
 
 logger = get_logger("sync_tick")
@@ -396,47 +394,31 @@ async def _process_new_files(
 
             filenames = list(filename_to_checksum.keys())
             job_name = f"Connector-{connector_name}-{sync_seq}-{batch_number}"
-            doc_id_dict = initialize_job_state(
+
+            # Steps 7, 8 & 9: create DB rows, enqueue tasks, launch pipeline.
+            # quota=0 / queued_for_op=0: connector tasks bypass user quota.
+            # file_checksum_dict omitted: connectors register checksums via
+            # add_connector_checksum_entry after the job completes.
+            doc_id_dict = await initialize_and_launch(
                 job_id=job_id,
                 operation=OperationType.INGESTION,
                 output_format=OutputFormat.JSON,
-                documents_info=filenames,
+                filenames=filenames,
+                staging_dir=batch_dir,
+                quota=0,
+                queued_for_op=0,
                 job_name=job_name,
                 source=JobSource.CONNECTOR,
+                connector_id=connector_id,
             )
 
-            # doc_id → checksum: built from doc_id_dict (filename→doc_id) + filename_to_checksum
+            # doc_id → checksum: used after job completes to register
+            # connector checksum entries via add_connector_checksum_entry.
             doc_id_to_checksum: dict[str, str] = {
                 doc_id: filename_to_checksum[filename]
                 for filename, doc_id in doc_id_dict.items()
                 if filename in filename_to_checksum
             }
-
-            # Enqueue all files into conversion_tasks as 'queued' (connector path —
-            # no pending phase, no quota). The dispatcher's C-ING turn picks them up.
-            await enqueue_conversion_tasks(
-                job_id=job_id,
-                op_key=OperationType.INGESTION,
-                filenames=filenames,
-                doc_id_dict=doc_id_dict,
-                staging_dir=batch_dir,
-                output_format=OutputFormat.JSON,
-                quota=0,          # unused for connector tasks
-                queued_for_op=0,  # unused for connector tasks
-                connector_id=connector_id,
-            )
-
-            # Launch the ingestion pipeline as a background task so it drives
-            # process → chunk → index after the dispatcher completes each file.
-            # Pass batch_dir as staging_dir so cleanup targets the correct subtree.
-            asyncio.create_task(
-                launch_ingest_pipeline(
-                    job_id=job_id,
-                    doc_id_dict=doc_id_dict,
-                    file_checksum_dict=filename_to_checksum,
-                    staging_dir=batch_dir,
-                )
-            )
 
             await _wait_for_job(job_id, connector_id, sync_seq)
 
@@ -533,6 +515,15 @@ async def _handle_interrupt(
     elif interrupt_type == InterruptType.DELETE_CONNECTOR:
         logger.info(f"Handling delete connector for {connector_id!r}")
         _cancel_tick(sync_seq, connector_id)
+        # Purge conversion tasks the tick may have enqueued before being interrupted.
+        # Must happen here (Case A only) — _run_teardown is shared with Case B where
+        # no tick was running so no in-flight tasks exist to purge.
+        from digitize.db.manager import db_manager
+        deleted_tasks = db_manager.delete_conversion_tasks_for_connector(connector_id)
+        if deleted_tasks:
+            logger.info(
+                f"Purged {deleted_tasks} queued conversion task(s) for connector {connector_id!r}"
+            )
         # Run full teardown: remove checksums, delete orphaned docs, delete connector row
         from digitize.api.v1.connectors import _run_teardown
         await _run_teardown(connector_id)

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1629,6 +1629,7 @@ class DatabaseManager:
         page_count: int,
         is_large: bool,
         status: ConversionTaskStatus = ConversionTaskStatus.QUEUED,
+        connector_id: Optional[str] = None,
     ) -> Optional[ConversionTask]:
         """
         Insert a single conversion_tasks row.
@@ -1643,6 +1644,7 @@ class DatabaseManager:
             page_count:    Document page count (0 for DOCX).
             is_large:      True when page_count >= heavy_doc_page_threshold.
             status:        Initial status — QUEUED or PENDING.
+            connector_id:  Owning connector UUID; None for user-submitted jobs.
 
         Returns:
             The created ConversionTask or None on failure.
@@ -1653,6 +1655,7 @@ class DatabaseManager:
                     task_id=task_id,
                     job_id=job_id,
                     doc_id=doc_id,
+                    connector_id=connector_id,
                     operation=operation,
                     cached_file=cached_file,
                     output_format=output_format,
@@ -1704,6 +1707,7 @@ class DatabaseManager:
                     task_id=t["task_id"],
                     job_id=t["job_id"],
                     doc_id=t["doc_id"],
+                    connector_id=t.get("connector_id"),
                     operation=t["operation"],
                     cached_file=t["cached_file"],
                     output_format=t["output_format"],
@@ -1730,8 +1734,8 @@ class DatabaseManager:
         then removes the object from the identity map so callers can use it
         freely after the ``with get_db_session()`` block exits.
         """
-        _ = (task.task_id, task.job_id, task.doc_id, task.operation,
-             task.cached_file, task.output_format, task.page_count,
+        _ = (task.task_id, task.job_id, task.doc_id, task.connector_id,
+             task.operation, task.cached_file, task.output_format, task.page_count,
              task.is_large, task.status, task.result_path, task.error,
              task.queued_at, task.started_at, task.completed_at)
         session.expunge(task)
@@ -1954,25 +1958,31 @@ class DatabaseManager:
             return False
 
     @staticmethod
-    def peek_head(operation: str) -> Optional[ConversionTask]:
+    def peek_head(operation: str, connector_id: Optional[str] = None) -> Optional[ConversionTask]:
         """
         Return the oldest 'queued' task for ``operation`` without locking.
+
+        Pass ``connector_id`` to scope the peek to a specific connector's queue
+        (dispatcher turn 2).  Pass None (default) for user task queues.
 
         Used by the dispatcher to inspect the head weight before attempting
         an atomic claim.
         """
         try:
             with get_db_session() as session:
-                stmt = (
+                filters = [
+                    ConversionTask.status == "queued",
+                    ConversionTask.operation == operation,
+                    ConversionTask.connector_id == connector_id
+                    if connector_id is not None
+                    else ConversionTask.connector_id.is_(None),
+                ]
+                task = session.scalar(
                     select(ConversionTask)
-                    .where(
-                        ConversionTask.status == ConversionTaskStatus.QUEUED,
-                        ConversionTask.operation == operation,
-                    )
+                    .where(*filters)
                     .order_by(ConversionTask.queued_at)
                     .limit(1)
                 )
-                task = session.scalar(stmt)
                 if task:
                     DatabaseManager._load_and_expunge_task(task, session)
                 return task
@@ -1981,9 +1991,12 @@ class DatabaseManager:
             return None
 
     @staticmethod
-    def claim_head(operation: str) -> Optional[ConversionTask]:
+    def claim_head(operation: str, connector_id: Optional[str] = None) -> Optional[ConversionTask]:
         """
         Atomically promote the oldest 'queued' task for ``operation`` to 'running'.
+
+        Pass ``connector_id`` to scope the claim to a specific connector's queue
+        (dispatcher turn 2).  Pass None (default) for user task queues.
 
         Uses SELECT … FOR UPDATE SKIP LOCKED so concurrent callers never
         claim the same task.
@@ -1994,33 +2007,33 @@ class DatabaseManager:
         """
         try:
             with get_db_session() as session:
-                # Subquery: find the head task_id under a row-level lock
+                filters = [
+                    ConversionTask.status == "queued",
+                    ConversionTask.operation == operation,
+                    ConversionTask.connector_id == connector_id
+                    if connector_id is not None
+                    else ConversionTask.connector_id.is_(None),
+                ]
                 subq = (
                     select(ConversionTask.task_id)
-                    .where(
-                        ConversionTask.status == ConversionTaskStatus.QUEUED,
-                        ConversionTask.operation == operation,
-                    )
+                    .where(*filters)
                     .order_by(ConversionTask.queued_at)
                     .limit(1)
                     .with_for_update(skip_locked=True)
                     .scalar_subquery()
                 )
-                now = datetime.now(timezone.utc)
                 stmt = (
                     update(ConversionTask)
                     .where(ConversionTask.task_id == subq)
                     .values(
                         status=ConversionTaskStatus.RUNNING,
-                        started_at=now,
+                        started_at=datetime.now(timezone.utc),
                     )
                     .returning(ConversionTask)
                 )
-                result = session.execute(stmt)
-                row = result.fetchone()
+                row = session.execute(stmt).fetchone()
                 if row is None:
                     return None
-                # row[0] is the ORM object returned by RETURNING *
                 task = row[0]
                 DatabaseManager._load_and_expunge_task(task, session)
                 return task
@@ -2031,10 +2044,14 @@ class DatabaseManager:
     @staticmethod
     def promote_pending(operation: str, quota: int) -> int:
         """
-        Promote as many 'pending' tasks as will fit under ``quota`` for ``operation``.
+        Promote as many 'pending' user tasks as will fit under ``quota`` for
+        ``operation``.
 
-        This keeps the 'queued' count ≤ quota while draining the pending backlog
-        in first-submitted-first-promoted order.
+        Only promotes tasks where ``connector_id IS NULL`` — connector tasks are
+        always inserted as 'queued' and never enter the pending backlog.
+
+        This keeps the user 'queued' count ≤ quota while draining the pending
+        backlog in first-submitted-first-promoted order.
 
         All three statements (count queued, select candidates, update status) run
         inside a single transaction under the same session-level advisory lock used
@@ -2061,11 +2078,12 @@ class DatabaseManager:
                 # sequence so no concurrent caller can interleave.
                 session.execute(text(f"SELECT pg_advisory_xact_lock({lock_key})"))
 
-                # Count currently queued tasks for this operation.
+                # Count currently queued user tasks for this operation.
                 queued_count = session.scalar(
                     select(func.count()).where(
                         ConversionTask.status == ConversionTaskStatus.QUEUED,
                         ConversionTask.operation == operation,
+                        ConversionTask.connector_id.is_(None),
                     )
                 ) or 0
 
@@ -2073,12 +2091,13 @@ class DatabaseManager:
                 if headroom == 0:
                     return 0
 
-                # Fetch the oldest pending tasks that fit under the quota.
+                # Fetch the oldest pending user tasks that fit under the quota.
                 candidates = session.execute(
                     select(ConversionTask.task_id, ConversionTask.cached_file)
                     .where(
                         ConversionTask.status == ConversionTaskStatus.PENDING,
                         ConversionTask.operation == operation,
+                        ConversionTask.connector_id.is_(None),
                     )
                     .order_by(ConversionTask.queued_at)
                     .limit(headroom)
@@ -2088,14 +2107,12 @@ class DatabaseManager:
                     return 0
 
                 candidate_ids = [row.task_id for row in candidates]
-                now = datetime.now(timezone.utc)
                 stmt = (
                     update(ConversionTask)
                     .where(ConversionTask.task_id.in_(candidate_ids))
-                    .values(status=ConversionTaskStatus.QUEUED, queued_at=now)
+                    .values(status=ConversionTaskStatus.QUEUED, queued_at=datetime.now(timezone.utc))
                 )
-                result = cast(CursorResult, session.execute(stmt))
-                promoted = result.rowcount
+                promoted = cast(CursorResult, session.execute(stmt)).rowcount
                 if promoted:
                     logger.debug(f"Promoted {promoted} pending → queued for {operation}")
                     for row in candidates:
@@ -2105,6 +2122,67 @@ class DatabaseManager:
                 return promoted
         except SQLAlchemyError as e:
             logger.error(f"DB error promoting pending tasks for {operation}: {e}", exc_info=True)
+            return 0
+
+    @staticmethod
+    def get_connector_ids_with_queued_tasks() -> List[str]:
+        """
+        Return connector IDs that have at least one 'queued' ingestion task,
+        ordered by their oldest queued_at (FIFO — longest-waiting connector first).
+
+        Called each tick by the dispatcher's connector turn (turn 2) to build
+        the round-robin list.
+        """
+        try:
+            with get_db_session() as session:
+                stmt = (
+                    select(ConversionTask.connector_id)
+                    .where(
+                        ConversionTask.status == "queued",
+                        ConversionTask.operation == "ingestion",
+                        ConversionTask.connector_id.is_not(None),
+                    )
+                    .group_by(ConversionTask.connector_id)
+                    .order_by(func.min(ConversionTask.queued_at))
+                )
+                return [row[0] for row in session.execute(stmt).all()]
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in get_connector_ids_with_queued_tasks: {e}", exc_info=True)
+            return []
+
+    @staticmethod
+    def delete_conversion_tasks_for_connector(connector_id: str) -> int:
+        """
+        Delete all queued conversion_tasks rows owned by ``connector_id``.
+
+        Called as the first step of connector teardown, before checksum rows
+        and document rows are removed, to ensure the dispatcher never picks up
+        tasks that belong to a connector being deleted.
+
+        Returns:
+            Number of rows deleted.
+        """
+        try:
+            with get_db_session() as session:
+                result = cast(
+                    CursorResult,
+                    session.execute(
+                        delete(ConversionTask).where(
+                            ConversionTask.connector_id == connector_id,
+                            ConversionTask.status == "queued",
+                        )
+                    ),
+                )
+                deleted = result.rowcount
+                if deleted:
+                    logger.info(
+                        f"Deleted {deleted} queued task(s) for connector {connector_id!r}"
+                    )
+                return deleted
+        except SQLAlchemyError as e:
+            logger.error(
+                f"DB error deleting tasks for connector {connector_id!r}: {e}", exc_info=True
+            )
             return 0
 
 

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1971,7 +1971,7 @@ class DatabaseManager:
         try:
             with get_db_session() as session:
                 filters = [
-                    ConversionTask.status == "queued",
+                    ConversionTask.status == ConversionTaskStatus.QUEUED,
                     ConversionTask.operation == operation,
                     ConversionTask.connector_id == connector_id
                     if connector_id is not None
@@ -2008,7 +2008,7 @@ class DatabaseManager:
         try:
             with get_db_session() as session:
                 filters = [
-                    ConversionTask.status == "queued",
+                    ConversionTask.status == ConversionTaskStatus.QUEUED,
                     ConversionTask.operation == operation,
                     ConversionTask.connector_id == connector_id
                     if connector_id is not None
@@ -2138,7 +2138,7 @@ class DatabaseManager:
                 stmt = (
                     select(ConversionTask.connector_id)
                     .where(
-                        ConversionTask.status == "queued",
+                        ConversionTask.status == ConversionTaskStatus.QUEUED,
                         ConversionTask.operation == "ingestion",
                         ConversionTask.connector_id.is_not(None),
                     )
@@ -2169,7 +2169,7 @@ class DatabaseManager:
                     session.execute(
                         delete(ConversionTask).where(
                             ConversionTask.connector_id == connector_id,
-                            ConversionTask.status == "queued",
+                            ConversionTask.status == ConversionTaskStatus.QUEUED,
                         )
                     ),
                 )

--- a/services/digitize/db/models.py
+++ b/services/digitize/db/models.py
@@ -347,6 +347,9 @@ class ConversionTask(Base):
     # Digitize document id; informational only
     doc_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
+    # Owning connector UUID — NULL for user-submitted jobs
+    connector_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
     # Operation type — 'ingestion' | 'digitization'
     operation: Mapped[str] = mapped_column(String(50), nullable=False)
 
@@ -398,6 +401,8 @@ class ConversionTask(Base):
         Index("idx_ct_status_op_queued", "status", "operation", "queued_at"),
         # Supports get_conversion_task_by_job_id — called by pipeline pollers
         Index("idx_ct_job_id", "job_id"),
+        # Supports dispatcher connector round-robin pick (turn 2: queued tasks per connector)
+        Index("idx_ct_connector_queued", "connector_id", "status", "queued_at"),
     )
 
     def __repr__(self) -> str:

--- a/services/digitize/db/scripts/init_schema.sql
+++ b/services/digitize/db/scripts/init_schema.sql
@@ -110,6 +110,7 @@ CREATE TABLE IF NOT EXISTS conversion_tasks (
     -- link back to the digitize job that owns this task
     job_id          VARCHAR(255)    REFERENCES jobs(job_id) ON DELETE SET NULL,
     doc_id          VARCHAR(255),                           -- informational; no FK
+    connector_id    VARCHAR(255),                           -- NULL for user jobs; connector UUID for connector jobs
     operation       VARCHAR(50)     NOT NULL,
     -- input
     cached_file     TEXT            NOT NULL,               -- absolute path at enqueue time
@@ -135,6 +136,10 @@ CREATE INDEX IF NOT EXISTS idx_ct_status_op_queued
 -- Supports get_conversion_task_by_job_id — avoids full-table scans on poll
 CREATE INDEX IF NOT EXISTS idx_ct_job_id
     ON conversion_tasks (job_id);
+
+-- Supports dispatcher connector round-robin pick (turn 2: queued tasks per connector)
+CREATE INDEX IF NOT EXISTS idx_ct_connector_queued
+    ON conversion_tasks (connector_id, status, queued_at);
 
 -- Create indexes with IF NOT EXISTS
 CREATE INDEX IF NOT EXISTS idx_jobs_submitted_at_status ON jobs(submitted_at DESC, status);

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -163,7 +163,7 @@ def connector_test_client(monkeypatch, tmp_path, mock_db_operations):
     monkeypatch.setattr(digitize_app.dg_util, "get_document_page_count", Mock(return_value=0))
     monkeypatch.setattr(jobs_router_module, "generate_file_checksum", Mock(return_value="sha256:abc123"))
     monkeypatch.setattr(jobs_router_module, "_run_digitize", Mock())
-    monkeypatch.setattr(jobs_router_module, "_run_ingest", Mock())
+    monkeypatch.setattr(digitize_app.dg_util, "initialize_and_launch", AsyncMock(return_value={"sample.pdf": "doc-1"}))
 
     monkeypatch.setattr(digitize_app, "configure_uvicorn_logging", Mock())
     monkeypatch.setattr(documents_router_module, "reset_db", Mock())

--- a/services/digitize/tests/test_connector_endpoints.py
+++ b/services/digitize/tests/test_connector_endpoints.py
@@ -162,7 +162,6 @@ def connector_test_client(monkeypatch, tmp_path, mock_db_operations):
     monkeypatch.setattr(digitize_app.dg_util, "enqueue_conversion_tasks", AsyncMock())
     monkeypatch.setattr(digitize_app.dg_util, "get_document_page_count", Mock(return_value=0))
     monkeypatch.setattr(jobs_router_module, "generate_file_checksum", Mock(return_value="sha256:abc123"))
-    monkeypatch.setattr(jobs_router_module, "_run_digitize", Mock())
     monkeypatch.setattr(digitize_app.dg_util, "initialize_and_launch", AsyncMock(return_value={"sample.pdf": "doc-1"}))
 
     monkeypatch.setattr(digitize_app, "configure_uvicorn_logging", Mock())

--- a/services/digitize/tests/test_conversion_dispatcher.py
+++ b/services/digitize/tests/test_conversion_dispatcher.py
@@ -2,9 +2,8 @@
 Unit tests for the conversion dispatcher — workers/conversion_dispatcher.py.
 
 These tests focus on:
-  - _other() helper
   - _try_claim_if_fits() head-of-line blocking logic
-  - dispatch_loop() round-robin behaviour (mocked DB + semaphore)
+  - dispatch_loop() 3-turn round-robin behaviour (mocked DB + semaphore)
   - _run_conversion() success / failure paths
 """
 
@@ -50,18 +49,22 @@ def _make_task(
 
 
 # ---------------------------------------------------------------------------
-# _other()
+# _op_turn cycle
 # ---------------------------------------------------------------------------
 
 @pytest.mark.unit
-class TestOther:
-    def test_ingestion_returns_digitization(self):
-        from digitize.workers.conversion_dispatcher import _other
-        assert _other("ingestion") == "digitization"
+class TestOpTurnCycle:
+    def test_turn_cycles_0_1_2(self):
+        """_op_turn increments mod 3 unconditionally each tick."""
+        assert (0 + 1) % 3 == 1
+        assert (1 + 1) % 3 == 2
+        assert (2 + 1) % 3 == 0
 
-    def test_digitization_returns_ingestion(self):
-        from digitize.workers.conversion_dispatcher import _other
-        assert _other("digitization") == "ingestion"
+    def test_turn_0_is_user_ingestion(self):
+        # Turn 0 = U-ING; turn 1 = U-DIG; turn 2 = C-ING
+        turns = {0: "ingestion", 1: "digitization", 2: "connector-ingestion"}
+        assert turns[0] == "ingestion"
+        assert turns[1] == "digitization"
 
 
 # ---------------------------------------------------------------------------
@@ -159,105 +162,175 @@ def _make_create_task_mock():
 @pytest.mark.unit
 class TestDispatchLoop:
 
-    def test_turn_flips_after_first_task_claimed(self):
+    def test_turn_advances_unconditionally_when_task_claimed(self):
+        """_op_turn increments every tick regardless of whether a task was dispatched."""
         import digitize.workers.conversion_dispatcher as mod
-        mod._rr_turn = "ingestion"
+        mod._op_turn = 0   # start at U-ING
 
-        first_t = _make_task(task_id="t-ing", operation="ingestion", is_large=False)
-        second_t = _make_task(task_id="t-dig", operation="digitization", is_large=False)
+        task_t = _make_task(task_id="t-ing", operation="ingestion", is_large=False)
 
-        # Set 4 units available so first AND second can be claimed
+        original_available = mod.conversion_semaphore._available
+        _set_semaphore_available(mod, 4)
+
+        try:
+            async def _run():
+                with patch.object(mod, "_try_claim_if_fits", return_value=task_t), \
+                     patch.object(mod.db_manager, "promote_pending", return_value=0), \
+                     patch.object(mod, "_dispatch_one", new_callable=AsyncMock), \
+                     patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+                    mock_sleep.side_effect = asyncio.CancelledError()
+                    try:
+                        await mod.dispatch_loop()
+                    except asyncio.CancelledError:
+                        pass
+
+                # One tick fired from turn=0 → must now be 1
+                assert mod._op_turn == 1
+
+            asyncio.run(_run())
+        finally:
+            _set_semaphore_available(mod, original_available)
+
+    def test_turn_advances_unconditionally_when_blocked(self):
+        """_op_turn advances even when nothing was dispatched (HOL block)."""
+        import digitize.workers.conversion_dispatcher as mod
+        mod._op_turn = 0
+
+        original_available = mod.conversion_semaphore._available
+        _set_semaphore_available(mod, 1)  # only 1 slot — large task will be blocked
+
+        try:
+            async def _run():
+                with patch.object(mod, "_try_claim_if_fits", return_value=None), \
+                     patch.object(mod.db_manager, "promote_pending", return_value=0), \
+                     patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+                    mock_sleep.side_effect = asyncio.CancelledError()
+                    try:
+                        await mod.dispatch_loop()
+                    except asyncio.CancelledError:
+                        pass
+
+                # Turn still advances even though nothing ran
+                assert mod._op_turn == 1
+
+            asyncio.run(_run())
+        finally:
+            _set_semaphore_available(mod, original_available)
+
+    def test_turn_0_dispatches_user_ingestion(self):
+        """Turn 0 attempts a user ingestion claim (connector_id=None)."""
+        import digitize.workers.conversion_dispatcher as mod
+        mod._op_turn = 0
+
+        claims = []
+
+        def _mock_claim(op, avail, connector_id=None):
+            claims.append((op, connector_id))
+            return None
+
+        original_available = mod.conversion_semaphore._available
+        _set_semaphore_available(mod, 4)
+
+        try:
+            async def _run():
+                with patch.object(mod, "_try_claim_if_fits", side_effect=_mock_claim), \
+                     patch.object(mod.db_manager, "promote_pending", return_value=0), \
+                     patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+                    mock_sleep.side_effect = asyncio.CancelledError()
+                    try:
+                        await mod.dispatch_loop()
+                    except asyncio.CancelledError:
+                        pass
+
+            asyncio.run(_run())
+        finally:
+            _set_semaphore_available(mod, original_available)
+
+        assert ("ingestion", None) in claims
+
+    def test_turn_1_dispatches_user_digitization(self):
+        """Turn 1 attempts a user digitization claim (connector_id=None)."""
+        import digitize.workers.conversion_dispatcher as mod
+        mod._op_turn = 1
+
+        claims = []
+
+        def _mock_claim(op, avail, connector_id=None):
+            claims.append((op, connector_id))
+            return None
+
+        original_available = mod.conversion_semaphore._available
+        _set_semaphore_available(mod, 4)
+
+        try:
+            async def _run():
+                with patch.object(mod, "_try_claim_if_fits", side_effect=_mock_claim), \
+                     patch.object(mod.db_manager, "promote_pending", return_value=0), \
+                     patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+                    mock_sleep.side_effect = asyncio.CancelledError()
+                    try:
+                        await mod.dispatch_loop()
+                    except asyncio.CancelledError:
+                        pass
+
+            asyncio.run(_run())
+        finally:
+            _set_semaphore_available(mod, original_available)
+
+        assert ("digitization", None) in claims
+
+    def test_turn_2_dispatches_connector_ingestion(self):
+        """Turn 2 picks the first connector with queued tasks and claims for it."""
+        import digitize.workers.conversion_dispatcher as mod
+        mod._op_turn = 2
+        mod._connector_rr_index = 0
+
+        claims = []
+
+        def _mock_claim(op, avail, connector_id=None):
+            claims.append((op, connector_id))
+            return None
+
+        original_available = mod.conversion_semaphore._available
+        _set_semaphore_available(mod, 4)
+
+        try:
+            async def _run():
+                with patch.object(mod, "_try_claim_if_fits", side_effect=_mock_claim), \
+                     patch.object(mod.db_manager, "get_connector_ids_with_queued_tasks",
+                                   return_value=["conn-1", "conn-2"]), \
+                     patch.object(mod.db_manager, "promote_pending", return_value=0), \
+                     patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+                    mock_sleep.side_effect = asyncio.CancelledError()
+                    try:
+                        await mod.dispatch_loop()
+                    except asyncio.CancelledError:
+                        pass
+
+            asyncio.run(_run())
+        finally:
+            _set_semaphore_available(mod, original_available)
+
+        # Should have tried to claim for conn-1 (index 0)
+        assert ("ingestion", "conn-1") in claims
+
+    def test_turn_2_no_op_when_no_connectors(self):
+        """Turn 2 is a no-op when no connectors have queued tasks."""
+        import digitize.workers.conversion_dispatcher as mod
+        mod._op_turn = 2
+
+        claims = []
+
         original_available = mod.conversion_semaphore._available
         _set_semaphore_available(mod, 4)
 
         try:
             async def _run():
                 with patch.object(mod, "_try_claim_if_fits",
-                                   side_effect=lambda op, avail: first_t if op == "ingestion" else second_t), \
-                     patch.object(mod.db_manager, "peek_head",
-                                   return_value=_make_task(is_large=False)), \
-                     patch.object(mod.db_manager, "get_queued_counts",
-                                   return_value={"ingestion": 0, "digitization": 0}), \
+                                   side_effect=lambda op, avail, connector_id=None: claims.append((op, connector_id)) or None), \
+                     patch.object(mod.db_manager, "get_connector_ids_with_queued_tasks",
+                                   return_value=[]), \
                      patch.object(mod.db_manager, "promote_pending", return_value=0), \
-                     patch.object(mod.conversion_semaphore, "acquire", new_callable=AsyncMock), \
-                     patch("asyncio.create_task", new=_make_create_task_mock()), \
-                     patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-                    mock_sleep.side_effect = asyncio.CancelledError()
-                    try:
-                        await mod.dispatch_loop()
-                    except asyncio.CancelledError:
-                        pass
-
-                # First was claimed → turn flips to "digitization"
-                assert mod._rr_turn == "digitization"
-
-            asyncio.run(_run())
-        finally:
-            _set_semaphore_available(mod, original_available)
-
-    def test_turn_does_not_flip_when_first_blocked(self):
-        """
-        If first type's head is a large file that can't fit (available=1),
-        _rr_turn must NOT flip.
-        """
-        import digitize.workers.conversion_dispatcher as mod
-        mod._rr_turn = "ingestion"
-
-        large_head = _make_task(task_id="t-large-ing", operation="ingestion", is_large=True)
-
-        original_available = mod.conversion_semaphore._available
-        _set_semaphore_available(mod, 1)  # only 1 free — can't fit large (weight 2)
-
-        try:
-            async def _run():
-                with patch.object(mod, "_try_claim_if_fits", return_value=None), \
-                     patch.object(mod.db_manager, "peek_head", return_value=large_head), \
-                     patch.object(mod.db_manager, "get_queued_counts",
-                                   return_value={"ingestion": 5, "digitization": 0}), \
-                     patch.object(mod.db_manager, "promote_pending", return_value=0), \
-                     patch("asyncio.create_task", new=_make_create_task_mock()), \
-                     patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-                    mock_sleep.side_effect = asyncio.CancelledError()
-                    try:
-                        await mod.dispatch_loop()
-                    except asyncio.CancelledError:
-                        pass
-
-                assert mod._rr_turn == "ingestion"  # unchanged
-
-            asyncio.run(_run())
-        finally:
-            _set_semaphore_available(mod, original_available)
-
-    def test_second_gets_no_budget_when_first_head_is_large_and_unavailable(self):
-        """
-        First (ING) head needs 2 units but only 1 is free → budget_for_second = 0.
-        No DIG task is queued so second_needed=0 → budget_for_first = available=1.
-        _try_claim_if_fits calls: ingestion receives 1, digitization receives 0.
-        """
-        import digitize.workers.conversion_dispatcher as mod
-        mod._rr_turn = "ingestion"
-
-        large_ing = _make_task(task_id="t-ing-large", operation="ingestion", is_large=True)
-
-        calls = []
-
-        def _mock_try_claim(op, avail):
-            calls.append((op, avail))
-            return None  # nothing can run
-
-        original_available = mod.conversion_semaphore._available
-        _set_semaphore_available(mod, 1)
-
-        try:
-            async def _run():
-                with patch.object(mod, "_try_claim_if_fits", side_effect=_mock_try_claim), \
-                     patch.object(mod.db_manager, "peek_head",
-                                   side_effect=lambda op: large_ing if op == "ingestion" else None), \
-                     patch.object(mod.db_manager, "get_queued_counts",
-                                   return_value={"ingestion": 5, "digitization": 0}), \
-                     patch.object(mod.db_manager, "promote_pending", return_value=0), \
-                     patch("asyncio.create_task", new=_make_create_task_mock()), \
                      patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
                     mock_sleep.side_effect = asyncio.CancelledError()
                     try:
@@ -269,96 +342,21 @@ class TestDispatchLoop:
         finally:
             _set_semaphore_available(mod, original_available)
 
-        # second_needed=0 (no DIG head) → budget_for_first = max(0, 1-0) = 1
-        # first_needed=2  (large ING)   → budget_for_second = max(0, 1-2) = 0
-        assert ("ingestion", 1) in calls
-        assert ("digitization", 0) in calls
-
-    def test_first_gets_no_budget_when_second_head_is_large_and_slot_needed(self):
-        """
-        Regression test for large-file starvation via the other queue.
-
-        Scenario (mirrors hol_blocking probe tick 1):
-          - _rr_turn = "digitization"  (turn just flipped to DIG as first)
-          - available = 1
-          - second queue (ING) head is a large task needing weight=2
-          - first queue (DIG) head is a normal task needing weight=1
-
-        Before the fix, DIG normal would be dispatched (budget=available=1 ≥ 1),
-        consuming the last slot and leaving the large ING task unable to ever
-        accumulate its required 2 free slots until DIG *and* all other running
-        tasks finished — indefinite starvation.
-
-        After the fix:
-          budget_for_first = max(0, available - second_needed)
-                           = max(0,     1     -      2       ) = 0
-        DIG must also be blocked; neither queue dispatches on this tick.
-        """
-        import digitize.workers.conversion_dispatcher as mod
-        mod._rr_turn = "digitization"
-
-        normal_dig = _make_task(task_id="t-dig-normal", operation="digitization", is_large=False)
-        large_ing  = _make_task(task_id="t-ing-large",  operation="ingestion",    is_large=True)
-
-        calls = []
-
-        def _mock_try_claim(op, avail):
-            calls.append((op, avail))
-            return None  # nothing should run
-
-        original_available = mod.conversion_semaphore._available
-        _set_semaphore_available(mod, 1)
-
-        try:
-            async def _run():
-                with patch.object(mod, "_try_claim_if_fits", side_effect=_mock_try_claim), \
-                     patch.object(mod.db_manager, "peek_head",
-                                   side_effect=lambda op: normal_dig if op == "digitization" else large_ing), \
-                     patch.object(mod.db_manager, "get_queued_counts",
-                                   return_value={"ingestion": 1, "digitization": 1}), \
-                     patch.object(mod.db_manager, "promote_pending", return_value=0), \
-                     patch("asyncio.create_task", new=_make_create_task_mock()), \
-                     patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
-                    mock_sleep.side_effect = asyncio.CancelledError()
-                    try:
-                        await mod.dispatch_loop()
-                    except asyncio.CancelledError:
-                        pass
-
-            asyncio.run(_run())
-        finally:
-            _set_semaphore_available(mod, original_available)
-
-        # second_needed=2 (large ING) → budget_for_first = max(0, 1-2) = 0
-        #   → DIG receives budget=0, _try_claim_if_fits("digitization", 0) → None, no dispatch
-        # first_needed=1  (normal DIG) → first_reservation=0 (only >1 triggers reservation)
-        #   → budget_for_second = max(0, available_after_first - 0) = max(0, 1-0) = 1
-        #   → ING receives budget=1, _try_claim_if_fits("ingestion", 1) → None
-        #     (large ING needs weight=2 > budget=1, so claim_head returns None inside the helper)
-        # Neither queue dispatches; the budget calculation is correct.
-        assert ("digitization", 0) in calls, (
-            "DIG normal must NOT be dispatched when large ING is waiting for 2 slots"
-        )
-        assert ("ingestion", 1) in calls, (
-            "ING receives budget=1 (no first_reservation for normal DIG head); "
-            "_try_claim_if_fits rejects it internally because weight=2 > budget=1"
-        )
+        # No claim should have been attempted
+        assert claims == []
 
     def test_promote_pending_called_each_tick(self):
         import digitize.workers.conversion_dispatcher as mod
-        mod._rr_turn = "ingestion"
+        mod._op_turn = 0
 
         promote_calls = []
 
         original_available = mod.conversion_semaphore._available
-        _set_semaphore_available(mod, 0)  # no capacity — skips claim logic
+        _set_semaphore_available(mod, 0)  # no capacity — _try_claim_if_fits returns None
 
         try:
             async def _run():
                 with patch.object(mod, "_try_claim_if_fits", return_value=None), \
-                     patch.object(mod.db_manager, "peek_head", return_value=None), \
-                     patch.object(mod.db_manager, "get_queued_counts",
-                                   return_value={"ingestion": 0, "digitization": 0}), \
                      patch.object(mod.db_manager, "promote_pending",
                                    side_effect=lambda op, q: promote_calls.append(op) or 0), \
                      patch("asyncio.create_task", new=_make_create_task_mock()), \
@@ -382,7 +380,7 @@ class TestDispatchLoop:
         The loop exits only on CancelledError.
         """
         import digitize.workers.conversion_dispatcher as mod
-        mod._rr_turn = "ingestion"
+        mod._op_turn = 0
 
         sleep_count = [0]
 

--- a/services/digitize/tests/test_conversion_dispatcher.py
+++ b/services/digitize/tests/test_conversion_dispatcher.py
@@ -77,16 +77,18 @@ class TestTryClaimIfFits:
         from digitize.workers import conversion_dispatcher as mod
 
         with patch.object(mod.db_manager, "peek_head", return_value=None):
-            result = mod._try_claim_if_fits("ingestion", available=4)
-        assert result is None
+            task, hol = mod._try_claim_if_fits("ingestion", available=4)
+        assert task is None
+        assert hol is False  # empty queue — not HOL-blocked
 
     def test_returns_none_when_head_too_large(self):
         from digitize.workers import conversion_dispatcher as mod
 
         head = _make_task(is_large=True)  # weight 2
         with patch.object(mod.db_manager, "peek_head", return_value=head):
-            result = mod._try_claim_if_fits("ingestion", available=1)  # only 1 free
-        assert result is None
+            task, hol = mod._try_claim_if_fits("ingestion", available=1)  # only 1 free
+        assert task is None
+        assert hol is True  # head exists but can't fit — HOL-blocked
 
     def test_claims_normal_task_when_capacity_available(self):
         from digitize.workers import conversion_dispatcher as mod
@@ -95,8 +97,9 @@ class TestTryClaimIfFits:
         claimed = _make_task(is_large=False)
         with patch.object(mod.db_manager, "peek_head", return_value=head), \
              patch.object(mod.db_manager, "claim_head", return_value=claimed):
-            result = mod._try_claim_if_fits("digitization", available=2)
-        assert result is claimed
+            task, hol = mod._try_claim_if_fits("digitization", available=2)
+        assert task is claimed
+        assert hol is False
 
     def test_claims_large_task_when_2_units_free(self):
         from digitize.workers import conversion_dispatcher as mod
@@ -105,18 +108,20 @@ class TestTryClaimIfFits:
         claimed = _make_task(is_large=True)
         with patch.object(mod.db_manager, "peek_head", return_value=head), \
              patch.object(mod.db_manager, "claim_head", return_value=claimed):
-            result = mod._try_claim_if_fits("ingestion", available=2)
-        assert result is claimed
+            task, hol = mod._try_claim_if_fits("ingestion", available=2)
+        assert task is claimed
+        assert hol is False
 
     def test_head_of_line_blocking_does_not_skip(self):
-        """Large head present → nothing behind it is skipped, returns None."""
+        """Large head present → nothing behind it is skipped, returns (None, True)."""
         from digitize.workers import conversion_dispatcher as mod
 
         head = _make_task(is_large=True)  # needs 2 units
         with patch.object(mod.db_manager, "peek_head", return_value=head), \
              patch.object(mod.db_manager, "claim_head") as mock_claim:
-            result = mod._try_claim_if_fits("ingestion", available=1)
-        assert result is None
+            task, hol = mod._try_claim_if_fits("ingestion", available=1)
+        assert task is None
+        assert hol is True
         mock_claim.assert_not_called()  # claim_head must never be called
 
     def test_zero_budget_returns_none(self):
@@ -124,8 +129,9 @@ class TestTryClaimIfFits:
 
         head = _make_task(is_large=False)  # weight 1
         with patch.object(mod.db_manager, "peek_head", return_value=head):
-            result = mod._try_claim_if_fits("ingestion", available=0)
-        assert result is None
+            task, hol = mod._try_claim_if_fits("ingestion", available=0)
+        assert task is None
+        assert hol is True  # head exists but zero budget — HOL-blocked
 
 
 # ---------------------------------------------------------------------------
@@ -162,8 +168,8 @@ def _make_create_task_mock():
 @pytest.mark.unit
 class TestDispatchLoop:
 
-    def test_turn_advances_unconditionally_when_task_claimed(self):
-        """_op_turn increments every tick regardless of whether a task was dispatched."""
+    def test_turn_advances_when_task_claimed(self):
+        """_op_turn increments when a task is successfully dispatched."""
         import digitize.workers.conversion_dispatcher as mod
         mod._op_turn = 0   # start at U-ING
 
@@ -174,7 +180,7 @@ class TestDispatchLoop:
 
         try:
             async def _run():
-                with patch.object(mod, "_try_claim_if_fits", return_value=task_t), \
+                with patch.object(mod, "_try_claim_if_fits", return_value=(task_t, False)), \
                      patch.object(mod.db_manager, "promote_pending", return_value=0), \
                      patch.object(mod, "_dispatch_one", new_callable=AsyncMock), \
                      patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
@@ -184,24 +190,24 @@ class TestDispatchLoop:
                     except asyncio.CancelledError:
                         pass
 
-                # One tick fired from turn=0 → must now be 1
+                # Task claimed on turn=0 → turn must advance to 1
                 assert mod._op_turn == 1
 
             asyncio.run(_run())
         finally:
             _set_semaphore_available(mod, original_available)
 
-    def test_turn_advances_unconditionally_when_blocked(self):
-        """_op_turn advances even when nothing was dispatched (HOL block)."""
+    def test_turn_advances_when_queue_empty(self):
+        """_op_turn advances when the queue is empty (not HOL-blocked)."""
         import digitize.workers.conversion_dispatcher as mod
         mod._op_turn = 0
 
         original_available = mod.conversion_semaphore._available
-        _set_semaphore_available(mod, 1)  # only 1 slot — large task will be blocked
+        _set_semaphore_available(mod, 4)
 
         try:
             async def _run():
-                with patch.object(mod, "_try_claim_if_fits", return_value=None), \
+                with patch.object(mod, "_try_claim_if_fits", return_value=(None, False)), \
                      patch.object(mod.db_manager, "promote_pending", return_value=0), \
                      patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
                     mock_sleep.side_effect = asyncio.CancelledError()
@@ -210,8 +216,34 @@ class TestDispatchLoop:
                     except asyncio.CancelledError:
                         pass
 
-                # Turn still advances even though nothing ran
+                # Empty queue on turn=0 → turn still advances to 1
                 assert mod._op_turn == 1
+
+            asyncio.run(_run())
+        finally:
+            _set_semaphore_available(mod, original_available)
+
+    def test_turn_held_when_hol_blocked(self):
+        """_op_turn does NOT advance when the lane is HOL-blocked."""
+        import digitize.workers.conversion_dispatcher as mod
+        mod._op_turn = 0
+
+        original_available = mod.conversion_semaphore._available
+        _set_semaphore_available(mod, 1)  # only 1 slot — large head can't fit
+
+        try:
+            async def _run():
+                with patch.object(mod, "_try_claim_if_fits", return_value=(None, True)), \
+                     patch.object(mod.db_manager, "promote_pending", return_value=0), \
+                     patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+                    mock_sleep.side_effect = asyncio.CancelledError()
+                    try:
+                        await mod.dispatch_loop()
+                    except asyncio.CancelledError:
+                        pass
+
+                # HOL-blocked on turn=0 → turn must stay at 0
+                assert mod._op_turn == 0
 
             asyncio.run(_run())
         finally:
@@ -226,7 +258,7 @@ class TestDispatchLoop:
 
         def _mock_claim(op, avail, connector_id=None):
             claims.append((op, connector_id))
-            return None
+            return None, False
 
         original_available = mod.conversion_semaphore._available
         _set_semaphore_available(mod, 4)
@@ -257,7 +289,7 @@ class TestDispatchLoop:
 
         def _mock_claim(op, avail, connector_id=None):
             claims.append((op, connector_id))
-            return None
+            return None, False
 
         original_available = mod.conversion_semaphore._available
         _set_semaphore_available(mod, 4)
@@ -289,7 +321,7 @@ class TestDispatchLoop:
 
         def _mock_claim(op, avail, connector_id=None):
             claims.append((op, connector_id))
-            return None
+            return None, False
 
         original_available = mod.conversion_semaphore._available
         _set_semaphore_available(mod, 4)
@@ -327,7 +359,7 @@ class TestDispatchLoop:
         try:
             async def _run():
                 with patch.object(mod, "_try_claim_if_fits",
-                                   side_effect=lambda op, avail, connector_id=None: claims.append((op, connector_id)) or None), \
+                                   side_effect=lambda op, avail, connector_id=None: claims.append((op, connector_id)) or (None, False)), \
                      patch.object(mod.db_manager, "get_connector_ids_with_queued_tasks",
                                    return_value=[]), \
                      patch.object(mod.db_manager, "promote_pending", return_value=0), \
@@ -356,7 +388,7 @@ class TestDispatchLoop:
 
         try:
             async def _run():
-                with patch.object(mod, "_try_claim_if_fits", return_value=None), \
+                with patch.object(mod, "_try_claim_if_fits", return_value=(None, False)), \
                      patch.object(mod.db_manager, "promote_pending",
                                    side_effect=lambda op, q: promote_calls.append(op) or 0), \
                      patch("asyncio.create_task", new=_make_create_task_mock()), \

--- a/services/digitize/tests/test_deduplication.py
+++ b/services/digitize/tests/test_deduplication.py
@@ -748,7 +748,10 @@ def jobs_test_client(monkeypatch, tmp_path, mock_db_operations):
     # Stub out pipeline background tasks.
     # Must be AsyncMock — asyncio.create_task() requires a coroutine.
     monkeypatch.setattr(jobs_router_module, "_run_digitize", AsyncMock())
-    monkeypatch.setattr(jobs_router_module, "_run_ingest", AsyncMock())
+    monkeypatch.setattr(digitize_app.dg_util, "launch_ingest_pipeline", AsyncMock())
+    monkeypatch.setattr(
+        digitize_app.dg_util, "initialize_and_launch", AsyncMock(return_value={"novel.pdf": "doc-1"})
+    )
 
     monkeypatch.setattr(digitize_app.dg_util, "generate_uuid", Mock(return_value="job-x"))
     monkeypatch.setattr(digitize_app.dg_util, "stage_upload_files", AsyncMock())
@@ -864,8 +867,8 @@ class TestDuplicateDetectionEndpoint:
             files=[self._pdf("old.pdf"), self._pdf("new.pdf")],
         )
 
-        init_call = cast(Mock, digitize_app.dg_util.initialize_job_state).call_args
-        already_exists_arg = init_call[1].get("already_exists_files", init_call[0][-1])
+        init_call = cast(AsyncMock, digitize_app.dg_util.initialize_and_launch).call_args
+        already_exists_arg = init_call.kwargs.get("already_exists_files", [])
         assert len(already_exists_arg) == 1
         assert already_exists_arg[0].filename == "old.pdf"
         assert already_exists_arg[0].existing_doc_id == "old-doc"
@@ -884,8 +887,8 @@ class TestDuplicateDetectionEndpoint:
             files=[self._pdf("new.pdf")],
         )
 
-        init_call = cast(Mock, digitize_app.dg_util.initialize_job_state).call_args
-        already_exists_arg = init_call[1].get("already_exists_files", [])
+        init_call = cast(AsyncMock, digitize_app.dg_util.initialize_and_launch).call_args
+        already_exists_arg = init_call.kwargs.get("already_exists_files", [])
         assert already_exists_arg == []
 
     def test_digitization_also_checks_ingestion_hash(self, jobs_test_client, monkeypatch):

--- a/services/digitize/tests/test_deduplication.py
+++ b/services/digitize/tests/test_deduplication.py
@@ -747,7 +747,6 @@ def jobs_test_client(monkeypatch, tmp_path, mock_db_operations):
 
     # Stub out pipeline background tasks.
     # Must be AsyncMock — asyncio.create_task() requires a coroutine.
-    monkeypatch.setattr(jobs_router_module, "_run_digitize", AsyncMock())
     monkeypatch.setattr(digitize_app.dg_util, "launch_ingest_pipeline", AsyncMock())
     monkeypatch.setattr(
         digitize_app.dg_util, "initialize_and_launch", AsyncMock(return_value={"novel.pdf": "doc-1"})

--- a/services/digitize/tests/test_digitize_app_endpoints.py
+++ b/services/digitize/tests/test_digitize_app_endpoints.py
@@ -60,7 +60,10 @@ def digitize_test_client(monkeypatch, tmp_path, mock_db_operations):
     # Stub out pipeline background tasks so TestClient doesn't execute them.
     # Must be AsyncMock — asyncio.create_task() requires a coroutine.
     monkeypatch.setattr(jobs_router, "_run_digitize", AsyncMock())
-    monkeypatch.setattr(jobs_router, "_run_ingest", AsyncMock())
+    monkeypatch.setattr(digitize_app.dg_util, "launch_ingest_pipeline", AsyncMock())
+    monkeypatch.setattr(
+        digitize_app.dg_util, "initialize_and_launch", AsyncMock(return_value={"sample.pdf": "doc-1"})
+    )
     monkeypatch.setattr(digitize_app.dg_util, "generate_uuid", Mock(return_value="job-123"))
     monkeypatch.setattr(digitize_app.dg_util, "stage_upload_files", AsyncMock())
     monkeypatch.setattr(digitize_app.dg_util, "initialize_job_state", Mock(return_value={"sample.pdf": "doc-1"}))
@@ -111,7 +114,7 @@ class TestRequestIdMiddleware:
 class TestCreateJobs:
     def test_successful_digitization_job_creation(self, digitize_test_client):
         stage_upload_files_mock = cast(AsyncMock, digitize_app.dg_util.stage_upload_files)
-        initialize_job_state_mock = cast(Mock, digitize_app.dg_util.initialize_job_state)
+        initialize_and_launch_mock = cast(AsyncMock, digitize_app.dg_util.initialize_and_launch)
 
         response = digitize_test_client.post(
             "/v1/jobs?operation=digitization&output_format=json",
@@ -122,14 +125,14 @@ class TestCreateJobs:
         assert response.json()["job_id"] == "job-123"
         assert "warnings" not in response.json()
         stage_upload_files_mock.assert_awaited_once()
-        initialize_job_state_mock.assert_called_once_with(
-            "job-123",
-            OperationType.DIGITIZATION,
-            OutputFormat.JSON,
-            ["sample.pdf"],
-            None,
-            already_exists_files=[],
-        )
+        initialize_and_launch_mock.assert_awaited_once()
+        call_kwargs = initialize_and_launch_mock.call_args.kwargs
+        assert call_kwargs["job_id"] == "job-123"
+        assert call_kwargs["operation"] == OperationType.DIGITIZATION
+        assert call_kwargs["output_format"] == OutputFormat.JSON
+        assert call_kwargs["filenames"] == ["sample.pdf"]
+        assert call_kwargs["job_name"] is None
+        assert call_kwargs["already_exists_files"] == []
 
     def test_successful_ingestion_job_creation(self, digitize_test_client):
         response = digitize_test_client.post(
@@ -172,7 +175,7 @@ class TestCreateJobs:
         assert response.status_code == 415
 
     def test_output_format_and_job_name_parameters(self, digitize_test_client):
-        initialize_job_state_mock = cast(Mock, digitize_app.dg_util.initialize_job_state)
+        initialize_and_launch_mock = cast(AsyncMock, digitize_app.dg_util.initialize_and_launch)
 
         response = digitize_test_client.post(
             "/v1/jobs?operation=digitization&output_format=md&job_name=My+Job",
@@ -180,23 +183,23 @@ class TestCreateJobs:
         )
 
         assert response.status_code == 202
-        initialize_job_state_mock.assert_called_with(
-            "job-123",
-            OperationType.DIGITIZATION,
-            OutputFormat.MD,
-            ["sample.pdf"],
-            "My Job",
-            already_exists_files=[],
-        )
+        initialize_and_launch_mock.assert_awaited()
+        call_kwargs = initialize_and_launch_mock.call_args.kwargs
+        assert call_kwargs["job_id"] == "job-123"
+        assert call_kwargs["operation"] == OperationType.DIGITIZATION
+        assert call_kwargs["output_format"] == OutputFormat.MD
+        assert call_kwargs["filenames"] == ["sample.pdf"]
+        assert call_kwargs["job_name"] == "My Job"
+        assert call_kwargs["already_exists_files"] == []
 
     def test_successful_digitization_job_creation_with_docx(self, digitize_test_client):
         """Test successful digitization job creation with DOCX file."""
         stage_upload_files_mock = cast(AsyncMock, digitize_app.dg_util.stage_upload_files)
-        initialize_job_state_mock = cast(Mock, digitize_app.dg_util.initialize_job_state)
+        initialize_and_launch_mock = cast(AsyncMock, digitize_app.dg_util.initialize_and_launch)
 
         # DOCX file signature: PK\x03\x04 (ZIP format)
         docx_header = b"PK\x03\x04\x14\x00\x06\x00"
-        
+
         response = digitize_test_client.post(
             "/v1/jobs?operation=digitization&output_format=json",
             files=[("files", ("document.docx", docx_header, "application/vnd.openxmlformats-officedocument.wordprocessingml.document"))],
@@ -206,14 +209,14 @@ class TestCreateJobs:
         assert response.json()["job_id"] == "job-123"
         assert "warnings" not in response.json()
         stage_upload_files_mock.assert_awaited_once()
-        initialize_job_state_mock.assert_called_once_with(
-            "job-123",
-            OperationType.DIGITIZATION,
-            OutputFormat.JSON,
-            ["document.docx"],
-            None,
-            already_exists_files=[],
-        )
+        initialize_and_launch_mock.assert_awaited_once()
+        call_kwargs = initialize_and_launch_mock.call_args.kwargs
+        assert call_kwargs["job_id"] == "job-123"
+        assert call_kwargs["operation"] == OperationType.DIGITIZATION
+        assert call_kwargs["output_format"] == OutputFormat.JSON
+        assert call_kwargs["filenames"] == ["document.docx"]
+        assert call_kwargs["job_name"] is None
+        assert call_kwargs["already_exists_files"] == []
 
     def test_successful_ingestion_job_creation_with_docx(self, digitize_test_client):
         """Test successful ingestion job creation with DOCX file."""

--- a/services/digitize/tests/test_digitize_app_endpoints.py
+++ b/services/digitize/tests/test_digitize_app_endpoints.py
@@ -59,7 +59,6 @@ def digitize_test_client(monkeypatch, tmp_path, mock_db_operations):
 
     # Stub out pipeline background tasks so TestClient doesn't execute them.
     # Must be AsyncMock — asyncio.create_task() requires a coroutine.
-    monkeypatch.setattr(jobs_router, "_run_digitize", AsyncMock())
     monkeypatch.setattr(digitize_app.dg_util, "launch_ingest_pipeline", AsyncMock())
     monkeypatch.setattr(
         digitize_app.dg_util, "initialize_and_launch", AsyncMock(return_value={"sample.pdf": "doc-1"})

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -688,7 +688,10 @@ class TestRunTickCancellation:
         with patch(f"{DB_MODULE}.get_connector_by_id", return_value=connector), \
              patch("digitize.connectors.sync_tick.build_scanner", return_value=mock_scanner), \
              patch(f"{DB_MODULE}.get_connector_sync_status", return_value=ConnectorStatus.DELETE_PENDING), \
-             patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close:
+             patch(f"{DB_MODULE}.finalize_sync_log_and_update_connector") as mock_close, \
+             patch("digitize.db.manager.db_manager") as mock_db_mgr, \
+             patch("digitize.api.v1.connectors._run_teardown", new_callable=AsyncMock):
+            mock_db_mgr.delete_conversion_tasks_for_connector.return_value = 0
             with pytest.raises(asyncio.CancelledError):
                 asyncio.run(run_tick("conn-1", sync_seq=10))
 
@@ -817,8 +820,10 @@ class TestHandleInterrupt:
 
     def test_delete_connector_calls_cancel_tick_and_teardown(self):
         with patch(f"{DB_MODULE}._cancel_tick") as mock_cancel, \
+             patch("digitize.db.manager.db_manager") as mock_db_mgr, \
              patch("digitize.api.v1.connectors._run_teardown",
                    new_callable=AsyncMock) as mock_teardown:
+            mock_db_mgr.delete_conversion_tasks_for_connector.return_value = 0
             asyncio.run(_handle_interrupt(sync_seq=3, connector_id="conn-B",
                                           interrupt_type=InterruptType.DELETE_CONNECTOR))
         mock_cancel.assert_called_once_with(3, "conn-B")
@@ -827,8 +832,10 @@ class TestHandleInterrupt:
     def test_delete_connector_does_not_call_sweep(self):
         """DELETE_CONNECTOR must not call _sweep_staging_dir."""
         with patch(f"{DB_MODULE}._cancel_tick"), \
+             patch("digitize.db.manager.db_manager") as mock_db_mgr, \
              patch("digitize.api.v1.connectors._run_teardown", new_callable=AsyncMock), \
              patch("digitize.api.v1.connectors._sweep_staging_dir") as mock_sweep:
+            mock_db_mgr.delete_conversion_tasks_for_connector.return_value = 0
             asyncio.run(_handle_interrupt(sync_seq=3, connector_id="conn-B",
                                           interrupt_type=InterruptType.DELETE_CONNECTOR))
         mock_sweep.assert_not_called()

--- a/services/digitize/tests/test_sync_tick.py
+++ b/services/digitize/tests/test_sync_tick.py
@@ -221,12 +221,10 @@ class TestProcessNewFiles:
 
         stack.enter_context(patch(f"{DB_MODULE}.add_connector_checksum_entry"))
         stack.enter_context(
-            patch(f"{DB_MODULE}.initialize_job_state", return_value={"report.pdf": "doc-1"})
+            patch(f"{DB_MODULE}.initialize_and_launch", new_callable=AsyncMock,
+                  return_value={"report.pdf": "doc-1"})
         )
         stack.enter_context(patch(f"{DB_MODULE}.generate_uuid", return_value="job-uuid-1"))
-        stack.enter_context(
-            patch(f"{DB_MODULE}.ingest", side_effect=ingest_raises)
-        )
         # _wait_for_job polls with asyncio.sleep(_JOB_POLL_INTERVAL=10s) until the
         # job reaches a terminal state.  With get_job mocked to return None the
         # status never becomes terminal → infinite sleep → test hangs.
@@ -282,10 +280,10 @@ class TestProcessNewFiles:
             mock_settings.digitize.staging_dir.__truediv__ = MagicMock(return_value=MagicMock())
             stack.enter_context(patch(f"{DB_MODULE}.add_connector_checksum_entry"))
             stack.enter_context(
-                patch(f"{DB_MODULE}.initialize_job_state", return_value={"b.pdf": "doc-2"})
+                patch(f"{DB_MODULE}.initialize_and_launch", new_callable=AsyncMock,
+                      return_value={"b.pdf": "doc-2"})
             )
             stack.enter_context(patch(f"{DB_MODULE}.generate_uuid", return_value="job-uuid"))
-            stack.enter_context(patch(f"{DB_MODULE}.ingest"))
             stack.enter_context(patch(f"{DB_MODULE}._wait_for_job", new_callable=AsyncMock))
             stack.enter_context(
                 patch(
@@ -370,10 +368,10 @@ class TestProcessNewFiles:
             mock_settings = stack.enter_context(patch(f"{DB_MODULE}.settings"))
             mock_settings.digitize.staging_dir.__truediv__ = MagicMock(return_value=MagicMock())
             stack.enter_context(
-                patch(f"{DB_MODULE}.initialize_job_state", return_value={"a.pdf": "doc-1", "b.pdf": "doc-2"})
+                patch(f"{DB_MODULE}.initialize_and_launch", new_callable=AsyncMock,
+                      return_value={"a.pdf": "doc-1", "b.pdf": "doc-2"})
             )
             stack.enter_context(patch(f"{DB_MODULE}.generate_uuid", return_value="job-uuid"))
-            stack.enter_context(patch(f"{DB_MODULE}.ingest"))
             stack.enter_context(patch(f"{DB_MODULE}._wait_for_job", new_callable=AsyncMock))
             stack.enter_context(
                 patch(f"{DB_MODULE}.get_job_document_stats", return_value=partial_stats)
@@ -1008,10 +1006,10 @@ class TestProcessNewFilesExtra:
         mock_settings.digitize.staging_dir.__truediv__ = MagicMock(return_value=MagicMock())
         stack.enter_context(patch(f"{DB_MODULE}.add_connector_checksum_entry"))
         stack.enter_context(
-            patch(f"{DB_MODULE}.initialize_job_state", return_value={"report.pdf": "doc-1"})
+            patch(f"{DB_MODULE}.initialize_and_launch", new_callable=AsyncMock,
+                  return_value={"report.pdf": "doc-1"})
         )
         stack.enter_context(patch(f"{DB_MODULE}.generate_uuid", return_value="job-uuid-1"))
-        stack.enter_context(patch(f"{DB_MODULE}.ingest"))
         stack.enter_context(patch(f"{DB_MODULE}._wait_for_job", new_callable=AsyncMock))
         stack.enter_context(
             patch(f"{DB_MODULE}.get_job_document_stats", return_value=self._completed_stats())
@@ -1077,10 +1075,10 @@ class TestProcessNewFilesExtra:
             mock_settings.digitize.staging_dir.__truediv__ = MagicMock(return_value=MagicMock())
             stack.enter_context(patch(f"{DB_MODULE}.add_connector_checksum_entry"))
             stack.enter_context(
-                patch(f"{DB_MODULE}.initialize_job_state", return_value={"file.pdf": "doc-1"})
+                patch(f"{DB_MODULE}.initialize_and_launch", new_callable=AsyncMock,
+                      return_value={"file.pdf": "doc-1"})
             )
             stack.enter_context(patch(f"{DB_MODULE}.generate_uuid", return_value="job-uuid-1"))
-            stack.enter_context(patch(f"{DB_MODULE}.ingest"))
             stack.enter_context(patch(f"{DB_MODULE}._wait_for_job", new_callable=AsyncMock))
             stack.enter_context(
                 patch(f"{DB_MODULE}.get_job_document_stats", return_value=self._completed_stats("file.pdf", "doc-1"))
@@ -1122,9 +1120,8 @@ class TestProcessNewFilesExtra:
 
         with self._base_patches():
             with patch.object(_st_mod, "_BATCH_SIZE", 1), \
-                 patch(f"{DB_MODULE}.initialize_job_state", side_effect=[
-                     {"a.pdf": "doc-1"}, {"b.pdf": "doc-2"}
-                 ]), \
+                 patch(f"{DB_MODULE}.initialize_and_launch", new_callable=AsyncMock,
+                       side_effect=[{"a.pdf": "doc-1"}, {"b.pdf": "doc-2"}]), \
                  patch(f"{DB_MODULE}.get_job_document_stats", side_effect=[
                      self._completed_stats("a.pdf", "doc-1"),
                      self._completed_stats("b.pdf", "doc-2"),
@@ -1140,13 +1137,11 @@ class TestProcessNewFilesExtra:
 
         with self._base_patches():
             with patch(f"{DB_MODULE}.validate_document_file", side_effect=ValueError("bad")), \
-                 patch(f"{DB_MODULE}.initialize_job_state") as mock_init, \
-                 patch(f"{DB_MODULE}.ingest") as mock_ingest:
+                 patch(f"{DB_MODULE}.initialize_and_launch", new_callable=AsyncMock) as mock_init:
                 asyncio.run(_process_new_files(1, "conn-1", "name", scanner,
                                                [("remote/fake.pdf", "ck1")]))
 
         mock_init.assert_not_called()
-        mock_ingest.assert_not_called()
 
     def test_all_files_invalid_does_not_set_batch_failed(self):
         """A batch where all files are skipped due to invalid format must not raise RuntimeError."""
@@ -1186,16 +1181,16 @@ class TestProcessNewFilesExtra:
 
         with self._base_patches():
             with patch(f"{DB_MODULE}.validate_document_file", side_effect=_validate), \
-                 patch(f"{DB_MODULE}.initialize_job_state",
+                 patch(f"{DB_MODULE}.initialize_and_launch", new_callable=AsyncMock,
                        return_value={"works.pdf": "doc-1"}) as mock_init:
                 result = asyncio.run(_process_new_files(1, "conn-1", "name", scanner,
                                                         [("works.pdf", "ck1"), ("fake.pdf", "ck2")]))
 
-        # initialize_job_state must only see the valid file
+        # initialize_and_launch must only see the valid file
         mock_init.assert_called_once()
         call_args = mock_init.call_args
         assert call_args is not None
-        assert call_args.kwargs["documents_info"] == ["works.pdf"]
+        assert call_args.kwargs["filenames"] == ["works.pdf"]
         # invalid file's remote path must be in the returned list
         assert result == ["fake.pdf"]
 

--- a/services/digitize/utils/jobs.py
+++ b/services/digitize/utils/jobs.py
@@ -6,6 +6,7 @@ retrieval, and bulk deletion helpers.
 """
 import asyncio
 import uuid
+from pathlib import Path
 from typing import Optional
 
 from common.misc_utils import get_logger
@@ -273,6 +274,63 @@ async def enqueue_conversion_tasks(
         )
 
     db_manager.create_conversion_tasks_batch(tasks)
+
+
+async def launch_ingest_pipeline(
+    job_id: str,
+    doc_id_dict: dict,
+    file_checksum_dict: Optional[dict] = None,
+    staging_dir: Optional[Path] = None,
+) -> None:
+    """
+    Fire-and-forget coroutine that drives the ingestion pipeline for *job_id*.
+
+    Runs the blocking ``ingest()`` call in a thread so the asyncio event loop
+    stays free.  Cleans up the staging directory when done regardless of outcome.
+
+    This is the single shared implementation used by both:
+    - ``api/v1/jobs.py`` — for user-submitted ingestion jobs, and
+    - ``connectors/sync_tick.py`` — for connector-sourced ingestion batches.
+
+    Parameters
+    ----------
+    job_id:
+        The job whose conversion_tasks rows the pipeline should poll and
+        process.
+    doc_id_dict:
+        Mapping of ``filename → doc_id`` as returned by
+        ``initialize_job_state()``.
+    file_checksum_dict:
+        Optional ``filename → md5-hex`` map used for deduplication.  Pass
+        the connector's ``filename_to_checksum`` dict here when calling from
+        ``sync_tick.py``.
+    staging_dir:
+        The staging directory to clean up after the pipeline finishes.
+        Defaults to ``settings.digitize.staging_dir / job_id`` (the path
+        used for user jobs).  Pass ``batch_dir`` when calling from
+        ``sync_tick.py`` (connector batches live under a different subtree).
+    """
+    from digitize.models import DocStatus, JobStatus
+    from digitize.utils.db import get_status_manager
+
+    resolved: Path = staging_dir if staging_dir is not None else settings.digitize.staging_dir / job_id
+
+    try:
+        logger.info(f"🚀 Ingestion pipeline started for job: {job_id}")
+        from digitize.pipeline.ingest import ingest
+        await asyncio.to_thread(ingest, resolved, job_id, doc_id_dict, file_checksum_dict)
+        logger.info(f"Ingestion pipeline for job {job_id} completed successfully")
+    except Exception as exc:
+        logger.error(f"Error in ingestion pipeline for job {job_id}: {exc}", exc_info=True)
+        status_mgr = get_status_manager(job_id)
+        status_mgr.update_job_progress(
+            "",
+            DocStatus.FAILED,
+            JobStatus.FAILED,
+            error=f"Error occurred while processing ingestion pipeline: {exc}",
+        )
+    finally:
+        cleanup_staging_directory(resolved.name, resolved.parent)
 
 
 async def stage_upload_files(

--- a/services/digitize/utils/jobs.py
+++ b/services/digitize/utils/jobs.py
@@ -204,6 +204,7 @@ async def enqueue_conversion_tasks(
     output_format: OutputFormat,
     quota: int,
     queued_for_op: int,
+    connector_id: Optional[str] = None,
 ) -> None:
     """
     Insert conversion_tasks rows for every file in the job in a single
@@ -217,8 +218,13 @@ async def enqueue_conversion_tasks(
     The batch insert is atomic: if any row fails the entire set is rolled
     back, leaving no partial state for the caller to reason about.
 
-    Slots up to the free quota are inserted as ``queued``; the rest as
-    ``pending`` (the dispatcher will promote them as capacity frees up).
+    For user jobs (connector_id=None): slots up to the free quota are
+    inserted as ``queued``; the rest as ``pending`` (promoted by the
+    dispatcher as capacity frees up).
+
+    For connector jobs (connector_id set): all tasks are inserted directly
+    as ``queued`` — connector tasks have no pending phase. The _BATCH_SIZE
+    cap in sync_tick controls how many tasks are enqueued per batch.
 
     Args:
         job_id:        Job identifier.
@@ -227,8 +233,9 @@ async def enqueue_conversion_tasks(
         doc_id_dict:   Mapping of filename → document ID.
         staging_dir:   Path to the job's staging directory.
         output_format: Requested output format.
-        quota:         Per-operation queue quota from settings.
-        queued_for_op: Number of tasks already queued for this operation.
+        quota:         Per-operation queue quota from settings (user jobs only).
+        queued_for_op: Number of tasks already queued for this operation (user jobs only).
+        connector_id:  Owning connector UUID; None for user-submitted jobs.
     """
     from digitize.db.manager import db_manager
 
@@ -241,11 +248,18 @@ async def enqueue_conversion_tasks(
         file_path = staging_dir / filename
         page_count = await asyncio.to_thread(get_document_page_count, str(file_path))
         is_large = page_count >= settings.digitize.heavy_doc_page_threshold
-        task_status = ConversionTaskStatus.QUEUED if idx < slots_free else ConversionTaskStatus.PENDING
+        # Connector tasks are always queued directly — no pending phase.
+        # User tasks respect the quota: slots_free queued, remainder pending.
+        task_status = (
+            ConversionTaskStatus.QUEUED
+            if (connector_id is not None or idx < slots_free)
+            else ConversionTaskStatus.PENDING
+        )
         tasks.append({
             "task_id":       task_id,
             "job_id":        job_id,
             "doc_id":        doc_id,
+            "connector_id":  connector_id,
             "operation":     op_key,
             "cached_file":   str(file_path),
             "output_format": output_format.value,
@@ -255,7 +269,7 @@ async def enqueue_conversion_tasks(
         })
         logger.debug(
             f"Prepared task {task_id} for {filename} "
-            f"(op={op_key}, status={task_status}, large={is_large})"
+            f"(op={op_key}, status={task_status}, large={is_large}, connector={connector_id})"
         )
 
     db_manager.create_conversion_tasks_batch(tasks)

--- a/services/digitize/utils/jobs.py
+++ b/services/digitize/utils/jobs.py
@@ -276,6 +276,121 @@ async def enqueue_conversion_tasks(
     db_manager.create_conversion_tasks_batch(tasks)
 
 
+async def initialize_and_launch(
+    job_id: str,
+    operation,                          # models.OperationType or str
+    output_format: OutputFormat,
+    filenames: list[str],
+    staging_dir: Path,
+    quota: int,
+    queued_for_op: int,
+    job_name: Optional[str] = None,
+    source: "JobSource" = None,
+    already_exists_files: Optional[list] = None,
+    file_checksum_dict: Optional[dict] = None,
+    connector_id: Optional[str] = None,
+) -> dict[str, str]:
+    """
+    Steps 7–9 of the job-creation flow, shared by the user API and the
+    connector sync path.
+
+      7. ``initialize_job_state``       — create jobs + documents DB rows.
+      8. ``enqueue_conversion_tasks``   — insert conversion_tasks rows.
+      9. ``launch_ingest_pipeline``     — fire-and-forget ingestion task.
+         (Digitization jobs skip step 9 here; the caller creates
+         ``_run_digitize`` after this function returns.)
+
+    If step 7 or 8 raises, staged files under *staging_dir* are cleaned up
+    immediately and the exception is re-raised.
+
+    Parameters
+    ----------
+    job_id:
+        Pre-generated job UUID.
+    operation:
+        ``OperationType.INGESTION`` / ``OperationType.DIGITIZATION`` or the
+        equivalent string value.
+    output_format:
+        Requested output format.
+    filenames:
+        Novel filenames to process (already-exists files excluded).
+    staging_dir:
+        Directory holding the staged files. Cleaned up here on error;
+        cleaned up by the pipeline on success.
+    quota:
+        Per-operation queue quota. Pass ``0`` for connector jobs.
+    queued_for_op:
+        Tasks already queued at submission time. Pass ``0`` for connector jobs.
+    job_name:
+        Optional human-readable job name.
+    source:
+        ``JobSource.USER`` (default) or ``JobSource.CONNECTOR``.
+    already_exists_files:
+        Files stripped by hash-dedup (user jobs only).
+    file_checksum_dict:
+        ``filename → md5-hex`` for novel files (user jobs only). Connector
+        jobs omit this — checksums are registered via
+        ``add_connector_checksum_entry`` after the job completes.
+    connector_id:
+        Owning connector UUID; ``None`` for user-submitted jobs.
+
+    Returns
+    -------
+    dict[str, str]
+        The ``filename → doc_id`` mapping produced by ``initialize_job_state``.
+    """
+    from digitize.db.models import JobSource as _JobSource
+    from digitize.models import OperationType
+
+    op_key = operation.value if hasattr(operation, "value") else operation
+    resolved_source = source if source is not None else _JobSource.USER
+
+    try:
+        doc_id_dict = initialize_job_state(
+            job_id=job_id,
+            operation=operation,
+            output_format=output_format,
+            documents_info=filenames,
+            job_name=job_name,
+            source=resolved_source,
+            already_exists_files=already_exists_files,
+        )
+
+        await enqueue_conversion_tasks(
+            job_id=job_id,
+            op_key=op_key,
+            filenames=filenames,
+            doc_id_dict=doc_id_dict,
+            staging_dir=staging_dir,
+            output_format=output_format,
+            quota=quota,
+            queued_for_op=queued_for_op,
+            connector_id=connector_id,
+        )
+    except Exception:
+        logger.error(
+            f"Job {job_id}: DB initialisation or enqueue failed — "
+            f"removing {len(filenames)} staged file(s)",
+        )
+        cleanup_staging_directory(staging_dir.name, staging_dir.parent)
+        raise
+
+    # Step 9: fire-and-forget ingestion pipeline.
+    # Digitization jobs use _run_digitize (owned by the caller); only ingestion
+    # uses launch_ingest_pipeline.
+    if op_key == OperationType.INGESTION.value:
+        asyncio.create_task(
+            launch_ingest_pipeline(
+                job_id=job_id,
+                doc_id_dict=doc_id_dict,
+                file_checksum_dict=file_checksum_dict,
+                staging_dir=staging_dir,
+            )
+        )
+
+    return doc_id_dict
+
+
 async def launch_ingest_pipeline(
     job_id: str,
     doc_id_dict: dict,
@@ -301,9 +416,11 @@ async def launch_ingest_pipeline(
         Mapping of ``filename → doc_id`` as returned by
         ``initialize_job_state()``.
     file_checksum_dict:
-        Optional ``filename → md5-hex`` map used for deduplication.  Pass
-        the connector's ``filename_to_checksum`` dict here when calling from
-        ``sync_tick.py``.
+        Optional ``filename → md5-hex`` map used to store ``file_hash`` on
+        each document upon completion.  Only meaningful for user-submitted
+        jobs — used by ``find_completed_document_by_hash`` for dedup on
+        subsequent uploads.  Connector jobs omit this; connectors manage
+        their own dedup via ``add_connector_checksum_entry``.
     staging_dir:
         The staging directory to clean up after the pipeline finishes.
         Defaults to ``settings.digitize.staging_dir / job_id`` (the path

--- a/services/digitize/utils/jobs.py
+++ b/services/digitize/utils/jobs.py
@@ -285,7 +285,7 @@ async def initialize_and_launch(
     quota: int,
     queued_for_op: int,
     job_name: Optional[str] = None,
-    source: "JobSource" = None,
+    source: Optional[JobSource] = None,
     already_exists_files: Optional[list] = None,
     file_checksum_dict: Optional[dict] = None,
     connector_id: Optional[str] = None,
@@ -297,8 +297,7 @@ async def initialize_and_launch(
       7. ``initialize_job_state``       — create jobs + documents DB rows.
       8. ``enqueue_conversion_tasks``   — insert conversion_tasks rows.
       9. ``launch_ingest_pipeline``     — fire-and-forget ingestion task.
-         (Digitization jobs skip step 9 here; the caller creates
-         ``_run_digitize`` after this function returns.)
+         ``launch_digitize_pipeline``   — fire-and-forget digitization task.
 
     If step 7 or 8 raises, staged files under *staging_dir* are cleaned up
     immediately and the exception is re-raised.
@@ -375,9 +374,7 @@ async def initialize_and_launch(
         cleanup_staging_directory(staging_dir.name, staging_dir.parent)
         raise
 
-    # Step 9: fire-and-forget ingestion pipeline.
-    # Digitization jobs use _run_digitize (owned by the caller); only ingestion
-    # uses launch_ingest_pipeline.
+    # Step 9: fire-and-forget pipeline task.
     if op_key == OperationType.INGESTION.value:
         asyncio.create_task(
             launch_ingest_pipeline(
@@ -387,8 +384,41 @@ async def initialize_and_launch(
                 staging_dir=staging_dir,
             )
         )
+    elif op_key == OperationType.DIGITIZATION.value:
+        asyncio.create_task(launch_digitize_pipeline(job_id, doc_id_dict))
 
     return doc_id_dict
+
+
+async def launch_digitize_pipeline(
+    job_id: str,
+    doc_id_dict: dict,
+) -> None:
+    """
+    Fire-and-forget coroutine that drives the digitization pipeline for *job_id*.
+
+    Runs the blocking ``digitize()`` call in a thread so the asyncio event loop
+    stays free.  Cleans up the staging directory when done regardless of outcome.
+    """
+    from digitize.models import DocStatus, JobStatus
+    from digitize.utils.db import get_status_manager
+
+    try:
+        logger.info(f"🚀 Digitization pipeline started for job: {job_id}")
+        from digitize.pipeline.digitize import digitize
+        await asyncio.to_thread(digitize, job_id, doc_id_dict)
+        logger.info(f"Digitization pipeline for job {job_id} completed successfully")
+    except Exception as exc:
+        logger.error(f"Error in digitization pipeline for job {job_id}: {exc}", exc_info=True)
+        status_mgr = get_status_manager(job_id)
+        status_mgr.update_job_progress(
+            "",
+            DocStatus.FAILED,
+            JobStatus.FAILED,
+            error=f"Error occurred while processing digitization pipeline: {exc}",
+        )
+    finally:
+        cleanup_staging_directory(job_id, settings.digitize.staging_dir)
 
 
 async def launch_ingest_pipeline(

--- a/services/digitize/workers/conversion_dispatcher.py
+++ b/services/digitize/workers/conversion_dispatcher.py
@@ -7,8 +7,7 @@ seconds and dispatches at most one task per tick.
 
 Scheduling
 ----------
-Three logical lanes are served in a fixed cycle — turn advances
-unconditionally every tick regardless of whether a task was dispatched:
+Three logical lanes are served in a fixed cycle:
 
   Turn 0 — U-ING : user ingestion
   Turn 1 — U-DIG : user digitization
@@ -17,11 +16,18 @@ unconditionally every tick regardless of whether a task was dispatched:
 This gives user lanes 2 out of every 3 dispatch opportunities and
 connector lanes 1 out of 3, with no lane ever starving.
 
-Head-of-line blocking
-----------------------
-If the oldest queued task for a lane needs more semaphore capacity than
-is currently available the dispatcher skips that lane's dispatch this
-tick.  Nothing behind the head is attempted; the turn still advances.
+Turn advancement
+----------------
+The turn advances when a task was claimed OR the queue was empty.
+It holds only when the head task exists but its weight exceeds available slots (HOL).
+
+- Task claimed (dispatched)           → advance
+- Queue empty for the lane            → advance (nothing to wait for; move on)
+- HOL-blocked (head weight > avail)   → hold — retry same lane next tick
+
+"Advance on empty" is critical: if a lane has nothing queued, holding its
+turn would starve the other lanes indefinitely.  HOL-hold is intentionally
+narrower — only fires when a real task is blocked on semaphore capacity.
 """
 
 import asyncio
@@ -38,7 +44,8 @@ from digitize.workers.conversion_semaphore import conversion_semaphore
 
 logger = get_logger("conversion_dispatcher")
 
-# 3-turn round-robin state — both integers advance unconditionally every tick.
+# 3-turn round-robin state.
+# _op_turn advances only when the current lane is not HOL-blocked.
 _op_turn: int = 0             # 0 = U-ING  1 = U-DIG  2 = C-ING
 _connector_rr_index: int = 0  # index into the live connector list for turn 2
 
@@ -52,21 +59,28 @@ def _try_claim_if_fits(
     operation: str,
     available: int,
     connector_id: str | None = None,
-) -> ConversionTask | None:
+) -> tuple[ConversionTask | None, bool]:
     """
     Peek at the head of the queue for ``operation`` (scoped to
     ``connector_id`` when given).  If the head task fits within
     ``available`` semaphore units, atomically claim and return it.
-    Returns None on HOL-block or empty queue.
+
+    Returns
+    -------
+    (task, hol_blocked)
+        task        — the claimed ConversionTask, or None if not dispatched.
+        hol_blocked — True when a head task exists but its weight exceeds
+                      ``available``.  False when the queue is empty or the
+                      task was claimed successfully.
     """
     head = db_manager.peek_head(operation, connector_id=connector_id)
     if head is None:
-        return None
+        return None, False  # empty queue — not HOL-blocked
 
     if (2 if head.is_large else 1) > available:
-        return None  # head can't run yet — hold the line
+        return None, True   # head can't run yet — HOL-blocked
 
-    return db_manager.claim_head(operation, connector_id=connector_id)
+    return db_manager.claim_head(operation, connector_id=connector_id), False
 
 async def _run_conversion(task: ConversionTask, weight: int) -> None:
     """
@@ -156,13 +170,15 @@ async def dispatch_loop() -> None:
             try:
                 available = conversion_semaphore.available
 
+                hol_blocked = False
+
                 if _op_turn == 0:                        # ── Turn 0: User Ingestion ──
-                    task = _try_claim_if_fits("ingestion", available)
+                    task, hol_blocked = _try_claim_if_fits("ingestion", available)
                     if task:
                         await _dispatch_one(task)
 
                 elif _op_turn == 1:                      # ── Turn 1: User Digitization ──
-                    task = _try_claim_if_fits("digitization", available)
+                    task, hol_blocked = _try_claim_if_fits("digitization", available)
                     if task:
                         await _dispatch_one(task)
 
@@ -170,12 +186,13 @@ async def dispatch_loop() -> None:
                     cids = db_manager.get_connector_ids_with_queued_tasks()
                     if cids:
                         cid = cids[_connector_rr_index % len(cids)]
-                        task = _try_claim_if_fits("ingestion", available, connector_id=cid)
+                        task, hol_blocked = _try_claim_if_fits("ingestion", available, connector_id=cid)
                         if task:
                             await _dispatch_one(task)
-                        _connector_rr_index = (_connector_rr_index + 1) % len(cids)
+                            _connector_rr_index = (_connector_rr_index + 1) % len(cids)
 
-                _op_turn = (_op_turn + 1) % 3            # ALWAYS advance — unconditional
+                if not hol_blocked:
+                    _op_turn = (_op_turn + 1) % 3        # advance only when not HOL-blocked
 
                 # Promote pending → queued for user lanes only.
                 # Connector tasks are always inserted as 'queued' — no promote needed.

--- a/services/digitize/workers/conversion_dispatcher.py
+++ b/services/digitize/workers/conversion_dispatcher.py
@@ -1,40 +1,27 @@
 """
-Conversion dispatcher — round-robin Docling conversion queue.
+Conversion dispatcher — 3-turn fair round-robin Docling conversion queue.
 
 A single long-running asyncio task (started in app.py lifespan) that
 polls the ``conversion_tasks`` table every ``conversion_poll_interval``
-seconds and drives at most one task per operation type per tick.
+seconds and dispatches at most one task per tick.
 
-Round-robin pick strategy
---------------------------
-On each poll tick the dispatcher alternates between operation types —
-it claims one ingestion task and one digitization task per iteration
-(subject to semaphore capacity), then loops.  This prevents a large
-ingestion batch from starving waiting digitization tasks.
+Scheduling
+----------
+Three logical lanes are served in a fixed cycle — turn advances
+unconditionally every tick regardless of whether a task was dispatched:
+
+  Turn 0 — U-ING : user ingestion
+  Turn 1 — U-DIG : user digitization
+  Turn 2 — C-ING : connector ingestion (round-robin across connectors)
+
+This gives user lanes 2 out of every 3 dispatch opportunities and
+connector lanes 1 out of 3, with no lane ever starving.
 
 Head-of-line blocking
 ----------------------
-If the oldest queued task for an operation needs more capacity (weight)
-than is currently available, the dispatcher skips that operation *and*
-reserves those units — it does NOT hand them to the other operation.
-This prevents indefinite starvation of large files.
-
-The reservation only applies when the other queue's head is itself a
-large task (needed > 1).  A normal task (needed=1) can always fit into
-whatever slots remain, so no pre-reservation is needed for it.
-
-  second_reservation = second_needed if second_needed > 1 else 0
-  budget_for_first   = available - second_reservation
-
-  first_reservation  = first_needed if first_needed > 1 else 0
-  budget_for_second  = available_after_first - first_reservation
-
-Example: first=ING-large(2), second=DIG-normal(1), available=2
-  Old (wrong): budget_for_first = max(0, 2-1) = 1  large ING blocked despite having room
-  New (fixed): budget_for_first = max(0, 2-0) = 2  large ING dispatched correctly
-
-Example: first=ING-normal(1), second=DIG-large(2), available=2
-  budget_for_first = max(0, 2-2) = 0  ING normal held back, both slots preserved for DIG large
+If the oldest queued task for a lane needs more semaphore capacity than
+is currently available the dispatcher skips that lane's dispatch this
+tick.  Nothing behind the head is attempted; the turn still advances.
 """
 
 import asyncio
@@ -51,8 +38,9 @@ from digitize.workers.conversion_semaphore import conversion_semaphore
 
 logger = get_logger("conversion_dispatcher")
 
-# Round-robin state — alternates each tick when a task was successfully claimed.
-_rr_turn: str = "ingestion"
+# 3-turn round-robin state — both integers advance unconditionally every tick.
+_op_turn: int = 0             # 0 = U-ING  1 = U-DIG  2 = C-ING
+_connector_rr_index: int = 0  # index into the live connector list for turn 2
 
 # Process pool — created lazily inside dispatch_loop() so worker processes are
 # not spawned on module import (which would affect test collection, CLI tools,
@@ -60,26 +48,25 @@ _rr_turn: str = "ingestion"
 _process_pool: ProcessPoolExecutor | None = None
 
 
-def _other(op: str) -> str:
-    return "digitization" if op == "ingestion" else "ingestion"
-
-
-def _try_claim_if_fits(operation: str, available: int) -> ConversionTask | None:
+def _try_claim_if_fits(
+    operation: str,
+    available: int,
+    connector_id: str | None = None,
+) -> ConversionTask | None:
     """
-    Peek at the head of ``operation``'s queue.  If it fits within
+    Peek at the head of the queue for ``operation`` (scoped to
+    ``connector_id`` when given).  If the head task fits within
     ``available`` semaphore units, atomically claim and return it.
-    Otherwise return None (head-of-line blocking — nothing behind it
-    is attempted).
+    Returns None on HOL-block or empty queue.
     """
-    head = db_manager.peek_head(operation)
+    head = db_manager.peek_head(operation, connector_id=connector_id)
     if head is None:
-        return None  # nothing queued for this type
+        return None
 
-    needed = 2 if head.is_large else 1
-    if needed > available:
+    if (2 if head.is_large else 1) > available:
         return None  # head can't run yet — hold the line
 
-    return db_manager.claim_head(operation)
+    return db_manager.claim_head(operation, connector_id=connector_id)
 
 async def _run_conversion(task: ConversionTask, weight: int) -> None:
     """
@@ -135,6 +122,18 @@ async def _run_conversion(task: ConversionTask, weight: int) -> None:
         await conversion_semaphore.release(weight)
 
 
+async def _dispatch_one(task: ConversionTask) -> None:
+    """Acquire a semaphore slot and fire the conversion coroutine."""
+    weight = 2 if task.is_large else 1
+    await conversion_semaphore.acquire(weight)
+    asyncio.create_task(_run_conversion(task, weight))
+    logger.debug(
+        f"Dispatched task {task.task_id} "
+        f"(op={task.operation}, file={Path(task.cached_file).name}, weight={weight}, "
+        f"semaphore={conversion_semaphore.available}/{conversion_semaphore.capacity})"
+    )
+
+
 async def dispatch_loop() -> None:
     """
     Long-running coroutine that polls the DB and dispatches conversion tasks.
@@ -143,82 +142,44 @@ async def dispatch_loop() -> None:
     The process pool is created here (not at module import) so worker
     processes are only spawned when the dispatcher actually starts.
     """
-    global _rr_turn, _process_pool
+    global _op_turn, _connector_rr_index, _process_pool
 
-    # Initialise the pool on first entry.  max_workers == semaphore capacity
-    # so a worker process is always immediately available when the semaphore
-    # grants a slot — no internal queuing in the pool.
     _process_pool = ProcessPoolExecutor(
         max_workers=conversion_semaphore.capacity  # default 4
     )
     logger.info(
-        f"Conversion dispatcher started "
-        f"(pool workers={conversion_semaphore.capacity})"
+        f"Conversion dispatcher started (pool workers={conversion_semaphore.capacity})"
     )
 
     try:
         while True:
             try:
                 available = conversion_semaphore.available
-                if available > 0:
-                    first, second = _rr_turn, _other(_rr_turn)
 
-                    # Peek at both heads up-front so each queue's budget can account
-                    # for the other queue's pending weight requirement.
-                    first_head  = db_manager.peek_head(first)
-                    second_head = db_manager.peek_head(second)
-                    first_needed  = (2 if first_head.is_large  else 1) if first_head  else 0
-                    second_needed = (2 if second_head.is_large else 1) if second_head else 0
+                if _op_turn == 0:                        # ── Turn 0: User Ingestion ──
+                    task = _try_claim_if_fits("ingestion", available)
+                    if task:
+                        await _dispatch_one(task)
 
-                    # Only reserve capacity for second's head when it is a large task
-                    # (needed > 1).  A normal task (needed=1) can always fit into
-                    # whatever remains after first runs — pre-reserving for it would
-                    # wrongly block a large first task that has exactly enough room now.
-                    second_reservation = second_needed if second_needed > 1 else 0
-                    budget_for_first = max(0, available - second_reservation)
-                    first_task = _try_claim_if_fits(first, budget_for_first)
-                    if first_task:
-                        weight = 2 if first_task.is_large else 1
-                        await conversion_semaphore.acquire(weight)
-                        asyncio.create_task(_run_conversion(first_task, weight))
-                        queued_counts = db_manager.get_queued_counts()
-                        logger.debug(
-                            f"Dispatched {first} task {first_task.task_id} "
-                            f"(file={Path(first_task.cached_file).name}, weight={weight}, "
-                            f"semaphore={conversion_semaphore.available}/{conversion_semaphore.capacity}, "
-                            f"queued ingestion={queued_counts['ingestion']}, queued digitization={queued_counts['digitization']})"
-                        )
+                elif _op_turn == 1:                      # ── Turn 1: User Digitization ──
+                    task = _try_claim_if_fits("digitization", available)
+                    if task:
+                        await _dispatch_one(task)
 
-                    # Re-read available after first may have acquired slots.
-                    # Using the stale pre-acquire value would give second too generous
-                    # a budget on the tick where first finally dispatches (e.g. large
-                    # ING acquires weight=2, available drops from 2→0, but stale
-                    # available=2 would yield budget_for_second=0 by coincidence only
-                    # when first_needed==available; for other values it over-grants).
-                    available_after_first = conversion_semaphore.available
+                else:                                    # ── Turn 2: Connector Ingestion ──
+                    cids = db_manager.get_connector_ids_with_queued_tasks()
+                    if cids:
+                        cid = cids[_connector_rr_index % len(cids)]
+                        task = _try_claim_if_fits("ingestion", available, connector_id=cid)
+                        if task:
+                            await _dispatch_one(task)
+                        _connector_rr_index = (_connector_rr_index + 1) % len(cids)
 
-                    # Same rule for second: only reserve if first's head is large.
-                    first_reservation = first_needed if first_needed > 1 else 0
-                    budget_for_second = max(0, available_after_first - first_reservation)
-                    second_task = _try_claim_if_fits(second, budget_for_second)
-                    if second_task:
-                        weight = 2 if second_task.is_large else 1
-                        await conversion_semaphore.acquire(weight)
-                        asyncio.create_task(_run_conversion(second_task, weight))
-                        queued_counts = db_manager.get_queued_counts()
-                        logger.debug(
-                            f"Dispatched {second} task {second_task.task_id} "
-                            f"(file={Path(second_task.cached_file).name}, weight={weight}, "
-                            f"semaphore={conversion_semaphore.available}/{conversion_semaphore.capacity}, "
-                            f"queued ingestion={queued_counts['ingestion']}, queued digitization={queued_counts['digitization']})"
-                        )
+                _op_turn = (_op_turn + 1) % 3            # ALWAYS advance — unconditional
 
-                    # Advance turn only when first was successfully claimed.
-                    if first_task:
-                        _rr_turn = second
-
-                # After each tick, promote pending → queued to backfill quota headroom.
-                db_manager.promote_pending("ingestion", settings.digitize.ingestion_queue_quota)
+                # Promote pending → queued for user lanes only.
+                # Connector tasks are always inserted as 'queued' — no promote needed.
+                db_manager.promote_pending("ingestion",    settings.digitize.ingestion_queue_quota)
                 db_manager.promote_pending("digitization", settings.digitize.digitization_queue_quota)
 
             except asyncio.CancelledError:


### PR DESCRIPTION
- Implements 3 lane fair round robin strategy to process U-ING, U-DIG and C-ING requests with each tick allocating prioirty to only one type in the same order. C-ING requests are further processed in round robin style in each subsequent connector tick turns.