### PR TITLE
fix: Rename VLLM_SPYRE to SENDNN_INFERENCE in spyre deployments

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.360
+TAG?=v0.0.361
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-dev/openshift/templates/reranker-inferenceservice.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/templates/reranker-inferenceservice.yaml
@@ -23,7 +23,7 @@ spec:
       resources:
         limits:
           cpu: "8"
-          memory: "5Gi"
+          memory: "4Gi"
         requests:
           cpu: "8"
           memory: "4Gi"

--- a/ai-services/assets/applications/rag-dev/openshift/templates/reranker-inferenceservice.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/templates/reranker-inferenceservice.yaml
@@ -23,10 +23,10 @@ spec:
       resources:
         limits:
           cpu: "8"
-          memory: "4Gi"
+          memory: "5Gi"
         requests:
           cpu: "8"
-          memory: "4Gi"
+          memory: "5Gi"
       runtime: cpu-temp
       storageUri: {{ .Values.reranker.storageUri }}
       args:

--- a/ai-services/assets/applications/rag-dev/openshift/templates/reranker-inferenceservice.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/templates/reranker-inferenceservice.yaml
@@ -26,7 +26,7 @@ spec:
           memory: "5Gi"
         requests:
           cpu: "8"
-          memory: "5Gi"
+          memory: "4Gi"
       runtime: cpu-temp
       storageUri: {{ .Values.reranker.storageUri }}
       args:

--- a/ai-services/assets/applications/rag/openshift/templates/reranker-inferenceservice.yaml
+++ b/ai-services/assets/applications/rag/openshift/templates/reranker-inferenceservice.yaml
@@ -21,12 +21,10 @@ spec:
       modelFormat:
         name: vLLM
       env:
-        - name: VLLM_SPYRE_WARMUP_BATCH_SIZES
+        - name: SENDNN_INFERENCE_WARMUP_BATCH_SIZES
           value: "4"
-        - name: VLLM_SPYRE_WARMUP_PROMPT_LENS
+        - name: SENDNN_INFERENCE_WARMUP_PROMPT_LENS
           value: "1024"
-        - name: VLLM_SPYRE_USE_CHUNKED_PREFILL
-          value: "0"
       resources:
         limits:
           cpu: "8"

--- a/ai-services/assets/applications/rag/openshift/templates/reranker-inferenceservice.yaml
+++ b/ai-services/assets/applications/rag/openshift/templates/reranker-inferenceservice.yaml
@@ -28,11 +28,11 @@ spec:
       resources:
         limits:
           cpu: "8"
-          memory: "4Gi"
+          memory: "5Gi"
           ibm.com/spyre_pf: "1"
         requests:
           cpu: "8"
-          memory: "4Gi"
+          memory: "5Gi"
           ibm.com/spyre_pf: "1"
       runtime: spyre-temp
       storageUri: {{ .Values.reranker.storageUri }}

--- a/ai-services/assets/applications/rag/openshift/templates/reranker-inferenceservice.yaml
+++ b/ai-services/assets/applications/rag/openshift/templates/reranker-inferenceservice.yaml
@@ -21,11 +21,11 @@ spec:
       modelFormat:
         name: vLLM
       env:
-        - name: VLLM_SPYRE_WARMUP_BATCH_SIZES
+        - name: SENDNN_INFERENCE_WARMUP_BATCH_SIZES
           value: "4"
-        - name: VLLM_SPYRE_WARMUP_PROMPT_LENS
+        - name: SENDNN_INFERENCE_WARMUP_PROMPT_LENS
           value: "1024"
-        - name: VLLM_SPYRE_USE_CHUNKED_PREFILL
+        - name: SENDNN_INFERENCE_USE_CHUNKED_PREFILL
           value: "0"
       resources:
         limits:

--- a/ai-services/assets/applications/rag/openshift/templates/reranker-inferenceservice.yaml
+++ b/ai-services/assets/applications/rag/openshift/templates/reranker-inferenceservice.yaml
@@ -21,11 +21,11 @@ spec:
       modelFormat:
         name: vLLM
       env:
-        - name: SENDNN_INFERENCE_WARMUP_BATCH_SIZES
+        - name: VLLM_SPYRE_WARMUP_BATCH_SIZES
           value: "4"
-        - name: SENDNN_INFERENCE_WARMUP_PROMPT_LENS
+        - name: VLLM_SPYRE_WARMUP_PROMPT_LENS
           value: "1024"
-        - name: SENDNN_INFERENCE_USE_CHUNKED_PREFILL
+        - name: VLLM_SPYRE_USE_CHUNKED_PREFILL
           value: "0"
       resources:
         limits:

--- a/ai-services/assets/applications/rag/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/vllm-server.yaml.tmpl
@@ -137,8 +137,6 @@ spec:
           value: "/models/{{ .Values.reranker.model.name }}"
         - name: AIU_WORLD_SIZE
           value: "1"
-        - name: SENDNN_INFERENCE_USE_CHUNKED_PREFILL
-          value: "0"
         - name: SENDNN_INFERENCE_WARMUP_BATCH_SIZES
           value: "4"
         - name: SENDNN_INFERENCE_WARMUP_PROMPT_LENS

--- a/ai-services/assets/applications/rag/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/vllm-server.yaml.tmpl
@@ -55,7 +55,7 @@ spec:
           value: "/models/{{ .Values.instruct.model.name }}"
         - name: AIU_WORLD_SIZE
           value: "4"
-        - name: VLLM_SPYRE_USE_CB
+        - name: SENDNN_INFERENCE_USE_CB
           value: "1"
         - name: MAX_MODEL_LEN
           value: "{{ .Values.instruct.model.maxModelLen }}"
@@ -137,11 +137,11 @@ spec:
           value: "/models/{{ .Values.reranker.model.name }}"
         - name: AIU_WORLD_SIZE
           value: "1"
-        - name: VLLM_SPYRE_USE_CHUNKED_PREFILL
+        - name: SENDNN_INFERENCE_USE_CHUNKED_PREFILL
           value: "0"
-        - name: VLLM_SPYRE_WARMUP_BATCH_SIZES
+        - name: SENDNN_INFERENCE_WARMUP_BATCH_SIZES
           value: "4"
-        - name: VLLM_SPYRE_WARMUP_PROMPT_LENS
+        - name: SENDNN_INFERENCE_WARMUP_PROMPT_LENS
           value: "1024"
         - name: MASTER_PORT
           value: "12356"

--- a/ai-services/assets/applications/rag/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/vllm-server.yaml.tmpl
@@ -55,7 +55,7 @@ spec:
           value: "/models/{{ .Values.instruct.model.name }}"
         - name: AIU_WORLD_SIZE
           value: "4"
-        - name: SENDNN_INFERENCE_USE_CB
+        - name: VLLM_SPYRE_USE_CB
           value: "1"
         - name: MAX_MODEL_LEN
           value: "{{ .Values.instruct.model.maxModelLen }}"

--- a/ai-services/assets/applications/rag/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/vllm-server.yaml.tmpl
@@ -55,7 +55,7 @@ spec:
           value: "/models/{{ .Values.instruct.model.name }}"
         - name: AIU_WORLD_SIZE
           value: "4"
-        - name: VLLM_SPYRE_USE_CB
+        - name: SENDNN_INFERENCE_USE_CB
           value: "1"
         - name: MAX_MODEL_LEN
           value: "{{ .Values.instruct.model.maxModelLen }}"

--- a/ai-services/assets/applications/rag/podman/templates/vllm-server.yaml.tmpl
+++ b/ai-services/assets/applications/rag/podman/templates/vllm-server.yaml.tmpl
@@ -55,8 +55,6 @@ spec:
           value: "/models/{{ .Values.instruct.model.name }}"
         - name: AIU_WORLD_SIZE
           value: "4"
-        - name: SENDNN_INFERENCE_USE_CB
-          value: "1"
         - name: MAX_MODEL_LEN
           value: "{{ .Values.instruct.model.maxModelLen }}"
         - name: MAX_BATCH_SIZE

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.360
+  image: icr.io/ai-services-cicd/ai-services:v0.0.361
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.360
+  image: icr.io/ai-services-cicd/ai-services:v0.0.361
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/components/reranker/vllm-spyre/openshift/metadata.yaml
+++ b/ai-services/assets/components/reranker/vllm-spyre/openshift/metadata.yaml
@@ -5,6 +5,6 @@ version: "1.0.0"
 resources:
   cpu: 8
   memory: 4294967296 # 4Gi in bytes
-  storage: 10737418240 # 10Gi for reranker model storage in bytes
+  storage: 5368709120 # 5Gi for reranker model storage in bytes
   accelerators:
     ibm.com/spyre_pf: 1

--- a/ai-services/assets/components/reranker/vllm-spyre/openshift/metadata.yaml
+++ b/ai-services/assets/components/reranker/vllm-spyre/openshift/metadata.yaml
@@ -4,7 +4,7 @@ version: "1.0.0"
 # Resource requirements
 resources:
   cpu: 8
-  memory: 4294967296 # 4Gi in bytes
-  storage: 5368709120 # 5Gi for reranker model storage in bytes
+  memory: 5368709120 # 5Gi in bytes
+  storage: 10737418240 # 10Gi for reranker model storage in bytes
   accelerators:
     ibm.com/spyre_pf: 1

--- a/ai-services/assets/components/reranker/vllm-spyre/openshift/templates/reranker-inferenceservice.yaml
+++ b/ai-services/assets/components/reranker/vllm-spyre/openshift/templates/reranker-inferenceservice.yaml
@@ -21,11 +21,11 @@ spec:
       modelFormat:
         name: vLLM
       env:
-        - name: VLLM_SPYRE_WARMUP_BATCH_SIZES
+        - name: SENDNN_INFERENCE_WARMUP_BATCH_SIZES
           value: "4"
-        - name: VLLM_SPYRE_WARMUP_PROMPT_LENS
+        - name: SENDNN_INFERENCE_WARMUP_PROMPT_LENS
           value: "1024"
-        - name: VLLM_SPYRE_USE_CHUNKED_PREFILL
+        - name: SENDNN_INFERENCE_USE_CHUNKED_PREFILL
           value: "0"
       resources:
         requests:

--- a/ai-services/assets/components/reranker/vllm-spyre/openshift/templates/reranker-inferenceservice.yaml
+++ b/ai-services/assets/components/reranker/vllm-spyre/openshift/templates/reranker-inferenceservice.yaml
@@ -25,8 +25,6 @@ spec:
           value: "4"
         - name: SENDNN_INFERENCE_WARMUP_PROMPT_LENS
           value: "1024"
-        - name: SENDNN_INFERENCE_USE_CHUNKED_PREFILL
-          value: "0"
       resources:
         requests:
           cpu: {{ .Values.resources.requests.cpu | quote }}

--- a/ai-services/assets/components/reranker/vllm-spyre/openshift/values.yaml
+++ b/ai-services/assets/components/reranker/vllm-spyre/openshift/values.yaml
@@ -2,9 +2,9 @@ model: ""
 resources:
   requests:
     cpu: "8"
-    memory: "4Gi"
+    memory: "5Gi"
     ibm.com/spyre_pf: "1"
   limits:
     cpu: "8"
-    memory: "4Gi"
+    memory: "5Gi"
     ibm.com/spyre_pf: "1"

--- a/ai-services/assets/components/reranker/vllm-spyre/podman/templates/reranker-server.yaml.tmpl
+++ b/ai-services/assets/components/reranker/vllm-spyre/podman/templates/reranker-server.yaml.tmpl
@@ -44,11 +44,11 @@ spec:
           value: "/models/{{ .Values.model }}"
         - name: AIU_WORLD_SIZE
           value: "1"
-        - name: VLLM_SPYRE_USE_CHUNKED_PREFILL
+        - name: SENDNN_INFERENCE_USE_CHUNKED_PREFILL
           value: "0"
-        - name: VLLM_SPYRE_WARMUP_BATCH_SIZES
+        - name: SENDNN_INFERENCE_WARMUP_BATCH_SIZES
           value: "4"
-        - name: VLLM_SPYRE_WARMUP_PROMPT_LENS
+        - name: SENDNN_INFERENCE_WARMUP_PROMPT_LENS
           value: "1024"
         - name: MASTER_PORT
           value: "12356"

--- a/ai-services/assets/components/reranker/vllm-spyre/podman/templates/reranker-server.yaml.tmpl
+++ b/ai-services/assets/components/reranker/vllm-spyre/podman/templates/reranker-server.yaml.tmpl
@@ -44,8 +44,6 @@ spec:
           value: "/models/{{ .Values.model }}"
         - name: AIU_WORLD_SIZE
           value: "1"
-        - name: SENDNN_INFERENCE_USE_CHUNKED_PREFILL
-          value: "0"
         - name: SENDNN_INFERENCE_WARMUP_BATCH_SIZES
           value: "4"
         - name: SENDNN_INFERENCE_WARMUP_PROMPT_LENS

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.360
+  image: icr.io/ai-services-cicd/ai-services:v0.0.361
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.360
+  image: icr.io/ai-services-cicd/ai-services:v0.0.361
   runtime: "podman"
   token: ""
   gatewayAddr: ""


### PR DESCRIPTION
Renamed VLLM_SPYRE to SENDNN_INFERENCE in spyre reranker deployments