### PR TITLE
Changes for remote register routes

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.315
+TAG?=v0.0.316
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.315
+  image: icr.io/ai-services-cicd/ai-services:v0.0.316
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/steps/info.md
+++ b/ai-services/assets/catalog/podman/steps/info.md
@@ -1,19 +1,19 @@
 Day N:
 
-{{- if ne .CATALOG_UI_DOMAIN "" }}
+{{- if ne .CATALOG_UI_ROUTE "" }}
 {{- if eq .UI_STATUS "running" }}
 
-- Catalog UI is available at https://{{ .CATALOG_UI_DOMAIN }}{{ if ne .HTTPS_PORT "443" }}:{{ .HTTPS_PORT }}{{ end }}
+- Catalog UI is available at {{ .CATALOG_UI_ROUTE }}
 {{- else }}
 
 - Catalog UI is unavailable. Please make sure '{{ .AppName }}--catalog-ui' container is running.
 {{- end }}
 {{- end }}
 
-{{- if ne .CATALOG_API_DOMAIN "" }}
+{{- if ne .CATALOG_API_ROUTE "" }}
 {{- if eq .BACKEND_STATUS "running" }}
 
-- Catalog Backend API is available at https://{{ .CATALOG_API_DOMAIN }}{{ if ne .HTTPS_PORT "443" }}:{{ .HTTPS_PORT }}{{ end }}
+- Catalog Backend API is available at {{ .CATALOG_API_ROUTE }}
 {{- else }}
 
 - Catalog Backend API is unavailable. Please make sure '{{ .AppName }}--catalog-backend' container is running.

--- a/ai-services/assets/catalog/podman/steps/next.md
+++ b/ai-services/assets/catalog/podman/steps/next.md
@@ -1,3 +1,3 @@
-- Access the Catalog UI at https://{{ .CATALOG_UI_DOMAIN }}{{ if ne .HTTPS_PORT "443" }}:{{ .HTTPS_PORT }}{{ end }}
+- Access the Catalog UI at {{ .CATALOG_UI_ROUTE }}
 
-- Access the Catalog Backend at https://{{ .CATALOG_API_DOMAIN }}{{ if ne .HTTPS_PORT "443" }}:{{ .HTTPS_PORT }}{{ end }}
+- Access the Catalog Backend at {{ .CATALOG_API_ROUTE }}

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.315
+  image: icr.io/ai-services-cicd/ai-services:v0.0.316
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.315
+  image: icr.io/ai-services-cicd/ai-services:v0.0.316
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/templates/worker.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/worker.yaml.tmpl
@@ -24,7 +24,7 @@ spec:
       command: ["/bin/sh", "-c"]
       args:
         - |
-          exec /usr/bin/ai-services worker grpcstream {{ .Values.worker.gatewayAddr }} --token={{ .Values.worker.token }} --runtime={{ .Values.worker.runtime }} {{ .Values.worker.optionalFlags }}
+          exec /usr/bin/ai-services worker grpcstream {{ .Values.worker.gatewayAddr }} --token={{ .Values.worker.token }} --runtime={{ .Values.worker.runtime }}
       env:
         - name: AI_SERVICES_LOG_LEVEL
           value: "info"
@@ -36,6 +36,12 @@ spec:
           value: "/run/containers/auth.json"
         - name: AI_SERVICES_BASE_DIR
           value: "{{ .BaseDir }}"
+        - name: CADDY_ADMIN_URL
+          value: "{{ .CaddyAdminURL }}"
+        - name: CADDY_HTTPS_PORT
+          value: "{{ .Values.caddy.httpsPort }}"
+        - name: DOMAIN_SUFFIX
+          value: "{{ .DomainSuffix }}"
       volumeMounts:
         - name: podman-socket
           mountPath: {{ .Values.worker.podman.uri }}

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.315
+  image: icr.io/ai-services-cicd/ai-services:v0.0.316
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,16 +1,13 @@
-caddy:
-  image: icr.io/ai-services-cicd/caddy:v2.11.4-2
-  adminPort: ""
-  httpsPort: ""
-
 worker:
   image: icr.io/ai-services-cicd/ai-services:v0.0.315
   runtime: "podman"
   token: ""
-  # optionalFlags covers basedir, sslCertPath, sslKeyPath, domainSuffix, and httpsPort flags that are forwarded from the
-  # 'worker join' command to the 'worker grpcstream' command running inside the container
-  optionalFlags: ""
   gatewayAddr: ""
   podman:
     uri: "/run/podman/podman.sock"
     authFileContent: ""
+
+caddy:
+  image: icr.io/ai-services-cicd/caddy:v2.11.4-2
+  adminPort: ""
+  httpsPort: ""

--- a/ai-services/cmd/ai-services/cmd/worker/join.go
+++ b/ai-services/cmd/ai-services/cmd/worker/join.go
@@ -200,33 +200,21 @@ var grpcStreamCmd = &cobra.Command{
 // grpcStreamRunE starts the long-lived gRPC CommandStream for the worker.
 // It is called inside the worker pod after the deploy step (Run) has completed.
 //
-// For Podman workers it computes the domain suffix from the TLS credentials,
-// builds the metadata map that the control plane needs to route traffic back to
-// this node, and initialises the Podman runtime before opening the stream.
+// For Podman workers it initialises the Podman runtime and builds the local
+// Caddy proxy router before opening the stream.
 //
 // For OpenShift workers it initialises the runtime scoped to the worker
-// namespace and opens the stream with an empty metadata map, since routing is
-// handled natively by the platform.
+// namespace and opens the stream, since routing is handled natively by the platform.
 func grpcStreamRunE(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	gatewayAddr := args[0]
 
 	var pr *workercaddy.ProxyRouter
 	var rt runtime.Runtime
-	var meta = make(map[string]string)
 
 	switch types.RuntimeType(runtimeType) {
 	case types.RuntimeTypePodman:
-		domainSuffix, err := utils.ComputeDomainSuffix(sslCertPath, sslKeyPath, domainName)
-		if err != nil {
-			return err
-		}
-		meta = map[string]string{
-			workerconstants.MetaKeyBaseDir:      baseDir,
-			workerconstants.MetaKeyDomainSuffix: domainSuffix,
-			workerconstants.MetaKeyHTTPSPort:    fmt.Sprintf("%d", httpsPort),
-		}
-
+		var err error
 		rt, err = runtime.CreateRuntime(types.RuntimeTypePodman, "")
 		if err != nil {
 			return fmt.Errorf("worker grpcstream: init runtime: %w", err)
@@ -235,7 +223,7 @@ func grpcStreamRunE(cmd *cobra.Command, args []string) error {
 		// ── Build Caddy proxy router (Podman only) ──────────────────────
 		// Must happen after Setup so the Caddy pod is running and its admin port
 		// is discoverable. For OpenShift workers routes are managed natively.
-		pr, err = workercaddy.New(ctx, rt)
+		pr, err = workercaddy.NewProxyRouter(ctx)
 		if err != nil {
 			return fmt.Errorf("worker grpcstream: init local Caddy manager: %w", err)
 		}
@@ -257,7 +245,7 @@ func grpcStreamRunE(cmd *cobra.Command, args []string) error {
 		},
 	}
 
-	return join.StartGrpcStream(ctx, rt, pr, opts, meta)
+	return join.StartGrpcStream(ctx, rt, pr, opts)
 }
 
 func newGrpcStreamCmd() *cobra.Command {

--- a/ai-services/internal/pkg/catalog/apiserver/services/deletion/repository/podman/deletion.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deletion/repository/podman/deletion.go
@@ -47,7 +47,6 @@ func NewPodmanDeletion(
 // When keepData is true, preserves underlying data (pods, volumes, orphaned components).
 // When keepData is false, deletes all data including application data directory.
 func (s *PodmanDeletion) PerformDeletion(ctx context.Context, appID uuid.UUID, services []models.Service, orphanedComponentIDs []uuid.UUID, keepData bool) {
-	// Get Caddy proxy manager - fail if CADDY_ADMIN_URL not set
 	proxyManager, err := proxy.GetCaddyProxyManager()
 	if err != nil {
 		common.HandleStepError(ctx, s.appRepo, appID, "failed to get Caddy proxy manager for app", err)

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/executor.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/executor.go
@@ -14,7 +14,6 @@ import (
 	openshiftRuntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/openshift"
 	podmanRuntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
-	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/stream"
 )
 
@@ -124,10 +123,7 @@ func (e *DeploymentExecutor) executeWorkerDeployment(
 	}
 }
 
-// runPodmanDeployer creates a PodmanDeployer backed by the RemoteRuntime and
-// injects the worker's registration metadata (domain suffix, HTTPS port, base
-// dir) via SetPodmanWorkerConfig so the deployer uses the correct values
-// instead of local environment variables.
+// runPodmanDeployer creates a PodmanDeployer backed by the RemoteRuntime.
 func (e *DeploymentExecutor) runPodmanDeployer(
 	ctx context.Context,
 	plan *DeploymentPlan,
@@ -135,13 +131,6 @@ func (e *DeploymentExecutor) runPodmanDeployer(
 	rt runtime.Runtime,
 ) error {
 	deployer := podman.NewPodmanDeployer(rt, e.catalogProvider, e.appRepo, e.serviceRepo, e.componentRepo)
-
-	meta, _ := e.workerRegistry.WorkerMetadata(plan.WorkerName)
-	deployer.SetPodmanWorkerConfig(podman.PodmanWorkerConfig{
-		DomainSuffix: meta[workerconstants.MetaKeyDomainSuffix],
-		HTTPSPort:    meta[workerconstants.MetaKeyHTTPSPort],
-		BaseDir:      meta[workerconstants.MetaKeyBaseDir],
-	})
 
 	return deployer.ExecuteDeployment(ctx, plan, req)
 }

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
@@ -14,7 +14,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
-	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/stream"
 )
 
@@ -298,10 +297,9 @@ func (p *DeploymentPlanner) WorkerDBID(workerName string) (uuid.UUID, bool) {
 	return p.workerRegistry.WorkerID(workerName)
 }
 
-// ValidateWorker confirms the named remote worker is connected and, for Podman
-// workers, that the required Caddy metadata (domainSuffix, httpsPort) is
-// present. Called from PlanDeployment before any DB records are written so the
-// Create API can return an error immediately on failure.
+// ValidateWorker confirms the named remote worker is connected. Called from
+// PlanDeployment before any DB records are written so the Create API can
+// return an error immediately on failure.
 func (p *DeploymentPlanner) ValidateWorker(ctx context.Context, workerName, runtimeType string) error {
 	if p.workerRegistry == nil {
 		return fmt.Errorf("worker deployment is not configured on this server")
@@ -314,26 +312,6 @@ func (p *DeploymentPlanner) ValidateWorker(ctx context.Context, workerName, runt
 
 	if !p.workerRegistry.IsWorkerConnected(ctx, workerName) {
 		return fmt.Errorf("worker %q is not connected", workerName)
-	}
-
-	// Validate all the metadata for deployment is present
-	if runtimeType == runtimeTypes.RuntimeTypePodman.String() {
-		meta, ok := p.workerRegistry.WorkerMetadata(workerName)
-		if !ok {
-			return fmt.Errorf("worker %q metadata not available", workerName)
-		}
-
-		if meta[workerconstants.MetaKeyDomainSuffix] == "" {
-			return fmt.Errorf("worker %q metadata missing %q", workerName, workerconstants.MetaKeyDomainSuffix)
-		}
-
-		if meta[workerconstants.MetaKeyHTTPSPort] == "" {
-			return fmt.Errorf("worker %q metadata missing %q", workerName, workerconstants.MetaKeyHTTPSPort)
-		}
-
-		if meta[workerconstants.MetaKeyBaseDir] == "" {
-			return fmt.Errorf("worker %q metadata missing %q", workerName, workerconstants.MetaKeyBaseDir)
-		}
 	}
 
 	return nil

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/podman/deployer.go
@@ -54,14 +54,6 @@ type (
 	SpyreCardPool  = deploymenttypes.SpyreCardPool
 )
 
-// PodmanWorkerConfig holds configuration sourced from a remote worker's
-// registration metadata.
-type PodmanWorkerConfig struct {
-	DomainSuffix string
-	HTTPSPort    string
-	BaseDir      string
-}
-
 // PodmanDeployer implements deployment execution for Podman runtime.
 type PodmanDeployer struct {
 	runtime         runtime.Runtime
@@ -69,9 +61,6 @@ type PodmanDeployer struct {
 	appRepo         repository.ApplicationRepository
 	serviceRepo     repository.ServiceRepository
 	componentRepo   repository.ComponentRepository
-	// workerConfig is non-nil for remote worker deployments. When set,
-	// getCaddyConfiguration uses its values instead of local env vars.
-	workerConfig *PodmanWorkerConfig
 }
 
 // NewPodmanDeployer creates a new PodmanDeployer instance.
@@ -89,13 +78,6 @@ func NewPodmanDeployer(
 		serviceRepo:     serviceRepo,
 		componentRepo:   componentRepo,
 	}
-}
-
-// SetPodmanWorkerConfig injects the Caddy configuration for a remote worker
-// deployment. When set, getCaddyConfiguration uses these values instead of
-// local env vars.
-func (d *PodmanDeployer) SetPodmanWorkerConfig(cfg PodmanWorkerConfig) {
-	d.workerConfig = &cfg
 }
 
 // ExecuteDeployment executes the deployment plan for an application or standalone service.
@@ -238,17 +220,16 @@ func (d *PodmanDeployer) extractModelsFromParams(params map[string]any, modelSet
 }
 
 // downloadModels downloads all models in the provided set.
-// For remote workers the command is sent over the gRPC stream so the download
-// runs on the worker node where the models directory lives; for local workers
-// helpers.DownloadModelContainer is called directly.
+// For remote workers the command is forwarded over the gRPC stream; the worker
+// resolves AI_SERVICES_BASE_DIR from its own environment to find the models
+// directory. For local deployments helpers.DownloadModelContainer is called
+// directly with the local models path.
 func (d *PodmanDeployer) downloadModels(ctx context.Context, modelSet map[string]bool) error {
 	if rt, ok := d.runtime.(*remoteruntime.RemoteRuntime); ok {
-		modelsPath := d.workerConfig.BaseDir + "/models"
 		for modelName := range modelSet {
 			logger.InfofCtx(ctx, "Downloading model: %s\n", modelName)
 			_, err := rt.Send(ctx, workerpb.CommandType_COMMAND_TYPE_DOWNLOAD_MODEL, payload.DownloadModel{
-				Model:     modelName,
-				TargetDir: modelsPath,
+				Model: modelName,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to download model %s: %w", modelName, err)
@@ -1114,7 +1095,7 @@ func (d *PodmanDeployer) getEnvParamsForComponent(ctx context.Context, podSpec *
 func (d *PodmanDeployer) registerApplicationRoutes(ctx context.Context, plan *DeploymentPlan) error {
 	logger.InfofCtx(ctx, "Registering routes for application '%s'\n", plan.ApplicationName)
 
-	domainSuffix, httpsPort, proxyManager, err := d.getCaddyConfiguration()
+	proxyManager, err := d.getProxyManager()
 	if err != nil {
 		return err
 	}
@@ -1126,7 +1107,7 @@ func (d *PodmanDeployer) registerApplicationRoutes(ctx context.Context, plan *De
 			continue
 		}
 
-		if err := d.registerServiceRoutes(ctx, svc, proxyManager, domainSuffix, httpsPort, &registrationErrors); err != nil {
+		if err := d.registerServiceRoutes(ctx, svc, proxyManager, &registrationErrors); err != nil {
 			registrationErrors = append(registrationErrors, err)
 		}
 	}
@@ -1140,40 +1121,24 @@ func (d *PodmanDeployer) registerApplicationRoutes(ctx context.Context, plan *De
 	return nil
 }
 
-// getCaddyConfiguration retrieves Caddy configuration and creates a ProxyManager.
-// For a remote runtime the domain/port come from the worker's registration
-// metadata (via workerConfig) and a RemoteProxyManager is returned.
-// For a local runtime both values are read from environment variables and a
-// local Caddy ProxyManager is returned.
-func (d *PodmanDeployer) getCaddyConfiguration() (string, string, proxy.ProxyManager, error) {
+// getProxyManager returns the appropriate ProxyManager for this deployment.
+// domainSuffix and httpsPort are intentionally not returned — RegisterRoute
+// on the ProxyManager reads both from its own environment (local or worker)
+// so the correct values are always used regardless of where Caddy is running.
+func (d *PodmanDeployer) getProxyManager() (proxy.ProxyManager, error) {
 	if rt, ok := d.runtime.(*remoteruntime.RemoteRuntime); ok {
-		pm := proxy.NewRemoteProxyManager(rt.Sender)
-
-		return d.workerConfig.DomainSuffix, d.workerConfig.HTTPSPort, pm, nil
+		return proxy.NewRemoteProxyManager(rt.Sender), nil
 	}
 
-	domainSuffix := utils.GetEnv("DOMAIN_SUFFIX", "")
-	if domainSuffix == "" {
-		return "", "", nil, fmt.Errorf("DOMAIN_SUFFIX environment variable not set")
-	}
-
-	httpsPort := utils.GetEnv("CADDY_HTTPS_PORT", catalogconstants.DefaultHTTPSPort)
-
-	proxyManager, err := proxy.GetCaddyProxyManager()
-	if err != nil {
-		return "", "", nil, err
-	}
-
-	return domainSuffix, httpsPort, proxyManager, nil
+	return proxy.GetCaddyProxyManager()
 }
 
 // registerServiceRoutes registers routes for a single service and updates its endpoints in the database.
+// domainSuffix and httpsPort are resolved by RegisterRoute from the ProxyManager's own environment.
 func (d *PodmanDeployer) registerServiceRoutes(
 	ctx context.Context,
 	svc *ServicePlan,
 	proxyManager proxy.ProxyManager,
-	domainSuffix string,
-	httpsPort string,
 	registrationErrors *[]error,
 ) error {
 	var serviceEndpoints []map[string]any
@@ -1185,7 +1150,6 @@ func (d *PodmanDeployer) registerServiceRoutes(
 			catalogconstants.CatalogAppName,
 			proxyManager,
 			routesAnnotation,
-			domainSuffix,
 			podName,
 		)
 		if err != nil {
@@ -1194,13 +1158,10 @@ func (d *PodmanDeployer) registerServiceRoutes(
 			continue
 		}
 
-		// Convert registered routes to endpoint format using route type
 		for _, route := range registeredRoutes {
-			url := catalogutils.BuildExternalURL(route.Domain, httpsPort)
-
 			endpoint := map[string]any{
 				"type": route.Type,
-				"url":  url,
+				"url":  route.ExternalURL,
 			}
 			serviceEndpoints = append(serviceEndpoints, endpoint)
 		}

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/context.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/context.go
@@ -39,12 +39,7 @@ func (c *Context) GetHostAdminURL(ctx context.Context) (string, error) {
 		return c.hostAdminURL, nil
 	}
 
-	rt, err := podman.NewPodmanClient()
-	if err != nil {
-		return "", fmt.Errorf("failed to initialize podman client: %w", err)
-	}
-
-	adminPort, err := getCaddyAdminPort(ctx, rt, c.podName)
+	adminPort, err := getCaddyAdminPort(ctx, c.podName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get Caddy admin port: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/helpers.go
@@ -8,14 +8,19 @@ import (
 	"text/template"
 
 	"github.com/project-ai-services/ai-services/assets"
-	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/proxy"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 )
 
 // getCaddyAdminPort retrieves the host port mapped to Caddy's admin API (container port 2019).
-func getCaddyAdminPort(ctx context.Context, runtime *podman.PodmanClient, podName string) (string, error) {
-	pod, err := runtime.InspectPod(ctx, podName)
+func getCaddyAdminPort(ctx context.Context, podName string) (string, error) {
+	pc, err := podman.NewPodmanClient()
+	if err != nil {
+		return "", fmt.Errorf("failed to initialize podman client: %w", err)
+	}
+
+	pod, err := pc.InspectPod(ctx, podName)
 	if err != nil {
 		return "", fmt.Errorf("failed to inspect Caddy pod: %w", err)
 	}
@@ -44,19 +49,19 @@ func getHTTPSPort(ctx context.Context, runtime *podman.PodmanClient, caddyPodNam
 	// Look for the HTTPS port mapping
 	// Ports is a map[string][]string where key is "containerPort/protocol" (e.g., "443/tcp")
 	// and value is list of host ports
-	httpsPortKey := catalogconstants.DefaultHTTPSPort + "/tcp"
+	httpsPortKey := proxy.DefaultHTTPSPort + "/tcp"
 	if hostPorts, ok := pod.Ports[httpsPortKey]; ok && len(hostPorts) > 0 {
 		return hostPorts[0], nil
 	}
 
 	// Also check without protocol suffix for compatibility
-	if hostPorts, ok := pod.Ports[catalogconstants.DefaultHTTPSPort]; ok && len(hostPorts) > 0 {
+	if hostPorts, ok := pod.Ports[proxy.DefaultHTTPSPort]; ok && len(hostPorts) > 0 {
 		return hostPorts[0], nil
 	}
 
 	// Fallback: search through all port mappings
 	for portKey, hostPorts := range pod.Ports {
-		if strings.HasPrefix(portKey, catalogconstants.DefaultHTTPSPort+"/") && len(hostPorts) > 0 {
+		if strings.HasPrefix(portKey, proxy.DefaultHTTPSPort+"/") && len(hostPorts) > 0 {
 			return hostPorts[0], nil
 		}
 	}

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/routes.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/routes.go
@@ -123,7 +123,7 @@ func extractSubdomainFromDomain(domain string) string {
 }
 
 // addRoutesToDomainMap stores each route's ExternalURL in the domain map under
-// a standardised key derived from the subdomain (e.g. "CATALOG_API_URL").
+// a standardised key derived from the subdomain (e.g. "CATALOG_API_ROUTE").
 // The full URL is used directly so callers don't need a separate HTTPS port.
 func addRoutesToDomainMap(routes []proxy.Route, routeDomains map[string]string) {
 	for _, route := range routes {
@@ -159,7 +159,7 @@ func parseRouteEntry(routeEntry, podName string) string {
 }
 
 // processRouteInfo queries Caddy for each route and adds its ExternalURL
-// to the routeURLs map under a standardised key (e.g. "CATALOG_API_URL").
+// to the routeURLs map under a standardised key (e.g. "CATALOG_API_ROUTE").
 // ExternalURL is now populated by GetRouteByID directly.
 func processRouteInfo(ctx context.Context, info TemplateRouteInfo, proxyManager proxy.ProxyManager, routeURLs map[string]string) {
 	for _, routeEntry := range strings.Split(info.RoutesAnnotation, ",") {

--- a/ai-services/internal/pkg/catalog/cli/common/podman/caddy/routes.go
+++ b/ai-services/internal/pkg/catalog/cli/common/podman/caddy/routes.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
+	"os"
 	"strings"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
@@ -33,6 +35,17 @@ func RegisterCatalogRoutes(ctx context.Context, runtime *podman.PodmanClient, ca
 		return nil, fmt.Errorf("failed to create proxy manager: %w", err)
 	}
 
+	// DOMAIN_SUFFIX and CADDY_HTTPS_PORT are not
+	// set in the process environment. Set them now so RegisterRoute can build
+	// the correct ExternalURL from them.
+	httpsPort, err := caddyCtx.GetHTTPSPort(ctx, runtime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Caddy HTTPS port: %w", err)
+	}
+
+	_ = os.Setenv(proxy.DomainSuffixEnvVar, caddyCtx.GetDomainSuffix())
+	_ = os.Setenv(proxy.CaddyHTTPSPortEnvVar, httpsPort)
+
 	// Build route domains map
 	routeDomains := make(map[string]string)
 
@@ -42,7 +55,7 @@ func RegisterCatalogRoutes(ctx context.Context, runtime *podman.PodmanClient, ca
 		logger.Debugf("Registering routes for pod: %s\n", info.PodName)
 
 		// Register routes and get the built routes back
-		routes, err := proxy.RegisterRoutesForAppAndReturn(ctx, constants.CatalogAppName, proxyManager, info.RoutesAnnotation, caddyCtx.GetDomainSuffix(), info.PodName)
+		routes, err := proxy.RegisterRoutesForAppAndReturn(ctx, constants.CatalogAppName, proxyManager, info.RoutesAnnotation, info.PodName)
 		if err != nil {
 			registrationErrors = append(registrationErrors, fmt.Errorf("pod %s: %w", info.PodName, err))
 
@@ -62,38 +75,40 @@ func RegisterCatalogRoutes(ctx context.Context, runtime *podman.PodmanClient, ca
 	return routeDomains, nil
 }
 
-// GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service.
-// Accepts pre-extracted route infos from templates.
-func GetCatalogRouteInfo(ctx context.Context, caddyCtx *Context, runtime *podman.PodmanClient, routeInfos []TemplateRouteInfo) (map[string]string, string, error) {
-	// Create proxy manager
+// GetCatalogRouteInfo retrieves route for the catalog service by querying
+// Caddy for existing routes.
+func GetCatalogRouteInfo(ctx context.Context, caddyCtx *Context, runtime *podman.PodmanClient, routeInfos []TemplateRouteInfo) (map[string]string, error) {
 	proxyManager, err := caddyCtx.CreateProxyManager(ctx)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to create proxy manager: %w", err)
+		return nil, fmt.Errorf("failed to create proxy manager: %w", err)
 	}
 
-	// Build route domains map by querying Caddy
-	routeDomains := make(map[string]string)
-	for _, info := range routeInfos {
-		processRouteInfo(ctx, info, proxyManager, routeDomains)
-	}
-
-	// Get Caddy HTTPS port
+	// Set CADDY_HTTPS_PORT from the live Caddy pod so GetRouteByID can build
+	// the correct ExternalURL even when called outside of configure (where the
+	// env var was not pre-set by RegisterCatalogRoutes).
 	httpsPort, err := caddyCtx.GetHTTPSPort(ctx, runtime)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Caddy HTTPS port: %w", err)
+		return nil, fmt.Errorf("failed to get Caddy HTTPS port: %w", err)
 	}
 
-	return routeDomains, httpsPort, nil
+	_ = os.Setenv(proxy.CaddyHTTPSPortEnvVar, httpsPort)
+
+	routeURLs := make(map[string]string)
+	for _, info := range routeInfos {
+		processRouteInfo(ctx, info, proxyManager, routeURLs)
+	}
+
+	return routeURLs, nil
 }
 
 // Helper functions for route processing
 
-// createRouteVariableName creates a standardized environment variable name from a subdomain.
-// Converts "catalog-ui" to "CATALOG_UI_DOMAIN".
+// createRouteVariableName creates a standardized key from a subdomain.
+// Converts "catalog-ui" to "CATALOG_UI_ROUTE".
 func createRouteVariableName(subdomain string) string {
 	sanitized := strings.ReplaceAll(subdomain, "-", "_")
 
-	return strings.ToUpper(fmt.Sprintf("%s_DOMAIN", sanitized))
+	return strings.ToUpper(fmt.Sprintf("%s_ROUTE", sanitized))
 }
 
 // extractSubdomainFromDomain extracts the subdomain from a full domain.
@@ -107,13 +122,24 @@ func extractSubdomainFromDomain(domain string) string {
 	return ""
 }
 
-// addRoutesToDomainMap adds routes to the domain map with standardized variable names.
+// addRoutesToDomainMap stores each route's ExternalURL in the domain map under
+// a standardised key derived from the subdomain (e.g. "CATALOG_API_URL").
+// The full URL is used directly so callers don't need a separate HTTPS port.
 func addRoutesToDomainMap(routes []proxy.Route, routeDomains map[string]string) {
 	for _, route := range routes {
-		subdomain := extractSubdomainFromDomain(route.Domain)
+		if route.ExternalURL == "" {
+			continue
+		}
+
+		parsed, err := url.Parse(route.ExternalURL)
+		if err != nil || parsed.Hostname() == "" {
+			continue
+		}
+
+		subdomain := extractSubdomainFromDomain(parsed.Hostname())
 		if subdomain != "" {
 			varName := createRouteVariableName(subdomain)
-			routeDomains[varName] = route.Domain
+			routeDomains[varName] = route.ExternalURL
 		}
 	}
 }
@@ -132,12 +158,10 @@ func parseRouteEntry(routeEntry, podName string) string {
 	return parts.Subdomain
 }
 
-// processRouteInfo processes route information and populates the routeDomains map.
-// Queries Caddy for each route and adds it to the map with a standardized variable name.
-func processRouteInfo(ctx context.Context, info TemplateRouteInfo, proxyManager proxy.ProxyManager, routeDomains map[string]string) {
-	// Parse routes annotation to extract subdomains
-	// Format: "port:subdomain:type, port:subdomain:type, ..."
-	// Example: "8081:catalog-ui:ui, 8080:catalog-api:api"
+// processRouteInfo queries Caddy for each route and adds its ExternalURL
+// to the routeURLs map under a standardised key (e.g. "CATALOG_API_URL").
+// ExternalURL is now populated by GetRouteByID directly.
+func processRouteInfo(ctx context.Context, info TemplateRouteInfo, proxyManager proxy.ProxyManager, routeURLs map[string]string) {
 	for _, routeEntry := range strings.Split(info.RoutesAnnotation, ",") {
 		subdomain := parseRouteEntry(strings.TrimSpace(routeEntry), info.PodName)
 		if subdomain == "" {
@@ -155,7 +179,7 @@ func processRouteInfo(ctx context.Context, info TemplateRouteInfo, proxyManager 
 
 		// Use standardized variable name creation
 		varName := createRouteVariableName(subdomain)
-		routeDomains[varName] = actualRoute.Domain
+		routeURLs[varName] = actualRoute.ExternalURL
 	}
 }
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -31,8 +31,8 @@ func DeployCatalog(ctx context.Context, opts catalogUtils.PodmanConfigureOptions
 		return err
 	}
 
-	// Collect and hash password
-	// If secret exist passwordHash will be empty
+	// Collect and hash password.
+	// If secret exists passwordHash will be empty.
 	passwordHash, err := catalogUtils.CollectAndHashPassword(ctx, deployCtx.Runtime)
 	if err != nil {
 		return err
@@ -119,20 +119,14 @@ func handlePostDeployment(ctx context.Context, caddyCtx *caddy.Context, deployCt
 		return fmt.Errorf("failed to extract route infos: %w", err)
 	}
 
-	// Register routes with Caddy and get the registered route domains
-	routeDomains, err := caddy.RegisterCatalogRoutes(ctx, deployCtx.Runtime, caddyCtx, routeInfos)
+	// Register routes with Caddy and get the registered route URLs
+	routeURLs, err := caddy.RegisterCatalogRoutes(ctx, deployCtx.Runtime, caddyCtx, routeInfos)
 	if err != nil {
 		return fmt.Errorf("route registration failed: %w", err)
 	}
 
-	// Get Caddy HTTPS port for next steps display
-	httpsPort, err := caddyCtx.GetHTTPSPort(ctx, deployCtx.Runtime)
-	if err != nil {
-		return fmt.Errorf("failed to get Caddy HTTPS port: %w", err)
-	}
-
 	// Print next steps with proxy route information
-	if err := helpers.PrintNextStepsWithProxy(ctx, deployCtx.TemplateProvider, deployCtx.Runtime, catalogconstants.CatalogAppName, catalogconstants.CatalogAppTemplate, routeDomains, httpsPort); err != nil {
+	if err := helpers.PrintNextStepsWithProxy(ctx, deployCtx.TemplateProvider, deployCtx.Runtime, catalogconstants.CatalogAppName, catalogconstants.CatalogAppTemplate, routeURLs); err != nil {
 		// do not want to fail the overall configure if we cannot print next steps
 		logger.Infof("failed to display next steps: %v\n", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/info/podman/info.go
+++ b/ai-services/internal/pkg/catalog/cli/info/podman/info.go
@@ -52,7 +52,7 @@ func DisplayCatalogInfo(ctx context.Context) error {
 
 	// Step 3: Fetch route information
 	tp := templates.NewEmbedTemplateProvider(&assets.CatalogFS, "")
-	routeDomains, httpsPort, err := GetCatalogRouteInfo(ctx, runtime)
+	routeURLs, err := GetCatalogRouteInfo(ctx, runtime)
 	if err != nil {
 		logger.Errorf("failed to get route info: %v\n", err)
 		// Continue with basic info display
@@ -64,7 +64,7 @@ func DisplayCatalogInfo(ctx context.Context) error {
 	}
 
 	// Step 4: Read and print the info.md file with route information
-	if err := helpers.PrintInfoWithProxy(ctx, tp, runtime, constants.CatalogAppName, catalogTemplate, routeDomains, httpsPort); err != nil {
+	if err := helpers.PrintInfoWithProxy(ctx, tp, runtime, constants.CatalogAppName, catalogTemplate, routeURLs); err != nil {
 		// not failing overall info command if we cannot display Info
 		logger.Errorf("failed to display info: %v\n", err)
 
@@ -74,26 +74,26 @@ func DisplayCatalogInfo(ctx context.Context) error {
 	return nil
 }
 
-// GetCatalogRouteInfo retrieves route domains and HTTPS port for the catalog service.
+// GetCatalogRouteInfo retrieves route URLs for the catalog service.
 // This orchestrates: deployContext gets pod name and route info from templates,
-// caddy.Context queries Caddy for route domains and HTTPS port.
-func GetCatalogRouteInfo(ctx context.Context, rt *podman.PodmanClient) (map[string]string, string, error) {
+// caddy.Context queries Caddy for route URLs.
+func GetCatalogRouteInfo(ctx context.Context, rt *podman.PodmanClient) (map[string]string, error) {
 	// Create deployment context to access templates
 	deployCtx, err := deploy.NewDeployContext()
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to create deployment context: %w", err)
+		return nil, fmt.Errorf("failed to create deployment context: %w", err)
 	}
 
 	// Get Caddy pod name from templates
 	caddyPodName, err := deployCtx.GetCaddyPodName()
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get Caddy pod name: %w", err)
+		return nil, fmt.Errorf("failed to get Caddy pod name: %w", err)
 	}
 
 	// Extract route infos from deployment context
 	routeInfos, err := deployCtx.ExtractRouteInfos()
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to extract route infos: %w", err)
+		return nil, fmt.Errorf("failed to extract route infos: %w", err)
 	}
 
 	// Create Caddy context (domain suffix not needed for querying existing routes)

--- a/ai-services/internal/pkg/catalog/constants/catalog.go
+++ b/ai-services/internal/pkg/catalog/constants/catalog.go
@@ -82,12 +82,6 @@ const (
 	RFC3339WithTimezone = "2006-01-02T15:04:05Z07:00"
 )
 
-// Network constants.
-const (
-	// DefaultHTTPSPort is the default HTTPS port.
-	DefaultHTTPSPort = "443"
-)
-
 // Environment variable name constants.
 const (
 	// DBEncryptionKeyEnv is the environment variable that holds the AES-256 key used to

--- a/ai-services/internal/pkg/catalog/utils/application_utils.go
+++ b/ai-services/internal/pkg/catalog/utils/application_utils.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
 	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
@@ -111,17 +110,6 @@ func UpdateComponentStatus(ctx context.Context, componentRepo dbrepo.ComponentRe
 	}
 
 	return nil
-}
-
-// BuildExternalURL constructs an HTTPS URL from a domain and optional port.
-// If the port is not the default HTTPS port (443), it appends the port to the URL.
-func BuildExternalURL(domain string, httpsPort string) string {
-	url := fmt.Sprintf("https://%s", domain)
-	if httpsPort != constants.DefaultHTTPSPort {
-		url = url + ":" + httpsPort
-	}
-
-	return url
 }
 
 // GenerateInstanceSlug creates a short slug from an ID using SHA256 hash.

--- a/ai-services/internal/pkg/catalog/utils/password.go
+++ b/ai-services/internal/pkg/catalog/utils/password.go
@@ -36,7 +36,7 @@ func HashPasswordPBKDF2(password string, iteration int) (string, error) {
 	return encoded, nil
 }
 
-// CollectAndHashPassword collects the password from user and returns the hashed password.
+// CollectAndHashPassword collects the password from the user and returns the hashed password.
 // Returns empty string if the secret already exists (no password needed).
 func CollectAndHashPassword(ctx context.Context, rt runtime.Runtime) (string, error) {
 	secretExists, err := rt.SecretExists(ctx, catalogConstants.CatalogSecretName)

--- a/ai-services/internal/pkg/cli/helpers/steps.go
+++ b/ai-services/internal/pkg/cli/helpers/steps.go
@@ -33,18 +33,12 @@ func PrintNextSteps(ctx context.Context, tp templates.Template, runtime runtime.
 	return nil
 }
 
-// PrintNextStepsWithProxy prints next steps with proxy route information.
-func PrintNextStepsWithProxy(ctx context.Context, tp templates.Template, runtime runtime.Runtime, app, appTemplate string, routeDomains map[string]string, httpsPort string) error {
+// PrintNextStepsWithProxy prints next steps with proxy route URL information.
+func PrintNextStepsWithProxy(ctx context.Context, tp templates.Template, runtime runtime.Runtime, app, appTemplate string, routeURLs map[string]string) error {
 	params := map[string]string{"AppName": app}
 
-	// Add route domains to params
-	for key, value := range routeDomains {
+	for key, value := range routeURLs {
 		params[key] = value
-	}
-
-	// Add HTTPS port to params if provided
-	if httpsPort != "" {
-		params["HTTPS_PORT"] = httpsPort
 	}
 
 	if err := renderStepsMarkdown(ctx, tp, runtime, appTemplate, params, nextStepsMDFile, nextStepsTitle); err != nil {
@@ -67,17 +61,11 @@ func PrintInfo(ctx context.Context, tp templates.Template, runtime runtime.Runti
 	return nil
 }
 
-// PrintInfoWithProxy prints info with proxy route information.
-func PrintInfoWithProxy(ctx context.Context, tp templates.Template, runtime runtime.Runtime, app, appTemplate string, routeDomains map[string]string, httpsPort string) error {
+// PrintInfoWithProxy prints info with proxy route URL information.
+func PrintInfoWithProxy(ctx context.Context, tp templates.Template, runtime runtime.Runtime, app, appTemplate string, routeURLs map[string]string) error {
 	params := map[string]string{"AppName": app}
 
-	// Add route domains to params
-	maps.Copy(params, routeDomains)
-
-	// Add HTTPS port to params if provided
-	if httpsPort != "" {
-		params["HTTPS_PORT"] = httpsPort
-	}
+	maps.Copy(params, routeURLs)
 
 	if err := renderStepsMarkdown(ctx, tp, runtime, appTemplate, params, infoMDFile, infoTitle); err != nil {
 		logger.InfofCtx(ctx, "Unable to load steps: %v\n", err)

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -49,9 +49,9 @@ func NewCaddyManager(adminURL, serverName string) ProxyManager {
 
 // GetCaddyProxyManager retrieves the Caddy admin URL from environment and creates a ProxyManager.
 func GetCaddyProxyManager() (ProxyManager, error) {
-	adminURL := utils.GetEnv("CADDY_ADMIN_URL", "")
+	adminURL := utils.GetEnv(CaddyAdminURLEnvVar, "")
 	if adminURL == "" {
-		return nil, fmt.Errorf("CADDY_ADMIN_URL environment variable not set")
+		return nil, fmt.Errorf("%s environment variable not set", CaddyAdminURLEnvVar)
 	}
 
 	return NewCaddyManager(adminURL, constants.CaddyServerName), nil
@@ -76,9 +76,22 @@ func (c *caddyManager) HealthCheck(ctx context.Context) error {
 	return nil
 }
 
-func (c *caddyManager) RegisterRoute(ctx context.Context, route Route) error {
+// RegisterRoute registers a route with Caddy and returns its external URL.
+// Both DOMAIN_SUFFIX and CADDY_HTTPS_PORT are read from the local environment
+// — the same machine that is running this Caddy instance — so the URL is
+// always correct regardless of whether this is the catalog or a remote worker.
+func (c *caddyManager) RegisterRoute(ctx context.Context, route Route) (string, error) {
 	if route.ID == "" {
-		return fmt.Errorf("cannot register route: route ID is empty")
+		return "", fmt.Errorf("cannot register route: route ID is empty")
+	}
+
+	if route.Domain == "" {
+		return "", fmt.Errorf("cannot register route %s: domain is empty", route.ID)
+	}
+
+	// Verify Caddy is reachable before attempting registration.
+	if err := c.HealthCheck(ctx); err != nil {
+		return "", fmt.Errorf("caddy health check failed: %w", err)
 	}
 
 	routeConfig := map[string]any{
@@ -93,24 +106,27 @@ func (c *caddyManager) RegisterRoute(ctx context.Context, route Route) error {
 
 	idURL, err := url.JoinPath(c.adminURL, "id", route.ID)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Check if route already exists
 	checkResp, err := c.httpClient.R().SetContext(ctx).Get(idURL)
 	if err != nil {
-		return fmt.Errorf("failed to check route existence: %w", err)
+		return "", fmt.Errorf("failed to check route existence: %w", err)
 	}
 
 	if checkResp.StatusCode() == http.StatusOK {
 		// Route already exists, skip registration
 		logger.DebugfCtx(ctx, "Route %s already exists, skipping registration\n", route.ID)
-
-		return nil
+	} else {
+		if err := c.createRoute(ctx, routeConfig); err != nil {
+			return "", err
+		}
 	}
 
-	// Route doesn't exist, create it
-	return c.createRoute(ctx, routeConfig)
+	httpsPort := utils.GetEnv(CaddyHTTPSPortEnvVar, DefaultHTTPSPort)
+
+	return buildExternalURL(route.Domain, httpsPort), nil
 }
 
 // Helper to append a new route to the server's route array.
@@ -190,9 +206,12 @@ func (c *caddyManager) GetRouteByID(ctx context.Context, routeID string) (*Route
 		return nil, fmt.Errorf("failed to extract domain from route %s: %w", routeID, err)
 	}
 
+	httpsPort := utils.GetEnv(CaddyHTTPSPortEnvVar, DefaultHTTPSPort)
+
 	return &Route{
-		ID:     routeID,
-		Domain: domain,
+		ID:          routeID,
+		Domain:      domain,
+		ExternalURL: buildExternalURL(domain, httpsPort),
 	}, nil
 }
 
@@ -224,47 +243,37 @@ func (c *caddyManager) UnregisterRoute(ctx context.Context, routeID string) erro
 	}
 }
 
-// RegisterRoutesForAppAndReturn registers routes for an application with Caddy proxy and returns the built routes.
-//
-// Parameters:
-//   - rt: Runtime interface for interacting with pods
-//   - appName: Name of the application (e.g., "ai-services" for catalog)
-//   - proxyManager: ProxyManager instance for route operations (reuse to avoid creating multiple instances)
-//   - routesAnnotation: Routes annotation value in format "port:subdomain,port:subdomain,..."
-//   - domainSuffix: Pre-computed domain suffix (e.g., "example.com" or "192.168.1.100.nip.io")
-//   - servicePodName: Name of the service pod for upstream configuration
-//
-// Returns:
-//   - []Route: List of successfully built and registered routes
-//   - error: nil if routes were registered successfully, error otherwise
+// RegisterRoutesForAppAndReturn registers routes for an application with Caddy
+// proxy and returns the built routes.
+// RegisterRoute reads DOMAIN_SUFFIX and CADDY_HTTPS_PORT from the process
+// environment to build the external URL — set by the pod template (in-pod) or
+// by RegisterCatalogRoutes before calling this function (configure-CLI).
 func RegisterRoutesForAppAndReturn(
 	ctx context.Context,
 	appName string,
 	proxyManager ProxyManager,
 	routesAnnotation string,
-	domainSuffix string,
 	servicePodName string,
 ) ([]Route, error) {
-	// Step 1: Perform health check on Caddy
-	if err := proxyManager.HealthCheck(ctx); err != nil {
-		return nil, fmt.Errorf(
-			"caddy health check failed, routes not registered: %w",
-			err,
-		)
-	}
-
-	// Step 2: Build routes from the annotation string using service pod name for upstreams
-	routes, err := BuildRoutesFromAnnotation(routesAnnotation, domainSuffix, servicePodName)
+	routes, err := BuildRoutesFromAnnotation(routesAnnotation, servicePodName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build routes: %w", err)
 	}
 
-	// Step 3: Register each route with Caddy
+	// Register each route with Caddy.
+	// RegisterRoute returns the fully-qualified ExternalURL, reading
+	// CADDY_HTTPS_PORT from the process env (set by the pod template,
+	// or temporarily set by RegisterCatalogRoutes).
 	var registrationErrors []error
-	for _, route := range routes {
-		if err := proxyManager.RegisterRoute(ctx, route); err != nil {
-			registrationErrors = append(registrationErrors, fmt.Errorf("route %s: %w", route.ID, err))
+	for i := range routes {
+		externalURL, err := proxyManager.RegisterRoute(ctx, routes[i])
+		if err != nil {
+			registrationErrors = append(registrationErrors, fmt.Errorf("route %s: %w", routes[i].ID, err))
+
+			continue
 		}
+
+		routes[i].ExternalURL = externalURL
 	}
 
 	// Return error if any routes failed to register
@@ -368,6 +377,16 @@ func unregisterRoutes(ctx context.Context, proxyManager ProxyManager, routeIDs m
 	}
 
 	return nil
+}
+
+// buildExternalURL constructs the HTTPS URL for a route domain and port.
+// Port is omitted when it equals the default HTTPS port (443).
+func buildExternalURL(domain, httpsPort string) string {
+	if httpsPort == DefaultHTTPSPort {
+		return fmt.Sprintf("https://%s", domain)
+	}
+
+	return fmt.Sprintf("https://%s:%s", domain, httpsPort)
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/proxy/caddy.go
+++ b/ai-services/internal/pkg/proxy/caddy.go
@@ -77,17 +77,26 @@ func (c *caddyManager) HealthCheck(ctx context.Context) error {
 }
 
 // RegisterRoute registers a route with Caddy and returns its external URL.
-// Both DOMAIN_SUFFIX and CADDY_HTTPS_PORT are read from the local environment
-// — the same machine that is running this Caddy instance — so the URL is
-// always correct regardless of whether this is the catalog or a remote worker.
+// DOMAIN_SUFFIX and CADDY_HTTPS_PORT are read from the local environment —
+// the same machine that is running this Caddy instance — so the domain and
+// URL are always correct regardless of whether this is the catalog or a
+// remote worker. Route.Domain carries the subdomain; the full hostname is
+// built as "<route.Domain>.<DOMAIN_SUFFIX>".
 func (c *caddyManager) RegisterRoute(ctx context.Context, route Route) (string, error) {
 	if route.ID == "" {
 		return "", fmt.Errorf("cannot register route: route ID is empty")
 	}
 
 	if route.Domain == "" {
-		return "", fmt.Errorf("cannot register route %s: domain is empty", route.ID)
+		return "", fmt.Errorf("cannot register route %s: domain/subdomain is empty", route.ID)
 	}
+
+	domainSuffix := utils.GetEnv(DomainSuffixEnvVar, "")
+	if domainSuffix == "" {
+		return "", fmt.Errorf("cannot register route %s: %s environment variable not set", route.ID, DomainSuffixEnvVar)
+	}
+
+	domain := route.Domain + "." + domainSuffix
 
 	// Verify Caddy is reachable before attempting registration.
 	if err := c.HealthCheck(ctx); err != nil {
@@ -96,7 +105,7 @@ func (c *caddyManager) RegisterRoute(ctx context.Context, route Route) (string, 
 
 	routeConfig := map[string]any{
 		"@id":   route.ID,
-		"match": []map[string]any{{"host": []string{route.Domain}}},
+		"match": []map[string]any{{"host": []string{domain}}},
 		"handle": []map[string]any{{
 			"handler":   "reverse_proxy",
 			"upstreams": []map[string]any{{"dial": route.Upstream}},
@@ -126,7 +135,7 @@ func (c *caddyManager) RegisterRoute(ctx context.Context, route Route) (string, 
 
 	httpsPort := utils.GetEnv(CaddyHTTPSPortEnvVar, DefaultHTTPSPort)
 
-	return buildExternalURL(route.Domain, httpsPort), nil
+	return buildExternalURL(domain, httpsPort), nil
 }
 
 // Helper to append a new route to the server's route array.

--- a/ai-services/internal/pkg/proxy/constants.go
+++ b/ai-services/internal/pkg/proxy/constants.go
@@ -1,0 +1,19 @@
+package proxy
+
+// DefaultHTTPSPort is the standard HTTPS port used as a fallback when
+// CADDY_HTTPS_PORT is not set and when building external route URLs.
+const DefaultHTTPSPort = "443"
+
+// Caddy-related environment variable names shared across packages.
+const (
+	// DomainSuffixEnvVar is the env var that holds the domain suffix used
+	// when building route hostnames (e.g. "example.com" or "10.0.0.1.nip.io").
+	DomainSuffixEnvVar = "DOMAIN_SUFFIX"
+
+	// CaddyHTTPSPortEnvVar is the env var that holds the Caddy HTTPS listener port.
+	CaddyHTTPSPortEnvVar = "CADDY_HTTPS_PORT"
+
+	// CaddyAdminURLEnvVar is the env var that holds the Caddy admin API URL
+	// (e.g. "http://ai-services--caddy:2019").
+	CaddyAdminURLEnvVar = "CADDY_ADMIN_URL"
+)

--- a/ai-services/internal/pkg/proxy/remote.go
+++ b/ai-services/internal/pkg/proxy/remote.go
@@ -24,9 +24,11 @@ func NewRemoteProxyManager(sender *stream.Sender) *RemoteProxyManager {
 	return &RemoteProxyManager{sender: sender}
 }
 
-// RegisterRoute implements ProxyManager.
-func (r *RemoteProxyManager) RegisterRoute(ctx context.Context, route Route) error {
-	_, err := r.send(ctx, payload.ProxyRoute{
+// RegisterRoute implements ProxyManager. It forwards the registration to the
+// remote worker and reads the ExternalURL back from the CommandResult — the
+// worker builds it from its own DOMAIN_SUFFIX/CADDY_HTTPS_PORT env vars.
+func (r *RemoteProxyManager) RegisterRoute(ctx context.Context, route Route) (string, error) {
+	res, err := r.send(ctx, payload.ProxyRoute{
 		Op:       payload.ProxyRouteOpRegister,
 		ID:       route.ID,
 		Domain:   route.Domain,
@@ -34,8 +36,21 @@ func (r *RemoteProxyManager) RegisterRoute(ctx context.Context, route Route) err
 		Terminal: route.Terminal,
 		Type:     route.Type,
 	})
+	if err != nil {
+		return "", err
+	}
 
-	return err
+	// Worker serialises the registered payload.Route (with ExternalURL) into Data.
+	if len(res.GetData()) == 0 {
+		return "", nil
+	}
+
+	var registered payload.Route
+	if err := json.Unmarshal(res.GetData(), &registered); err != nil {
+		return "", fmt.Errorf("remote proxy manager: unmarshal registered route: %w", err)
+	}
+
+	return registered.ExternalURL, nil
 }
 
 // UnregisterRoute implements ProxyManager.

--- a/ai-services/internal/pkg/proxy/types.go
+++ b/ai-services/internal/pkg/proxy/types.go
@@ -4,8 +4,9 @@ import "context"
 
 // ProxyManager defines the interface for managing reverse proxy routes.
 type ProxyManager interface {
-	// RegisterRoute registers a new route with the proxy
-	RegisterRoute(ctx context.Context, route Route) error
+	// RegisterRoute registers a new route with the proxy and returns the
+	// fully-qualified external URL for the route.
+	RegisterRoute(ctx context.Context, route Route) (string, error)
 
 	// UnregisterRoute removes a route from the proxy by its ID
 	UnregisterRoute(ctx context.Context, routeID string) error
@@ -33,6 +34,12 @@ type Route struct {
 
 	// Type indicates the endpoint type
 	Type string
+
+	// ExternalURL is the fully-qualified HTTPS URL for this route
+	// (e.g., "https://service.example.com" or "https://service.example.com:8443").
+	// Populated by RegisterRoutesForAppAndReturn; empty when routes are built
+	// without a known HTTPS port.
+	ExternalURL string
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/proxy/utils.go
+++ b/ai-services/internal/pkg/proxy/utils.go
@@ -1,33 +1,12 @@
 package proxy
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
-
-// GetCaddyAdminPort retrieves the host port mapped to Caddy's admin API (container port 2019).
-func GetCaddyAdminPort(ctx context.Context, rt runtime.Runtime, podName string) (string, error) {
-	pod, err := rt.InspectPod(ctx, podName)
-	if err != nil {
-		return "", fmt.Errorf("failed to inspect Caddy pod: %w", err)
-	}
-
-	// Get port mappings from the Ports field
-	// Ports is a map[string][]string where key is "containerPort/protocol" and value is list of host ports
-	// Example: {"2019/tcp": ["37249"], "443/tcp": ["39341"]}
-	for containerPort, hostPorts := range pod.Ports {
-		// Check if this is the admin API port (2019)
-		if strings.HasPrefix(containerPort, "2019/") && len(hostPorts) > 0 {
-			return hostPorts[0], nil
-		}
-	}
-
-	return "", fmt.Errorf("admin port mapping not found in pod ports")
-}
 
 // RouteEntryParts represents the parsed components of a route entry.
 type RouteEntryParts struct {
@@ -76,30 +55,30 @@ func ParseRouteEntry(routeEntry string) (*RouteEntryParts, error) {
 // BuildRoutesFromAnnotation parses a routes annotation string and builds Route objects.
 // The annotation format is: "port:subdomain:type, port:subdomain:type, ...".
 // Example: "8081:catalog-ui:ui, 8080:catalog-api:api".
-// The domainSuffix is pre-computed (e.g., "example.com" or "192.168.1.100.nip.io").
-func BuildRoutesFromAnnotation(routesAnnotation, domainSuffix, podName string) ([]Route, error) {
+// DOMAIN_SUFFIX is read from env and combined with each subdomain to form the full Domain.
+func BuildRoutesFromAnnotation(routesAnnotation, podName string) ([]Route, error) {
 	if routesAnnotation == "" {
 		return nil, nil
 	}
 
+	domainSuffix := utils.GetEnv(DomainSuffixEnvVar, "")
+	if domainSuffix == "" {
+		return nil, fmt.Errorf("%s environment variable not set", DomainSuffixEnvVar)
+	}
+
 	routes := []Route{}
 
-	// Parse routes annotation (format: "port:subdomain:type, port:subdomain:type, ...")
 	for _, r := range strings.Split(routesAnnotation, ",") {
 		r = strings.TrimSpace(r)
 		if r == "" {
 			continue
 		}
 
-		// Parse the route entry using shared helper
 		parts, err := ParseRouteEntry(r)
 		if err != nil {
 			return nil, err
 		}
 
-		// Build route - use pod name as upstream since containers are in the same pod
-		// Domain is simply: subdomain.domainSuffix
-		// Route ID uses just the subdomain since subdomains are already globally unique
 		route := Route{
 			ID:       parts.Subdomain,
 			Domain:   fmt.Sprintf("%s.%s", parts.Subdomain, domainSuffix),

--- a/ai-services/internal/pkg/proxy/utils.go
+++ b/ai-services/internal/pkg/proxy/utils.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
-	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 // RouteEntryParts represents the parsed components of a route entry.
@@ -55,15 +54,12 @@ func ParseRouteEntry(routeEntry string) (*RouteEntryParts, error) {
 // BuildRoutesFromAnnotation parses a routes annotation string and builds Route objects.
 // The annotation format is: "port:subdomain:type, port:subdomain:type, ...".
 // Example: "8081:catalog-ui:ui, 8080:catalog-api:api".
-// DOMAIN_SUFFIX is read from env and combined with each subdomain to form the full Domain.
+// Domain is set to the subdomain (e.g. "catalog-api"). RegisterRoute appends
+// DOMAIN_SUFFIX from the local environment to form the full hostname, so the
+// catalog and every remote worker each use their own domain suffix.
 func BuildRoutesFromAnnotation(routesAnnotation, podName string) ([]Route, error) {
 	if routesAnnotation == "" {
 		return nil, nil
-	}
-
-	domainSuffix := utils.GetEnv(DomainSuffixEnvVar, "")
-	if domainSuffix == "" {
-		return nil, fmt.Errorf("%s environment variable not set", DomainSuffixEnvVar)
 	}
 
 	routes := []Route{}
@@ -81,7 +77,7 @@ func BuildRoutesFromAnnotation(routesAnnotation, podName string) ([]Route, error
 
 		route := Route{
 			ID:       parts.Subdomain,
-			Domain:   fmt.Sprintf("%s.%s", parts.Subdomain, domainSuffix),
+			Domain:   parts.Subdomain,
 			Upstream: fmt.Sprintf("%s:%s", podName, parts.Port),
 			Terminal: true,
 			Type:     parts.Type,

--- a/ai-services/internal/pkg/worker/caddy/router.go
+++ b/ai-services/internal/pkg/worker/caddy/router.go
@@ -7,10 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/proxy"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
-	workerpodman "github.com/project-ai-services/ai-services/internal/pkg/worker/deploy/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/payload"
 )
 
@@ -21,16 +18,14 @@ type ProxyRouter struct {
 	pm proxy.ProxyManager
 }
 
-// New builds a ProxyRouter by discovering the Caddy admin port from the
-// named pod via the runtime and pointing the HTTP client at it.
-func New(ctx context.Context, rt runtime.Runtime) (*ProxyRouter, error) {
-	adminPort, err := proxy.GetCaddyAdminPort(ctx, rt, workerpodman.WorkerCaddyPodName)
+// NewProxyRouter builds a ProxyRouter pointed at the local Caddy admin API.
+// CADDY_ADMIN_URL is injected into the worker pod at deploy time;
+// GetCaddyProxyManager reads it directly.
+func NewProxyRouter(ctx context.Context) (*ProxyRouter, error) {
+	pm, err := proxy.GetCaddyProxyManager()
 	if err != nil {
-		return nil, fmt.Errorf("caddy router: discover admin port: %w", err)
+		return nil, fmt.Errorf("caddy router: %w", err)
 	}
-
-	adminURL := fmt.Sprintf("http://localhost:%s", adminPort)
-	pm := proxy.NewCaddyManager(adminURL, constants.CaddyServerName)
 
 	return &ProxyRouter{pm: pm}, nil
 }
@@ -47,7 +42,21 @@ func (pr *ProxyRouter) ManageProxyRoute(ctx context.Context, op payload.ProxyRou
 
 	switch op {
 	case payload.ProxyRouteOpRegister:
-		return nil, pr.pm.RegisterRoute(ctx, r)
+		// RegisterRoute returns the external URL built from the worker's own
+		// CADDY_HTTPS_PORT env var — the correct port for this machine.
+		externalURL, err := pr.pm.RegisterRoute(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+
+		return &payload.Route{
+			ID:          r.ID,
+			Domain:      r.Domain,
+			Upstream:    r.Upstream,
+			Terminal:    r.Terminal,
+			Type:        r.Type,
+			ExternalURL: externalURL,
+		}, nil
 
 	case payload.ProxyRouteOpUnregister:
 		return nil, pr.pm.UnregisterRoute(ctx, route.ID)

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -23,18 +23,12 @@ const (
 	// BaseDirEnvVar is injected into the Caddy container at deploy time; read back by uninstall.
 	BaseDirEnvVar = "AI_SERVICES_BASE_DIR"
 
-	// MetaKeyBaseDir, MetaKeyDomainSuffix, MetaKeyHTTPSPort are RegisterRequest.Metadata keys sent during join.
-	MetaKeyBaseDir      = "basedir"
-	MetaKeyDomainSuffix = "domainSuffix"
-	MetaKeyHTTPSPort    = "httpsPort"
-
 	// ArgParamCaddyHTTPSPort, ArgParamWorkerToken, ArgParamWorkerGatewayAddr,
-	// ArgParamWorkerOptionalFlags, ArgParamWorkerPodmanURI, and ArgParamWorkerAuthFile
-	// are template value-override keys used when deploying worker pods.
-	ArgParamCaddyHTTPSPort      = "caddy.httpsPort"
-	ArgParamWorkerToken         = "worker.token"
-	ArgParamWorkerGatewayAddr   = "worker.gatewayAddr"
-	ArgParamWorkerOptionalFlags = "worker.optionalFlags"
-	ArgParamWorkerPodmanURI     = "worker.podman.uri"
-	ArgParamWorkerAuthFile      = "worker.podman.authFileContent"
+	// ArgParamWorkerPodmanURI, and ArgParamWorkerAuthFile are template
+	// value-override keys used when deploying worker pods.
+	ArgParamCaddyHTTPSPort    = "caddy.httpsPort"
+	ArgParamWorkerToken       = "worker.token"
+	ArgParamWorkerGatewayAddr = "worker.gatewayAddr"
+	ArgParamWorkerPodmanURI   = "worker.podman.uri"
+	ArgParamWorkerAuthFile    = "worker.podman.authFileContent"
 )

--- a/ai-services/internal/pkg/worker/deploy/podman/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/podman/deploy.go
@@ -177,6 +177,11 @@ func deployAll(ctx context.Context, rt runtime.Runtime, tp templates.Template, o
 		return fmt.Errorf("worker setup: load templates: %w", err)
 	}
 
+	domainSuffix, err := utils.ComputeDomainSuffix(opts.Setup.SSLCertPath, opts.Setup.SSLKeyPath, opts.Setup.DomainName)
+	if err != nil {
+		return fmt.Errorf("worker setup: compute domain suffix: %w", err)
+	}
+
 	argParams, err := buildArgParams(opts)
 	if err != nil {
 		return err
@@ -192,6 +197,8 @@ func deployAll(ctx context.Context, rt runtime.Runtime, tp templates.Template, o
 		"AppName":         workerconstants.WorkerAppName,
 		"AppTemplateName": workerApp,
 		"Version":         appMetadata.Version,
+		"CaddyAdminURL":   fmt.Sprintf("http://%s:2019", WorkerCaddyPodName),
+		"DomainSuffix":    domainSuffix,
 		"Values":          values,
 	}
 
@@ -222,12 +229,11 @@ func buildArgParams(opts workertypes.PodmanWorkerOptions) (map[string]string, er
 	}
 
 	return map[string]string{
-		workerconstants.ArgParamCaddyHTTPSPort:      strconv.Itoa(opts.Setup.HTTPSPort),
-		workerconstants.ArgParamWorkerToken:         opts.Token,
-		workerconstants.ArgParamWorkerGatewayAddr:   opts.GatewayAddr,
-		workerconstants.ArgParamWorkerOptionalFlags: getOptionalFlags(opts.Setup),
-		workerconstants.ArgParamWorkerPodmanURI:     strings.TrimPrefix(podmanURI, "unix://"),
-		workerconstants.ArgParamWorkerAuthFile:      authFileBase64,
+		workerconstants.ArgParamCaddyHTTPSPort:    strconv.Itoa(opts.Setup.HTTPSPort),
+		workerconstants.ArgParamWorkerToken:       opts.Token,
+		workerconstants.ArgParamWorkerGatewayAddr: opts.GatewayAddr,
+		workerconstants.ArgParamWorkerPodmanURI:   strings.TrimPrefix(podmanURI, "unix://"),
+		workerconstants.ArgParamWorkerAuthFile:    authFileBase64,
 	}, nil
 }
 
@@ -286,25 +292,4 @@ func renderAndDeploy(ctx context.Context, rt runtime.Runtime, tmpls map[string]*
 
 	return clipodman.DeployPodAndReadinessCheck(ctx, rt, &podSpec, tmplName,
 		bytes.NewReader(rendered.Bytes()), deployOpts)
-}
-
-// getOptionalFlags builds the optional CLI flags string that is forwarded from
-// the 'worker join' command to the 'worker grpcstream' command running inside
-// the container.
-func getOptionalFlags(opts workertypes.Options) string {
-	var flags string
-	if opts.BaseDir != "" {
-		flags += fmt.Sprintf("--basedir '%s' ", opts.BaseDir)
-	}
-	if opts.SSLCertPath != "" && opts.SSLKeyPath != "" {
-		flags += fmt.Sprintf("--ssl-cert '%s' --ssl-key '%s' ", opts.SSLCertPath, opts.SSLKeyPath)
-	}
-	if opts.DomainName != "" {
-		flags += fmt.Sprintf("--domain-name %s ", opts.DomainName)
-	}
-	if opts.HTTPSPort > 0 {
-		flags += fmt.Sprintf("--https-port %d", opts.HTTPSPort)
-	}
-
-	return flags
 }

--- a/ai-services/internal/pkg/worker/dispatch/dispatch.go
+++ b/ai-services/internal/pkg/worker/dispatch/dispatch.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	workercaddy "github.com/project-ai-services/ai-services/internal/pkg/worker/caddy"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/payload"
 	workerpb "github.com/project-ai-services/ai-services/internal/pkg/worker/proto"
@@ -228,7 +229,7 @@ func handle(ctx context.Context, rt runtime.Runtime, pr *workercaddy.ProxyRouter
 			return nil, fmt.Errorf("decode download_model payload: %w", err)
 		}
 
-		return nil, helpers.DownloadModelContainer(ctx, req.Model, req.TargetDir)
+		return nil, helpers.DownloadModelContainer(ctx, req.Model, utils.GetModelsPath())
 
 	// ── Caddy proxy management ────────────────────────────────────────────────
 

--- a/ai-services/internal/pkg/worker/join/join.go
+++ b/ai-services/internal/pkg/worker/join/join.go
@@ -52,7 +52,7 @@ const (
 
 // StartGrpcStream dials the catalog gRPC worker-gateway, registers with the
 // bootstrap token, and holds the CommandStream open.
-func StartGrpcStream(ctx context.Context, rt runtime.Runtime, pr *workercaddy.ProxyRouter, opts workertypes.GrpcStreamOptions, meta map[string]string) error {
+func StartGrpcStream(ctx context.Context, rt runtime.Runtime, pr *workercaddy.ProxyRouter, opts workertypes.GrpcStreamOptions) error {
 	// ── Step 1: Dial the gateway ─────────────────────────────────────────────
 	logger.InfofCtx(ctx, "Connecting to catalog gateway at %s...\n", opts.GatewayAddr)
 
@@ -65,7 +65,7 @@ func StartGrpcStream(ctx context.Context, rt runtime.Runtime, pr *workercaddy.Pr
 	client := workerpb.NewWorkerGatewayClient(conn)
 
 	// ── Step 2: Register + stream loop ───────────────────────────────────────
-	return runRegistrationLoop(ctx, rt, pr, client, opts.Token, meta)
+	return runRegistrationLoop(ctx, rt, pr, client, opts.Token)
 }
 
 // ─── registration loop ────────────────────────────────────────────────────────
@@ -73,8 +73,8 @@ func StartGrpcStream(ctx context.Context, rt runtime.Runtime, pr *workercaddy.Pr
 // runRegistrationLoop calls Register and then enters the CommandStream retry
 // loop.  If the stream comes back with codes.Unauthenticated it re-registers
 // before reconnecting.
-func runRegistrationLoop(ctx context.Context, rt runtime.Runtime, pr *workercaddy.ProxyRouter, client workerpb.WorkerGatewayClient, token string, meta map[string]string) error {
-	workerName, err := register(ctx, client, token, rt.Type(), meta)
+func runRegistrationLoop(ctx context.Context, rt runtime.Runtime, pr *workercaddy.ProxyRouter, client workerpb.WorkerGatewayClient, token string) error {
+	workerName, err := register(ctx, client, token, rt.Type())
 	if err != nil {
 		return fmt.Errorf("worker join: register: %w", err)
 	}
@@ -86,13 +86,12 @@ func runRegistrationLoop(ctx context.Context, rt runtime.Runtime, pr *workercadd
 
 // register calls the Register RPC once and returns the worker name bound by
 // the control plane.
-func register(ctx context.Context, client workerpb.WorkerGatewayClient, token string, rt types.RuntimeType, meta map[string]string) (string, error) {
+func register(ctx context.Context, client workerpb.WorkerGatewayClient, token string, rt types.RuntimeType) (string, error) {
 	logger.InfolnCtx(ctx, "Registering worker with catalog control plane...")
 
 	resp, err := client.Register(ctx, &workerpb.RegisterRequest{
 		PreSharedToken: token,
 		RuntimeType:    rt.String(),
-		Metadata:       meta,
 	})
 	// TODO: When registrations fails due to "token already used" error
 	// attempt registretion without token.

--- a/ai-services/internal/pkg/worker/payload/payload.go
+++ b/ai-services/internal/pkg/worker/payload/payload.go
@@ -58,8 +58,7 @@ type ExecInContainer struct {
 }
 
 type DownloadModel struct {
-	Model     string `json:"model"`
-	TargetDir string `json:"targetDir"`
+	Model string `json:"model"`
 }
 
 // ─── Network ──────────────────────────────────────────────────────────────────
@@ -96,11 +95,12 @@ type ProxyRoute struct {
 
 // Route represents a Caddy reverse-proxy route on a worker node.
 type Route struct {
-	ID       string // unique route identifier used as @id in Caddy config
-	Domain   string // hostname to match (e.g. "service.example.com")
-	Upstream string // backend address (e.g. "10.88.0.5:8080")
-	Terminal bool   // stop route matching after this route
-	Type     string // endpoint type label (e.g. "ui", "api")
+	ID          string // unique route identifier used as @id in Caddy config
+	Domain      string // hostname to match (e.g. "service.example.com")
+	Upstream    string // backend address (e.g. "10.88.0.5:8080")
+	Terminal    bool   // stop route matching after this route
+	Type        string // endpoint type label (e.g. "ui", "api")
+	ExternalURL string // fully-qualified HTTPS URL built by the worker from its own env
 }
 
 // ─── HTTP proxy ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Previously, BuildRoutesFromAnnotation read DOMAIN_SUFFIX from the environment at parse time and stamped the full domain (catalog-api.example.com) directly onto each route. This was correct for the catalog but broken for remote workers: the routes were serialised into the gRPC payload and sent to the worker, which then registered the catalog's domain in its own Caddy instead of its own.

The fix splits responsibility cleanly across two layers:

- BuildRoutesFromAnnotation (utils.go) — now sets Route.Domain to just the subdomain (e.g. "catalog-api"). No env read, no domain construction. The subdomain travels through the gRPC payload as neutral data.

- RegisterRoute (caddy.go) — now owns full domain construction. It reads DOMAIN_SUFFIX from the local environment on whichever machine is running Caddy, then builds domain = route.Domain + "." + domainSuffix. Both the Caddy host-match rule and the returned ExternalURL use this locally-assembled domain.

The effect: the catalog registers catalog-api.<catalog-domain> against its own Caddy, and a remote worker registers catalog-api.<worker-domain> against its own Caddy — each using the DOMAIN_SUFFIX of the machine where Caddy is actually running.