### PR TITLE
use worker join flow in catalog for local

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.348
+TAG?=v0.0.349
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.348
+  image: icr.io/ai-services-cicd/ai-services:v0.0.349
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.348
+  image: icr.io/ai-services-cicd/ai-services:v0.0.349
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.348
+  image: icr.io/ai-services-cicd/ai-services:v0.0.349
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.348
+  image: icr.io/ai-services-cicd/ai-services:v0.0.349
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -2790,6 +2790,13 @@ const docTemplate = `{
                             "additionalProperties": true
                         }
                     },
+                    "403": {
+                        "description": "Local worker cannot be deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
                     "404": {
                         "description": "Worker not found",
                         "schema": {

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -2784,6 +2784,13 @@
                             "additionalProperties": true
                         }
                     },
+                    "403": {
+                        "description": "Local worker cannot be deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
                     "404": {
                         "description": "Worker not found",
                         "schema": {

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -2859,6 +2859,11 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "403":
+          description: Local worker cannot be deleted
+          schema:
+            additionalProperties: true
+            type: object
         "404":
           description: Worker not found
           schema:

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
@@ -75,22 +75,26 @@ func (h *WorkerHandler) CreateWorker(c *gin.Context) {
 		return
 	}
 
+	// "Local" is reserved for the catalog-machine worker registered by the
+	// configure flow. It is only allowed when LOCAL_WORKER=true, meaning this
+	// catalog instance is configured to host a co-located worker.
+	// Preserve the canonical casing so the DB row matches LocalWorkerName exactly.
+	if strings.EqualFold(req.WorkerName, workerconstants.LocalWorkerName) {
+		if utils.GetEnv(workerconstants.LocalWorkerEnvVar, "") != "true" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("worker name %q is reserved", req.WorkerName)})
+
+			return
+		}
+
+		req.WorkerName = workerconstants.LocalWorkerName
+	}
+
 	ctx := c.Request.Context()
 
 	gatewayAddress, err := h.gatewayAddress(ctx)
 	if err != nil {
 		logger.ErrorfCtx(ctx, "worker handler: failed to resolve gateway address: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve worker gateway address"})
-
-		return
-	}
-
-	// "Local" is reserved for the catalog-machine worker registered by the
-	// configure flow. It is only allowed when LOCAL_WORKER=true, meaning this
-	// catalog instance is configured to host a co-located worker.
-	if strings.EqualFold(req.WorkerName, workerconstants.LocalWorkerName) &&
-		utils.GetEnv(workerconstants.LocalWorkerEnvVar, "") != "true" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("worker name %q is reserved", req.WorkerName)})
 
 		return
 	}
@@ -224,6 +228,7 @@ func (h *WorkerHandler) GetWorker(c *gin.Context) {
 //	@Param			id	path	string	true	"Worker ID (UUID)"
 //	@Success		204	"Worker deleted"
 //	@Failure		400	{object}	map[string]interface{}	"Invalid worker ID"
+//	@Failure		403	{object}	map[string]interface{}	"Local worker cannot be deleted"
 //	@Failure		404	{object}	map[string]interface{}	"Worker not found"
 //	@Failure		500	{object}	map[string]interface{}	"Internal error"
 //	@Security		BearerAuth
@@ -237,6 +242,27 @@ func (h *WorkerHandler) DeleteWorker(c *gin.Context) {
 	}
 
 	ctx := c.Request.Context()
+
+	// Resolve the worker name before deletion so we can block the Local worker.
+	w, err := h.repo.GetByID(ctx, workerID)
+	if err != nil {
+		logger.ErrorfCtx(ctx, "worker handler: failed to fetch worker %s: %v", workerID, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete worker"})
+
+		return
+	}
+
+	if w == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "worker not found"})
+
+		return
+	}
+
+	if strings.EqualFold(w.Name, workerconstants.LocalWorkerName) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "the Local worker cannot be deleted"})
+
+		return
+	}
 
 	deleted, err := h.reg.Deregister(ctx, workerID)
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
@@ -85,6 +85,16 @@ func (h *WorkerHandler) CreateWorker(c *gin.Context) {
 		return
 	}
 
+	// "Local" is reserved for the catalog-machine worker registered by the
+	// configure flow. It is only allowed when LOCAL_WORKER=true, meaning this
+	// catalog instance is configured to host a co-located worker.
+	if strings.EqualFold(req.WorkerName, workerconstants.LocalWorkerName) &&
+		utils.GetEnv(workerconstants.LocalWorkerEnvVar, "") != "true" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("worker name %q is reserved", req.WorkerName)})
+
+		return
+	}
+
 	token, err := h.reg.Preregister(ctx, req.WorkerName)
 	if err != nil {
 		logger.ErrorfCtx(ctx, "worker handler: failed to register worker %q: %v", req.WorkerName, err)

--- a/ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go
@@ -96,14 +96,14 @@ func handlePostDeployment(ctx context.Context, tp templates.Template, runtime *r
 		return fmt.Errorf("admin password verification failed: %w", err)
 	}
 
-	// Step 8 (was Step 7): Join as local worker
+	// Step 8: Join as local worker
 	if !opts.SkipLocalWorker {
 		if err := JoinAsLocalWorker(ctx, runtime, catalogClient); err != nil {
 			return fmt.Errorf("local worker join failed: %w", err)
 		}
 	}
 
-	// Step 9 (was Step 8): Print next steps with route URLs
+	// Step 9: Print next steps with route URLs
 	if err := helpers.PrintNextSteps(ctx, tp, runtime, catalogconstants.CatalogAppName, catalogconstants.CatalogAppTemplate); err != nil {
 		logger.Infof("failed to display next steps: %v\n", err)
 

--- a/ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/project-ai-services/ai-services/assets"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure"
+	configureutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure/utils"
 	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
@@ -29,7 +30,7 @@ func DeployCatalog(ctx context.Context, opts catalogutils.OpenShiftConfigureOpti
 	tp := templates.NewEmbedTemplateProvider(&assets.CatalogFS, "")
 
 	// Step 1: Fetch the operation timeout from metadata (or use the user-supplied timeout)
-	timeout, err := getOperationTimeout(ctx, tp, opts.Timeout)
+	timeout, err := getOperationTimeout(tp, opts.Timeout)
 	if err != nil {
 		return err
 	}
@@ -46,8 +47,17 @@ func DeployCatalog(ctx context.Context, opts catalogutils.OpenShiftConfigureOpti
 		return fmt.Errorf("failed to create OpenShift client: %w", err)
 	}
 
-	// Step 4: Collect and hash password (if secret doesn't exist)
-	passwordHash, err := catalogutils.CollectAndHashPassword(ctx, runtime)
+	// Step 4: Collect the admin password.
+	//
+	// Fresh install (secret absent): prompt with confirmation → hash stored in the
+	//   new secret, plaintext used to login after deploy.
+	// Reconfigure (secret present): prompt without confirmation → verify by login.
+	secretExists, err := runtime.SecretExists(ctx, catalogconstants.CatalogSecretName)
+	if err != nil {
+		return fmt.Errorf("failed to check catalog secret: %w", err)
+	}
+
+	passwordHash, adminPassword, err := configureutils.CollectAdminPassword(secretExists)
 	if err != nil {
 		return err
 	}
@@ -67,14 +77,33 @@ func DeployCatalog(ctx context.Context, opts catalogutils.OpenShiftConfigureOpti
 
 	logger.Infoln("-------")
 
-	// Step 7: Join as local worker
+	// Step 7: Login to catalog API, join as local worker, print next steps
+	return handlePostDeployment(ctx, tp, runtime, opts, adminPassword)
+}
+
+// handlePostDeployment logs in to the catalog API (verifying the admin password),
+// optionally joins the local worker, and prints next steps.
+func handlePostDeployment(ctx context.Context, tp templates.Template, runtime *runtimeOpenshift.OpenshiftClient, opts catalogutils.OpenShiftConfigureOptions, adminPassword string) error {
+	// Login to the catalog API — this both verifies the admin password and gives
+	// us a client to reuse for local worker registration without a second login.
+	catalogAPIURL, err := getCatalogAPIURL(ctx, runtime)
+	if err != nil {
+		return fmt.Errorf("failed to resolve catalog API URL: %w", err)
+	}
+
+	catalogClient, err := configure.LoginToCatalog(ctx, catalogAPIURL, adminPassword)
+	if err != nil {
+		return fmt.Errorf("admin password verification failed: %w", err)
+	}
+
+	// Step 8 (was Step 7): Join as local worker
 	if !opts.SkipLocalWorker {
-		if err := JoinAsLocalWorker(ctx); err != nil {
+		if err := JoinAsLocalWorker(ctx, runtime, catalogClient); err != nil {
 			return fmt.Errorf("local worker join failed: %w", err)
 		}
 	}
 
-	// Step 8: Print next steps with route URLs
+	// Step 9 (was Step 8): Print next steps with route URLs
 	if err := helpers.PrintNextSteps(ctx, tp, runtime, catalogconstants.CatalogAppName, catalogconstants.CatalogAppTemplate); err != nil {
 		logger.Infof("failed to display next steps: %v\n", err)
 
@@ -84,7 +113,7 @@ func DeployCatalog(ctx context.Context, opts catalogutils.OpenShiftConfigureOpti
 	return nil
 }
 
-func getOperationTimeout(ctx context.Context, tp templates.Template, timeout time.Duration) (time.Duration, error) {
+func getOperationTimeout(tp templates.Template, timeout time.Duration) (time.Duration, error) {
 	// populate the operation timeout if it's either not set or set negatively
 	if timeout <= 0 {
 		var appMetadata templates.AppMetadata

--- a/ai-services/internal/pkg/catalog/cli/configure/openshift/local_worker.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/openshift/local_worker.go
@@ -4,26 +4,36 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure"
+	catalogclient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
+	runtimeOpenshift "github.com/project-ai-services/ai-services/internal/pkg/runtime/openshift"
 	workeropenshift "github.com/project-ai-services/ai-services/internal/pkg/worker/deploy/openshift"
 	workertypes "github.com/project-ai-services/ai-services/internal/pkg/worker/types"
+)
+
+const (
+	// catalogAPIRouteName is the OpenShift route name for the catalog backend API.
+	catalogAPIRouteName = "catalog-api"
 )
 
 // JoinAsLocalWorker deploys the worker on OpenShift and connects it to the
 // catalog-backend as the "Local" worker.
 //
-// The catalog-backend gateway skips ValidateToken when LOCAL_WORKER=true, so
-// the sentinel LocalWorkerToken is used and no token needs to live in any TokenStore.
-func JoinAsLocalWorker(ctx context.Context) error {
+// It uses the already-authenticated catalog client to call POST /api/v1/workers,
+// obtaining a real bootstrap token without a second login.
+func JoinAsLocalWorker(ctx context.Context, rt *runtimeOpenshift.OpenshiftClient, c *catalogclient.Client) error {
 	logger.InfolnCtx(ctx, "Joining this machine as the Local worker...")
 
-	gatewayAddr := fmt.Sprintf("%s:%d", workerconstants.OpenShiftGatewayServiceEndpoint, workerconstants.WorkerGatewayPort)
+	token, gatewayAddr, err := configure.RegisterLocalWorker(ctx, c)
+	if err != nil {
+		return fmt.Errorf("local worker join: %w", err)
+	}
 
 	opts := workertypes.OpenshiftWorkerOptions{
 		WorkerConnectionOptions: workertypes.WorkerConnectionOptions{
 			GatewayAddr: gatewayAddr,
-			Token:       workerconstants.LocalWorkerToken,
+			Token:       token,
 		},
 	}
 
@@ -34,4 +44,21 @@ func JoinAsLocalWorker(ctx context.Context) error {
 	logger.InfolnCtx(ctx, "Local worker joined successfully.")
 
 	return nil
+}
+
+// getCatalogAPIURL looks up the catalog-api OpenShift route and returns the
+// full HTTPS URL, e.g. "https://catalog-api.apps.cluster.example.com".
+func getCatalogAPIURL(ctx context.Context, rt *runtimeOpenshift.OpenshiftClient) (string, error) {
+	routes, err := rt.ListRoutes(ctx, "")
+	if err != nil {
+		return "", fmt.Errorf("list routes: %w", err)
+	}
+
+	for _, r := range routes {
+		if r.Name == catalogAPIRouteName {
+			return "https://" + r.HostPort, nil
+		}
+	}
+
+	return "", fmt.Errorf("route %q not found in namespace", catalogAPIRouteName)
 }

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -9,6 +9,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure"
+	configureutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure/utils"
 	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
@@ -28,7 +29,12 @@ func DeployCatalog(ctx context.Context, opts catalogUtils.PodmanConfigureOptions
 
 	// Collect and hash password.
 	// If secret exists passwordHash will be empty.
-	passwordHash, err := catalogUtils.CollectAndHashPassword(ctx, deployCtx.Runtime)
+	secretExists, err := deployCtx.Runtime.SecretExists(ctx, catalogconstants.CatalogSecretName)
+	if err != nil {
+		return fmt.Errorf("failed to check catalog secret: %w", err)
+	}
+
+	passwordHash, adminPassword, err := configureutils.CollectAdminPassword(secretExists)
 	if err != nil {
 		return err
 	}
@@ -43,7 +49,7 @@ func DeployCatalog(ctx context.Context, opts catalogUtils.PodmanConfigureOptions
 		return err
 	}
 
-	return handlePostDeployment(ctx, caddyCtx, deployCtx, opts)
+	return handlePostDeployment(ctx, caddyCtx, deployCtx, opts, adminPassword)
 }
 
 func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployContext, opts catalogUtils.PodmanConfigureOptions, passwordHash string) (*caddy.Context, error) {
@@ -103,8 +109,9 @@ func executeCatalogDeployment(ctx context.Context, deployCtx *deploy.DeployConte
 	return caddyCtx, nil
 }
 
-// handlePostDeployment handles route registration and next steps display after catalog deployment.
-func handlePostDeployment(ctx context.Context, caddyCtx *caddy.Context, deployCtx *deploy.DeployContext, opts catalogUtils.PodmanConfigureOptions) error {
+// handlePostDeployment handles route registration, login verification,
+// local worker join, and next steps display after catalog deployment.
+func handlePostDeployment(ctx context.Context, caddyCtx *caddy.Context, deployCtx *deploy.DeployContext, opts catalogUtils.PodmanConfigureOptions, adminPassword string) error {
 	logger.Debugln("handling post deployment steps...")
 
 	// Extract route infos from deployment context
@@ -119,8 +126,16 @@ func handlePostDeployment(ctx context.Context, caddyCtx *caddy.Context, deployCt
 		return fmt.Errorf("route registration failed: %w", err)
 	}
 
+	// Login to the catalog API — this both verifies the admin password and gives
+	// us a client to reuse for local worker registration without a second login.
+	catalogAPIURL := routeURLs["CATALOG_API_ROUTE"]
+	catalogClient, err := configure.LoginToCatalog(ctx, catalogAPIURL, adminPassword)
+	if err != nil {
+		return fmt.Errorf("admin password verification failed: %w", err)
+	}
+
 	if !opts.SkipLocalWorker {
-		if err := JoinAsLocalWorker(ctx, deployCtx.Runtime, opts); err != nil {
+		if err := JoinAsLocalWorker(ctx, deployCtx.Runtime, opts, catalogClient); err != nil {
 			return fmt.Errorf("local worker join failed: %v", err)
 		}
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -128,7 +128,7 @@ func handlePostDeployment(ctx context.Context, caddyCtx *caddy.Context, deployCt
 
 	// Login to the catalog API — this both verifies the admin password and gives
 	// us a client to reuse for local worker registration without a second login.
-	catalogAPIURL := routeURLs["CATALOG_API_ROUTE"]
+	catalogAPIURL := routeURLs[catalogconstants.CatalogAPIRouteKey]
 	catalogClient, err := configure.LoginToCatalog(ctx, catalogAPIURL, adminPassword)
 	if err != nil {
 		return fmt.Errorf("admin password verification failed: %w", err)

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/local_worker.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/local_worker.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure"
+	catalogclient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	podmanruntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
-	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	workerpodman "github.com/project-ai-services/ai-services/internal/pkg/worker/deploy/podman"
 	workertypes "github.com/project-ai-services/ai-services/internal/pkg/worker/types"
 )
@@ -15,18 +16,20 @@ import (
 // JoinAsLocalWorker deploys the worker pod on this machine and connects it to
 // the catalog-backend as the "Local" worker.
 //
-// A sentinel token (LocalWorkerToken) is passed so the worker pod's
-// join guard is satisfied. The catalog-backend gateway skips ValidateToken when
-// LOCAL_WORKER=true, so no token needs to live in any TokenStore.
-func JoinAsLocalWorker(ctx context.Context, rt *podmanruntime.PodmanClient, opts catalogUtils.PodmanConfigureOptions) error {
+// It uses the already-authenticated catalog client to call POST /api/v1/workers,
+// obtaining a real bootstrap token without a second login.
+func JoinAsLocalWorker(ctx context.Context, rt *podmanruntime.PodmanClient, opts catalogUtils.PodmanConfigureOptions, c *catalogclient.Client) error {
 	logger.InfolnCtx(ctx, "Joining this machine as the Local worker...")
 
-	gatewayAddr := fmt.Sprintf("%s:%d", workerconstants.PodmanGatewayPodName, opts.WorkerGatewayPort)
+	token, gatewayAddr, err := configure.RegisterLocalWorker(ctx, c)
+	if err != nil {
+		return fmt.Errorf("local worker join: %w", err)
+	}
 
 	workerOpts := workertypes.PodmanWorkerOptions{
 		WorkerConnectionOptions: workertypes.WorkerConnectionOptions{
 			GatewayAddr: gatewayAddr,
-			Token:       workerconstants.LocalWorkerToken,
+			Token:       token,
 		},
 		Setup: workertypes.Options{
 			BaseDir:     opts.BaseDir,

--- a/ai-services/internal/pkg/catalog/cli/configure/utils/utils.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/utils/utils.go
@@ -4,9 +4,28 @@ import (
 	"context"
 	"fmt"
 
+	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
+
+// CollectAdminPassword prompts the operator for the admin password.
+//
+// Fresh install (secretExists=false): prompts with confirmation and returns the
+// bcrypt hash alongside the plaintext so the caller can both store the secret
+// and log in to the running catalog.
+//
+// Reconfigure (secretExists=true): prompts without confirmation, returns an
+// empty hash (the secret already exists) and the plaintext for login.
+func CollectAdminPassword(secretExists bool) (passwordHash, adminPassword string, err error) {
+	if !secretExists {
+		return catalogutils.PromptNewAdminPassword()
+	}
+
+	adminPassword, err = catalogutils.PromptExistingAdminPassword()
+
+	return "", adminPassword, err
+}
 
 // ConfirmCatalogReset displays a warning about catalog service unavailability and prompts for user confirmation.
 // The flagName parameter is used to customize the warning and confirmation messages.

--- a/ai-services/internal/pkg/catalog/cli/configure/worker.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/worker.go
@@ -1,0 +1,46 @@
+package configure
+
+import (
+	"context"
+	"fmt"
+
+	catalogclient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
+)
+
+const (
+	// CatalogAdminUser is the default admin username created during catalog configure.
+	CatalogAdminUser = "admin"
+)
+
+// LoginToCatalog logs in to the catalog API and returns the authenticated client.
+// A successful return both proves the credentials are correct and provides a
+// client that callers can reuse — no second login is needed.
+func LoginToCatalog(ctx context.Context, catalogAPIURL, adminPassword string) (*catalogclient.Client, error) {
+	logger.InfolnCtx(ctx, "Logging in to catalog API...")
+
+	c, err := catalogclient.NewWithLogin(ctx, catalogAPIURL, CatalogAdminUser, adminPassword, true)
+	if err != nil {
+		return nil, fmt.Errorf("login to catalog API at %s: %w", catalogAPIURL, err)
+	}
+
+	logger.InfolnCtx(ctx, "Admin credentials verified.")
+
+	return c, nil
+}
+
+// RegisterLocalWorker pre-registers the Local worker using the already-authenticated
+// client and returns the bootstrap token and gateway address.
+func RegisterLocalWorker(ctx context.Context, c *catalogclient.Client) (token, gatewayAddr string, err error) {
+	logger.InfolnCtx(ctx, "Registering local worker via catalog API...")
+
+	resp, err := catalogclient.NewWorkerClientFromClient(c).CreateWorker(ctx, workerconstants.LocalWorkerName)
+	if err != nil {
+		return "", "", fmt.Errorf("register local worker: %w", err)
+	}
+
+	return resp.Token, resp.GatewayAddress, nil
+}
+
+// Made with Bob

--- a/ai-services/internal/pkg/catalog/cli/configure/worker.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/worker.go
@@ -5,13 +5,9 @@ import (
 	"fmt"
 
 	catalogclient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
+	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
-)
-
-const (
-	// CatalogAdminUser is the default admin username created during catalog configure.
-	CatalogAdminUser = "admin"
 )
 
 // LoginToCatalog logs in to the catalog API and returns the authenticated client.
@@ -20,7 +16,7 @@ const (
 func LoginToCatalog(ctx context.Context, catalogAPIURL, adminPassword string) (*catalogclient.Client, error) {
 	logger.InfolnCtx(ctx, "Logging in to catalog API...")
 
-	c, err := catalogclient.NewWithLogin(ctx, catalogAPIURL, CatalogAdminUser, adminPassword, true)
+	c, err := catalogclient.NewWithLogin(ctx, catalogAPIURL, catalogconstants.CatalogAdminUser, adminPassword, true)
 	if err != nil {
 		return nil, fmt.Errorf("login to catalog API at %s: %w", catalogAPIURL, err)
 	}

--- a/ai-services/internal/pkg/catalog/client/worker.go
+++ b/ai-services/internal/pkg/catalog/client/worker.go
@@ -41,6 +41,12 @@ func NewWorkerClient(ctx context.Context) (*WorkerClient, error) {
 	return &WorkerClient{client: c}, nil
 }
 
+// NewWorkerClientFromClient creates a WorkerClient from an already-authenticated Client.
+// Use this when you have obtained a Client via NewWithLogin (e.g. during catalog configure).
+func NewWorkerClientFromClient(c *Client) *WorkerClient {
+	return &WorkerClient{client: c}
+}
+
 // ServerURL returns the catalog API server URL this client is connected to.
 func (c *WorkerClient) ServerURL() string {
 	return c.client.ServerURL()

--- a/ai-services/internal/pkg/catalog/constants/catalog.go
+++ b/ai-services/internal/pkg/catalog/constants/catalog.go
@@ -58,6 +58,11 @@ const (
 	CatalogMTLSSecretName = "catalog-mtls-encryption-secret"
 	// CatalogDeploymentName represent the catalog deployment name.
 	CatalogDeploymentName = "catalog-backend"
+	// CatalogAdminUser is the default admin username created during catalog configure.
+	CatalogAdminUser = "admin"
+	// CatalogAPIRouteKey is the routeURLs map key for the catalog backend API URL,
+	// populated by caddy.RegisterCatalogRoutes during podman configure.
+	CatalogAPIRouteKey = "CATALOG_API_ROUTE"
 )
 
 // Pagination constants.

--- a/ai-services/internal/pkg/catalog/utils/password.go
+++ b/ai-services/internal/pkg/catalog/utils/password.go
@@ -1,16 +1,13 @@
 package utils
 
 import (
-	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"syscall"
 
-	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"golang.org/x/crypto/pbkdf2"
 	"golang.org/x/term"
 )
@@ -36,39 +33,49 @@ func HashPasswordPBKDF2(password string, iteration int) (string, error) {
 	return encoded, nil
 }
 
-// CollectAndHashPassword collects the password from the user and returns the hashed password.
-// Returns empty string if the secret already exists (no password needed).
-func CollectAndHashPassword(ctx context.Context, rt runtime.Runtime) (string, error) {
-	secretExists, err := rt.SecretExists(ctx, catalogConstants.CatalogSecretName)
+// PromptNewAdminPassword prompts for a new password (with confirmation) and
+// returns both the PBKDF2 hash and the plaintext.
+// Used during fresh catalog configure when no secret exists yet.
+func PromptNewAdminPassword() (passwordHash, plaintext string, err error) {
+	plaintext, err = promptForNewPassword()
 	if err != nil {
-		return "", fmt.Errorf("failed to check existing secrets: %w", err)
+		return "", "", fmt.Errorf("failed to read admin password: %w", err)
 	}
 
-	if secretExists {
-		return "", nil
+	passwordHash, err = HashPasswordPBKDF2(plaintext, defaultPasswordIterations)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to hash password: %w", err)
 	}
 
-	return PromptAndHashPassword()
+	return passwordHash, plaintext, nil
+}
+
+// PromptExistingAdminPassword prompts for the current admin password (no
+// confirmation, no hashing) and returns the plaintext.
+// Used when the catalog secret already exists and we just need to authenticate.
+func PromptExistingAdminPassword() (string, error) {
+	password, err := readPasswordFromTerminal("Enter admin password for authentication: ")
+	if err != nil {
+		return "", fmt.Errorf("failed to read admin password: %w", err)
+	}
+
+	if password == "" {
+		return "", fmt.Errorf("password cannot be empty")
+	}
+
+	return password, nil
 }
 
 // PromptAndHashPassword prompts for a new password and returns its hash.
 // Used for resets where the secret already exists.
 func PromptAndHashPassword() (string, error) {
-	adminPassword, err := promptForPassword()
-	if err != nil {
-		return "", fmt.Errorf("failed to read admin password: %w", err)
-	}
+	hash, _, err := PromptNewAdminPassword()
 
-	passwordHash, err := HashPasswordPBKDF2(adminPassword, defaultPasswordIterations)
-	if err != nil {
-		return "", fmt.Errorf("failed to hash password: %w", err)
-	}
-
-	return passwordHash, nil
+	return hash, err
 }
 
-// promptForPassword prompts the user to enter a password securely with confirmation.
-func promptForPassword() (string, error) {
+// promptForNewPassword prompts the user to enter a password securely with confirmation.
+func promptForNewPassword() (string, error) {
 	password, err := readPasswordFromTerminal("Enter admin password: ")
 	if err != nil {
 		return "", err
@@ -95,6 +102,7 @@ func readPasswordFromTerminal(prompt string) (string, error) {
 	fmt.Print(prompt)
 	passwordBytes, err := term.ReadPassword(int(syscall.Stdin))
 	fmt.Println()
+
 	if err != nil {
 		return "", err
 	}

--- a/ai-services/internal/pkg/worker/constants/constants.go
+++ b/ai-services/internal/pkg/worker/constants/constants.go
@@ -86,10 +86,6 @@ const (
 	// LocalWorkerEnvVar is the environment variable name that enables local-worker mode.
 	LocalWorkerEnvVar = "LOCAL_WORKER"
 
-	// LocalWorkerToken is the bootstrap token used for the local
-	// self-join. The catalog-backend gateway accepts this token without
-	// ValidateToken when LOCAL_WORKER=true.
-	LocalWorkerToken = "local-worker"
 	// MTLSEncryptionKeyEnv is the environment variable that holds the AES-256 key used to
 	// encrypt mTLS private key files at rest (gateway CA key, server key, worker client key).
 	// Sourced from the catalog-mtls-encryption-secret Podman/OpenShift secret at runtime.

--- a/ai-services/internal/pkg/worker/gateway/gateway.go
+++ b/ai-services/internal/pkg/worker/gateway/gateway.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
-	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	workerpb "github.com/project-ai-services/ai-services/internal/pkg/worker/proto"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/registry"
@@ -136,23 +135,13 @@ func (g *Gateway) runSweeper(ctx context.Context) {
 // cannot self-assign a name different from what was pre-registered by an admin.
 // Metadata supplied in the request is persisted to the DB metadata JSON column.
 func (g *Gateway) Register(ctx context.Context, req *workerpb.RegisterRequest) (*workerpb.RegisterResponse, error) {
-	// 1. Resolve worker name from token or bypass for the local self-join.
-	//
-	// When LOCAL_WORKER=true the catalog-backend trusts its own worker pod
-	// unconditionally: no token is required. The worker sends an empty token and
-	// the gateway assigns the reserved LocalWorkerName without any DB lookup.
-	var workerName string
-	if utils.GetEnv(workerconstants.LocalWorkerEnvVar, "") == "true" && req.GetPreSharedToken() == workerconstants.LocalWorkerToken {
-		workerName = workerconstants.LocalWorkerName
-		logger.InfofCtx(ctx, "WorkerGateway: local self-join for %q — skipping token validation", workerName)
-	} else {
-		var err error
-		workerName, err = g.registry.ValidateToken(req.GetPreSharedToken())
-		if err != nil {
-			logger.WarningfCtx(ctx, "WorkerGateway: rejected registration: %v", err)
+	// 1. Validate the bootstrap token. Every worker — including the local one —
+	//    must present a token issued by Preregister via the catalog API.
+	workerName, err := g.registry.ValidateToken(req.GetPreSharedToken())
+	if err != nil {
+		logger.WarningfCtx(ctx, "WorkerGateway: rejected registration: %v", err)
 
-			return nil, status.Errorf(codes.Unauthenticated, "registration rejected: %v", err)
-		}
+		return nil, status.Errorf(codes.Unauthenticated, "registration rejected: %v", err)
 	}
 
 	// 2. Parse, validate, and sign the CSR (required for mTLS). See sign.go: signWorkerCSR.


### PR DESCRIPTION
Make use of register API for local worker join in catalog configure.

Replace the LocalWorkerToken gateway bypass with a proper POST /api/v1/workers flow: catalog configure logs in once, pre-registers the local worker via the catalog API to get a real bootstrap token, and passes the authenticated client to JoinAsLocalWorker — no sentinel token, no second login.

Added case to not allow deleting Local worker.