### PR TITLE
Generic steps/md files rendering

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.319
+TAG?=v0.0.320
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.319
+  image: icr.io/ai-services-cicd/ai-services:v0.0.320
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.319
+  image: icr.io/ai-services-cicd/ai-services:v0.0.320
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/services/chat/openshift/steps/vars_file.yaml
+++ b/ai-services/assets/services/chat/openshift/steps/vars_file.yaml
@@ -1,9 +1,11 @@
 containers:
   - name: "ui"
+    workload: "chat-bot-ui"
     format: ".Status"
     alias: UI_STATUS
 
   - name: "backend-server"
+    workload: "chat-bot-api"
     format: ".Status"
     alias: API_STATUS
 

--- a/ai-services/assets/services/chat/podman/steps/info.md
+++ b/ai-services/assets/services/chat/podman/steps/info.md
@@ -11,7 +11,7 @@ Day N:
 {{- end }}
 
 {{- if ne .API_URL "" }}
-{{- if eq .API_STATUS "running" }}
+{{- if eq .BACKEND_STATUS "running" }}
 
 - {{ .SERVICE_NAME }} API is available to use at {{ .API_URL }}.
 {{- else }}

--- a/ai-services/assets/services/chat/podman/steps/info.md
+++ b/ai-services/assets/services/chat/podman/steps/info.md
@@ -11,7 +11,7 @@ Day N:
 {{- end }}
 
 {{- if ne .API_URL "" }}
-{{- if eq .BACKEND_STATUS "running" }}
+{{- if eq .API_STATUS "running" }}
 
 - {{ .SERVICE_NAME }} API is available to use at {{ .API_URL }}.
 {{- else }}

--- a/ai-services/assets/services/chat/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/chat/podman/steps/vars_file.yaml
@@ -1,8 +1,8 @@
 containers:
-  - name: "{{ .AppName }}--chat-bot-ui"
+  - name: "chat-{{ .InstanceSlug }}-chat-bot-ui"
     format: ".Status"
     alias: UI_STATUS
 
-  - name: "{{ .AppName }}--chat-bot-backend-server"
+  - name: "chat-{{ .InstanceSlug }}-chat-bot-backend-server"
     format: ".Status"
     alias: API_STATUS

--- a/ai-services/assets/services/chat/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/chat/podman/steps/vars_file.yaml
@@ -1,14 +1,3 @@
-pods:
-  - name: "{{ .AppName }}--chat-bot"
-    format: "index .Ports \"3000/tcp\" 0"
-    default: ""
-    alias: UI_PORT
-
-  - name: "{{ .AppName }}--chat-bot"
-    format: "index .Ports \"5000/tcp\" 0"
-    default: ""
-    alias: BACKEND_PORT
-
 containers:
   - name: "{{ .AppName }}--chat-bot-ui"
     format: ".Status"
@@ -16,10 +5,4 @@ containers:
 
   - name: "{{ .AppName }}--chat-bot-backend-server"
     format: ".Status"
-    alias: BACKEND_STATUS
-
-hosts:
-  - fetch: HOST_IP
-    type: ip
-
-# Made with Bob
+    alias: API_STATUS

--- a/ai-services/assets/services/chat/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/chat/podman/steps/vars_file.yaml
@@ -1,8 +1,8 @@
 containers:
-  - name: "chat-{{ .InstanceSlug }}-chat-bot-ui"
+  - name: "chat-bot-{{ .InstanceSlug }}-ui"
     format: ".Status"
     alias: UI_STATUS
 
-  - name: "chat-{{ .InstanceSlug }}-chat-bot-backend-server"
+  - name: "chat-bot-{{ .InstanceSlug }}-backend-server"
     format: ".Status"
     alias: API_STATUS

--- a/ai-services/assets/services/digitize/openshift/steps/vars_file.yaml
+++ b/ai-services/assets/services/digitize/openshift/steps/vars_file.yaml
@@ -1,9 +1,11 @@
 containers:
   - name: "digitize-ui"
+    workload: "digitize-ui"
     format: ".Status"
     alias: UI_STATUS
 
   - name: "digitize-api"
+    workload: "digitize-api"
     format: ".Status"
     alias: API_STATUS
 

--- a/ai-services/assets/services/digitize/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/digitize/podman/steps/vars_file.yaml
@@ -1,8 +1,8 @@
 containers:
-  - name: "digitize-{{ .InstanceSlug }}-digitize-ui"
+  - name: "digitize-{{ .InstanceSlug }}-ui"
     format: ".Status"
     alias: UI_STATUS
 
-  - name: "digitize-{{ .InstanceSlug }}-digitize-backend-server"
+  - name: "digitize-{{ .InstanceSlug }}-backend-server"
     format: ".Status"
     alias: API_STATUS

--- a/ai-services/assets/services/digitize/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/digitize/podman/steps/vars_file.yaml
@@ -1,8 +1,8 @@
 containers:
-  - name: "{{ .AppName }}--digitize-ui"
+  - name: "digitize-{{ .InstanceSlug }}-digitize-ui"
     format: ".Status"
     alias: UI_STATUS
 
-  - name: "{{ .AppName }}--digitize-backend-server"
+  - name: "digitize-{{ .InstanceSlug }}-digitize-backend-server"
     format: ".Status"
     alias: API_STATUS

--- a/ai-services/assets/services/digitize/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/digitize/podman/steps/vars_file.yaml
@@ -1,25 +1,8 @@
-pods:
-  - name: "{{ .AppName }}--digitize"
-    format: "index .Ports \"4000/tcp\" 0"
-    default: ""
-    alias: DIGITIZE_API_PORT
-
-  - name: "{{ .AppName }}--digitize"
-    format: "index .Ports \"4001/tcp\" 0"
-    default: ""
-    alias: DIGITIZE_UI_PORT
-
 containers:
   - name: "{{ .AppName }}--digitize-ui"
     format: ".Status"
-    alias: DIGITIZE_UI_STATUS
+    alias: UI_STATUS
 
   - name: "{{ .AppName }}--digitize-backend-server"
     format: ".Status"
-    alias: DIGITIZE_API_STATUS
-
-hosts:
-  - fetch: HOST_IP
-    type: ip
-
-# Made with Bob
+    alias: API_STATUS

--- a/ai-services/assets/services/extract/openshift/steps/vars_file.yaml
+++ b/ai-services/assets/services/extract/openshift/steps/vars_file.yaml
@@ -1,5 +1,6 @@
 containers:
   - name: "extract-api"
+    workload: "extract-api"
     format: ".Status"
     alias: API_STATUS
 

--- a/ai-services/assets/services/extract/podman/steps/info.md
+++ b/ai-services/assets/services/extract/podman/steps/info.md
@@ -1,7 +1,7 @@
 Day N:
 
 {{- if ne .API_URL "" }}
-{{- if eq .EXTRACT_API_STATUS "running" }}
+{{- if eq .API_STATUS "running" }}
 
 - {{ .SERVICE_NAME }} API is available to use at {{ .API_URL }}. Use this endpoint for entity extraction via programmatic access.
 {{- else }}

--- a/ai-services/assets/services/extract/podman/steps/info.md
+++ b/ai-services/assets/services/extract/podman/steps/info.md
@@ -1,9 +1,11 @@
 Day N:
 
-{{- if eq .API_STATUS "running" }}
+{{- if ne .API_URL "" }}
+{{- if eq .EXTRACT_API_STATUS "running" }}
 
 - {{ .SERVICE_NAME }} API is available to use at {{ .API_URL }}. Use this endpoint for entity extraction via programmatic access.
 {{- else }}
 
 - {{ .SERVICE_NAME }} API is unavailable to use. Please make sure 'extract-api' pod is running.
+{{- end }}
 {{- end }}

--- a/ai-services/assets/services/extract/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/extract/podman/steps/vars_file.yaml
@@ -1,4 +1,4 @@
 containers:
-  - name: "{{ .AppName }}--extract-api-extract-api"
+  - name: "extract-{{ .InstanceSlug }}-extract-api"
     format: ".Status"
     alias: API_STATUS

--- a/ai-services/assets/services/extract/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/extract/podman/steps/vars_file.yaml
@@ -1,4 +1,4 @@
 containers:
-  - name: "extract-{{ .InstanceSlug }}-extract-api"
+  - name: "extract-api-{{ .InstanceSlug }}-extract-api"
     format: ".Status"
     alias: API_STATUS

--- a/ai-services/assets/services/extract/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/extract/podman/steps/vars_file.yaml
@@ -1,0 +1,14 @@
+pods:
+  - name: "{{ .AppName }}--extract-api"
+    format: "index .Ports \"9500/tcp\" 0"
+    default: ""
+    alias: EXTRACT_API_PORT
+
+containers:
+  - name: "{{ .AppName }}--extract-api-extract-api"
+    format: ".Status"
+    alias: EXTRACT_API_STATUS
+
+hosts:
+  - fetch: HOST_IP
+    type: ip

--- a/ai-services/assets/services/extract/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/extract/podman/steps/vars_file.yaml
@@ -1,14 +1,4 @@
-pods:
-  - name: "{{ .AppName }}--extract-api"
-    format: "index .Ports \"9500/tcp\" 0"
-    default: ""
-    alias: EXTRACT_API_PORT
-
 containers:
   - name: "{{ .AppName }}--extract-api-extract-api"
     format: ".Status"
-    alias: EXTRACT_API_STATUS
-
-hosts:
-  - fetch: HOST_IP
-    type: ip
+    alias: API_STATUS

--- a/ai-services/assets/services/similarity/openshift/steps/vars_file.yaml
+++ b/ai-services/assets/services/similarity/openshift/steps/vars_file.yaml
@@ -1,5 +1,6 @@
 containers:
   - name: "similarity-api"
+    workload: "similarity-api"
     format: ".Status"
     alias: API_STATUS
 

--- a/ai-services/assets/services/similarity/podman/steps/info.md
+++ b/ai-services/assets/services/similarity/podman/steps/info.md
@@ -1,7 +1,7 @@
 Day N:
 
 {{- if ne .API_URL "" }}
-{{- if eq .API_STATUS "running" }}
+{{- if eq .SIMILARITY_API_STATUS "running" }}
 
 - {{ .SERVICE_NAME }} Search API is available to use at {{ .API_URL }}
 {{- else }}

--- a/ai-services/assets/services/similarity/podman/steps/info.md
+++ b/ai-services/assets/services/similarity/podman/steps/info.md
@@ -1,7 +1,7 @@
 Day N:
 
 {{- if ne .API_URL "" }}
-{{- if eq .SIMILARITY_API_STATUS "running" }}
+{{- if eq .API_STATUS "running" }}
 
 - {{ .SERVICE_NAME }} Search API is available to use at {{ .API_URL }}
 {{- else }}

--- a/ai-services/assets/services/similarity/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/similarity/podman/steps/vars_file.yaml
@@ -1,16 +1,4 @@
-pods:
-  - name: "{{ .AppName }}--similarity-api"
-    format: "index .Ports \"7000/tcp\" 0"
-    default: ""
-    alias: SIMILARITY_API_PORT
-
 containers:
   - name: "{{ .AppName }}--similarity-api-similarity-api"
     format: ".Status"
-    alias: SIMILARITY_API_STATUS
-
-hosts:
-  - fetch: HOST_IP
-    type: ip
-
-# Made with Bob
+    alias: API_STATUS

--- a/ai-services/assets/services/similarity/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/similarity/podman/steps/vars_file.yaml
@@ -1,4 +1,4 @@
 containers:
-  - name: "similarity-{{ .InstanceSlug }}-similarity-api"
+  - name: "similarity-api-{{ .InstanceSlug }}-similarity-api"
     format: ".Status"
     alias: API_STATUS

--- a/ai-services/assets/services/similarity/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/similarity/podman/steps/vars_file.yaml
@@ -1,4 +1,4 @@
 containers:
-  - name: "{{ .AppName }}--similarity-api-similarity-api"
+  - name: "similarity-{{ .InstanceSlug }}-similarity-api"
     format: ".Status"
     alias: API_STATUS

--- a/ai-services/assets/services/summarize/openshift/steps/vars_file.yaml
+++ b/ai-services/assets/services/summarize/openshift/steps/vars_file.yaml
@@ -1,5 +1,6 @@
 containers:
   - name: "summarize-api"
+    workload: "summarize-api"
     format: ".Status"
     alias: API_STATUS
 

--- a/ai-services/assets/services/summarize/podman/steps/info.md
+++ b/ai-services/assets/services/summarize/podman/steps/info.md
@@ -1,7 +1,7 @@
 Day N:
 
 {{- if ne .API_URL "" }}
-{{- if eq .SUMMARIZE_API_STATUS "running" }}
+{{- if eq .API_STATUS "running" }}
 
 - {{ .SERVICE_NAME }} API is available to use at {{ .API_URL }}. Use this endpoint for document summarization via programmatic access.
 {{- else }}

--- a/ai-services/assets/services/summarize/podman/steps/info.md
+++ b/ai-services/assets/services/summarize/podman/steps/info.md
@@ -1,9 +1,11 @@
 Day N:
 
-{{- if eq .API_STATUS "running" }}
+{{- if ne .API_URL "" }}
+{{- if eq .SUMMARIZE_API_STATUS "running" }}
 
 - {{ .SERVICE_NAME }} API is available to use at {{ .API_URL }}. Use this endpoint for document summarization via programmatic access.
 {{- else }}
 
 - {{ .SERVICE_NAME }} API is unavailable to use. Please make sure 'summarize-api' pod is running.
+{{- end }}
 {{- end }}

--- a/ai-services/assets/services/summarize/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/summarize/podman/steps/vars_file.yaml
@@ -1,4 +1,4 @@
 containers:
-  - name: "{{ .AppName }}--summarize-api-summarize-api"
+  - name: "summarize-{{ .InstanceSlug }}-summarize-api"
     format: ".Status"
     alias: API_STATUS

--- a/ai-services/assets/services/summarize/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/summarize/podman/steps/vars_file.yaml
@@ -1,4 +1,4 @@
 containers:
-  - name: "summarize-{{ .InstanceSlug }}-summarize-api"
+  - name: "summarize-api-{{ .InstanceSlug }}-summarize-api"
     format: ".Status"
     alias: API_STATUS

--- a/ai-services/assets/services/summarize/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/summarize/podman/steps/vars_file.yaml
@@ -1,16 +1,4 @@
-pods:
-  - name: "{{ .AppName }}--summarize-api"
-    format: "index .Ports \"6000/tcp\" 0"
-    default: ""
-    alias: SUMMARIZE_API_PORT
-
 containers:
   - name: "{{ .AppName }}--summarize-api-summarize-api"
     format: ".Status"
-    alias: SUMMARIZE_API_STATUS
-
-hosts:
-  - fetch: HOST_IP
-    type: ip
-
-# Made with Bob
+    alias: API_STATUS

--- a/ai-services/assets/services/translate/openshift/steps/vars_file.yaml
+++ b/ai-services/assets/services/translate/openshift/steps/vars_file.yaml
@@ -1,5 +1,6 @@
 containers:
   - name: "translate-api"
+    workload: "translate-api"
     format: ".Status"
     alias: API_STATUS
 

--- a/ai-services/assets/services/translate/podman/steps/info.md
+++ b/ai-services/assets/services/translate/podman/steps/info.md
@@ -1,9 +1,11 @@
 Day N:
 
-{{- if eq .API_STATUS "running" }}
+{{- if ne .API_URL "" }}
+{{- if eq .TRANSLATE_API_STATUS "running" }}
 
 - {{ .SERVICE_NAME }} API is available to use at {{ .API_URL }}. Use this endpoint for document translation via programmatic access.
 {{- else }}
 
 - {{ .SERVICE_NAME }} API is unavailable to use. Please make sure 'translate-api' pod is running.
+{{- end }}
 {{- end }}

--- a/ai-services/assets/services/translate/podman/steps/info.md
+++ b/ai-services/assets/services/translate/podman/steps/info.md
@@ -1,7 +1,7 @@
 Day N:
 
 {{- if ne .API_URL "" }}
-{{- if eq .TRANSLATE_API_STATUS "running" }}
+{{- if eq .API_STATUS "running" }}
 
 - {{ .SERVICE_NAME }} API is available to use at {{ .API_URL }}. Use this endpoint for document translation via programmatic access.
 {{- else }}

--- a/ai-services/assets/services/translate/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/translate/podman/steps/vars_file.yaml
@@ -1,14 +1,4 @@
-pods:
-  - name: "{{ .AppName }}--translate-api"
-    format: "index .Ports \"9000/tcp\" 0"
-    default: ""
-    alias: TRANSLATE_API_PORT
-
 containers:
   - name: "{{ .AppName }}--translate-api-translate-api"
     format: ".Status"
-    alias: TRANSLATE_API_STATUS
-
-hosts:
-  - fetch: HOST_IP
-    type: ip
+    alias: API_STATUS

--- a/ai-services/assets/services/translate/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/translate/podman/steps/vars_file.yaml
@@ -1,0 +1,14 @@
+pods:
+  - name: "{{ .AppName }}--translate-api"
+    format: "index .Ports \"9000/tcp\" 0"
+    default: ""
+    alias: TRANSLATE_API_PORT
+
+containers:
+  - name: "{{ .AppName }}--translate-api-translate-api"
+    format: ".Status"
+    alias: TRANSLATE_API_STATUS
+
+hosts:
+  - fetch: HOST_IP
+    type: ip

--- a/ai-services/assets/services/translate/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/translate/podman/steps/vars_file.yaml
@@ -1,4 +1,4 @@
 containers:
-  - name: "translate-{{ .InstanceSlug }}-translate-api"
+  - name: "translate-api-{{ .InstanceSlug }}-translate-api"
     format: ".Status"
     alias: API_STATUS

--- a/ai-services/assets/services/translate/podman/steps/vars_file.yaml
+++ b/ai-services/assets/services/translate/podman/steps/vars_file.yaml
@@ -1,4 +1,4 @@
 containers:
-  - name: "{{ .AppName }}--translate-api-translate-api"
+  - name: "translate-{{ .InstanceSlug }}-translate-api"
     format: ".Status"
     alias: API_STATUS

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.319
+  image: icr.io/ai-services-cicd/ai-services:v0.0.320
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.319
+  image: icr.io/ai-services-cicd/ai-services:v0.0.320
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -19,14 +19,15 @@ import (
 	apiModels "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	appFlags "github.com/project-ai-services/ai-services/internal/pkg/cli/constants/application"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/flagvalidator"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
-	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	cliutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/image"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
@@ -562,49 +563,53 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 	logger.Infoln("-------")
 
 	for _, service := range application.Services {
-		params := map[string]string{}
-		params["SERVICE_NAME"] = service.Type
-
-		// Populate endpoint URLs from the service endpoints stored in the DB
-		for _, endpoint := range service.Endpoints {
-			urlType, urlTypeOk := endpoint["type"].(string)
-			url, urlOk := endpoint["url"].(string)
-			if urlTypeOk && urlOk {
-				params[strings.ToUpper(urlType)+"_URL"] = url
-			}
-		}
-
-		rawFiles, err := appClient.GetServiceSteps(ctx, service.CatalogID, runtimeType)
-		if err != nil {
-			logger.Warningf("Failed to load next steps for service '%s': %v\n", service.CatalogID, err)
-
-			continue
-		}
-
-		// Populate status params generically from vars_file.yaml
-		if appPS != nil {
-			if err := populateStatusFromVarsFile(rawFiles, params, appPS.Services, instanceSlug, rt); err != nil {
-				logger.WarningfCtx(ctx, "failed to populate status for '%s': %v\n", service.CatalogID, err)
-			}
-		}
-
-		tmpls, err := parseStepsTemplates(rawFiles)
-		if err != nil {
-			logger.Warningf("Failed to parse next steps templates for service '%s': %v\n", service.CatalogID, err)
-
-			continue
-		}
-
-		err = printNextStepsMD(tmpls, params)
-		if err != nil {
-			logger.Warningf("Failed to render next steps for service '%s': %v\n", service.CatalogID, err)
-		}
+		printServiceNextSteps(ctx, appClient, appPS, service, instanceSlug, rt)
 	}
 
 	// Print the info command regardless of whether any service has next.md
 	logger.Infof("\n- For detailed endpoint information, use: `ai-services application info %s --runtime %s`\n", application.Name, runtimeType)
 
 	return nil
+}
+
+// printServiceNextSteps renders and prints the next.md template for a single service.
+func printServiceNextSteps(ctx context.Context, appClient *catalogClient.ApplicationClient, appPS *catalogTypes.ApplicationPSResponse, service catalogTypes.ApplicationService, instanceSlug string, rt runtimeTypes.RuntimeType) {
+	params := map[string]string{}
+	params["SERVICE_NAME"] = service.Type
+
+	// Populate endpoint URLs from the service endpoints stored in the DB
+	for _, endpoint := range service.Endpoints {
+		urlType, urlTypeOk := endpoint["type"].(string)
+		url, urlOk := endpoint["url"].(string)
+		if urlTypeOk && urlOk {
+			params[strings.ToUpper(urlType)+"_URL"] = url
+		}
+	}
+
+	rawFiles, err := appClient.GetServiceSteps(ctx, service.CatalogID, runtimeType)
+	if err != nil {
+		logger.Warningf("Failed to load next steps for service '%s': %v\n", service.CatalogID, err)
+
+		return
+	}
+
+	// Populate status params generically from vars_file.yaml
+	if appPS != nil {
+		if err := populateStatusFromVarsFile(rawFiles, params, appPS.Services, instanceSlug, rt); err != nil {
+			logger.WarningfCtx(ctx, "failed to populate status for '%s': %v\n", service.CatalogID, err)
+		}
+	}
+
+	tmpls, err := parseStepsTemplates(rawFiles)
+	if err != nil {
+		logger.Warningf("Failed to parse next steps templates for service '%s': %v\n", service.CatalogID, err)
+
+		return
+	}
+
+	if err = printNextStepsMD(tmpls, params); err != nil {
+		logger.Warningf("Failed to render next steps for service '%s': %v\n", service.CatalogID, err)
+	}
 }
 
 // printNextStepsMD renders and prints the next.md template for a service.

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -576,7 +576,7 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 			continue
 		}
 
-		err = printNextStepsMD(tmpls, params)
+		err = printNextStepsMD(tmpls, params, application.Name, runtimeType)
 		if err != nil {
 			logger.Warningf("Failed to render next steps for service '%s': %v\n", service.CatalogID, err)
 		}
@@ -589,7 +589,7 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 }
 
 // printNextStepsMD renders and prints the next.md template for a service.
-func printNextStepsMD(tmpls map[string]*template.Template, params map[string]string) error {
+func printNextStepsMD(tmpls map[string]*template.Template, params map[string]string, _, _ string) error {
 	tmpl, ok := tmpls["next.md"]
 	if !ok {
 		// next.md doesn't exist for this service, skip

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -546,6 +546,14 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 		return fmt.Errorf("failed to get application: %w", err)
 	}
 
+	// Fetch pod/container status for vars_file.yaml-driven status population
+	appPS, err := appClient.GetApplicationPS(ctx, app.ID)
+	if err != nil {
+		logger.Warningf("Failed to get application pods for next steps: %v\n", err)
+	}
+
+	rt := vars.RuntimeFactory.GetRuntimeType()
+
 	logger.Infoln("\nNext Steps:")
 	logger.Infoln("-------")
 
@@ -553,7 +561,7 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 		params := map[string]string{}
 		params["SERVICE_NAME"] = service.Type
 
-		// Add endpoint URLs to params
+		// Populate endpoint URLs from the service endpoints stored in the DB
 		for _, endpoint := range service.Endpoints {
 			urlType, urlTypeOk := endpoint["type"].(string)
 			url, urlOk := endpoint["url"].(string)
@@ -567,6 +575,13 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 			logger.Warningf("Failed to load next steps for service '%s': %v\n", service.CatalogID, err)
 
 			continue
+		}
+
+		// Populate status params generically from vars_file.yaml
+		if appPS != nil {
+			if err := populateStatusFromVarsFile(rawFiles, params, appPS.Services, appPS.Name, rt); err != nil {
+				logger.WarningfCtx(ctx, "failed to populate status for '%s': %v\n", service.CatalogID, err)
+			}
 		}
 
 		tmpls, err := parseStepsTemplates(rawFiles)

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -551,7 +551,7 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 	// Fetch pod/container status for vars_file.yaml-driven status population
 	appPS, err := appClient.GetApplicationPS(ctx, app.ID)
 	if err != nil {
-		logger.Warningf("Failed to get application pods for next steps: %v\n", err)
+		return fmt.Errorf("failed to get application pods for next steps: %w", err)
 	}
 
 	rt := vars.RuntimeFactory.GetRuntimeType()
@@ -594,10 +594,8 @@ func printServiceNextSteps(ctx context.Context, appClient *catalogClient.Applica
 	}
 
 	// Populate status params generically from vars_file.yaml
-	if appPS != nil {
-		if err := populateStatusFromVarsFile(rawFiles, params, appPS.Services, instanceSlug, rt); err != nil {
-			logger.WarningfCtx(ctx, "failed to populate status for '%s': %v\n", service.CatalogID, err)
-		}
+	if err := populateStatusFromVarsFile(rawFiles, params, appPS.Services, instanceSlug, rt); err != nil {
+		logger.WarningfCtx(ctx, "failed to populate status for '%s': %v\n", service.CatalogID, err)
 	}
 
 	tmpls, err := parseStepsTemplates(rawFiles)

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -576,7 +576,7 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 			continue
 		}
 
-		err = printNextStepsMD(tmpls, params, application.Name, runtimeType)
+		err = printNextStepsMD(tmpls, params)
 		if err != nil {
 			logger.Warningf("Failed to render next steps for service '%s': %v\n", service.CatalogID, err)
 		}
@@ -589,7 +589,7 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 }
 
 // printNextStepsMD renders and prints the next.md template for a service.
-func printNextStepsMD(tmpls map[string]*template.Template, params map[string]string, _, _ string) error {
+func printNextStepsMD(tmpls map[string]*template.Template, params map[string]string) error {
 	tmpl, ok := tmpls["next.md"]
 	if !ok {
 		// next.md doesn't exist for this service, skip

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -23,6 +23,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/flagvalidator"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
+	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	cliutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/image"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
@@ -554,6 +555,9 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 
 	rt := vars.RuntimeFactory.GetRuntimeType()
 
+	// InstanceSlug is derived from the application UUID — same as at deploy time
+	instanceSlug := catalogUtils.GenerateInstanceSlug(app.ID)
+
 	logger.Infoln("\nNext Steps:")
 	logger.Infoln("-------")
 
@@ -579,7 +583,7 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 
 		// Populate status params generically from vars_file.yaml
 		if appPS != nil {
-			if err := populateStatusFromVarsFile(rawFiles, params, appPS.Services, appPS.Name, rt); err != nil {
+			if err := populateStatusFromVarsFile(rawFiles, params, appPS.Services, instanceSlug, rt); err != nil {
 				logger.WarningfCtx(ctx, "failed to populate status for '%s': %v\n", service.CatalogID, err)
 			}
 		}

--- a/ai-services/cmd/ai-services/cmd/application/info.go
+++ b/ai-services/cmd/ai-services/cmd/application/info.go
@@ -14,6 +14,7 @@ import (
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	cliUtils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
@@ -105,13 +106,16 @@ func renderApplicationInfo(ctx context.Context, appName string, rt types.Runtime
 	logger.Infoln("Application Template: " + application.CatalogID)
 	logger.Infoln("Application Version: " + application.Version)
 
-	return printServicesInfo(ctx, appClient, application.Services, appPS, rt)
+	return printServicesInfo(ctx, appClient, application.Services, appPS, app.ID, rt)
 }
 
-func printServicesInfo(ctx context.Context, appClient *catalogClient.ApplicationClient, services []catalogTypes.ApplicationService, appPS *catalogTypes.ApplicationPSResponse, rt types.RuntimeType) error {
+func printServicesInfo(ctx context.Context, appClient *catalogClient.ApplicationClient, services []catalogTypes.ApplicationService, appPS *catalogTypes.ApplicationPSResponse, appID string, rt types.RuntimeType) error {
 	logger.Infoln("Info:")
 	logger.Infoln("-------")
 	logger.Infoln("Day N: ")
+
+	// InstanceSlug is derived from the application UUID — same as at deploy time
+	instanceSlug := catalogUtils.GenerateInstanceSlug(appID)
 
 	for _, service := range services {
 		params := map[string]string{}
@@ -132,7 +136,7 @@ func printServicesInfo(ctx context.Context, appClient *catalogClient.Application
 		}
 
 		// Populate status params generically from vars_file.yaml
-		if err := populateStatusFromVarsFile(rawFiles, params, appPS.Services, appPS.Name, rt); err != nil {
+		if err := populateStatusFromVarsFile(rawFiles, params, appPS.Services, instanceSlug, rt); err != nil {
 			logger.WarningfCtx(ctx, "failed to populate status for '%s': %v\n", service.CatalogID, err)
 		}
 
@@ -182,24 +186,25 @@ type varsFileContainers struct {
 }
 
 // populateStatusFromVarsFile reads the containers section of vars_file.yaml, renders each
-// name template (supports {{ .AppName }} for Podman), then looks up status from appPods:
-//   - Podman: matches the rendered name against pod container names
-//   - OpenShift: matches the rendered name as a pod-name prefix
+// name template, then looks up status from appPods:
+//   - Podman: name renders to "{catalogID}-{instanceSlug}-{containerName}";
+//     matched exactly against Pod.Containers[].Name.
+//   - OpenShift: name is a plain pod-name prefix (e.g. "digitize-ui"); matched against Pod.PodName.
 //
-// For each match with Format ".Status", alias → "running" (healthy) or "" is set in params.
-func populateStatusFromVarsFile(rawFiles map[string]string, params map[string]string, appPods []catalogTypes.Pod, appName string, rt types.RuntimeType) error {
+// For each entry with Format ".Status", alias → "running" (healthy) or "" is set in params.
+func populateStatusFromVarsFile(rawFiles map[string]string, params map[string]string, appPods []catalogTypes.Pod, instanceSlug string, rt types.RuntimeType) error {
 	raw, ok := rawFiles["vars_file.yaml"]
 	if !ok {
 		return nil
 	}
 
-	// Render the vars_file template so {{ .AppName }} is resolved (Podman uses this)
+	// Render the vars_file template — {{ .InstanceSlug }} expands to the computed slug
 	var rendered bytes.Buffer
 	tmpl, err := template.New("vars").Parse(raw)
 	if err != nil {
 		return fmt.Errorf("parse vars_file.yaml: %w", err)
 	}
-	if err := tmpl.Execute(&rendered, map[string]string{"AppName": appName}); err != nil {
+	if err := tmpl.Execute(&rendered, map[string]string{"InstanceSlug": instanceSlug}); err != nil {
 		return fmt.Errorf("execute vars_file.yaml: %w", err)
 	}
 
@@ -223,8 +228,9 @@ func populateStatusFromVarsFile(rawFiles map[string]string, params map[string]st
 // resolveContainerStatus returns "running" when the named container/pod is healthy,
 // using a runtime-appropriate lookup strategy derived from vars_file.yaml entries.
 //
-//   - Podman: name is the full container name (e.g. "myapp--chat-bot-ui"); matched
-//     against Pod.Containers[].Name inside all pods.
+//   - Podman: name is the full container name after template rendering
+//     (e.g. "custom-chatbot-abc123-custom-chatbot"); matched exactly against
+//     Pod.Containers[].Name.
 //   - OpenShift: name is a pod-name prefix (e.g. "digitize-ui"); matched against
 //     Pod.PodName with a HasPrefix check, healthy at the pod level.
 func resolveContainerStatus(name string, appPods []catalogTypes.Pod, rt types.RuntimeType) string {

--- a/ai-services/cmd/ai-services/cmd/application/info.go
+++ b/ai-services/cmd/ai-services/cmd/application/info.go
@@ -179,17 +179,21 @@ func parseStepsTemplates(rawFiles map[string]string) (map[string]*template.Templ
 // varsFileContainers is the minimal shape of vars_file.yaml needed for status resolution.
 type varsFileContainers struct {
 	Containers []struct {
-		Name   string `yaml:"name"`
-		Format string `yaml:"format"`
-		Alias  string `yaml:"alias"`
+		Name     string `yaml:"name"`
+		Workload string `yaml:"workload"`
+		Format   string `yaml:"format"`
+		Alias    string `yaml:"alias"`
 	} `yaml:"containers"`
 }
 
 // populateStatusFromVarsFile reads the containers section of vars_file.yaml, renders each
-// name template, then looks up status from appPods:
-//   - Podman: name renders to "{catalogID}-{instanceSlug}-{containerName}";
-//     matched exactly against Pod.Containers[].Name.
-//   - OpenShift: name is a plain pod-name prefix (e.g. "digitize-ui"); matched against Pod.PodName.
+// name template with InstanceSlug, then resolves container health from appPods.
+//
+// Podman: name is the full rendered container name (e.g. "chat-bot-{slug}-ui"), matched
+// exactly against PodContainer.Name. The workload field is ignored.
+//
+// OpenShift: workload is the deployment name (e.g. "chat-bot-ui"); pod.PodName is
+// prefix-matched against workload and container name is exact-matched against c.Name.
 //
 // For each entry with Format ".Status", alias → "running" (healthy) or "" is set in params.
 func populateStatusFromVarsFile(rawFiles map[string]string, params map[string]string, appPods []catalogTypes.Pod, instanceSlug string, rt types.RuntimeType) error {
@@ -219,21 +223,20 @@ func populateStatusFromVarsFile(rawFiles map[string]string, params map[string]st
 			continue
 		}
 		alias := strings.ReplaceAll(c.Alias, "-", "_")
-		params[alias] = resolveContainerStatus(c.Name, appPods, rt)
+		params[alias] = resolveContainerStatus(c.Name, c.Workload, appPods, rt)
 	}
 
 	return nil
 }
 
-// resolveContainerStatus returns "running" when the named container/pod is healthy,
-// using a runtime-appropriate lookup strategy derived from vars_file.yaml entries.
+// resolveContainerStatus returns "running" when the named container is healthy.
 //
-//   - Podman: name is the full container name after template rendering
-//     (e.g. "custom-chatbot-abc123-custom-chatbot"); matched exactly against
-//     Pod.Containers[].Name.
-//   - OpenShift: name is a pod-name prefix (e.g. "digitize-ui"); matched against
-//     Pod.PodName with a HasPrefix check, healthy at the pod level.
-func resolveContainerStatus(name string, appPods []catalogTypes.Pod, rt types.RuntimeType) string {
+// Podman: name is the full container name matched exactly against PodContainer.Name.
+//
+// OpenShift: workload is the deployment name; pod.PodName must have the workload as a
+// prefix (OCP pod names are "{workload}-{replicaSetHash}-{podHash}"), and container
+// name is exact-matched against PodContainer.Name (ContainerStatus.Name from pod spec).
+func resolveContainerStatus(name, workload string, appPods []catalogTypes.Pod, rt types.RuntimeType) string {
 	switch rt {
 	case types.RuntimeTypePodman:
 		for _, pod := range appPods {
@@ -245,8 +248,12 @@ func resolveContainerStatus(name string, appPods []catalogTypes.Pod, rt types.Ru
 		}
 	case types.RuntimeTypeOpenShift:
 		for _, pod := range appPods {
-			if strings.HasPrefix(pod.PodName, name) && pod.Healthy {
-				return "running"
+			if strings.HasPrefix(pod.PodName, workload+"-") {
+				for _, c := range pod.Containers {
+					if c.Name == name && c.Healthy {
+						return "running"
+					}
+				}
 			}
 		}
 	}

--- a/ai-services/cmd/ai-services/cmd/application/info.go
+++ b/ai-services/cmd/ai-services/cmd/application/info.go
@@ -8,13 +8,13 @@ import (
 	"text/template"
 
 	"github.com/spf13/cobra"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	cliUtils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
-	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
@@ -117,10 +117,7 @@ func printServicesInfo(ctx context.Context, appClient *catalogClient.Application
 		params := map[string]string{}
 		params["SERVICE_NAME"] = service.Type
 
-		uiStatus, apiStatus := getContainerStatus(appPS.Services, service.CatalogID, rt)
-		params["UI_STATUS"] = uiStatus
-		params["API_STATUS"] = apiStatus
-
+		// Populate endpoint URLs from the service endpoints stored in the DB
 		for _, endpoint := range service.Endpoints {
 			urlType, urlTypeOk := endpoint["type"].(string)
 			url, urlOk := endpoint["url"].(string)
@@ -132,6 +129,11 @@ func printServicesInfo(ctx context.Context, appClient *catalogClient.Application
 		rawFiles, err := appClient.GetServiceSteps(ctx, service.CatalogID, rt.String())
 		if err != nil {
 			return fmt.Errorf("failed to load service steps for '%s': %w", service.CatalogID, err)
+		}
+
+		// Populate status params generically from vars_file.yaml
+		if err := populateStatusFromVarsFile(rawFiles, params, appPS.Services, appPS.Name, rt); err != nil {
+			logger.WarningfCtx(ctx, "failed to populate status for '%s': %v\n", service.CatalogID, err)
 		}
 
 		tmpls, err := parseStepsTemplates(rawFiles)
@@ -170,72 +172,80 @@ func parseStepsTemplates(rawFiles map[string]string) (map[string]*template.Templ
 	return tmpls, nil
 }
 
-func getContainerStatus(services []catalogTypes.Pod, catalogID string, rt types.RuntimeType) (string, string) {
-	switch rt {
-	case types.RuntimeTypePodman:
-		return printPodmanContainerStatus(services, catalogID)
-	case types.RuntimeTypeOpenShift:
-		return printOpenshiftPodStatus(services, catalogID)
-	default:
-		return "", ""
-	}
+// varsFileContainers is the minimal shape of vars_file.yaml needed for status resolution.
+type varsFileContainers struct {
+	Containers []struct {
+		Name   string `yaml:"name"`
+		Format string `yaml:"format"`
+		Alias  string `yaml:"alias"`
+	} `yaml:"containers"`
 }
 
-func printPodmanContainerStatus(services []catalogTypes.Pod, catalogID string) (string, string) {
-	uiStatus, apiStatus := "", ""
-	for _, servicePod := range services {
-		if strings.HasPrefix(servicePod.PodName, catalogID) {
-			for _, podContainer := range servicePod.Containers {
-				// TODO: Set the container status in info.md generically
-				uiContainerName := fmt.Sprintf("%s-ui", servicePod.PodName)
-				apiContainerName := ""
-				if strings.Contains(podContainer.Name, "backend-server") {
-					apiContainerName = podContainer.Name
-				} else {
-					apiContainerName = fmt.Sprintf("%s-%s-api", servicePod.PodName, catalogID)
-				}
-
-				if podContainer.Name == uiContainerName && podContainer.Healthy {
-					uiStatus = "running"
-				}
-				if podContainer.Name == apiContainerName && podContainer.Healthy {
-					apiStatus = "running"
-				}
-			}
-		}
+// populateStatusFromVarsFile reads the containers section of vars_file.yaml, renders each
+// name template (supports {{ .AppName }} for Podman), then looks up status from appPods:
+//   - Podman: matches the rendered name against pod container names
+//   - OpenShift: matches the rendered name as a pod-name prefix
+//
+// For each match with Format ".Status", alias → "running" (healthy) or "" is set in params.
+func populateStatusFromVarsFile(rawFiles map[string]string, params map[string]string, appPods []catalogTypes.Pod, appName string, rt types.RuntimeType) error {
+	raw, ok := rawFiles["vars_file.yaml"]
+	if !ok {
+		return nil
 	}
 
-	return uiStatus, apiStatus
-}
+	// Render the vars_file template so {{ .AppName }} is resolved (Podman uses this)
+	var rendered bytes.Buffer
+	tmpl, err := template.New("vars").Parse(raw)
+	if err != nil {
+		return fmt.Errorf("parse vars_file.yaml: %w", err)
+	}
+	if err := tmpl.Execute(&rendered, map[string]string{"AppName": appName}); err != nil {
+		return fmt.Errorf("execute vars_file.yaml: %w", err)
+	}
 
-/*
-1. For each service fetch all labels
-2. See if that service has ai-services.io/component-type label
-3. If yes, check if value is api or ui
-4. Update status accordingly.
-*/
-func printOpenshiftPodStatus(services []catalogTypes.Pod, catalogID string) (string, string) {
-	uiStatus, apiStatus := "", ""
+	var vf varsFileContainers
+	if err := yaml.Unmarshal(rendered.Bytes(), &vf); err != nil {
+		return fmt.Errorf("unmarshal vars_file.yaml: %w", err)
+	}
 
-	for _, service := range services {
-		if !strings.HasPrefix(service.PodName, catalogID) {
+	for _, c := range vf.Containers {
+		// Only handle ".Status" format entries — those drive a status alias
+		if strings.TrimSpace(c.Format) != ".Status" {
 			continue
 		}
+		alias := strings.ReplaceAll(c.Alias, "-", "_")
+		params[alias] = resolveContainerStatus(c.Name, appPods, rt)
+	}
 
-		component := service.Labels[constants.ComponentLabelKey]
-		switch component {
-		case "ui":
-			if service.Healthy {
-				uiStatus = "running"
+	return nil
+}
+
+// resolveContainerStatus returns "running" when the named container/pod is healthy,
+// using a runtime-appropriate lookup strategy derived from vars_file.yaml entries.
+//
+//   - Podman: name is the full container name (e.g. "myapp--chat-bot-ui"); matched
+//     against Pod.Containers[].Name inside all pods.
+//   - OpenShift: name is a pod-name prefix (e.g. "digitize-ui"); matched against
+//     Pod.PodName with a HasPrefix check, healthy at the pod level.
+func resolveContainerStatus(name string, appPods []catalogTypes.Pod, rt types.RuntimeType) string {
+	switch rt {
+	case types.RuntimeTypePodman:
+		for _, pod := range appPods {
+			for _, c := range pod.Containers {
+				if c.Name == name && c.Healthy {
+					return "running"
+				}
 			}
-		case "api":
-			if service.Healthy {
-				apiStatus = "running"
+		}
+	case types.RuntimeTypeOpenShift:
+		for _, pod := range appPods {
+			if strings.HasPrefix(pod.PodName, name) && pod.Healthy {
+				return "running"
 			}
 		}
 	}
 
-	return uiStatus, apiStatus
+	return ""
 }
 
 func printInfo(tmpls map[string]*template.Template, params map[string]string) error {

--- a/ai-services/cmd/ai-services/cmd/application/info.go
+++ b/ai-services/cmd/ai-services/cmd/application/info.go
@@ -239,26 +239,33 @@ func populateStatusFromVarsFile(rawFiles map[string]string, params map[string]st
 func resolveContainerStatus(name, workload string, appPods []catalogTypes.Pod, rt types.RuntimeType) string {
 	switch rt {
 	case types.RuntimeTypePodman:
-		for _, pod := range appPods {
-			for _, c := range pod.Containers {
-				if c.Name == name && c.Healthy {
-					return "running"
-				}
-			}
+		if isContainerHealthyInPods(name, appPods, "") {
+			return "running"
 		}
 	case types.RuntimeTypeOpenShift:
-		for _, pod := range appPods {
-			if strings.HasPrefix(pod.PodName, workload+"-") {
-				for _, c := range pod.Containers {
-					if c.Name == name && c.Healthy {
-						return "running"
-					}
-				}
-			}
+		if isContainerHealthyInPods(name, appPods, workload+"-") {
+			return "running"
 		}
 	}
 
 	return ""
+}
+
+// isContainerHealthyInPods reports whether the named container is healthy in any pod
+// whose PodName has the given prefix (use an empty prefix to match all pods).
+func isContainerHealthyInPods(name string, pods []catalogTypes.Pod, podPrefix string) bool {
+	for _, pod := range pods {
+		if podPrefix != "" && !strings.HasPrefix(pod.PodName, podPrefix) {
+			continue
+		}
+		for _, c := range pod.Containers {
+			if c.Name == name && c.Healthy {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func printInfo(tmpls map[string]*template.Template, params map[string]string) error {

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
@@ -3,6 +3,7 @@ package deployment
 import (
 	"context"
 	"fmt"
+	"path"
 
 	"github.com/google/uuid"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
@@ -142,7 +143,7 @@ func (p *DeploymentPlanner) processService(
 
 	servicePlan := &ServicePlan{
 		CatalogID:     svc.CatalogID,
-		CatalogPath:   fmt.Sprintf("%s/%s", servicePath, runtimeType),
+		CatalogPath:   path.Join(servicePath, runtimeType),
 		Version:       svc.Version,
 		ComponentRefs: make([]string, 0),
 	}
@@ -218,7 +219,7 @@ func (p *DeploymentPlanner) processComponent(
 		Hash:           componentHash,
 		ComponentType:  comp.ComponentType,
 		ProviderID:     comp.ProviderID,
-		CatalogPath:    fmt.Sprintf("%s/%s", componentPath, runtimeType),
+		CatalogPath:    path.Join(componentPath, runtimeType),
 		Version:        comp.Version,
 		Params:         comp.Params,
 		UsedByServices: []string{catalogID},

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/openshift/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/openshift/deployer.go
@@ -3,6 +3,7 @@ package openshift
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"maps"
 	"strings"
 	"time"
@@ -133,7 +134,7 @@ func (d *OpenShiftDeployer) deployPrerequisites(ctx context.Context, ns string) 
 		chartPath := prereqRoot + "/" + entry.Name()
 		release := entry.Name() // e.g. "serving-runtime-cpu"
 
-		if err := helmInstallOrUpgrade(ctx, ns, release, chartPath, map[string]any{}, ""); err != nil {
+		if err := helmInstallOrUpgrade(ctx, ns, release, chartPath, &assets.CatalogFS, map[string]any{}, ""); err != nil {
 			return fmt.Errorf("failed to deploy prerequisite '%s': %w", release, err)
 		}
 	}
@@ -168,7 +169,14 @@ func (d *OpenShiftDeployer) deployComponentsConcurrently(ctx context.Context, ns
 // deployComponent installs or upgrades the Helm chart for a single component,
 // then registers the deterministic KServe predictor endpoint in the database.
 func (d *OpenShiftDeployer) deployComponent(ctx context.Context, ns string, plan *DeploymentPlan, comp *ComponentPlan) error {
-	if err := helmInstallOrUpgrade(ctx, ns, catalogutils.HelmReleaseName(plan.ApplicationID, strings.ReplaceAll(comp.ComponentType, "_", "-")), comp.CatalogPath, comp.Values, comp.DatabaseID.String()); err != nil {
+	componentKey := fmt.Sprintf("%s/%s", comp.ComponentType, comp.ProviderID)
+
+	fsys, err := d.catalogProvider.GetItemFS(componentKey)
+	if err != nil {
+		return fmt.Errorf("failed to get filesystem for component %s: %w", componentKey, err)
+	}
+
+	if err := helmInstallOrUpgrade(ctx, ns, catalogutils.HelmReleaseName(plan.ApplicationID, strings.ReplaceAll(comp.ComponentType, "_", "-")), comp.CatalogPath, fsys, comp.Values, comp.DatabaseID.String()); err != nil {
 		return err
 	}
 
@@ -225,7 +233,12 @@ func (d *OpenShiftDeployer) deployServicesConcurrently(ctx context.Context, ns s
 func (d *OpenShiftDeployer) deployService(ctx context.Context, ns string, plan *DeploymentPlan, svc *ServicePlan) error {
 	releaseName := catalogutils.HelmReleaseName(plan.ApplicationID, svc.CatalogID)
 
-	if err := helmInstallOrUpgrade(ctx, ns, releaseName, svc.CatalogPath, svc.Values, svc.DatabaseID.String()); err != nil {
+	fsys, err := d.catalogProvider.GetItemFS(svc.CatalogID)
+	if err != nil {
+		return fmt.Errorf("failed to get filesystem for service %s: %w", svc.CatalogID, err)
+	}
+
+	if err := helmInstallOrUpgrade(ctx, ns, releaseName, svc.CatalogPath, fsys, svc.Values, svc.DatabaseID.String()); err != nil {
 		return err
 	}
 
@@ -305,12 +318,12 @@ func (d *OpenShiftDeployer) updateComponentEndpoint(ctx context.Context, ns stri
 	return nil
 }
 
-// helmInstallOrUpgrade loads the chart at catalogPath from the embedded CatalogFS and
+// helmInstallOrUpgrade loads the chart at catalogPath from fsys and
 // performs helm install (if the release doesn't exist) or upgrade.
 // templateID is injected as a --set override (not part of values.yaml) so that
 // ai-services.io/template labels carry the DB UUID, matching the Podman convention.
-func helmInstallOrUpgrade(ctx context.Context, namespace, release, catalogPath string, values map[string]any, templateID string) error {
-	chart, err := catalogutils.LoadChartFromCatalogFS(catalogPath)
+func helmInstallOrUpgrade(ctx context.Context, namespace, release, catalogPath string, fsys fs.FS, values map[string]any, templateID string) error {
+	chart, err := catalogutils.LoadChartFromFS(fsys, catalogPath)
 	if err != nil {
 		return fmt.Errorf("failed to load chart at %s: %w", catalogPath, err)
 	}

--- a/ai-services/internal/pkg/catalog/catalog.go
+++ b/ai-services/internal/pkg/catalog/catalog.go
@@ -372,6 +372,13 @@ func (p *CatalogProvider) getItemFS(key string) (fs.FS, error) {
 	return item.itemFS, nil
 }
 
+// GetItemFS returns the filesystem for the catalog item identified by key.
+// Embedded items return &assets.CatalogFS; bundle items return an os.DirFS
+// rooted at their extracted directory on disk.
+func (p *CatalogProvider) GetItemFS(key string) (fs.FS, error) {
+	return p.getItemFS(key)
+}
+
 // ToServiceSummary converts a Service to ServiceSummary.
 func ToServiceSummary(service *types.Service) types.ServiceSummary {
 	return types.ServiceSummary{

--- a/ai-services/internal/pkg/catalog/catalog.go
+++ b/ai-services/internal/pkg/catalog/catalog.go
@@ -144,7 +144,7 @@ func (p *CatalogProvider) loadBundleItems(ctx context.Context, items map[string]
 		// Map catalog_type "service"/"component" → "services"/"components" to match
 		// the embedded-FS dispatch keys used in parseAndStoreMetadata.
 		catalogType := b.CatalogType + "s"
-		if err := parseAndStoreMetadataWithFS(ctx, catalogType, "metadata.yaml", ".", bundleFS, data, items); err != nil {
+		if err := parseAndStoreMetadataWithFS(ctx, catalogType, "metadata.yaml", "", bundleFS, data, items); err != nil {
 			logger.ErrorfCtx(ctx, "bundle %s: failed to parse metadata: %v", b.ID, err)
 		}
 	}

--- a/ai-services/internal/pkg/catalog/catalog.go
+++ b/ai-services/internal/pkg/catalog/catalog.go
@@ -360,23 +360,16 @@ func (p *CatalogProvider) GetCatalogItemPath(id string) (string, error) {
 	return item.Path, nil
 }
 
-// getItemFS returns the filesystem for the catalog item identified by key.
+// GetItemFS returns the filesystem for the catalog item identified by key.
 // Every item carries a non-nil itemFS: &assets.CatalogFS for embedded items,
 // os.DirFS for bundle items.
-func (p *CatalogProvider) getItemFS(key string) (fs.FS, error) {
+func (p *CatalogProvider) GetItemFS(key string) (fs.FS, error) {
 	item, ok := p.getItem(key)
 	if !ok {
 		return nil, fmt.Errorf("item '%s' not found", key)
 	}
 
 	return item.itemFS, nil
-}
-
-// GetItemFS returns the filesystem for the catalog item identified by key.
-// Embedded items return &assets.CatalogFS; bundle items return an os.DirFS
-// rooted at their extracted directory on disk.
-func (p *CatalogProvider) GetItemFS(key string) (fs.FS, error) {
-	return p.getItemFS(key)
 }
 
 // ToServiceSummary converts a Service to ServiceSummary.
@@ -729,7 +722,7 @@ func (p *CatalogProvider) LoadServiceValues(serviceID string, argParams map[stri
 	runtimeStr := string(runtime)
 
 	// Read values.yaml using the item's own filesystem (embedded or bundle os.DirFS)
-	itemFS, err := p.getItemFS(serviceID)
+	itemFS, err := p.GetItemFS(serviceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
 	}
@@ -781,7 +774,7 @@ func (p *CatalogProvider) LoadComponentValues(componentType, providerID string, 
 	runtimeStr := string(runtime)
 
 	// Read values.yaml using the item's own filesystem (embedded or bundle os.DirFS)
-	itemFS, err := p.getItemFS(componentKey)
+	itemFS, err := p.GetItemFS(componentKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
 	}
@@ -828,7 +821,7 @@ func (p *CatalogProvider) LoadComponentRuntimeMetadata(componentType, providerID
 	catalogPath := filepath.Join(componentPath, runtimeType)
 
 	// Read metadata.yaml using the item's own filesystem
-	itemFS, err := p.getItemFS(componentKey)
+	itemFS, err := p.GetItemFS(componentKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
 	}
@@ -865,7 +858,7 @@ func (p *CatalogProvider) LoadComponentTemplates(componentType, providerID strin
 	catalogPath := filepath.Join(componentPath, runtimeStr, "templates")
 
 	// Load all template files using the item's own filesystem
-	itemFS, err := p.getItemFS(componentKey)
+	itemFS, err := p.GetItemFS(componentKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
 	}
@@ -930,7 +923,7 @@ func (p *CatalogProvider) LoadServiceRuntimeMetadata(serviceID, runtimeType stri
 	catalogPath := filepath.Join(servicePath, runtimeType)
 
 	// Read metadata.yaml using the item's own filesystem
-	itemFS, err := p.getItemFS(serviceID)
+	itemFS, err := p.GetItemFS(serviceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
 	}
@@ -966,7 +959,7 @@ func (p *CatalogProvider) LoadServiceTemplates(serviceID string) (map[string]*te
 	catalogPath := filepath.Join(servicePath, runtimeStr, "templates")
 
 	// Load all template files using the item's own filesystem
-	itemFS, err := p.getItemFS(serviceID)
+	itemFS, err := p.GetItemFS(serviceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
 	}
@@ -1033,7 +1026,7 @@ func (p *CatalogProvider) LoadServicesMD(serviceID string) (map[string]*texttemp
 	catalogPath := filepath.Join(servicePath, runtimeStr, "steps")
 
 	// Load all md files using the item's own filesystem
-	itemFS, err := p.getItemFS(serviceID)
+	itemFS, err := p.GetItemFS(serviceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
 	}
@@ -1100,7 +1093,7 @@ func (p *CatalogProvider) GetServiceSteps(serviceID string, runtime runtimeTypes
 
 	stepsPath := filepath.Join(servicePath, string(runtime), "steps")
 
-	itemFS, err := p.getItemFS(serviceID)
+	itemFS, err := p.GetItemFS(serviceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get item filesystem: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/deploy_options.go
+++ b/ai-services/internal/pkg/catalog/deploy_options.go
@@ -308,7 +308,7 @@ func (p *CatalogProvider) GetComponentProviderParams(ctx context.Context, compon
 		return nil, fmt.Errorf("failed to get component path: %w", err)
 	}
 
-	itemFS, err := p.getItemFS(componentKey)
+	itemFS, err := p.GetItemFS(componentKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get component filesystem: %w", err)
 	}
@@ -350,7 +350,7 @@ func (p *CatalogProvider) GetConnectorProviderParams(ctx context.Context, connec
 		return nil, fmt.Errorf("failed to get connector path: %w", err)
 	}
 
-	itemFS, err := p.getItemFS(connectorKey)
+	itemFS, err := p.GetItemFS(connectorKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get connector filesystem: %w", err)
 	}
@@ -393,7 +393,7 @@ func (p *CatalogProvider) GetServiceParams(ctx context.Context, serviceID, runti
 		return nil, fmt.Errorf("failed to get service path: %w", err)
 	}
 
-	itemFS, err := p.getItemFS(serviceID)
+	itemFS, err := p.GetItemFS(serviceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get service filesystem: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/utils/common.go
+++ b/ai-services/internal/pkg/catalog/utils/common.go
@@ -112,14 +112,20 @@ func SanitizeFilePath(path string) string {
 
 // LoadChartFromCatalogFS walks assets.CatalogFS at catalogPath and returns a Helm chart.
 func LoadChartFromCatalogFS(catalogPath string) (helmchart.Charter, error) {
+	return LoadChartFromFS(&assets.CatalogFS, catalogPath)
+}
+
+// LoadChartFromFS walks the given filesystem at catalogPath and returns a Helm chart.
+// Use this for bundle items that are stored on disk (os.DirFS) rather than embedded.
+func LoadChartFromFS(fsys fs.FS, catalogPath string) (helmchart.Charter, error) {
 	var files []*archive.BufferedFile
 
-	err := fs.WalkDir(&assets.CatalogFS, catalogPath, func(p string, d fs.DirEntry, err error) error {
+	err := fs.WalkDir(fsys, catalogPath, func(p string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
 			return err
 		}
 
-		data, err := assets.CatalogFS.ReadFile(p)
+		data, err := fs.ReadFile(fsys, p)
 		if err != nil {
 			return err
 		}

--- a/ai-services/internal/pkg/catalog/utils/common.go
+++ b/ai-services/internal/pkg/catalog/utils/common.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/project-ai-services/ai-services/assets"
 	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/helm"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
@@ -110,13 +109,7 @@ func SanitizeFilePath(path string) string {
 	return cleanPath
 }
 
-// LoadChartFromCatalogFS walks assets.CatalogFS at catalogPath and returns a Helm chart.
-func LoadChartFromCatalogFS(catalogPath string) (helmchart.Charter, error) {
-	return LoadChartFromFS(&assets.CatalogFS, catalogPath)
-}
-
 // LoadChartFromFS walks the given filesystem at catalogPath and returns a Helm chart.
-// Use this for bundle items that are stored on disk (os.DirFS) rather than embedded.
 func LoadChartFromFS(fsys fs.FS, catalogPath string) (helmchart.Charter, error) {
 	var files []*archive.BufferedFile
 


### PR DESCRIPTION
- Currently the next.md and info.md rendering is hardcoded which doesnt work for BYOS.
- Ensuring the above is made generic by making use of vars_file.yaml (Which was not used earlier).
- Updates in vars_file for both podman and openshift to make it generic.
- Ensuring consistency of namings in vars_file and remove redundant ones for all emebedded services.
- Allows user to have their own custom alias defined in vars_file and use in the md.
- Continuation of this PR: https://github.com/IBM/project-ai-services/pull/1377

Note:
- Require this PR: https://github.com/IBM/project-ai-services/pull/1377 to be merged before merging this.
- Also includes a bug fix on Openshift where the Helm chart load was not considering custom bundles.