### PR TITLE
Removing deprecated opensearch param

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.339
+TAG?=v0.0.340
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-dev/openshift/templates/opensearch-statefulset.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/templates/opensearch-statefulset.yaml
@@ -36,10 +36,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: cluster.initial_master_nodes
+            - name: cluster.initial_cluster_manager_nodes
               value: "{{ range $i := until (int .Values.opensearch.replicas) }}{{ if $i }},{{ end }}opensearch-{{ $i }}{{ end }}"
             - name: discovery.seed_hosts
-              value: opensearch-headless
+              value: "opensearch-headless"
             - name: network.host
               value: 0.0.0.0
             - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD

--- a/ai-services/assets/applications/rag/openshift/templates/opensearch-statefulset.yaml
+++ b/ai-services/assets/applications/rag/openshift/templates/opensearch-statefulset.yaml
@@ -36,10 +36,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: cluster.initial_master_nodes
+            - name: cluster.initial_cluster_manager_nodes
               value: "{{ range $i := until (int .Values.opensearch.replicas) }}{{ if $i }},{{ end }}opensearch-{{ $i }}{{ end }}"
             - name: discovery.seed_hosts
-              value: opensearch-headless
+              value: "opensearch-headless"
             - name: network.host
               value: 0.0.0.0
             - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.339
+  image: icr.io/ai-services-cicd/ai-services:v0.0.340
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.339
+  image: icr.io/ai-services-cicd/ai-services:v0.0.340
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/components/vector_db/opensearch/openshift/templates/opensearch-statefulset.yaml
+++ b/ai-services/assets/components/vector_db/opensearch/openshift/templates/opensearch-statefulset.yaml
@@ -36,10 +36,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: cluster.initial_master_nodes
+            - name: cluster.initial_cluster_manager_nodes
               value: "{{ range $i := until (int .Values.replicas) }}{{ if $i }},{{ end }}opensearch-{{ $i }}{{ end }}"
             - name: discovery.seed_hosts
-              value: opensearch-headless
+              value: "opensearch-headless"
             - name: network.host
               value: 0.0.0.0
             - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.339
+  image: icr.io/ai-services-cicd/ai-services:v0.0.340
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.339
+  image: icr.io/ai-services-cicd/ai-services:v0.0.340
   runtime: "podman"
   token: ""
   gatewayAddr: ""


### PR DESCRIPTION
Changing from `cluster.initial_master_nodes` to `initial_cluster_manager_nodes` since `initial_master_nodes` is deprecated and will be removed in 4.x