### PR TITLE
Support hostAliases for Openshift worker

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.341
+TAG?=v0.0.342
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.341
+  image: icr.io/ai-services-cicd/ai-services:v0.0.342
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.341
+  image: icr.io/ai-services-cicd/ai-services:v0.0.342
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/templates/worker.yaml
+++ b/ai-services/assets/worker/openshift/templates/worker.yaml
@@ -22,6 +22,16 @@ spec:
     spec:
       serviceAccountName: ai-services-sa
       automountServiceAccountToken: true
+      {{- if .Values.hostAliases }}
+      hostAliases:
+      {{- range .Values.hostAliases }}
+      - ip: "{{ .IP }}"
+        hostnames:
+        {{- range .Hostnames }}
+          - "{{ . }}"
+        {{- end }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: worker
           image: "{{ .Values.worker.image }}"

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.341
+  image: icr.io/ai-services-cicd/ai-services:v0.0.342
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.341
+  image: icr.io/ai-services-cicd/ai-services:v0.0.342
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/cmd/ai-services/cmd/worker/join.go
+++ b/ai-services/cmd/ai-services/cmd/worker/join.go
@@ -177,13 +177,15 @@ func joinRunE(cmd *cobra.Command, args []string) error {
 				Token:       token,
 			},
 			Setup: workertypes.Options{
-				BaseDir:     aiServicesDir,
-				HTTPSPort:   httpsPort,
-				DomainName:  domainName,
-				SSLCertPath: catalogUtils.SanitizeFilePath(sslCertPath),
-				SSLKeyPath:  catalogUtils.SanitizeFilePath(sslKeyPath),
-				HostAliases: parseAddHosts(addHosts),
-			},
+					CommonWorkerOptions: workertypes.CommonWorkerOptions{
+						HostAliases: parseAddHosts(addHosts),
+					},
+					BaseDir:     aiServicesDir,
+					HTTPSPort:   httpsPort,
+					DomainName:  domainName,
+					SSLCertPath: catalogUtils.SanitizeFilePath(sslCertPath),
+					SSLKeyPath:  catalogUtils.SanitizeFilePath(sslKeyPath),
+				},
 		}
 
 		// Setup worker node
@@ -195,6 +197,9 @@ func joinRunE(cmd *cobra.Command, args []string) error {
 			WorkerConnectionOptions: workertypes.WorkerConnectionOptions{
 				GatewayAddr: gatewayAddr,
 				Token:       token,
+			},
+			CommonWorkerOptions: workertypes.CommonWorkerOptions{
+				HostAliases: parseAddHosts(addHosts),
 			},
 		}
 		if err := workeropenshift.DeployWorker(ctx, opts); err != nil {

--- a/ai-services/cmd/ai-services/cmd/worker/join.go
+++ b/ai-services/cmd/ai-services/cmd/worker/join.go
@@ -258,7 +258,7 @@ func configureFlags(c *cobra.Command) {
 		"Add an extra entry to the worker pod's /etc/hosts (repeatable).\n"+
 			"Format: DOMAIN:IP\n"+
 			"Note: Supported for podman runtime only.\n"+
-			"Example: --add-host catalog.example.com:10.20.188.75\n")
+			"Example: --add-host catalog-worker-gateway.example.com:10.20.188.75\n")
 }
 
 func newJoinCmd() *cobra.Command {

--- a/ai-services/cmd/ai-services/cmd/worker/join.go
+++ b/ai-services/cmd/ai-services/cmd/worker/join.go
@@ -177,15 +177,15 @@ func joinRunE(cmd *cobra.Command, args []string) error {
 				Token:       token,
 			},
 			Setup: workertypes.Options{
-					CommonWorkerOptions: workertypes.CommonWorkerOptions{
-						HostAliases: parseAddHosts(addHosts),
-					},
-					BaseDir:     aiServicesDir,
-					HTTPSPort:   httpsPort,
-					DomainName:  domainName,
-					SSLCertPath: catalogUtils.SanitizeFilePath(sslCertPath),
-					SSLKeyPath:  catalogUtils.SanitizeFilePath(sslKeyPath),
+				CommonWorkerOptions: workertypes.CommonWorkerOptions{
+					HostAliases: parseAddHosts(addHosts),
 				},
+				BaseDir:     aiServicesDir,
+				HTTPSPort:   httpsPort,
+				DomainName:  domainName,
+				SSLCertPath: catalogUtils.SanitizeFilePath(sslCertPath),
+				SSLKeyPath:  catalogUtils.SanitizeFilePath(sslKeyPath),
+			},
 		}
 
 		// Setup worker node

--- a/ai-services/internal/pkg/constants/common.go
+++ b/ai-services/internal/pkg/constants/common.go
@@ -10,7 +10,7 @@ const (
 	OperatorPollTimeout  = 3 * time.Minute
 
 	// HelmTimeout is the default timeout for a Helm install/upgrade operation.
-	HelmTimeout = 10 * time.Minute
+	HelmTimeout = 20 * time.Minute
 	// HelmUninstallTimeout is the default timeout for a Helm uninstall operation.
 	HelmUninstallTimeout = 5 * time.Minute
 	// PredictorWaitTimeout is the maximum time to wait for a KServe InferenceService

--- a/ai-services/internal/pkg/worker/deploy/openshift/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/openshift/deploy.go
@@ -62,6 +62,8 @@ func prepareValues(tp templates.Template, opts workertypes.OpenshiftWorkerOption
 		return nil, fmt.Errorf("failed to prepare values: %w", err)
 	}
 
+	values["hostAliases"] = opts.HostAliases
+
 	return values, nil
 }
 

--- a/ai-services/internal/pkg/worker/dispatch/dispatch.go
+++ b/ai-services/internal/pkg/worker/dispatch/dispatch.go
@@ -45,7 +45,7 @@ func Dispatch(ctx context.Context, rt runtime.Runtime, pr *workercaddy.ProxyRout
 }
 
 // defaultHelmTimeout is used when the caller does not supply a timeout.
-const defaultHelmTimeout = 10 * time.Minute
+const defaultHelmTimeout = 20 * time.Minute
 
 // ─── router ───────────────────────────────────────────────────────────────────
 

--- a/ai-services/internal/pkg/worker/types/models.go
+++ b/ai-services/internal/pkg/worker/types/models.go
@@ -22,16 +22,6 @@ type PodmanWorkerOptions struct {
 	Setup Options
 }
 
-// OpenshiftWorkerOptions carries everything needed to join a worker to the catalog control plane.
-type OpenshiftWorkerOptions struct {
-	WorkerConnectionOptions
-}
-
-// GrpcStreamOptions carries everything needed to join a worker to the catalog control plane.
-type GrpcStreamOptions struct {
-	WorkerConnectionOptions
-}
-
 // HostAlias maps an IP address to one or more hostnames, injected into the
 // worker pod's /etc/hosts file via the Kubernetes hostAliases spec field.
 type HostAlias struct {
@@ -39,8 +29,29 @@ type HostAlias struct {
 	Hostnames []string
 }
 
+// CommonWorkerOptions holds options that are shared across all runtime types.
+type CommonWorkerOptions struct {
+	// HostAliases is an optional list of extra /etc/hosts entries to inject
+	// into the worker pod. Each entry is supplied via --add-host=DOMAIN:IP on
+	// the CLI and is rendered into the pod spec's hostAliases field.
+	HostAliases []HostAlias
+}
+
+// OpenshiftWorkerOptions carries everything needed to join a worker to the catalog control plane.
+type OpenshiftWorkerOptions struct {
+	WorkerConnectionOptions
+	CommonWorkerOptions
+}
+
+// GrpcStreamOptions carries everything needed to join a worker to the catalog control plane.
+type GrpcStreamOptions struct {
+	WorkerConnectionOptions
+}
+
 // Options carries the parameters needed to set up the worker node.
 type Options struct {
+	CommonWorkerOptions
+
 	// BaseDir is the host directory used for worker data / config volumes
 	// (Caddy config, models, etc.).
 	// Set once at first join; ignored on subsequent runs if already deployed.
@@ -58,8 +69,4 @@ type Options struct {
 	// SSLKeyPath is the path to a user-provided SSL private key (PEM).
 	// Must be used together with SSLCertPath.
 	SSLKeyPath string
-	// HostAliases is an optional list of extra /etc/hosts entries to inject
-	// into the worker pod. Each entry is supplied via --add-host=DOMAIN:IP on
-	// the CLI and is rendered into the pod spec's hostAliases field.
-	HostAliases []HostAlias
 }


### PR DESCRIPTION
- This is to support adding hostAliases for Openshift remote worker to allow worker pod to be able to join to the remote Openshift cluster.
- Also increases Helm Install timeout to 20 mins as 10 mins is quite less as I see isvc storage initilizers sometimes takes time to initialize.