### PR TITLE
fix: extraction service fixes

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.343
+TAG?=v0.0.344
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -120,7 +120,7 @@ extract:
   # @description Host port for the Extract API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/extract-service:v0.0.8
+  image: icr.io/ai-services-cicd/extract-service:v0.0.9
   # @hidden
   log_level: "INFO"
   database: "extract_metadata"

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.343
+  image: icr.io/ai-services-cicd/ai-services:v0.0.344
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.343
+  image: icr.io/ai-services-cicd/ai-services:v0.0.344
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/services/extract/openshift/values.yaml
+++ b/ai-services/assets/services/extract/openshift/values.yaml
@@ -1,5 +1,5 @@
 extract:
-  image: icr.io/ai-services-cicd/extract-service:v0.0.8
+  image: icr.io/ai-services-cicd/extract-service:v0.0.9
   log_level: "INFO"
   database: "extract_metadata"
   resources:

--- a/ai-services/assets/services/extract/podman/values.yaml
+++ b/ai-services/assets/services/extract/podman/values.yaml
@@ -1,6 +1,6 @@
 extract:
   port: ""
-  image: icr.io/ai-services-cicd/extract-service:v0.0.8
+  image: icr.io/ai-services-cicd/extract-service:v0.0.9
   log_level: "INFO"
   database: "extract_metadata"
 

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.343
+  image: icr.io/ai-services-cicd/ai-services:v0.0.344
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.343
+  image: icr.io/ai-services-cicd/ai-services:v0.0.344
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/services/extract/Makefile
+++ b/services/extract/Makefile
@@ -1,5 +1,5 @@
 IMAGE=extract-service
-TAG?=v0.0.8
+TAG?=v0.0.9
 
 run:
 	PORT=$${PORT:-6000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/extract/api/v1/jobs.py
+++ b/services/extract/api/v1/jobs.py
@@ -70,6 +70,30 @@ logger = get_logger("jobs_router")
 
 
 # ---------------------------------------------------------------------------
+# Module-level schema resolution helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_schema_id(schema_id: str):
+    """Return the schema row for *schema_id*, raising 404 if not found."""
+    row = db_repo.get_schema_by_id(schema_id)
+    if row is None:
+        msg = f"No schema with id {schema_id!r}."
+        logger.error(msg)
+        raise ExtractException(404, "SCHEMA_NOT_FOUND", msg)
+    return row
+
+
+def _resolve_schema_name(schema_name: str):
+    """Return the schema row for *schema_name*, raising 404 if not found."""
+    row = db_repo.get_schema_by_name(schema_name)
+    if row is None:
+        msg = f"No schema with name {schema_name!r}."
+        logger.error(msg)
+        raise ExtractException(404, "SCHEMA_NOT_FOUND", msg)
+    return row
+
+
+# ---------------------------------------------------------------------------
 # POST /v1/extract — Synchronous extraction
 # ---------------------------------------------------------------------------
 
@@ -110,7 +134,20 @@ async def extract_sync(request: Request, body: ExtractionRequest) -> JSONRespons
         msg = "text field is empty"
         logger.error(msg)
         raise ExtractException(400, "INVALID_REQUEST", msg)
-    schema_row = resolve_schema(body.schema_id)
+    if not body.schema_name and not body.schema_id:
+        raise ExtractException(
+            400,
+            "INVALID_REQUEST",
+            "Either schema_id or schema_name must be provided.")
+    elif body.schema_id:
+        schema_row = _resolve_schema_id(body.schema_id)
+        if body.schema_name and schema_row.name != body.schema_name:
+            raise ExtractException(
+                400,
+                "INVALID_REQUEST",
+                "Schema name and id are not for the same record")
+    else:
+        schema_row = _resolve_schema_name(body.schema_name)
 
     # ------------------------------------------------------------------
     # 2. Semaphore check (non-blocking — reject immediately if saturated)
@@ -126,7 +163,7 @@ async def extract_sync(request: Request, body: ExtractionRequest) -> JSONRespons
     llm_model_dict = get_llm_endpoint()
     llm_endpoint: str = llm_model_dict.get("llm_endpoint", "")
     llm_model: str = llm_model_dict.get("llm_model", "")
-    max_model_len: int = llm_model_dict.get('max_model_len', "")
+    max_model_len: int = llm_model_dict.get("max_model_len", 0)
 
     # ------------------------------------------------------------------
     # 3–8. Core extraction
@@ -297,18 +334,28 @@ async def extract_sync(request: Request, body: ExtractionRequest) -> JSONRespons
         "against a registered schema.  Returns immediately with a `job_id`.\n\n"
         "**Form parameters:**\n"
         "- `files` (required): One or more `.txt` or `.md` files (no duplicates)\n"
-        "- `schema_id` (required): ID of a registered extraction schema\n"
+        "- `schema_id` (optional): ID of a registered extraction schema\n"
+        "- `schema_name` (optional): Name of a registered extraction schema\n"
         "- `job_name` (optional): Human-readable label for the job\n"
+        "\nEither `schema_id` or `schema_name` must be provided.\n"
     ),
     tags=["jobs"],
 )
 async def create_extract_job(
     files: List[UploadFile] = File(...),
-    schema_id: str = Form(...),
+    schema_id: Optional[str] = Form(None),
+    schema_name: Optional[str] = Form(None),
     job_name: Optional[str] = Form(None),
 ) -> JobCreatedResponse:
     """Validate, stage, record, and enqueue an async extraction job (single or batch)."""
     check_job_admission()
+
+    if not schema_id and not schema_name:
+        raise ExtractException(
+            400,
+            "INVALID_REQUEST",
+            "Either schema_id or schema_name must be provided.",
+        )
 
     # ------------------------------------------------------------------
     # 1. File count validation
@@ -391,7 +438,15 @@ async def create_extract_job(
     # ------------------------------------------------------------------
     # 3. Schema lookup
     # ------------------------------------------------------------------
-    resolve_schema(schema_id)
+    if schema_id:
+        schema_row = _resolve_schema_id(schema_id)
+        if schema_name and schema_row.name != schema_name:
+            raise ExtractException(
+                400,
+                "INVALID_REQUEST",
+                "Schema name and id are not for the same record")
+    else:
+        schema_row = _resolve_schema_name(schema_name)
 
     # ------------------------------------------------------------------
     # 4. Stage all files, create job + document rows
@@ -469,7 +524,8 @@ async def create_extract_job(
         "- `offset` (int): Records to skip. Default: 0\n"
         "- `status` (string): Filter by `accepted`, `in_progress`, `completed`, "
         "`completed_with_errors`, or `failed`\n"
-        "- `schema_id` (string): Filter jobs by the schema they extract against\n"
+        "- `schema_id` (string): Filter jobs by schema ID\n"
+        "- `schema_name` (string): Filter jobs by schema name\n"
     ),
     tags=["jobs"],
 )
@@ -479,6 +535,7 @@ async def list_extract_jobs(
     offset: int = Query(default=0, ge=0, description="Records to skip"),
     status: Optional[str] = Query(default=None, description="Status filter"),
     schema_id: Optional[str] = Query(default=None, description="Filter by schema_id"),
+    schema_name: Optional[str] = Query(default=None, description="Filter by schema_name"),
 ) -> JobsListResponse:
     """Retrieve a list of extraction jobs with pagination and optional status/schema filtering."""
     _VALID_STATUSES = {s.value for s in JobStatus}
@@ -493,6 +550,7 @@ async def list_extract_jobs(
     rows, total = db_repo.list_jobs(
         status=status,
         schema_id=schema_id,
+        schema_name=schema_name,
         limit=limit,
         offset=offset,
         latest=bool(latest),
@@ -577,9 +635,22 @@ async def get_extract_job(job_id: str) -> JobDetailResponse:
             error=row.error,
         )
     else:
-        msg = f"No documents found for job {job_id!r}"
-        logger.error(msg)
-        raise ExtractException(404, "RESOURCE_NOT_FOUND", msg)
+        # Job exists but has no document rows — return the bare job status.
+        return JobDetailResponse(
+            job_id=row.job_id,
+            job_name=row.job_name,
+            schema_id=row.schema_id,
+            status=row.status,
+            documents=None,
+            file_count=row.file_count,
+            files_completed=None,
+            files_failed=None,
+            files_pending=None,
+            metadata=row.job_metadata,
+            submitted_at=fmt_dt(row.submitted_at) or "",
+            completed_at=fmt_dt(row.completed_at) or "",
+            error=row.error,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/services/extract/api/v1/jobs.py
+++ b/services/extract/api/v1/jobs.py
@@ -290,7 +290,7 @@ async def extract_sync(request: Request, body: ExtractionRequest) -> JSONRespons
         content={
             "data": {
                 "extraction": parsed_output,
-                "schema_id": body.schema_id,
+                "schema_id": schema_row.schema_id,
                 "source": {
                     "input_type": "text",
                     "input_tokens": input_tokens,
@@ -464,6 +464,7 @@ async def create_extract_job(
             row = db_repo.create_job(
                 job_id=job_id,
                 schema_id=schema_id,
+                schema_name=schema_name,
                 job_name=job_name,
                 submitted_at=datetime.now(timezone.utc),
                 file_count=len(files),

--- a/services/extract/api/v1/schema.py
+++ b/services/extract/api/v1/schema.py
@@ -8,9 +8,9 @@ Exposes one router:
 
 import asyncio
 import uuid
-from typing import  Optional
+from typing import  Optional, Annotated
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Body, Query
 from fastapi.responses import  Response
 from sqlalchemy.exc import IntegrityError
 from common.misc_utils import get_logger, get_llm_endpoint
@@ -68,7 +68,30 @@ logger = get_logger("schema_router")
     ),
     tags=["schemas"],
 )
-async def register_schema(body: SchemaRegisterRequest) -> SchemaCreatedResponse:
+async def register_schema(body: Annotated[SchemaRegisterRequest, Body(
+    openapi_examples={
+        "example": {
+            "summary": "Default Example",
+            "description": "Default Example",
+            "value": {
+                "name": "example_schema",
+                "description": "string",
+                "json_schema": {
+                  "type":"object",
+                  "basic": {}
+                },
+                "examples": [
+                  {
+                    "output": {
+                      "example_argument1": "example value"
+                    },
+                    "text": "Sample test"
+                  }
+                ],
+                "custom_prompt": "string"
+            }
+        }
+    }),]) -> SchemaCreatedResponse:
     """Register and validate a new schema for data extraction."""
     # --- Conflict check (name uniqueness) ---
     if db_repo.schema_name_exists(body.name):

--- a/services/extract/db/manager.py
+++ b/services/extract/db/manager.py
@@ -91,6 +91,27 @@ class DatabaseManager:
             return None
 
     @staticmethod
+    def get_schema_by_name(schema_name: str) -> Optional[ExtractionSchema]:
+        """Return a schema row or None if not found."""
+        try:
+            with get_db_session() as session:
+                row = session.scalar(
+                    select(ExtractionSchema).where(ExtractionSchema.name == schema_name)
+                )
+                if row:
+                    # Eagerly load all columns before session closes.
+                    _ = (
+                        row.schema_id, row.name, row.description, row.json_schema,
+                        row.examples, row.custom_prompt, row.schema_tokens,
+                        row.examples_tokens, row.custom_prompt_tokens, row.created_at,
+                    )
+                    session.expunge(row)
+                return row
+        except SQLAlchemyError as exc:
+            logger.error(f"DB error retrieving schema {schema_name}: {exc}", exc_info=True)
+            return None
+
+    @staticmethod
     def schema_name_exists(name: str) -> bool:
         """Return True when a schema with *name* already exists."""
         try:
@@ -228,6 +249,7 @@ class DatabaseManager:
         file_count: int,
         job_name: Optional[str] = None,
         submitted_at: Optional[datetime] = None,
+        schema_name: Optional[str] = None,
     ) -> Optional[ExtractJob]:
         """Insert a new extract_jobs row with status='accepted'."""
         try:
@@ -236,6 +258,7 @@ class DatabaseManager:
                     job_id=job_id,
                     job_name=job_name,
                     schema_id=schema_id,
+                    schema_name=schema_name,
                     status="accepted",
                     file_count=file_count,
                     submitted_at=submitted_at or datetime.now(timezone.utc),
@@ -262,8 +285,8 @@ class DatabaseManager:
                 )
                 if row:
                     _ = (
-                        row.job_id, row.job_name, row.schema_id, row.status,
-                        row.submitted_at, row.completed_at, row.error,
+                        row.job_id, row.job_name, row.schema_id, row.schema_name,
+                        row.status, row.submitted_at, row.completed_at, row.error,
                         row.digitize_job_id, row.digitize_doc_id,
                         row.job_metadata, row.updated_at, row.file_count,
                     )
@@ -331,6 +354,7 @@ class DatabaseManager:
     def list_jobs(
         status: Optional[str] = None,
         schema_id: Optional[str] = None,
+        schema_name: Optional[str] = None,
         limit: int = 20,
         offset: int = 0,
         latest: bool = False,
@@ -343,6 +367,8 @@ class DatabaseManager:
                     stmt = stmt.where(ExtractJob.status == status)
                 if schema_id:
                     stmt = stmt.where(ExtractJob.schema_id == schema_id)
+                if schema_name:
+                    stmt = stmt.where(ExtractJob.schema_name == schema_name)
 
                 count_stmt = select(func.count()).select_from(stmt.subquery())
                 total = session.scalar(count_stmt) or 0

--- a/services/extract/db/models.py
+++ b/services/extract/db/models.py
@@ -92,6 +92,11 @@ class ExtractJob(Base):
         nullable=False,
     )
 
+    schema_name: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        nullable=True,
+    )
+
     status: Mapped[str] = mapped_column(String(50), nullable=False)
     submitted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
@@ -121,6 +126,7 @@ class ExtractJob(Base):
         ),
         Index("idx_extract_jobs_submitted_at_status", "submitted_at", "status"),
         Index("idx_extract_jobs_schema_id", "schema_id"),
+        Index("idx_extract_jobs_schema_name", "schema_name"),
     )
 
     def __repr__(self) -> str:  # pragma: no cover

--- a/services/extract/db/scripts/init_schema.sql
+++ b/services/extract/db/scripts/init_schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS extract_jobs (
     job_name            VARCHAR(500),
     schema_id           VARCHAR(255) NOT NULL
                             REFERENCES schemas(schema_id) ON DELETE RESTRICT,
+    schema_name         VARCHAR(255),
     status              VARCHAR(50)  NOT NULL,
     submitted_at        TIMESTAMP WITH TIME ZONE NOT NULL,
     completed_at        TIMESTAMP WITH TIME ZONE,
@@ -94,6 +95,12 @@ BEGIN
     END IF;
 END
 $$;
+
+CREATE INDEX IF NOT EXISTS idx_extract_jobs_schema_name
+    ON extract_jobs(schema_name);
+
+-- Migration: add schema_name to existing deployments
+ALTER TABLE extract_jobs ADD COLUMN IF NOT EXISTS schema_name VARCHAR(255);
 
 -- updated_at auto-maintenance trigger (jobs only — schemas are immutable after INSERT)
 CREATE OR REPLACE FUNCTION update_extract_jobs_updated_at_column()

--- a/services/extract/models.py
+++ b/services/extract/models.py
@@ -27,8 +27,28 @@ class JobStatus(str):
 class ExampleItem(BaseModel):
     """A single few-shot example stored with a schema."""
 
-    text: str = Field(..., description="Source text for this example")
-    output: Dict[str, Any] = Field(..., description="Expected extraction output")
+    text: Optional[str] = Field(None, description="Source text for this example", json_schema_extra={
+        "example":"First line\nSecond line"})
+    output: Dict[str, Any] = Field(..., description="Expected extraction output", json_schema_extra={
+            "examples": [{
+                "example_argument1": "example value",
+                "another_argument": 123
+        }]
+    })
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples":
+            [
+                {
+                    "text": "First line\nSecond line",
+                    "output": {
+                        "example_argument1": "example value"
+                    }
+                }
+            ]
+        }
+    )
 
 
 class SchemaRegisterRequest(BaseModel):
@@ -191,7 +211,8 @@ class ExtractionRequest(BaseModel):
     """Request body for POST /v1/extract."""
 
     text: str = Field(..., min_length=1, description="Raw text to extract from")
-    schema_id: str = Field(..., min_length=1, description="ID of a registered schema")
+    schema_id: Optional[str] = Field(default=None, min_length=1, description="ID of a registered schema")
+    schema_name: Optional[str] = Field(default=None, min_length=1, description="Registered schema name")
 
 
 class ExtractionSourceInfo(BaseModel):

--- a/services/extract/tests/unit/test_extract_sync.py
+++ b/services/extract/tests/unit/test_extract_sync.py
@@ -51,6 +51,7 @@ VALID_EXTRACTION = {
 
 def _mock_schema_row(
     schema_id="schema-001",
+    name="my-schema",
     json_schema=None,
     examples=None,
     custom_prompt=None,
@@ -60,6 +61,7 @@ def _mock_schema_row(
 ):
     row = Mock()
     row.schema_id = schema_id
+    row.name = name
     row.json_schema = json_schema or SIMPLE_SCHEMA
     row.examples = examples
     row.custom_prompt = custom_prompt
@@ -286,6 +288,16 @@ class TestExtractionRequestModel:
         assert req.text == "hello"
         assert req.schema_id == "abc-123"
 
+    def test_valid_with_schema_name(self):
+        req = ExtractionRequest(text="hello", schema_name="my-schema")
+        assert req.schema_name == "my-schema"
+        assert req.schema_id is None
+
+    def test_valid_with_both_schema_id_and_name(self):
+        req = ExtractionRequest(text="hello", schema_id="abc-123", schema_name="my-schema")
+        assert req.schema_id == "abc-123"
+        assert req.schema_name == "my-schema"
+
     def test_empty_text_rejected(self):
         with pytest.raises(Exception):
             ExtractionRequest(text="", schema_id="abc")
@@ -294,13 +306,20 @@ class TestExtractionRequestModel:
         with pytest.raises(Exception):
             ExtractionRequest(text="hello", schema_id="")
 
+    def test_empty_schema_name_rejected(self):
+        with pytest.raises(Exception):
+            ExtractionRequest(text="hello", schema_name="")
+
     def test_missing_text_rejected(self):
         with pytest.raises(Exception):
             ExtractionRequest(schema_id="abc")
 
-    def test_missing_schema_id_rejected(self):
-        with pytest.raises(Exception):
-            ExtractionRequest(text="hello")
+    def test_schema_id_and_name_both_optional(self):
+        """Both schema_id and schema_name are optional at the model level.
+        The endpoint validates that at least one is provided."""
+        req = ExtractionRequest(text="hello")
+        assert req.schema_id is None
+        assert req.schema_name is None
 
 
 # ---------------------------------------------------------------------------
@@ -378,10 +397,11 @@ class TestExtractSyncEndpoint:
         )
         assert resp.status_code == 422
 
-    def test_400_missing_schema_id(self, extract_test_client):
+    def test_400_missing_schema_id_and_name(self, extract_test_client):
+        """Neither schema_id nor schema_name → 400 INVALID_REQUEST."""
         resp = extract_test_client.post("/v1/extract", json={"text": "hello"})
-        assert resp.status_code == 422
-        assert resp.json()["detail"][0]["type"] == "missing"
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "INVALID_REQUEST"
 
     def test_400_missing_text(self, extract_test_client):
         resp = extract_test_client.post("/v1/extract", json={"schema_id": "abc"})
@@ -395,6 +415,85 @@ class TestExtractSyncEndpoint:
         )
         assert resp.status_code == 422
         assert resp.json()["detail"][0]["type"] == "string_too_short"
+
+    # ── schema_name resolution ────────────────────────────────────────────
+
+    def test_200_resolve_by_schema_name(self, extract_test_client, monkeypatch):
+        """schema_name resolves the schema when schema_id is omitted."""
+        schema_row = _mock_schema_row()
+        good_json = json.dumps(VALID_EXTRACTION)
+        _setup_happy_path(monkeypatch, schema_row, input_tokens=100, raw_output=good_json)
+        monkeypatch.setattr(
+            "extract.api.v1.jobs.db_repo.get_schema_by_name",
+            Mock(return_value=schema_row),
+        )
+
+        resp = extract_test_client.post(
+            "/v1/extract",
+            json={"text": "some invoice text", "schema_name": "my-schema"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["extraction"] == VALID_EXTRACTION
+
+    def test_schema_id_takes_priority_over_schema_name(self, extract_test_client, monkeypatch):
+        """When both schema_id and schema_name are given, schema_id is used."""
+        schema_row = _mock_schema_row()
+        good_json = json.dumps(VALID_EXTRACTION)
+        _setup_happy_path(monkeypatch, schema_row, input_tokens=100, raw_output=good_json)
+        mock_by_name = Mock(return_value=schema_row)
+        monkeypatch.setattr("extract.api.v1.jobs.db_repo.get_schema_by_name", mock_by_name)
+
+        resp = extract_test_client.post(
+            "/v1/extract",
+            json={"text": "hello", "schema_id": "schema-001", "schema_name": "my-schema"},
+        )
+
+        assert resp.status_code == 200
+        mock_by_name.assert_not_called()
+
+    def test_400_schema_id_and_name_mismatch(self, extract_test_client, monkeypatch):
+        """Both schema_id and schema_name provided but name does not match the resolved row → 400."""
+        schema_row = _mock_schema_row(name="actual-schema-name")
+        monkeypatch.setattr(
+            "extract.api.v1.jobs.db_repo.get_schema_by_id", Mock(return_value=schema_row)
+        )
+
+        resp = extract_test_client.post(
+            "/v1/extract",
+            json={"text": "hello", "schema_id": "schema-001", "schema_name": "wrong-name"},
+        )
+
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "INVALID_REQUEST"
+        assert "not for the same record" in resp.json()["error"]["message"]
+
+    def test_200_schema_id_and_name_match(self, extract_test_client, monkeypatch):
+        """Both schema_id and schema_name provided and name matches → 200, no name lookup."""
+        schema_row = _mock_schema_row(name="my-schema")
+        good_json = json.dumps(VALID_EXTRACTION)
+        _setup_happy_path(monkeypatch, schema_row, input_tokens=100, raw_output=good_json)
+        mock_by_name = Mock(return_value=schema_row)
+        monkeypatch.setattr("extract.api.v1.jobs.db_repo.get_schema_by_name", mock_by_name)
+
+        resp = extract_test_client.post(
+            "/v1/extract",
+            json={"text": "hello", "schema_id": "schema-001", "schema_name": "my-schema"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["extraction"] == VALID_EXTRACTION
+        mock_by_name.assert_not_called()
+
+    def test_404_unknown_schema_name(self, extract_test_client):
+        """schema_name that does not exist → 404 SCHEMA_NOT_FOUND."""
+        with patch("extract.api.v1.jobs.db_repo.get_schema_by_name", return_value=None):
+            resp = extract_test_client.post(
+                "/v1/extract",
+                json={"text": "hello", "schema_name": "nonexistent-schema"},
+            )
+        assert resp.status_code == 404
+        assert resp.json()["error"]["code"] == "SCHEMA_NOT_FOUND"
 
     # ── 404 Not Found ─────────────────────────────────────────────────────
 

--- a/services/extract/tests/unit/test_extract_sync.py
+++ b/services/extract/tests/unit/test_extract_sync.py
@@ -436,6 +436,24 @@ class TestExtractSyncEndpoint:
         assert resp.status_code == 200
         assert resp.json()["data"]["extraction"] == VALID_EXTRACTION
 
+    def test_200_resolve_by_schema_name_returns_resolved_schema_id(self, extract_test_client, monkeypatch):
+        """Response schema_id comes from the resolved row, not the (absent) request field."""
+        schema_row = _mock_schema_row(schema_id="schema-001")
+        good_json = json.dumps(VALID_EXTRACTION)
+        _setup_happy_path(monkeypatch, schema_row, input_tokens=100, raw_output=good_json)
+        monkeypatch.setattr(
+            "extract.api.v1.jobs.db_repo.get_schema_by_name",
+            Mock(return_value=schema_row),
+        )
+
+        resp = extract_test_client.post(
+            "/v1/extract",
+            json={"text": "some invoice text", "schema_name": "my-schema"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["schema_id"] == "schema-001"
+
     def test_schema_id_takes_priority_over_schema_name(self, extract_test_client, monkeypatch):
         """When both schema_id and schema_name are given, schema_id is used."""
         schema_row = _mock_schema_row()

--- a/services/extract/tests/unit/test_job_endpoints.py
+++ b/services/extract/tests/unit/test_job_endpoints.py
@@ -306,6 +306,26 @@ class TestCreateExtractJob:
         assert resp.status_code == 202
         assert "job_id" in resp.json()
 
+    def test_202_accepted_via_schema_name_passes_name_to_db(self, extract_test_client):
+        """schema_name is forwarded to create_job so it is persisted on the job row."""
+        mock_create_job = Mock(return_value=_mock_job_row(status="accepted"))
+        with patch("extract.api.v1.jobs.db_repo.get_schema_by_name", return_value=_mock_schema_row()), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.stage_multiple_files"), \
+             patch("extract.api.v1.jobs.db_repo.create_job", mock_create_job), \
+             patch("extract.api.v1.jobs.db_repo.create_documents", return_value=True), \
+             patch("extract.api.v1.jobs.validate_file_content", new=AsyncMock()), \
+             patch("extract.api.v1.jobs.process_batch_job", new=AsyncMock()), \
+             _patch_extract_limiter_free():
+            extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_name": "my-schema"},
+                files=[("files", ("doc.txt", b"invoice text content", "text/plain"))],
+            )
+
+        _, kwargs = mock_create_job.call_args
+        assert kwargs.get("schema_name") == "my-schema"
+
     def test_400_missing_schema_id_and_name(self, extract_test_client):
         """Neither schema_id nor schema_name → 400 INVALID_REQUEST."""
         with _patch_extract_limiter_free():

--- a/services/extract/tests/unit/test_job_endpoints.py
+++ b/services/extract/tests/unit/test_job_endpoints.py
@@ -78,9 +78,10 @@ def _mock_doc_row(
     return row
 
 
-def _mock_schema_row(schema_id="schema-001"):
+def _mock_schema_row(schema_id="schema-001", name="my-schema"):
     row = Mock()
     row.schema_id = schema_id
+    row.name = name
     return row
 
 
@@ -284,6 +285,117 @@ class TestCreateExtractJob:
         assert resp.json()["error"]["code"] == "DATABASE_ERROR"
 
 
+    # ── schema_name form field ────────────────────────────────────────────
+
+    def test_202_accepted_via_schema_name(self, extract_test_client):
+        """schema_name form field resolves the schema when schema_id is omitted."""
+        with patch("extract.api.v1.jobs.db_repo.get_schema_by_name", return_value=_mock_schema_row()), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.stage_multiple_files"), \
+             patch("extract.api.v1.jobs.db_repo.create_job", return_value=_mock_job_row(status="accepted")), \
+             patch("extract.api.v1.jobs.db_repo.create_documents", return_value=True), \
+             patch("extract.api.v1.jobs.validate_file_content", new=AsyncMock()), \
+             patch("extract.api.v1.jobs.process_batch_job", new=AsyncMock()), \
+             _patch_extract_limiter_free():
+            resp = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_name": "my-schema"},
+                files=[("files", ("doc.txt", b"invoice text content", "text/plain"))],
+            )
+
+        assert resp.status_code == 202
+        assert "job_id" in resp.json()
+
+    def test_400_missing_schema_id_and_name(self, extract_test_client):
+        """Neither schema_id nor schema_name → 400 INVALID_REQUEST."""
+        with _patch_extract_limiter_free():
+            resp = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={},
+                files=[("files", ("doc.txt", b"invoice text content", "text/plain"))],
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "INVALID_REQUEST"
+
+    def test_schema_id_takes_priority_over_schema_name(self, extract_test_client):
+        """When both schema_id and schema_name are given, schema_id is used."""
+        schema_row = _mock_schema_row()
+        mock_by_name = Mock(return_value=schema_row)
+        with patch("extract.api.v1.jobs.db_repo.get_schema_by_id", return_value=schema_row), \
+             patch("extract.api.v1.jobs.db_repo.get_schema_by_name", mock_by_name), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.stage_multiple_files"), \
+             patch("extract.api.v1.jobs.db_repo.create_job", return_value=_mock_job_row(status="accepted")), \
+             patch("extract.api.v1.jobs.db_repo.create_documents", return_value=True), \
+             patch("extract.api.v1.jobs.validate_file_content", new=AsyncMock()), \
+             patch("extract.api.v1.jobs.process_batch_job", new=AsyncMock()), \
+             _patch_extract_limiter_free():
+            resp = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_id": "schema-001", "schema_name": "my-schema"},
+                files=[("files", ("doc.txt", b"invoice text content", "text/plain"))],
+            )
+
+        assert resp.status_code == 202
+        mock_by_name.assert_not_called()
+
+    def test_400_schema_id_and_name_mismatch(self, extract_test_client):
+        """Both schema_id and schema_name provided but name doesn't match resolved row → 400."""
+        schema_row = _mock_schema_row(name="actual-schema-name")
+        with patch("extract.api.v1.jobs.db_repo.get_schema_by_id", return_value=schema_row), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.validate_file_content", new=AsyncMock()), \
+             _patch_extract_limiter_free():
+            resp = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_id": "schema-001", "schema_name": "wrong-name"},
+                files=[("files", ("doc.txt", b"invoice text content", "text/plain"))],
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "INVALID_REQUEST"
+        assert "not for the same record" in resp.json()["error"]["message"]
+
+    def test_202_schema_id_and_name_match(self, extract_test_client):
+        """Both schema_id and schema_name provided and name matches → 202, no name lookup."""
+        schema_row = _mock_schema_row(name="my-schema")
+        mock_by_name = Mock(return_value=schema_row)
+        with patch("extract.api.v1.jobs.db_repo.get_schema_by_id", return_value=schema_row), \
+             patch("extract.api.v1.jobs.db_repo.get_schema_by_name", mock_by_name), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.stage_multiple_files"), \
+             patch("extract.api.v1.jobs.db_repo.create_job", return_value=_mock_job_row(status="accepted")), \
+             patch("extract.api.v1.jobs.db_repo.create_documents", return_value=True), \
+             patch("extract.api.v1.jobs.validate_file_content", new=AsyncMock()), \
+             patch("extract.api.v1.jobs.process_batch_job", new=AsyncMock()), \
+             _patch_extract_limiter_free():
+            resp = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_id": "schema-001", "schema_name": "my-schema"},
+                files=[("files", ("doc.txt", b"invoice text content", "text/plain"))],
+            )
+
+        assert resp.status_code == 202
+        assert "job_id" in resp.json()
+        mock_by_name.assert_not_called()
+
+    def test_404_unknown_schema_name(self, extract_test_client):
+        """schema_name that does not exist → 404 SCHEMA_NOT_FOUND."""
+        with patch("extract.api.v1.jobs.db_repo.get_schema_by_name", return_value=None), \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.validate_file_content", new=AsyncMock()), \
+             _patch_extract_limiter_free():
+            resp = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_name": "nonexistent-schema"},
+                files=[("files", ("doc.txt", b"invoice text content", "text/plain"))],
+            )
+
+        assert resp.status_code == 404
+        assert resp.json()["error"]["code"] == "SCHEMA_NOT_FOUND"
+
+
 # ---------------------------------------------------------------------------
 # GET /v1/extract/jobs
 # ---------------------------------------------------------------------------
@@ -319,21 +431,35 @@ class TestListExtractJobs:
         with patch("extract.api.v1.jobs.db_repo.list_jobs", return_value=([], 0)) as mock_list:
             extract_test_client.get("/v1/extract/jobs?status=completed")
         mock_list.assert_called_once_with(
-            status="completed", schema_id=None, limit=20, offset=0, latest=False
+            status="completed", schema_id=None, schema_name=None, limit=20, offset=0, latest=False
         )
 
     def test_schema_id_filter_passed_to_db(self, extract_test_client):
         with patch("extract.api.v1.jobs.db_repo.list_jobs", return_value=([], 0)) as mock_list:
             extract_test_client.get("/v1/extract/jobs?schema_id=schema-001")
         mock_list.assert_called_once_with(
-            status=None, schema_id="schema-001", limit=20, offset=0, latest=False
+            status=None, schema_id="schema-001", schema_name=None, limit=20, offset=0, latest=False
+        )
+
+    def test_schema_name_filter_passed_to_db(self, extract_test_client):
+        with patch("extract.api.v1.jobs.db_repo.list_jobs", return_value=([], 0)) as mock_list:
+            extract_test_client.get("/v1/extract/jobs?schema_name=my-schema")
+        mock_list.assert_called_once_with(
+            status=None, schema_id=None, schema_name="my-schema", limit=20, offset=0, latest=False
+        )
+
+    def test_schema_name_and_id_filters_together(self, extract_test_client):
+        with patch("extract.api.v1.jobs.db_repo.list_jobs", return_value=([], 0)) as mock_list:
+            extract_test_client.get("/v1/extract/jobs?schema_id=schema-001&schema_name=my-schema")
+        mock_list.assert_called_once_with(
+            status=None, schema_id="schema-001", schema_name="my-schema", limit=20, offset=0, latest=False
         )
 
     def test_pagination_params_passed_to_db(self, extract_test_client):
         with patch("extract.api.v1.jobs.db_repo.list_jobs", return_value=([], 0)) as mock_list:
             extract_test_client.get("/v1/extract/jobs?limit=5&offset=10")
         mock_list.assert_called_once_with(
-            status=None, schema_id=None, limit=5, offset=10, latest=False
+            status=None, schema_id=None, schema_name=None, limit=5, offset=10, latest=False
         )
 
     def test_400_invalid_status_value(self, extract_test_client):
@@ -834,3 +960,8 @@ def _patch_extract_limiter_free():
     """Patch extract_limiter so locked() is False and async-with passes."""
     import asyncio
     return patch("extract.state.extract_limiter", asyncio.BoundedSemaphore(1))
+
+
+# Legacy alias used by schema_name tests (same behaviour as _patch_extract_limiter_free
+# but kept separate to preserve the original test intent).
+_patch_job_limiter_free = _patch_extract_limiter_free

--- a/services/extract/tests/unit/test_process_extract_job.py
+++ b/services/extract/tests/unit/test_process_extract_job.py
@@ -136,6 +136,49 @@ def _make_async_cm_mock():
     return cm
 
 
+def _standard_patches(
+    *,
+    job_row=None,
+    schema_row=None,
+    file_text: str = "INVOICE #INV-001 Vendor: Acme TOTAL: EUR 100",
+    input_tokens: int = 50,
+    reserved_output: int = 512,
+    vllm_response=None,
+    validate_return=None,
+    update_job_return: bool = True,
+):
+    """
+    Return a dict of patch targets and their configured mocks for the happy path.
+    Callers override individual entries as needed.
+    """
+    if job_row is None:
+        job_row = _mock_job_row()
+    if schema_row is None:
+        schema_row = _mock_schema_row()
+    if vllm_response is None:
+        vllm_response = _vllm_response(VALID_EXTRACTION_JSON)
+    if validate_return is None:
+        validate_return = (VALID_EXTRACTION, 1, 0, 0)
+
+    patches = {
+        # Semaphores: replaced with loop-agnostic async context-manager mocks.
+        "extract.state.job_limiter": _make_async_cm_mock(),
+        "extract.api.v1.jobs.concurrency_limiter": _make_async_cm_mock(),
+        "extract.api.v1.jobs.get_llm_endpoint": Mock(return_value=LLM_DICT),
+        "extract.api.v1.jobs.db_repo.get_job_by_id": Mock(return_value=job_row),
+        "extract.api.v1.jobs.db_repo.update_job": Mock(return_value=update_job_return),
+        "extract.api.v1.jobs._resolve_schema_id": Mock(return_value=schema_row),
+        "extract.api.v1.jobs._tokenize": Mock(return_value=input_tokens),
+        "extract.api.v1.jobs.check_extraction_budget": Mock(return_value=reserved_output),
+        "extract.api.v1.jobs.render_few_shot_block": Mock(return_value=""),
+        "extract.api.v1.jobs.build_messages": Mock(return_value=[{"role": "user", "content": "..."}]),
+        "extract.api.v1.jobs.call_vllm_safe": AsyncMock(return_value=vllm_response),
+        "extract.api.v1.jobs.validate_with_retry": AsyncMock(return_value=validate_return),
+        "extract.api.v1.jobs.cleanup_staging_directory": Mock(),
+    }
+    return patches
+
+
 def _apply_patches(patches: dict):
     """Context-manager stack for all patch targets."""
     from contextlib import ExitStack


### PR DESCRIPTION
Made `ExampleItem.text` optional
Fixed `SchemaRegisterRequest` Swagger example body
Added an option to provide `schema_name` instead of `schema_id` for job submission and sync extraction endpoints.