### PR TITLE
fix: Make StorageURI generic based on model (OpenShift)

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.347
+TAG?=v0.0.348
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.347
+  image: icr.io/ai-services-cicd/ai-services:v0.0.348
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.347
+  image: icr.io/ai-services-cicd/ai-services:v0.0.348
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/components/embedding/vllm-cpu/openshift/templates/embedding-inferenceservice.yaml
+++ b/ai-services/assets/components/embedding/vllm-cpu/openshift/templates/embedding-inferenceservice.yaml
@@ -28,7 +28,7 @@ spec:
           cpu: {{ .Values.resources.limits.cpu | quote }}
           memory: {{ .Values.resources.limits.memory | quote }}
       runtime: cpu-temp
-      storageUri: {{ .Values.storageUri }}
+      storageUri: hf://{{ .Values.model }}
       args:
         - --served-model-name={{ .Values.model }}
         - --max-model-len=512

--- a/ai-services/assets/components/embedding/vllm-cpu/openshift/values.yaml
+++ b/ai-services/assets/components/embedding/vllm-cpu/openshift/values.yaml
@@ -1,5 +1,4 @@
-storageUri: hf://ibm-granite/granite-embedding-278m-multilingual
-model: ibm-granite/granite-embedding-278m-multilingual
+model: ""
 resources:
   requests:
     cpu: "8"

--- a/ai-services/assets/components/llm/vllm-cpu/openshift/templates/instruct-inferenceservice.yaml
+++ b/ai-services/assets/components/llm/vllm-cpu/openshift/templates/instruct-inferenceservice.yaml
@@ -44,4 +44,4 @@ spec:
           cpu: {{ .Values.resources.limits.cpu | quote }}
           memory: {{ .Values.resources.limits.memory | quote }}
       runtime: cpu-temp
-      storageUri: {{ .Values.storageUri }}
+      storageUri: hf://{{ .Values.model }}

--- a/ai-services/assets/components/llm/vllm-cpu/openshift/values.yaml
+++ b/ai-services/assets/components/llm/vllm-cpu/openshift/values.yaml
@@ -1,5 +1,4 @@
-storageUri: hf://ibm-granite/granite-3.3-8b-instruct
-model: ibm-granite/granite-3.3-8b-instruct
+model: ""
 apiKey: ""
 resources:
   requests:

--- a/ai-services/assets/components/llm/vllm-spyre/openshift/templates/instruct-inferenceservice.yaml
+++ b/ai-services/assets/components/llm/vllm-spyre/openshift/templates/instruct-inferenceservice.yaml
@@ -45,4 +45,4 @@ spec:
           memory: {{ .Values.resources.limits.memory | quote }}
           ibm.com/spyre_pf: {{ index .Values.resources.limits "ibm.com/spyre_pf" | quote }}
       runtime: spyre-temp
-      storageUri: {{ .Values.storageUri }}
+      storageUri: hf://{{ .Values.model }}

--- a/ai-services/assets/components/llm/vllm-spyre/openshift/values.yaml
+++ b/ai-services/assets/components/llm/vllm-spyre/openshift/values.yaml
@@ -1,5 +1,4 @@
-storageUri: hf://ibm-granite/granite-3.3-8b-instruct
-model: ibm-granite/granite-3.3-8b-instruct
+model: ""
 apiKey: ""
 resources:
   requests:

--- a/ai-services/assets/components/reranker/vllm-cpu/openshift/templates/reranker-inferenceservice.yaml
+++ b/ai-services/assets/components/reranker/vllm-cpu/openshift/templates/reranker-inferenceservice.yaml
@@ -28,6 +28,6 @@ spec:
           cpu: {{ .Values.resources.limits.cpu | quote }}
           memory: {{ .Values.resources.limits.memory | quote }}
       runtime: cpu-temp
-      storageUri: {{ .Values.storageUri }}
+      storageUri: hf://{{ .Values.model }}
       args:
         - --served-model-name={{ .Values.model }}

--- a/ai-services/assets/components/reranker/vllm-cpu/openshift/values.yaml
+++ b/ai-services/assets/components/reranker/vllm-cpu/openshift/values.yaml
@@ -1,5 +1,4 @@
-storageUri: hf://BAAI/bge-reranker-v2-m3
-model: BAAI/bge-reranker-v2-m3
+model: ""
 resources:
   requests:
     cpu: "8"

--- a/ai-services/assets/components/reranker/vllm-spyre/openshift/templates/reranker-inferenceservice.yaml
+++ b/ai-services/assets/components/reranker/vllm-spyre/openshift/templates/reranker-inferenceservice.yaml
@@ -37,7 +37,7 @@ spec:
           memory: {{ .Values.resources.limits.memory | quote }}
           ibm.com/spyre_pf: {{ index .Values.resources.limits "ibm.com/spyre_pf" | quote }}
       runtime: spyre-temp
-      storageUri: {{ .Values.storageUri }}
+      storageUri: hf://{{ .Values.model }}
       args:
         - --served-model-name={{ .Values.model }}
         - -tp 1

--- a/ai-services/assets/components/reranker/vllm-spyre/openshift/values.yaml
+++ b/ai-services/assets/components/reranker/vllm-spyre/openshift/values.yaml
@@ -1,5 +1,4 @@
-storageUri: hf://BAAI/bge-reranker-v2-m3
-model: BAAI/bge-reranker-v2-m3
+model: ""
 resources:
   requests:
     cpu: "8"

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.347
+  image: icr.io/ai-services-cicd/ai-services:v0.0.348
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.347
+  image: icr.io/ai-services-cicd/ai-services:v0.0.348
   runtime: "podman"
   token: ""
   gatewayAddr: ""


### PR DESCRIPTION
Currently storageURI is hardcoded to granite3.3-8b model which needs to be dynamically computed to support multiple models.