### PR TITLE
Support local service endpoint and podname for remote deployments

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.331
+TAG?=v0.0.332
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.331
+  image: icr.io/ai-services-cicd/ai-services:v0.0.332
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.331
+  image: icr.io/ai-services-cicd/ai-services:v0.0.332
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.331
+  image: icr.io/ai-services-cicd/ai-services:v0.0.332
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.331
+  image: icr.io/ai-services-cicd/ai-services:v0.0.332
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -52,6 +52,14 @@ const (
 	ArgParamWorkerAuthFile    = "worker.podman.authFileContent"
 
 	// GatewayServerName is the default DNS SAN embedded in the auto-generated
-	// gateway server certificate for the local/podman flow.
+	// gateway server certificate for the local flow.
 	GatewayServerName = "gateway.ai-services.internal"
+
+	// GatewayPodName is the Podman catalog pod DNS name embedded in the
+	// auto-generated gateway server certificate.
+	GatewayPodName = "ai-services--catalog"
+
+	// GatewayServiceEndpoint is the OpenShift service DNS name embedded in the
+	// auto-generated gateway server certificate.
+	GatewayServiceEndpoint = "catalog-api.ai-services.svc.cluster.local"
 )

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -51,15 +51,15 @@ const (
 	ArgParamWorkerPodmanURI   = "worker.podman.uri"
 	ArgParamWorkerAuthFile    = "worker.podman.authFileContent"
 
-	// GatewayServerName is the default DNS SAN embedded in the auto-generated
-	// gateway server certificate for the local flow.
-	GatewayServerName = "gateway.ai-services.internal"
+	// PodmanGatewayServerName is the default DNS SAN embedded in the auto-generated
+	// gateway server certificate for the Podman runtime.
+	PodmanGatewayServerName = "gateway.ai-services.internal"
 
-	// GatewayPodName is the Podman catalog pod DNS name embedded in the
+	// PodmanGatewayPodName is the Podman catalog pod DNS name embedded in the
 	// auto-generated gateway server certificate.
-	GatewayPodName = "ai-services--catalog"
+	PodmanGatewayPodName = "ai-services--catalog"
 
-	// GatewayServiceEndpoint is the OpenShift service DNS name embedded in the
-	// auto-generated gateway server certificate.
-	GatewayServiceEndpoint = "catalog-api.ai-services.svc.cluster.local"
+	// OpenShiftGatewayServiceEndpoint is the OpenShift service DNS name embedded in the
+	// auto-generated gateway server certificate for internal cluster communication.
+	OpenShiftGatewayServiceEndpoint = "catalog-api.ai-services.svc.cluster.local"
 )

--- a/ai-services/internal/pkg/worker/gateway/pki.go
+++ b/ai-services/internal/pkg/worker/gateway/pki.go
@@ -133,9 +133,9 @@ func generateAndPersistPKI(ctx context.Context, pkiDir string, runtimeType types
 		if err != nil {
 			return empty, fmt.Errorf("resolve gateway route host for cert SAN: %w", err)
 		}
-		serverNames = []string{route, workerconstants.GatewayServiceEndpoint}
+		serverNames = []string{route, workerconstants.OpenShiftGatewayServiceEndpoint}
 	case types.RuntimeTypePodman:
-		serverNames = []string{workerconstants.GatewayServerName, workerconstants.GatewayPodName}
+		serverNames = []string{workerconstants.PodmanGatewayServerName, workerconstants.PodmanGatewayPodName}
 	}
 
 	if err := os.MkdirAll(pkiDir, dirPerm); err != nil {

--- a/ai-services/internal/pkg/worker/gateway/pki.go
+++ b/ai-services/internal/pkg/worker/gateway/pki.go
@@ -126,14 +126,14 @@ func generateServerCert(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, serve
 func generateAndPersistPKI(ctx context.Context, pkiDir string, runtimeType types.RuntimeType) (pkiResult, error) {
 	empty := pkiResult{}
 
-	serverNames := []string{workerconstants.GatewayServerName}
+	serverNames := []string{}
 	switch runtimeType {
 	case types.RuntimeTypeOpenShift:
-		host, err := GatewayRouteHost(ctx)
+		route, err := GatewayRouteHost(ctx)
 		if err != nil {
 			return empty, fmt.Errorf("resolve gateway route host for cert SAN: %w", err)
 		}
-		serverNames = []string{host, workerconstants.GatewayServiceEndpoint}
+		serverNames = []string{route, workerconstants.GatewayServiceEndpoint}
 	case types.RuntimeTypePodman:
 		serverNames = []string{workerconstants.GatewayServerName, workerconstants.GatewayPodName}
 	}

--- a/ai-services/internal/pkg/worker/gateway/pki.go
+++ b/ai-services/internal/pkg/worker/gateway/pki.go
@@ -93,8 +93,8 @@ func generateCA() (*ecdsa.PrivateKey, *x509.Certificate, []byte, error) {
 }
 
 // generateServerCert creates a new ECDSA P-256 server key and signs it with the CA.
-// serverName is the hostname embedded as the DNS SAN (must match what workers dial).
-func generateServerCert(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, serverName string) (*ecdsa.PrivateKey, []byte, error) {
+// serverNames are the hostnames embedded as DNS SANs (must match what workers dial).
+func generateServerCert(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, serverNames []string) (*ecdsa.PrivateKey, []byte, error) {
 	srvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, nil, fmt.Errorf("generate server key: %w", err)
@@ -103,7 +103,7 @@ func generateServerCert(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, serve
 	srvTemplate := &x509.Certificate{
 		SerialNumber: srvSerial,
 		Subject:      pkix.Name{CommonName: "Catalog"},
-		DNSNames:     []string{serverName},
+		DNSNames:     serverNames,
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().Add(serverCertTTL),
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
@@ -120,19 +120,22 @@ func generateServerCert(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, serve
 // generateAndPersistPKI creates a new ECDSA P-256 root CA and signs a server
 // certificate, then writes all four PEM files to pkiDir.
 //
-// For OpenShift the server cert's DNS SAN is populated by fetching the live
-// passthrough route host via GatewayRouteHost rather than using a hardcoded
-// hostname. For all other runtimes the static internal name is used.
+// For OpenShift the server cert's DNS SANs include both the live passthrough
+// route host and the internal service endpoint. For Podman they include the
+// catalog pod name and the static internal name.
 func generateAndPersistPKI(ctx context.Context, pkiDir string, runtimeType types.RuntimeType) (pkiResult, error) {
 	empty := pkiResult{}
 
-	serverName := workerconstants.GatewayServerName
-	if runtimeType == types.RuntimeTypeOpenShift {
+	serverNames := []string{workerconstants.GatewayServerName}
+	switch runtimeType {
+	case types.RuntimeTypeOpenShift:
 		host, err := GatewayRouteHost(ctx)
 		if err != nil {
 			return empty, fmt.Errorf("resolve gateway route host for cert SAN: %w", err)
 		}
-		serverName = host
+		serverNames = []string{host, workerconstants.GatewayServiceEndpoint}
+	case types.RuntimeTypePodman:
+		serverNames = []string{workerconstants.GatewayServerName, workerconstants.GatewayPodName}
 	}
 
 	if err := os.MkdirAll(pkiDir, dirPerm); err != nil {
@@ -144,7 +147,7 @@ func generateAndPersistPKI(ctx context.Context, pkiDir string, runtimeType types
 		return empty, err
 	}
 
-	srvKey, srvCertDER, err := generateServerCert(caCert, caKey, serverName)
+	srvKey, srvCertDER, err := generateServerCert(caCert, caKey, serverNames)
 	if err != nil {
 		return empty, err
 	}

--- a/ai-services/internal/pkg/worker/join/tls.go
+++ b/ai-services/internal/pkg/worker/join/tls.go
@@ -99,7 +99,7 @@ func buildTLSConfig(gatewayAddr, tlsDir string, clientCert *tls.Certificate) (*t
 
 func gatewayServerName(gatewayAddr string) string {
 	if gatewayAddr == "" {
-		return workerconstants.GatewayServerName
+		return workerconstants.PodmanGatewayServerName
 	}
 	if parsed, err := url.Parse(gatewayAddr); err == nil && parsed.Host != "" {
 		gatewayAddr = parsed.Host
@@ -108,10 +108,10 @@ func gatewayServerName(gatewayAddr string) string {
 		gatewayAddr = host
 	}
 	if gatewayAddr == "" {
-		return workerconstants.GatewayServerName
+		return workerconstants.PodmanGatewayServerName
 	}
 	if ip := net.ParseIP(gatewayAddr); ip != nil {
-		return workerconstants.GatewayServerName
+		return workerconstants.PodmanGatewayServerName
 	}
 
 	return gatewayAddr


### PR DESCRIPTION
- This is to allow internal pod-pod communication in Podman and Openshift to be able to establish grpc stream with mtls enabled between gateway and worker pods.