### PR TITLE
fix: use proper container path for certs

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.343
+TAG?=v0.0.344
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/templates/catalog-backend.yaml
+++ b/ai-services/assets/catalog/openshift/templates/catalog-backend.yaml
@@ -144,7 +144,7 @@ spec:
             - name: catalog-bundles
               mountPath: /data/catalog-bundles
             - name: gateway-pki
-              mountPath: /var/lib/ai-services/gateway-pki
+              mountPath: /data/gateway-pki
           resources:
             requests:
               memory: "{{ .Values.backend.resources.requests.memory }}"

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.343
+  image: icr.io/ai-services-cicd/ai-services:v0.0.344
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -157,7 +157,7 @@ spec:
         - name: ai-services-data
           mountPath: {{ .BaseDir }}
         - name: gateway-pki
-          mountPath: /var/lib/ai-services/gateway-pki
+          mountPath: /data/gateway-pki
         - name: catalog-secret
           mountPath: /etc/secret/catalog-secret
           readOnly: true

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.343
+  image: icr.io/ai-services-cicd/ai-services:v0.0.344
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/templates/worker.yaml
+++ b/ai-services/assets/worker/openshift/templates/worker.yaml
@@ -61,7 +61,7 @@ spec:
               cpu: "{{ .Values.worker.resources.limits.cpu }}"
           volumeMounts:
             - name: worker-tls
-              mountPath: /var/lib/ai-services/worker-tls
+              mountPath: /data/worker-tls
       volumes:
         - name: worker-tls
           persistentVolumeClaim:

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.343
+  image: icr.io/ai-services-cicd/ai-services:v0.0.344
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/templates/worker.yaml.tmpl
+++ b/ai-services/assets/worker/podman/templates/worker.yaml.tmpl
@@ -69,7 +69,7 @@ spec:
           mountPath: /etc/secret/worker-mtls-encryption-secret
           readOnly: true
         - name: worker-tls
-          mountPath: /var/lib/ai-services/worker-tls
+          mountPath: /data/worker-tls
         - name: ai-services-data
           mountPath: {{ .BaseDir }}
       resources:

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.343
+  image: icr.io/ai-services-cicd/ai-services:v0.0.344
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -25,13 +25,13 @@ const (
 	// credentials are stored. The host-side `worker join` command also writes
 	// to this path (outside a container). Single source of truth shared between
 	// the join, deploy, and uninstall packages.
-	WorkerTLSDir = "/var/lib/ai-services/worker-tls"
+	WorkerTLSDir = "/data/worker-tls"
 
 	// GatewayPKIDir is the mount path inside the catalog container where gateway
 	// PKI files (CA key/cert, server key/cert) are persisted. Backed by the
 	// gateway-pki podman PVC. Single source of truth shared between gateway and
 	// the catalog pod template.
-	GatewayPKIDir = "/var/lib/ai-services/gateway-pki"
+	GatewayPKIDir = "/data/gateway-pki"
 
 	// WorkerCaddyPodName is the name of the Caddy reverse-proxy pod.
 	WorkerCaddyPodName = "ai-services--caddy"

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -22,9 +22,10 @@ const (
 	WorkerAppTemplate     = "worker"
 	WorkerHelmReleaseName = "ai-services-worker"
 	// WorkerTLSDir is the mount path inside the worker container where mTLS
-	// credentials are stored. The host-side `worker join` command also writes
-	// to this path (outside a container). Single source of truth shared between
-	// the join, deploy, and uninstall packages.
+	// credentials are stored. Backed by the worker-tls Podman PVC; the path is
+	// container-internal and must not overlap with the ai-services-data hostPath
+	// bind mount. Single source of truth shared between the join, deploy, and
+	// uninstall packages.
 	WorkerTLSDir = "/data/worker-tls"
 
 	// GatewayPKIDir is the mount path inside the catalog container where gateway


### PR DESCRIPTION
The mount paths were moved to non-overlapping container-internal paths:
- worker-tls → /data/worker-tls
- gateway-pki → /data/gateway-pki


This will avoid conflict with the default hostPath mount used by BaseDir.