### PR TITLE
make deploy-options API runtime-aware via query param

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.310
+TAG?=v0.0.311
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.310
+  image: icr.io/ai-services-cicd/ai-services:v0.0.311
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.310
+  image: icr.io/ai-services-cicd/ai-services:v0.0.311
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -4,7 +4,7 @@ caddy:
   httpsPort: ""
 
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.310
+  image: icr.io/ai-services-cicd/ai-services:v0.0.311
   runtime: "podman"
   token: ""
   # optionalFlags covers basedir, sslCertPath, sslKeyPath, domainSuffix, and httpsPort flags that are forwarded from the

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -620,7 +620,7 @@ func buildArchitecturePayload(ctx context.Context, _ catalogClient.CatalogSource
 	}
 
 	// Get deploy options for the architecture
-	deployOptions, err := appClient.GetArchitectureDeployOptions(ctx, arch.ID)
+	deployOptions, err := appClient.GetArchitectureDeployOptions(ctx, archID, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get deploy options: %w", err)
 	}
@@ -667,7 +667,7 @@ func buildServicePayload(ctx context.Context, serviceID, appName string) (*apiMo
 	}
 
 	// Get deploy options for the service
-	deployOptions, err := appClient.GetServiceDeployOptions(ctx, serviceID)
+	deployOptions, err := appClient.GetServiceDeployOptions(ctx, serviceID, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get deploy options: %w", err)
 	}

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -952,7 +952,7 @@ func collectProviderSelection(compDeployOpt catalogTypes.DeployOptionsComponent,
 // User-provided params override defaults.
 func applySchemaDefaults(ctx context.Context, appClient *catalogClient.ApplicationClient, componentType, providerID string, userParams map[string]string) (map[string]any, error) {
 	// Fetch schema from API
-	schema, err := appClient.GetComponentProviderParams(ctx, componentType, providerID)
+	schema, err := appClient.GetComponentProviderParams(ctx, componentType, providerID, string(vars.RuntimeFactory.GetRuntimeType()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch schema: %w", err)
 	}

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -620,7 +620,7 @@ func buildArchitecturePayload(ctx context.Context, _ catalogClient.CatalogSource
 	}
 
 	// Get deploy options for the architecture
-	deployOptions, err := appClient.GetArchitectureDeployOptions(ctx, archID, "")
+	deployOptions, err := appClient.GetArchitectureDeployOptions(ctx, arch.ID, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get deploy options: %w", err)
 	}

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -10,6 +10,7 @@ import (
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 var (
@@ -68,7 +69,7 @@ func displayServiceParameters(ctx context.Context, source catalogClient.CatalogS
 	logger.Infof("Supported Parameters for '%s':", serviceID)
 
 	// Display service's own parameters
-	schema, err := source.GetServiceParams(ctx, serviceID)
+	schema, err := provider.GetServiceParams(ctx, serviceID, string(vars.RuntimeFactory.GetRuntimeType()))
 	if err == nil && schema != nil {
 		displaySchemaParameters(schema, serviceID)
 	}
@@ -104,7 +105,7 @@ func displayServiceInArchitecture(ctx context.Context, source catalogClient.Cata
 	}
 
 	// Display service parameters
-	schema, err := source.GetServiceParams(ctx, serviceID)
+	schema, err := provider.GetServiceParams(ctx, serviceID, string(vars.RuntimeFactory.GetRuntimeType()))
 	if err == nil && schema != nil {
 		displaySchemaParameters(schema, serviceID)
 	}
@@ -139,7 +140,7 @@ func displayComponentsParameters(ctx context.Context, source catalogClient.Catal
 					displayedComponents[componentKey] = true
 				}
 
-				schema, err := source.GetComponentProviderParams(ctx, comp.ComponentType, comp.ID)
+				schema, err := provider.GetComponentProviderParams(ctx, comp.ComponentType, comp.ID, string(vars.RuntimeFactory.GetRuntimeType()))
 				if err == nil && schema != nil {
 					displaySchemaParameters(schema, componentKey)
 				}

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -69,7 +69,7 @@ func displayServiceParameters(ctx context.Context, source catalogClient.CatalogS
 	logger.Infof("Supported Parameters for '%s':", serviceID)
 
 	// Display service's own parameters
-	schema, err := provider.GetServiceParams(ctx, serviceID, string(vars.RuntimeFactory.GetRuntimeType()))
+	schema, err := source.GetServiceParams(ctx, serviceID, string(vars.RuntimeFactory.GetRuntimeType()))
 	if err == nil && schema != nil {
 		displaySchemaParameters(schema, serviceID)
 	}
@@ -105,7 +105,7 @@ func displayServiceInArchitecture(ctx context.Context, source catalogClient.Cata
 	}
 
 	// Display service parameters
-	schema, err := provider.GetServiceParams(ctx, serviceID, string(vars.RuntimeFactory.GetRuntimeType()))
+	schema, err := source.GetServiceParams(ctx, serviceID, string(vars.RuntimeFactory.GetRuntimeType()))
 	if err == nil && schema != nil {
 		displaySchemaParameters(schema, serviceID)
 	}
@@ -140,7 +140,7 @@ func displayComponentsParameters(ctx context.Context, source catalogClient.Catal
 					displayedComponents[componentKey] = true
 				}
 
-				schema, err := provider.GetComponentProviderParams(ctx, comp.ComponentType, comp.ID, string(vars.RuntimeFactory.GetRuntimeType()))
+				schema, err := source.GetComponentProviderParams(ctx, comp.ComponentType, comp.ID, string(vars.RuntimeFactory.GetRuntimeType()))
 				if err == nil && schema != nil {
 					displaySchemaParameters(schema, componentKey)
 				}

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -1493,6 +1493,12 @@ const docTemplate = `{
                         "name": "provider_id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target runtime type: 'podman' or 'openshift'. Defaults to server runtime when absent.",
+                        "name": "runtime",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1504,7 +1510,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Bad Request - Invalid component_type or provider_id",
+                        "description": "Bad Request - Invalid component_type, provider_id, or runtime parameter",
                         "schema": {
                             "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
                         }
@@ -2350,6 +2356,12 @@ const docTemplate = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target runtime type: 'podman' or 'openshift'. Defaults to server runtime when absent.",
+                        "name": "runtime",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -2361,7 +2373,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Bad Request - Invalid service ID",
+                        "description": "Bad Request - Invalid service ID or runtime parameter",
                         "schema": {
                             "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
                         }

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -730,6 +730,12 @@ const docTemplate = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target runtime type: 'podman' or 'openshift'. Defaults to server runtime when absent.",
+                        "name": "runtime",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -737,6 +743,12 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.DeployOptionsArchitecture"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid runtime parameter",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
                         }
                     },
                     "401": {
@@ -2164,6 +2176,12 @@ const docTemplate = `{
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target runtime type: 'podman' or 'openshift'. Defaults to server runtime when absent.",
+                        "name": "runtime",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -2171,6 +2189,12 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.DeployOptionsService"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid runtime parameter",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
                         }
                     },
                     "401": {

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -724,6 +724,12 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target runtime type: 'podman' or 'openshift'. Defaults to server runtime when absent.",
+                        "name": "runtime",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -731,6 +737,12 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.DeployOptionsArchitecture"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid runtime parameter",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
                         }
                     },
                     "401": {
@@ -2158,6 +2170,12 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target runtime type: 'podman' or 'openshift'. Defaults to server runtime when absent.",
+                        "name": "runtime",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -2165,6 +2183,12 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.DeployOptionsService"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid runtime parameter",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
                         }
                     },
                     "401": {

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -1487,6 +1487,12 @@
                         "name": "provider_id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target runtime type: 'podman' or 'openshift'. Defaults to server runtime when absent.",
+                        "name": "runtime",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1498,7 +1504,7 @@
                         }
                     },
                     "400": {
-                        "description": "Bad Request - Invalid component_type or provider_id",
+                        "description": "Bad Request - Invalid component_type, provider_id, or runtime parameter",
                         "schema": {
                             "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
                         }
@@ -2344,6 +2350,12 @@
                         "name": "id",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Target runtime type: 'podman' or 'openshift'. Defaults to server runtime when absent.",
+                        "name": "runtime",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -2355,7 +2367,7 @@
                         }
                     },
                     "400": {
-                        "description": "Bad Request - Invalid service ID",
+                        "description": "Bad Request - Invalid service ID or runtime parameter",
                         "schema": {
                             "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
                         }

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -1410,6 +1410,11 @@ paths:
         name: id
         required: true
         type: string
+      - description: 'Target runtime type: ''podman'' or ''openshift''. Defaults to
+          server runtime when absent.'
+        in: query
+        name: runtime
+        type: string
       produces:
       - application/json
       responses:
@@ -1417,6 +1422,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.DeployOptionsArchitecture'
+        "400":
+          description: Invalid runtime parameter
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
         "401":
           description: Unauthorized - Invalid or missing access token
           schema:
@@ -2373,6 +2382,11 @@ paths:
         name: id
         required: true
         type: string
+      - description: 'Target runtime type: ''podman'' or ''openshift''. Defaults to
+          server runtime when absent.'
+        in: query
+        name: runtime
+        type: string
       produces:
       - application/json
       responses:
@@ -2380,6 +2394,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.DeployOptionsService'
+        "400":
+          description: Invalid runtime parameter
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
         "401":
           description: Unauthorized - Invalid or missing access token
           schema:

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -1924,6 +1924,11 @@ paths:
         name: provider_id
         required: true
         type: string
+      - description: 'Target runtime type: ''podman'' or ''openshift''. Defaults to
+          server runtime when absent.'
+        in: query
+        name: runtime
+        type: string
       produces:
       - application/json
       responses:
@@ -1935,7 +1940,8 @@ paths:
             additionalProperties: true
             type: object
         "400":
-          description: Bad Request - Invalid component_type or provider_id
+          description: Bad Request - Invalid component_type, provider_id, or runtime
+            parameter
           schema:
             $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
         "401":
@@ -2501,6 +2507,11 @@ paths:
         name: id
         required: true
         type: string
+      - description: 'Target runtime type: ''podman'' or ''openshift''. Defaults to
+          server runtime when absent.'
+        in: query
+        name: runtime
+        type: string
       produces:
       - application/json
       responses:
@@ -2511,7 +2522,7 @@ paths:
             additionalProperties: true
             type: object
         "400":
-          description: Bad Request - Invalid service ID
+          description: Bad Request - Invalid service ID or runtime parameter
           schema:
             $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
         "401":

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
@@ -149,20 +149,22 @@ func (h *CatalogHandler) GetServiceDetails(c *gin.Context) {
 //	@Tags			Catalog
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			id	path		string	true	"Architecture ID (e.g., 'rag')"
-//	@Success		200	{object}	types.DeployOptionsArchitecture
-//	@Failure		401	{object}	ErrorResponse	"Unauthorized - Invalid or missing access token"
-//	@Failure		404	{object}	ErrorResponse	"Architecture not found"
-//	@Failure		500	{object}	ErrorResponse	"Internal Server Error"
+//	@Param			id		path		string	true	"Architecture ID (e.g., 'rag')"
+//	@Param			runtime	query		string	false	"Target runtime type: 'podman' or 'openshift'. Defaults to server runtime when absent."
+//	@Success		200		{object}	types.DeployOptionsArchitecture
+//	@Failure		400		{object}	ErrorResponse	"Invalid runtime parameter"
+//	@Failure		401		{object}	ErrorResponse	"Unauthorized - Invalid or missing access token"
+//	@Failure		404		{object}	ErrorResponse	"Architecture not found"
+//	@Failure		500		{object}	ErrorResponse	"Internal Server Error"
 //	@Router			/architectures/{id}/deploy-options [get]
 func (h *CatalogHandler) GetArchitectureDeployOptions(c *gin.Context) {
 	architectureID := c.Param("id")
 
-	// runtime is optional; defaults to the server's local runtime when absent.
-	// Pass ?runtime=openshift to get deploy options scoped to an OpenShift worker.
-	rt := c.Query("runtime")
-	if rt == "" {
-		rt = string(vars.RuntimeFactory.GetRuntimeType())
+	rt, err := resolveRuntimeParam(c.Query("runtime"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+
+		return
 	}
 
 	deployOptions, err := h.provider.GetArchitectureDeployOptions(c.Request.Context(), architectureID, rt)
@@ -184,20 +186,22 @@ func (h *CatalogHandler) GetArchitectureDeployOptions(c *gin.Context) {
 //	@Tags			Catalog
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			id	path		string	true	"Service ID (e.g., 'digitize', 'chat')"
-//	@Success		200	{object}	types.DeployOptionsService
-//	@Failure		401	{object}	ErrorResponse	"Unauthorized - Invalid or missing access token"
-//	@Failure		404	{object}	ErrorResponse	"Service not found"
-//	@Failure		500	{object}	ErrorResponse	"Internal Server Error"
+//	@Param			id		path		string	true	"Service ID (e.g., 'digitize', 'chat')"
+//	@Param			runtime	query		string	false	"Target runtime type: 'podman' or 'openshift'. Defaults to server runtime when absent."
+//	@Success		200		{object}	types.DeployOptionsService
+//	@Failure		400		{object}	ErrorResponse	"Invalid runtime parameter"
+//	@Failure		401		{object}	ErrorResponse	"Unauthorized - Invalid or missing access token"
+//	@Failure		404		{object}	ErrorResponse	"Service not found"
+//	@Failure		500		{object}	ErrorResponse	"Internal Server Error"
 //	@Router			/services/{id}/deploy-options [get]
 func (h *CatalogHandler) GetServiceDeployOptions(c *gin.Context) {
 	serviceID := c.Param("id")
 
-	// runtime is optional; defaults to the server's local runtime when absent.
-	// Pass ?runtime=openshift to get deploy options scoped to an OpenShift worker.
-	rt := c.Query("runtime")
-	if rt == "" {
-		rt = string(vars.RuntimeFactory.GetRuntimeType())
+	rt, err := resolveRuntimeParam(c.Query("runtime"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+
+		return
 	}
 
 	deployOptions, err := h.provider.GetServiceDeployOptions(c.Request.Context(), serviceID, rt)
@@ -556,6 +560,24 @@ func (h *CatalogHandler) GetServiceSteps(c *gin.Context) {
 // ErrorResponse represents an error response.
 type ErrorResponse struct {
 	Error string `json:"error"`
+}
+
+// resolveRuntimeParam validates the optional ?runtime= query parameter.
+// When raw is empty, the server's local runtime is returned.
+// When raw is non-empty, it must be "podman" or "openshift"; any other value
+// returns an error so the handler can respond with HTTP 400.
+func resolveRuntimeParam(raw string) (string, error) {
+	if raw == "" {
+		return string(vars.RuntimeFactory.GetRuntimeType()), nil
+	}
+
+	rt := runtimeTypes.RuntimeType(raw)
+	if !rt.Valid() {
+		return "", fmt.Errorf("invalid runtime %q: must be %q or %q",
+			raw, runtimeTypes.RuntimeTypePodman, runtimeTypes.RuntimeTypeOpenShift)
+	}
+
+	return string(rt), nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
@@ -158,7 +158,14 @@ func (h *CatalogHandler) GetServiceDetails(c *gin.Context) {
 func (h *CatalogHandler) GetArchitectureDeployOptions(c *gin.Context) {
 	architectureID := c.Param("id")
 
-	deployOptions, err := h.provider.GetArchitectureDeployOptions(c.Request.Context(), architectureID)
+	// runtime is optional; defaults to the server's local runtime when absent.
+	// Pass ?runtime=openshift to get deploy options scoped to an OpenShift worker.
+	rt := c.Query("runtime")
+	if rt == "" {
+		rt = string(vars.RuntimeFactory.GetRuntimeType())
+	}
+
+	deployOptions, err := h.provider.GetArchitectureDeployOptions(c.Request.Context(), architectureID, rt)
 	if err != nil {
 		c.JSON(http.StatusNotFound, ErrorResponse{
 			Error: fmt.Sprintf("Failed to get deploy options for architecture '%s': %v", architectureID, err),
@@ -186,7 +193,14 @@ func (h *CatalogHandler) GetArchitectureDeployOptions(c *gin.Context) {
 func (h *CatalogHandler) GetServiceDeployOptions(c *gin.Context) {
 	serviceID := c.Param("id")
 
-	deployOptions, err := h.provider.GetServiceDeployOptions(c.Request.Context(), serviceID)
+	// runtime is optional; defaults to the server's local runtime when absent.
+	// Pass ?runtime=openshift to get deploy options scoped to an OpenShift worker.
+	rt := c.Query("runtime")
+	if rt == "" {
+		rt = string(vars.RuntimeFactory.GetRuntimeType())
+	}
+
+	deployOptions, err := h.provider.GetServiceDeployOptions(c.Request.Context(), serviceID, rt)
 	if err != nil {
 		c.JSON(http.StatusNotFound, ErrorResponse{
 			Error: fmt.Sprintf("Failed to get deploy options for service '%s': %v", serviceID, err),
@@ -217,7 +231,7 @@ func (h *CatalogHandler) GetComponentProviderParams(c *gin.Context) {
 	componentType := c.Param("component_type")
 	providerID := c.Param("provider_id")
 
-	schema, err := h.provider.GetComponentProviderParams(c.Request.Context(), componentType, providerID)
+	schema, err := h.provider.GetComponentProviderParams(c.Request.Context(), componentType, providerID, string(vars.RuntimeFactory.GetRuntimeType()))
 	if err != nil {
 		c.JSON(http.StatusNotFound, ErrorResponse{
 			Error: fmt.Sprintf("Failed to get parameters for provider '%s/%s': %v", componentType, providerID, err),
@@ -314,7 +328,7 @@ func (h *CatalogHandler) GetConnectorProviderParams(c *gin.Context) {
 func (h *CatalogHandler) GetServiceParams(c *gin.Context) {
 	serviceID := c.Param("id")
 
-	schema, err := h.provider.GetServiceParams(c.Request.Context(), serviceID)
+	schema, err := h.provider.GetServiceParams(c.Request.Context(), serviceID, string(vars.RuntimeFactory.GetRuntimeType()))
 	if err != nil {
 		c.JSON(http.StatusNotFound, ErrorResponse{
 			Error: fmt.Sprintf("Failed to get parameters for service '%s': %v", serviceID, err),

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
@@ -225,8 +225,9 @@ func (h *CatalogHandler) GetServiceDeployOptions(c *gin.Context) {
 //	@Security		BearerAuth
 //	@Param			component_type	path		string					true	"Component type (e.g., 'vector_db', 'llm', 'embedding', 'reranker')"
 //	@Param			provider_id		path		string					true	"Provider identifier (e.g., 'opensearch', 'vllm', 'watsonx')"
+//	@Param			runtime			query		string					false	"Target runtime type: 'podman' or 'openshift'. Defaults to server runtime when absent."
 //	@Success		200				{object}	map[string]interface{}	"JSON Schema object with $schema, type, and properties. Properties may include x-data-id field indicating data should be populated from metadata specifications (e.g., supported_models)"
-//	@Failure		400				{object}	ErrorResponse			"Bad Request - Invalid component_type or provider_id"
+//	@Failure		400				{object}	ErrorResponse			"Bad Request - Invalid component_type, provider_id, or runtime parameter"
 //	@Failure		401				{object}	ErrorResponse			"Unauthorized - Invalid or missing access token"
 //	@Failure		404				{object}	ErrorResponse			"Component type or provider not found"
 //	@Failure		500				{object}	ErrorResponse			"Internal Server Error"
@@ -235,7 +236,14 @@ func (h *CatalogHandler) GetComponentProviderParams(c *gin.Context) {
 	componentType := c.Param("component_type")
 	providerID := c.Param("provider_id")
 
-	schema, err := h.provider.GetComponentProviderParams(c.Request.Context(), componentType, providerID, string(vars.RuntimeFactory.GetRuntimeType()))
+	rt, err := resolveRuntimeParam(c.Query("runtime"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+
+		return
+	}
+
+	schema, err := h.provider.GetComponentProviderParams(c.Request.Context(), componentType, providerID, rt)
 	if err != nil {
 		c.JSON(http.StatusNotFound, ErrorResponse{
 			Error: fmt.Sprintf("Failed to get parameters for provider '%s/%s': %v", componentType, providerID, err),
@@ -322,17 +330,25 @@ func (h *CatalogHandler) GetConnectorProviderParams(c *gin.Context) {
 //	@Tags			Catalog
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			id	path		string					true	"Service ID (e.g., 'chat', 'digitize', 'similarity')"
-//	@Success		200	{object}	map[string]interface{}	"JSON Schema object with $schema, type, and properties defining service parameters"
-//	@Failure		400	{object}	ErrorResponse			"Bad Request - Invalid service ID"
-//	@Failure		401	{object}	ErrorResponse			"Unauthorized - Invalid or missing access token"
-//	@Failure		404	{object}	ErrorResponse			"Service not found"
-//	@Failure		500	{object}	ErrorResponse			"Internal Server Error"
+//	@Param			id		path		string					true	"Service ID (e.g., 'chat', 'digitize', 'similarity')"
+//	@Param			runtime	query		string					false	"Target runtime type: 'podman' or 'openshift'. Defaults to server runtime when absent."
+//	@Success		200		{object}	map[string]interface{}	"JSON Schema object with $schema, type, and properties defining service parameters"
+//	@Failure		400		{object}	ErrorResponse			"Bad Request - Invalid service ID or runtime parameter"
+//	@Failure		401		{object}	ErrorResponse			"Unauthorized - Invalid or missing access token"
+//	@Failure		404		{object}	ErrorResponse			"Service not found"
+//	@Failure		500		{object}	ErrorResponse			"Internal Server Error"
 //	@Router			/services/{id}/params [get]
 func (h *CatalogHandler) GetServiceParams(c *gin.Context) {
 	serviceID := c.Param("id")
 
-	schema, err := h.provider.GetServiceParams(c.Request.Context(), serviceID, string(vars.RuntimeFactory.GetRuntimeType()))
+	rt, err := resolveRuntimeParam(c.Query("runtime"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+
+		return
+	}
+
+	schema, err := h.provider.GetServiceParams(c.Request.Context(), serviceID, rt)
 	if err != nil {
 		c.JSON(http.StatusNotFound, ErrorResponse{
 			Error: fmt.Sprintf("Failed to get parameters for service '%s': %v", serviceID, err),

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -361,7 +361,7 @@ func (s *ApplicationServiceBase) filterComponentMetadata(ctx context.Context, co
 	}
 
 	// Load component schema to determine which fields are sensitive
-	schema, err := s.Provider.GetComponentProviderParams(ctx, componentType, providerID)
+	schema, err := s.Provider.GetComponentProviderParams(ctx, componentType, providerID, string(vars.RuntimeFactory.GetRuntimeType()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to load schema for component %s/%s: %w", componentType, providerID, err)
 	}
@@ -797,7 +797,7 @@ func (s *ApplicationServiceBase) addServiceResources(
 	runtimeClient runtime.Runtime,
 	totals *resourceTotals,
 ) error {
-	runtimeMetadata, err := catalogProvider.LoadServiceRuntimeMetadata(service.CatalogID)
+	runtimeMetadata, err := catalogProvider.LoadServiceRuntimeMetadata(service.CatalogID, string(vars.RuntimeFactory.GetRuntimeType()))
 	if err != nil {
 		return fmt.Errorf("failed to load service runtime metadata for catalog ID %s: %w", service.CatalogID, err)
 	}
@@ -851,7 +851,7 @@ func (s *ApplicationServiceBase) processComponentResources(
 		return fmt.Errorf("failed to get component %s: %w", componentID, err)
 	}
 
-	runtimeMetadata, err := catalogProvider.LoadComponentRuntimeMetadata(component.Type, component.Provider)
+	runtimeMetadata, err := catalogProvider.LoadComponentRuntimeMetadata(component.Type, component.Provider, string(vars.RuntimeFactory.GetRuntimeType()))
 	if err != nil {
 		return fmt.Errorf("failed to load runtime metadata for component %s/%s: %w", component.Type, component.Provider, err)
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -452,7 +452,7 @@ func (d *PodmanDeployer) loadComponentResources(comp *ComponentPlan) (*types.Com
 		return nil, nil, nil, fmt.Errorf("failed to load component from catalog: %w", err)
 	}
 
-	metadata, err := d.catalogProvider.LoadComponentRuntimeMetadata(comp.ComponentType, comp.ProviderID)
+	metadata, err := d.catalogProvider.LoadComponentRuntimeMetadata(comp.ComponentType, comp.ProviderID, string(vars.RuntimeFactory.GetRuntimeType()))
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to load component runtime metadata: %w", err)
 	}
@@ -646,7 +646,7 @@ func (d *PodmanDeployer) deployService(ctx context.Context, plan *DeploymentPlan
 	logger.InfofCtx(ctx, "Service %s loaded: %s\n", service.ID, service.Name)
 
 	// Load runtime-specific metadata (contains PodTemplateExecutions)
-	serviceAppMetadata, err := d.catalogProvider.LoadServiceRuntimeMetadata(svc.CatalogID)
+	serviceAppMetadata, err := d.catalogProvider.LoadServiceRuntimeMetadata(svc.CatalogID, string(vars.RuntimeFactory.GetRuntimeType()))
 	if err != nil {
 		return fmt.Errorf("failed to load service runtime metadata: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/catalog.go
+++ b/ai-services/internal/pkg/catalog/catalog.go
@@ -807,7 +807,9 @@ func (p *CatalogProvider) LoadComponentValues(componentType, providerID string, 
 
 // LoadComponentRuntimeMetadata loads runtime-specific metadata for a component.
 // This includes PodTemplateExecutions and other runtime configuration.
-func (p *CatalogProvider) LoadComponentRuntimeMetadata(componentType, providerID string) (*clitemplates.AppMetadata, error) {
+// runtimeType selects the runtime subdirectory (e.g. "podman" or "openshift").
+// Pass string(vars.RuntimeFactory.GetRuntimeType()) when targeting the local runtime.
+func (p *CatalogProvider) LoadComponentRuntimeMetadata(componentType, providerID, runtimeType string) (*clitemplates.AppMetadata, error) {
 	// Get component path from catalog
 	componentKey := fmt.Sprintf("%s/%s", componentType, providerID)
 	componentPath, err := p.GetCatalogItemPath(componentKey)
@@ -815,12 +817,8 @@ func (p *CatalogProvider) LoadComponentRuntimeMetadata(componentType, providerID
 		return nil, fmt.Errorf("failed to get component path: %w", err)
 	}
 
-	// Get runtime
-	runtime := vars.RuntimeFactory.GetRuntimeType()
-	runtimeStr := string(runtime)
-
 	// Build catalog path with runtime
-	catalogPath := filepath.Join(componentPath, runtimeStr)
+	catalogPath := filepath.Join(componentPath, runtimeType)
 
 	// Read metadata.yaml using the item's own filesystem
 	itemFS, err := p.getItemFS(componentKey)
@@ -912,19 +910,17 @@ func (p *CatalogProvider) LoadComponentTemplates(componentType, providerID strin
 
 // LoadServiceRuntimeMetadata loads runtime-specific metadata for a service.
 // This includes PodTemplateExecutions and other runtime configuration.
-func (p *CatalogProvider) LoadServiceRuntimeMetadata(serviceID string) (*clitemplates.AppMetadata, error) {
+// runtimeType selects the runtime subdirectory (e.g. "podman" or "openshift").
+// Pass string(vars.RuntimeFactory.GetRuntimeType()) when targeting the local runtime.
+func (p *CatalogProvider) LoadServiceRuntimeMetadata(serviceID, runtimeType string) (*clitemplates.AppMetadata, error) {
 	// Get service path from catalog
 	servicePath, err := p.GetCatalogItemPath(serviceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get service path: %w", err)
 	}
 
-	// Get runtime
-	runtime := vars.RuntimeFactory.GetRuntimeType()
-	runtimeStr := string(runtime)
-
 	// Build catalog path with runtime
-	catalogPath := filepath.Join(servicePath, runtimeStr)
+	catalogPath := filepath.Join(servicePath, runtimeType)
 
 	// Read metadata.yaml using the item's own filesystem
 	itemFS, err := p.getItemFS(serviceID)

--- a/ai-services/internal/pkg/catalog/client/application.go
+++ b/ai-services/internal/pkg/catalog/client/application.go
@@ -276,14 +276,17 @@ func (c *ApplicationClient) GetArchitectureDeployOptions(ctx context.Context, ar
 }
 
 // GetComponentProviderParams retrieves the parameter schema for a specific component provider.
-// runtimeType is currently unused by the params endpoint (it has no ?runtime= param) but is
-// accepted to satisfy the CatalogSource / EmbeddedCatalog interfaces.
-func (c *ApplicationClient) GetComponentProviderParams(ctx context.Context, componentType, providerID, _ string) (map[string]any, error) {
+// runtimeType is optional; when non-empty it is sent as the ?runtime= query parameter so the
+// server returns the schema for that runtime (e.g. "podman" or "openshift").
+func (c *ApplicationClient) GetComponentProviderParams(ctx context.Context, componentType, providerID, runtimeType string) (map[string]any, error) {
 	var result map[string]any
-	resp, err := c.client.HTTPClient().R().
+	req := c.client.HTTPClient().R().
 		SetContext(ctx).
-		SetResult(&result).
-		Get(fmt.Sprintf(compProviderParamsRoute, componentType, providerID))
+		SetResult(&result)
+	if runtimeType != "" {
+		req = req.SetQueryParam("runtime", runtimeType)
+	}
+	resp, err := req.Get(fmt.Sprintf(compProviderParamsRoute, componentType, providerID))
 	if err != nil {
 		return nil, fmt.Errorf("get component provider params: %w", err)
 	}
@@ -474,14 +477,17 @@ func (c *ApplicationClient) GetServiceDetails(ctx context.Context, serviceID str
 }
 
 // GetServiceParams retrieves the parameter schema for a specific service from the catalog API.
-// runtimeType is currently unused by the params endpoint (it has no ?runtime= param) but is
-// accepted to satisfy the CatalogSource / EmbeddedCatalog interfaces.
-func (c *ApplicationClient) GetServiceParams(ctx context.Context, serviceID, _ string) (map[string]any, error) {
+// runtimeType is optional; when non-empty it is sent as the ?runtime= query parameter so the
+// server returns the schema for that runtime (e.g. "podman" or "openshift").
+func (c *ApplicationClient) GetServiceParams(ctx context.Context, serviceID, runtimeType string) (map[string]any, error) {
 	var result map[string]any
-	resp, err := c.client.HTTPClient().R().
+	req := c.client.HTTPClient().R().
 		SetContext(ctx).
-		SetResult(&result).
-		Get(fmt.Sprintf(svcParamsRoute, serviceID))
+		SetResult(&result)
+	if runtimeType != "" {
+		req = req.SetQueryParam("runtime", runtimeType)
+	}
+	resp, err := req.Get(fmt.Sprintf(svcParamsRoute, serviceID))
 	if err != nil {
 		return nil, fmt.Errorf("get service params: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/client/application.go
+++ b/ai-services/internal/pkg/catalog/client/application.go
@@ -229,18 +229,17 @@ func (c *ApplicationClient) CreateApplication(ctx context.Context, req *models.C
 
 // GetServiceDeployOptions retrieves deploy options for a specific service.
 // It returns available providers and dependency rules for the service and its components.
-// runtimeType is optional; when non-empty it is appended as ?runtime=<runtimeType> so the
+// runtimeType is optional; when non-empty it is sent as the ?runtime= query parameter so the
 // server returns schemas and resource specs for that runtime (e.g. "podman" or "openshift").
 func (c *ApplicationClient) GetServiceDeployOptions(ctx context.Context, serviceID, runtimeType string) (*types.DeployOptionsService, error) {
 	var result types.DeployOptionsService
-	url := fmt.Sprintf(svcDeployOptionsRoute, serviceID)
-	if runtimeType != "" {
-		url += "?runtime=" + runtimeType
-	}
-	resp, err := c.client.HTTPClient().R().
+	req := c.client.HTTPClient().R().
 		SetContext(ctx).
-		SetResult(&result).
-		Get(url)
+		SetResult(&result)
+	if runtimeType != "" {
+		req = req.SetQueryParam("runtime", runtimeType)
+	}
+	resp, err := req.Get(fmt.Sprintf(svcDeployOptionsRoute, serviceID))
 	if err != nil {
 		return nil, fmt.Errorf("get service deploy options: %w", err)
 	}
@@ -254,18 +253,17 @@ func (c *ApplicationClient) GetServiceDeployOptions(ctx context.Context, service
 
 // GetArchitectureDeployOptions retrieves deploy options for an architecture.
 // It returns available providers and dependency rules for all services in the architecture.
-// runtimeType is optional; when non-empty it is appended as ?runtime=<runtimeType> so the
+// runtimeType is optional; when non-empty it is sent as the ?runtime= query parameter so the
 // server returns schemas and resource specs for that runtime (e.g. "podman" or "openshift").
 func (c *ApplicationClient) GetArchitectureDeployOptions(ctx context.Context, architectureID, runtimeType string) (*types.DeployOptionsArchitecture, error) {
 	var result types.DeployOptionsArchitecture
-	url := fmt.Sprintf(archDeployOptionsRoute, architectureID)
-	if runtimeType != "" {
-		url += "?runtime=" + runtimeType
-	}
-	resp, err := c.client.HTTPClient().R().
+	req := c.client.HTTPClient().R().
 		SetContext(ctx).
-		SetResult(&result).
-		Get(url)
+		SetResult(&result)
+	if runtimeType != "" {
+		req = req.SetQueryParam("runtime", runtimeType)
+	}
+	resp, err := req.Get(fmt.Sprintf(archDeployOptionsRoute, architectureID))
 	if err != nil {
 		return nil, fmt.Errorf("get architecture deploy options: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/client/application.go
+++ b/ai-services/internal/pkg/catalog/client/application.go
@@ -229,12 +229,18 @@ func (c *ApplicationClient) CreateApplication(ctx context.Context, req *models.C
 
 // GetServiceDeployOptions retrieves deploy options for a specific service.
 // It returns available providers and dependency rules for the service and its components.
-func (c *ApplicationClient) GetServiceDeployOptions(ctx context.Context, serviceID string) (*types.DeployOptionsService, error) {
+// runtimeType is optional; when non-empty it is appended as ?runtime=<runtimeType> so the
+// server returns schemas and resource specs for that runtime (e.g. "podman" or "openshift").
+func (c *ApplicationClient) GetServiceDeployOptions(ctx context.Context, serviceID, runtimeType string) (*types.DeployOptionsService, error) {
 	var result types.DeployOptionsService
+	url := fmt.Sprintf(svcDeployOptionsRoute, serviceID)
+	if runtimeType != "" {
+		url += "?runtime=" + runtimeType
+	}
 	resp, err := c.client.HTTPClient().R().
 		SetContext(ctx).
 		SetResult(&result).
-		Get(fmt.Sprintf(svcDeployOptionsRoute, serviceID))
+		Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("get service deploy options: %w", err)
 	}
@@ -248,12 +254,18 @@ func (c *ApplicationClient) GetServiceDeployOptions(ctx context.Context, service
 
 // GetArchitectureDeployOptions retrieves deploy options for an architecture.
 // It returns available providers and dependency rules for all services in the architecture.
-func (c *ApplicationClient) GetArchitectureDeployOptions(ctx context.Context, architectureID string) (*types.DeployOptionsArchitecture, error) {
+// runtimeType is optional; when non-empty it is appended as ?runtime=<runtimeType> so the
+// server returns schemas and resource specs for that runtime (e.g. "podman" or "openshift").
+func (c *ApplicationClient) GetArchitectureDeployOptions(ctx context.Context, architectureID, runtimeType string) (*types.DeployOptionsArchitecture, error) {
 	var result types.DeployOptionsArchitecture
+	url := fmt.Sprintf(archDeployOptionsRoute, architectureID)
+	if runtimeType != "" {
+		url += "?runtime=" + runtimeType
+	}
 	resp, err := c.client.HTTPClient().R().
 		SetContext(ctx).
 		SetResult(&result).
-		Get(fmt.Sprintf(archDeployOptionsRoute, architectureID))
+		Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("get architecture deploy options: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/client/application.go
+++ b/ai-services/internal/pkg/catalog/client/application.go
@@ -278,7 +278,9 @@ func (c *ApplicationClient) GetArchitectureDeployOptions(ctx context.Context, ar
 }
 
 // GetComponentProviderParams retrieves the parameter schema for a specific component provider.
-func (c *ApplicationClient) GetComponentProviderParams(ctx context.Context, componentType, providerID string) (map[string]any, error) {
+// runtimeType is currently unused by the params endpoint (it has no ?runtime= param) but is
+// accepted to satisfy the CatalogSource / EmbeddedCatalog interfaces.
+func (c *ApplicationClient) GetComponentProviderParams(ctx context.Context, componentType, providerID, _ string) (map[string]any, error) {
 	var result map[string]any
 	resp, err := c.client.HTTPClient().R().
 		SetContext(ctx).
@@ -474,7 +476,9 @@ func (c *ApplicationClient) GetServiceDetails(ctx context.Context, serviceID str
 }
 
 // GetServiceParams retrieves the parameter schema for a specific service from the catalog API.
-func (c *ApplicationClient) GetServiceParams(ctx context.Context, serviceID string) (map[string]any, error) {
+// runtimeType is currently unused by the params endpoint (it has no ?runtime= param) but is
+// accepted to satisfy the CatalogSource / EmbeddedCatalog interfaces.
+func (c *ApplicationClient) GetServiceParams(ctx context.Context, serviceID, _ string) (map[string]any, error) {
 	var result map[string]any
 	resp, err := c.client.HTTPClient().R().
 		SetContext(ctx).

--- a/ai-services/internal/pkg/catalog/client/catalog_source.go
+++ b/ai-services/internal/pkg/catalog/client/catalog_source.go
@@ -38,9 +38,11 @@ type CatalogSource interface {
 	// LoadService returns the full details of a single service.
 	LoadService(ctx context.Context, id string) (*types.Service, error)
 	// GetServiceParams returns the JSON schema for a service's parameters.
-	GetServiceParams(ctx context.Context, serviceID string) (map[string]any, error)
+	// runtimeType selects the runtime subdirectory (e.g. "podman" or "openshift").
+	GetServiceParams(ctx context.Context, serviceID, runtimeType string) (map[string]any, error)
 	// GetComponentProviderParams returns the JSON schema for a component provider's parameters.
-	GetComponentProviderParams(ctx context.Context, componentType, providerID string) (map[string]any, error)
+	// runtimeType selects the runtime subdirectory (e.g. "podman" or "openshift").
+	GetComponentProviderParams(ctx context.Context, componentType, providerID, runtimeType string) (map[string]any, error)
 }
 
 // NewCatalogSource builds a CatalogSource that tries the catalog API first and
@@ -147,23 +149,23 @@ func (s *apiSource) LoadService(ctx context.Context, id string) (*types.Service,
 	return svc, err
 }
 
-func (s *apiSource) GetServiceParams(ctx context.Context, serviceID string) (map[string]any, error) {
-	schema, err := s.api.GetServiceParams(ctx, serviceID)
+func (s *apiSource) GetServiceParams(ctx context.Context, serviceID, runtimeType string) (map[string]any, error) {
+	schema, err := s.api.GetServiceParams(ctx, serviceID, runtimeType)
 	if err != nil && isConnectivityError(err) {
 		logger.DebugfCtx(ctx, "API GetServiceParams unreachable, falling back to embedded: %v", err)
 
-		return s.embedded.GetServiceParams(ctx, serviceID)
+		return s.embedded.GetServiceParams(ctx, serviceID, runtimeType)
 	}
 
 	return schema, err
 }
 
-func (s *apiSource) GetComponentProviderParams(ctx context.Context, componentType, providerID string) (map[string]any, error) {
-	schema, err := s.api.GetComponentProviderParams(ctx, componentType, providerID)
+func (s *apiSource) GetComponentProviderParams(ctx context.Context, componentType, providerID, runtimeType string) (map[string]any, error) {
+	schema, err := s.api.GetComponentProviderParams(ctx, componentType, providerID, runtimeType)
 	if err != nil && isConnectivityError(err) {
 		logger.DebugfCtx(ctx, "API GetComponentProviderParams unreachable, falling back to embedded: %v", err)
 
-		return s.embedded.GetComponentProviderParams(ctx, componentType, providerID)
+		return s.embedded.GetComponentProviderParams(ctx, componentType, providerID, runtimeType)
 	}
 
 	return schema, err
@@ -182,8 +184,8 @@ type EmbeddedCatalog interface {
 	ListComponents() ([]types.Component, error)
 	LoadArchitecture(id string) (*types.Architecture, error)
 	LoadService(id string) (*types.Service, error)
-	GetServiceParams(ctx context.Context, serviceID string) (map[string]any, error)
-	GetComponentProviderParams(ctx context.Context, componentType, providerID string) (map[string]any, error)
+	GetServiceParams(ctx context.Context, serviceID, runtimeType string) (map[string]any, error)
+	GetComponentProviderParams(ctx context.Context, componentType, providerID, runtimeType string) (map[string]any, error)
 }
 
 type embeddedOnlySource struct {
@@ -210,12 +212,12 @@ func (s *embeddedOnlySource) LoadService(_ context.Context, id string) (*types.S
 	return loadServiceFromEmbedded(s.embedded, id)
 }
 
-func (s *embeddedOnlySource) GetServiceParams(ctx context.Context, serviceID string) (map[string]any, error) {
-	return s.embedded.GetServiceParams(ctx, serviceID)
+func (s *embeddedOnlySource) GetServiceParams(ctx context.Context, serviceID, runtimeType string) (map[string]any, error) {
+	return s.embedded.GetServiceParams(ctx, serviceID, runtimeType)
 }
 
-func (s *embeddedOnlySource) GetComponentProviderParams(ctx context.Context, componentType, providerID string) (map[string]any, error) {
-	return s.embedded.GetComponentProviderParams(ctx, componentType, providerID)
+func (s *embeddedOnlySource) GetComponentProviderParams(ctx context.Context, componentType, providerID, runtimeType string) (map[string]any, error) {
+	return s.embedded.GetComponentProviderParams(ctx, componentType, providerID, runtimeType)
 }
 
 // --------------------------------------------------------------------------

--- a/ai-services/internal/pkg/catalog/deploy_options.go
+++ b/ai-services/internal/pkg/catalog/deploy_options.go
@@ -138,9 +138,10 @@ func (p *CatalogProvider) getServiceVersion(serviceID, runtimeType string) strin
 }
 
 // addServiceSchemaIfPresent adds schema URL to service if it has non-empty properties.
+// The URL includes ?runtime= so the UI fetches the correct runtime-specific schema.
 func (p *CatalogProvider) addServiceSchemaIfPresent(ctx context.Context, deployOptionsService *types.DeployOptionsService, serviceID, runtimeType string) {
 	if schema, err := p.GetServiceParams(ctx, serviceID, runtimeType); err == nil && hasNonEmptyProperties(schema) {
-		deployOptionsService.Schema = fmt.Sprintf("/api/v1/services/%s/params", serviceID)
+		deployOptionsService.Schema = fmt.Sprintf("/api/v1/services/%s/params?runtime=%s", serviceID, runtimeType)
 	}
 }
 
@@ -194,9 +195,10 @@ func (p *CatalogProvider) GetServiceDeployOptions(ctx context.Context, serviceID
 		Resources:  resources,
 	}
 
-	// Only add schema if the service has non-empty schema properties
+	// Only add schema if the service has non-empty schema properties.
+	// Include ?runtime= so the UI fetches the correct runtime-specific schema.
 	if schema, err := p.GetServiceParams(ctx, serviceID, runtimeType); err == nil && hasNonEmptyProperties(schema) {
-		deployOptions.Schema = fmt.Sprintf("/api/v1/services/%s/params", serviceID)
+		deployOptions.Schema = fmt.Sprintf("/api/v1/services/%s/params?runtime=%s", serviceID, runtimeType)
 	}
 
 	return deployOptions, nil
@@ -271,9 +273,10 @@ func (p *CatalogProvider) buildProvider(ctx context.Context, comp types.Componen
 		Resources:   resources,
 	}
 
-	// Only add schema if the schema file has non-empty properties
+	// Only add schema if the schema file has non-empty properties.
+	// Include ?runtime= so the UI fetches the correct runtime-specific schema.
 	if schema, err := p.GetComponentProviderParams(ctx, componentType, comp.ID, runtimeType); err == nil && hasNonEmptyProperties(schema) {
-		provider.Schema = fmt.Sprintf("/api/v1/components/%s/providers/%s/params", componentType, comp.ID)
+		provider.Schema = fmt.Sprintf("/api/v1/components/%s/providers/%s/params?runtime=%s", componentType, comp.ID, runtimeType)
 	}
 
 	return provider

--- a/ai-services/internal/pkg/catalog/deploy_options.go
+++ b/ai-services/internal/pkg/catalog/deploy_options.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // GetArchitectureDeployOptions returns deploy options for all services in an architecture.
 // Global components are read from architecture metadata, service components from service metadata.
-func (p *CatalogProvider) GetArchitectureDeployOptions(ctx context.Context, architectureID string) (*types.DeployOptionsArchitecture, error) {
+// runtimeType controls which runtime subdirectory is read for resources and schemas
+// (e.g. "podman" or "openshift"). Pass string(vars.RuntimeFactory.GetRuntimeType()) for the
+// local runtime, or pass the runtime type declared by a remote worker.
+func (p *CatalogProvider) GetArchitectureDeployOptions(ctx context.Context, architectureID, runtimeType string) (*types.DeployOptionsArchitecture, error) {
 	// Load architecture metadata
 	arch, err := p.LoadArchitecture(architectureID)
 	if err != nil {
@@ -21,13 +23,13 @@ func (p *CatalogProvider) GetArchitectureDeployOptions(ctx context.Context, arch
 	}
 
 	// Build global components from architecture metadata
-	globalComponents, err := p.buildGlobalComponents(ctx, arch.GlobalComponents)
+	globalComponents, err := p.buildGlobalComponents(ctx, arch.GlobalComponents, runtimeType)
 	if err != nil {
 		return nil, err
 	}
 
 	// Build services with their components from service metadata
-	services, err := p.buildArchitectureServices(ctx, arch.Services)
+	services, err := p.buildArchitectureServices(ctx, arch.Services, runtimeType)
 	if err != nil {
 		return nil, err
 	}
@@ -42,10 +44,10 @@ func (p *CatalogProvider) GetArchitectureDeployOptions(ctx context.Context, arch
 }
 
 // buildGlobalComponents builds deploy options for global components.
-func (p *CatalogProvider) buildGlobalComponents(ctx context.Context, compRefs []types.ComponentReference) ([]types.DeployOptionsComponent, error) {
+func (p *CatalogProvider) buildGlobalComponents(ctx context.Context, compRefs []types.ComponentReference, runtimeType string) ([]types.DeployOptionsComponent, error) {
 	globalComponents := make([]types.DeployOptionsComponent, 0, len(compRefs))
 	for _, compRef := range compRefs {
-		component, err := p.buildDeployOptionsComponent(ctx, compRef.Type, false)
+		component, err := p.buildDeployOptionsComponent(ctx, compRef.Type, false, runtimeType)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build global component '%s': %w", compRef.Type, err)
 		}
@@ -56,10 +58,10 @@ func (p *CatalogProvider) buildGlobalComponents(ctx context.Context, compRefs []
 }
 
 // buildArchitectureServices builds deploy options for all services in an architecture.
-func (p *CatalogProvider) buildArchitectureServices(ctx context.Context, svcRefs []types.ServiceReference) ([]types.DeployOptionsService, error) {
+func (p *CatalogProvider) buildArchitectureServices(ctx context.Context, svcRefs []types.ServiceReference, runtimeType string) ([]types.DeployOptionsService, error) {
 	services := make([]types.DeployOptionsService, 0, len(svcRefs))
 	for _, svcRef := range svcRefs {
-		deployOptionsService, err := p.buildSingleService(ctx, svcRef.ID)
+		deployOptionsService, err := p.buildSingleService(ctx, svcRef.ID, runtimeType)
 		if err != nil {
 			return nil, err
 		}
@@ -70,24 +72,24 @@ func (p *CatalogProvider) buildArchitectureServices(ctx context.Context, svcRefs
 }
 
 // buildSingleService builds deploy options for a single service.
-func (p *CatalogProvider) buildSingleService(ctx context.Context, serviceID string) (*types.DeployOptionsService, error) {
+func (p *CatalogProvider) buildSingleService(ctx context.Context, serviceID, runtimeType string) (*types.DeployOptionsService, error) {
 	service, err := p.LoadService(serviceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load service '%s': %w", serviceID, err)
 	}
 
 	// Load service runtime metadata to get version
-	serviceVersion := p.getServiceVersion(service.ID)
+	serviceVersion := p.getServiceVersion(service.ID, runtimeType)
 
 	// Build all components for this service from its dependencies
-	components, err := p.buildServiceComponents(ctx, service.ID, service.Dependencies)
+	components, err := p.buildServiceComponents(ctx, service.ID, service.Dependencies, runtimeType)
 	if err != nil {
 		return nil, err
 	}
 
 	// Load resources from runtime-specific metadata
 	var resources *types.Resources
-	runtimeMetadata, err := p.LoadServiceRuntimeMetadata(service.ID)
+	runtimeMetadata, err := p.LoadServiceRuntimeMetadata(service.ID, runtimeType)
 	if err == nil && runtimeMetadata.Resources != nil {
 		// Convert RuntimeResources to types.Resources
 		resources = &types.Resources{
@@ -107,16 +109,16 @@ func (p *CatalogProvider) buildSingleService(ctx context.Context, serviceID stri
 	}
 
 	// Only add schema if the service has non-empty schema properties
-	p.addServiceSchemaIfPresent(ctx, deployOptionsService, service.ID)
+	p.addServiceSchemaIfPresent(ctx, deployOptionsService, service.ID, runtimeType)
 
 	return deployOptionsService, nil
 }
 
 // buildServiceComponents builds deploy options components for a service's dependencies.
-func (p *CatalogProvider) buildServiceComponents(ctx context.Context, serviceID string, dependencies []types.DependencyReference) ([]types.DeployOptionsComponent, error) {
+func (p *CatalogProvider) buildServiceComponents(ctx context.Context, serviceID string, dependencies []types.DependencyReference, runtimeType string) ([]types.DeployOptionsComponent, error) {
 	components := make([]types.DeployOptionsComponent, 0, len(dependencies))
 	for _, dep := range dependencies {
-		component, err := p.buildDeployOptionsComponent(ctx, dep.ID, true)
+		component, err := p.buildDeployOptionsComponent(ctx, dep.ID, true, runtimeType)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build component '%s' for service '%s': %w", dep.ID, serviceID, err)
 		}
@@ -127,8 +129,8 @@ func (p *CatalogProvider) buildServiceComponents(ctx context.Context, serviceID 
 }
 
 // getServiceVersion retrieves the version for a service, returning empty string if not found.
-func (p *CatalogProvider) getServiceVersion(serviceID string) string {
-	if runtimeMetadata, err := p.LoadServiceRuntimeMetadata(serviceID); err == nil {
+func (p *CatalogProvider) getServiceVersion(serviceID, runtimeType string) string {
+	if runtimeMetadata, err := p.LoadServiceRuntimeMetadata(serviceID, runtimeType); err == nil {
 		return runtimeMetadata.Version
 	}
 
@@ -136,14 +138,17 @@ func (p *CatalogProvider) getServiceVersion(serviceID string) string {
 }
 
 // addServiceSchemaIfPresent adds schema URL to service if it has non-empty properties.
-func (p *CatalogProvider) addServiceSchemaIfPresent(ctx context.Context, deployOptionsService *types.DeployOptionsService, serviceID string) {
-	if schema, err := p.GetServiceParams(ctx, serviceID); err == nil && hasNonEmptyProperties(schema) {
+func (p *CatalogProvider) addServiceSchemaIfPresent(ctx context.Context, deployOptionsService *types.DeployOptionsService, serviceID, runtimeType string) {
+	if schema, err := p.GetServiceParams(ctx, serviceID, runtimeType); err == nil && hasNonEmptyProperties(schema) {
 		deployOptionsService.Schema = fmt.Sprintf("/api/v1/services/%s/params", serviceID)
 	}
 }
 
 // GetServiceDeployOptions returns deploy options for a specific service.
-func (p *CatalogProvider) GetServiceDeployOptions(ctx context.Context, serviceID string) (*types.DeployOptionsService, error) {
+// runtimeType controls which runtime subdirectory is read for resources and schemas
+// (e.g. "podman" or "openshift"). Pass string(vars.RuntimeFactory.GetRuntimeType()) for the
+// local runtime, or pass the runtime type declared by a remote worker.
+func (p *CatalogProvider) GetServiceDeployOptions(ctx context.Context, serviceID, runtimeType string) (*types.DeployOptionsService, error) {
 	// Load service metadata
 	service, err := p.LoadService(serviceID)
 	if err != nil {
@@ -152,14 +157,14 @@ func (p *CatalogProvider) GetServiceDeployOptions(ctx context.Context, serviceID
 
 	// Load service runtime metadata to get version
 	serviceVersion := ""
-	if runtimeMetadata, err := p.LoadServiceRuntimeMetadata(service.ID); err == nil {
+	if runtimeMetadata, err := p.LoadServiceRuntimeMetadata(service.ID, runtimeType); err == nil {
 		serviceVersion = runtimeMetadata.Version
 	}
 
 	// Build components list
 	components := make([]types.DeployOptionsComponent, 0, len(service.Dependencies))
 	for _, dep := range service.Dependencies {
-		component, err := p.buildDeployOptionsComponent(ctx, dep.ID, true)
+		component, err := p.buildDeployOptionsComponent(ctx, dep.ID, true, runtimeType)
 		if err != nil {
 			logger.ErrorfCtx(ctx, "failed to build component '%s': %v", dep.ID, err)
 
@@ -170,7 +175,7 @@ func (p *CatalogProvider) GetServiceDeployOptions(ctx context.Context, serviceID
 
 	// Load resources from runtime-specific metadata
 	var resources *types.Resources
-	runtimeMetadata, err := p.LoadServiceRuntimeMetadata(service.ID)
+	runtimeMetadata, err := p.LoadServiceRuntimeMetadata(service.ID, runtimeType)
 	if err == nil && runtimeMetadata.Resources != nil {
 		// Convert RuntimeResources to types.Resources
 		resources = &types.Resources{
@@ -190,7 +195,7 @@ func (p *CatalogProvider) GetServiceDeployOptions(ctx context.Context, serviceID
 	}
 
 	// Only add schema if the service has non-empty schema properties
-	if schema, err := p.GetServiceParams(ctx, serviceID); err == nil && hasNonEmptyProperties(schema) {
+	if schema, err := p.GetServiceParams(ctx, serviceID, runtimeType); err == nil && hasNonEmptyProperties(schema) {
 		deployOptions.Schema = fmt.Sprintf("/api/v1/services/%s/params", serviceID)
 	}
 
@@ -199,7 +204,7 @@ func (p *CatalogProvider) GetServiceDeployOptions(ctx context.Context, serviceID
 
 // buildDeployOptionsComponent builds a DeployOptionsComponent for a given component type.
 // includeResources controls whether to include resource information in providers.
-func (p *CatalogProvider) buildDeployOptionsComponent(ctx context.Context, componentType string, includeResources bool) (*types.DeployOptionsComponent, error) {
+func (p *CatalogProvider) buildDeployOptionsComponent(ctx context.Context, componentType string, includeResources bool, runtimeType string) (*types.DeployOptionsComponent, error) {
 	// List all components of this type
 	allComponents, err := p.ListComponents()
 	if err != nil {
@@ -221,7 +226,7 @@ func (p *CatalogProvider) buildDeployOptionsComponent(ctx context.Context, compo
 		}
 
 		// Build provider with version, resources and schema
-		provider := p.buildProvider(ctx, comp, componentType, includeResources)
+		provider := p.buildProvider(ctx, comp, componentType, includeResources, runtimeType)
 		providers = append(providers, provider)
 	}
 
@@ -238,12 +243,12 @@ func (p *CatalogProvider) buildDeployOptionsComponent(ctx context.Context, compo
 }
 
 // buildProvider builds a DeployOptionsProvider from a component, including version, resources and schema if applicable.
-func (p *CatalogProvider) buildProvider(ctx context.Context, comp types.Component, componentType string, includeResources bool) types.DeployOptionsProvider {
+func (p *CatalogProvider) buildProvider(ctx context.Context, comp types.Component, componentType string, includeResources bool, runtimeType string) types.DeployOptionsProvider {
 	// Load component runtime metadata
 	providerVersion := ""
 	var resources *types.Resources
 
-	if runtimeMetadata, err := p.LoadComponentRuntimeMetadata(componentType, comp.ID); err == nil {
+	if runtimeMetadata, err := p.LoadComponentRuntimeMetadata(componentType, comp.ID, runtimeType); err == nil {
 		providerVersion = runtimeMetadata.Version
 
 		// Only include resources if requested and available
@@ -267,7 +272,7 @@ func (p *CatalogProvider) buildProvider(ctx context.Context, comp types.Componen
 	}
 
 	// Only add schema if the schema file has non-empty properties
-	if schema, err := p.GetComponentProviderParams(ctx, componentType, comp.ID); err == nil && hasNonEmptyProperties(schema) {
+	if schema, err := p.GetComponentProviderParams(ctx, componentType, comp.ID, runtimeType); err == nil && hasNonEmptyProperties(schema) {
 		provider.Schema = fmt.Sprintf("/api/v1/components/%s/providers/%s/params", componentType, comp.ID)
 	}
 
@@ -285,7 +290,9 @@ func hasNonEmptyProperties(schema map[string]any) bool {
 
 // GetComponentProviderParams returns the JSON schema for a specific provider's configuration.
 // If the schema file is not present, returns an empty schema instead of failing.
-func (p *CatalogProvider) GetComponentProviderParams(ctx context.Context, componentType, providerID string) (map[string]any, error) {
+// runtimeType selects the runtime subdirectory (e.g. "podman" or "openshift").
+// Pass string(vars.RuntimeFactory.GetRuntimeType()) when targeting the local runtime.
+func (p *CatalogProvider) GetComponentProviderParams(ctx context.Context, componentType, providerID, runtimeType string) (map[string]any, error) {
 	// Verify component exists and get its path
 	_, err := p.LoadComponent(componentType, providerID)
 	if err != nil {
@@ -303,8 +310,7 @@ func (p *CatalogProvider) GetComponentProviderParams(ctx context.Context, compon
 		return nil, fmt.Errorf("failed to get component filesystem: %w", err)
 	}
 
-	runtimeStr := string(vars.RuntimeFactory.GetRuntimeType())
-	schemaPath := filepath.Join(componentPath, runtimeStr, "values.schema.json")
+	schemaPath := filepath.Join(componentPath, runtimeType, "values.schema.json")
 	schemaData, err := itemFS.Open(schemaPath)
 	if err != nil {
 		// Schema file is optional — return an empty schema rather than failing.
@@ -370,7 +376,9 @@ func (p *CatalogProvider) GetConnectorProviderParams(ctx context.Context, connec
 
 // GetServiceParams returns the JSON schema for a specific service's configuration.
 // If the schema file is not present, returns an empty schema instead of failing.
-func (p *CatalogProvider) GetServiceParams(ctx context.Context, serviceID string) (map[string]any, error) {
+// runtimeType selects the runtime subdirectory (e.g. "podman" or "openshift").
+// Pass string(vars.RuntimeFactory.GetRuntimeType()) when targeting the local runtime.
+func (p *CatalogProvider) GetServiceParams(ctx context.Context, serviceID, runtimeType string) (map[string]any, error) {
 	// Verify service exists and get its path
 	_, err := p.LoadService(serviceID)
 	if err != nil {
@@ -387,8 +395,7 @@ func (p *CatalogProvider) GetServiceParams(ctx context.Context, serviceID string
 		return nil, fmt.Errorf("failed to get service filesystem: %w", err)
 	}
 
-	runtimeStr := string(vars.RuntimeFactory.GetRuntimeType())
-	schemaPath := filepath.Join(servicePath, runtimeStr, "values.schema.json")
+	schemaPath := filepath.Join(servicePath, runtimeType, "values.schema.json")
 	schemaFile, err := itemFS.Open(schemaPath)
 	if err != nil {
 		// Schema file is optional — return an empty schema rather than failing.

--- a/ai-services/internal/pkg/catalog/model_extractor.go
+++ b/ai-services/internal/pkg/catalog/model_extractor.go
@@ -8,6 +8,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // GetArchitectureModels collects all unique models from component schemas across
@@ -129,7 +130,7 @@ func (p *CatalogProvider) collectComponentsByTypeModels(ctx context.Context, com
 // For components, models are read from values.schema.json file using GetComponentProviderParams.
 func (p *CatalogProvider) addComponentModels(ctx context.Context, componentType, componentID string, allModels map[string]bool) error {
 	// Use existing GetComponentProviderParams to load the schema
-	schema, err := p.GetComponentProviderParams(ctx, componentType, componentID)
+	schema, err := p.GetComponentProviderParams(ctx, componentType, componentID, string(vars.RuntimeFactory.GetRuntimeType()))
 	if err != nil {
 		return fmt.Errorf("failed to get component schema for %s/%s: %w", componentType, componentID, err)
 	}

--- a/ai-services/internal/pkg/catalog/validators/validation.go
+++ b/ai-services/internal/pkg/catalog/validators/validation.go
@@ -14,6 +14,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	pkgutils "github.com/project-ai-services/ai-services/internal/pkg/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // ValidationError represents a validation error with HTTP status code.
@@ -110,7 +111,7 @@ func (v *ApplicationValidator) validateVersion(
 // ValidateServiceVersion validates that the service version matches the runtime metadata.
 func (v *ApplicationValidator) ValidateServiceVersion(serviceID, requestedVersion string) error {
 	return v.validateVersion("Service", serviceID, requestedVersion, func() (string, error) {
-		metadata, err := v.provider.LoadServiceRuntimeMetadata(serviceID)
+		metadata, err := v.provider.LoadServiceRuntimeMetadata(serviceID, string(vars.RuntimeFactory.GetRuntimeType()))
 		if err != nil {
 			return "", err
 		}
@@ -124,7 +125,7 @@ func (v *ApplicationValidator) ValidateComponentVersion(componentType, providerI
 	itemID := fmt.Sprintf("%s/%s", componentType, providerID)
 
 	return v.validateVersion("Component", itemID, requestedVersion, func() (string, error) {
-		metadata, err := v.provider.LoadComponentRuntimeMetadata(componentType, providerID)
+		metadata, err := v.provider.LoadComponentRuntimeMetadata(componentType, providerID, string(vars.RuntimeFactory.GetRuntimeType()))
 		if err != nil {
 			return "", err
 		}
@@ -153,14 +154,14 @@ func (v *ApplicationValidator) validateParamsWithSchema(
 // ValidateServiceParams validates service-level parameters against schema.
 func (v *ApplicationValidator) ValidateServiceParams(ctx context.Context, serviceID string, params map[string]any) error {
 	return v.validateParamsWithSchema(params, func() (map[string]any, error) {
-		return v.provider.GetServiceParams(ctx, serviceID)
+		return v.provider.GetServiceParams(ctx, serviceID, string(vars.RuntimeFactory.GetRuntimeType()))
 	}, fmt.Sprintf("service '%s'", serviceID))
 }
 
 // ValidateComponentParams validates component parameters against schema.
 func (v *ApplicationValidator) ValidateComponentParams(ctx context.Context, componentType, providerID string, params map[string]any) error {
 	return v.validateParamsWithSchema(params, func() (map[string]any, error) {
-		return v.provider.GetComponentProviderParams(ctx, componentType, providerID)
+		return v.provider.GetComponentProviderParams(ctx, componentType, providerID, string(vars.RuntimeFactory.GetRuntimeType()))
 	}, fmt.Sprintf("component '%s/%s'", componentType, providerID))
 }
 


### PR DESCRIPTION
The deploy-options endpoints (GET /architectures/{id}/deploy-options and GET /services/{id}/deploy-options) previously hard-coded the server's own runtime when reading catalog metadata, resource specs, and parameter schemas.

This PR adds an optional `?runtime=podman|openshift` query parameter to both endpoints. When provided, resources and schemas are read from the matching runtime subdirectory in the catalog. When omitted, the server's local runtime is used.