### PR TITLE
Miscellaneous Digitize Improvements

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.313
+TAG?=v0.0.314
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.54
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.55
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.54
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.55
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.54
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.55
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.54
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.55
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.54
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.55
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.313
+  image: icr.io/ai-services-cicd/ai-services:v0.0.314
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.313
+  image: icr.io/ai-services-cicd/ai-services:v0.0.314
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/services/digitize/openshift/values.yaml
+++ b/ai-services/assets/services/digitize/openshift/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.54
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.55
   log_level: "INFO"
   database: "digitize_metadata"
   numShards: 1

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.54
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.55
   log_level: "INFO"
   database: "digitize_metadata"
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.313
+  image: icr.io/ai-services-cicd/ai-services:v0.0.314
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -4,7 +4,7 @@ caddy:
   httpsPort: ""
 
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.313
+  image: icr.io/ai-services-cicd/ai-services:v0.0.314
   runtime: "podman"
   token: ""
   # optionalFlags covers basedir, sslCertPath, sslKeyPath, domainSuffix, and httpsPort flags that are forwarded from the

--- a/services/common/llm_utils.py
+++ b/services/common/llm_utils.py
@@ -1,11 +1,8 @@
-import logging
 import os
 import requests
 import time
 import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from tqdm import tqdm
-
 from common.misc_utils import get_logger, resolve_model_max_len
 from common.settings import settings
 from common.retry_utils import retry_on_transient_error
@@ -13,7 +10,7 @@ import common.misc_utils as misc_utils
 
 logger = get_logger("LLM")
 
-is_debug = logger.isEnabledFor(logging.DEBUG)
+
 
 def apply_token_buffer(max_tokens: int, token_buffer_ratio: float | None = None, context: str = "LLM") -> int:
     """
@@ -46,13 +43,6 @@ def apply_token_buffer(max_tokens: int, token_buffer_ratio: float | None = None,
     )
     
     return effective_max_tokens
-
-def tqdm_wrapper(iterable, **kwargs):
-    """Wrapper for tqdm that only shows progress bar in debug mode."""
-    if is_debug:
-        return tqdm(iterable, **kwargs)
-    else:
-        return iterable
 
 @retry_on_transient_error(max_retries=3, initial_delay=1.0, backoff_multiplier=2.0)
 def summarize_and_classify_single_table(prompt, gen_model, llm_endpoint, max_tokens: int = 1024):
@@ -140,8 +130,7 @@ def summarize_and_classify_tables(table_mds, gen_model, llm_endpoint, doc_path, 
             executor.submit(summarize_and_classify_single_table, prompt, gen_model, llm_endpoint, max_tokens): idx
             for idx, prompt in enumerate(all_prompts)
         }
-        for future in tqdm_wrapper(as_completed(futures), total=len(all_prompts),
-                                   desc=f"Summarizing and classifying tables of '{doc_path}'"):
+        for future in as_completed(futures):
             idx = futures[future]
             try:
                 results[idx] = future.result()

--- a/services/common/llm_utils.py
+++ b/services/common/llm_utils.py
@@ -134,6 +134,7 @@ def summarize_and_classify_tables(table_mds, gen_model, llm_endpoint, doc_path, 
             idx = futures[future]
             try:
                 results[idx] = future.result()
+                logger.debug(f"Summarized table {idx + 1}/{len(all_prompts)} from '{doc_path}'")
             except Exception as e:
                 error_msg = f"Failed to process table {idx}: {str(e)}"
                 logger.error(error_msg)

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.54
+TAG?=v0.0.55
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/parsing/docx.py
+++ b/services/digitize/parsing/docx.py
@@ -12,8 +12,6 @@ from typing import Dict, List, Tuple, Optional
 from docx import Document
 
 from common.misc_utils import get_logger
-from common.llm_utils import tqdm_wrapper
-
 logger = get_logger("docx_utils")
 
 # Constants for page estimation

--- a/services/digitize/parsing/docx.py
+++ b/services/digitize/parsing/docx.py
@@ -239,7 +239,6 @@ def recover_table_caption_from_body_context(converted_doc, table_ix: int, search
         logger.debug(f"recover_table_caption_from_body_context: {target_ref} -> section header fallback '{section_header}'")
         return section_header
 
-    logger.debug(f"recover_table_caption_from_body_context: {target_ref} -> no caption found")
     return ""
 
 def estimate_docx_page_count(docx_path: str) -> int:

--- a/services/digitize/pipeline/digitize.py
+++ b/services/digitize/pipeline/digitize.py
@@ -11,7 +11,7 @@ document status transitions for digitization jobs.
 import time
 from pathlib import Path
 
-from common.misc_utils import get_logger, get_utc_timestamp
+from common.misc_utils import cleanup_staging_directory, get_logger, get_utc_timestamp
 from digitize.db.manager import db_manager
 from digitize.db.models import ConversionTaskStatus
 from digitize.models import JobStatus, DocStatus
@@ -117,6 +117,13 @@ def digitize(
     except _DeadlineExceeded as exc:
         _fail(str(exc))
         return
+
+    finally:
+        # Remove the staging directory once the full digitization pipeline has
+        # finished (success, failure, timeout, or cancellation).  _run_digitize
+        # also calls cleanup_staging_directory in its own finally — that call is
+        # idempotent and will be a no-op once the directory is already gone.
+        cleanup_staging_directory(job_id, settings.digitize.staging_dir)
 
     if task is None or task.status == ConversionTaskStatus.FAILED:
         _fail((task.error or "Conversion failed") if task else "Task row missing")

--- a/services/digitize/pipeline/ingest.py
+++ b/services/digitize/pipeline/ingest.py
@@ -306,3 +306,11 @@ def ingest(
                 raise fnf_error
 
         return None
+
+    finally:
+        # Remove the staging directory now that all processing (conversion,
+        # page loading, chunking, indexing) has finished.  Callers that do
+        # their own cleanup (sync_tick, _run_ingest) will find the directory
+        # already gone — cleanup_staging_directory is idempotent.
+        if job_id:
+            cleanup_staging_directory(job_id, directory_path.parent)

--- a/services/digitize/processing/orchestrator.py
+++ b/services/digitize/processing/orchestrator.py
@@ -19,7 +19,6 @@ from docling_core.types.doc.document import DoclingDocument
 from sentence_splitter import SentenceSplitter
 
 from common.lang_utils import LanguageCodes, to_sentence_splitter_lang
-from common.llm_utils import tqdm_wrapper
 from common.misc_utils import (
     get_logger,
     get_utc_timestamp,
@@ -173,7 +172,7 @@ def chunk_text(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None, 
             current_subsection = None
             current_subsubsection = None
 
-            for idx, block in enumerate(tqdm_wrapper(data, desc=f"Chunking text from '{input_path}'")):
+            for idx, block in enumerate(data):
                 label = block.get("label")
                 text = block.get("text", "").strip()
                 page_no = block.get("page", 0)
@@ -265,7 +264,7 @@ def chunk_tables(input_path, out_path, emb_endpoint, max_tokens=512, doc_id=None
         if tab_data:
             tab_data_list = list(tab_data.values())
 
-            for block in tqdm_wrapper(tab_data_list, desc=f"Chunking tables of '{input_path}'"):
+            for block in tab_data_list:
                 caption = block.get('caption', '')
                 summary = block.get("summary", '')
                 page_number = block.get('page_number')

--- a/services/digitize/processing/orchestrator.py
+++ b/services/digitize/processing/orchestrator.py
@@ -64,8 +64,6 @@ def split_text_into_token_chunks(text, emb_endpoint, max_tokens=512, overlap=50,
     Returns:
         List of text chunks
     """
-    logger.debug(f"Using language for chunking: {language}")
-
     sentences = SentenceSplitter(language=language).split(text)
     chunks = []
     current_chunk = []

--- a/services/digitize/processing/tables.py
+++ b/services/digitize/processing/tables.py
@@ -290,7 +290,7 @@ def process_table(converted_doc, doc_path, out_path, gen_model, gen_endpoint, do
         raw_markdown = table.export_to_markdown(doc=converted_doc)
         caption = table.caption_text(doc=converted_doc)
 
-        if not caption:
+        if not caption and is_docx:
             caption = recover_table_caption_from_body_context(converted_doc, table_ix)
 
         # Clean the markdown to fix parser glitches and recover hidden captions

--- a/services/digitize/processing/tables.py
+++ b/services/digitize/processing/tables.py
@@ -290,6 +290,11 @@ def process_table(converted_doc, doc_path, out_path, gen_model, gen_endpoint, do
         raw_markdown = table.export_to_markdown(doc=converted_doc)
         caption = table.caption_text(doc=converted_doc)
 
+        # DOCX only: caption_text() returns empty for most Word tables because
+        # Docling rarely populates captions[]. The recovery function scans nearby
+        # body/parent refs for a matching "Table X-Y ..." paragraph.
+        # Skipped for PDFs: Docling stores PDF captions in captions[] (already
+        # handled above), and the section-header fallback would give false positives.
         if not caption and is_docx:
             caption = recover_table_caption_from_body_context(converted_doc, table_ix)
 

--- a/services/digitize/processing/tables.py
+++ b/services/digitize/processing/tables.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from rapidfuzz import fuzz
 
 from common.lang_utils import LanguageCodes, get_prompt_for_language
-from common.llm_utils import summarize_and_classify_tables, tqdm_wrapper
+from common.llm_utils import summarize_and_classify_tables
 from common.misc_utils import get_logger
 from digitize.settings import settings
 
@@ -283,7 +283,7 @@ def process_table(converted_doc, doc_path, out_path, gen_model, gen_endpoint, do
     from digitize.parsing.docx import recover_table_caption_from_body_context
 
     table_dict = {}
-    for table_ix, table in enumerate(tqdm_wrapper(converted_doc.tables, desc=f"Processing table content for '{doc_path}'")):
+    for table_ix, table in enumerate(converted_doc.tables):
         table_dict[table_ix] = {}
 
         # Use Markdown format for better LLM understanding

--- a/services/digitize/processing/text.py
+++ b/services/digitize/processing/text.py
@@ -10,7 +10,6 @@ import json
 import time
 
 from common.lang_utils import LanguageCodes
-from common.llm_utils import tqdm_wrapper
 from common.misc_utils import get_logger
 
 logger = get_logger("processing.text")
@@ -49,7 +48,7 @@ def process_text_docx(converted_doc, docx_path, out_path):
 
     structured_output = []
     last_header_level = 0
-    for text_obj in tqdm_wrapper(converted_doc.texts, desc=f"Processing text content of '{docx_path}'"):
+    for text_obj in converted_doc.texts:
         label = text_obj.label
         if label in excluded_labels:
             continue
@@ -131,7 +130,7 @@ def process_text(converted_doc, doc_path, out_path):
 
     structured_output = []
     last_header_level = 0
-    for text_obj in tqdm_wrapper(converted_doc.texts, desc=f"Processing text content of '{doc_path}'"):
+    for text_obj in converted_doc.texts:
         label = text_obj.label
         if label in excluded_labels:
             continue

--- a/services/digitize/tests/test_conversion_dispatcher.py
+++ b/services/digitize/tests/test_conversion_dispatcher.py
@@ -528,38 +528,6 @@ class TestRunConversion:
 
 
 # ---------------------------------------------------------------------------
-# _safe_remove()
-# ---------------------------------------------------------------------------
-
-@pytest.mark.unit
-class TestSafeRemove:
-    def test_deletes_existing_file(self, tmp_path):
-        from digitize.workers.conversion_dispatcher import _safe_remove
-
-        f = tmp_path / "staged.pdf"
-        f.write_bytes(b"%PDF")
-        assert f.exists()
-
-        _safe_remove(str(f))
-        assert not f.exists()
-
-    def test_silently_ignores_missing_file(self, tmp_path):
-        from digitize.workers.conversion_dispatcher import _safe_remove
-
-        missing = str(tmp_path / "ghost.pdf")
-        # Must not raise
-        _safe_remove(missing)
-
-    def test_silently_ignores_permission_error(self, tmp_path):
-        from digitize.workers.conversion_dispatcher import _safe_remove
-        from unittest.mock import patch
-
-        with patch("pathlib.Path.unlink", side_effect=PermissionError("no write")):
-            # Must not propagate
-            _safe_remove(str(tmp_path / "locked.pdf"))
-
-
-# ---------------------------------------------------------------------------
 # _run_conversion() — page_count from task row + file cleanup
 # ---------------------------------------------------------------------------
 

--- a/services/digitize/tests/test_conversion_dispatcher.py
+++ b/services/digitize/tests/test_conversion_dispatcher.py
@@ -612,8 +612,11 @@ class TestRunConversionUpdated:
         # Confirm no pages metadata was written anywhere in this call.
         # (page_count lives on the task row for the pipeline to consume.)
 
-    def test_cached_file_deleted_on_success(self, tmp_path):
-        """After successful conversion the staged input file must be removed."""
+    def test_cached_file_preserved_on_success(self, tmp_path):
+        """After successful conversion the staged input file must NOT be removed.
+        Cleanup is the responsibility of the pipeline layer (_run_ingest /
+        _run_digitize / sync_tick) which reads the result and then calls
+        cleanup_staging_directory() after all post-conversion processing."""
         import digitize.workers.conversion_dispatcher as mod
 
         cached = tmp_path / "file.pdf"
@@ -629,24 +632,20 @@ class TestRunConversionUpdated:
         async def _run():
             with patch.object(mod.db_manager, "update_task_status"), \
                  patch.object(mod.conversion_semaphore, "release", new_callable=AsyncMock), \
-                 patch("digitize.utils.db.get_status_manager") as mock_gsm, \
-                 patch("asyncio.get_running_loop") as mock_loop, \
-                 patch("common.misc_utils.get_utc_timestamp", return_value="ts"):
+                 patch("asyncio.get_running_loop") as mock_loop:
 
                 mock_event_loop = MagicMock()
                 mock_event_loop.run_in_executor = AsyncMock(return_value=(result_path, 1.0))
                 mock_loop.return_value = mock_event_loop
-                mock_gsm.return_value = Mock()
-                mock_gsm.return_value.update_doc_metadata = Mock()
-                mock_gsm.return_value.update_job_progress = Mock()
 
                 await mod._run_conversion(task, weight=1)
 
         asyncio.run(_run())
-        assert not cached.exists(), "Staged input file should be deleted after success"
+        assert cached.exists(), "Staged input file must be preserved for the pipeline layer"
 
-    def test_cached_file_deleted_on_failure(self, tmp_path):
-        """The staged file is removed even when the conversion raises."""
+    def test_cached_file_preserved_on_failure(self, tmp_path):
+        """The staged file must NOT be removed when conversion raises.
+        The pipeline layer is responsible for cleanup regardless of outcome."""
         import digitize.workers.conversion_dispatcher as mod
 
         cached = tmp_path / "file.pdf"
@@ -660,7 +659,6 @@ class TestRunConversionUpdated:
         async def _run():
             with patch.object(mod.db_manager, "update_task_status"), \
                  patch.object(mod.conversion_semaphore, "release", new_callable=AsyncMock), \
-                 patch("digitize.utils.db.get_status_manager") as mock_gsm, \
                  patch("asyncio.get_running_loop") as mock_loop:
 
                 mock_event_loop = MagicMock()
@@ -668,11 +666,8 @@ class TestRunConversionUpdated:
                     side_effect=RuntimeError("conversion crashed")
                 )
                 mock_loop.return_value = mock_event_loop
-                mock_gsm.return_value = Mock()
-                mock_gsm.return_value.update_doc_metadata = Mock()
-                mock_gsm.return_value.update_job_progress = Mock()
 
                 await mod._run_conversion(task, weight=1)
 
         asyncio.run(_run())
-        assert not cached.exists(), "Staged file should be deleted even on conversion failure"
+        assert cached.exists(), "Staged file must be preserved for the pipeline layer even on failure"

--- a/services/digitize/workers/conversion_dispatcher.py
+++ b/services/digitize/workers/conversion_dispatcher.py
@@ -96,7 +96,9 @@ async def _run_conversion(task: ConversionTask, weight: int) -> None:
     """
     Execute a single conversion task inside the shared process pool.
     Releases the semaphore unconditionally in the finally block.
-    Deletes the staged input file on completion or failure (best-effort).
+    Staged input files are NOT deleted here — each pipeline (_run_ingest,
+    _run_digitize, sync_tick batch loop) deletes them via its own
+    cleanup_staging_directory() call after the full pipeline finishes.
 
     Responsibility boundary
     -----------------------
@@ -138,8 +140,9 @@ async def _run_conversion(task: ConversionTask, weight: int) -> None:
         db_manager.update_task_status(task.task_id, ConversionTaskStatus.FAILED, error=str(exc))
 
     finally:
-        # Delete the staged input file — result_path is kept until user exports.
-        _safe_remove(task.cached_file)
+        # Do NOT delete task.cached_file here — the pipeline layer owns staging
+        # cleanup after all post-conversion processing (page loading, chunking,
+        # indexing) has finished.  See _run_ingest / _run_digitize / sync_tick.
         await conversion_semaphore.release(weight)
 
 

--- a/services/digitize/workers/conversion_dispatcher.py
+++ b/services/digitize/workers/conversion_dispatcher.py
@@ -81,17 +81,6 @@ def _try_claim_if_fits(operation: str, available: int) -> ConversionTask | None:
 
     return db_manager.claim_head(operation)
 
-
-def _safe_remove(file_path: str) -> None:
-    """Delete a file best-effort — logs but never raises."""
-    try:
-        p = Path(file_path)
-        if p.exists():
-            p.unlink()
-    except Exception as exc:
-        logger.warning(f"Could not remove cached file {file_path!r}: {exc}")
-
-
 async def _run_conversion(task: ConversionTask, weight: int) -> None:
     """
     Execute a single conversion task inside the shared process pool.


### PR DESCRIPTION
This PR includes following focused cleanups to the digitize service: 

1. moving staging directory cleanup to the correct pipeline boundary & fix UT
2. restricting a caption-recovery fallback to DOCX-only paths
3. removing the tqdm progress-bar wrapper that was used for debug-mode visibility.
4. remove redundant log during chunking
5. debug message after summarization of each table