### PR TITLE
Bump digitize version to use spacy

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.322
+TAG?=v0.0.323
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.55
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.56
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.55
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.56
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.55
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.56
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.55
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.56
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.55
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.56
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.322
+  image: icr.io/ai-services-cicd/ai-services:v0.0.323
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.322
+  image: icr.io/ai-services-cicd/ai-services:v0.0.323
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/services/digitize/openshift/values.yaml
+++ b/ai-services/assets/services/digitize/openshift/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.55
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.56
   log_level: "INFO"
   database: "digitize_metadata"
   numShards: 1

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.55
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.56
   log_level: "INFO"
   database: "digitize_metadata"
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.322
+  image: icr.io/ai-services-cicd/ai-services:v0.0.323
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.322
+  image: icr.io/ai-services-cicd/ai-services:v0.0.323
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/services/digitize/Containerfile
+++ b/services/digitize/Containerfile
@@ -1,4 +1,4 @@
-FROM icr.io/ai-services-cicd/service-base:v0.0.36
+FROM icr.io/ai-services-cicd/service-base:v0.0.38
 
 WORKDIR /opt/services/digitize
 

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.55
+TAG?=v0.0.56
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT


### PR DESCRIPTION
Part of https://github.com/IBM/project-ai-services/pull/1386 added the spacy image to service-base. Now updating digitize service to use the new base to consume spacy.