### PR TITLE
API for Steps md rendering and integrate with CLIs

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.308
+TAG?=v0.0.309
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.308
+  image: icr.io/ai-services-cicd/ai-services:v0.0.309
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.308
+  image: icr.io/ai-services-cicd/ai-services:v0.0.309
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -4,7 +4,7 @@ caddy:
   httpsPort: ""
 
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.308
+  image: icr.io/ai-services-cicd/ai-services:v0.0.309
   runtime: "podman"
   token: ""
   # optionalFlags covers basedir, sslCertPath, sslKeyPath, domainSuffix, and httpsPort flags that are forwarded from the

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -578,20 +578,23 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 			continue
 		}
 
-		err = printNextStepsMD(tmpls, params, application.Name, runtimeType)
+		err = printNextStepsMD(tmpls, params)
 		if err != nil {
 			logger.Warningf("Failed to render next steps for service '%s': %v\n", service.CatalogID, err)
 		}
 	}
 
+	// Print the info command regardless of whether any service has next.md
+	logger.Infof("\n- For detailed endpoint information, use: `ai-services application info %s --runtime %s`\n", application.Name, runtimeType)
+
 	return nil
 }
 
 // printNextStepsMD renders and prints the next.md template for a service.
-func printNextStepsMD(tmpls map[string]*template.Template, params map[string]string, appName, runtime string) error {
+func printNextStepsMD(tmpls map[string]*template.Template, params map[string]string) error {
 	tmpl, ok := tmpls["next.md"]
 	if !ok {
-		// next.md doesn't exist for this service, return nil
+		// next.md doesn't exist for this service, skip
 		return nil
 	}
 
@@ -606,9 +609,6 @@ func printNextStepsMD(tmpls map[string]*template.Template, params map[string]str
 	if strings.TrimSpace(value) != "" {
 		logger.Infoln(value)
 	}
-
-	// Print the info command for all services
-	logger.Infof("\n- For detailed endpoint information, use: `ai-services application info %s --runtime %s`\n", appName, runtime)
 
 	return nil
 }

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -16,7 +16,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/bootstrap"
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	apiModels "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
@@ -445,27 +444,26 @@ func checkApplicationExists(ctx context.Context, appClient *catalogClient.Applic
 }
 
 // buildCatalogPayload builds the catalog API payload for the given template.
+// It uses CatalogSource so that custom bundle templates (not in the embedded catalog)
+// are resolved via the catalog API.
 func buildCatalogPayload(ctx context.Context, appName string) (*apiModels.CreateApplicationRequest, error) {
-	// Initialize catalog provider
-	provider, err := catalog.NewCatalogProvider(nil)
+	source, err := catalogClient.NewCatalogSource(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create catalog provider: %w", err)
+		return nil, fmt.Errorf("failed to initialise catalog source: %w", err)
 	}
 
-	// Determine if template is architecture or service
-	isArchitecture := provider.ArchitectureExists(templateName)
-	isService := provider.ServiceExists(templateName)
-
-	if !isArchitecture && !isService {
-		return nil, fmt.Errorf("template '%s' not found as architecture or service", templateName)
+	// Try architecture first; fall through to service on not-found.
+	arch, err := source.LoadArchitecture(ctx, templateName)
+	if err == nil {
+		return buildArchitecturePayload(ctx, source, arch, appName)
 	}
 
-	// Build the payload
-	if isArchitecture {
-		return buildArchitecturePayload(ctx, provider, templateName, appName)
+	svc, err := source.LoadService(ctx, templateName)
+	if err == nil {
+		return buildServicePayload(ctx, svc.ID, appName)
 	}
 
-	return buildServicePayload(ctx, templateName, appName)
+	return nil, fmt.Errorf("template '%s' not found as architecture or service", templateName)
 }
 
 // pollApplicationStatus polls the application status until it's ready or fails.
@@ -614,13 +612,7 @@ func printNextStepsMD(tmpls map[string]*template.Template, params map[string]str
 }
 
 // buildArchitecturePayload builds the payload for an architecture deployment.
-func buildArchitecturePayload(ctx context.Context, provider *catalog.CatalogProvider, archID, appName string) (*apiModels.CreateApplicationRequest, error) {
-	// Load architecture metadata
-	arch, err := provider.LoadArchitecture(archID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load architecture: %w", err)
-	}
-
+func buildArchitecturePayload(ctx context.Context, _ catalogClient.CatalogSource, arch *catalogTypes.Architecture, appName string) (*apiModels.CreateApplicationRequest, error) {
 	// Create application client for API calls
 	appClient, err := catalogClient.NewApplicationClient(ctx)
 	if err != nil {
@@ -628,7 +620,7 @@ func buildArchitecturePayload(ctx context.Context, provider *catalog.CatalogProv
 	}
 
 	// Get deploy options for the architecture
-	deployOptions, err := appClient.GetArchitectureDeployOptions(ctx, archID)
+	deployOptions, err := appClient.GetArchitectureDeployOptions(ctx, arch.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get deploy options: %w", err)
 	}
@@ -658,7 +650,7 @@ func buildArchitecturePayload(ctx context.Context, provider *catalog.CatalogProv
 	}
 
 	return &apiModels.CreateApplicationRequest{
-		CatalogID:  archID,
+		CatalogID:  arch.ID,
 		Name:       appName,
 		Services:   services,
 		Version:    arch.Version,

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -548,11 +548,6 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 		return fmt.Errorf("failed to get application: %w", err)
 	}
 
-	catalogProvider, err := catalog.NewCatalogProvider(nil)
-	if err != nil {
-		return fmt.Errorf("failed to create catalog provider: %w", err)
-	}
-
 	logger.Infoln("\nNext Steps:")
 	logger.Infoln("-------")
 
@@ -569,9 +564,16 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 			}
 		}
 
-		tmpls, err := catalogProvider.LoadServicesMD(service.CatalogID)
+		rawFiles, err := appClient.GetServiceSteps(ctx, service.CatalogID, runtimeType)
 		if err != nil {
 			logger.Warningf("Failed to load next steps for service '%s': %v\n", service.CatalogID, err)
+
+			continue
+		}
+
+		tmpls, err := parseStepsTemplates(rawFiles)
+		if err != nil {
+			logger.Warningf("Failed to parse next steps templates for service '%s': %v\n", service.CatalogID, err)
 
 			continue
 		}

--- a/ai-services/cmd/ai-services/cmd/application/info.go
+++ b/ai-services/cmd/ai-services/cmd/application/info.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	cliUtils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
@@ -106,15 +105,10 @@ func renderApplicationInfo(ctx context.Context, appName string, rt types.Runtime
 	logger.Infoln("Application Template: " + application.CatalogID)
 	logger.Infoln("Application Version: " + application.Version)
 
-	return printServicesInfo(application.Services, appPS, rt)
+	return printServicesInfo(ctx, appClient, application.Services, appPS, rt)
 }
 
-func printServicesInfo(services []catalogTypes.ApplicationService, appPS *catalogTypes.ApplicationPSResponse, rt types.RuntimeType) error {
-	catalogProvider, err := catalog.NewCatalogProvider(nil)
-	if err != nil {
-		return fmt.Errorf("failed to create catalog provider: %w", err)
-	}
-
+func printServicesInfo(ctx context.Context, appClient *catalogClient.ApplicationClient, services []catalogTypes.ApplicationService, appPS *catalogTypes.ApplicationPSResponse, rt types.RuntimeType) error {
 	logger.Infoln("Info:")
 	logger.Infoln("-------")
 	logger.Infoln("Day N: ")
@@ -135,9 +129,14 @@ func printServicesInfo(services []catalogTypes.ApplicationService, appPS *catalo
 			}
 		}
 
-		tmpls, err := catalogProvider.LoadServicesMD(service.CatalogID)
+		rawFiles, err := appClient.GetServiceSteps(ctx, service.CatalogID, rt.String())
 		if err != nil {
-			return fmt.Errorf("failed to load service md files: %w", err)
+			return fmt.Errorf("failed to load service steps for '%s': %w", service.CatalogID, err)
+		}
+
+		tmpls, err := parseStepsTemplates(rawFiles)
+		if err != nil {
+			return fmt.Errorf("failed to parse steps templates for '%s': %w", service.CatalogID, err)
 		}
 
 		err = printInfo(tmpls, params)
@@ -147,6 +146,28 @@ func printServicesInfo(services []catalogTypes.ApplicationService, appPS *catalo
 	}
 
 	return nil
+}
+
+// parseStepsTemplates parses the raw steps file contents (as returned by GetServiceSteps)
+// into text/template instances keyed by filename. Only .md files are parsed as templates;
+// other files (e.g. vars_file.yaml) are available as raw content under their own key.
+func parseStepsTemplates(rawFiles map[string]string) (map[string]*template.Template, error) {
+	tmpls := make(map[string]*template.Template, len(rawFiles))
+
+	for name, content := range rawFiles {
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+
+		tmpl, err := template.New(name).Parse(content)
+		if err != nil {
+			return nil, fmt.Errorf("parse template %s: %w", name, err)
+		}
+
+		tmpls[name] = tmpl
+	}
+
+	return tmpls, nil
 }
 
 func getContainerStatus(services []catalogTypes.Pod, catalogID string, rt types.RuntimeType) (string, string) {

--- a/ai-services/cmd/ai-services/cmd/application/templates.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/project-ai-services/ai-services/assets"
 	appTemplates "github.com/project-ai-services/ai-services/cmd/ai-services/cmd/application/templates"
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
@@ -117,12 +116,7 @@ func init() {
 // It always tries the API first and falls back to the embedded catalog when the
 // API is unreachable or the user is not logged in.
 func listCatalogTemplates(cmd *cobra.Command) error {
-	embedded, err := catalog.NewCatalogProvider(nil)
-	if err != nil {
-		return fmt.Errorf("failed to load embedded catalog: %w", err)
-	}
-
-	source, err := catalogClient.NewCatalogSource(cmd.Context(), embedded)
+	source, err := catalogClient.NewCatalogSource(cmd.Context())
 	if err != nil {
 		return err
 	}

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
@@ -35,14 +34,9 @@ func NewParametersCmd() *cobra.Command {
 				return fmt.Errorf("--template flag is required")
 			}
 
-			embedded, err := catalog.NewCatalogProvider(nil)
-			if err != nil {
-				return fmt.Errorf("failed to load embedded catalog: %w", err)
-			}
-
 			// NewCatalogSource tries the API first, falls back to the embedded
 			// catalog when the user is not logged in.
-			source, err := catalogClient.NewCatalogSource(cmd.Context(), embedded)
+			source, err := catalogClient.NewCatalogSource(cmd.Context())
 			if err != nil {
 				return err
 			}

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -2305,6 +2305,73 @@ const docTemplate = `{
                 }
             }
         },
+        "/services/{id}/steps": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all files under the service's steps directory for the requested runtime\n(e.g. info.md, next.md, vars_file.yaml). Both embedded and custom bundle services\nare supported. The response is a JSON object keyed by filename with the raw file\ncontent as a string value.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Catalog"
+                ],
+                "summary": "Get steps files for a service",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Service ID (e.g., 'chat', 'digitize')",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Runtime type: 'podman' or 'openshift' (default: podman)",
+                        "name": "runtime",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Map of filename to raw file content",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid runtime value",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - Invalid or missing access token",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Service not found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/workers": {
             "get": {
                 "security": [

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -2299,6 +2299,73 @@
                 }
             }
         },
+        "/services/{id}/steps": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all files under the service's steps directory for the requested runtime\n(e.g. info.md, next.md, vars_file.yaml). Both embedded and custom bundle services\nare supported. The response is a JSON object keyed by filename with the raw file\ncontent as a string value.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Catalog"
+                ],
+                "summary": "Get steps files for a service",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Service ID (e.g., 'chat', 'digitize')",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Runtime type: 'podman' or 'openshift' (default: podman)",
+                        "name": "runtime",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Map of filename to raw file content",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid runtime value",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - Invalid or missing access token",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Service not found",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/workers": {
             "get": {
                 "security": [

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -2465,6 +2465,53 @@ paths:
       summary: Get service parameters
       tags:
       - Catalog
+  /services/{id}/steps:
+    get:
+      description: |-
+        Returns all files under the service's steps directory for the requested runtime
+        (e.g. info.md, next.md, vars_file.yaml). Both embedded and custom bundle services
+        are supported. The response is a JSON object keyed by filename with the raw file
+        content as a string value.
+      parameters:
+      - description: Service ID (e.g., 'chat', 'digitize')
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: 'Runtime type: ''podman'' or ''openshift'' (default: podman)'
+        in: query
+        name: runtime
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Map of filename to raw file content
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Invalid runtime value
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "401":
+          description: Unauthorized - Invalid or missing access token
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "404":
+          description: Service not found
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/internal_pkg_catalog_apiserver_handlers.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get steps files for a service
+      tags:
+      - Catalog
   /workers:
     get:
       description: Returns all registered workers and their current status from the

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/catalog.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
@@ -481,6 +482,61 @@ func parseExcludeProviders(c *gin.Context) []string {
 	}
 
 	return result
+}
+
+// GetServiceSteps godoc
+//
+//	@Summary		Get steps files for a service
+//	@Description	Returns all files under the service's steps directory for the requested runtime
+//	@Description	(e.g. info.md, next.md, vars_file.yaml). Both embedded and custom bundle services
+//	@Description	are supported. The response is a JSON object keyed by filename with the raw file
+//	@Description	content as a string value.
+//	@Tags			Catalog
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id		path		string				true	"Service ID (e.g., 'chat', 'digitize')"
+//	@Param			runtime	query		string				false	"Runtime type: 'podman' or 'openshift' (default: podman)"
+//	@Success		200		{object}	map[string]string	"Map of filename to raw file content"
+//	@Failure		400		{object}	ErrorResponse		"Invalid runtime value"
+//	@Failure		401		{object}	ErrorResponse		"Unauthorized - Invalid or missing access token"
+//	@Failure		404		{object}	ErrorResponse		"Service not found"
+//	@Failure		500		{object}	ErrorResponse		"Internal Server Error"
+//	@Router			/services/{id}/steps [get]
+func (h *CatalogHandler) GetServiceSteps(c *gin.Context) {
+	id := c.Param("id")
+
+	runtimeParam := c.DefaultQuery("runtime", string(runtimeTypes.RuntimeTypePodman))
+	rt := runtimeTypes.RuntimeType(runtimeParam)
+
+	if !rt.Valid() {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: fmt.Sprintf("invalid runtime %q: must be 'podman' or 'openshift'", runtimeParam),
+		})
+
+		return
+	}
+
+	files, err := h.provider.GetServiceSteps(id, rt)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, catalog.ErrCatalogItemNotFound) {
+			status = http.StatusNotFound
+		}
+
+		c.JSON(status, ErrorResponse{
+			Error: fmt.Sprintf("Failed to get steps for service '%s': %v", id, err),
+		})
+
+		return
+	}
+
+	// Convert []byte values to strings for JSON serialisation.
+	result := make(map[string]string, len(files))
+	for name, content := range files {
+		result[name] = string(content)
+	}
+
+	c.JSON(http.StatusOK, result)
 }
 
 // ErrorResponse represents an error response.

--- a/ai-services/internal/pkg/catalog/apiserver/router.go
+++ b/ai-services/internal/pkg/catalog/apiserver/router.go
@@ -71,6 +71,7 @@ func registerCatalogRoutes(v1 *gin.RouterGroup, catalog *handlers.CatalogHandler
 		g.GET("/services/:id/params", catalog.GetServiceParams)
 		g.GET("/services/:id/images", catalog.GetServiceImages)
 		g.GET("/services/:id/models", catalog.GetServiceModels)
+		g.GET("/services/:id/steps", catalog.GetServiceSteps)
 		g.GET("/components/:component_type/providers/:provider_id/params", catalog.GetComponentProviderParams)
 		g.GET("/connectors", catalog.ListConnectorProviders)
 		g.GET("/connectors/:connector_type/providers/:provider_id/params", catalog.GetConnectorProviderParams)

--- a/ai-services/internal/pkg/catalog/catalog.go
+++ b/ai-services/internal/pkg/catalog/catalog.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -1099,6 +1100,11 @@ func (p *CatalogProvider) GetServiceSteps(serviceID string, runtime runtimeTypes
 	itemFS, err := p.getItemFS(serviceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
+	}
+
+	// do early return if steps folder is not present
+	if _, err = fs.Stat(itemFS, stepsPath); errors.Is(err, fs.ErrNotExist) {
+		return map[string][]byte{}, nil
 	}
 
 	files := make(map[string][]byte)

--- a/ai-services/internal/pkg/catalog/catalog.go
+++ b/ai-services/internal/pkg/catalog/catalog.go
@@ -1079,4 +1079,52 @@ func (p *CatalogProvider) LoadServicesMD(serviceID string) (map[string]*texttemp
 	return templates, nil
 }
 
+// GetServiceSteps returns the raw contents of every file under <runtime>/steps/ for
+// the given service, keyed by filename (e.g. "info.md", "next.md", "vars_file.yaml").
+// runtime must be a valid RuntimeType ("podman" or "openshift").
+// Both embedded and custom bundle services are supported.
+// Returns ErrCatalogItemNotFound when the service ID is unknown.
+func (p *CatalogProvider) GetServiceSteps(serviceID string, runtime runtimeTypes.RuntimeType) (map[string][]byte, error) {
+	if !p.ServiceExists(serviceID) {
+		return nil, fmt.Errorf("%w: service '%s'", ErrCatalogItemNotFound, serviceID)
+	}
+
+	servicePath, err := p.GetCatalogItemPath(serviceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get service path: %w", err)
+	}
+
+	stepsPath := filepath.Join(servicePath, string(runtime), "steps")
+
+	itemFS, err := p.getItemFS(serviceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
+	}
+
+	files := make(map[string][]byte)
+
+	err = fs.WalkDir(itemFS, stepsPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		data, err := fs.ReadFile(itemFS, path)
+		if err != nil {
+			return fmt.Errorf("failed to read steps file %s: %w", path, err)
+		}
+
+		files[d.Name()] = data
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk steps directory: %w", err)
+	}
+
+	return files, nil
+}
+
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/client/application.go
+++ b/ai-services/internal/pkg/catalog/client/application.go
@@ -30,6 +30,7 @@ const (
 	servicesRoute           = "/api/v1/services"
 	getServiceRoute         = "/api/v1/services/%s"
 	svcParamsRoute          = "/api/v1/services/%s/params"
+	svcStepsRoute           = "/api/v1/services/%s/steps"
 )
 
 // HTTPError represents an HTTP error with status code.
@@ -473,6 +474,35 @@ func (c *ApplicationClient) GetServiceParams(ctx context.Context, serviceID stri
 
 	if resp.IsError() {
 		return nil, fmt.Errorf("get service params: server returned HTTP %d: %s", resp.StatusCode(), utils.ParseErrorResponse(resp))
+	}
+
+	return result, nil
+}
+
+// GetServiceSteps calls GET /api/v1/services/:id/steps and returns all files under
+// the service's steps directory keyed by filename (e.g. "info.md", "next.md", "vars_file.yaml").
+// runtime selects which runtime's steps to return ("podman" or "openshift");
+// when empty the server defaults to "podman".
+func (c *ApplicationClient) GetServiceSteps(ctx context.Context, serviceID, runtime string) (map[string]string, error) {
+	var result map[string]string
+	req := c.client.HTTPClient().R().
+		SetContext(ctx).
+		SetResult(&result)
+
+	if runtime != "" {
+		req.SetQueryParam("runtime", runtime)
+	}
+
+	resp, err := req.Get(fmt.Sprintf(svcStepsRoute, serviceID))
+	if err != nil {
+		return nil, fmt.Errorf("get service steps: %w", err)
+	}
+
+	if resp.IsError() {
+		return nil, &HTTPError{
+			StatusCode: resp.StatusCode(),
+			Message:    utils.ParseErrorResponse(resp),
+		}
 	}
 
 	return result, nil

--- a/ai-services/internal/pkg/catalog/client/application.go
+++ b/ai-services/internal/pkg/catalog/client/application.go
@@ -473,7 +473,10 @@ func (c *ApplicationClient) GetServiceParams(ctx context.Context, serviceID stri
 	}
 
 	if resp.IsError() {
-		return nil, fmt.Errorf("get service params: server returned HTTP %d: %s", resp.StatusCode(), utils.ParseErrorResponse(resp))
+		return nil, &HTTPError{
+			StatusCode: resp.StatusCode(),
+			Message:    utils.ParseErrorResponse(resp),
+		}
 	}
 
 	return result, nil

--- a/ai-services/internal/pkg/catalog/client/catalog_source.go
+++ b/ai-services/internal/pkg/catalog/client/catalog_source.go
@@ -44,16 +44,18 @@ type CatalogSource interface {
 }
 
 // NewCatalogSource builds a CatalogSource that tries the catalog API first and
-// falls back to the provided embedded catalog when the user is not logged in.
+// falls back to the local embedded catalog when the user is not logged in.
 // Any other client-init error (bad config, etc.) is returned to the caller.
 //
 // If the API is reachable but returns a non-connectivity error (e.g. 4xx/5xx),
 // the error is propagated so the caller sees it rather than silently falling
 // back to stale embedded data.
-//
-// embedded must not be nil; it is consulted lazily — only when an API call
-// fails with a connectivity error, or when the user is not logged in.
-func NewCatalogSource(ctx context.Context, embedded EmbeddedCatalog) (CatalogSource, error) {
+func NewCatalogSource(ctx context.Context) (CatalogSource, error) {
+	embedded, err := newEmbeddedCatalog()
+	if err != nil {
+		return nil, err
+	}
+
 	apiClient, err := NewApplicationClient(ctx)
 	if err != nil {
 		if !errors.Is(err, config.ErrNotLoggedIn) {
@@ -70,6 +72,18 @@ func NewCatalogSource(ctx context.Context, embedded EmbeddedCatalog) (CatalogSou
 		api:      apiClient,
 		embedded: embedded,
 	}, nil
+}
+
+// newEmbeddedCatalog creates a local CatalogProvider with no bundle DB.
+// It is the embedded fallback used when the catalog API is unreachable or
+// the user is not logged in.
+func newEmbeddedCatalog() (EmbeddedCatalog, error) {
+	provider, err := catalog.NewCatalogProvider(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create embedded catalog provider: %w", err)
+	}
+
+	return provider, nil
 }
 
 // --------------------------------------------------------------------------

--- a/docs/proposals/catalog/custom-service-templates-proposal.md
+++ b/docs/proposals/catalog/custom-service-templates-proposal.md
@@ -385,7 +385,7 @@ Five additional catalog-read endpoints are added under the authenticated `v1` ca
 | `GET` | `/api/v1/services/:id/images` | Return the complete list of container images required to deploy a service and all its component dependencies (both embedded and custom bundle services). The response includes catalog asset images (tool image and catalog infrastructure images). Returns `404` if `:id` is not a known service. |
 | `GET` | `/api/v1/architectures/:id/images` | Return the complete list of container images required to deploy an architecture and all its services and component dependencies (both embedded and custom bundle architectures). The response includes catalog asset images (tool image and catalog infrastructure images). Returns `404` if `:id` is not a known architecture. |
 | `GET` | `/api/v1/services/:id/models` | Return model metadata for a service. |
-| `GET` | `/api/v1/services/:id/md` | Return the service's Markdown description. |
+| `GET` | `/api/v1/services/:id/steps` | Return all files under the service's `steps/` directory for the requested runtime. Response is a JSON object keyed by filename (e.g. `info.md`, `next.md`, `vars_file.yaml`) with raw file content as string values. Accepts `?runtime=podman\|openshift` (default: `podman`). Returns `400` for an invalid runtime, `404` if `:id` is not a known service. |
 | `GET` | `/api/v1/architectures/:id/models` | Return model metadata for an architecture. |
 
 #### 6.2.1 Create Bundle — `POST /api/v1/catalog/bundles`
@@ -1235,6 +1235,23 @@ func (c *ApplicationClient) DeleteBundle(bundleID string) error
 // ValidationResult) on success, or a *ValidationError on 422.
 func (c *ApplicationClient) ValidateBundle(filePath string) (bundlesvc.ValidationResult, error)
 ```
+
+#### `ApplicationClient` steps method (client/application.go)
+
+CLIs retrieve steps files through [`internal/pkg/catalog/client/application.go`](ai-services/internal/pkg/catalog/client/application.go) instead of reading embedded assets directly. This allows custom bundle services to supply their own `steps/` files, which the server returns transparently alongside built-in ones.
+
+```go
+// GetServiceSteps calls GET /api/v1/services/:id/steps and returns all files under
+// the service's steps directory keyed by filename
+// (e.g. "info.md", "next.md", "vars_file.yaml").
+// runtime selects which runtime's steps to return ("podman" or "openshift");
+// when empty the server defaults to "podman".
+func (c *ApplicationClient) GetServiceSteps(ctx context.Context, serviceID, runtime string) (map[string]string, error)
+```
+
+The server-side implementation lives in `CatalogProvider.GetServiceSteps(serviceID string, runtime runtimeTypes.RuntimeType)`, which walks `<runtime>/steps/` in the item's own `fs.FS` — identical for embedded services (backed by `assets.CatalogFS`) and custom bundle services (backed by `os.DirFS`).
+
+The `application info` and `application create` CLI commands call `GetServiceSteps` with the runtime already known from the `--runtime` flag (e.g. `rt.String()`) and parse only `.md` files from the response into `text/template` instances via the shared `parseStepsTemplates` helper. `vars_file.yaml` is included in the response for future use but is currently consumed only by the legacy embed path.
 
 ---
 


### PR DESCRIPTION
- Currently the CLI directly uses embedded assets to print the info and next steps.
- This will not work for custom assets as it resides inside volume.
- So a separate API is exposed so that it returns steps md for both embedded and custom assets.