### PR TITLE
worker api having msg and apps

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.320
+TAG?=v0.0.321
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.320
+  image: icr.io/ai-services-cicd/ai-services:v0.0.321
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.320
+  image: icr.io/ai-services-cicd/ai-services:v0.0.321
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.320
+  image: icr.io/ai-services-cicd/ai-services:v0.0.321
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.320
+  image: icr.io/ai-services-cicd/ai-services:v0.0.321
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -129,6 +129,7 @@ func buildAPIServerOptions(ctx context.Context, pool *pgxpool.Pool, secretKey, a
 		CatalogProvider:    catalogProvider,
 		WorkerGatewayPort:  workerGatewayPort,
 		WorkerRegistry:     workerReg,
+		WorkerRepository:   workerRepo,
 	}
 	cleanup := func() {
 		blacklist.Stop()

--- a/ai-services/cmd/ai-services/cmd/catalog/worker.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/worker.go
@@ -153,7 +153,7 @@ func printWorkerTable(workers []catalogtypes.Worker) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, workerTablePadding, ' ', 0)
-	if _, err := fmt.Fprintln(w, "ID\tNAME\tRUNTIME\tSTATUS\tLAST HEARTBEAT"); err != nil {
+	if _, err := fmt.Fprintln(w, "ID\tNAME\tRUNTIME\tSTATUS\tMESSAGE\tLAST HEARTBEAT\tAPPS"); err != nil {
 		return err
 	}
 
@@ -163,8 +163,13 @@ func printWorkerTable(workers []catalogtypes.Worker) error {
 			hb = worker.LastHeartbeat.UTC().Format(time.RFC3339)
 		}
 
-		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
-			worker.ID, worker.Name, worker.RuntimeType, worker.Status, hb); err != nil {
+		msg := worker.Message
+		if msg == "" {
+			msg = "-"
+		}
+
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%d\n",
+			worker.ID, worker.Name, worker.RuntimeType, worker.Status, msg, hb, len(worker.ApplicationIDs)); err != nil {
 			return err
 		}
 	}

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -2539,7 +2539,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns all registered workers and their current status from the database.",
+                "description": "Returns all registered workers, their current status, human-readable message, and connected application IDs.",
                 "produces": [
                     "application/json"
                 ],
@@ -2619,6 +2619,59 @@ const docTemplate = `{
             }
         },
         "/workers/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the worker with the given ID, including its status message and connected application IDs.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Workers"
+                ],
+                "summary": "Get a single worker",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker ID (UUID)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Worker details",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Worker"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid worker ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Worker not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
             "delete": {
                 "security": [
                     {
@@ -3868,10 +3921,19 @@ const docTemplate = `{
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Worker": {
             "type": "object",
             "properties": {
+                "application_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "id": {
                     "type": "string"
                 },
                 "last_heartbeat": {
+                    "type": "string"
+                },
+                "message": {
                     "type": "string"
                 },
                 "metadata": {

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -2533,7 +2533,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns all registered workers and their current status from the database.",
+                "description": "Returns all registered workers, their current status, human-readable message, and connected application IDs.",
                 "produces": [
                     "application/json"
                 ],
@@ -2613,6 +2613,59 @@
             }
         },
         "/workers/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns the worker with the given ID, including its status message and connected application IDs.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Workers"
+                ],
+                "summary": "Get a single worker",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Worker ID (UUID)",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Worker details",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Worker"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid worker ID",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Worker not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            },
             "delete": {
                 "security": [
                     {
@@ -3862,10 +3915,19 @@
         "github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Worker": {
             "type": "object",
             "properties": {
+                "application_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "id": {
                     "type": "string"
                 },
                 "last_heartbeat": {
+                    "type": "string"
+                },
+                "message": {
                     "type": "string"
                 },
                 "metadata": {

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -847,9 +847,15 @@ definitions:
     - Dead
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Worker:
     properties:
+      application_ids:
+        items:
+          type: string
+        type: array
       id:
         type: string
       last_heartbeat:
+        type: string
+      message:
         type: string
       metadata:
         additionalProperties: {}
@@ -2646,8 +2652,8 @@ paths:
       - Catalog
   /workers:
     get:
-      description: Returns all registered workers and their current status from the
-        database.
+      description: Returns all registered workers, their current status, human-readable
+        message, and connected application IDs.
       produces:
       - application/json
       responses:
@@ -2736,6 +2742,42 @@ paths:
       security:
       - BearerAuth: []
       summary: Deregister a worker
+      tags:
+      - Workers
+    get:
+      description: Returns the worker with the given ID, including its status message
+        and connected application IDs.
+      parameters:
+      - description: Worker ID (UUID)
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Worker details
+          schema:
+            $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Worker'
+        "400":
+          description: Invalid worker ID
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Worker not found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal error
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get a single worker
       tags:
       - Workers
 securityDefinitions:

--- a/ai-services/internal/pkg/catalog/apiserver/apiserver.go
+++ b/ai-services/internal/pkg/catalog/apiserver/apiserver.go
@@ -39,6 +39,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
 	bundlesvc "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/bundle"
+	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/gateway"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/registry"
@@ -62,6 +63,8 @@ type APIServerOptions struct {
 	// WorkerRegistry holds the in-memory state of all connected workers and owns
 	// the bootstrap token store.
 	WorkerRegistry *registry.Registry
+	// WorkerRepository is the DB-backed store for worker rows.
+	WorkerRepository dbrepo.WorkerRepository
 }
 
 // APIserver represents the API server instance, holding the configuration and authentication provider.
@@ -77,6 +80,7 @@ type APIserver struct {
 
 	workerGatewayPort int
 	workerRegistry    *registry.Registry
+	workerRepository  dbrepo.WorkerRepository
 }
 
 // NewAPIserver creates a new instance of the API server with the provided options, setting default values where necessary.
@@ -100,6 +104,7 @@ func NewAPIserver(options APIServerOptions) *APIserver {
 		catalogProvider:    options.CatalogProvider,
 		workerGatewayPort:  options.WorkerGatewayPort,
 		workerRegistry:     options.WorkerRegistry,
+		workerRepository:   options.WorkerRepository,
 	}
 }
 
@@ -120,7 +125,7 @@ func (a *APIserver) Start(ctx context.Context) error {
 	}
 	logger.InfofCtx(ctx, "Worker gateway started on %s", gatewayAddr)
 
-	r := CreateRouter(a.authService, a.tokenManager, a.blacklist, a.applicationService, a.workerRegistry, a.datasourceService, a.bundleService, a.catalogProvider)
+	r := CreateRouter(a.authService, a.tokenManager, a.blacklist, a.applicationService, a.workerRegistry, a.workerRepository, a.datasourceService, a.bundleService, a.catalogProvider)
 
 	if err := r.Run(fmt.Sprintf(":%d", a.port)); err != nil {
 		return err

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
@@ -1,23 +1,28 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	catalogtypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/registry"
 )
 
 // WorkerHandler handles worker management endpoints.
 type WorkerHandler struct {
-	reg *registry.Registry
+	reg  *registry.Registry
+	repo repository.WorkerRepository
 }
 
 // NewWorkerHandler creates a new WorkerHandler.
-func NewWorkerHandler(reg *registry.Registry) *WorkerHandler {
-	return &WorkerHandler{reg: reg}
+func NewWorkerHandler(reg *registry.Registry, repo repository.WorkerRepository) *WorkerHandler {
+	return &WorkerHandler{reg: reg, repo: repo}
 }
 
 // createWorkerReq is the request body for registering a new worker.
@@ -66,6 +71,7 @@ func (h *WorkerHandler) CreateWorker(c *gin.Context) {
 
 	token, err := h.reg.Preregister(ctx, req.WorkerName)
 	if err != nil {
+		logger.ErrorfCtx(ctx, "worker handler: failed to register worker %q: %v", req.WorkerName, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to register worker"})
 
 		return
@@ -80,7 +86,7 @@ func (h *WorkerHandler) CreateWorker(c *gin.Context) {
 // ListWorkers godoc
 //
 //	@Summary		List all workers
-//	@Description	Returns all registered workers and their current status from the database.
+//	@Description	Returns all registered workers, their current status, human-readable message, and connected application IDs.
 //	@Tags			Workers
 //	@Produce		json
 //	@Success		200	{array}		catalogtypes.Worker		"List of workers"
@@ -88,28 +94,78 @@ func (h *WorkerHandler) CreateWorker(c *gin.Context) {
 //	@Security		BearerAuth
 //	@Router			/workers [get]
 func (h *WorkerHandler) ListWorkers(c *gin.Context) {
-	workers, err := h.reg.List(c.Request.Context())
+	ctx := c.Request.Context()
+
+	workers, err := h.reg.List(ctx)
 	if err != nil {
+		logger.ErrorfCtx(ctx, "worker handler: failed to list workers: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list workers"})
+
+		return
+	}
+
+	appIDMap, err := h.fetchAppIDs(ctx, workers)
+	if err != nil {
+		logger.ErrorfCtx(ctx, "worker handler: failed to fetch application IDs for workers: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch application IDs"})
 
 		return
 	}
 
 	result := make([]catalogtypes.Worker, len(workers))
 	for i, w := range workers {
-		result[i] = catalogtypes.Worker{
-			ID:            w.ID.String(),
-			Name:          w.Name,
-			RuntimeType:   catalogtypes.WorkerRuntimeType(w.RuntimeType),
-			Status:        catalogtypes.WorkerStatus(w.Status),
-			LastHeartbeat: w.LastHeartbeat,
-			Metadata:      w.Metadata,
-			RegisteredAt:  w.RegisteredAt.UTC().Format("2006-01-02T15:04:05Z"),
-			UpdatedAt:     w.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z"),
-		}
+		result[i] = toAPIWorker(w, appIDMap[w.ID])
 	}
 
 	c.JSON(http.StatusOK, result)
+}
+
+// GetWorker godoc
+//
+//	@Summary		Get a single worker
+//	@Description	Returns the worker with the given ID, including its status message and connected application IDs.
+//	@Tags			Workers
+//	@Produce		json
+//	@Param			id	path		string					true	"Worker ID (UUID)"
+//	@Success		200	{object}	catalogtypes.Worker		"Worker details"
+//	@Failure		400	{object}	map[string]interface{}	"Invalid worker ID"
+//	@Failure		404	{object}	map[string]interface{}	"Worker not found"
+//	@Failure		500	{object}	map[string]interface{}	"Internal error"
+//	@Security		BearerAuth
+//	@Router			/workers/{id} [get]
+func (h *WorkerHandler) GetWorker(c *gin.Context) {
+	workerID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid worker id"})
+
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	w, err := h.repo.GetByID(ctx, workerID)
+	if err != nil {
+		logger.ErrorfCtx(ctx, "worker handler: failed to fetch worker %s: %v", workerID, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch worker"})
+
+		return
+	}
+
+	if w == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "worker not found"})
+
+		return
+	}
+
+	appIDMap, err := h.repo.GetApplicationIDsByWorkerIDs(ctx, []uuid.UUID{workerID})
+	if err != nil {
+		logger.ErrorfCtx(ctx, "worker handler: failed to fetch application IDs for worker %s: %v", workerID, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch application IDs"})
+
+		return
+	}
+
+	c.JSON(http.StatusOK, toAPIWorker(*w, appIDMap[workerID]))
 }
 
 // DeleteWorker godoc
@@ -138,6 +194,7 @@ func (h *WorkerHandler) DeleteWorker(c *gin.Context) {
 
 	deleted, err := h.reg.Deregister(ctx, workerID)
 	if err != nil {
+		logger.ErrorfCtx(ctx, "worker handler: failed to deregister worker %s: %v", workerID, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete worker"})
 
 		return
@@ -150,4 +207,45 @@ func (h *WorkerHandler) DeleteWorker(c *gin.Context) {
 	}
 
 	c.Status(http.StatusNoContent)
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+// fetchAppIDs does a single bulk query for all workers and returns a map of workerID → appIDs.
+func (h *WorkerHandler) fetchAppIDs(ctx context.Context, workers []models.Worker) (map[uuid.UUID][]uuid.UUID, error) {
+	if h.repo == nil || len(workers) == 0 {
+		return map[uuid.UUID][]uuid.UUID{}, nil
+	}
+
+	ids := make([]uuid.UUID, len(workers))
+	for i, w := range workers {
+		ids[i] = w.ID
+	}
+
+	return h.repo.GetApplicationIDsByWorkerIDs(ctx, ids)
+}
+
+// toAPIWorker converts a DB worker model to the public API type, populating
+// Message and ApplicationIDs from the provided slice.
+func toAPIWorker(w models.Worker, appIDs []uuid.UUID) catalogtypes.Worker {
+	out := catalogtypes.Worker{
+		ID:            w.ID.String(),
+		Name:          w.Name,
+		RuntimeType:   catalogtypes.WorkerRuntimeType(w.RuntimeType),
+		Status:        catalogtypes.WorkerStatus(w.Status),
+		Message:       w.Message,
+		LastHeartbeat: w.LastHeartbeat,
+		Metadata:      w.Metadata,
+		RegisteredAt:  w.RegisteredAt.UTC().Format("2006-01-02T15:04:05Z"),
+		UpdatedAt:     w.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+	}
+
+	if len(appIDs) > 0 {
+		out.ApplicationIDs = make([]string, len(appIDs))
+		for i, id := range appIDs {
+			out.ApplicationIDs[i] = id.String()
+		}
+	}
+
+	return out
 }

--- a/ai-services/internal/pkg/catalog/apiserver/router.go
+++ b/ai-services/internal/pkg/catalog/apiserver/router.go
@@ -12,13 +12,14 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
 	bundlesvc "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/bundle"
+	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/registry"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 )
 
 // CreateRouter sets up the Gin router with the necessary routes and authentication middleware for the API server.
-func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist repository.TokenBlacklist, appService repository.ApplicationServiceInterface, workerReg *registry.Registry, datasourceSvc repository.DatasourceServiceInterface, bundleService bundlesvc.BundleServiceInterface, catalogProvider *catalog.CatalogProvider) *gin.Engine {
+func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist repository.TokenBlacklist, appService repository.ApplicationServiceInterface, workerReg *registry.Registry, workerRepo dbrepo.WorkerRepository, datasourceSvc repository.DatasourceServiceInterface, bundleService bundlesvc.BundleServiceInterface, catalogProvider *catalog.CatalogProvider) *gin.Engine {
 	if mode := os.Getenv("GIN_MODE"); mode != "" {
 		gin.SetMode(mode)
 	}
@@ -39,7 +40,7 @@ func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist r
 	datasourceH := handlers.NewDatasourceHandler(datasourceSvc)
 	registerCatalogRoutes(v1, handlers.NewCatalogHandler(catalogProvider), handlers.NewResourcesHandler(), auth)
 	registerApplicationRoutes(v1, handlers.NewApplicationHandler(appService), datasourceH, auth)
-	registerWorkerRoutes(v1, handlers.NewWorkerHandler(workerReg), auth)
+	registerWorkerRoutes(v1, handlers.NewWorkerHandler(workerReg, workerRepo), auth)
 	registerDatasourceRoutes(v1, datasourceH, auth)
 	registerBundleRoutes(v1, handlers.NewBundleHandler(bundleService), auth)
 
@@ -123,6 +124,7 @@ func registerWorkerRoutes(v1 *gin.RouterGroup, h *handlers.WorkerHandler, authMw
 	{
 		g.POST("", h.CreateWorker)
 		g.GET("", h.ListWorkers)
+		g.GET("/:id", h.GetWorker)
 		g.DELETE("/:id", h.DeleteWorker)
 	}
 }

--- a/ai-services/internal/pkg/catalog/db/migrations/assets/20260801000002_create_workers_table.sql
+++ b/ai-services/internal/pkg/catalog/db/migrations/assets/20260801000002_create_workers_table.sql
@@ -24,6 +24,8 @@ CREATE TYPE worker_status AS ENUM (
 -- runtime_type:   execution environment the worker runs on.
 --                 'unknown' until the worker connects and declares its runtime.
 -- status:         lifecycle state of the worker (pending | ready | disconnected).
+-- message:        human-readable reason for the current status, set by the catalog
+--                 on status transitions.
 -- last_heartbeat: timestamp of the most recent heartbeat received from the worker;
 --                 NULL until the first heartbeat arrives.
 -- registered_at:  when the worker first registered with the system.
@@ -34,6 +36,7 @@ CREATE TABLE workers (
     name           TEXT                NOT NULL UNIQUE,
     runtime_type   worker_runtime_type NOT NULL DEFAULT 'unknown',
     status         worker_status       NOT NULL DEFAULT 'pending',
+    message        TEXT,
     last_heartbeat TIMESTAMPTZ,
     metadata       JSONB,
     registered_at  TIMESTAMPTZ         NOT NULL DEFAULT NOW(),

--- a/ai-services/internal/pkg/catalog/db/models/worker.go
+++ b/ai-services/internal/pkg/catalog/db/models/worker.go
@@ -32,6 +32,7 @@ type Worker struct {
 	Name          string            `json:"name"`
 	RuntimeType   WorkerRuntimeType `json:"runtime_type"`
 	Status        WorkerStatus      `json:"status"`
+	Message       string            `json:"message,omitempty"`
 	LastHeartbeat *time.Time        `json:"last_heartbeat,omitempty"`
 	Metadata      map[string]any    `json:"metadata,omitempty"`
 	RegisteredAt  time.Time         `json:"registered_at"`

--- a/ai-services/internal/pkg/catalog/db/repository/worker_repo.go
+++ b/ai-services/internal/pkg/catalog/db/repository/worker_repo.go
@@ -19,6 +19,7 @@ import (
 type WorkerUpdate struct {
 	Status        *models.WorkerStatus
 	LastHeartbeat *time.Time
+	Message       *string
 }
 
 // WorkerRepository defines the interface for worker data operations.
@@ -31,8 +32,13 @@ type WorkerRepository interface {
 	Delete(ctx context.Context, id uuid.UUID) (bool, error)
 	// GetAll returns all worker rows ordered by registered_at ascending.
 	GetAll(ctx context.Context) ([]models.Worker, error)
+	// GetByID returns the worker with the given UUID, or (nil, nil) if not found.
+	GetByID(ctx context.Context, id uuid.UUID) (*models.Worker, error)
 	// GetByName returns the worker with the given name, or (nil, nil) if not found.
 	GetByName(ctx context.Context, name string) (*models.Worker, error)
+	// GetApplicationIDsByWorkerIDs returns a map of worker UUID → list of application UUIDs
+	// for every worker ID in the provided slice. Workers with no applications are not included.
+	GetApplicationIDsByWorkerIDs(ctx context.Context, workerIDs []uuid.UUID) (map[uuid.UUID][]uuid.UUID, error)
 }
 
 // workerRepo implements WorkerRepository using pgx.
@@ -95,15 +101,21 @@ func (r *workerRepo) Update(ctx context.Context, id uuid.UUID, update WorkerUpda
 		statusArg = *update.Status
 	}
 
+	var messageArg sql.NullString
+	if update.Message != nil {
+		messageArg = sql.NullString{String: *update.Message, Valid: true}
+	}
+
 	query := `
 		UPDATE workers
 		SET status         = COALESCE($1, status),
 		    last_heartbeat = COALESCE($2, last_heartbeat),
+		    message        = COALESCE($3, message),
 		    updated_at     = NOW()
-		WHERE id = $3
+		WHERE id = $4
 	`
 
-	_, err := r.pool.Exec(ctx, query, statusArg, hb, id)
+	_, err := r.pool.Exec(ctx, query, statusArg, hb, messageArg, id)
 	if err != nil {
 		return fmt.Errorf("failed to update worker %q: %w", id, err)
 	}
@@ -127,7 +139,7 @@ func (r *workerRepo) Delete(ctx context.Context, id uuid.UUID) (bool, error) {
 // GetAll returns all worker rows ordered by registered_at ascending.
 func (r *workerRepo) GetAll(ctx context.Context) ([]models.Worker, error) {
 	query := `
-		SELECT id, name, runtime_type, status, last_heartbeat, metadata, registered_at, updated_at
+		SELECT id, name, runtime_type, status, message, last_heartbeat, metadata, registered_at, updated_at
 		FROM workers
 		ORDER BY registered_at ASC
 	`
@@ -143,17 +155,21 @@ func (r *workerRepo) GetAll(ctx context.Context) ([]models.Worker, error) {
 	for rows.Next() {
 		var (
 			w            models.Worker
+			message      sql.NullString
 			hb           sql.NullTime
 			metadataJSON []byte
 		)
 
 		if err := rows.Scan(
 			&w.ID, &w.Name, &w.RuntimeType, &w.Status,
-			&hb, &metadataJSON, &w.RegisteredAt, &w.UpdatedAt,
+			&message, &hb, &metadataJSON, &w.RegisteredAt, &w.UpdatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan worker row: %w", err)
 		}
 
+		if message.Valid {
+			w.Message = message.String
+		}
 		if hb.Valid {
 			w.LastHeartbeat = &hb.Time
 		}
@@ -173,32 +189,36 @@ func (r *workerRepo) GetAll(ctx context.Context) ([]models.Worker, error) {
 	return workers, nil
 }
 
-// GetByName returns the worker with the given name, or (nil, nil) if not found.
-func (r *workerRepo) GetByName(ctx context.Context, name string) (*models.Worker, error) {
+// GetByID returns the worker with the given UUID, or (nil, nil) if not found.
+func (r *workerRepo) GetByID(ctx context.Context, id uuid.UUID) (*models.Worker, error) {
 	query := `
-		SELECT id, name, runtime_type, status, last_heartbeat, metadata, registered_at, updated_at
+		SELECT id, name, runtime_type, status, message, last_heartbeat, metadata, registered_at, updated_at
 		FROM workers
-		WHERE name = $1
+		WHERE id = $1
 	`
 
 	var (
 		w            models.Worker
+		message      sql.NullString
 		hb           sql.NullTime
 		metadataJSON []byte
 	)
 
-	err := r.pool.QueryRow(ctx, query, name).Scan(
+	err := r.pool.QueryRow(ctx, query, id).Scan(
 		&w.ID, &w.Name, &w.RuntimeType, &w.Status,
-		&hb, &metadataJSON, &w.RegisteredAt, &w.UpdatedAt,
+		&message, &hb, &metadataJSON, &w.RegisteredAt, &w.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 
-		return nil, fmt.Errorf("failed to get worker %q: %w", name, err)
+		return nil, fmt.Errorf("failed to get worker %q: %w", id, err)
 	}
 
+	if message.Valid {
+		w.Message = message.String
+	}
 	if hb.Valid {
 		w.LastHeartbeat = &hb.Time
 	}
@@ -210,6 +230,88 @@ func (r *workerRepo) GetByName(ctx context.Context, name string) (*models.Worker
 	}
 
 	return &w, nil
+}
+
+// GetByName returns the worker with the given name, or (nil, nil) if not found.
+func (r *workerRepo) GetByName(ctx context.Context, name string) (*models.Worker, error) {
+	query := `
+		SELECT id, name, runtime_type, status, message, last_heartbeat, metadata, registered_at, updated_at
+		FROM workers
+		WHERE name = $1
+	`
+
+	var (
+		w            models.Worker
+		message      sql.NullString
+		hb           sql.NullTime
+		metadataJSON []byte
+	)
+
+	err := r.pool.QueryRow(ctx, query, name).Scan(
+		&w.ID, &w.Name, &w.RuntimeType, &w.Status,
+		&message, &hb, &metadataJSON, &w.RegisteredAt, &w.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("failed to get worker %q: %w", name, err)
+	}
+
+	if message.Valid {
+		w.Message = message.String
+	}
+	if hb.Valid {
+		w.LastHeartbeat = &hb.Time
+	}
+
+	if len(metadataJSON) > 0 {
+		if err := json.Unmarshal(metadataJSON, &w.Metadata); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal worker metadata: %w", err)
+		}
+	}
+
+	return &w, nil
+}
+
+// GetApplicationIDsByWorkerIDs returns a map of worker UUID → []application UUID
+// for all worker IDs in the given slice. A single query is used regardless of slice length.
+// Workers with no applications are omitted from the result.
+func (r *workerRepo) GetApplicationIDsByWorkerIDs(ctx context.Context, workerIDs []uuid.UUID) (map[uuid.UUID][]uuid.UUID, error) {
+	if len(workerIDs) == 0 {
+		return map[uuid.UUID][]uuid.UUID{}, nil
+	}
+
+	query := `
+		SELECT worker_id, id
+		FROM applications
+		WHERE worker_id = ANY($1)
+		ORDER BY worker_id, created_at ASC
+	`
+
+	rows, err := r.pool.Query(ctx, query, workerIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query application IDs by worker IDs: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[uuid.UUID][]uuid.UUID)
+
+	for rows.Next() {
+		var workerID, appID uuid.UUID
+		if err := rows.Scan(&workerID, &appID); err != nil {
+			return nil, fmt.Errorf("failed to scan application row: %w", err)
+		}
+
+		result[workerID] = append(result[workerID], appID)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating application rows: %w", err)
+	}
+
+	return result, nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/types/worker.go
+++ b/ai-services/internal/pkg/catalog/types/worker.go
@@ -12,12 +12,14 @@ type WorkerRuntimeType string
 // It uses plain strings for timestamps so the wire format is stable
 // regardless of DB model changes.
 type Worker struct {
-	ID            string            `json:"id"`
-	Name          string            `json:"name"`
-	RuntimeType   WorkerRuntimeType `json:"runtime_type"`
-	Status        WorkerStatus      `json:"status"`
-	LastHeartbeat *time.Time        `json:"last_heartbeat,omitempty"`
-	Metadata      map[string]any    `json:"metadata,omitempty"`
-	RegisteredAt  string            `json:"registered_at"`
-	UpdatedAt     string            `json:"updated_at"`
+	ID             string            `json:"id"`
+	Name           string            `json:"name"`
+	RuntimeType    WorkerRuntimeType `json:"runtime_type"`
+	Status         WorkerStatus      `json:"status"`
+	Message        string            `json:"message,omitempty"`
+	LastHeartbeat  *time.Time        `json:"last_heartbeat,omitempty"`
+	Metadata       map[string]any    `json:"metadata,omitempty"`
+	ApplicationIDs []string          `json:"application_ids,omitempty"`
+	RegisteredAt   string            `json:"registered_at"`
+	UpdatedAt      string            `json:"updated_at"`
 }

--- a/ai-services/internal/pkg/worker/gateway/gateway_test.go
+++ b/ai-services/internal/pkg/worker/gateway/gateway_test.go
@@ -80,6 +80,15 @@ func (r *fakeWorkerRepo) GetAll(_ context.Context) ([]models.Worker, error) {
 	return out, nil
 }
 
+func (r *fakeWorkerRepo) GetByID(_ context.Context, id uuid.UUID) (*models.Worker, error) {
+	w, ok := r.byID[id]
+	if !ok {
+		return nil, nil
+	}
+	cp := *w
+	return &cp, nil
+}
+
 func (r *fakeWorkerRepo) GetByName(_ context.Context, name string) (*models.Worker, error) {
 	w, ok := r.workers[name]
 	if !ok {
@@ -87,6 +96,10 @@ func (r *fakeWorkerRepo) GetByName(_ context.Context, name string) (*models.Work
 	}
 	cp := *w
 	return &cp, nil
+}
+
+func (r *fakeWorkerRepo) GetApplicationIDsByWorkerIDs(_ context.Context, _ []uuid.UUID) (map[uuid.UUID][]uuid.UUID, error) {
+	return map[uuid.UUID][]uuid.UUID{}, nil
 }
 
 var _ repository.WorkerRepository = (*fakeWorkerRepo)(nil)

--- a/ai-services/internal/pkg/worker/registry/messages.go
+++ b/ai-services/internal/pkg/worker/registry/messages.go
@@ -1,0 +1,10 @@
+package registry
+
+// Worker status messages written to the database on lifecycle transitions.
+const (
+	// MsgDisconnected is set when a worker's gRPC stream closes cleanly.
+	MsgDisconnected = "disconnected — connection stream closed"
+
+	// MsgLostHeartbeat is set by the sweeper when a worker stops sending heartbeats.
+	MsgLostHeartbeat = "lost heartbeat — no ping received within the timeout window"
+)

--- a/ai-services/internal/pkg/worker/registry/registry.go
+++ b/ai-services/internal/pkg/worker/registry/registry.go
@@ -203,7 +203,11 @@ func (r *Registry) Disconnect(ctx context.Context, workerName string) {
 	r.mu.Unlock()
 
 	if ok && r.repo != nil && entry.DBID != uuid.Nil {
-		if err := r.repo.Update(ctx, entry.DBID, repository.WorkerUpdate{Status: utils.Ptr(models.WorkerStatusDisconnected)}); err != nil {
+		msg := MsgDisconnected
+		if err := r.repo.Update(ctx, entry.DBID, repository.WorkerUpdate{
+			Status:  utils.Ptr(models.WorkerStatusDisconnected),
+			Message: &msg,
+		}); err != nil {
 			logger.WarningfCtx(ctx, "worker registry: DB disconnect update failed for %s: %v", workerName, err)
 		}
 	}
@@ -233,7 +237,11 @@ func (r *Registry) SweepStale(ctx context.Context, timeout time.Duration) {
 		}
 		if w.LastHeartbeat == nil || now.Sub(*w.LastHeartbeat) > timeout {
 			logger.WarningfCtx(ctx, "worker registry: worker %s heartbeat timed out — marking disconnected", w.Name)
-			if err := r.repo.Update(ctx, w.ID, repository.WorkerUpdate{Status: utils.Ptr(models.WorkerStatusDisconnected)}); err != nil {
+			msg := MsgLostHeartbeat
+			if err := r.repo.Update(ctx, w.ID, repository.WorkerUpdate{
+				Status:  utils.Ptr(models.WorkerStatusDisconnected),
+				Message: &msg,
+			}); err != nil {
 				logger.WarningfCtx(ctx, "worker registry: failed to update stale worker %s: %v", w.Name, err)
 			}
 		}

--- a/ai-services/internal/pkg/worker/registry/registry_test.go
+++ b/ai-services/internal/pkg/worker/registry/registry_test.go
@@ -73,6 +73,15 @@ func (r *fakeWorkerRepo) GetAll(_ context.Context) ([]models.Worker, error) {
 	return out, nil
 }
 
+func (r *fakeWorkerRepo) GetByID(_ context.Context, id uuid.UUID) (*models.Worker, error) {
+	w, ok := r.byID[id]
+	if !ok {
+		return nil, nil
+	}
+	cp := *w
+	return &cp, nil
+}
+
 func (r *fakeWorkerRepo) GetByName(_ context.Context, name string) (*models.Worker, error) {
 	w, ok := r.workers[name]
 	if !ok {
@@ -80,6 +89,10 @@ func (r *fakeWorkerRepo) GetByName(_ context.Context, name string) (*models.Work
 	}
 	cp := *w
 	return &cp, nil
+}
+
+func (r *fakeWorkerRepo) GetApplicationIDsByWorkerIDs(_ context.Context, _ []uuid.UUID) (map[uuid.UUID][]uuid.UUID, error) {
+	return map[uuid.UUID][]uuid.UUID{}, nil
 }
 
 var _ repository.WorkerRepository = (*fakeWorkerRepo)(nil)


### PR DESCRIPTION
- DB schema — added message TEXT column to the workers table to persist status transition reasons.
- Worker messages — new messages.go constants (MsgDisconnected, MsgLostHeartbeat) as the single source of truth; registry's Disconnect and SweepStale write these to the DB.
- Worker repo — WorkerUpdate gained a Message field; Update() persists it; new GetApplicationIDsByWorkerIDs bulk-queries which applications belong to a set of workers.
- API types — catalogtypes.Worker now exposes message and application_ids on the wire.
- Worker handler — NewWorkerHandler takes a WorkerRepository; ListWorkers enriches every worker with its message and app IDs in one query; new GET /workers/:id single-worker endpoint added.
- CLI — worker list table gained MESSAGE and APPS columns (app count, not IDs).