### PR TITLE
AISERVICES-1730: Uninstalling worker pods from the given runtime.

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.318
+TAG?=v0.0.319
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.318
+  image: icr.io/ai-services-cicd/ai-services:v0.0.319
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.318
+  image: icr.io/ai-services-cicd/ai-services:v0.0.319
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.318
+  image: icr.io/ai-services-cicd/ai-services:v0.0.319
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/templates/worker.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/worker.yaml.tmpl
@@ -7,6 +7,7 @@ metadata:
     ai-services.io/template: "{{ .AppTemplateName }}"
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/component: "worker"
+    ai-services.io/volume: "podman-auth-secret"
   annotations:
     run.oci.keep_original_groups: "1"
 spec:

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.318
+  image: icr.io/ai-services-cicd/ai-services:v0.0.319
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/cmd/ai-services/cmd/worker/uninstall.go
+++ b/ai-services/cmd/ai-services/cmd/worker/uninstall.go
@@ -1,13 +1,12 @@
 package worker
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 
 	cmdcommon "github.com/project-ai-services/ai-services/cmd/ai-services/cmd/common"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	workeruninstall "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall"
+	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 )
 
 // Flag variables for the worker uninstall command.
@@ -40,8 +39,8 @@ Application pods deployed on this worker by the catalog are not touched.`,
 
 			return cmdcommon.InitAndValidateRuntimeFlag(uninstallRuntimeType)
 		},
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return workeruninstall.Uninstall(context.Background(), workeruninstall.Options{
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return workeruninstall.Uninstall(cmd.Context(), workerutils.UninstallOptions{
 				RuntimeType: vars.RuntimeFactory.GetRuntimeType(),
 				AutoYes:     uninstallAutoYes,
 			})

--- a/ai-services/internal/pkg/catalog/apiserver/services/deletion/repository/podman/deletion.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deletion/repository/podman/deletion.go
@@ -16,6 +16,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // PodmanDeletion handles application deletion operations.
@@ -259,7 +260,7 @@ func (s *PodmanDeletion) deleteVolumesFromPods(ctx context.Context, pods []runti
 
 	// Extract volume names from pod labels
 	for _, pod := range pods {
-		if volumeNames, ok := pod.Labels[catalogconstants.CatalogVolumeLabel]; ok && volumeNames != "" {
+		if volumeNames, ok := pod.Labels[vars.VolumeLabel]; ok && volumeNames != "" {
 			// Split comma-separated volume names (in case a pod has multiple volumes)
 			volumes := strings.Split(volumeNames, ",")
 			for _, volumeName := range volumes {

--- a/ai-services/internal/pkg/catalog/apiserver/services/deletion/repository/podman/deletion.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deletion/repository/podman/deletion.go
@@ -15,6 +15,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/proxy"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 // PodmanDeletion handles application deletion operations.
@@ -175,7 +176,7 @@ func (s *PodmanDeletion) deletePods(ctx context.Context, pods []runtimeTypes.Pod
 	for _, pod := range pods {
 		if err := s.rt.DeletePod(ctx, pod.ID, &forceDelete); err != nil {
 			// Ignore "not found" errors - pod already deleted or never existed
-			if catalogutils.IsNotFoundError(err) {
+			if utils.IsNotFoundError(err) {
 				logger.InfofCtx(ctx, "Pod %s already deleted or does not exist", pod.ID)
 
 				continue
@@ -281,7 +282,7 @@ func (s *PodmanDeletion) deleteVolumesFromPods(ctx context.Context, pods []runti
 	for volumeName := range volumesToDelete {
 		if err := s.rt.DeleteVolume(ctx, volumeName); err != nil {
 			// Ignore "not found" errors - volume already deleted or never existed
-			if catalogutils.IsNotFoundError(err) {
+			if utils.IsNotFoundError(err) {
 				logger.InfofCtx(ctx, "Volume %s already deleted or does not exist", volumeName)
 
 				continue
@@ -335,7 +336,7 @@ func (s *PodmanDeletion) deleteSecretsFromPods(ctx context.Context, pods []runti
 	for secretName := range secretsToDelete {
 		if err := s.rt.DeleteSecret(ctx, secretName); err != nil {
 			// Ignore "not found" errors - secret already deleted or never existed
-			if catalogutils.IsNotFoundError(err) {
+			if utils.IsNotFoundError(err) {
 				logger.InfofCtx(ctx, "Secret %s already deleted or does not exist", secretName)
 
 				continue

--- a/ai-services/internal/pkg/catalog/apiserver/services/deletion/repository/podman/deletion.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deletion/repository/podman/deletion.go
@@ -11,12 +11,12 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
 	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/proxy"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
-	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // PodmanDeletion handles application deletion operations.
@@ -260,7 +260,7 @@ func (s *PodmanDeletion) deleteVolumesFromPods(ctx context.Context, pods []runti
 
 	// Extract volume names from pod labels
 	for _, pod := range pods {
-		if volumeNames, ok := pod.Labels[vars.VolumeLabel]; ok && volumeNames != "" {
+		if volumeNames, ok := pod.Labels[constants.VolumeLabel]; ok && volumeNames != "" {
 			// Split comma-separated volume names (in case a pod has multiple volumes)
 			volumes := strings.Split(volumeNames, ",")
 			for _, volumeName := range volumes {

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
-	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 func ResetPodmanAuth(ctx context.Context) error {
@@ -29,8 +29,8 @@ func ResetPodmanAuth(ctx context.Context) error {
 	}
 
 	// Delete podman auth secret.
-	logger.InfofCtx(ctx, "Deleting catalog podman auth secret %s", vars.PodmanAuthSecret)
-	err = deployCtx.Runtime.DeleteSecret(ctx, vars.PodmanAuthSecret)
+	logger.InfofCtx(ctx, "Deleting catalog podman auth secret %s", constants.PodmanAuthSecret)
+	err = deployCtx.Runtime.DeleteSecret(ctx, constants.PodmanAuthSecret)
 	if err != nil {
 		return fmt.Errorf("failed to delete existing catalog podman auth secret: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
-	catalogConstant "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 func ResetPodmanAuth(ctx context.Context) error {
@@ -29,8 +29,8 @@ func ResetPodmanAuth(ctx context.Context) error {
 	}
 
 	// Delete podman auth secret.
-	logger.InfofCtx(ctx, "Deleting catalog podman auth secret %s", catalogConstant.CatalogPodmanAuthSecretName)
-	err = deployCtx.Runtime.DeleteSecret(ctx, catalogConstant.CatalogPodmanAuthSecretName)
+	logger.InfofCtx(ctx, "Deleting catalog podman auth secret %s", vars.PodmanAuthSecret)
+	err = deployCtx.Runtime.DeleteSecret(ctx, vars.PodmanAuthSecret)
 	if err != nil {
 		return fmt.Errorf("failed to delete existing catalog podman auth secret: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/uninstall/openshift/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/openshift/uninstall.go
@@ -8,12 +8,12 @@ import (
 	utils "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/uninstall/utils"
 	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
+	internalutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	openshiftruntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/openshift"
 	"github.com/project-ai-services/ai-services/internal/pkg/spinner"
-	internalutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 )
 
 // UninstallCatalog removes the catalog helm release and optionally cleans up PVCs and catalog namespace.

--- a/ai-services/internal/pkg/catalog/cli/uninstall/openshift/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/openshift/uninstall.go
@@ -13,6 +13,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	openshiftruntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/openshift"
 	"github.com/project-ai-services/ai-services/internal/pkg/spinner"
+	internalutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 )
 
 // UninstallCatalog removes the catalog helm release and optionally cleans up PVCs and catalog namespace.
@@ -63,16 +64,12 @@ func UninstallCatalog(ctx context.Context, opts utils.UninstallOptions) error {
 }
 
 func confirmDeletion(ctx context.Context, rt runtime.Runtime, autoYes bool) (bool, error) {
-	if autoYes {
-		return true, nil
-	}
-
 	pods, err := clicommon.GetCatalogPods(ctx, rt)
 	if err != nil || len(pods) == 0 {
 		return false, err
 	}
 
-	return utils.ConfirmDeletion(ctx, pods)
+	return internalutils.ConfirmUninstall(ctx, pods, autoYes)
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -35,10 +35,8 @@ func UninstallCatalog(ctx context.Context, opts cliutils.UninstallOptions) error
 	logger.Warningln("Ensure no applications are running before uninstalling the catalog, as they may go stale when the catalog is uninstalled and will need to be deleted manually")
 
 	// Confirm deletion if not auto-yes
-	if !opts.AutoYes {
-		if confirmed, err := cliutils.ConfirmDeletion(ctx, pods); !confirmed || err != nil {
-			return err
-		}
+	if confirmed, err := podmanutils.ConfirmUninstall(ctx, pods, opts.AutoYes); !confirmed || err != nil {
+		return err
 	}
 
 	return performCleanup(ctx, rt, pods, opts.SkipCleanup)

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -3,7 +3,6 @@ package podman
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -12,6 +11,7 @@ import (
 	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 
+	podmanutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
@@ -75,7 +75,7 @@ func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.P
 	volumesToDelete, volumesToSkip := fetchVolumesToDelete(pods)
 
 	// Delete catalog pods
-	if err := podsDeletion(ctx, rt, pods); err != nil {
+	if err := podmanutils.DeletePods(ctx, rt, pods); err != nil {
 		return err
 	}
 
@@ -85,13 +85,13 @@ func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.P
 	}
 
 	// Delete volumes (only those without skip-cleanup label)
-	if err := deleteVolumes(ctx, rt, volumesToDelete); err != nil {
+	if err := podmanutils.DeleteVolumes(ctx, rt, volumesToDelete); err != nil {
 		return err
 	}
 
 	// Delete models data
 	modelsDataPath := filepath.Join(baseDir, "models")
-	if err := dataDeletion(modelsDataPath); err != nil {
+	if err := podmanutils.RemoveDataDir(ctx, modelsDataPath); err != nil {
 		return err
 	}
 
@@ -130,31 +130,7 @@ func cleanupSkippedResources(ctx context.Context, rt *podman.PodmanClient, secre
 	}
 
 	// Delete volumes with skip-cleanup label (only when --skip-cleanup is not set)
-	return deleteVolumes(ctx, rt, volumesToSkip)
-}
-
-// podsDeletion removes all catalog pods.
-func podsDeletion(ctx context.Context, rt *podman.PodmanClient, pods []types.Pod) error {
-	var errors []string
-
-	for _, pod := range pods {
-		logger.Infof("Deleting pod: %s\n", pod.Name)
-
-		if err := rt.DeletePod(ctx, pod.ID, utils.BoolPtr(true)); err != nil {
-			errors = append(errors, fmt.Sprintf("pod %s: %v", pod.Name, err))
-
-			continue
-		}
-
-		logger.Infof("Successfully removed pod: %s\n", pod.Name)
-	}
-
-	// Aggregate errors at the end
-	if len(errors) > 0 {
-		return fmt.Errorf("failed to remove pods: \n%s", strings.Join(errors, "\n"))
-	}
-
-	return nil
+	return podmanutils.DeleteVolumes(ctx, rt, volumesToSkip)
 }
 
 // We are currently associating secret names with pods via pod labels and relying on those labels for secret cleanup.
@@ -216,64 +192,6 @@ func fetchVolumesToDelete(pods []types.Pod) ([]string, []string) {
 	}
 
 	return volumesToDelete, volumesToSkip
-}
-
-// dataDeletion removes the specified data directory.
-func dataDeletion(dataPath string) error {
-	// Check if data directory exists
-	if _, err := os.Stat(dataPath); os.IsNotExist(err) {
-		logger.Infof("data directory does not exist: %s\n", dataPath)
-
-		return nil
-	}
-
-	logger.Infof("Deleting data at: %s\n", dataPath)
-
-	// Remove the data directory
-	if err := os.RemoveAll(dataPath); err != nil {
-		return fmt.Errorf("failed to remove database data directory: %w", err)
-	}
-
-	logger.Infof("Successfully removed data at: %s\n", dataPath)
-
-	return nil
-}
-
-// deleteVolumes removes the specified volumes.
-func deleteVolumes(ctx context.Context, rt *podman.PodmanClient, volumeNames []string) error {
-	if len(volumeNames) == 0 {
-		// Just return if there are no volumes to delete.
-		return nil
-	}
-
-	logger.Infof("Deleting %d volume(s)\n", len(volumeNames))
-
-	var errors []string
-	for _, volumeName := range volumeNames {
-		logger.Infof("Deleting volume: %s\n", volumeName)
-
-		if err := rt.DeleteVolume(ctx, volumeName); err != nil {
-			// Ignore "not found" errors - volume already deleted or never existed
-			if utils.IsNotFoundError(err) {
-				logger.Infof("Volume %s already deleted or does not exist\n", volumeName)
-
-				continue
-			}
-
-			errors = append(errors, fmt.Sprintf("volume %s: %v", volumeName, err))
-
-			continue
-		}
-
-		logger.Infof("Successfully deleted volume: %s\n", volumeName)
-	}
-
-	// Aggregate errors at the end
-	if len(errors) > 0 {
-		return fmt.Errorf("failed to remove volumes: \n%s", strings.Join(errors, "\n"))
-	}
-
-	return nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -16,6 +16,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // UninstallCatalog removes the catalog service and all associated resources.
@@ -58,7 +59,7 @@ func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.P
 	logger.Infof("Using base directory for cleanup: %s\n", baseDir)
 
 	secretsToDelete, secretsToSkip := fetchSecretsToDelete(pods)
-	secretsToDelete = append(secretsToDelete, catalogConstants.PodmanAuthSecret, catalogConstants.CatalogConnectorSecretName)
+	secretsToDelete = append(secretsToDelete, vars.PodmanAuthSecret, catalogConstants.CatalogConnectorSecretName)
 
 	// Checking if 'catalog-caddy-cert-secret' is created as part of catalog configure
 	// If secret is created adding it to 'secretsToDelete' list
@@ -78,7 +79,7 @@ func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.P
 	}
 
 	// Delete catalog secrets
-	if err := deleteSecrets(ctx, rt, secretsToDelete); err != nil {
+	if err := podmanutils.DeleteSecrets(ctx, rt, secretsToDelete); err != nil {
 		return err
 	}
 
@@ -103,17 +104,6 @@ func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.P
 	return nil
 }
 
-// deleteSecrets removes the specified secrets.
-func deleteSecrets(ctx context.Context, rt *podman.PodmanClient, secrets []string) error {
-	for _, secret := range secrets {
-		if err := rt.DeleteSecret(ctx, secret); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // cleanupSkippedResources deletes secrets and volumes that are preserved when --skip-cleanup is set.
 func cleanupSkippedResources(ctx context.Context, rt *podman.PodmanClient, secretsToSkip []string, volumesToSkip []string, skipCleanup bool) error {
 	if skipCleanup {
@@ -123,7 +113,7 @@ func cleanupSkippedResources(ctx context.Context, rt *podman.PodmanClient, secre
 	}
 
 	// Delete catalog secrets
-	if err := deleteSecrets(ctx, rt, secretsToSkip); err != nil {
+	if err := podmanutils.DeleteSecrets(ctx, rt, secretsToSkip); err != nil {
 		return err
 	}
 
@@ -159,7 +149,7 @@ func fetchVolumesToDelete(pods []types.Pod) ([]string, []string) {
 
 	for _, pod := range pods {
 		// fetch volume names from pod labels
-		if volumeNames, ok := pod.Labels[catalogConstants.CatalogVolumeLabel]; ok && volumeNames != "" {
+		if volumeNames, ok := pod.Labels[vars.VolumeLabel]; ok && volumeNames != "" {
 			// Check if this pod has skip-cleanup label for volumes
 			_, hasSkipLabel := pod.Labels[catalogConstants.CatalogVolumeSkipLabel]
 

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -254,7 +254,7 @@ func deleteVolumes(ctx context.Context, rt *podman.PodmanClient, volumeNames []s
 
 		if err := rt.DeleteVolume(ctx, volumeName); err != nil {
 			// Ignore "not found" errors - volume already deleted or never existed
-			if catalogUtils.IsNotFoundError(err) {
+			if utils.IsNotFoundError(err) {
 				logger.Infof("Volume %s already deleted or does not exist\n", volumeName)
 
 				continue

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -12,11 +12,11 @@ import (
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 
 	podmanutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
-	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 // UninstallCatalog removes the catalog service and all associated resources.
@@ -59,7 +59,7 @@ func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.P
 	logger.Infof("Using base directory for cleanup: %s\n", baseDir)
 
 	secretsToDelete, secretsToSkip := fetchSecretsToDelete(pods)
-	secretsToDelete = append(secretsToDelete, vars.PodmanAuthSecret, catalogConstants.CatalogConnectorSecretName)
+	secretsToDelete = append(secretsToDelete, constants.PodmanAuthSecret, catalogConstants.CatalogConnectorSecretName)
 
 	// Checking if 'catalog-caddy-cert-secret' is created as part of catalog configure
 	// If secret is created adding it to 'secretsToDelete' list
@@ -149,7 +149,7 @@ func fetchVolumesToDelete(pods []types.Pod) ([]string, []string) {
 
 	for _, pod := range pods {
 		// fetch volume names from pod labels
-		if volumeNames, ok := pod.Labels[vars.VolumeLabel]; ok && volumeNames != "" {
+		if volumeNames, ok := pod.Labels[constants.VolumeLabel]; ok && volumeNames != "" {
 			// Check if this pod has skip-cleanup label for volumes
 			_, hasSkipLabel := pod.Labels[catalogConstants.CatalogVolumeSkipLabel]
 

--- a/ai-services/internal/pkg/catalog/cli/uninstall/utils/utils.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/utils/utils.go
@@ -1,12 +1,7 @@
 package utils
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
-	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 // UninstallOptions contains the configuration for uninstalling the catalog service.
@@ -14,27 +9,4 @@ type UninstallOptions struct {
 	Runtime     types.RuntimeType
 	AutoYes     bool
 	SkipCleanup bool
-}
-
-// ConfirmDeletion prompts the user to confirm deletion and logs pods to be deleted.
-func ConfirmDeletion(ctx context.Context, pods []types.Pod) (bool, error) {
-	// Print pods to be deleted
-	logger.InfofCtx(ctx, "Below are the list of pods to be deleted")
-	for _, pod := range pods {
-		logger.InfofCtx(ctx, "\t-> %s\n", pod.Name)
-	}
-
-	// Confirm deletion
-	confirmed, err := utils.ConfirmAction("\nDo you want to continue?")
-	if err != nil {
-		return false, fmt.Errorf("failed to get confirmation: %w", err)
-	}
-
-	if !confirmed {
-		logger.InfolnCtx(ctx, "Deletion cancelled")
-
-		return false, nil
-	}
-
-	return true, nil
 }

--- a/ai-services/internal/pkg/catalog/constants/catalog.go
+++ b/ai-services/internal/pkg/catalog/constants/catalog.go
@@ -46,12 +46,8 @@ const (
 	CatalogSecretLabel = "ai-services.io/secret"
 	// CatalogSecretSkipLabel represents if catalog secret associated with pod should be skipped while deletion.
 	CatalogSecretSkipLabel = "ai-services.io/secret-skip-cleanup"
-	// CatalogVolumeLabel represents the catalog volume name associated with Catalog Pod.
-	CatalogVolumeLabel = "ai-services.io/volume"
 	// CatalogVolumeSkipLabel represents if catalog volume associated with pod should be skipped while deletion.
 	CatalogVolumeSkipLabel = "ai-services.io/volume-skip-cleanup"
-	// PodmanAuthSecret represents podman auth secret name.
-	PodmanAuthSecret = "podman-auth-secret"
 	// CatalogSecretName represents the catalog secret name.
 	CatalogSecretName = "catalog-secret"
 	// CatalogCertSecretName represents caddy cert secret name.
@@ -60,8 +56,6 @@ const (
 	CatalogDBSecretName = "catalog-db-secret"
 	// CatalogConnectorSecretName represents the catalog connector encryption key secret name.
 	CatalogConnectorSecretName = "catalog-db-encryption-secret"
-	// CatalogPodmanAuthSecretName represent the podman auth secret name.
-	CatalogPodmanAuthSecretName = "podman-auth-secret"
 	// CatalogDeploymentName represent the catalog deployment name.
 	CatalogDeploymentName = "catalog-backend"
 )

--- a/ai-services/internal/pkg/catalog/utils/application_utils.go
+++ b/ai-services/internal/pkg/catalog/utils/application_utils.go
@@ -122,20 +122,6 @@ func GenerateInstanceSlug(id string) string {
 	return hexHash[:10]
 }
 
-// IsNotFoundError checks if an error indicates a resource was not found.
-// Returns true for "no such pod", "no such secret", "no such volume" errors.
-func IsNotFoundError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errMsg := err.Error()
-
-	return strings.Contains(errMsg, "no such pod") ||
-		strings.Contains(errMsg, "no pod with name or ID") ||
-		strings.Contains(errMsg, "no such secret") ||
-		strings.Contains(errMsg, "no such volume")
-}
-
 // CalculateComponentHash creates a unique hash for a component configuration.
 // Components with same type, provider, and params will have the same hash.
 func CalculateComponentHash(componentType string, providerID string, params map[string]any) string {

--- a/ai-services/internal/pkg/cli/utils/common.go
+++ b/ai-services/internal/pkg/cli/utils/common.go
@@ -139,7 +139,7 @@ func GetPodsFromApplicationsPS(ctx context.Context, appName string) ([]types.Pod
 	return pods, nil
 }
 
-// ConfirmUninstall prompts the user to confirm uninstall and logs pods to be deleted.Add a comment on  lines R21 to R41Add diff commentMarkdown input:  edit mode selected.WritePreviewAdd a suggestionHeadingBold(command b) command⌘ bBItalic(command i) command⌘ iIQuote(command shift right angle bracket) command⌘ shift⇧ right angle bracket>Code(command e) command⌘ eELink(command k) command⌘ kKUnordered list(command 8) command⌘ 88Numbered list(command shift ampersand) command⌘ shift⇧ ampersand&Task list(command shift l) command⌘ shift⇧ lLMentionReferenceMore itemsSaved repliesAdd FilesPaste, drop, or click to add filesCancelCommentStart a review
+// ConfirmUninstall prompts the user to confirm uninstall and logs pods to be deleted.
 func ConfirmUninstall(ctx context.Context, pods []types.Pod, autoYes bool) (bool, error) {
 	if autoYes {
 		return true, nil

--- a/ai-services/internal/pkg/cli/utils/common.go
+++ b/ai-services/internal/pkg/cli/utils/common.go
@@ -10,6 +10,7 @@ import (
 	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
@@ -136,4 +137,31 @@ func GetPodsFromApplicationsPS(ctx context.Context, appName string) ([]types.Pod
 	}
 
 	return pods, nil
+}
+
+// ConfirmUninstall prompts the user to confirm uninstall and logs pods to be deleted.Add a comment on  lines R21 to R41Add diff commentMarkdown input:  edit mode selected.WritePreviewAdd a suggestionHeadingBold(command b) command⌘ bBItalic(command i) command⌘ iIQuote(command shift right angle bracket) command⌘ shift⇧ right angle bracket>Code(command e) command⌘ eELink(command k) command⌘ kKUnordered list(command 8) command⌘ 88Numbered list(command shift ampersand) command⌘ shift⇧ ampersand&Task list(command shift l) command⌘ shift⇧ lLMentionReferenceMore itemsSaved repliesAdd FilesPaste, drop, or click to add filesCancelCommentStart a review
+func ConfirmUninstall(ctx context.Context, pods []types.Pod, autoYes bool) (bool, error) {
+	if autoYes {
+		return true, nil
+	}
+
+	// Print pods to be deleted
+	logger.InfofCtx(ctx, "Below are the list of pods to be deleted")
+	for _, pod := range pods {
+		logger.InfofCtx(ctx, "\t-> %s\n", pod.Name)
+	}
+
+	// Confirm Uninstall
+	confirmed, err := utils.ConfirmAction("\nDo you want to continue?")
+	if err != nil {
+		return false, fmt.Errorf("failed to get confirmation: %w", err)
+	}
+
+	if !confirmed {
+		logger.InfolnCtx(ctx, "Uninstall cancelled")
+
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/ai-services/internal/pkg/cli/utils/podman.go
+++ b/ai-services/internal/pkg/cli/utils/podman.go
@@ -117,3 +117,24 @@ func DeletePods(ctx context.Context, rt runtime.Runtime, pods []types.Pod) error
 
 	return nil
 }
+
+// DeleteSecrets iterates over the provided secret names and removes each one via the
+// runtime. "Not found" errors are treated as no-ops (the secret was already deleted
+// or never existed) and are logged without aborting the loop. Any other deletion
+// error is returned immediately, halting further processing.
+func DeleteSecrets(ctx context.Context, rt runtime.Runtime, secrets []string) error {
+	for _, secret := range secrets {
+		if err := rt.DeleteSecret(ctx, secret); err != nil {
+			if utils.IsNotFoundError(err) {
+				logger.InfofCtx(ctx, "Secret %s already deleted or does not exist\n", secret)
+
+				continue
+			}
+
+			return err
+		}
+		logger.Infof("Successfully deleted secret: %s\n", secret)
+	}
+
+	return nil
+}

--- a/ai-services/internal/pkg/cli/utils/podman.go
+++ b/ai-services/internal/pkg/cli/utils/podman.go
@@ -1,9 +1,16 @@
 package utils
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 // PodmanRun executes `podman <args>` via the CLI and returns combined stdout+stderr.
@@ -30,4 +37,83 @@ func PodmanContainerName(c map[string]any) string {
 	}
 
 	return ""
+}
+
+// DeleteVolumes removes the specified volumes.
+func DeleteVolumes(ctx context.Context, rt runtime.Runtime, volumeNames []string) error {
+	if len(volumeNames) == 0 {
+		// Just return if there are no volumes to delete.
+		return nil
+	}
+
+	logger.Infof("Deleting %d volume(s)\n", len(volumeNames))
+
+	var errors []string
+	for _, volumeName := range volumeNames {
+		logger.Infof("Deleting volume: %s\n", volumeName)
+
+		if err := rt.DeleteVolume(ctx, volumeName); err != nil {
+			// Ignore "not found" errors - volume already deleted or never existed
+			if utils.IsNotFoundError(err) {
+				logger.Infof("Volume %s already deleted or does not exist\n", volumeName)
+
+				continue
+			}
+
+			errors = append(errors, fmt.Sprintf("volume %s: %v", volumeName, err))
+
+			continue
+		}
+
+		logger.Infof("Successfully deleted volume: %s\n", volumeName)
+	}
+
+	// Aggregate errors at the end
+	if len(errors) > 0 {
+		return fmt.Errorf("failed to remove volumes: \n%s", strings.Join(errors, "\n"))
+	}
+
+	return nil
+}
+
+// RemoveDataDir deletes the directory at dataPath if it exists, logging a note when absent.
+func RemoveDataDir(ctx context.Context, dataPath string) error {
+	if _, err := os.Stat(dataPath); os.IsNotExist(err) {
+		logger.InfofCtx(ctx, "data directory does not exist, skipping: %s\n", dataPath)
+
+		return nil
+	}
+
+	logger.InfofCtx(ctx, "Deleting data at: %s\n", dataPath)
+
+	if err := os.RemoveAll(dataPath); err != nil {
+		return fmt.Errorf("failed to remove data directory %s: %w", dataPath, err)
+	}
+
+	logger.InfofCtx(ctx, "Successfully removed data at: %s\n", dataPath)
+
+	return nil
+}
+
+// DeletePods force-deletes every pod in the list and aggregates any errors.
+func DeletePods(ctx context.Context, rt runtime.Runtime, pods []types.Pod) error {
+	var errs []string
+
+	for _, p := range pods {
+		logger.InfofCtx(ctx, "Deleting pod: %s\n", p.Name)
+
+		if err := rt.DeletePod(ctx, p.ID, utils.BoolPtr(true)); err != nil {
+			errs = append(errs, fmt.Sprintf("pod %s: %v", p.Name, err))
+
+			continue
+		}
+
+		logger.InfofCtx(ctx, "Deleted pod: %s\n", p.Name)
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to delete pods:\n%s", strings.Join(errs, "\n"))
+	}
+
+	return nil
 }

--- a/ai-services/internal/pkg/constants/common.go
+++ b/ai-services/internal/pkg/constants/common.go
@@ -101,3 +101,10 @@ const (
 	Starting HealthStatus = "starting"
 	NotReady HealthStatus = "unhealthy"
 )
+
+const (
+	// PodmanAuthSecret represents podman auth secret name.
+	PodmanAuthSecret = "podman-auth-secret"
+	// VolumeLabel represents the volume name associated with Pod.
+	VolumeLabel = "ai-services.io/volume"
+)

--- a/ai-services/internal/pkg/helm/helm.go
+++ b/ai-services/internal/pkg/helm/helm.go
@@ -18,10 +18,6 @@ import (
 
 const uninstallHelmTimeout = 5 * time.Minute
 
-var (
-	ErrReleaseNotFound = errors.New("no release found")
-)
-
 type Helm struct {
 	namespace    string
 	actionConfig *action.Configuration

--- a/ai-services/internal/pkg/helm/helm.go
+++ b/ai-services/internal/pkg/helm/helm.go
@@ -168,7 +168,7 @@ func (h *Helm) Uninstall(release string, opts *UninstallOpts) error {
 	return nil
 }
 
-func (h *Helm) UninstallRelease(ctx context.Context, release string) error {
+func (h *Helm) UninstallRelease(release string) error {
 	exists, err := h.IsReleaseExist(release)
 	if err != nil {
 		return fmt.Errorf("failed to check '%s' release existence: %w", release, err)

--- a/ai-services/internal/pkg/helm/helm.go
+++ b/ai-services/internal/pkg/helm/helm.go
@@ -16,6 +16,12 @@ import (
 	"helm.sh/helm/v4/pkg/storage/driver"
 )
 
+const uninstallHelmTimeout = 5 * time.Minute
+
+var (
+	ErrReleaseNotFound = errors.New("no release found")
+)
+
 type Helm struct {
 	namespace    string
 	actionConfig *action.Configuration
@@ -164,4 +170,17 @@ func (h *Helm) Uninstall(release string, opts *UninstallOpts) error {
 	}
 
 	return nil
+}
+
+func (h *Helm) UninstallRelease(ctx context.Context, release string) error {
+	exists, err := h.IsReleaseExist(release)
+	if err != nil {
+		return fmt.Errorf("failed to check '%s' release existence: %w", release, err)
+	}
+
+	if !exists {
+		return driver.ErrReleaseNotFound
+	}
+
+	return h.Uninstall(release, &UninstallOpts{Timeout: uninstallHelmTimeout})
 }

--- a/ai-services/internal/pkg/utils/util.go
+++ b/ai-services/internal/pkg/utils/util.go
@@ -809,3 +809,17 @@ func IndentString(s string, spaces int) string {
 
 	return prefix + strings.Join(lines, "\n")
 }
+
+// IsNotFoundError checks if an error indicates a resource was not found.
+// Returns true for "no such pod", "no such secret", "no such volume" errors.
+func IsNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errMsg := err.Error()
+
+	return strings.Contains(errMsg, "no such pod") ||
+		strings.Contains(errMsg, "no pod with name or ID") ||
+		strings.Contains(errMsg, "no such secret") ||
+		strings.Contains(errMsg, "no such volume")
+}

--- a/ai-services/internal/pkg/vars/var.go
+++ b/ai-services/internal/pkg/vars/var.go
@@ -33,3 +33,10 @@ var (
 	RetryCount    = 3
 	RetryInterval = 5 * time.Second
 )
+
+const (
+	// PodmanAuthSecret represents podman auth secret name.
+	PodmanAuthSecret = "podman-auth-secret"
+	// VolumeLabel represents the volume name associated with Pod.
+	VolumeLabel = "ai-services.io/volume"
+)

--- a/ai-services/internal/pkg/vars/var.go
+++ b/ai-services/internal/pkg/vars/var.go
@@ -33,10 +33,3 @@ var (
 	RetryCount    = 3
 	RetryInterval = 5 * time.Second
 )
-
-const (
-	// PodmanAuthSecret represents podman auth secret name.
-	PodmanAuthSecret = "podman-auth-secret"
-	// VolumeLabel represents the volume name associated with Pod.
-	VolumeLabel = "ai-services.io/volume"
-)

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -19,6 +19,10 @@ const (
 	WorkerAppName         = "ai-services"
 	WorkerAppTemplate     = "worker"
 	WorkerHelmReleaseName = "ai-services-worker"
+	WorkerCaddyPodName    = "ai-services--caddy"
+
+	WorkerPodmanAuthSecretName = "podman-auth-secret"
+	WorkerVolumeLabel          = "ai-services.io/volume"
 
 	// BaseDirEnvVar is injected into the Caddy container at deploy time; read back by uninstall.
 	BaseDirEnvVar = "AI_SERVICES_BASE_DIR"

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -22,7 +22,7 @@ const (
 	WorkerAppTemplate     = "worker"
 	WorkerHelmReleaseName = "ai-services-worker"
 
-	// WorkerCaddyPodName is the name of the Caddy reverse-proxy pod deployed by
+	// WorkerCaddyPodName is the name of the Caddy reverse-proxy pod.
 	WorkerCaddyPodName    = "ai-services--caddy"
 
 	WorkerPodmanAuthSecretName = "podman-auth-secret"

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -16,17 +16,14 @@ const (
 	// WorkerDataSubDir is the on-disk subtree written by deploy.Setup; removed by uninstall.
 	WorkerDataSubDir = "worker"
 
-	WorkerAppName         = "ai-services"
+	WorkerAppName = "ai-services"
 	// WorkerAppTemplate is the app name passed to the template provider.
 	// Resolves to assets/worker/<runtime>/templates/.
 	WorkerAppTemplate     = "worker"
 	WorkerHelmReleaseName = "ai-services-worker"
 
 	// WorkerCaddyPodName is the name of the Caddy reverse-proxy pod.
-	WorkerCaddyPodName    = "ai-services--caddy"
-
-	WorkerPodmanAuthSecretName = "podman-auth-secret"
-	WorkerVolumeLabel          = "ai-services.io/volume"
+	WorkerCaddyPodName = "ai-services--caddy"
 
 	// BaseDirEnvVar is injected into the Caddy container at deploy time; read back by uninstall.
 	BaseDirEnvVar = "AI_SERVICES_BASE_DIR"

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -17,8 +17,12 @@ const (
 	WorkerDataSubDir = "worker"
 
 	WorkerAppName         = "ai-services"
+	// WorkerAppTemplate is the app name passed to the template provider.
+	// Resolves to assets/worker/<runtime>/templates/.
 	WorkerAppTemplate     = "worker"
 	WorkerHelmReleaseName = "ai-services-worker"
+
+	// WorkerCaddyPodName is the name of the Caddy reverse-proxy pod deployed by
 	WorkerCaddyPodName    = "ai-services--caddy"
 
 	WorkerPodmanAuthSecretName = "podman-auth-secret"

--- a/ai-services/internal/pkg/worker/deploy/podman/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/podman/deploy.go
@@ -32,14 +32,6 @@ import (
 )
 
 const (
-	// WorkerCaddyPodName is the name of the Caddy reverse-proxy pod deployed by
-	// Setup. Exported so join.go can look up the pod's admin port after setup.
-	WorkerCaddyPodName = "ai-services--caddy"
-
-	// workerApp is the app name passed to the template provider.
-	// Resolves to assets/worker/<runtime>/templates/.
-	workerApp = "worker"
-
 	caddyfileSubDir = "worker/caddy"
 	caddyfilePath   = "worker/podman/Caddyfile.tmpl"
 
@@ -130,7 +122,7 @@ func CheckStatus(ctx context.Context, rt runtime.Runtime, tp templates.Template)
 
 	logger.InfofCtx(ctx, "List of existing resources: %v", existingResources)
 
-	tmpls, err := tp.LoadAllTemplates(workerApp)
+	tmpls, err := tp.LoadAllTemplates(workerconstants.WorkerAppTemplate)
 	if err != nil {
 		return false, nil, fmt.Errorf("worker setup: load templates: %w", err)
 	}
@@ -168,11 +160,11 @@ func writeCaddyfile(baseDir string) error {
 // deploys each one in the order defined by metadata.yaml podTemplateExecutions.
 func deployAll(ctx context.Context, rt runtime.Runtime, tp templates.Template, opts workertypes.PodmanWorkerOptions, existingResources []string) error {
 	var appMetadata templates.AppMetadata
-	if err := tp.LoadMetadata(workerApp, true, &appMetadata); err != nil {
+	if err := tp.LoadMetadata(workerconstants.WorkerAppTemplate, true, &appMetadata); err != nil {
 		return fmt.Errorf("worker setup: load metadata: %w", err)
 	}
 
-	tmpls, err := tp.LoadAllTemplates(workerApp)
+	tmpls, err := tp.LoadAllTemplates(workerconstants.WorkerAppTemplate)
 	if err != nil {
 		return fmt.Errorf("worker setup: load templates: %w", err)
 	}
@@ -187,7 +179,7 @@ func deployAll(ctx context.Context, rt runtime.Runtime, tp templates.Template, o
 		return err
 	}
 
-	values, err := tp.LoadValues(workerApp, nil, argParams)
+	values, err := tp.LoadValues(workerconstants.WorkerAppTemplate, nil, argParams)
 	if err != nil {
 		return fmt.Errorf("worker setup: load values: %w", err)
 	}
@@ -195,9 +187,9 @@ func deployAll(ctx context.Context, rt runtime.Runtime, tp templates.Template, o
 	params := map[string]any{
 		"BaseDir":         opts.Setup.BaseDir,
 		"AppName":         workerconstants.WorkerAppName,
-		"AppTemplateName": workerApp,
+		"AppTemplateName": workerconstants.WorkerAppTemplate,
 		"Version":         appMetadata.Version,
-		"CaddyAdminURL":   fmt.Sprintf("http://%s:2019", WorkerCaddyPodName),
+		"CaddyAdminURL":   fmt.Sprintf("http://%s:2019", workerconstants.WorkerCaddyPodName),
 		"DomainSuffix":    domainSuffix,
 		"Values":          values,
 	}

--- a/ai-services/internal/pkg/worker/uninstall/common.go
+++ b/ai-services/internal/pkg/worker/uninstall/common.go
@@ -1,0 +1,30 @@
+// Package uninstall removes all worker-node components deployed by
+// `worker join`: the Caddy reverse-proxy pod and the on-disk worker data
+// directory (Caddyfile, caddy state, etc.).
+//
+// It is intentionally scoped to what `worker join` created.  Application pods
+// deployed on the worker by the catalog are the operator's responsibility and
+// are not touched here.
+package uninstall
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	workeropenshift "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/openshift"
+	workerpodman "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/podman"
+	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
+)
+
+// Uninstall removes all worker components deployed by `worker join`.
+func Uninstall(ctx context.Context, opts workerutils.UninstallOptions) error {
+	switch opts.RuntimeType {
+	case types.RuntimeTypePodman:
+		return workerpodman.Uninstall(ctx, opts)
+	case types.RuntimeTypeOpenShift:
+		return workeropenshift.Uninstall(ctx, opts)
+	default:
+		return fmt.Errorf("unsupported runtime type: %s", opts.RuntimeType)
+	}
+}

--- a/ai-services/internal/pkg/worker/uninstall/openshift/uninstall.go
+++ b/ai-services/internal/pkg/worker/uninstall/openshift/uninstall.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	clituils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/helm"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
@@ -12,7 +13,6 @@ import (
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 	"helm.sh/helm/v4/pkg/storage/driver"
-	clituils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 )
 
 // Uninstall removes all worker components deployed by `worker join`.
@@ -26,7 +26,7 @@ func Uninstall(ctx context.Context, opts workerutils.UninstallOptions) error {
 	}
 
 	pods, err := rt.ListPods(ctx, map[string][]string{
-		"label": {fmt.Sprintf(workerconstants.WorkerPodLabel)},
+		"label": {workerconstants.WorkerPodLabel},
 	})
 	if err != nil {
 		return fmt.Errorf("worker uninstall: list pods: %w", err)
@@ -53,7 +53,7 @@ func Uninstall(ctx context.Context, opts workerutils.UninstallOptions) error {
 		return fmt.Errorf("failed to create Helm client: %w", err)
 	}
 
-	if err := helmClient.UninstallRelease(ctx, release); err != nil {
+	if err := helmClient.UninstallRelease(release); err != nil {
 		if errors.Is(err, driver.ErrReleaseNotFound) {
 			logger.InfofCtx(ctx, "Skipping uninstall of '%s': no release found.", release)
 

--- a/ai-services/internal/pkg/worker/uninstall/openshift/uninstall.go
+++ b/ai-services/internal/pkg/worker/uninstall/openshift/uninstall.go
@@ -1,0 +1,68 @@
+package openshift
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/helm"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/spinner"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
+	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
+	"helm.sh/helm/v4/pkg/storage/driver"
+)
+
+// Uninstall removes all worker components deployed by `worker join`.
+func Uninstall(ctx context.Context, opts workerutils.UninstallOptions) error {
+	namespace := workerconstants.WorkerAppName
+	release := workerconstants.WorkerHelmReleaseName
+
+	rt, err := runtime.CreateRuntime(opts.RuntimeType, namespace)
+	if err != nil {
+		return fmt.Errorf("worker uninstall: init runtime: %w", err)
+	}
+
+	pods, err := rt.ListPods(ctx, map[string][]string{
+		"label": {fmt.Sprintf(workerconstants.WorkerPodLabel)},
+	})
+	if err != nil {
+		return fmt.Errorf("worker uninstall: list pods: %w", err)
+	}
+
+	if len(pods) == 0 {
+		logger.InfolnCtx(ctx, "No worker pods found — nothing to uninstall.")
+
+		return nil
+	}
+
+	// Confirm Uninstall unless auto-yes is set
+	if confirmed, err := workerutils.ConfirmUninstall(ctx, pods, opts.AutoYes); err != nil || !confirmed {
+		return err
+	}
+
+	logger.InfolnCtx(ctx, "Proceeding with uninstall...")
+
+	s := spinner.New("Uninstalling worker service...")
+	s.Start(ctx)
+
+	helmClient, err := helm.NewHelm(namespace)
+	if err != nil {
+		return fmt.Errorf("failed to create Helm client: %w", err)
+	}
+
+	if err := helmClient.UninstallRelease(ctx, release); err != nil {
+		if errors.Is(err, driver.ErrReleaseNotFound) {
+			logger.InfofCtx(ctx, "Skipping uninstall of '%s': no release found.", release)
+
+			return nil
+		}
+
+		return err
+	}
+
+	s.Stop("Worker service uninstalled successfully")
+
+	return nil
+}

--- a/ai-services/internal/pkg/worker/uninstall/openshift/uninstall.go
+++ b/ai-services/internal/pkg/worker/uninstall/openshift/uninstall.go
@@ -12,6 +12,7 @@ import (
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 	"helm.sh/helm/v4/pkg/storage/driver"
+	clituils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 )
 
 // Uninstall removes all worker components deployed by `worker join`.
@@ -38,7 +39,7 @@ func Uninstall(ctx context.Context, opts workerutils.UninstallOptions) error {
 	}
 
 	// Confirm Uninstall unless auto-yes is set
-	if confirmed, err := workerutils.ConfirmUninstall(ctx, pods, opts.AutoYes); err != nil || !confirmed {
+	if confirmed, err := clituils.ConfirmUninstall(ctx, pods, opts.AutoYes); err != nil || !confirmed {
 		return err
 	}
 

--- a/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 
 	podmanutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
-	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 )
@@ -76,7 +76,7 @@ func performCleanup(ctx context.Context, rt runtime.Runtime, pods []types.Pod) e
 		return err
 	}
 
-	secretsToDelete := []string{vars.PodmanAuthSecret}
+	secretsToDelete := []string{constants.PodmanAuthSecret}
 	if err := podmanutils.DeleteSecrets(ctx, rt, secretsToDelete); err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func performCleanup(ctx context.Context, rt runtime.Runtime, pods []types.Pod) e
 func fetchVolumesToDelete(pods []types.Pod) []string {
 	volumesToDelete := []string{}
 	for _, pod := range pods {
-		if volumeNames, ok := pod.Labels[vars.VolumeLabel]; ok && volumeNames != "" {
+		if volumeNames, ok := pod.Labels[constants.VolumeLabel]; ok && volumeNames != "" {
 			volumes := strings.Split(volumeNames, ",")
 			volumesToDelete = append(volumesToDelete, volumes...)
 		}

--- a/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
@@ -11,6 +11,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 )
@@ -71,8 +72,8 @@ func performCleanup(ctx context.Context, rt runtime.Runtime, pods []types.Pod) e
 
 	logger.InfofCtx(ctx, "Using base directory for cleanup: %s\n", baseDir)
 
-	secretsToDelete := []string{workerconstants.WorkerPodmanAuthSecretName}
-	if err := deleteSecrets(ctx, rt, secretsToDelete); err != nil {
+	secretsToDelete := []string{vars.PodmanAuthSecret}
+	if err := podmanutils.DeleteSecrets(ctx, rt, secretsToDelete); err != nil {
 		return err
 	}
 
@@ -92,7 +93,7 @@ func performCleanup(ctx context.Context, rt runtime.Runtime, pods []types.Pod) e
 func fetchVolumesToDelete(pods []types.Pod) []string {
 	volumesToDelete := []string{}
 	for _, pod := range pods {
-		if volumeNames, ok := pod.Labels[workerconstants.WorkerVolumeLabel]; ok && volumeNames != "" {
+		if volumeNames, ok := pod.Labels[vars.VolumeLabel]; ok && volumeNames != "" {
 			volumes := strings.Split(volumeNames, ",")
 			volumesToDelete = append(volumesToDelete, volumes...)
 		}
@@ -154,22 +155,4 @@ func getWorkerPodList(ctx context.Context, rt runtime.Runtime) ([]types.Pod, err
 	}
 
 	return podList, nil
-}
-
-// deleteSecrets removes the specified secrets.
-func deleteSecrets(ctx context.Context, rt runtime.Runtime, secrets []string) error {
-	for _, secret := range secrets {
-		if err := rt.DeleteSecret(ctx, secret); err != nil {
-			if utils.IsNotFoundError(err) {
-				logger.Infof("Secret %s already deleted or does not exist\n", secret)
-
-				continue
-			}
-
-			return err
-		}
-		logger.Infof("Successfully deleted secret: %s\n", secret)
-	}
-
-	return nil
 }

--- a/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
@@ -1,11 +1,4 @@
-// Package uninstall removes all worker-node components deployed by
-// `worker join`: the Caddy reverse-proxy pod and the on-disk worker data
-// directory (Caddyfile, caddy state, etc.).
-//
-// It is intentionally scoped to what `worker join` created.  Application pods
-// deployed on the worker by the catalog are the operator's responsibility and
-// are not touched here.
-package uninstall
+package podman
 
 import (
 	"context"
@@ -19,27 +12,17 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
+	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 )
 
-// Options carries the parameters needed to uninstall a worker node.
-type Options struct {
-	// RuntimeType is the local runtime (podman / openshift).
-	RuntimeType types.RuntimeType
-
-	// AutoYes skips the interactive confirmation prompt.
-	AutoYes bool
-}
-
 // Uninstall removes all worker components deployed by `worker join`.
-func Uninstall(ctx context.Context, opts Options) error {
+func Uninstall(ctx context.Context, opts workerutils.UninstallOptions) error {
 	rt, err := runtime.CreateRuntime(opts.RuntimeType, "")
 	if err != nil {
 		return fmt.Errorf("worker uninstall: init runtime: %w", err)
 	}
 
-	pods, err := rt.ListPods(ctx, map[string][]string{
-		"label": {workerconstants.WorkerProxyLabel},
-	})
+	pods, err := getWorkerPodList(ctx, rt)
 	if err != nil {
 		return fmt.Errorf("worker uninstall: list pods: %w", err)
 	}
@@ -52,7 +35,7 @@ func Uninstall(ctx context.Context, opts Options) error {
 
 	logger.Warningln("Ensure no application pods are running on this worker before uninstalling, as they will become unreachable and will need to be deleted manually.")
 
-	if ok, err := confirmUninstall(ctx, pods, opts.AutoYes); err != nil || !ok {
+	if ok, err := workerutils.ConfirmUninstall(ctx, pods, opts.AutoYes); err != nil || !ok {
 		return err
 	}
 
@@ -76,7 +59,7 @@ func performCleanup(ctx context.Context, rt runtime.Runtime, pods []types.Pod) e
 
 	var baseDir string
 
-	config, err := getWorkerCaddyPodConfig(ctx, rt, pods[0].ID)
+	config, err := getWorkerCaddyPodConfig(ctx, rt, pods)
 	if err != nil {
 		logger.WarningfCtx(ctx, "Failed to retrieve BaseDir from worker pod: %v. Using default BaseDir.\n", err)
 		baseDir = utils.GetBaseDir()
@@ -84,7 +67,19 @@ func performCleanup(ctx context.Context, rt runtime.Runtime, pods []types.Pod) e
 		baseDir = config.BaseDir
 	}
 
+	volumesToDelete := fetchVolumesToDelete(pods)
+
 	logger.InfofCtx(ctx, "Using base directory for cleanup: %s\n", baseDir)
+
+	secretsToDelete := []string{workerconstants.WorkerPodmanAuthSecretName}
+	if err := deleteSecrets(ctx, rt, secretsToDelete); err != nil {
+		return err
+	}
+
+	// Delete volumes (only those without skip-cleanup label)
+	if err := deleteVolumes(ctx, rt, volumesToDelete); err != nil {
+		return err
+	}
 
 	if err := deletePods(ctx, rt, pods); err != nil {
 		return err
@@ -94,11 +89,31 @@ func performCleanup(ctx context.Context, rt runtime.Runtime, pods []types.Pod) e
 
 	return removeDataDir(ctx, workerDataPath)
 }
+func fetchVolumesToDelete(pods []types.Pod) []string {
+	volumesToDelete := []string{}
+	for _, pod := range pods {
+		if volumeNames, ok := pod.Labels[workerconstants.WorkerVolumeLabel]; ok && volumeNames != "" {
+			volumes := strings.Split(volumeNames, ",")
+			volumesToDelete = append(volumesToDelete, volumes...)
+		}
+	}
+	
+	return volumesToDelete
+}
 
 // getWorkerCaddyPodConfig retrieves worker Caddy pod configuration by inspecting
 // the running pod and its containers. It extracts the AI_SERVICES_BASE_DIR
 // environment variable injected by caddy.yaml.tmpl at deploy time.
-func getWorkerCaddyPodConfig(ctx context.Context, rt runtime.Runtime, podID string) (*WorkerCaddyConfig, error) {
+func getWorkerCaddyPodConfig(ctx context.Context, rt runtime.Runtime, pods []types.Pod) (*WorkerCaddyConfig, error) {
+	podID := ""
+	for _, pod := range pods {
+		if pod.Name == workerconstants.WorkerCaddyPodName {
+			podID = pod.ID
+		}
+	}
+	if podID == "" {
+		return nil, fmt.Errorf("no pod found with name '%s'", workerconstants.WorkerCaddyPodName)
+	}
 	pInfo, err := rt.InspectPod(ctx, podID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect pod %s: %w", podID, err)
@@ -125,29 +140,20 @@ func extractConfigFromEnv(env map[string]string, config *WorkerCaddyConfig) {
 	}
 }
 
-// confirmUninstall prints the pod list and prompts the user when autoYes is false.
-// Returns (false, nil) when the user declines, (true, nil) when confirmed.
-func confirmUninstall(ctx context.Context, pods []types.Pod, autoYes bool) (bool, error) {
-	if autoYes {
-		return true, nil
+func getWorkerPodList(ctx context.Context, rt runtime.Runtime) ([]types.Pod, error) {
+	labels := []string{workerconstants.WorkerProxyLabel, workerconstants.WorkerPodLabel}
+
+	var podList []types.Pod
+	for _, label := range labels {
+		pods, err := rt.ListPods(ctx, map[string][]string{"label": {label}})
+		if err != nil {
+			return nil, err
+		}
+
+		podList = append(podList, pods...)
 	}
-
-	logger.InfolnCtx(ctx, "The following worker pods will be deleted:")
-
-	for _, p := range pods {
-		logger.InfofCtx(ctx, "  -> %s\n", p.Name)
-	}
-
-	confirmed, err := utils.ConfirmAction("\nDo you want to continue?")
-	if err != nil {
-		return false, fmt.Errorf("worker uninstall: confirmation: %w", err)
-	}
-
-	if !confirmed {
-		logger.InfolnCtx(ctx, "Uninstall cancelled.")
-	}
-
-	return confirmed, nil
+	
+	return podList, nil
 }
 
 // deletePods force-deletes every pod in the list and aggregates any errors.
@@ -168,6 +174,60 @@ func deletePods(ctx context.Context, rt runtime.Runtime, pods []types.Pod) error
 
 	if len(errs) > 0 {
 		return fmt.Errorf("failed to delete pods:\n%s", strings.Join(errs, "\n"))
+	}
+
+	return nil
+}
+
+// deleteSecrets removes the specified secrets.
+func deleteSecrets(ctx context.Context, rt runtime.Runtime, secrets []string) error {
+	for _, secret := range secrets {
+		exists, err := rt.SecretExists(ctx, workerconstants.WorkerPodmanAuthSecretName)
+		if err != nil {
+			return err
+		}
+		if exists {
+			if err := rt.DeleteSecret(ctx, secret); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// deleteVolumes removes the specified volumes.
+func deleteVolumes(ctx context.Context, rt runtime.Runtime, volumeNames []string) error {
+	if len(volumeNames) == 0 {
+		// Just return if there are no volumes to delete.
+		return nil
+	}
+
+	logger.Infof("Deleting %d volume(s)\n", len(volumeNames))
+
+	var errors []string
+	for _, volumeName := range volumeNames {
+		logger.Infof("Deleting volume: %s\n", volumeName)
+
+		if err := rt.DeleteVolume(ctx, volumeName); err != nil {
+			// Ignore "not found" errors - volume already deleted or never existed
+			if utils.IsNotFoundError(err) {
+				logger.Infof("Volume %s already deleted or does not exist\n", volumeName)
+
+				continue
+			}
+
+			errors = append(errors, fmt.Sprintf("volume %s: %v", volumeName, err))
+
+			continue
+		}
+
+		logger.Infof("Successfully deleted volume: %s\n", volumeName)
+	}
+
+	// Aggregate errors at the end
+	if len(errors) > 0 {
+		return fmt.Errorf("failed to remove volumes: \n%s", strings.Join(errors, "\n"))
 	}
 
 	return nil

--- a/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
@@ -3,10 +3,10 @@ package podman
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
+	podmanutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
@@ -77,17 +77,17 @@ func performCleanup(ctx context.Context, rt runtime.Runtime, pods []types.Pod) e
 	}
 
 	// Delete volumes (only those without skip-cleanup label)
-	if err := deleteVolumes(ctx, rt, volumesToDelete); err != nil {
+	if err := podmanutils.DeleteVolumes(ctx, rt, volumesToDelete); err != nil {
 		return err
 	}
 
-	if err := deletePods(ctx, rt, pods); err != nil {
+	if err := podmanutils.DeletePods(ctx, rt, pods); err != nil {
 		return err
 	}
 
 	workerDataPath := filepath.Join(baseDir, workerconstants.WorkerDataSubDir)
 
-	return removeDataDir(ctx, workerDataPath)
+	return podmanutils.RemoveDataDir(ctx, workerDataPath)
 }
 func fetchVolumesToDelete(pods []types.Pod) []string {
 	volumesToDelete := []string{}
@@ -97,7 +97,7 @@ func fetchVolumesToDelete(pods []types.Pod) []string {
 			volumesToDelete = append(volumesToDelete, volumes...)
 		}
 	}
-	
+
 	return volumesToDelete
 }
 
@@ -152,102 +152,24 @@ func getWorkerPodList(ctx context.Context, rt runtime.Runtime) ([]types.Pod, err
 
 		podList = append(podList, pods...)
 	}
-	
+
 	return podList, nil
-}
-
-// deletePods force-deletes every pod in the list and aggregates any errors.
-func deletePods(ctx context.Context, rt runtime.Runtime, pods []types.Pod) error {
-	var errs []string
-
-	for _, p := range pods {
-		logger.InfofCtx(ctx, "Deleting pod: %s\n", p.Name)
-
-		if err := rt.DeletePod(ctx, p.ID, utils.BoolPtr(true)); err != nil {
-			errs = append(errs, fmt.Sprintf("pod %s: %v", p.Name, err))
-
-			continue
-		}
-
-		logger.InfofCtx(ctx, "Deleted pod: %s\n", p.Name)
-	}
-
-	if len(errs) > 0 {
-		return fmt.Errorf("failed to delete pods:\n%s", strings.Join(errs, "\n"))
-	}
-
-	return nil
 }
 
 // deleteSecrets removes the specified secrets.
 func deleteSecrets(ctx context.Context, rt runtime.Runtime, secrets []string) error {
 	for _, secret := range secrets {
-		exists, err := rt.SecretExists(ctx, workerconstants.WorkerPodmanAuthSecretName)
-		if err != nil {
-			return err
-		}
-		if exists {
-			if err := rt.DeleteSecret(ctx, secret); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-// deleteVolumes removes the specified volumes.
-func deleteVolumes(ctx context.Context, rt runtime.Runtime, volumeNames []string) error {
-	if len(volumeNames) == 0 {
-		// Just return if there are no volumes to delete.
-		return nil
-	}
-
-	logger.Infof("Deleting %d volume(s)\n", len(volumeNames))
-
-	var errors []string
-	for _, volumeName := range volumeNames {
-		logger.Infof("Deleting volume: %s\n", volumeName)
-
-		if err := rt.DeleteVolume(ctx, volumeName); err != nil {
-			// Ignore "not found" errors - volume already deleted or never existed
+		if err := rt.DeleteSecret(ctx, secret); err != nil {
 			if utils.IsNotFoundError(err) {
-				logger.Infof("Volume %s already deleted or does not exist\n", volumeName)
+				logger.Infof("Secret %s already deleted or does not exist\n", secret)
 
 				continue
 			}
 
-			errors = append(errors, fmt.Sprintf("volume %s: %v", volumeName, err))
-
-			continue
+			return err
 		}
-
-		logger.Infof("Successfully deleted volume: %s\n", volumeName)
+		logger.Infof("Successfully deleted secret: %s\n", secret)
 	}
-
-	// Aggregate errors at the end
-	if len(errors) > 0 {
-		return fmt.Errorf("failed to remove volumes: \n%s", strings.Join(errors, "\n"))
-	}
-
-	return nil
-}
-
-// removeDataDir deletes path if it exists, logging a note when absent.
-func removeDataDir(ctx context.Context, dataPath string) error {
-	if _, err := os.Stat(dataPath); os.IsNotExist(err) {
-		logger.InfofCtx(ctx, "data directory does not exist, skipping: %s\n", dataPath)
-
-		return nil
-	}
-
-	logger.InfofCtx(ctx, "Deleting data at: %s\n", dataPath)
-
-	if err := os.RemoveAll(dataPath); err != nil {
-		return fmt.Errorf("failed to remove data directory %s: %w", dataPath, err)
-	}
-
-	logger.InfofCtx(ctx, "Successfully removed data at: %s\n", dataPath)
 
 	return nil
 }

--- a/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
@@ -72,17 +72,16 @@ func performCleanup(ctx context.Context, rt runtime.Runtime, pods []types.Pod) e
 
 	logger.InfofCtx(ctx, "Using base directory for cleanup: %s\n", baseDir)
 
+	if err := podmanutils.DeletePods(ctx, rt, pods); err != nil {
+		return err
+	}
+
 	secretsToDelete := []string{vars.PodmanAuthSecret}
 	if err := podmanutils.DeleteSecrets(ctx, rt, secretsToDelete); err != nil {
 		return err
 	}
 
-	// Delete volumes (only those without skip-cleanup label)
 	if err := podmanutils.DeleteVolumes(ctx, rt, volumesToDelete); err != nil {
-		return err
-	}
-
-	if err := podmanutils.DeletePods(ctx, rt, pods); err != nil {
 		return err
 	}
 

--- a/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
@@ -35,7 +35,7 @@ func Uninstall(ctx context.Context, opts workerutils.UninstallOptions) error {
 
 	logger.Warningln("Ensure no application pods are running on this worker before uninstalling, as they will become unreachable and will need to be deleted manually.")
 
-	if ok, err := workerutils.ConfirmUninstall(ctx, pods, opts.AutoYes); err != nil || !ok {
+	if ok, err := podmanutils.ConfirmUninstall(ctx, pods, opts.AutoYes); err != nil || !ok {
 		return err
 	}
 

--- a/ai-services/internal/pkg/worker/uninstall/utils/utils.go
+++ b/ai-services/internal/pkg/worker/uninstall/utils/utils.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+)
+
+// UninstallOptions carries the parameters needed to uninstall a worker node.
+type UninstallOptions struct {
+	// RuntimeType is the local runtime (podman / openshift).
+	RuntimeType types.RuntimeType
+
+	// AutoYes skips the interactive confirmation prompt.
+	AutoYes bool
+}
+
+// ConfirmUninstall prompts the user to confirm uninstall and logs pods to be deleted.
+func ConfirmUninstall(ctx context.Context, pods []types.Pod, autoYes bool) (bool, error) {
+	if autoYes {
+		return true, nil
+	}
+
+	// Print pods to be deleted
+	logger.InfofCtx(ctx, "Below are the list of pods to be deleted")
+	for _, pod := range pods {
+		logger.InfofCtx(ctx, "\t-> %s\n", pod.Name)
+	}
+
+	// Confirm Uninstall
+	confirmed, err := utils.ConfirmAction("\nDo you want to continue?")
+	if err != nil {
+		return false, fmt.Errorf("failed to get confirmation: %w", err)
+	}
+
+	if !confirmed {
+		logger.InfolnCtx(ctx, "Uninstall cancelled")
+
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/ai-services/internal/pkg/worker/uninstall/utils/utils.go
+++ b/ai-services/internal/pkg/worker/uninstall/utils/utils.go
@@ -1,12 +1,7 @@
 package utils
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
-	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
 
 // UninstallOptions carries the parameters needed to uninstall a worker node.
@@ -16,31 +11,4 @@ type UninstallOptions struct {
 
 	// AutoYes skips the interactive confirmation prompt.
 	AutoYes bool
-}
-
-// ConfirmUninstall prompts the user to confirm uninstall and logs pods to be deleted.
-func ConfirmUninstall(ctx context.Context, pods []types.Pod, autoYes bool) (bool, error) {
-	if autoYes {
-		return true, nil
-	}
-
-	// Print pods to be deleted
-	logger.InfofCtx(ctx, "Below are the list of pods to be deleted")
-	for _, pod := range pods {
-		logger.InfofCtx(ctx, "\t-> %s\n", pod.Name)
-	}
-
-	// Confirm Uninstall
-	confirmed, err := utils.ConfirmAction("\nDo you want to continue?")
-	if err != nil {
-		return false, fmt.Errorf("failed to get confirmation: %w", err)
-	}
-
-	if !confirmed {
-		logger.InfolnCtx(ctx, "Uninstall cancelled")
-
-		return false, nil
-	}
-
-	return true, nil
 }


### PR DESCRIPTION
- Added support cleanup worker pod for both podman and openshift runtime, via `worker uninstall` cmd.
- Allowing uninstall to continue if secret is not present in the machine for podman runtime.