### PR TITLE
Bump Opensearch image version

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.348
+TAG?=v0.0.349
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -38,7 +38,7 @@ ingest:
 
 opensearch:
   # @hidden
-  image: icr.io/ai-services-cicd/opensearch:3.7.0-ppc64le
+  image: icr.io/ai-services-cicd/opensearch:3.8.0-ppc64le
   # @description Sets the memory limit for the Opensearch service(Default: 8Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   memoryLimit: 8Gi
   auth:

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -79,7 +79,7 @@ ingest:
 
 opensearch:
   # @hidden
-  image: icr.io/ai-services-cicd/opensearch:3.7.0-ppc64le
+  image: icr.io/ai-services-cicd/opensearch:3.8.0-ppc64le
   # @description Sets the memory limit for the Opensearch service(Default: 8Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   memoryLimit: 8Gi
   # @description Sets the storage limit for the Opensearch service(Default: 10Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -38,7 +38,7 @@ ingest:
 
 opensearch:
   # @hidden
-  image: icr.io/ai-services-cicd/opensearch:3.7.0-ppc64le
+  image: icr.io/ai-services-cicd/opensearch:3.8.0-ppc64le
   # @description Sets the memory limit for the Opensearch service(Default: 8Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   memoryLimit: 8Gi
   auth:

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -79,7 +79,7 @@ ingest:
 
 opensearch:
   # @hidden
-  image: icr.io/ai-services-cicd/opensearch:3.7.0-ppc64le
+  image: icr.io/ai-services-cicd/opensearch:3.8.0-ppc64le
   # @description Sets the memory limit for the Opensearch service(Default: 8Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   memoryLimit: 8Gi
   # @description Sets the storage limit for the Opensearch service(Default: 10Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -36,7 +36,7 @@ ingest:
 
 opensearch:
   # @hidden
-  image: icr.io/ai-services-cicd/opensearch:3.7.0-ppc64le
+  image: icr.io/ai-services-cicd/opensearch:3.8.0-ppc64le
   # @description Sets the memory limit for the Opensearch service(Default: 8Gi). Override by passing a value with a unit suffix (e.g., Mi, Gi).
   memoryLimit: 8Gi
   auth:

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.348
+  image: icr.io/ai-services-cicd/ai-services:v0.0.349
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.348
+  image: icr.io/ai-services-cicd/ai-services:v0.0.349
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/components/vector_db/opensearch/openshift/values.yaml
+++ b/ai-services/assets/components/vector_db/opensearch/openshift/values.yaml
@@ -1,4 +1,4 @@
-image: icr.io/ai-services-cicd/opensearch:3.7.0-ppc64le
+image: icr.io/ai-services-cicd/opensearch:3.8.0-ppc64le
 memoryLimit: 8Gi
 storage: 10Gi
 replicas: 1

--- a/ai-services/assets/components/vector_db/opensearch/podman/values.yaml
+++ b/ai-services/assets/components/vector_db/opensearch/podman/values.yaml
@@ -1,4 +1,4 @@
-image: icr.io/ai-services-cicd/opensearch:3.7.0-ppc64le
+image: icr.io/ai-services-cicd/opensearch:3.8.0-ppc64le
 memoryLimit: 8Gi
 auth:
   username: "admin"

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.348
+  image: icr.io/ai-services-cicd/ai-services:v0.0.349
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.348
+  image: icr.io/ai-services-cicd/ai-services:v0.0.349
   runtime: "podman"
   token: ""
   gatewayAddr: ""


### PR DESCRIPTION
Bumping Opensearch image to v3.8.0 - 
```
ira@Unknown_0a:f8:7f:48:1c:90 ~ % podman inspect icr.io/ai-services-cicd/opensearch:3.8.0-ppc64le
[
     {
          "Id": "c3bc0eaf3a991cb93a9425aa8a2540f12c2a8d96d96bfd05b8cb116eeaf6500c",
          "Digest": "sha256:49d299ff204f67c200435cd9849e8901cfcb7ef6a1ec322fb1822a15415074b2",
          "RepoTags": [
               "icr.io/ai-services-cicd/opensearch:3.8.0-ppc64le",
               "icr.io/ai-services-private/opensearch:3.8.0-ppc64le-26"
          ],
          ....
```