### PR TITLE
increase predictor pods timeout to 15 mins

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.317
+TAG?=v0.0.318
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.317
+  image: icr.io/ai-services-cicd/ai-services:v0.0.318
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.317
+  image: icr.io/ai-services-cicd/ai-services:v0.0.318
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.317
+  image: icr.io/ai-services-cicd/ai-services:v0.0.318
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.317
+  image: icr.io/ai-services-cicd/ai-services:v0.0.318
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/openshift/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/openshift/deployer.go
@@ -25,7 +25,7 @@ import (
 const (
 	defaultHelmTimeout    = 10 * time.Minute
 	predictorPollInterval = 15 * time.Second
-	predictorWaitTimeout  = 10 * time.Minute
+	predictorWaitTimeout  = 15 * time.Minute
 )
 
 // Type aliases for deployment plan types.


### PR DESCRIPTION
## Problem
https://jsw.ibm.com/browse/AISERVICES-1726
llm-predictor pod sometime takes more than 10 mins to come up, but eventually get ready. 

Error:
```
failed to deploy 5ea63b9d1b26295f1d5eb09d24ca4900: InferenceService \"llm\" is not ready yet: 
timed out waiting for InferenceService \"llm\" to become ready: context deadline exceeded
```

```
NAME                                   READY   STATUS             RESTARTS      AGE
embedding-predictor-849548464b-g4qxw   1/1     Running            0             121m
llm-predictor-5f4bcddf8b-vnkv4         1/1     Running            0             121m
reranker-predictor-b565c57d7-hjplg     1/1     Running            0             121m
```

## Solution
Adding a buffer to timeout and increasing it to 15 mins