### PR TITLE
Worker pod correctness

### DIFF
--- a/.github/scripts/check_image_names.py
+++ b/.github/scripts/check_image_names.py
@@ -87,6 +87,7 @@ COMPONENTS = {
     "ai-services/Makefile": [
         ("ai-services/assets/catalog/podman/values.yaml", "backend"),
         ("ai-services/assets/catalog/openshift/values.yaml", "backend"),
+        ("ai-services/assets/worker/podman/values.yaml", "worker"),
     ],
     "images/postgres/Makefile": [
         ("ai-services/assets/catalog/podman/values.yaml", "db"),

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.302
+TAG?=v0.0.303
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.303
+TAG?=v0.0.304
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.303
+  image: icr.io/ai-services-cicd/ai-services:v0.0.304
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.302
+  image: icr.io/ai-services-cicd/ai-services:v0.0.303
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.302
+  image: icr.io/ai-services-cicd/ai-services:v0.0.303
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.303
+  image: icr.io/ai-services-cicd/ai-services:v0.0.304
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/podman/metadata.yaml
+++ b/ai-services/assets/worker/podman/metadata.yaml
@@ -2,5 +2,5 @@ name: ai-services-worker
 version: 0.0.1
 description: "Worker node services for Project AI-Services"
 podTemplateExecutions:
-  - [caddy.yaml.tmpl]
+  - [auth-secret.yaml.tmpl, caddy.yaml.tmpl]
   - [worker.yaml.tmpl]

--- a/ai-services/assets/worker/podman/templates/auth-secret.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/auth-secret.yaml.tmpl
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: podman-auth-secret
+  labels:
+    ai-services.io/application: "{{ .AppName }}"
+    ai-services.io/template: "{{ .AppTemplateName }}"
+    ai-services.io/version: "{{ .Version }}"
+type: Opaque
+data:
+  auth.json: {{ .Values.worker.podman.authFileContent }}

--- a/ai-services/assets/worker/podman/templates/worker.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/worker.yaml.tmpl
@@ -7,6 +7,8 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/component: "worker"
+  annotations:
+    run.oci.keep_original_groups: "1"
 spec:
   restartPolicy: always
   containers:
@@ -30,6 +32,8 @@ spec:
           value: "service"
         - name: CONTAINER_HOST
           value: "unix://{{ .Values.worker.podman.uri }}"
+        - name: REGISTRY_AUTH_FILE
+          value: "/run/containers/auth.json"
       volumeMounts:
         - name: podman-socket
           mountPath: {{ .Values.worker.podman.uri }}

--- a/ai-services/assets/worker/podman/templates/worker.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/worker.yaml.tmpl
@@ -34,12 +34,20 @@ spec:
           value: "unix://{{ .Values.worker.podman.uri }}"
         - name: REGISTRY_AUTH_FILE
           value: "/run/containers/auth.json"
+        - name: AI_SERVICES_BASE_DIR
+          value: "{{ .BaseDir }}"
       volumeMounts:
         - name: podman-socket
           mountPath: {{ .Values.worker.podman.uri }}
+        - name: podman-auth
+          mountPath: /run/containers/auth.json
+          subPath: auth.json
+          readOnly: true
         - name: iommu-groups
           mountPath: /sys/kernel/iommu_groups
           readOnly: true
+        - name: ai-services-data
+          mountPath: {{ .BaseDir }}
       resources:
         requests:
           podman.io/device=/dev/vfio: 4
@@ -53,7 +61,14 @@ spec:
         # For root podman: /run/podman/podman.sock
         path: {{ .Values.worker.podman.uri }}
         type: Socket
+    - name: podman-auth
+      secret:
+        secretName: podman-auth-secret
     - name: iommu-groups
       hostPath:
         path: /sys/kernel/iommu_groups
         type: Directory
+    - name: ai-services-data
+      hostPath:
+        path: {{ .BaseDir }}
+        type: DirectoryOrCreate

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -4,10 +4,10 @@ caddy:
   httpsPort: ""
 
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.285
+  image: icr.io/ai-services-cicd/ai-services:v0.0.304
   runtime: "podman"
   token: ""
-  # optionalFlags covers sslCertPath, sslKeyPath, domainSuffix, and httpsPort flags that are forwarded from the
+  # optionalFlags covers basedir, sslCertPath, sslKeyPath, domainSuffix, and httpsPort flags that are forwarded from the
   # 'worker join' command to the 'worker grpcserver' command running inside the container
   optionalFlags: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -13,3 +13,4 @@ worker:
   gatewayAddr: ""
   podman:
     uri: "/run/podman/podman.sock"
+    authFileContent: ""

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
-	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -877,20 +875,10 @@ func (pc *PodmanClient) ExecInContainerWithCmd(_ context.Context, _, _ string, _
 // ─── HTTP proxy tunnel ────────────────────────────────────────────────────────
 
 // HTTPProxy makes an HTTP request to targetURL from the worker node and returns
-// the response to the control plane. The targetURL hostname may be a Podman
-// pod name — it is resolved to the pod's infra-container IP via the Podman
-// socket before the request is made.
-//
-// TODO: pod IP resolution works for rootful Podman where the pod network bridge
-// is visible on the host. For rootless Podman the resolved IP lives inside a
-// private network namespace and is unreachable from the host process; use a
-// Caddy-proxied URL or a hostPort mapping in that case.
+// the response to the control plane. The worker pod runs in the same Podman
+// network as the target pods, so pod-name DNS resolution works natively inside
+// the container without any host-side IP lookup.
 func (pc *PodmanClient) HTTPProxy(ctx context.Context, method, targetURL string, headers map[string]string, body []byte) (*types.HTTPProxyResponse, error) {
-	resolvedURL, err := pc.resolvePodNameInURL(targetURL)
-	if err != nil {
-		return nil, fmt.Errorf("HTTPProxy: resolve pod IP: %w", err)
-	}
-
 	client := resty.New()
 
 	req := client.R().SetContext(ctx)
@@ -901,7 +889,7 @@ func (pc *PodmanClient) HTTPProxy(ctx context.Context, method, targetURL string,
 		req.SetBody(body)
 	}
 
-	resp, err := req.Execute(method, resolvedURL)
+	resp, err := req.Execute(method, targetURL)
 	if err != nil {
 		return nil, fmt.Errorf("HTTPProxy: execute request: %w", err)
 	}
@@ -916,73 +904,4 @@ func (pc *PodmanClient) HTTPProxy(ctx context.Context, method, targetURL string,
 		Headers:    respHeaders,
 		Body:       resp.Body(),
 	}, nil
-}
-
-// resolvePodNameInURL rewrites the hostname in rawURL from a Podman pod name
-// to the pod's infra-container IP address. If the hostname is already an IP
-// or localhost it is returned unchanged.
-func (pc *PodmanClient) resolvePodNameInURL(rawURL string) (string, error) {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return "", fmt.Errorf("parse URL %q: %w", rawURL, err)
-	}
-
-	host := u.Hostname() // strips port if present
-
-	// Already an IP or localhost — nothing to do.
-	if host == "localhost" || net.ParseIP(host) != nil {
-		return rawURL, nil
-	}
-
-	// Treat the hostname as a pod name and resolve it to the pod's IP.
-	podIP, err := pc.podNameToIP(host)
-	if err != nil {
-		return "", fmt.Errorf("resolve pod %q to IP: %w", host, err)
-	}
-
-	// Rebuild the URL with the IP in place of the pod name.
-	if port := u.Port(); port != "" {
-		u.Host = net.JoinHostPort(podIP, port)
-	} else {
-		u.Host = podIP
-	}
-
-	return u.String(), nil
-}
-
-// podNameToIP inspects the named pod and returns its infra-container IP address.
-func (pc *PodmanClient) podNameToIP(podName string) (string, error) {
-	podReport, err := pods.Inspect(pc.Context, podName, nil)
-	if err != nil {
-		return "", fmt.Errorf("inspect pod %q: %w", podName, err)
-	}
-
-	infraID := podReport.InfraContainerID
-	if infraID == "" {
-		return "", fmt.Errorf("pod %q has no infra container", podName)
-	}
-
-	ctr, err := containers.Inspect(pc.Context, infraID, nil)
-	if err != nil {
-		return "", fmt.Errorf("inspect infra container of pod %q: %w", podName, err)
-	}
-
-	if ctr.NetworkSettings == nil {
-		return "", fmt.Errorf("pod %q infra container has no network settings", podName)
-	}
-
-	ip := ctr.NetworkSettings.IPAddress
-	if ip == "" {
-		// Fall back to the first network if the top-level IPAddress is empty
-		// (common in rootless Podman with named networks).
-		for _, n := range ctr.NetworkSettings.Networks {
-			if n.IPAddress != "" {
-				return n.IPAddress, nil
-			}
-		}
-
-		return "", fmt.Errorf("pod %q: no IP address found in network settings", podName)
-	}
-
-	return ip, nil
 }

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -23,4 +23,14 @@ const (
 	MetaKeyBaseDir      = "basedir"
 	MetaKeyDomainSuffix = "domainSuffix"
 	MetaKeyHTTPSPort    = "httpsPort"
+
+	// ArgParamCaddyHTTPSPort, ArgParamWorkerToken, ArgParamWorkerGatewayAddr,
+	// ArgParamWorkerOptionalFlags, ArgParamWorkerPodmanURI, and ArgParamWorkerAuthFile
+	// are template value-override keys used when deploying worker pods.
+	ArgParamCaddyHTTPSPort      = "caddy.httpsPort"
+	ArgParamWorkerToken         = "worker.token"
+	ArgParamWorkerGatewayAddr   = "worker.gatewayAddr"
+	ArgParamWorkerOptionalFlags = "worker.optionalFlags"
+	ArgParamWorkerPodmanURI     = "worker.podman.uri"
+	ArgParamWorkerAuthFile      = "worker.podman.authFileContent"
 )

--- a/ai-services/internal/pkg/worker/deploy/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/deploy.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
+	"strings"
 	ttemplate "text/template"
 
 	"github.com/project-ai-services/ai-services/assets"
@@ -21,6 +22,7 @@ import (
 	podmodels "github.com/project-ai-services/ai-services/internal/pkg/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/specs"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 
 	k8syaml "sigs.k8s.io/yaml"
@@ -168,20 +170,32 @@ func deployAll(ctx context.Context, rt runtime.Runtime, tp templates.Template, o
 	if err != nil {
 		return fmt.Errorf("worker setup: load templates: %w", err)
 	}
+
+	// Resolve the actual podman socket path from the host environment so the
+	// worker container gets the correct CONTAINER_HOST and volume mount.
+	podmanURI, err := utils.ResolvePodmanURI()
+	if err != nil {
+		return fmt.Errorf("worker setup: resolve podman URI: %w", err)
+	}
+	podmanSocketPath := strings.TrimPrefix(podmanURI, "unix://")
+
 	values, err := tp.LoadValues(workerApp, nil, map[string]string{
 		"caddy.httpsPort":      strconv.Itoa(opts.HTTPSPort),
 		"worker.token":         token,
 		"worker.gatewayAddr":   gatewayAddr,
 		"worker.optionalFlags": getOptionalFlags(opts),
+		"worker.podman.uri":    podmanSocketPath,
 	})
 	if err != nil {
 		return fmt.Errorf("worker setup: load values: %w", err)
 	}
 
 	params := map[string]any{
-		"BaseDir": opts.BaseDir,
-		"AppName": WorkerAppName,
-		"Values":  values,
+		"BaseDir":         opts.BaseDir,
+		"AppName":         WorkerAppName,
+		"AppTemplateName": workerApp,
+		"Version":         appMetadata.Version,
+		"Values":          values,
 	}
 
 	for _, layer := range appMetadata.PodTemplateExecutions {
@@ -233,6 +247,9 @@ func renderAndDeploy(ctx context.Context, rt runtime.Runtime, tmpls map[string]*
 // the container.
 func getOptionalFlags(opts Options) string {
 	var flags string
+	if opts.BaseDir != "" {
+		flags += fmt.Sprintf("--basedir '%s' ", opts.BaseDir)
+	}
 	if opts.SSLCertPath != "" && opts.SSLKeyPath != "" {
 		flags += fmt.Sprintf("--ssl-cert '%s' --ssl-key '%s' ", opts.SSLCertPath, opts.SSLKeyPath)
 	}

--- a/ai-services/internal/pkg/worker/deploy/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/deploy.go
@@ -7,6 +7,7 @@ package deploy
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -171,21 +172,12 @@ func deployAll(ctx context.Context, rt runtime.Runtime, tp templates.Template, o
 		return fmt.Errorf("worker setup: load templates: %w", err)
 	}
 
-	// Resolve the actual podman socket path from the host environment so the
-	// worker container gets the correct CONTAINER_HOST and volume mount.
-	podmanURI, err := utils.ResolvePodmanURI()
+	argParams, err := buildArgParams(opts, gatewayAddr, token)
 	if err != nil {
-		return fmt.Errorf("worker setup: resolve podman URI: %w", err)
+		return err
 	}
-	podmanSocketPath := strings.TrimPrefix(podmanURI, "unix://")
 
-	values, err := tp.LoadValues(workerApp, nil, map[string]string{
-		"caddy.httpsPort":      strconv.Itoa(opts.HTTPSPort),
-		"worker.token":         token,
-		"worker.gatewayAddr":   gatewayAddr,
-		"worker.optionalFlags": getOptionalFlags(opts),
-		"worker.podman.uri":    podmanSocketPath,
-	})
+	values, err := tp.LoadValues(workerApp, nil, argParams)
 	if err != nil {
 		return fmt.Errorf("worker setup: load values: %w", err)
 	}
@@ -207,6 +199,55 @@ func deployAll(ctx context.Context, rt runtime.Runtime, tp templates.Template, o
 	}
 
 	return nil
+}
+
+// buildArgParams resolves host-specific runtime values (podman socket, auth
+// file) and assembles the full map of template arg overrides for deployAll.
+func buildArgParams(opts Options, gatewayAddr, token string) (map[string]string, error) {
+	// Resolve the actual podman socket path from the host environment so the
+	// worker container gets the correct CONTAINER_HOST and volume mount.
+	podmanURI, err := utils.ResolvePodmanURI()
+	if err != nil {
+		return nil, fmt.Errorf("worker setup: resolve podman URI: %w", err)
+	}
+
+	authFileBase64, err := readAuthFileBase64()
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]string{
+		"caddy.httpsPort":               strconv.Itoa(opts.HTTPSPort),
+		"worker.token":                  token,
+		"worker.gatewayAddr":            gatewayAddr,
+		"worker.optionalFlags":          getOptionalFlags(opts),
+		"worker.podman.uri":             strings.TrimPrefix(podmanURI, "unix://"),
+		"worker.podman.authFileContent": authFileBase64,
+	}, nil
+}
+
+// readAuthFileBase64 reads the podman auth file and returns its contents
+// base64-encoded. If the file does not exist, it returns an encoded empty
+// JSON object and logs a warning.
+func readAuthFileBase64() (string, error) {
+	authFilePath, err := utils.GetAuthFilePath()
+	if err != nil {
+		return "", fmt.Errorf("worker setup: resolve auth file path: %w", err)
+	}
+
+	content, err := os.ReadFile(authFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Warningln("Podman auth file not found. Image pulls may fail if the registry requires authentication.")
+			// TODO: worker join- > worker --reset-podman-auth when implemented
+			logger.Warningln("Run 'podman login' then re-run 'worker join' to update credentials.")
+			content = []byte("{}")
+		} else {
+			return "", fmt.Errorf("worker setup: read auth file %s: %w", authFilePath, err)
+		}
+	}
+
+	return base64.StdEncoding.EncodeToString(content), nil
 }
 
 // renderAndDeploy renders a single pod template and deploys it.

--- a/ai-services/internal/pkg/worker/deploy/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/deploy.go
@@ -217,12 +217,12 @@ func buildArgParams(opts Options, gatewayAddr, token string) (map[string]string,
 	}
 
 	return map[string]string{
-		"caddy.httpsPort":               strconv.Itoa(opts.HTTPSPort),
-		"worker.token":                  token,
-		"worker.gatewayAddr":            gatewayAddr,
-		"worker.optionalFlags":          getOptionalFlags(opts),
-		"worker.podman.uri":             strings.TrimPrefix(podmanURI, "unix://"),
-		"worker.podman.authFileContent": authFileBase64,
+		workerconstants.ArgParamCaddyHTTPSPort:      strconv.Itoa(opts.HTTPSPort),
+		workerconstants.ArgParamWorkerToken:         token,
+		workerconstants.ArgParamWorkerGatewayAddr:   gatewayAddr,
+		workerconstants.ArgParamWorkerOptionalFlags: getOptionalFlags(opts),
+		workerconstants.ArgParamWorkerPodmanURI:     strings.TrimPrefix(podmanURI, "unix://"),
+		workerconstants.ArgParamWorkerAuthFile:      authFileBase64,
 	}, nil
 }
 


### PR DESCRIPTION
### Worker pod correctness (the bulk of the work)

1. Image bumped v0.0.285 → v0.0.304 — fixes the unknown flag: --token / missing grpcserver subcommand error
2. Added REGISTRY_AUTH_FILE, AI_SERVICES_BASE_DIR env vars, podman-auth secret mount, ai-services-data basedir mount, and run.oci.keep_original_groups annotation — all missing vs the catalog backend
3. New auth-secret.yaml.tmpl + layer 1 in metadata.yaml — creates podman-auth-secret on the worker machine at join time (same pattern as catalog; reset-podman-auth flag to follow)
4. deploy.go now resolves the actual podman socket at runtime, reads + base64-encodes the auth file, passes AppTemplateName/Version to templates, and forwards --basedir via optionalFlags

### HTTPProxy simplification

- Removed podNameToIP + resolvePodNameInURL — the worker runs in the same podman network so pod-name DNS works natively; no host-side IP lookup needed
### Image version tracking

- Catalog + worker pinned to v0.0.304; CI script now enforces parity between them

