### PR TITLE
Accept schema json example part of extract sync and async requests

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.361
+TAG?=v0.0.362
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -120,7 +120,7 @@ extract:
   # @description Host port for the Extract API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/extract-service:v0.0.9
+  image: icr.io/ai-services-cicd/extract-service:v0.0.10
   # @hidden
   log_level: "INFO"
   database: "extract_metadata"

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.361
+  image: icr.io/ai-services-cicd/ai-services:v0.0.362
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.361
+  image: icr.io/ai-services-cicd/ai-services:v0.0.362
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/services/extract/openshift/values.yaml
+++ b/ai-services/assets/services/extract/openshift/values.yaml
@@ -1,5 +1,5 @@
 extract:
-  image: icr.io/ai-services-cicd/extract-service:v0.0.9
+  image: icr.io/ai-services-cicd/extract-service:v0.0.10
   log_level: "INFO"
   database: "extract_metadata"
   resources:

--- a/ai-services/assets/services/extract/podman/values.yaml
+++ b/ai-services/assets/services/extract/podman/values.yaml
@@ -1,6 +1,6 @@
 extract:
   port: ""
-  image: icr.io/ai-services-cicd/extract-service:v0.0.9
+  image: icr.io/ai-services-cicd/extract-service:v0.0.10
   log_level: "INFO"
   database: "extract_metadata"
 

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.361
+  image: icr.io/ai-services-cicd/ai-services:v0.0.362
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.361
+  image: icr.io/ai-services-cicd/ai-services:v0.0.362
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/services/extract/Makefile
+++ b/services/extract/Makefile
@@ -1,5 +1,5 @@
 IMAGE=extract-service
-TAG?=v0.0.9
+TAG?=v0.0.10
 
 run:
 	PORT=$${PORT:-6000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/extract/api/v1/jobs.py
+++ b/services/extract/api/v1/jobs.py
@@ -48,7 +48,6 @@ from extract.utils.job import (
     check_job_admission,
     process_batch_job,
     process_file,
-    resolve_schema,
     validate_and_resolve_file,
     validate_file_content,
     delete_all_job_files,
@@ -152,7 +151,6 @@ async def extract_sync(request: Request, body: ExtractionRequest) -> JSONRespons
         msg = "text field is empty"
         logger.error(msg)
         raise ExtractException(400, "INVALID_REQUEST", msg)
-
 
     # ------------------------------------------------------------------
     # 2. Semaphore check (non-blocking — reject immediately if saturated)
@@ -335,10 +333,12 @@ async def extract_sync(request: Request, body: ExtractionRequest) -> JSONRespons
         "against a registered schema.  Returns immediately with a `job_id`.\n\n"
         "**Form parameters:**\n"
         "- `files` (required): One or more `.txt` or `.md` files (no duplicates)\n"
-        "- `schema_id` (optional): ID of a registered extraction schema\n"
-        "- `schema_name` (optional): Name of a registered extraction schema\n"
+        "- `schema_id` (optional): ID of a registered schema\n"
+        "- `schema_name` (optional): Name of a registered schema\n"
+        "- `json_schema` (optional): Ephemeral JSON Schema\n"
+        "- `json_example` (optional): Ephemeral JSON example\n"
         "- `job_name` (optional): Human-readable label for the job\n"
-        "\nEither `schema_id` or `schema_name` must be provided.\n"
+        "\nEither `schema_id` or `schema_name` or `json_schema` or `json_example` must be provided.\n"
     ),
     tags=["jobs"],
 )
@@ -346,17 +346,12 @@ async def create_extract_job(
     files: List[UploadFile] = File(...),
     schema_id: Optional[str] = Form(None),
     schema_name: Optional[str] = Form(None),
+    json_schema: Optional[str] = Form(None),
+    json_example: Optional[str] = Form(None),
     job_name: Optional[str] = Form(None),
 ) -> JobCreatedResponse:
     """Validate, stage, record, and enqueue an async extraction job (single or batch)."""
     check_job_admission()
-
-    if not schema_id and not schema_name:
-        raise ExtractException(
-            400,
-            "INVALID_REQUEST",
-            "Either schema_id or schema_name must be provided.",
-        )
 
     # ------------------------------------------------------------------
     # 1. File count validation
@@ -439,15 +434,60 @@ async def create_extract_job(
     # ------------------------------------------------------------------
     # 3. Schema lookup
     # ------------------------------------------------------------------
-    if schema_id:
-        schema_row = _resolve_schema_id(schema_id)
-        if schema_name and schema_row.name != schema_name:
+    json_schema_dict: Optional[dict] = None
+    if json_schema is not None:
+        try:
+            json_schema_dict = json.loads(json_schema)
+        except json.JSONDecodeError as exc:
             raise ExtractException(
-                400,
-                "INVALID_REQUEST",
-                "Schema name and id are not for the same record")
-    else:
-        schema_row = _resolve_schema_name(schema_name)
+                400, "INVALID_REQUEST", f"json_schema is not valid JSON: {exc}"
+            )
+
+    json_example_dict: Optional[dict] = None
+    if json_example is not None:
+        try:
+            json_example_dict = json.loads(json_example)
+        except json.JSONDecodeError as exc:
+            raise ExtractException(
+                400, "INVALID_REQUEST", f"json_example is not valid JSON: {exc}"
+            )
+
+    llm_model_dict = get_llm_endpoint()
+    llm_endpoint: str = llm_model_dict.get("llm_endpoint", "")
+
+    try:
+        schema_row = resolve_schema_input(
+            schema_id=schema_id,
+            schema_name=schema_name,
+            json_schema=json_schema_dict,
+            json_example=json_example_dict,
+            llm_endpoint=llm_endpoint,
+        )
+    except SchemaValidationError as exc:
+        raise ExtractException(exc.status, exc.code, exc.message)
+
+    if schema_row.schema_id is None:
+        # Ephemeral schema, register it to satisfy DB foreign key constraint
+        ephemeral_id = f"ephemeral-{uuid.uuid4()}"
+        ephemeral_name = f"ephemeral-{ephemeral_id}"
+        db_row = db_repo.create_schema(
+            schema_id=ephemeral_id,
+            name=ephemeral_name,
+            json_schema=schema_row.json_schema,
+            schema_tokens=schema_row.schema_tokens,
+            examples_tokens=schema_row.examples_tokens,
+            custom_prompt_tokens=schema_row.custom_prompt_tokens,
+            examples=schema_row.examples,
+            custom_prompt=schema_row.custom_prompt,
+            is_schema_inferred=True if json_example_dict is not None else False,
+        )
+        if db_row is None:
+            raise ExtractException(500, "DATABASE_ERROR", "Failed to register ephemeral schema for batch job.")
+        schema_row = db_row
+
+    resolved_schema_id = schema_row.schema_id
+    if resolved_schema_id is None:
+        raise ExtractException(500, "DATABASE_ERROR", "Resolved schema ID is missing.")
 
     # ------------------------------------------------------------------
     # 4. Stage all files, create job + document rows
@@ -464,7 +504,7 @@ async def create_extract_job(
         try:
             row = db_repo.create_job(
                 job_id=job_id,
-                schema_id=schema_id,
+                schema_id=resolved_schema_id,
                 schema_name=schema_name,
                 job_name=job_name,
                 submitted_at=datetime.now(timezone.utc),
@@ -496,7 +536,7 @@ async def create_extract_job(
         _success = True
         asyncio.create_task(process_batch_job(job_id))
         logger.info(
-            f"Accepted extraction job {job_id} (schema={schema_id}, "
+            f"Accepted extraction job {job_id} (schema={schema_row.schema_id}, "
             f"files={len(files)}, job_name={job_name!r})"
         )
         return JobCreatedResponse(job_id=job_id, file_count=len(files))

--- a/services/extract/api/v1/jobs.py
+++ b/services/extract/api/v1/jobs.py
@@ -59,10 +59,12 @@ from extract.utils.job import (
     validate_file_extension,
 )
 from extract.utils.schema import (
+    SchemaValidationError,
     _tokenize,
     check_extraction_budget,
     compute_reserved_output,
     fmt_dt,
+    resolve_schema_input,
 )
 
 router = APIRouter()
@@ -131,23 +133,26 @@ async def extract_sync(request: Request, body: ExtractionRequest) -> JSONRespons
     # 1. Basic field validation
     # ------------------------------------------------------------------
     if not body.text.strip():
+        raise ExtractException(400, "INVALID_REQUEST", "text field is empty")
+
+    llm_model_dict = get_llm_endpoint()
+    llm_endpoint: str = llm_model_dict.get("llm_endpoint", "")
+    llm_model: str = llm_model_dict.get("llm_model", "")
+    max_model_len: int = llm_model_dict.get('max_model_len', "")
+
+    try:
+        schema_row = resolve_schema_input(
+            schema_id=body.schema_id,
+            schema_name=body.schema_name,
+            json_schema=body.json_schema,
+            json_example=body.json_example,
+            llm_endpoint=llm_endpoint,
+        )
+    except SchemaValidationError as exc:
         msg = "text field is empty"
         logger.error(msg)
         raise ExtractException(400, "INVALID_REQUEST", msg)
-    if not body.schema_name and not body.schema_id:
-        raise ExtractException(
-            400,
-            "INVALID_REQUEST",
-            "Either schema_id or schema_name must be provided.")
-    elif body.schema_id:
-        schema_row = _resolve_schema_id(body.schema_id)
-        if body.schema_name and schema_row.name != body.schema_name:
-            raise ExtractException(
-                400,
-                "INVALID_REQUEST",
-                "Schema name and id are not for the same record")
-    else:
-        schema_row = _resolve_schema_name(body.schema_name)
+
 
     # ------------------------------------------------------------------
     # 2. Semaphore check (non-blocking — reject immediately if saturated)
@@ -160,10 +165,6 @@ async def extract_sync(request: Request, body: ExtractionRequest) -> JSONRespons
             msg,
         )
 
-    llm_model_dict = get_llm_endpoint()
-    llm_endpoint: str = llm_model_dict.get("llm_endpoint", "")
-    llm_model: str = llm_model_dict.get("llm_model", "")
-    max_model_len: int = llm_model_dict.get("max_model_len", 0)
 
     # ------------------------------------------------------------------
     # 3–8. Core extraction

--- a/services/extract/db/manager.py
+++ b/services/extract/db/manager.py
@@ -91,15 +91,14 @@ class DatabaseManager:
             return None
 
     @staticmethod
-    def get_schema_by_name(schema_name: str) -> Optional[ExtractionSchema]:
-        """Return a schema row or None if not found."""
+    def get_schema_by_name(name: str) -> Optional[ExtractionSchema]:
+        """Return a schema row by its unique name, or None if not found."""
         try:
             with get_db_session() as session:
                 row = session.scalar(
-                    select(ExtractionSchema).where(ExtractionSchema.name == schema_name)
+                    select(ExtractionSchema).where(ExtractionSchema.name == name)
                 )
                 if row:
-                    # Eagerly load all columns before session closes.
                     _ = (
                         row.schema_id, row.name, row.description, row.json_schema,
                         row.examples, row.custom_prompt, row.schema_tokens,
@@ -108,7 +107,7 @@ class DatabaseManager:
                     session.expunge(row)
                 return row
         except SQLAlchemyError as exc:
-            logger.error(f"DB error retrieving schema {schema_name}: {exc}", exc_info=True)
+            logger.error(f"DB error retrieving schema by name {name!r}: {exc}", exc_info=True)
             return None
 
     @staticmethod

--- a/services/extract/models.py
+++ b/services/extract/models.py
@@ -236,24 +236,6 @@ class ExtractionRequest(BaseModel):
         ),
     )
 
-    @field_validator("json_schema", "json_example", "schema_name", "schema_id", mode="before")
-    @classmethod
-    def _at_least_one_schema_source(cls, v: Any, info: Any) -> Any:  # noqa: N805
-        # Individual field validators cannot see sibling fields; mutual-exclusivity
-        # is enforced in the model-level validator below.
-        return v
-
-    def model_post_init(self, __context: Any) -> None:  # noqa: D401
-        """Ensure exactly one schema source is present."""
-        provided = [
-            f
-            for f in ("schema_id", "schema_name", "json_schema", "json_example")
-            if getattr(self, f) is not None
-        ]
-        if not provided:
-            raise ValueError(
-                "One of schema_id, schema_name, json_schema, or json_example must be provided."
-            )
 
 
 class ExtractionSourceInfo(BaseModel):

--- a/services/extract/models.py
+++ b/services/extract/models.py
@@ -208,11 +208,52 @@ class JobResultResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 class ExtractionRequest(BaseModel):
-    """Request body for POST /v1/extract."""
+    """Request body for POST /v1/extract.
+
+    Exactly one schema source must be supplied, resolved in priority order:
+    ``schema_id`` → ``schema_name`` → ``json_schema`` → ``json_example``.
+    """
 
     text: str = Field(..., min_length=1, description="Raw text to extract from")
-    schema_id: Optional[str] = Field(default=None, min_length=1, description="ID of a registered schema")
-    schema_name: Optional[str] = Field(default=None, min_length=1, description="Registered schema name")
+    schema_id: Optional[str] = Field(
+        None, min_length=1, description="ID of a registered schema"
+    )
+    schema_name: Optional[str] = Field(
+        None, min_length=1, description="Name of a registered schema"
+    )
+    json_schema: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "Raw JSON Schema draft 2020-12 (root must be type:object). "
+            "Used as an ephemeral, unregistered schema for this request."
+        ),
+    )
+    json_example: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "A single JSON object whose structure is used to infer an ephemeral "
+            "schema for this request."
+        ),
+    )
+
+    @field_validator("json_schema", "json_example", "schema_name", "schema_id", mode="before")
+    @classmethod
+    def _at_least_one_schema_source(cls, v: Any, info: Any) -> Any:  # noqa: N805
+        # Individual field validators cannot see sibling fields; mutual-exclusivity
+        # is enforced in the model-level validator below.
+        return v
+
+    def model_post_init(self, __context: Any) -> None:  # noqa: D401
+        """Ensure exactly one schema source is present."""
+        provided = [
+            f
+            for f in ("schema_id", "schema_name", "json_schema", "json_example")
+            if getattr(self, f) is not None
+        ]
+        if not provided:
+            raise ValueError(
+                "One of schema_id, schema_name, json_schema, or json_example must be provided."
+            )
 
 
 class ExtractionSourceInfo(BaseModel):

--- a/services/extract/tests/unit/test_extract_sync.py
+++ b/services/extract/tests/unit/test_extract_sync.py
@@ -320,6 +320,23 @@ class TestExtractionRequestModel:
         req = ExtractionRequest(text="hello")
         assert req.schema_id is None
         assert req.schema_name is None
+    def test_no_schema_source_rejected(self):
+        with pytest.raises(Exception):
+            ExtractionRequest(text="hello")
+
+    def test_schema_name_accepted(self):
+        req = ExtractionRequest(text="hello", schema_name="my-schema")
+        assert req.schema_name == "my-schema"
+        assert req.schema_id is None
+
+    def test_json_schema_accepted(self):
+        schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+        req = ExtractionRequest(text="hello", json_schema=schema)
+        assert req.json_schema == schema
+
+    def test_json_example_accepted(self):
+        req = ExtractionRequest(text="hello", json_example={"name": "Alice"})
+        assert req.json_example == {"name": "Alice"}
 
 
 # ---------------------------------------------------------------------------
@@ -399,9 +416,12 @@ class TestExtractSyncEndpoint:
 
     def test_400_missing_schema_id_and_name(self, extract_test_client):
         """Neither schema_id nor schema_name → 400 INVALID_REQUEST."""
+    def test_422_no_schema_source(self, extract_test_client):
         resp = extract_test_client.post("/v1/extract", json={"text": "hello"})
         assert resp.status_code == 400
         assert resp.json()["error"]["code"] == "INVALID_REQUEST"
+        assert resp.status_code == 422
+        assert resp.json()["detail"][0]["type"] == "value_error"
 
     def test_400_missing_text(self, extract_test_client):
         resp = extract_test_client.post("/v1/extract", json={"schema_id": "abc"})

--- a/services/extract/tests/unit/test_extract_sync.py
+++ b/services/extract/tests/unit/test_extract_sync.py
@@ -320,9 +320,6 @@ class TestExtractionRequestModel:
         req = ExtractionRequest(text="hello")
         assert req.schema_id is None
         assert req.schema_name is None
-    def test_no_schema_source_rejected(self):
-        with pytest.raises(Exception):
-            ExtractionRequest(text="hello")
 
     def test_schema_name_accepted(self):
         req = ExtractionRequest(text="hello", schema_name="my-schema")
@@ -416,12 +413,9 @@ class TestExtractSyncEndpoint:
 
     def test_400_missing_schema_id_and_name(self, extract_test_client):
         """Neither schema_id nor schema_name → 400 INVALID_REQUEST."""
-    def test_422_no_schema_source(self, extract_test_client):
         resp = extract_test_client.post("/v1/extract", json={"text": "hello"})
         assert resp.status_code == 400
         assert resp.json()["error"]["code"] == "INVALID_REQUEST"
-        assert resp.status_code == 422
-        assert resp.json()["detail"][0]["type"] == "value_error"
 
     def test_400_missing_text(self, extract_test_client):
         resp = extract_test_client.post("/v1/extract", json={"schema_id": "abc"})

--- a/services/extract/tests/unit/test_job_endpoints.py
+++ b/services/extract/tests/unit/test_job_endpoints.py
@@ -284,6 +284,102 @@ class TestCreateExtractJob:
         assert resp.status_code == 500
         assert resp.json()["error"]["code"] == "DATABASE_ERROR"
 
+    def test_202_by_schema_name(self, extract_test_client):
+        schema_row = _mock_schema_row()
+        with patch("extract.api.v1.jobs.resolve_schema_input", return_value=schema_row) as mock_resolve, \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.stage_multiple_files"), \
+             patch("extract.api.v1.jobs.db_repo.create_job", return_value=_mock_job_row(status="accepted")), \
+             patch("extract.api.v1.jobs.db_repo.create_documents", return_value=True), \
+             patch("extract.api.v1.jobs.validate_file_content", new=AsyncMock()), \
+             patch("extract.api.v1.jobs.process_batch_job", new=AsyncMock()), \
+             _patch_extract_limiter_free():
+            resp = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"schema_name": "my-schema"},
+                files=[("files", ("doc.txt", b"content", "text/plain"))],
+            )
+
+        assert resp.status_code == 202
+        body = resp.json()
+        assert "job_id" in body
+        mock_resolve.assert_called_once()
+
+    def test_202_by_json_schema(self, extract_test_client):
+        from extract.utils.schema import _EphemeralSchemaRow
+        ephemeral_row = _EphemeralSchemaRow(json_schema={"type": "object"})
+        registered_row = _mock_schema_row(schema_id="ephemeral-123")
+        
+        with patch("extract.api.v1.jobs.resolve_schema_input", return_value=ephemeral_row), \
+             patch("extract.api.v1.jobs.db_repo.create_schema", return_value=registered_row) as mock_create_schema, \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.stage_multiple_files"), \
+             patch("extract.api.v1.jobs.db_repo.create_job", return_value=_mock_job_row(status="accepted", schema_id="ephemeral-123")), \
+             patch("extract.api.v1.jobs.db_repo.create_documents", return_value=True), \
+             patch("extract.api.v1.jobs.validate_file_content", new=AsyncMock()), \
+             patch("extract.api.v1.jobs.process_batch_job", new=AsyncMock()), \
+             _patch_extract_limiter_free():
+            resp = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"json_schema": '{"type": "object"}'},
+                files=[("files", ("doc.txt", b"content", "text/plain"))],
+            )
+
+        assert resp.status_code == 202
+        body = resp.json()
+        assert "job_id" in body
+        mock_create_schema.assert_called_once()
+
+    def test_202_by_json_example(self, extract_test_client):
+        from extract.utils.schema import _EphemeralSchemaRow
+        ephemeral_row = _EphemeralSchemaRow(json_schema={"type": "object"})
+        registered_row = _mock_schema_row(schema_id="ephemeral-456")
+        
+        with patch("extract.api.v1.jobs.resolve_schema_input", return_value=ephemeral_row), \
+             patch("extract.api.v1.jobs.db_repo.create_schema", return_value=registered_row) as mock_create_schema, \
+             patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.stage_multiple_files"), \
+             patch("extract.api.v1.jobs.db_repo.create_job", return_value=_mock_job_row(status="accepted", schema_id="ephemeral-456")), \
+             patch("extract.api.v1.jobs.db_repo.create_documents", return_value=True), \
+             patch("extract.api.v1.jobs.validate_file_content", new=AsyncMock()), \
+             patch("extract.api.v1.jobs.process_batch_job", new=AsyncMock()), \
+             _patch_extract_limiter_free():
+            resp = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"json_example": '{"name": "Alice"}'},
+                files=[("files", ("doc.txt", b"content", "text/plain"))],
+            )
+
+        assert resp.status_code == 202
+        body = resp.json()
+        assert "job_id" in body
+        mock_create_schema.assert_called_once()
+
+    def test_400_all_schema_params_missing(self, extract_test_client):
+        with patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.validate_file_content", new=AsyncMock()), \
+             _patch_extract_limiter_free():
+            resp = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={},
+                files=[("files", ("doc.txt", b"content", "text/plain"))],
+            )
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "INVALID_REQUEST"
+
+    def test_400_invalid_json_schema_format(self, extract_test_client):
+        with patch("extract.api.v1.jobs.validate_file_extension", return_value=(True, ".txt")), \
+             patch("extract.api.v1.jobs.validate_file_content", new=AsyncMock()), \
+             _patch_extract_limiter_free():
+            resp = extract_test_client.post(
+                "/v1/extract/jobs",
+                data={"json_schema": "not-valid-json"},
+                files=[("files", ("doc.txt", b"content", "text/plain"))],
+            )
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "INVALID_REQUEST"
+        assert "json_schema is not valid JSON" in resp.json()["error"]["message"]
+
 
     # ── schema_name form field ────────────────────────────────────────────
 

--- a/services/extract/utils/schema.py
+++ b/services/extract/utils/schema.py
@@ -760,6 +760,14 @@ def resolve_schema_input(
             raise ExtractException(
                 404, "SCHEMA_NOT_FOUND", f"No schema with id {schema_id!r}."
             )
+        if schema_name is not None and row.name != schema_name:
+            logger.error(
+                "Schema name mismatch: schema_id=%r resolved to name %r, but request specified schema_name=%r",
+                schema_id, row.name, schema_name
+            )
+            raise ExtractException(
+                400, "INVALID_REQUEST", "Schema name and id are not for the same record"
+            )
         return row
 
     # ── Priority 2: schema_name ───────────────────────────────────────────

--- a/services/extract/utils/schema.py
+++ b/services/extract/utils/schema.py
@@ -688,4 +688,136 @@ def fmt_dt(dt) -> Optional[str]:
         dt = dt.replace(tzinfo=timezone.utc)
     return dt.isoformat().replace("+00:00", "Z")
 
+# ---------------------------------------------------------------------------
+# Schema input resolver — used by the sync extraction endpoint
+# ---------------------------------------------------------------------------
+
+class _EphemeralSchemaRow:
+    """Minimal duck-type for a schema DB row, used for ephemeral (unregistered) schemas.
+
+    Carries only the fields that ``extract_sync`` reads from a registered row.
+    Token counts are computed on-demand inside :func:`resolve_schema_input`.
+    """
+
+    def __init__(
+        self,
+        json_schema: Dict[str, Any],
+        schema_tokens: int = 0,
+        examples_tokens: int = 0,
+        custom_prompt_tokens: int = 0,
+    ) -> None:
+        self.schema_id: Optional[str] = None
+        self.json_schema = json_schema
+        self.examples: Optional[List[Dict[str, Any]]] = None
+        self.custom_prompt: Optional[str] = None
+        self.schema_tokens = schema_tokens
+        self.examples_tokens = examples_tokens
+        self.custom_prompt_tokens = custom_prompt_tokens
+
+
+def resolve_schema_input(
+    schema_id: Optional[str],
+    schema_name: Optional[str],
+    json_schema: Optional[Dict[str, Any]],
+    json_example: Optional[Dict[str, Any]],
+    llm_endpoint: str,
+):
+    """Resolve and validate the schema source for a sync extraction request.
+
+    Priority: ``schema_id`` → ``schema_name`` → ``json_schema`` → ``json_example``.
+
+    For registered schemas (``schema_id`` / ``schema_name``), the stored DB row
+    is returned directly — token counts are pre-computed at registration time.
+
+    For ephemeral schemas (``json_schema`` / ``json_example``), the same
+    structural validations applied during schema registration are performed:
+
+    - ``json_schema``: normalized then validated with
+      :func:`validate_json_schema_structure`.
+    - ``json_example``: inferred via :func:`infer_schema_from_examples`, which
+      applies the same inference logic used during registration.
+
+    Token counts for ephemeral schemas are computed here so that
+    ``check_extraction_budget`` can use them.
+
+    Returns:
+        A DB row object (or :class:`_EphemeralSchemaRow`) whose attributes
+        ``json_schema``, ``examples``, ``custom_prompt``, ``schema_tokens``,
+        ``examples_tokens``, and ``custom_prompt_tokens`` are all populated.
+
+    Raises:
+        :class:`ExtractException` (404) when a registered schema cannot be found.
+        :class:`SchemaValidationError` (400) when an ephemeral schema fails
+        structural validation.
+    """
+    from extract.db.manager import db_repo  # local import to avoid circular deps
+
+    # ── Priority 1: schema_id ─────────────────────────────────────────────
+    if schema_id is not None:
+        row = db_repo.get_schema_by_id(schema_id)
+        if row is None:
+            logger.error("Schema not found for schema_id=%r", schema_id)
+            raise ExtractException(
+                404, "SCHEMA_NOT_FOUND", f"No schema with id {schema_id!r}."
+            )
+        return row
+
+    # ── Priority 2: schema_name ───────────────────────────────────────────
+    if schema_name is not None:
+        row = db_repo.get_schema_by_name(schema_name)
+        if row is None:
+            logger.error("Schema not found for schema_name=%r", schema_name)
+            raise ExtractException(
+                404, "SCHEMA_NOT_FOUND", f"No schema with name {schema_name!r}."
+            )
+        return row
+
+    # ── Priority 3: raw JSON Schema ───────────────────────────────────────
+    if json_schema is not None:
+        try:
+            normalized = normalize_schema(json_schema)
+            validate_json_schema_structure(normalized)
+        except SchemaValidationError as exc:
+            logger.error(
+                "Ephemeral json_schema failed validation: [%s] %s", exc.code, exc.message
+            )
+            raise
+        schema_tokens, _, _ = compute_token_counts(normalized, None, None, llm_endpoint)
+        return _EphemeralSchemaRow(
+            json_schema=normalized,
+            schema_tokens=schema_tokens,
+        )
+
+    # ── Priority 4: JSON example ──────────────────────────────────────────
+    if json_example is not None:
+        if not isinstance(json_example, dict) or not json_example:
+            logger.error("json_example is not a non-empty object: %r", type(json_example).__name__)
+            raise SchemaValidationError(
+                "INVALID_EXAMPLE",
+                "json_example must be a non-empty JSON object.",
+                status=400,
+            )
+        # Wrap as an example record so infer_schema_from_examples can process it.
+        examples_raw = [{"text": "", "output": json_example}]
+        try:
+            normalized = infer_schema_from_examples(examples_raw)
+        except SchemaValidationError as exc:
+            logger.error(
+                "Schema inference from json_example failed: [%s] %s", exc.code, exc.message
+            )
+            raise
+        schema_tokens, _, _ = compute_token_counts(normalized, None, None, llm_endpoint)
+        return _EphemeralSchemaRow(
+            json_schema=normalized,
+            schema_tokens=schema_tokens,
+        )
+
+    # Guard: ExtractionRequest.model_post_init ensures we never reach here at runtime.
+    logger.error("resolve_schema_input called with all schema inputs None")
+    raise ExtractException(
+        400, "INVALID_REQUEST",
+        "One of schema_id, schema_name, json_schema, or json_example must be provided.",
+    )
+
+
 # Made with Bob


### PR DESCRIPTION
Now both sync and async routes for entity extraction will accept raw_json_schema or json_example isntead of schema_id so user can get flexibility while passing input.