### PR TITLE
feat: disconnect application from datasources

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.311
+TAG?=v0.0.312
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.311
+  image: icr.io/ai-services-cicd/ai-services:v0.0.312
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.311
+  image: icr.io/ai-services-cicd/ai-services:v0.0.312
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -4,7 +4,7 @@ caddy:
   httpsPort: ""
 
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.311
+  image: icr.io/ai-services-cicd/ai-services:v0.0.312
   runtime: "podman"
   token: ""
   # optionalFlags covers basedir, sslCertPath, sslKeyPath, domainSuffix, and httpsPort flags that are forwarded from the

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -504,6 +504,72 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Removes a single datasource connector from each eligible service in a running application and deletes the service_dependency record.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Datasources"
+                ],
+                "summary": "Disconnect a datasource from an application",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Application ID (UUID)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Datasource ID (UUID)",
+                        "name": "datasource_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Datasource disconnected successfully"
+                    },
+                    "400": {
+                        "description": "Invalid application or datasource ID",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Datasource not connected to this application",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "502": {
+                        "description": "Downstream Digitize service returned an error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/applications/{id}/ps": {

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -498,6 +498,72 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Removes a single datasource connector from each eligible service in a running application and deletes the service_dependency record.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Datasources"
+                ],
+                "summary": "Disconnect a datasource from an application",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Application ID (UUID)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Datasource ID (UUID)",
+                        "name": "datasource_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Datasource disconnected successfully"
+                    },
+                    "400": {
+                        "description": "Invalid application or datasource ID",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Datasource not connected to this application",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "502": {
+                        "description": "Downstream Digitize service returned an error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/applications/{id}/ps": {

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -1225,6 +1225,50 @@ paths:
       tags:
       - Datasources
   /applications/{id}/datasources/{datasource_id}:
+    delete:
+      description: Removes a single datasource connector from each eligible service
+        in a running application and deletes the service_dependency record.
+      parameters:
+      - description: Application ID (UUID)
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Datasource ID (UUID)
+        in: path
+        name: datasource_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Datasource disconnected successfully
+        "400":
+          description: Invalid application or datasource ID
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "404":
+          description: Datasource not connected to this application
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "502":
+          description: Downstream Digitize service returned an error
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Disconnect a datasource from an application
+      tags:
+      - Datasources
     get:
       description: Returns the catalog identity and live sync state of a datasource
         connected to the given application. Sync fields are sourced from the linked

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/datasource_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/datasource_handler.go
@@ -449,4 +449,57 @@ func (h *DatasourceHandler) GetApplicationDatasource(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
+// DisconnectDatasourcesFromApplication godoc
+//
+//	@Summary		Disconnect a datasource from an application
+//	@Description	Removes a single datasource connector from each eligible service in a running application and deletes the service_dependency record.
+//	@Tags			Datasources
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id				path	string	true	"Application ID (UUID)"
+//	@Param			datasource_id	path	string	true	"Datasource ID (UUID)"
+//	@Success		204				"Datasource disconnected successfully"
+//	@Failure		400				{object}	ErrorResponse	"Invalid application or datasource ID"
+//	@Failure		401				{object}	ErrorResponse	"Unauthorized"
+//	@Failure		404				{object}	ErrorResponse	"Datasource not connected to this application"
+//	@Failure		502				{object}	ErrorResponse	"Downstream Digitize service returned an error"
+//	@Failure		500				{object}	ErrorResponse	"Internal Server Error"
+//	@Router			/applications/{id}/datasources/{datasource_id} [delete]
+func (h *DatasourceHandler) DisconnectDatasourcesFromApplication(c *gin.Context) {
+	applicationID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: fmt.Sprintf("Invalid application ID: %v", err),
+		})
+
+		return
+	}
+
+	datasourceID, err := uuid.Parse(c.Param("datasource_id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: fmt.Sprintf("Invalid datasource ID: %v", err),
+		})
+
+		return
+	}
+
+	if err := h.datasourceSvc.DisconnectDatasourcesFromApplication(c.Request.Context(), applicationID, datasourceID); err != nil {
+		if valErr, ok := err.(*repository.ValidationError); ok {
+			c.JSON(valErr.Code, ErrorResponse{Error: valErr.Message})
+
+			return
+		}
+
+		logger.ErrorfCtx(c.Request.Context(), "failed to disconnect datasource from application: %v", err)
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: "Failed to disconnect datasource from application",
+		})
+
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service/datasource_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service/datasource_service.go
@@ -33,6 +33,8 @@ type ValidationError = validators.ValidationError
 // services that accept datasource connectors.
 type ServiceConnectorClientInterface interface {
 	Connect(ctx context.Context, baseURL string, req apimodels.ConnectDatasourceRequest) error
+	// Disconnect calls DELETE /v1/connectors/{connectorID} on the service.
+	Disconnect(ctx context.Context, baseURL, connectorID string) error
 }
 
 // DatasourceService is the single implementation of the datasource connector business logic.
@@ -799,6 +801,92 @@ func (s *DatasourceService) GetApplicationDatasource(ctx context.Context, applic
 		Provider:       apimodels.DatasourceProviderInfo{ID: connector.Provider, Name: providerName},
 		ServiceDetails: serviceDetails,
 	}, nil
+}
+
+// DisconnectDatasourcesFromApplication removes a single datasource connector from each
+// service it is connected to within the given application, then removes the
+// service_dependency rows.
+//
+// Flow:
+//  1. Verify the application exists — return 404 if not.
+//  2. Verify the datasource exists — return 404 if not.
+//  3. Query service_dependencies for (datasourceID, applicationID) to confirm the datasource
+//     is actually connected. Return 404 if no rows are found.
+//  4. For each confirmed row, call DELETE /v1/connectors/{id} on the Digitize endpoint,
+//     then remove the service_dependency row.
+func (s *DatasourceService) DisconnectDatasourcesFromApplication(ctx context.Context, applicationID uuid.UUID, datasourceID uuid.UUID) error {
+	// Step 1: verify application exists.
+	app, err := s.appRepo.GetByID(ctx, applicationID)
+	if err != nil {
+		return fmt.Errorf("failed to load application: %w", err)
+	}
+
+	if app == nil {
+		return &ValidationError{
+			Code:    http.StatusNotFound,
+			Message: fmt.Sprintf("application %s not found", applicationID),
+		}
+	}
+
+	// Step 2: verify datasource exists.
+	if _, err := s.loadConnector(ctx, datasourceID); err != nil {
+		return err
+	}
+
+	// Step 3: confirm the datasource is connected to this application.
+	linkedServices, err := s.svcDepRepo.GetLinkedServiceEndpoints(ctx, datasourceID, dbmodels.DependencyTypeConnector)
+	if err != nil {
+		return fmt.Errorf("failed to query connected services: %w", err)
+	}
+
+	var appLinked []dbrepo.LinkedServiceRow
+	for _, svc := range linkedServices {
+		if svc.ApplicationID == applicationID {
+			appLinked = append(appLinked, svc)
+		}
+	}
+
+	if len(appLinked) == 0 {
+		return &ValidationError{
+			Code:    http.StatusNotFound,
+			Message: fmt.Sprintf("datasource %s is not connected to application %s", datasourceID, applicationID),
+		}
+	}
+
+	return s.disconnectOneDatasource(ctx, datasourceID, appLinked)
+}
+
+// disconnectOneDatasource calls DELETE /v1/connectors/{id} on each linked service and
+// removes the service_dependency row.
+// A 404 from the downstream service is treated as success — the connector was already
+// removed (idempotency for partial-failure retries). The 404 handling lives here rather
+// than in the client so that other callers of Disconnect can choose to treat 404 as an
+// error if appropriate. DB cleanup failures are logged but do not block the caller.
+func (s *DatasourceService) disconnectOneDatasource(ctx context.Context, datasourceID uuid.UUID, linkedServices []dbrepo.LinkedServiceRow) error {
+	for _, svc := range linkedServices {
+		url := extractAPIEndpointURL(svc.EndpointsJSON)
+		if url != "" {
+			if err := s.serviceClient.Disconnect(ctx, url, datasourceID.String()); err != nil {
+				// 404 means the connector is already gone on the downstream side —
+				// treat as success so we still clean up the DB row.
+				var httpErr *catalogclient.ServiceHTTPError
+				if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+					logger.InfofCtx(ctx, "connector %s not found from service %s, continuing cleanup", datasourceID, svc.ServiceCatalogID)
+				} else {
+					return &ValidationError{
+						Code:    http.StatusBadGateway,
+						Message: fmt.Sprintf("failed to disconnect datasource from service %s: %v", svc.ServiceCatalogID, err),
+					}
+				}
+			}
+		}
+
+		if err := s.svcDepRepo.RemoveDependency(ctx, svc.ServiceID, datasourceID); err != nil {
+			logger.ErrorfCtx(ctx, "failed to remove connector dependency for service %s: %v", svc.ServiceID, err)
+		}
+	}
+
+	return nil
 }
 
 // resolveLinkedEndpoint confirms that datasourceID is linked to a service belonging to

--- a/ai-services/internal/pkg/catalog/apiserver/repository/interface.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/interface.go
@@ -15,6 +15,9 @@ type DatasourceServiceInterface interface {
 	CreateDatasource(ctx context.Context, req apimodels.CreateDatasourceRequest) (*apimodels.CreateDatasourceResponse, error)
 	// ConnectDatasourcesToApplication links one or more datasource connectors to each eligible service in a running application.
 	ConnectDatasourcesToApplication(ctx context.Context, applicationID uuid.UUID, datasourceIDs []uuid.UUID) (*apimodels.ConnectDatasourcesResponse, error)
+	// DisconnectDatasourcesFromApplication removes a single datasource connector from each
+	// eligible service in a running application and removes the service_dependency record.
+	DisconnectDatasourcesFromApplication(ctx context.Context, applicationID uuid.UUID, datasourceID uuid.UUID) error
 	// GetDatasource retrieves a single datasource by ID with non-sensitive metadata and
 	// connected services enriched with live sync state from each service's Digitize pod.
 	// Returns a *ValidationError with code 404 when the connector does not exist.

--- a/ai-services/internal/pkg/catalog/apiserver/router.go
+++ b/ai-services/internal/pkg/catalog/apiserver/router.go
@@ -112,6 +112,8 @@ func registerApplicationRoutes(v1 *gin.RouterGroup, h *handlers.ApplicationHandl
 		g.PUT("/:id/datasources", datasourceH.ConnectDatasourcesToApplication)
 		// GET /api/v1/applications/:id/datasources/:datasource_id — get datasource status for application
 		g.GET("/:id/datasources/:datasource_id", datasourceH.GetApplicationDatasource)
+		// DELETE /api/v1/applications/:id/datasources/:datasource_id — disconnect a single datasource from application
+		g.DELETE("/:id/datasources/:datasource_id", datasourceH.DisconnectDatasourcesFromApplication)
 	}
 }
 

--- a/ai-services/internal/pkg/catalog/client/service.go
+++ b/ai-services/internal/pkg/catalog/client/service.go
@@ -19,6 +19,17 @@ const (
 	serviceConnectPath = "/v1/connectors"
 )
 
+// ServiceHTTPError is returned by client methods when the downstream service responds
+// with a non-2xx status code. Callers can type-assert to inspect the status code and
+// decide whether to treat specific codes (e.g. 404) as non-fatal.
+type ServiceHTTPError struct {
+	StatusCode int
+}
+
+func (e *ServiceHTTPError) Error() string {
+	return fmt.Sprintf("service returned status %d", e.StatusCode)
+}
+
 // serviceUpdatePayload is the request body for PUT /v1/connectors/<connector_id>.
 // Only the fields being updated are sent; the service performs a partial update.
 type serviceUpdatePayload struct {
@@ -114,6 +125,22 @@ func (c *ServiceClient) Connect(ctx context.Context, baseURL string, req apimode
 
 	if resp.IsError() {
 		return fmt.Errorf("service returned unexpected status %d", resp.StatusCode())
+	}
+
+	return nil
+}
+
+// Disconnect calls DELETE /v1/connectors/{connectorID} on the given service base URL.
+func (c *ServiceClient) Disconnect(ctx context.Context, baseURL, connectorID string) error {
+	resp, err := c.http.R().
+		SetContext(ctx).
+		Delete(baseURL + serviceConnectPath + "/" + connectorID)
+	if err != nil {
+		return fmt.Errorf("service DELETE request failed: %w", err)
+	}
+
+	if resp.IsError() {
+		return &ServiceHTTPError{StatusCode: resp.StatusCode()}
 	}
 
 	return nil

--- a/docs/proposals/data-source-connectors/catalog-datasource-connectors-proposal.md
+++ b/docs/proposals/data-source-connectors/catalog-datasource-connectors-proposal.md
@@ -966,40 +966,15 @@ When `PUT /api/v1/connectors/datasources/:id` is called:
 
 ### 7.4 Disconnect Flow
 
-When `DELETE /api/v1/applications/:id/connectors/datasources/:datasource_id` is called:
+When `DELETE /api/v1/applications/:id/datasources/:datasource_id` is called:
 
-1. Query `service_dependencies` where `dependency_id = datasource_id` and `dependency_type = 'connector'`, joined to `services` to filter to this application. Return `404` if no rows found.
-2. For each row, call `DELETE /v1/connectors/<dependency_id>` on its downstream Digitize pod, using the row's `dependency_id` as the `connector_id`.
-   - If the call returns `404` (connector already gone on the downstream side), treat as success and continue to the next service.
-   - If the call returns `409 Conflict` (a sync tick is currently in progress on the Digitize side), record the error for that service and continue to the next.
-   - If the call fails with any other error: record the error for that service and continue to the next — do **not** skip the remaining services.
-3. For every service whose downstream call succeeded (or returned `404`), delete the corresponding `service_dependencies` row.
-4. Return `200 OK`. If any downstream calls failed, include a `propagation_errors` array so the UI can show an inline error against each affected service. The user retriggers by re-submitting the disconnect from the UI.
-
-**Response when all disconnections succeed:**
-
-```json
-{
-  "application_id": "app-uuid-1",
-  "datasource_id": "550e8400-e29b-41d4-a716-446655440000"
-}
-```
-
-**Response when one or more disconnections fail:**
-
-```json
-{
-  "application_id": "app-uuid-1",
-  "datasource_id": "550e8400-e29b-41d4-a716-446655440000",
-  "propagation_errors": [
-    {
-      "service_id": "svc-uuid-1",
-      "service_name": "Digitize",
-      "error": "failed to reach digitize service: connection refused"
-    }
-  ]
-}
-```
+1. Query `service_dependencies` scoped to the given `datasource_id` and filter to services belonging to `application_id`. Return `404 Not Found` with `"datasource <id> is not connected to application <id>"` if no rows match — the datasource was never connected, or was already fully disconnected.
+2. For each confirmed row, call `DELETE /v1/connectors/<datasource_id>` on its downstream Digitize pod.
+   - If the call returns `404` (connector already removed on the downstream side — e.g. a previous attempt reached the service but failed before the DB row was cleaned up), treat as success and continue. This makes the operation **idempotent**.
+   - If the service has no registered API endpoint, skip the downstream call and proceed directly to DB cleanup.
+   - If the call fails with any other non-2xx status, return `502 Bad Gateway` immediately.
+3. Delete the corresponding `service_dependencies` row. A failure here is logged but does not block the response.
+4. Return `204 No Content`.
 
 ### 7.5 Connected Services Fetch Flow
 


### PR DESCRIPTION
Adds a DELETE /api/v1/applications/:id/datasources endpoint that disconnects one or more datasource connectors in an application.

- Accepts a list of datasource_ids in the request body; each datasource is processed independently

