### PR TITLE
fix: handle missing catalog pod in worker join and worker uninstall

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.345
+TAG?=v0.0.346
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/templates/rbac.yaml
+++ b/ai-services/assets/catalog/openshift/templates/rbac.yaml
@@ -1,9 +1,9 @@
-{{- if not (lookup "v1" "ServiceAccount" "ai-services" "ai-services-sa") }}
+{{- if not (lookup "v1" "ServiceAccount" .Release.Namespace "ai-services-sa") }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ai-services-sa
-  namespace: ai-services
+  namespace: {{ .Release.Namespace }}
 {{- end }}
 ---
 {{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "ai-services-manager") }}
@@ -58,7 +58,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ai-services-sa
-    namespace: ai-services
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: ai-services-manager
@@ -76,7 +76,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ai-services-sa
-    namespace: ai-services
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: cluster-monitoring-view

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.345
+  image: icr.io/ai-services-cicd/ai-services:v0.0.346
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.345
+  image: icr.io/ai-services-cicd/ai-services:v0.0.346
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/templates/rbac.yaml
+++ b/ai-services/assets/worker/openshift/templates/rbac.yaml
@@ -1,9 +1,9 @@
-{{- if not (lookup "v1" "ServiceAccount" "ai-services" "ai-services-sa") }}
+{{- if not (lookup "v1" "ServiceAccount" .Release.Namespace "ai-services-sa") }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ai-services-sa
-  namespace: ai-services
+  namespace: {{ .Release.Namespace }}
 {{- end }}
 ---
 {{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "ai-services-manager") }}
@@ -58,7 +58,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ai-services-sa
-    namespace: ai-services
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: ai-services-manager
@@ -76,7 +76,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: ai-services-sa
-    namespace: ai-services
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: cluster-monitoring-view

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.345
+  image: icr.io/ai-services-cicd/ai-services:v0.0.346
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.345
+  image: icr.io/ai-services-cicd/ai-services:v0.0.346
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/cmd/ai-services/cmd/common/common.go
+++ b/ai-services/cmd/ai-services/cmd/common/common.go
@@ -53,11 +53,17 @@ func validateRuntimeType(runtimeType types.RuntimeType) error {
 	}
 }
 
-// IsCatalogLocalWorker inspects the running catalog pod and returns true when
+// IsCatalogLocalWorker inspects the named catalog pod and returns true when
 // the LOCAL_WORKER environment variable is set to "true" inside it.
-func IsCatalogLocalWorker(ctx context.Context, rt runtime.Runtime) (bool, error) {
-	pod, err := rt.InspectPod(ctx, workerconstants.PodmanGatewayPodName)
+// If the catalog pod does not exist on this node, it returns false, nil —
+// which is the expected state on a standalone remote worker.
+func IsCatalogLocalWorker(ctx context.Context, rt runtime.Runtime, podName string) (bool, error) {
+	pod, err := rt.InspectPod(ctx, podName)
 	if err != nil {
+		if utils.IsNotFoundError(err) {
+			return false, nil
+		}
+
 		return false, fmt.Errorf("inspect catalog pod: %w", err)
 	}
 

--- a/ai-services/cmd/ai-services/cmd/common/common.go
+++ b/ai-services/cmd/ai-services/cmd/common/common.go
@@ -3,7 +3,6 @@
 package common
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -14,7 +13,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
-	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 )
 
 // InitAndValidateRuntimeFlag validates the runtime flag value, initialises
@@ -51,31 +49,4 @@ func validateRuntimeType(runtimeType types.RuntimeType) error {
 	default:
 		return fmt.Errorf("unsupported runtime type: %s", runtimeType)
 	}
-}
-
-// IsCatalogLocalWorker inspects the named catalog pod and returns true when
-// the LOCAL_WORKER environment variable is set to "true" inside it.
-// If the catalog pod does not exist on this node, it returns false, nil —
-// which is the expected state on a standalone remote worker.
-func IsCatalogLocalWorker(ctx context.Context, rt runtime.Runtime, podName string) (bool, error) {
-	pod, err := rt.InspectPod(ctx, podName)
-	if err != nil {
-		if utils.IsNotFoundError(err) {
-			return false, nil
-		}
-
-		return false, fmt.Errorf("inspect catalog pod: %w", err)
-	}
-
-	for _, container := range pod.Containers {
-		cInfo, err := rt.InspectContainer(ctx, container.ID)
-		if err != nil {
-			return false, fmt.Errorf("inspect container %s failed: %w", container.ID, err)
-		}
-		if cInfo.Env[workerconstants.LocalWorkerEnvVar] == "true" {
-			return true, nil
-		}
-	}
-
-	return false, nil
 }

--- a/ai-services/cmd/ai-services/cmd/worker/join.go
+++ b/ai-services/cmd/ai-services/cmd/worker/join.go
@@ -17,6 +17,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	workercaddy "github.com/project-ai-services/ai-services/internal/pkg/worker/caddy"
+	workercommon "github.com/project-ai-services/ai-services/internal/pkg/worker/common"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	workeropenshift "github.com/project-ai-services/ai-services/internal/pkg/worker/deploy/openshift"
 	workerpodman "github.com/project-ai-services/ai-services/internal/pkg/worker/deploy/podman"
@@ -102,19 +103,24 @@ func joinPreRunE(cmd *cobra.Command, _ []string) error {
 // catalog control plane, which means it cannot be managed as a standalone worker.
 func checkNotLocalWorker(ctx context.Context) error {
 	rtType := vars.RuntimeFactory.GetRuntimeType()
-	rt, err := runtime.CreateRuntime(rtType, "")
+	rt, err := runtime.CreateRuntime(rtType, workerconstants.WorkerAppName)
 	if err != nil {
 		return fmt.Errorf("worker join: init runtime: %w", err)
 	}
-	podName := workerconstants.PodmanGatewayPodName
-	if rtType == types.RuntimeTypeOpenShift {
-		podName = workerconstants.OpenShiftCatalogPodName
+
+	var localWorker bool
+
+	switch rtType {
+	case types.RuntimeTypeOpenShift:
+		localWorker, err = workercommon.IsOpenShiftLocalWorker(ctx, rt)
+	default:
+		localWorker, err = workercommon.IsPodmanLocalWorker(ctx, rt)
 	}
-	isLocalWorker, err := cmdcommon.IsCatalogLocalWorker(ctx, rt, podName)
+
 	if err != nil {
 		return fmt.Errorf("could not determine LOCAL_WORKER from catalog pod: %w", err)
 	}
-	if isLocalWorker {
+	if localWorker {
 		return fmt.Errorf("the worker is already co-located with the control plane and cannot be joined independently")
 	}
 

--- a/ai-services/cmd/ai-services/cmd/worker/join.go
+++ b/ai-services/cmd/ai-services/cmd/worker/join.go
@@ -95,13 +95,22 @@ func joinPreRunE(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	ctx := context.Background()
+	return checkNotLocalWorker(context.Background())
+}
+
+// checkNotLocalWorker returns an error when this node is co-located with the
+// catalog control plane, which means it cannot be managed as a standalone worker.
+func checkNotLocalWorker(ctx context.Context) error {
 	rtType := vars.RuntimeFactory.GetRuntimeType()
 	rt, err := runtime.CreateRuntime(rtType, "")
 	if err != nil {
 		return fmt.Errorf("worker join: init runtime: %w", err)
 	}
-	isLocalWorker, err := cmdcommon.IsCatalogLocalWorker(ctx, rt)
+	podName := workerconstants.PodmanGatewayPodName
+	if rtType == types.RuntimeTypeOpenShift {
+		podName = workerconstants.OpenShiftCatalogPodName
+	}
+	isLocalWorker, err := cmdcommon.IsCatalogLocalWorker(ctx, rt, podName)
 	if err != nil {
 		return fmt.Errorf("could not determine LOCAL_WORKER from catalog pod: %w", err)
 	}

--- a/ai-services/cmd/ai-services/cmd/worker/join.go
+++ b/ai-services/cmd/ai-services/cmd/worker/join.go
@@ -95,7 +95,7 @@ func joinPreRunE(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	return checkNotLocalWorker(context.Background())
+	return checkNotLocalWorker(cmd.Context())
 }
 
 // checkNotLocalWorker returns an error when this node is co-located with the

--- a/ai-services/cmd/ai-services/cmd/worker/uninstall.go
+++ b/ai-services/cmd/ai-services/cmd/worker/uninstall.go
@@ -1,10 +1,17 @@
 package worker
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	cmdcommon "github.com/project-ai-services/ai-services/cmd/ai-services/cmd/common"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
+	workercommon "github.com/project-ai-services/ai-services/internal/pkg/worker/common"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	workeruninstall "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall"
 	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 )
@@ -40,15 +47,7 @@ Application pods deployed on this worker by the catalog are not touched.`,
 
 			return cmdcommon.InitAndValidateRuntimeFlag(uninstallRuntimeType)
 		},
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			cmd.SilenceUsage = true
-
-			return workeruninstall.Uninstall(cmd.Context(), workerutils.UninstallOptions{
-				RuntimeType: vars.RuntimeFactory.GetRuntimeType(),
-				AutoYes:     uninstallAutoYes,
-				SkipCleanup: skipCleanup,
-			})
-		},
+		RunE: uninstallRunE,
 	}
 
 	cmdcommon.ConfigureRuntimeFlag(cmd, &uninstallRuntimeType)
@@ -60,4 +59,48 @@ Application pods deployed on this worker by the catalog are not touched.`,
 		"Skip deleting worker voulme (default=false)")
 
 	return cmd
+}
+
+func uninstallRunE(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+	ctx := cmd.Context()
+	rtType := vars.RuntimeFactory.GetRuntimeType()
+
+	rt, err := runtime.CreateRuntime(rtType, workerconstants.WorkerAppName)
+	if err != nil {
+		return fmt.Errorf("worker uninstall: init runtime: %w", err)
+	}
+
+	if err := checkNotLocalWorkerForRuntime(ctx, rtType, rt); err != nil {
+		return err
+	}
+
+	return workeruninstall.Uninstall(ctx, workerutils.UninstallOptions{
+		RuntimeType: rtType,
+		AutoYes:     uninstallAutoYes,
+		SkipCleanup: skipCleanup,
+	})
+}
+
+func checkNotLocalWorkerForRuntime(ctx context.Context, rtType types.RuntimeType, rt runtime.Runtime) error {
+	var (
+		localWorker bool
+		err         error
+	)
+
+	switch rtType {
+	case types.RuntimeTypeOpenShift:
+		localWorker, err = workercommon.IsOpenShiftLocalWorker(ctx, rt)
+	default:
+		localWorker, err = workercommon.IsPodmanLocalWorker(ctx, rt)
+	}
+
+	if err != nil {
+		return fmt.Errorf("could not determine LOCAL_WORKER from catalog pod: %w", err)
+	}
+	if localWorker {
+		return fmt.Errorf("the worker is co-located with the control plane and cannot be uninstalled independently")
+	}
+
+	return nil
 }

--- a/ai-services/cmd/ai-services/cmd/worker/uninstall.go
+++ b/ai-services/cmd/ai-services/cmd/worker/uninstall.go
@@ -1,7 +1,6 @@
 package worker
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -48,7 +47,6 @@ Application pods deployed on this worker by the catalog are not touched.`,
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmd.SilenceUsage = true
-			ctx := context.Background()
 			runtimeType := vars.RuntimeFactory.GetRuntimeType()
 			rt, err := runtime.CreateRuntime(runtimeType, "")
 			if err != nil {
@@ -58,7 +56,7 @@ Application pods deployed on this worker by the catalog are not touched.`,
 			if runtimeType == types.RuntimeTypeOpenShift {
 				podName = workerconstants.OpenShiftCatalogPodName
 			}
-			isLocalWorker, err := cmdcommon.IsCatalogLocalWorker(ctx, rt, podName)
+			isLocalWorker, err := cmdcommon.IsCatalogLocalWorker(cmd.Context(), rt, podName)
 			if err != nil {
 				return fmt.Errorf("could not determine LOCAL_WORKER from catalog pod: %w", err)
 			}

--- a/ai-services/cmd/ai-services/cmd/worker/uninstall.go
+++ b/ai-services/cmd/ai-services/cmd/worker/uninstall.go
@@ -8,7 +8,9 @@ import (
 
 	cmdcommon "github.com/project-ai-services/ai-services/cmd/ai-services/cmd/common"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	workeruninstall "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall"
 	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 )
@@ -52,7 +54,11 @@ Application pods deployed on this worker by the catalog are not touched.`,
 			if err != nil {
 				return fmt.Errorf("worker uninstall: init runtime: %w", err)
 			}
-			isLocalWorker, err := cmdcommon.IsCatalogLocalWorker(ctx, rt)
+			podName := workerconstants.PodmanGatewayPodName
+			if runtimeType == types.RuntimeTypeOpenShift {
+				podName = workerconstants.OpenShiftCatalogPodName
+			}
+			isLocalWorker, err := cmdcommon.IsCatalogLocalWorker(ctx, rt, podName)
 			if err != nil {
 				return fmt.Errorf("could not determine LOCAL_WORKER from catalog pod: %w", err)
 			}

--- a/ai-services/cmd/ai-services/cmd/worker/uninstall.go
+++ b/ai-services/cmd/ai-services/cmd/worker/uninstall.go
@@ -1,15 +1,10 @@
 package worker
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	cmdcommon "github.com/project-ai-services/ai-services/cmd/ai-services/cmd/common"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
-	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	workeruninstall "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall"
 	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 )
@@ -47,25 +42,9 @@ Application pods deployed on this worker by the catalog are not touched.`,
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmd.SilenceUsage = true
-			runtimeType := vars.RuntimeFactory.GetRuntimeType()
-			rt, err := runtime.CreateRuntime(runtimeType, "")
-			if err != nil {
-				return fmt.Errorf("worker uninstall: init runtime: %w", err)
-			}
-			podName := workerconstants.PodmanGatewayPodName
-			if runtimeType == types.RuntimeTypeOpenShift {
-				podName = workerconstants.OpenShiftCatalogPodName
-			}
-			isLocalWorker, err := cmdcommon.IsCatalogLocalWorker(cmd.Context(), rt, podName)
-			if err != nil {
-				return fmt.Errorf("could not determine LOCAL_WORKER from catalog pod: %w", err)
-			}
-			if isLocalWorker {
-				return fmt.Errorf("the worker is co-located with the control plane and cannot be uninstalled independently")
-			}
 
 			return workeruninstall.Uninstall(cmd.Context(), workerutils.UninstallOptions{
-				RuntimeType: runtimeType,
+				RuntimeType: vars.RuntimeFactory.GetRuntimeType(),
 				AutoYes:     uninstallAutoYes,
 				SkipCleanup: skipCleanup,
 			})

--- a/ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go
@@ -3,6 +3,7 @@ package openshift
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"helm.sh/helm/v4/pkg/chart"
@@ -117,9 +118,7 @@ func generateArgParams(ctx context.Context, rt *runtimeOpenshift.OpenshiftClient
 	argParams := make(map[string]string)
 	argParams[configure.ArgParamAdminPasswordHash] = passwordHash
 
-	if skipLocalWorker {
-		argParams[configure.ArgParamLocalWorker] = "false"
-	}
+	argParams[configure.ArgParamLocalWorker] = strconv.FormatBool(!skipLocalWorker)
 
 	dbSecretExists, err := rt.SecretExists(ctx, catalogconstants.CatalogDBSecretName)
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -3,6 +3,7 @@ package podman
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
@@ -189,9 +190,7 @@ func generateArgParams(passwordHash, sslCertPath, sslKeyPath string, httpsPort, 
 	argParams[configure.ArgParamDBPassword] = dbPassword
 	argParams[constants.ArgParamCaddyHTTPSPort] = fmt.Sprintf("%d", httpsPort)
 	argParams[configure.ArgParamWorkerGatewayPort] = fmt.Sprintf("%d", workerGatewayPort)
-	if skipLocalWorker {
-		argParams[configure.ArgParamLocalWorker] = "false"
-	}
+	argParams[configure.ArgParamLocalWorker] = strconv.FormatBool(!skipLocalWorker)
 	argParams[constants.ArgParamCaddyFileContent] = utils.IndentString(caddyFileContent, utils.CaddyFileIndent)
 	argParams[constants.ArgParamSSLCertFileContent] = utils.IndentString(sslCertContent, utils.CertContentIndent)
 	argParams[constants.ArgParamSSLKeyFileContent] = utils.IndentString(sslKeyContent, utils.CertContentIndent)

--- a/ai-services/internal/pkg/catalog/cli/uninstall/openshift/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/openshift/uninstall.go
@@ -66,7 +66,7 @@ func UninstallCatalog(ctx context.Context, opts utils.UninstallOptions) error {
 	// Uninstall the co-located local worker.
 	if err := workeruninstall.Uninstall(ctx, workerutils.UninstallOptions{
 		RuntimeType: types.RuntimeTypeOpenShift,
-		AutoYes:     opts.AutoYes,
+		AutoYes:     true,
 		SkipCleanup: opts.SkipCleanup,
 	}); err != nil {
 		return fmt.Errorf("worker uninstalled failed: %w", err)

--- a/ai-services/internal/pkg/catalog/cli/uninstall/openshift/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/openshift/uninstall.go
@@ -15,6 +15,7 @@ import (
 	openshiftruntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/openshift"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/spinner"
+	workercommon "github.com/project-ai-services/ai-services/internal/pkg/worker/common"
 	workeruninstall "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall"
 	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 )
@@ -29,11 +30,36 @@ func UninstallCatalog(ctx context.Context, opts utils.UninstallOptions) error {
 		return fmt.Errorf("failed to create openshift client: %w", err)
 	}
 
+	// Check before catalog pods are deleted whether a local worker is co-located.
+	isLocalWorker, err := workercommon.IsOpenShiftLocalWorker(ctx, rt)
+	if err != nil {
+		return fmt.Errorf("failed to check local worker: %w", err)
+	}
+
 	// Confirm deletion unless auto-yes is set
 	if confirmed, err := confirmDeletion(ctx, rt, opts.AutoYes); err != nil || !confirmed {
 		return err
 	}
 
+	if err := uninstallCatalogResources(ctx, rt, catalog, namespace, opts.SkipCleanup); err != nil {
+		return err
+	}
+
+	// Only uninstall the co-located worker if LOCAL_WORKER is true
+	if isLocalWorker {
+		if err := workeruninstall.Uninstall(ctx, workerutils.UninstallOptions{
+			RuntimeType: types.RuntimeTypeOpenShift,
+			AutoYes:     true,
+			SkipCleanup: opts.SkipCleanup,
+		}); err != nil {
+			return fmt.Errorf("worker uninstall failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func uninstallCatalogResources(ctx context.Context, rt runtime.Runtime, catalog, namespace string, skipCleanup bool) error {
 	logger.InfolnCtx(ctx, "Proceeding with uninstall...")
 
 	s := spinner.New("Uninstalling catalog service...")
@@ -45,7 +71,7 @@ func UninstallCatalog(ctx context.Context, opts utils.UninstallOptions) error {
 		return fmt.Errorf("failed to uninstall catalog: %w", err)
 	}
 
-	if !opts.SkipCleanup {
+	if !skipCleanup {
 		logger.DebuglnCtx(ctx, "Delete catalog PVCs...")
 
 		if err := rt.DeletePVCs(ctx, fmt.Sprintf("%s=%s", constants.ApplicationAnnotationKey, catalog)); err != nil {
@@ -62,15 +88,6 @@ func UninstallCatalog(ctx context.Context, opts utils.UninstallOptions) error {
 	}
 
 	s.Stop("Catalog service uninstalled successfully")
-
-	// Uninstall the co-located local worker.
-	if err := workeruninstall.Uninstall(ctx, workerutils.UninstallOptions{
-		RuntimeType: types.RuntimeTypeOpenShift,
-		AutoYes:     true,
-		SkipCleanup: opts.SkipCleanup,
-	}); err != nil {
-		return fmt.Errorf("worker uninstalled failed: %w", err)
-	}
 
 	return nil
 }

--- a/ai-services/internal/pkg/runtime/openshift/mapper.go
+++ b/ai-services/internal/pkg/runtime/openshift/mapper.go
@@ -17,6 +17,7 @@ func toOpenshiftPodList(pods *corev1.PodList) []types.Pod {
 			Name:       pod.Name,
 			Status:     string(pod.Status.Phase),
 			Labels:     pod.Labels,
+			Env:        extractPodEnv(pod.Spec.Containers),
 			Containers: toOpenshiftContainerList(pod.Status.ContainerStatuses),
 			Created:    pod.CreationTimestamp.Time,
 			Ports:      extractPodPorts(pod.Spec.Containers),
@@ -33,10 +34,24 @@ func toOpenshiftPod(pod *corev1.Pod) *types.Pod {
 		Status:     string(pod.Status.Phase),
 		State:      string(pod.Status.Phase),
 		Labels:     pod.Labels,
+		Env:        extractPodEnv(pod.Spec.Containers),
 		Containers: toOpenshiftContainerList(pod.Status.ContainerStatuses),
 		Created:    pod.CreationTimestamp.Time,
 		Ports:      extractPodPorts(pod.Spec.Containers),
 	}
+}
+
+// extractPodEnv merges env vars from all containers in the pod spec into a
+// single map.
+func extractPodEnv(containers []corev1.Container) map[string]string {
+	env := make(map[string]string)
+	for _, c := range containers {
+		for _, e := range c.Env {
+			env[e.Name] = e.Value
+		}
+	}
+
+	return env
 }
 
 func extractPodPorts(containers []corev1.Container) map[string][]string {

--- a/ai-services/internal/pkg/runtime/types/types.go
+++ b/ai-services/internal/pkg/runtime/types/types.go
@@ -31,6 +31,7 @@ type Pod struct {
 	Status           string
 	Health           string
 	Labels           map[string]string
+	Env              map[string]string
 	Containers       []Container
 	Created          time.Time
 	Ports            map[string][]string

--- a/ai-services/internal/pkg/worker/common/common.go
+++ b/ai-services/internal/pkg/worker/common/common.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
+)
+
+// IsPodmanLocalWorker returns true when the catalog pod on this Podman node has
+// LOCAL_WORKER=true in any of its container env vars.
+func IsPodmanLocalWorker(ctx context.Context, rt runtime.Runtime) (bool, error) {
+	pod, err := rt.InspectPod(ctx, workerconstants.PodmanGatewayPodName)
+	if err != nil {
+		if utils.IsNotFoundError(err) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("inspect catalog pod: %w", err)
+	}
+
+	for _, container := range pod.Containers {
+		cInfo, err := rt.InspectContainer(ctx, container.ID)
+		if err != nil {
+			return false, fmt.Errorf("inspect container %s: %w", container.ID, err)
+		}
+		if cInfo.Env[workerconstants.LocalWorkerEnvVar] == "true" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// IsOpenShiftLocalWorker returns true when any catalog-backend pod in the
+// namespace has LOCAL_WORKER=true in its pod spec env vars.
+func IsOpenShiftLocalWorker(ctx context.Context, rt runtime.Runtime) (bool, error) {
+	pods, err := rt.ListPods(ctx, map[string][]string{
+		"label": {workerconstants.CatalogBackendPodLabel + "=" + workerconstants.CatalogBackendPodLabelValue},
+	})
+	if err != nil {
+		return false, fmt.Errorf("list catalog-backend pods: %w", err)
+	}
+
+	for _, pod := range pods {
+		if pod.Env[workerconstants.LocalWorkerEnvVar] == "true" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -13,6 +13,11 @@ const (
 	// WorkerPodLabel is the pod label set to identify worker pod deployed or not.
 	WorkerPodLabel = "ai-services.io/component=worker"
 
+	// CatalogBackendPodLabel is the label key used to identify the catalog-backend pod on OpenShift.
+	CatalogBackendPodLabel = "ai-services.io/component"
+	// CatalogBackendPodLabelValue is the label value for the catalog-backend pod.
+	CatalogBackendPodLabelValue = "catalog-backend"
+
 	// WorkerDataSubDir is the on-disk subtree written by deploy.Setup; removed by uninstall.
 	WorkerDataSubDir = "worker"
 

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -70,6 +70,10 @@ const (
 	// auto-generated gateway server certificate.
 	PodmanGatewayPodName = "ai-services--catalog"
 
+	// OpenShiftCatalogPodName is the pod name prefix used by the catalog-backend
+	// Deployment on OpenShift.
+	OpenShiftCatalogPodName = "catalog-backend"
+
 	// OpenShiftGatewayServiceEndpoint is the OpenShift service DNS name embedded in the
 	// auto-generated gateway server certificate for internal cluster communication.
 	OpenShiftGatewayServiceEndpoint = "catalog-api.ai-services.svc.cluster.local"

--- a/ai-services/internal/pkg/worker/uninstall/openshift/uninstall.go
+++ b/ai-services/internal/pkg/worker/uninstall/openshift/uninstall.go
@@ -10,7 +10,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/spinner"
-	workercommon "github.com/project-ai-services/ai-services/internal/pkg/worker/common"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 )
@@ -22,14 +21,6 @@ func Uninstall(ctx context.Context, opts workerutils.UninstallOptions) error {
 	rt, err := runtime.CreateRuntime(opts.RuntimeType, namespace)
 	if err != nil {
 		return fmt.Errorf("worker uninstall: init runtime: %w", err)
-	}
-
-	localWorker, err := workercommon.IsOpenShiftLocalWorker(ctx, rt)
-	if err != nil {
-		return fmt.Errorf("worker uninstall failed: %w", err)
-	}
-	if localWorker {
-		return fmt.Errorf("the worker is co-located with the control plane and cannot be uninstalled independently")
 	}
 
 	pods, err := rt.ListPods(ctx, map[string][]string{

--- a/ai-services/internal/pkg/worker/uninstall/openshift/uninstall.go
+++ b/ai-services/internal/pkg/worker/uninstall/openshift/uninstall.go
@@ -10,6 +10,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/spinner"
+	workercommon "github.com/project-ai-services/ai-services/internal/pkg/worker/common"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 )
@@ -17,11 +18,18 @@ import (
 // Uninstall removes all worker components deployed by `worker join`.
 func Uninstall(ctx context.Context, opts workerutils.UninstallOptions) error {
 	namespace := workerconstants.WorkerAppName
-	release := workerconstants.WorkerHelmReleaseName
 
 	rt, err := runtime.CreateRuntime(opts.RuntimeType, namespace)
 	if err != nil {
 		return fmt.Errorf("worker uninstall: init runtime: %w", err)
+	}
+
+	localWorker, err := workercommon.IsOpenShiftLocalWorker(ctx, rt)
+	if err != nil {
+		return fmt.Errorf("worker uninstall failed: %w", err)
+	}
+	if localWorker {
+		return fmt.Errorf("the worker is co-located with the control plane and cannot be uninstalled independently")
 	}
 
 	pods, err := rt.ListPods(ctx, map[string][]string{
@@ -42,6 +50,12 @@ func Uninstall(ctx context.Context, opts workerutils.UninstallOptions) error {
 		return err
 	}
 
+	return performCleanup(ctx, rt, namespace, opts.SkipCleanup)
+}
+
+func performCleanup(ctx context.Context, rt runtime.Runtime, namespace string, skipCleanup bool) error {
+	release := workerconstants.WorkerHelmReleaseName
+
 	logger.InfolnCtx(ctx, "Proceeding with uninstall...")
 
 	s := spinner.New("Uninstalling worker service...")
@@ -51,7 +65,7 @@ func Uninstall(ctx context.Context, opts workerutils.UninstallOptions) error {
 		return err
 	}
 
-	if !opts.SkipCleanup {
+	if !skipCleanup {
 		logger.DebuglnCtx(ctx, "Delete worker PVCs...")
 
 		if err := rt.DeletePVCs(ctx, fmt.Sprintf("%s=%s", constants.ApplicationAnnotationKey, workerconstants.WorkerHelmReleaseName)); err != nil {

--- a/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
@@ -11,7 +11,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
-	workercommon "github.com/project-ai-services/ai-services/internal/pkg/worker/common"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 )
@@ -21,14 +20,6 @@ func Uninstall(ctx context.Context, opts workerutils.UninstallOptions) error {
 	rt, err := runtime.CreateRuntime(opts.RuntimeType, "")
 	if err != nil {
 		return fmt.Errorf("worker uninstall: init runtime: %w", err)
-	}
-
-	localWorker, err := workercommon.IsPodmanLocalWorker(ctx, rt)
-	if err != nil {
-		return fmt.Errorf("worker uninstall failed: %w", err)
-	}
-	if localWorker {
-		return fmt.Errorf("the worker is co-located with the control plane and cannot be uninstalled independently")
 	}
 
 	pods, err := getWorkerPodList(ctx, rt)

--- a/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/worker/uninstall/podman/uninstall.go
@@ -11,6 +11,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	workercommon "github.com/project-ai-services/ai-services/internal/pkg/worker/common"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 )
@@ -20,6 +21,14 @@ func Uninstall(ctx context.Context, opts workerutils.UninstallOptions) error {
 	rt, err := runtime.CreateRuntime(opts.RuntimeType, "")
 	if err != nil {
 		return fmt.Errorf("worker uninstall: init runtime: %w", err)
+	}
+
+	localWorker, err := workercommon.IsPodmanLocalWorker(ctx, rt)
+	if err != nil {
+		return fmt.Errorf("worker uninstall failed: %w", err)
+	}
+	if localWorker {
+		return fmt.Errorf("the worker is co-located with the control plane and cannot be uninstalled independently")
 	}
 
 	pods, err := getWorkerPodList(ctx, rt)


### PR DESCRIPTION
IsCatalogLocalWorker failed with an error when the catalog pod was absent (expected on a remote worker node) and always passed the Podman pod name regardless of runtime.

Now:
1. Return false, nil when InspectPod returns a not-found error
2. Accept podName as a parameter instead of hard-coding it