### PR TITLE
Podman domain san

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.335
+TAG?=v0.0.336
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.335
+  image: icr.io/ai-services-cicd/ai-services:v0.0.336
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.335
+  image: icr.io/ai-services-cicd/ai-services:v0.0.336
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.335
+  image: icr.io/ai-services-cicd/ai-services:v0.0.336
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.335
+  image: icr.io/ai-services-cicd/ai-services:v0.0.336
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/cmd/ai-services/cmd/catalog/worker.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/worker.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	catalogtypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 )
 
 // NewWorkerCmd returns the parent command for worker management.
@@ -149,7 +151,7 @@ If the worker is currently connected its gRPC stream is also cleaned up.`,
 // e.g. "https://catalog-api.10.0.0.1.nip.io" → "gateway.10.0.0.1.nip.io:9090"
 // Falls back to "<catalog-server-host>:9090" if the subdomain cannot be parsed.
 func gatewayAddrFromServerURL(serverURL string) string {
-	const defaultGatewayPort = "9090"
+	defaultGatewayPort := strconv.Itoa(workerconstants.WorkerGatewayPort)
 
 	parsed, err := url.Parse(serverURL)
 	if err != nil || parsed.Host == "" {

--- a/ai-services/cmd/ai-services/cmd/catalog/worker.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/worker.go
@@ -2,10 +2,7 @@ package catalog
 
 import (
 	"fmt"
-	"net/url"
 	"os"
-	"strconv"
-	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -14,7 +11,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	catalogtypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 )
 
 // NewWorkerCmd returns the parent command for worker management.
@@ -72,7 +68,7 @@ Pass the token to the worker node and run:
 			logger.Infof("  Token: %s\n", resp.Token)
 			logger.Infoln("\nRun the following command on the worker node:")
 			logger.Infof("  ai-services worker join %s --token %s --runtime <runtime>\n",
-				gatewayAddrFromServerURL(c.ServerURL()), resp.Token)
+				resp.GatewayAddress, resp.Token)
 			logger.Infoln("\nThe token is single-use and expires after 24 hours.")
 
 			return nil
@@ -144,27 +140,6 @@ If the worker is currently connected its gRPC stream is also cleaned up.`,
 	}
 
 	return cmd
-}
-
-// gatewayAddrFromServerURL derives the worker gateway dial address from the
-// catalog API server URL stored in credentials.
-// e.g. "https://catalog-api.10.0.0.1.nip.io" → "gateway.10.0.0.1.nip.io:9090"
-// Falls back to "<catalog-server-host>:9090" if the subdomain cannot be parsed.
-func gatewayAddrFromServerURL(serverURL string) string {
-	defaultGatewayPort := strconv.Itoa(workerconstants.WorkerGatewayPort)
-
-	parsed, err := url.Parse(serverURL)
-	if err != nil || parsed.Host == "" {
-		return serverURL + ":" + defaultGatewayPort
-	}
-
-	host := parsed.Hostname()
-	// Replace the first subdomain (e.g. "catalog-api") with "gateway".
-	if idx := strings.Index(host, "."); idx != -1 {
-		return "gateway" + host[idx:] + ":" + defaultGatewayPort
-	}
-
-	return host + ":" + defaultGatewayPort
 }
 
 // ─── helpers ──────────────────────────────────────────────────────────────────

--- a/ai-services/cmd/ai-services/cmd/catalog/worker.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/worker.go
@@ -2,7 +2,9 @@ package catalog
 
 import (
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -66,8 +68,10 @@ Pass the token to the worker node and run:
 			logger.Infoln("Worker registered successfully.")
 			logger.Infof("  Name:  %s\n", resp.WorkerName)
 			logger.Infof("  Token: %s\n", resp.Token)
-			logger.Infoln("\nPass this token to the worker daemon with --token.")
-			logger.Infoln("The token is single-use and expires after 24 hours.")
+			logger.Infoln("\nRun the following command on the worker node:")
+			logger.Infof("  ai-services worker join %s --token %s --runtime <runtime>\n",
+				gatewayAddrFromServerURL(c.ServerURL()), resp.Token)
+			logger.Infoln("\nThe token is single-use and expires after 24 hours.")
 
 			return nil
 		},
@@ -138,6 +142,27 @@ If the worker is currently connected its gRPC stream is also cleaned up.`,
 	}
 
 	return cmd
+}
+
+// gatewayAddrFromServerURL derives the worker gateway dial address from the
+// catalog API server URL stored in credentials.
+// e.g. "https://catalog-api.10.0.0.1.nip.io" → "gateway.10.0.0.1.nip.io:9090"
+// Falls back to "<catalog-server-host>:9090" if the subdomain cannot be parsed.
+func gatewayAddrFromServerURL(serverURL string) string {
+	const defaultGatewayPort = "9090"
+
+	parsed, err := url.Parse(serverURL)
+	if err != nil || parsed.Host == "" {
+		return serverURL + ":" + defaultGatewayPort
+	}
+
+	host := parsed.Hostname()
+	// Replace the first subdomain (e.g. "catalog-api") with "gateway".
+	if idx := strings.Index(host, "."); idx != -1 {
+		return "gateway" + host[idx:] + ":" + defaultGatewayPort
+	}
+
+	return host + ":" + defaultGatewayPort
 }
 
 // ─── helpers ──────────────────────────────────────────────────────────────────

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -4207,6 +4207,9 @@ const docTemplate = `{
         "internal_pkg_catalog_apiserver_handlers.createWorkerResp": {
             "type": "object",
             "properties": {
+                "gateway_address": {
+                    "type": "string"
+                },
                 "token": {
                     "type": "string"
                 },

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -4201,6 +4201,9 @@
         "internal_pkg_catalog_apiserver_handlers.createWorkerResp": {
             "type": "object",
             "properties": {
+                "gateway_address": {
+                    "type": "string"
+                },
                 "token": {
                     "type": "string"
                 },

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -997,6 +997,8 @@ definitions:
     type: object
   internal_pkg_catalog_apiserver_handlers.createWorkerResp:
     properties:
+      gateway_address:
+        type: string
       token:
         type: string
       worker_name:

--- a/ai-services/internal/pkg/catalog/apiserver/apiserver.go
+++ b/ai-services/internal/pkg/catalog/apiserver/apiserver.go
@@ -134,7 +134,7 @@ func (a *APIserver) Start(ctx context.Context) error {
 	}
 	logger.InfofCtx(ctx, "Worker gateway started on %s", gatewayAddr)
 
-	r := CreateRouter(a.authService, a.tokenManager, a.blacklist, a.applicationService, a.workerRegistry, a.workerRepository, a.datasourceService, a.bundleService, a.catalogProvider)
+	r := CreateRouter(a.authService, a.tokenManager, a.blacklist, a.applicationService, a.workerRegistry, a.workerRepository, a.workerGatewayPort, a.datasourceService, a.bundleService, a.catalogProvider)
 
 	if err := r.Run(fmt.Sprintf(":%d", a.port)); err != nil {
 		return err

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
@@ -101,16 +101,11 @@ func (h *WorkerHandler) CreateWorker(c *gin.Context) {
 }
 
 func (h *WorkerHandler) gatewayAddress(ctx context.Context) (string, error) {
-	port := fmt.Sprintf("%d", h.gatewayPort)
 	if h.runtimeType == types.RuntimeTypeOpenShift {
-		host, err := gateway.GatewayRouteHost(ctx)
-		if err != nil {
-			return "", err
-		}
-
-		return host + ":" + port, nil
+		return gateway.GatewayRouteHost(ctx)
 	}
 
+	port := fmt.Sprintf("%d", h.gatewayPort)
 	domainSuffix := utils.GetEnv("DOMAIN_SUFFIX", "")
 	if domainSuffix == "" {
 		return "", fmt.Errorf("DOMAIN_SUFFIX environment variable not set")

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -11,18 +12,24 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	catalogtypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
+	"github.com/project-ai-services/ai-services/internal/pkg/worker/gateway"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/registry"
 )
 
 // WorkerHandler handles worker management endpoints.
 type WorkerHandler struct {
-	reg  *registry.Registry
-	repo repository.WorkerRepository
+	reg         *registry.Registry
+	repo        repository.WorkerRepository
+	runtimeType types.RuntimeType
+	gatewayPort int
 }
 
 // NewWorkerHandler creates a new WorkerHandler.
-func NewWorkerHandler(reg *registry.Registry, repo repository.WorkerRepository) *WorkerHandler {
-	return &WorkerHandler{reg: reg, repo: repo}
+func NewWorkerHandler(reg *registry.Registry, repo repository.WorkerRepository, runtimeType types.RuntimeType, gatewayPort int) *WorkerHandler {
+	return &WorkerHandler{reg: reg, repo: repo, runtimeType: runtimeType, gatewayPort: gatewayPort}
 }
 
 // createWorkerReq is the request body for registering a new worker.
@@ -32,8 +39,9 @@ type createWorkerReq struct {
 
 // createWorkerResp is the response body for a newly registered worker.
 type createWorkerResp struct {
-	WorkerName string `json:"worker_name"`
-	Token      string `json:"token"`
+	WorkerName     string `json:"worker_name"`
+	GatewayAddress string `json:"gateway_address"`
+	Token          string `json:"token"`
 }
 
 // CreateWorker godoc
@@ -69,6 +77,14 @@ func (h *WorkerHandler) CreateWorker(c *gin.Context) {
 
 	ctx := c.Request.Context()
 
+	gatewayAddress, err := h.gatewayAddress(ctx)
+	if err != nil {
+		logger.ErrorfCtx(ctx, "worker handler: failed to resolve gateway address: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve worker gateway address"})
+
+		return
+	}
+
 	token, err := h.reg.Preregister(ctx, req.WorkerName)
 	if err != nil {
 		logger.ErrorfCtx(ctx, "worker handler: failed to register worker %q: %v", req.WorkerName, err)
@@ -78,9 +94,29 @@ func (h *WorkerHandler) CreateWorker(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, createWorkerResp{
-		WorkerName: req.WorkerName,
-		Token:      token,
+		WorkerName:     req.WorkerName,
+		GatewayAddress: gatewayAddress,
+		Token:          token,
 	})
+}
+
+func (h *WorkerHandler) gatewayAddress(ctx context.Context) (string, error) {
+	port := fmt.Sprintf("%d", h.gatewayPort)
+	if h.runtimeType == types.RuntimeTypeOpenShift {
+		host, err := gateway.GatewayRouteHost(ctx)
+		if err != nil {
+			return "", err
+		}
+
+		return host + ":" + port, nil
+	}
+
+	domainSuffix := utils.GetEnv("DOMAIN_SUFFIX", "")
+	if domainSuffix == "" {
+		return "", fmt.Errorf("DOMAIN_SUFFIX environment variable not set")
+	}
+
+	return workerconstants.WorkerGatewayName + "." + domainSuffix + ":" + port, nil
 }
 
 // ListWorkers godoc

--- a/ai-services/internal/pkg/catalog/apiserver/router.go
+++ b/ai-services/internal/pkg/catalog/apiserver/router.go
@@ -13,13 +13,15 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
 	bundlesvc "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/bundle"
 	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/registry"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 )
 
 // CreateRouter sets up the Gin router with the necessary routes and authentication middleware for the API server.
-func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist repository.TokenBlacklist, appService repository.ApplicationServiceInterface, workerReg *registry.Registry, workerRepo dbrepo.WorkerRepository, datasourceSvc repository.DatasourceServiceInterface, bundleService bundlesvc.BundleServiceInterface, catalogProvider *catalog.CatalogProvider) *gin.Engine {
+func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist repository.TokenBlacklist, appService repository.ApplicationServiceInterface, workerReg *registry.Registry, workerRepo dbrepo.WorkerRepository, workerGatewayPort int, datasourceSvc repository.DatasourceServiceInterface, bundleService bundlesvc.BundleServiceInterface, catalogProvider *catalog.CatalogProvider) *gin.Engine {
 	if mode := os.Getenv("GIN_MODE"); mode != "" {
 		gin.SetMode(mode)
 	}
@@ -40,7 +42,11 @@ func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist r
 	datasourceH := handlers.NewDatasourceHandler(datasourceSvc)
 	registerCatalogRoutes(v1, handlers.NewCatalogHandler(catalogProvider), handlers.NewResourcesHandler(workerReg), auth)
 	registerApplicationRoutes(v1, handlers.NewApplicationHandler(appService), datasourceH, auth)
-	registerWorkerRoutes(v1, handlers.NewWorkerHandler(workerReg, workerRepo), auth)
+	runtimeType := types.RuntimeTypePodman
+	if vars.RuntimeFactory != nil {
+		runtimeType = vars.RuntimeFactory.GetRuntimeType()
+	}
+	registerWorkerRoutes(v1, handlers.NewWorkerHandler(workerReg, workerRepo, runtimeType, workerGatewayPort), auth)
 	registerDatasourceRoutes(v1, datasourceH, auth)
 	registerBundleRoutes(v1, handlers.NewBundleHandler(bundleService), auth)
 

--- a/ai-services/internal/pkg/catalog/client/worker.go
+++ b/ai-services/internal/pkg/catalog/client/worker.go
@@ -21,8 +21,9 @@ type CreateWorkerRequest struct {
 
 // CreateWorkerResponse is the payload returned by POST /api/v1/workers.
 type CreateWorkerResponse struct {
-	WorkerName string `json:"worker_name"`
-	Token      string `json:"token"`
+	WorkerName     string `json:"worker_name"`
+	GatewayAddress string `json:"gateway_address"`
+	Token          string `json:"token"`
 }
 
 // WorkerClient provides methods for interacting with the worker management API.

--- a/ai-services/internal/pkg/catalog/client/worker.go
+++ b/ai-services/internal/pkg/catalog/client/worker.go
@@ -40,6 +40,11 @@ func NewWorkerClient(ctx context.Context) (*WorkerClient, error) {
 	return &WorkerClient{client: c}, nil
 }
 
+// ServerURL returns the catalog API server URL this client is connected to.
+func (c *WorkerClient) ServerURL() string {
+	return c.client.ServerURL()
+}
+
 // CreateWorker pre-registers a new worker by name and returns its bootstrap token.
 func (c *WorkerClient) CreateWorker(ctx context.Context, name string) (*CreateWorkerResponse, error) {
 	var result CreateWorkerResponse

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -54,13 +54,8 @@ const (
 	ArgParamWorkerPodmanURI   = "worker.podman.uri"
 	ArgParamWorkerAuthFile    = "worker.podman.authFileContent"
 
-	// PodmanGatewayServerName is the default DNS SAN embedded in the auto-generated
-	// gateway server certificate for the Podman runtime.
-	PodmanGatewayServerName = "gateway.ai-services.internal"
-
-	// PodmanGatewayPodName is the Podman catalog pod DNS name embedded in the
-	// auto-generated gateway server certificate.
-	PodmanGatewayPodName = "ai-services--catalog"
+	// WorkerGatewayName is the DNS name used by the catalog worker gateway route.
+	WorkerGatewayName = "catalog-worker-gateway"
 
 	// OpenShiftGatewayServiceEndpoint is the OpenShift service DNS name embedded in the
 	// auto-generated gateway server certificate for internal cluster communication.

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -42,6 +42,9 @@ const (
 	// MetaKeyBaseDir is the worker metadata key sent during Register and stored in worker.metadata JSON.
 	MetaKeyBaseDir = "baseDir"
 
+	// WorkerGatewayPort is the default port used by the catalog gRPC worker gateway.
+	WorkerGatewayPort = 9090
+
 	// ArgParamCaddyHTTPSPort, ArgParamWorkerToken, ArgParamWorkerGatewayAddr,
 	// ArgParamWorkerPodmanURI, and ArgParamWorkerAuthFile are template
 	// value-override keys used when deploying worker pods.

--- a/ai-services/internal/pkg/worker/gateway/gateway_test.go
+++ b/ai-services/internal/pkg/worker/gateway/gateway_test.go
@@ -463,3 +463,77 @@ func TestGateway_CommandStream_Disconnect(t *testing.T) {
 		t.Error("expected worker-4 to be removed from registry after disconnect")
 	}
 }
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PKI / SAN tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestGenerateServerCert_MultiSAN(t *testing.T) {
+	caKey, caCert, _, err := generateCA()
+	if err != nil {
+		t.Fatalf("generateCA: %v", err)
+	}
+
+	sans := []string{"gateway.ai-services.internal", "gateway.10.0.0.1.nip.io"}
+	_, certDER, err := generateServerCert(caCert, caKey, sans)
+	if err != nil {
+		t.Fatalf("generateServerCert: %v", err)
+	}
+
+	parsed, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+
+	got := make(map[string]bool, len(parsed.DNSNames))
+	for _, n := range parsed.DNSNames {
+		got[n] = true
+	}
+	for _, want := range sans {
+		if !got[want] {
+			t.Errorf("expected SAN %q in cert, got DNSNames=%v", want, parsed.DNSNames)
+		}
+	}
+}
+
+func TestGenerateAndPersistPKI_PodmanSANs(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Setenv("DOMAIN_SUFFIX", "10.0.0.1.nip.io")
+
+	res, err := generateAndPersistPKI(t.Context(), dir, "podman")
+	if err != nil {
+		t.Fatalf("generateAndPersistPKI: %v", err)
+	}
+
+	leaf, err := x509.ParseCertificate(res.serverCert.Certificate[0])
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+
+	// Exactly one SAN: the domain-derived name only — no internal constant.
+	if len(leaf.DNSNames) != 1 || leaf.DNSNames[0] != "gateway.10.0.0.1.nip.io" {
+		t.Errorf("expected SAN [gateway.10.0.0.1.nip.io]; got DNSNames=%v", leaf.DNSNames)
+	}
+}
+
+func TestGenerateAndPersistPKI_PodmanNoEnv(t *testing.T) {
+	dir := t.TempDir()
+
+	// DOMAIN_SUFFIX not set: must return an error, not a partial cert.
+	t.Setenv("DOMAIN_SUFFIX", "")
+
+	_, err := generateAndPersistPKI(t.Context(), dir, "podman")
+	if err == nil {
+		t.Fatal("expected error when DOMAIN_SUFFIX is unset, got nil")
+	}
+}
+
+func TestGenerateAndPersistPKI_UnknownRuntime(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := generateAndPersistPKI(t.Context(), dir, "unknown")
+	if err == nil {
+		t.Fatal("expected error for unsupported runtime type, got nil")
+	}
+}

--- a/ai-services/internal/pkg/worker/gateway/gateway_test.go
+++ b/ai-services/internal/pkg/worker/gateway/gateway_test.go
@@ -474,7 +474,7 @@ func TestGenerateServerCert_MultiSAN(t *testing.T) {
 		t.Fatalf("generateCA: %v", err)
 	}
 
-	sans := []string{"gateway.ai-services.internal", "gateway.10.0.0.1.nip.io"}
+	sans := []string{"catalog-worker-gateway.example.com"}
 	_, certDER, err := generateServerCert(caCert, caKey, sans)
 	if err != nil {
 		t.Fatalf("generateServerCert: %v", err)
@@ -498,8 +498,7 @@ func TestGenerateServerCert_MultiSAN(t *testing.T) {
 
 func TestGenerateAndPersistPKI_PodmanSANs(t *testing.T) {
 	dir := t.TempDir()
-
-	t.Setenv("DOMAIN_SUFFIX", "10.0.0.1.nip.io")
+	t.Setenv("DOMAIN_SUFFIX", "example.com")
 
 	res, err := generateAndPersistPKI(t.Context(), dir, "podman")
 	if err != nil {
@@ -511,19 +510,15 @@ func TestGenerateAndPersistPKI_PodmanSANs(t *testing.T) {
 		t.Fatalf("ParseCertificate: %v", err)
 	}
 
-	// Exactly one SAN: the domain-derived name only — no internal constant.
-	if len(leaf.DNSNames) != 1 || leaf.DNSNames[0] != "gateway.10.0.0.1.nip.io" {
-		t.Errorf("expected SAN [gateway.10.0.0.1.nip.io]; got DNSNames=%v", leaf.DNSNames)
+	if len(leaf.DNSNames) != 1 || leaf.DNSNames[0] != "catalog-worker-gateway.example.com" {
+		t.Errorf("expected SANs [catalog-worker-gateway.example.com]; got DNSNames=%v", leaf.DNSNames)
 	}
 }
 
-func TestGenerateAndPersistPKI_PodmanNoEnv(t *testing.T) {
-	dir := t.TempDir()
-
-	// DOMAIN_SUFFIX not set: must return an error, not a partial cert.
+func TestGenerateAndPersistPKI_PodmanNoDomain(t *testing.T) {
 	t.Setenv("DOMAIN_SUFFIX", "")
 
-	_, err := generateAndPersistPKI(t.Context(), dir, "podman")
+	_, err := generateAndPersistPKI(t.Context(), t.TempDir(), "podman")
 	if err == nil {
 		t.Fatal("expected error when DOMAIN_SUFFIX is unset, got nil")
 	}

--- a/ai-services/internal/pkg/worker/gateway/pki.go
+++ b/ai-services/internal/pkg/worker/gateway/pki.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 )
 
@@ -93,8 +94,9 @@ func generateCA() (*ecdsa.PrivateKey, *x509.Certificate, []byte, error) {
 }
 
 // generateServerCert creates a new ECDSA P-256 server key and signs it with the CA.
-// serverNames are the hostnames embedded as DNS SANs (must match what workers dial).
-func generateServerCert(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, serverNames []string) (*ecdsa.PrivateKey, []byte, error) {
+// dnsNames is the list of DNS SANs embedded in the cert — must exactly match the
+// hostname(s) workers will use to dial the gateway.
+func generateServerCert(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, dnsNames []string) (*ecdsa.PrivateKey, []byte, error) {
 	srvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, nil, fmt.Errorf("generate server key: %w", err)
@@ -103,7 +105,7 @@ func generateServerCert(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, serve
 	srvTemplate := &x509.Certificate{
 		SerialNumber: srvSerial,
 		Subject:      pkix.Name{CommonName: "Catalog"},
-		DNSNames:     serverNames,
+		DNSNames:     dnsNames,
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().Add(serverCertTTL),
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
@@ -121,22 +123,34 @@ func generateServerCert(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, serve
 // certificate, then writes all four PEM files to pkiDir.
 //
 // For OpenShift the server cert's DNS SANs include both the live passthrough
-// route host and the internal service endpoint. For Podman they include the
-// catalog pod name and the static internal name.
+// route host and the internal service endpoint. For Podman the SAN is
+// "gateway.<DOMAIN_SUFFIX>" — DOMAIN_SUFFIX is injected into the backend
+// container by the pod template and covers nip.io auto-suffix, --domain-name,
+// and cert-extracted domains. Workers must always dial by domain name; dialling
+// by raw IP is not supported.
 func generateAndPersistPKI(ctx context.Context, pkiDir string, runtimeType types.RuntimeType) (pkiResult, error) {
 	empty := pkiResult{}
 
-	serverNames := []string{}
+	var dnsNames []string
+
 	switch runtimeType {
 	case types.RuntimeTypeOpenShift:
 		route, err := GatewayRouteHost(ctx)
 		if err != nil {
 			return empty, fmt.Errorf("resolve gateway route host for cert SAN: %w", err)
 		}
-		serverNames = []string{route, workerconstants.OpenShiftGatewayServiceEndpoint}
+		dnsNames = []string{route, workerconstants.OpenShiftGatewayServiceEndpoint}
 	case types.RuntimeTypePodman:
-		serverNames = []string{workerconstants.PodmanGatewayServerName, workerconstants.PodmanGatewayPodName}
+		domainSuffix := utils.GetEnv("DOMAIN_SUFFIX", "")
+		if domainSuffix == "" {
+			return empty, fmt.Errorf("DOMAIN_SUFFIX environment variable not set — cannot generate gateway server cert")
+		}
+		dnsNames = []string{"gateway." + domainSuffix, workerconstants.PodmanGatewayServerName, workerconstants.PodmanGatewayPodName}
+	default:
+		return empty, fmt.Errorf("unsupported runtime type %q for gateway PKI generation", runtimeType)
 	}
+
+	logger.InfofCtx(ctx, "worker gateway: generating server cert with SANs: %v", dnsNames)
 
 	if err := os.MkdirAll(pkiDir, dirPerm); err != nil {
 		return empty, fmt.Errorf("mkdir %s: %w", pkiDir, err)
@@ -147,7 +161,7 @@ func generateAndPersistPKI(ctx context.Context, pkiDir string, runtimeType types
 		return empty, err
 	}
 
-	srvKey, srvCertDER, err := generateServerCert(caCert, caKey, serverNames)
+	srvKey, srvCertDER, err := generateServerCert(caCert, caKey, dnsNames)
 	if err != nil {
 		return empty, err
 	}

--- a/ai-services/internal/pkg/worker/gateway/pki.go
+++ b/ai-services/internal/pkg/worker/gateway/pki.go
@@ -123,31 +123,35 @@ func generateServerCert(caCert *x509.Certificate, caKey *ecdsa.PrivateKey, dnsNa
 // certificate, then writes all four PEM files to pkiDir.
 //
 // For OpenShift the server cert's DNS SANs include both the live passthrough
-// route host and the internal service endpoint. For Podman the SAN is
-// "gateway.<DOMAIN_SUFFIX>" — DOMAIN_SUFFIX is injected into the backend
-// container by the pod template and covers nip.io auto-suffix, --domain-name,
-// and cert-extracted domains. Workers must always dial by domain name; dialling
-// by raw IP is not supported.
-func generateAndPersistPKI(ctx context.Context, pkiDir string, runtimeType types.RuntimeType) (pkiResult, error) {
-	empty := pkiResult{}
-
-	var dnsNames []string
-
+// route host and the internal service endpoint. For Podman the SAN includes the
+// domain-derived gateway name.
+func serverCertDNSNames(ctx context.Context, runtimeType types.RuntimeType) ([]string, error) {
 	switch runtimeType {
 	case types.RuntimeTypeOpenShift:
 		route, err := GatewayRouteHost(ctx)
 		if err != nil {
-			return empty, fmt.Errorf("resolve gateway route host for cert SAN: %w", err)
+			return nil, fmt.Errorf("resolve gateway route host for cert SAN: %w", err)
 		}
-		dnsNames = []string{route, workerconstants.OpenShiftGatewayServiceEndpoint}
+
+		return []string{route, workerconstants.OpenShiftGatewayServiceEndpoint}, nil
 	case types.RuntimeTypePodman:
 		domainSuffix := utils.GetEnv("DOMAIN_SUFFIX", "")
 		if domainSuffix == "" {
-			return empty, fmt.Errorf("DOMAIN_SUFFIX environment variable not set — cannot generate gateway server cert")
+			return nil, fmt.Errorf("DOMAIN_SUFFIX environment variable not set — cannot generate gateway server cert")
 		}
-		dnsNames = []string{"gateway." + domainSuffix, workerconstants.PodmanGatewayServerName, workerconstants.PodmanGatewayPodName}
+
+		return []string{workerconstants.WorkerGatewayName + "." + domainSuffix}, nil
 	default:
-		return empty, fmt.Errorf("unsupported runtime type %q for gateway PKI generation", runtimeType)
+		return nil, fmt.Errorf("unsupported runtime type %q for gateway PKI generation", runtimeType)
+	}
+}
+
+func generateAndPersistPKI(ctx context.Context, pkiDir string, runtimeType types.RuntimeType) (pkiResult, error) {
+	empty := pkiResult{}
+
+	dnsNames, err := serverCertDNSNames(ctx, runtimeType)
+	if err != nil {
+		return empty, err
 	}
 
 	logger.InfofCtx(ctx, "worker gateway: generating server cert with SANs: %v", dnsNames)

--- a/ai-services/internal/pkg/worker/join/join.go
+++ b/ai-services/internal/pkg/worker/join/join.go
@@ -20,6 +20,7 @@ package join
 import (
 	"context"
 	"fmt"
+	"net"
 	"time"
 
 	"google.golang.org/grpc"
@@ -54,6 +55,13 @@ const (
 // StartGrpcStream dials the catalog gRPC worker-gateway, registers with the
 // bootstrap token, and holds the CommandStream open.
 func StartGrpcStream(ctx context.Context, rt runtime.Runtime, pr *workercaddy.ProxyRouter, opts workertypes.GrpcStreamOptions) error {
+	if opts.GatewayAddr == "" {
+		return fmt.Errorf("worker join: gateway address is required (e.g. gateway.10.0.0.1.nip.io:9090)")
+	}
+	if _, _, err := net.SplitHostPort(opts.GatewayAddr); err != nil {
+		return fmt.Errorf("worker join: invalid gateway address %q — must be host:port (e.g. gateway.10.0.0.1.nip.io:9090)", opts.GatewayAddr)
+	}
+
 	tlsDir := workerconstants.WorkerTLSDir
 	// ── Step 1: Check for existing valid mTLS credentials & stream loop ────────────────────
 	if hasValidTLSCredentials(ctx, tlsDir) {

--- a/ai-services/internal/pkg/worker/join/tls.go
+++ b/ai-services/internal/pkg/worker/join/tls.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 )
 
 const (
@@ -66,9 +65,8 @@ func loadClientCert(tlsDir string) (tls.Certificate, error) {
 	return cert, nil
 }
 
-// buildTLSConfig returns a *tls.Config for dialing the gateway. When the target
-// includes a host or IP, we verify against that exact address. Otherwise we fall
-// back to the podman/internal default name.
+// buildTLSConfig returns a *tls.Config for dialing the gateway. The gateway
+// address must contain a DNS hostname so it can be verified against the server certificate SANs.
 func buildTLSConfig(gatewayAddr, tlsDir string, clientCert *tls.Certificate) (*tls.Config, error) {
 	cfg := &tls.Config{}
 	if clientCert != nil {
@@ -87,7 +85,11 @@ func buildTLSConfig(gatewayAddr, tlsDir string, clientCert *tls.Certificate) (*t
 			return nil, fmt.Errorf("parse ca.crt: no valid certificates found")
 		}
 		cfg.RootCAs = pool
-		cfg.ServerName = gatewayServerName(gatewayAddr)
+		serverName, err := gatewayServerName(gatewayAddr)
+		if err != nil {
+			return nil, err
+		}
+		cfg.ServerName = serverName
 	case os.IsNotExist(err):
 		cfg.InsecureSkipVerify = true //nolint:gosec // intentional TOFU bootstrap fallback
 	default:
@@ -97,24 +99,25 @@ func buildTLSConfig(gatewayAddr, tlsDir string, clientCert *tls.Certificate) (*t
 	return cfg, nil
 }
 
-func gatewayServerName(gatewayAddr string) string {
+func gatewayServerName(gatewayAddr string) (string, error) {
 	if gatewayAddr == "" {
-		return workerconstants.PodmanGatewayServerName
+		return "", fmt.Errorf("gateway address is empty")
 	}
 	if parsed, err := url.Parse(gatewayAddr); err == nil && parsed.Host != "" {
 		gatewayAddr = parsed.Host
 	}
-	if host, _, err := net.SplitHostPort(gatewayAddr); err == nil {
-		gatewayAddr = host
+	host, _, err := net.SplitHostPort(gatewayAddr)
+	if err != nil {
+		return "", fmt.Errorf("invalid gateway address %q: must be host:port", gatewayAddr)
 	}
-	if gatewayAddr == "" {
-		return workerconstants.PodmanGatewayServerName
+	if host == "" {
+		return "", fmt.Errorf("invalid gateway address %q: hostname is empty", gatewayAddr)
 	}
-	if ip := net.ParseIP(gatewayAddr); ip != nil {
-		return workerconstants.PodmanGatewayServerName
+	if net.ParseIP(host) != nil {
+		return "", fmt.Errorf("invalid gateway address %q: IP addresses are not supported", gatewayAddr)
 	}
 
-	return gatewayAddr
+	return host, nil
 }
 
 // writeTLSMaterial creates tlsDir (mode 0700) and writes the three PEM files


### PR DESCRIPTION
## Summary

- Return the worker gateway address from the catalog worker registration API.
- Use the API-provided gateway address in the generated `worker join` command.
- Generate Podman gateway certificates with a SAN matching the domain-derived gateway hostname.
- Support the configured gateway port in the returned address.
- Reject empty, malformed, and IP-based gateway addresses during TLS server-name validation.
- Add unit coverage for domain-derived SAN generation and missing `DOMAIN_SUFFIX` validation.

## Worker registration

The catalog worker registration API now returns the worker name, gateway address, and single-use bootstrap token:

```json
{
  "worker_name": "worker0",
  "gateway_address": "catalog-worker-gateway.example.com:9090",
  "token": "***"
}
```
Join message:
```
$ ./bin/ai-services-linux-ppc64le catalog worker register worker0

Worker registered successfully.
  Name:  worker0
  Token: ***

Run the following command on the worker node:
  ai-services worker join catalog-worker-gateway.example.com:9090 --token *** --runtime <runtime>

The token is single-use and expires after 24 hours.
```

Note: If the configured custom domain is not resolvable from the worker environment, provide an explicit host mapping with --add-host during the worker join.


```
$ ./bin/ai-services-linux-ppc64le worker join \
    catalog-worker-gateway.example.com:9090 \
    --token *** \
    --runtime podman \
    --add-host catalog-worker-gateway.example.com:<gatewayIP>
```