### PR TITLE
correct worker gateway address and server cert SANs

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.342
+TAG?=v0.0.343
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.342
+  image: icr.io/ai-services-cicd/ai-services:v0.0.343
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.342
+  image: icr.io/ai-services-cicd/ai-services:v0.0.343
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.342
+  image: icr.io/ai-services-cicd/ai-services:v0.0.343
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.342
+  image: icr.io/ai-services-cicd/ai-services:v0.0.343
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
@@ -102,7 +102,11 @@ func (h *WorkerHandler) CreateWorker(c *gin.Context) {
 
 func (h *WorkerHandler) gatewayAddress(ctx context.Context) (string, error) {
 	if h.runtimeType == types.RuntimeTypeOpenShift {
-		return gateway.GatewayRouteHost(ctx)
+		host, err := gateway.GatewayRouteHost(ctx)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s:%d", host, workerconstants.OpenShiftRoutePort), nil
 	}
 
 	port := fmt.Sprintf("%d", h.gatewayPort)

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
@@ -106,6 +106,7 @@ func (h *WorkerHandler) gatewayAddress(ctx context.Context) (string, error) {
 		if err != nil {
 			return "", err
 		}
+
 		return fmt.Sprintf("%s:%d", host, workerconstants.OpenShiftRoutePort), nil
 	}
 

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -49,6 +49,11 @@ const (
 	// WorkerGatewayPort is the default port used by the catalog gRPC worker gateway.
 	WorkerGatewayPort = 9090
 
+	// OpenShiftRoutePort is the port used by OpenShift passthrough routes.
+	// All OpenShift routes (including the worker-gateway passthrough route) are
+	// always reachable on port 443 via the cluster ingress router.
+	OpenShiftRoutePort = 443
+
 	// ArgParamWorkerToken, ArgParamWorkerGatewayAddr,
 	// ArgParamWorkerPodmanURI, and ArgParamWorkerAuthFile are template
 	// value-override keys used when deploying worker pods.

--- a/ai-services/internal/pkg/worker/gateway/gateway_test.go
+++ b/ai-services/internal/pkg/worker/gateway/gateway_test.go
@@ -512,8 +512,9 @@ func TestGenerateAndPersistPKI_PodmanSANs(t *testing.T) {
 		t.Fatalf("ParseCertificate: %v", err)
 	}
 
-	if len(leaf.DNSNames) != 1 || leaf.DNSNames[0] != "catalog-worker-gateway.example.com" {
-		t.Errorf("expected SANs [catalog-worker-gateway.example.com]; got DNSNames=%v", leaf.DNSNames)
+	expectedSANs := []string{"catalog-worker-gateway.example.com", workerconstants.PodmanGatewayPodName}
+	if len(leaf.DNSNames) != len(expectedSANs) || leaf.DNSNames[0] != expectedSANs[0] || leaf.DNSNames[1] != expectedSANs[1] {
+		t.Errorf("expected SANs %v; got DNSNames=%v", expectedSANs, leaf.DNSNames)
 	}
 }
 

--- a/ai-services/internal/pkg/worker/gateway/pki.go
+++ b/ai-services/internal/pkg/worker/gateway/pki.go
@@ -172,7 +172,10 @@ func serverCertDNSNames(ctx context.Context, runtimeType types.RuntimeType) ([]s
 			return nil, fmt.Errorf("DOMAIN_SUFFIX environment variable not set — cannot generate gateway server cert")
 		}
 
-		return []string{workerconstants.WorkerGatewayName + "." + domainSuffix}, nil
+		return []string{
+			workerconstants.WorkerGatewayName + "." + domainSuffix,
+			workerconstants.PodmanGatewayPodName,
+		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported runtime type %q for gateway PKI generation", runtimeType)
 	}


### PR DESCRIPTION
fix: correct worker gateway address and server cert SANs

1. Restore host:443 for OpenShift gateway address (bare hostname broke worker StartGrpcStream validation)
2. Add PodmanGatewayPodName to Podman server cert SANs (was defined but never wired in, causing TLS failures for internal pod DNS connections)
3. Bump image to v0.0.343