### PR TITLE
Cleanup process pool after every conversion to avoid mem corruption

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.334
+TAG?=v0.0.335
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.58
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.59
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.58
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.59
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.58
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.59
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.58
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.59
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.58
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.59
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.334
+  image: icr.io/ai-services-cicd/ai-services:v0.0.335
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.334
+  image: icr.io/ai-services-cicd/ai-services:v0.0.335
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/services/digitize/openshift/values.yaml
+++ b/ai-services/assets/services/digitize/openshift/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.58
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.59
   log_level: "INFO"
   database: "digitize_metadata"
   numShards: 1

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.58
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.59
   log_level: "INFO"
   database: "digitize_metadata"
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.334
+  image: icr.io/ai-services-cicd/ai-services:v0.0.335
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.334
+  image: icr.io/ai-services-cicd/ai-services:v0.0.335
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.58
+TAG?=v0.0.59
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/workers/conversion_dispatcher.py
+++ b/services/digitize/workers/conversion_dispatcher.py
@@ -31,6 +31,7 @@ narrower — only fires when a real task is blocked on semaphore capacity.
 """
 
 import asyncio
+import multiprocessing
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
@@ -159,7 +160,9 @@ async def dispatch_loop() -> None:
     global _op_turn, _connector_rr_index, _process_pool
 
     _process_pool = ProcessPoolExecutor(
-        max_workers=conversion_semaphore.capacity  # default 4
+        max_workers=conversion_semaphore.capacity,  # default 4
+        mp_context=multiprocessing.get_context("spawn"),
+        max_tasks_per_child=1,
     )
     logger.info(
         f"Conversion dispatcher started (pool workers={conversion_semaphore.capacity})"


### PR DESCRIPTION
**Problem:**
During a large batch ingestion job, the service crashed with:
```
concurrent.futures.process.BrokenProcessPool: A process in the process pool was
terminated abruptly while the future was running or pending.
```
This caused the entire application to restart, marking all in-progress and queued conversion tasks as failed.

**Analysis:**
The root cause is unbounded memory growth in long-lived worker processes. The ProcessPoolExecutor was created with no max_tasks_per_child limit, so the same 4 worker processes were reused for the entire lifetime of the application. Each Docling DocumentConverter.convert() call loads ML model weights and accumulates internal layout/page state that Python's GC does not fully reclaim between tasks. After processing several hundred-page documents back-to-back (e.g. 1952 pages + 1562 pages + 1494 pages in the same workers without recycling), memory pressure grew until the OS OOM-killer terminated a worker process mid-task, poisoning the entire pool.

A secondary issue is that the default fork start method on Linux causes each worker to inherit the parent process's full memory image (FastAPI, SQLAlchemy, all loaded modules) before Docling even starts, inflating the baseline RSS of every worker.

**Fix:**

Two changes to the ProcessPoolExecutor construction in conversion_dispatcher.py:

- `max_tasks_per_child=1` — recycles each worker process after it completes one conversion task. All Docling model state, ML tensors, and intermediate page data are freed at the OS level between tasks. Since each conversion takes minutes, the process respawn cost is negligible.
- `mp_context=multiprocessing.get_context("spawn")` — workers start with a clean Python interpreter instead of a fork of the parent, so the parent's loaded application state is not duplicated into every worker's address space before the task begins.