### PR TITLE
Add Namespace and Worker name to Application ps

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.349
+TAG?=v0.0.350
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.349
+  image: icr.io/ai-services-cicd/ai-services:v0.0.350
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.349
+  image: icr.io/ai-services-cicd/ai-services:v0.0.350
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.349
+  image: icr.io/ai-services-cicd/ai-services:v0.0.350
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.349
+  image: icr.io/ai-services-cicd/ai-services:v0.0.350
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/cmd/ai-services/cmd/application/ps.go
+++ b/ai-services/cmd/ai-services/cmd/application/ps.go
@@ -191,27 +191,21 @@ func renderApplicationPS(ctx context.Context, opts appTypes.ListOptions) error {
 	return nil
 }
 
-// PS table column indices (normal output).
+// PS table column indices (shared across normal and wide output).
 const (
-	psColAppName = 0
-	psColWorker  = 1
-	psColRuntime = 5
-)
-
-// PS table column indices (wide output).
-const (
-	psWideColAppName = 0
-	psWideColWorker  = 1
-	psWideColRuntime = 6
+	psColAppName  = 0
+	psColWorker   = 1
+	psColRuntime  = 2
+	psColNamespace = 3
 )
 
 // setApplicationPSTableHeaders sets the table headers and collapse indices based on output format.
 func setApplicationPSTableHeaders(printer *utils.Printer, outputWide bool) {
 	if outputWide {
-		printer.SetHeaders("APPLICATION NAME", "WORKER", "NAMESPACE", "POD ID", "POD NAME", "STATUS", "RUNTIME", "CREATED", "CONTAINERS")
-		printer.SetCollapseIndices(psWideColAppName, psWideColWorker, psWideColRuntime)
+		printer.SetHeaders("APPLICATION NAME", "WORKER", "RUNTIME", "NAMESPACE", "POD ID", "POD NAME", "STATUS", "CREATED", "CONTAINERS")
+		printer.SetCollapseIndices(psColAppName, psColWorker, psColRuntime)
 	} else {
-		printer.SetHeaders("APPLICATION NAME", "WORKER", "NAMESPACE", "POD NAME", "STATUS", "RUNTIME")
+		printer.SetHeaders("APPLICATION NAME", "WORKER", "RUNTIME", "NAMESPACE", "POD NAME", "STATUS")
 		printer.SetCollapseIndices(psColAppName, psColWorker, psColRuntime)
 	}
 }

--- a/ai-services/cmd/ai-services/cmd/application/ps.go
+++ b/ai-services/cmd/ai-services/cmd/application/ps.go
@@ -177,13 +177,13 @@ func renderApplicationPS(ctx context.Context, opts appTypes.ListOptions) error {
 
 		// Process services pods
 		for _, pod := range psResp.Services {
-			rows := cliUtils.BuildPodRowFromAPI(psResp.Name, pod, opts.OutputWide)
+			rows := cliUtils.BuildPodRowFromAPI(psResp.Name, psResp.WorkerName, psResp.Namespace, pod, opts.OutputWide)
 			printer.AppendRow(rows...)
 		}
 
 		// Process components pods
 		for _, pod := range psResp.Components {
-			rows := cliUtils.BuildPodRowFromAPI(psResp.Name, pod, opts.OutputWide)
+			rows := cliUtils.BuildPodRowFromAPI(psResp.Name, psResp.WorkerName, psResp.Namespace, pod, opts.OutputWide)
 			printer.AppendRow(rows...)
 		}
 	}
@@ -194,8 +194,8 @@ func renderApplicationPS(ctx context.Context, opts appTypes.ListOptions) error {
 // setApplicationPSTableHeaders sets the table headers based on output format.
 func setApplicationPSTableHeaders(printer *utils.Printer, outputWide bool) {
 	if outputWide {
-		printer.SetHeaders("APPLICATION NAME", "POD ID", "POD NAME", "STATUS", "CREATED", "CONTAINERS")
+		printer.SetHeaders("APPLICATION NAME", "WORKER", "NAMESPACE", "POD ID", "POD NAME", "STATUS", "CREATED", "CONTAINERS")
 	} else {
-		printer.SetHeaders("APPLICATION NAME", "POD NAME", "STATUS")
+		printer.SetHeaders("APPLICATION NAME", "WORKER", "NAMESPACE", "POD NAME", "STATUS")
 	}
 }

--- a/ai-services/cmd/ai-services/cmd/application/ps.go
+++ b/ai-services/cmd/ai-services/cmd/application/ps.go
@@ -191,17 +191,27 @@ func renderApplicationPS(ctx context.Context, opts appTypes.ListOptions) error {
 	return nil
 }
 
+// PS table column indices (normal output).
+const (
+	psColAppName = 0
+	psColWorker  = 1
+	psColRuntime = 5
+)
+
+// PS table column indices (wide output).
+const (
+	psWideColAppName = 0
+	psWideColWorker  = 1
+	psWideColRuntime = 6
+)
+
 // setApplicationPSTableHeaders sets the table headers and collapse indices based on output format.
-//
-// Column indices for collapsing:
-//   - normal: APPLICATION NAME(0), WORKER(1), RUNTIME(5)
-//   - wide:   APPLICATION NAME(0), WORKER(1), RUNTIME(6)
 func setApplicationPSTableHeaders(printer *utils.Printer, outputWide bool) {
 	if outputWide {
 		printer.SetHeaders("APPLICATION NAME", "WORKER", "NAMESPACE", "POD ID", "POD NAME", "STATUS", "RUNTIME", "CREATED", "CONTAINERS")
-		printer.SetCollapseIndices(0, 1, 6)
+		printer.SetCollapseIndices(psWideColAppName, psWideColWorker, psWideColRuntime)
 	} else {
 		printer.SetHeaders("APPLICATION NAME", "WORKER", "NAMESPACE", "POD NAME", "STATUS", "RUNTIME")
-		printer.SetCollapseIndices(0, 1, 5)
+		printer.SetCollapseIndices(psColAppName, psColWorker, psColRuntime)
 	}
 }

--- a/ai-services/cmd/ai-services/cmd/application/ps.go
+++ b/ai-services/cmd/ai-services/cmd/application/ps.go
@@ -164,7 +164,7 @@ func renderApplicationPS(ctx context.Context, opts appTypes.ListOptions) error {
 	printer := utils.NewTableWriter()
 	defer printer.CloseTableWriter()
 
-	// Set table headers based on output format
+	// Set table headers and collapse indices based on output format
 	setApplicationPSTableHeaders(printer, opts.OutputWide)
 
 	// Process each application ID
@@ -177,13 +177,13 @@ func renderApplicationPS(ctx context.Context, opts appTypes.ListOptions) error {
 
 		// Process services pods
 		for _, pod := range psResp.Services {
-			rows := cliUtils.BuildPodRowFromAPI(psResp.Name, psResp.WorkerName, psResp.Namespace, pod, opts.OutputWide)
+			rows := cliUtils.BuildPodRowFromAPI(psResp.Name, psResp.WorkerName, psResp.Namespace, psResp.RuntimeType, pod, opts.OutputWide)
 			printer.AppendRow(rows...)
 		}
 
 		// Process components pods
 		for _, pod := range psResp.Components {
-			rows := cliUtils.BuildPodRowFromAPI(psResp.Name, psResp.WorkerName, psResp.Namespace, pod, opts.OutputWide)
+			rows := cliUtils.BuildPodRowFromAPI(psResp.Name, psResp.WorkerName, psResp.Namespace, psResp.RuntimeType, pod, opts.OutputWide)
 			printer.AppendRow(rows...)
 		}
 	}
@@ -191,11 +191,17 @@ func renderApplicationPS(ctx context.Context, opts appTypes.ListOptions) error {
 	return nil
 }
 
-// setApplicationPSTableHeaders sets the table headers based on output format.
+// setApplicationPSTableHeaders sets the table headers and collapse indices based on output format.
+//
+// Column indices for collapsing:
+//   - normal: APPLICATION NAME(0), WORKER(1), RUNTIME(5)
+//   - wide:   APPLICATION NAME(0), WORKER(1), RUNTIME(6)
 func setApplicationPSTableHeaders(printer *utils.Printer, outputWide bool) {
 	if outputWide {
-		printer.SetHeaders("APPLICATION NAME", "WORKER", "NAMESPACE", "POD ID", "POD NAME", "STATUS", "CREATED", "CONTAINERS")
+		printer.SetHeaders("APPLICATION NAME", "WORKER", "NAMESPACE", "POD ID", "POD NAME", "STATUS", "RUNTIME", "CREATED", "CONTAINERS")
+		printer.SetCollapseIndices(0, 1, 6)
 	} else {
-		printer.SetHeaders("APPLICATION NAME", "WORKER", "NAMESPACE", "POD NAME", "STATUS")
+		printer.SetHeaders("APPLICATION NAME", "WORKER", "NAMESPACE", "POD NAME", "STATUS", "RUNTIME")
+		printer.SetCollapseIndices(0, 1, 5)
 	}
 }

--- a/ai-services/cmd/ai-services/cmd/application/ps.go
+++ b/ai-services/cmd/ai-services/cmd/application/ps.go
@@ -193,9 +193,9 @@ func renderApplicationPS(ctx context.Context, opts appTypes.ListOptions) error {
 
 // PS table column indices (shared across normal and wide output).
 const (
-	psColAppName  = 0
-	psColWorker   = 1
-	psColRuntime  = 2
+	psColAppName   = 0
+	psColWorker    = 1
+	psColRuntime   = 2
 	psColNamespace = 3
 )
 

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -3528,11 +3528,17 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
+                "namespace": {
+                    "type": "string"
+                },
                 "services": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Pod"
                     }
+                },
+                "worker_name": {
+                    "type": "string"
                 }
             }
         },

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -3531,6 +3531,9 @@ const docTemplate = `{
                 "namespace": {
                     "type": "string"
                 },
+                "runtime_type": {
+                    "type": "string"
+                },
                 "services": {
                     "type": "array",
                     "items": {

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -3525,6 +3525,9 @@
                 "namespace": {
                     "type": "string"
                 },
+                "runtime_type": {
+                    "type": "string"
+                },
                 "services": {
                     "type": "array",
                     "items": {

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -3522,11 +3522,17 @@
                 "name": {
                     "type": "string"
                 },
+                "namespace": {
+                    "type": "string"
+                },
                 "services": {
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Pod"
                     }
+                },
+                "worker_name": {
+                    "type": "string"
                 }
             }
         },

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -540,6 +540,8 @@ definitions:
         type: string
       namespace:
         type: string
+      runtime_type:
+        type: string
       services:
         items:
           $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Pod'

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -538,10 +538,14 @@ definitions:
         type: string
       name:
         type: string
+      namespace:
+        type: string
       services:
         items:
           $ref: '#/definitions/github_com_project-ai-services_ai-services_internal_pkg_catalog_types.Pod'
         type: array
+      worker_name:
+        type: string
     type: object
   github_com_project-ai-services_ai-services_internal_pkg_catalog_types.ApplicationResourcesResponse:
     properties:

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -1170,12 +1170,23 @@ func (s *ApplicationServiceBase) ApplicationsPs(ctx context.Context, appID uuid.
 		return nil, fmt.Errorf("failed to collect component pods: %w", err)
 	}
 
-	return &types.ApplicationPSResponse{
+	psResp := &types.ApplicationPSResponse{
 		ID:         app.ID.String(),
 		Name:       app.Name,
 		Services:   servicePods,
 		Components: componentPods,
-	}, nil
+	}
+
+	if app.WorkerID != nil {
+		workerInfo := s.buildWorkerInfo(*app.WorkerID)
+		psResp.WorkerName = workerInfo.Name
+		// Namespace is only meaningful for OpenShift workers
+		if runtimeTypes.RuntimeType(workerInfo.RuntimeType) == runtimeTypes.RuntimeTypeOpenShift {
+			psResp.Namespace = catalogutils.AppNamespace(app.ID)
+		}
+	}
+
+	return psResp, nil
 }
 
 func (s *ApplicationServiceBase) collectServicePods(

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -1171,10 +1171,11 @@ func (s *ApplicationServiceBase) ApplicationsPs(ctx context.Context, appID uuid.
 	}
 
 	psResp := &types.ApplicationPSResponse{
-		ID:         app.ID.String(),
-		Name:       app.Name,
-		Services:   servicePods,
-		Components: componentPods,
+		ID:          app.ID.String(),
+		Name:        app.Name,
+		RuntimeType: s.RuntimeType.String(),
+		Services:    servicePods,
+		Components:  componentPods,
 	}
 
 	if app.WorkerID != nil {
@@ -1183,6 +1184,10 @@ func (s *ApplicationServiceBase) ApplicationsPs(ctx context.Context, appID uuid.
 		// Namespace is only meaningful for OpenShift workers
 		if runtimeTypes.RuntimeType(workerInfo.RuntimeType) == runtimeTypes.RuntimeTypeOpenShift {
 			psResp.Namespace = catalogutils.AppNamespace(app.ID)
+		}
+		// Override runtime type with the worker's actual runtime when available
+		if workerInfo.RuntimeType != "" {
+			psResp.RuntimeType = workerInfo.RuntimeType
 		}
 	}
 

--- a/ai-services/internal/pkg/catalog/types/application_response.go
+++ b/ai-services/internal/pkg/catalog/types/application_response.go
@@ -90,12 +90,13 @@ type ApplicationMemInfo struct {
 
 // ApplicationPSResponse represents the response for pod/container status.
 type ApplicationPSResponse struct {
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	WorkerName string `json:"worker_name,omitempty"`
-	Namespace  string `json:"namespace,omitempty"`
-	Services   []Pod  `json:"services"`
-	Components []Pod  `json:"components"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	WorkerName  string `json:"worker_name,omitempty"`
+	Namespace   string `json:"namespace,omitempty"`
+	RuntimeType string `json:"runtime_type,omitempty"`
+	Services    []Pod  `json:"services"`
+	Components  []Pod  `json:"components"`
 }
 
 type Status string

--- a/ai-services/internal/pkg/catalog/types/application_response.go
+++ b/ai-services/internal/pkg/catalog/types/application_response.go
@@ -92,6 +92,8 @@ type ApplicationMemInfo struct {
 type ApplicationPSResponse struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`
+	WorkerName string `json:"worker_name,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
 	Services   []Pod  `json:"services"`
 	Components []Pod  `json:"components"`
 }

--- a/ai-services/internal/pkg/cli/utils/common.go
+++ b/ai-services/internal/pkg/cli/utils/common.go
@@ -38,12 +38,12 @@ func FetchApplications(ctx context.Context, appClient *catalogClient.Application
 }
 
 // BuildPodRowFromAPI builds a table row from API response data.
-func BuildPodRowFromAPI(appName, workerName, namespace string, pod catalogTypes.Pod, wideOutput bool) []string {
+func BuildPodRowFromAPI(appName, workerName, namespace, runtimeType string, pod catalogTypes.Pod, wideOutput bool) []string {
 	status := getPodStatusFromAPI(pod)
 
-	// If wide option flag is not set, return appName, workerName, namespace, podName and status only
+	// If wide option flag is not set, return appName, workerName, namespace, podName, status and runtimeType only
 	if !wideOutput {
-		return []string{appName, workerName, namespace, pod.PodName, status}
+		return []string{appName, workerName, namespace, pod.PodName, status, runtimeType}
 	}
 
 	containerNames := getContainerNamesFromAPI(pod)
@@ -68,6 +68,7 @@ func BuildPodRowFromAPI(appName, workerName, namespace string, pod catalogTypes.
 		pod.PodID[:12],
 		pod.PodName,
 		status,
+		runtimeType,
 		created,
 		strings.Join(containerNames, ", "),
 	}

--- a/ai-services/internal/pkg/cli/utils/common.go
+++ b/ai-services/internal/pkg/cli/utils/common.go
@@ -38,12 +38,12 @@ func FetchApplications(ctx context.Context, appClient *catalogClient.Application
 }
 
 // BuildPodRowFromAPI builds a table row from API response data.
-func BuildPodRowFromAPI(appName string, pod catalogTypes.Pod, wideOutput bool) []string {
+func BuildPodRowFromAPI(appName, workerName, namespace string, pod catalogTypes.Pod, wideOutput bool) []string {
 	status := getPodStatusFromAPI(pod)
 
-	// If wide option flag is not set, return appName, podName and status only
+	// If wide option flag is not set, return appName, workerName, namespace, podName and status only
 	if !wideOutput {
-		return []string{appName, pod.PodName, status}
+		return []string{appName, workerName, namespace, pod.PodName, status}
 	}
 
 	containerNames := getContainerNamesFromAPI(pod)
@@ -63,6 +63,8 @@ func BuildPodRowFromAPI(appName string, pod catalogTypes.Pod, wideOutput bool) [
 
 	return []string{
 		appName,
+		workerName,
+		namespace,
 		pod.PodID[:12],
 		pod.PodName,
 		status,

--- a/ai-services/internal/pkg/cli/utils/common.go
+++ b/ai-services/internal/pkg/cli/utils/common.go
@@ -41,9 +41,9 @@ func FetchApplications(ctx context.Context, appClient *catalogClient.Application
 func BuildPodRowFromAPI(appName, workerName, namespace, runtimeType string, pod catalogTypes.Pod, wideOutput bool) []string {
 	status := getPodStatusFromAPI(pod)
 
-	// If wide option flag is not set, return appName, workerName, namespace, podName, status and runtimeType only
+	// If wide option flag is not set, return normal columns only
 	if !wideOutput {
-		return []string{appName, workerName, namespace, pod.PodName, status, runtimeType}
+		return []string{appName, workerName, runtimeType, namespace, pod.PodName, status}
 	}
 
 	containerNames := getContainerNamesFromAPI(pod)
@@ -51,12 +51,10 @@ func BuildPodRowFromAPI(appName, workerName, namespace, runtimeType string, pod 
 	// Parse the Created string and convert to TimeAgo format
 	created := "N/A"
 	if pod.Created != "" {
-		// Try to parse the Created timestamp
 		parsedTime, err := time.Parse(catalogConstants.RFC3339WithTimezone, pod.Created)
 		if err == nil {
 			created = utils.TimeAgo(parsedTime)
 		} else {
-			// If parsing fails, use the original string
 			created = pod.Created
 		}
 	}
@@ -64,11 +62,11 @@ func BuildPodRowFromAPI(appName, workerName, namespace, runtimeType string, pod 
 	return []string{
 		appName,
 		workerName,
+		runtimeType,
 		namespace,
 		pod.PodID[:12],
 		pod.PodName,
 		status,
-		runtimeType,
 		created,
 		strings.Join(containerNames, ", "),
 	}

--- a/ai-services/internal/pkg/utils/printer.go
+++ b/ai-services/internal/pkg/utils/printer.go
@@ -9,12 +9,15 @@ import (
 )
 
 const (
-	columnPadding             = 2
-	collapseLeadingColumnsNum = 2
+	columnPadding = 2
 )
 
+// defaultCollapseIndices are the column indices collapsed by default (APPLICATION NAME, WORKER).
+var defaultCollapseIndices = []int{0, 1}
+
 type Printer struct {
-	model table.Model
+	model           table.Model
+	collapseIndices []int
 }
 
 func NewTableWriter() *Printer {
@@ -39,7 +42,12 @@ func NewTableWriter() *Printer {
 
 	t.SetStyles(styles)
 
-	return &Printer{model: t}
+	return &Printer{model: t, collapseIndices: defaultCollapseIndices}
+}
+
+// SetCollapseIndices overrides which column indices are collapsed when rendering.
+func (p *Printer) SetCollapseIndices(indices ...int) {
+	p.collapseIndices = indices
 }
 
 func (p *Printer) SetHeaders(headers ...string) {
@@ -58,26 +66,32 @@ func (p *Printer) AppendRow(cells ...string) {
 	p.model.SetRows(append(p.model.Rows(), table.Row(cells)))
 }
 
-func collapseLeadingColumns(rows []table.Row, n int) []table.Row {
-	if len(rows) == 0 {
+// collapseColumns blanks repeated values in the given column indices across rows.
+// The first index is the anchor column (APPLICATION NAME): when it changes, all
+// tracked columns re-print; when it stays the same, they are all blanked.
+func collapseColumns(rows []table.Row, indices []int) []table.Row {
+	if len(rows) == 0 || len(indices) == 0 {
 		return rows
 	}
 
-	last := make([]string, n)
+	anchor := indices[0]
+	last := make(map[int]string, len(indices))
 	for i, r := range rows {
 		if len(r) == 0 {
 			continue
 		}
 
-		for col := 0; col < n && col < len(r); col++ {
-			if r[col] == last[col] {
-				r[col] = "" // blank repeated values
+		// Only the anchor column drives whether all tracked columns print or collapse.
+		anchorChanged := anchor < len(r) && r[anchor] != last[anchor]
+
+		for _, col := range indices {
+			if col >= len(r) {
+				continue
+			}
+			if anchorChanged {
+				last[col] = r[col] // re-print and update baseline
 			} else {
-				last[col] = r[col]
-				// reset all subsequent tracked columns when a parent changes
-				for j := col + 1; j < n; j++ {
-					last[j] = ""
-				}
+				r[col] = "" // blank repeated value
 			}
 		}
 
@@ -89,7 +103,7 @@ func collapseLeadingColumns(rows []table.Row, n int) []table.Row {
 
 func (p *Printer) CloseTableWriter() {
 	cols := p.model.Columns()
-	rows := collapseLeadingColumns(p.model.Rows(), collapseLeadingColumnsNum)
+	rows := collapseColumns(p.model.Rows(), p.collapseIndices)
 
 	// Width of rows is computed here before rendering
 	for colIdx := range cols {

--- a/ai-services/internal/pkg/utils/printer.go
+++ b/ai-services/internal/pkg/utils/printer.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	columnPadding = 2
+	columnPadding             = 2
+	collapseLeadingColumnsNum = 2
 )
 
 type Printer struct {
@@ -88,7 +89,7 @@ func collapseLeadingColumns(rows []table.Row, n int) []table.Row {
 
 func (p *Printer) CloseTableWriter() {
 	cols := p.model.Columns()
-	rows := collapseLeadingColumns(p.model.Rows(), 2)
+	rows := collapseLeadingColumns(p.model.Rows(), collapseLeadingColumnsNum)
 
 	// Width of rows is computed here before rendering
 	for colIdx := range cols {

--- a/ai-services/internal/pkg/utils/printer.go
+++ b/ai-services/internal/pkg/utils/printer.go
@@ -57,21 +57,27 @@ func (p *Printer) AppendRow(cells ...string) {
 	p.model.SetRows(append(p.model.Rows(), table.Row(cells)))
 }
 
-func collapseFirstColumn(rows []table.Row) []table.Row {
+func collapseLeadingColumns(rows []table.Row, n int) []table.Row {
 	if len(rows) == 0 {
 		return rows
 	}
 
-	last := ""
+	last := make([]string, n)
 	for i, r := range rows {
 		if len(r) == 0 {
 			continue
 		}
 
-		if r[0] == last {
-			r[0] = "" // blank repeated values
-		} else {
-			last = r[0]
+		for col := 0; col < n && col < len(r); col++ {
+			if r[col] == last[col] {
+				r[col] = "" // blank repeated values
+			} else {
+				last[col] = r[col]
+				// reset all subsequent tracked columns when a parent changes
+				for j := col + 1; j < n; j++ {
+					last[j] = ""
+				}
+			}
 		}
 
 		rows[i] = r
@@ -82,7 +88,7 @@ func collapseFirstColumn(rows []table.Row) []table.Row {
 
 func (p *Printer) CloseTableWriter() {
 	cols := p.model.Columns()
-	rows := collapseFirstColumn(p.model.Rows())
+	rows := collapseLeadingColumns(p.model.Rows(), 2)
 
 	// Width of rows is computed here before rendering
 	for colIdx := range cols {


### PR DESCRIPTION
- Currently the app ps doesnt print worker name and namespace which makes it really difficult through CLI to know the worker to which the application is deployed and also the namespace it resides if openshift (in case of podman it is empty)