### PR TITLE
prepend v prefix to version strings on UI

### DIFF
--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -1,5 +1,5 @@
 ui:
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.65
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.66
   resources:
     requests:
       memory: "512Mi"

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -1,6 +1,6 @@
 ui:
   port: ""
-  image: icr.io/ai-services-cicd/catalog-ui:v0.0.65
+  image: icr.io/ai-services-cicd/catalog-ui:v0.0.66
 
 backend:
   port: ""

--- a/ui/catalog/Makefile
+++ b/ui/catalog/Makefile
@@ -1,6 +1,6 @@
 REGISTRY ?= icr.io/ai-services-private
 IMAGE ?= catalog-ui
-TAG ?= v0.0.65
+TAG ?= v0.0.66
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 
 CONTAINER_BUILDER ?= podman

--- a/ui/catalog/src/components/DeployFlow/DigitalAssistant/steps/DAStepTwo.tsx
+++ b/ui/catalog/src/components/DeployFlow/DigitalAssistant/steps/DAStepTwo.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useEffect } from "react";
+import { formatVersion } from "@/utils/string";
 import { InlineNotification } from "@carbon/react";
 import styles from "../../Shared/DeployFlow.shared.module.scss";
 import type { StepProps } from "../types";
@@ -247,7 +248,9 @@ export const DAStepTwo: React.FC<DAStepProps> = ({
   );
 
   const serviceVersionOptions = useMemo(
-    () => [{ id: deployOptions.version, text: deployOptions.version }],
+    () => [
+      { id: deployOptions.version, text: formatVersion(deployOptions.version) },
+    ],
     [deployOptions.version],
   );
 

--- a/ui/catalog/src/components/DeployFlow/Services/steps/ServicesStepTwo.tsx
+++ b/ui/catalog/src/components/DeployFlow/Services/steps/ServicesStepTwo.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useEffect } from "react";
+import { formatVersion } from "@/utils/string";
 import { InlineLoading, InlineNotification } from "@carbon/react";
 import { sumProviderResources } from "../../Shared/utils/resources";
 import { COMPONENT_TYPES } from "@/constants";
@@ -174,7 +175,9 @@ export const ServicesStepTwo: React.FC<StepProps> = ({
   );
 
   const serviceVersionOptions = useMemo(
-    () => [{ id: deployOptions.version, text: deployOptions.version }],
+    () => [
+      { id: deployOptions.version, text: formatVersion(deployOptions.version) },
+    ],
     [deployOptions.version],
   );
 

--- a/ui/catalog/src/components/DeployFlow/Shared/steps/SharedStepOne.tsx
+++ b/ui/catalog/src/components/DeployFlow/Shared/steps/SharedStepOne.tsx
@@ -10,6 +10,7 @@ import {
   InlineNotification,
 } from "@carbon/react";
 import { Information } from "@carbon/icons-react";
+import { formatVersion } from "@/utils/string";
 import styles from "../DeployFlow.shared.module.scss";
 import type { DeployFormData } from "../types";
 
@@ -52,7 +53,7 @@ export const SharedStepOne = ({
   onComponentError,
 }: SharedStepOneProps) => {
   const isNameValid = !!formData.name.trim();
-  const versionOptions = [{ id: version, text: version }];
+  const versionOptions = [{ id: version, text: formatVersion(version) }];
 
   useEffect(() => {
     onComponentError?.(failedComponentNames.length > 0);

--- a/ui/catalog/src/components/DeploymentDetails/DeploymentDetails.tsx
+++ b/ui/catalog/src/components/DeploymentDetails/DeploymentDetails.tsx
@@ -31,6 +31,7 @@ import type {
   ApplicationDetailsApiResponse,
   AcceleratorCards as AcceleratorCardType,
 } from "@/types/api.types";
+import { formatVersion } from "@/utils/string";
 import styles from "./DeploymentDetails.module.scss";
 import { api } from "@/api/axios";
 import axios from "axios";
@@ -689,7 +690,7 @@ const DeploymentDetails = ({
                           Service version
                         </span>
                         <span className={styles.serviceDetailValue}>
-                          {deploymentServiceData.serviceVersion}
+                          {formatVersion(deploymentServiceData.serviceVersion)}
                         </span>
                       </div>
 

--- a/ui/catalog/src/components/ServiceDetailPanel/ServiceDetailPanel.tsx
+++ b/ui/catalog/src/components/ServiceDetailPanel/ServiceDetailPanel.tsx
@@ -7,6 +7,7 @@ import {
   type AboutSection,
 } from "@/services/serviceDetails.api";
 import { transformServiceDetails } from "@/utils/serviceDetailsTransform";
+import { formatVersion } from "@/utils/string";
 import { useServiceDetailsStore } from "@/store/serviceDetails.store";
 import styles from "./ServiceDetailPanel.module.scss";
 
@@ -73,7 +74,11 @@ const renderNestedFields = (
 const renderSection = (section: AboutSection, sectionIndex: number) => {
   // Handle single value field
   if (section.value) {
-    return renderField(section.title, section.value);
+    const displayValue =
+      section.title.toLowerCase() === "version"
+        ? formatVersion(section.value)
+        : section.value;
+    return renderField(section.title, displayValue);
   }
 
   // Handle array of values

--- a/ui/catalog/src/utils/string.tsx
+++ b/ui/catalog/src/utils/string.tsx
@@ -60,3 +60,9 @@ export const parseMarkdownLinks = (text: string): ReactNode => {
 
   return parts.length > 0 ? parts : text;
 };
+
+// Formats a version string for display by prepending "v" if not already present
+export const formatVersion = (version: string | undefined | null): string => {
+  if (!version) return "";
+  return version.startsWith("v") ? version : `v${version}`;
+};


### PR DESCRIPTION
Added a util function named `formatVersion` to append v to all the displayed versions on the UI. Eg: 1.0.0 -> v1.0.0