### PR TITLE
[BYOS] Minor Fixes for custom component

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.361
+TAG?=v0.0.362
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.361
+  image: icr.io/ai-services-cicd/ai-services:v0.0.362
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.361
+  image: icr.io/ai-services-cicd/ai-services:v0.0.362
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.361
+  image: icr.io/ai-services-cicd/ai-services:v0.0.362
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.361
+  image: icr.io/ai-services-cicd/ai-services:v0.0.362
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/cmd/ai-services/cmd/application/templates.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -14,6 +15,7 @@ import (
 	catalogTypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/templates"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 var (
@@ -130,6 +132,8 @@ func listCatalogTemplates(cmd *cobra.Command) error {
 		return err
 	}
 
+	runtimeType := string(vars.RuntimeFactory.GetRuntimeType())
+
 	architectures, err := source.ListArchitectures(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("failed to list architectures: %w", err)
@@ -138,11 +142,6 @@ func listCatalogTemplates(cmd *cobra.Command) error {
 	services, err := source.ListServices(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("failed to list services: %w", err)
-	}
-
-	components, err := source.ListComponents(cmd.Context())
-	if err != nil {
-		return fmt.Errorf("failed to list components: %w", err)
 	}
 
 	// Section 1: Deployment Architectures with list of services
@@ -154,7 +153,7 @@ func listCatalogTemplates(cmd *cobra.Command) error {
 	// Section 2: Deployment Services with metadata and required components
 	logger.Infoln("\nAvailable Services:")
 	for _, svc := range services {
-		displayServiceWithComponents(svc, components)
+		displayServiceWithComponents(cmd.Context(), source, svc, runtimeType)
 	}
 
 	// Inform user about parameters subcommand
@@ -180,29 +179,40 @@ func displayArchitectureWithServiceList(arch catalogTypes.ArchitectureSummary) {
 }
 
 // displayServiceWithComponents displays a service with its metadata and required components.
-func displayServiceWithComponents(svc catalogTypes.ServiceSummary, components []catalogTypes.Component) {
+// It calls GetServiceDeployOptions so that custom bundle providers from the catalog volume
+// are included alongside the embedded ones.
+func displayServiceWithComponents(ctx context.Context, source catalogClient.CatalogSource, svc catalogTypes.ServiceSummary, runtimeType string) {
 	logger.Infof("- %s (%s)", svc.ID, svc.Name)
 	if svc.Description != "" {
 		logger.Infof("  Description: %s", svc.Description)
 	}
 
-	// Display component dependencies
-	if len(svc.Dependencies) > 0 {
+	if len(svc.Dependencies) == 0 {
+		return
+	}
+
+	deployOpts, err := source.GetServiceDeployOptions(ctx, svc.ID, runtimeType)
+	if err != nil {
+		// Fall back to dependency IDs only — better than nothing.
 		logger.Infoln("  Required Components:")
 		for _, dep := range svc.Dependencies {
-			// Find matching components by type
-			matchingComps := []string{}
-			for _, comp := range components {
-				if comp.ComponentType == dep.ID {
-					matchingComps = append(matchingComps, comp.ID)
-				}
-			}
+			logger.Infof("    %s: (providers unavailable)", dep.ID)
+		}
 
-			if len(matchingComps) > 0 {
-				logger.Infof("    %s: %s", dep.ID, strings.Join(matchingComps, ", "))
-			} else {
-				logger.Infof("    %s: (no components available)", dep.ID)
-			}
+		return
+	}
+
+	logger.Infoln("  Required Components:")
+	for _, comp := range deployOpts.Components {
+		providerIDs := make([]string, 0, len(comp.Providers))
+		for _, p := range comp.Providers {
+			providerIDs = append(providerIDs, p.ID)
+		}
+
+		if len(providerIDs) > 0 {
+			logger.Infof("    %s: %s", comp.Type, strings.Join(providerIDs, ", "))
+		} else {
+			logger.Infof("    %s: (no providers available)", comp.Type)
 		}
 	}
 }

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -96,6 +96,7 @@ func displayArchitectureParameters(ctx context.Context, source catalogClient.Cat
 		deployOpts, err := source.GetServiceDeployOptions(ctx, svcRef.ID, runtimeType())
 		if err != nil {
 			logger.Warningf("skipping parameters for service '%s': %v", svcRef.ID, err)
+
 			continue
 		}
 		displayDeployOptionsParameters(ctx, source, deployOpts, displayedComponents)

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -47,16 +47,14 @@ func NewParametersCmd() *cobra.Command {
 				return err
 			}
 
-			// Try to load as architecture first
-			arch, err := source.LoadArchitecture(cmd.Context(), templateID)
-			if err == nil {
-				return displayArchitectureParameters(cmd.Context(), source, templateID, arch.Services)
+			// Try to display as architecture first
+			if err := displayArchitectureParameters(cmd.Context(), source, templateID); err == nil {
+				return nil
 			}
 
-			// Try to load as service
-			service, err := source.LoadService(cmd.Context(), templateID)
-			if err == nil {
-				return displayServiceParameters(cmd.Context(), source, templateID, service.Dependencies)
+			// Try to display as service
+			if err := displayServiceParameters(cmd.Context(), source, templateID); err == nil {
+				return nil
 			}
 
 			return fmt.Errorf("template '%s' not found as service or architecture", templateID)
@@ -69,22 +67,27 @@ func NewParametersCmd() *cobra.Command {
 	return cmd
 }
 
-// displayServiceParameters displays all parameters for a specific service.
-func displayServiceParameters(ctx context.Context, source catalogClient.CatalogSource, serviceID string, _ []catalogTypes.DependencyReference) error {
-	logger.Infof("Supported Parameters for '%s':", serviceID)
-
+// displayServiceParameters loads a service and displays its parameters.
+func displayServiceParameters(ctx context.Context, source catalogClient.CatalogSource, serviceID string) error {
 	deployOpts, err := source.GetServiceDeployOptions(ctx, serviceID, runtimeType())
 	if err != nil {
 		return fmt.Errorf("failed to get deploy options for service '%s': %w", serviceID, err)
 	}
+
+	logger.Infof("Supported Parameters for '%s':", serviceID)
 
 	displayDeployOptionsParameters(ctx, source, deployOpts, nil)
 
 	return nil
 }
 
-// displayArchitectureParameters displays all parameters for all services in an architecture.
-func displayArchitectureParameters(ctx context.Context, source catalogClient.CatalogSource, archID string, services []catalogTypes.ServiceReference) error {
+// displayArchitectureParameters loads an architecture and displays parameters for all its services.
+func displayArchitectureParameters(ctx context.Context, source catalogClient.CatalogSource, archID string) error {
+	arch, err := source.LoadArchitecture(ctx, archID)
+	if err != nil {
+		return err
+	}
+
 	logger.Infof("Supported Parameters for '%s':", archID)
 
 	// Track displayed components to avoid duplicates across services
@@ -92,7 +95,7 @@ func displayArchitectureParameters(ctx context.Context, source catalogClient.Cat
 
 	// Display parameters for each service in the architecture.
 	// Log a warning if a service fails so the user knows output may be incomplete.
-	for _, svcRef := range services {
+	for _, svcRef := range arch.Services {
 		deployOpts, err := source.GetServiceDeployOptions(ctx, svcRef.ID, runtimeType())
 		if err != nil {
 			logger.Warningf("skipping parameters for service '%s': %v", svcRef.ID, err)

--- a/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates/parameters.go
@@ -13,6 +13,11 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
+// runtimeType returns the current runtime type as a string.
+func runtimeType() string {
+	return string(vars.RuntimeFactory.GetRuntimeType())
+}
+
 var (
 	templateID string
 )
@@ -65,90 +70,68 @@ func NewParametersCmd() *cobra.Command {
 }
 
 // displayServiceParameters displays all parameters for a specific service.
-func displayServiceParameters(ctx context.Context, source catalogClient.CatalogSource, serviceID string, dependencies []catalogTypes.DependencyReference) error {
+func displayServiceParameters(ctx context.Context, source catalogClient.CatalogSource, serviceID string, _ []catalogTypes.DependencyReference) error {
 	logger.Infof("Supported Parameters for '%s':", serviceID)
 
-	// Display service's own parameters
-	schema, err := source.GetServiceParams(ctx, serviceID, string(vars.RuntimeFactory.GetRuntimeType()))
-	if err == nil && schema != nil {
-		displaySchemaParameters(schema, serviceID)
+	deployOpts, err := source.GetServiceDeployOptions(ctx, serviceID, runtimeType())
+	if err != nil {
+		return fmt.Errorf("failed to get deploy options for service '%s': %w", serviceID, err)
 	}
 
-	// Display component parameters
-	return displayComponentsParameters(ctx, source, dependencies, nil)
+	displayDeployOptionsParameters(ctx, source, deployOpts, nil)
+
+	return nil
 }
 
 // displayArchitectureParameters displays all parameters for all services in an architecture.
 func displayArchitectureParameters(ctx context.Context, source catalogClient.CatalogSource, archID string, services []catalogTypes.ServiceReference) error {
 	logger.Infof("Supported Parameters for '%s':", archID)
 
-	// Track displayed components to avoid duplicates
+	// Track displayed components to avoid duplicates across services
 	displayedComponents := make(map[string]bool)
 
 	// Display parameters for each service in the architecture.
 	// Log a warning if a service fails so the user knows output may be incomplete.
 	for _, svcRef := range services {
-		if err := displayServiceInArchitecture(ctx, source, svcRef.ID, displayedComponents); err != nil {
+		deployOpts, err := source.GetServiceDeployOptions(ctx, svcRef.ID, runtimeType())
+		if err != nil {
 			logger.Warningf("skipping parameters for service '%s': %v", svcRef.ID, err)
+			continue
 		}
+		displayDeployOptionsParameters(ctx, source, deployOpts, displayedComponents)
 	}
 
 	return nil
 }
 
-// displayServiceInArchitecture displays parameters for a single service within an architecture.
-func displayServiceInArchitecture(ctx context.Context, source catalogClient.CatalogSource, serviceID string, displayedComponents map[string]bool) error {
-	// Load the service to get its dependencies
-	service, err := source.LoadService(ctx, serviceID)
-	if err != nil {
-		return err
-	}
-
-	// Display service parameters
-	schema, err := source.GetServiceParams(ctx, serviceID, string(vars.RuntimeFactory.GetRuntimeType()))
+// displayDeployOptionsParameters displays service and component parameters from deploy options.
+// If displayedComponents map is provided, it tracks and skips duplicate component providers.
+func displayDeployOptionsParameters(ctx context.Context, source catalogClient.CatalogSource, deployOpts *catalogTypes.DeployOptionsService, displayedComponents map[string]bool) {
+	// Display the service's own parameters
+	schema, err := source.GetServiceParams(ctx, deployOpts.ID, runtimeType())
 	if err == nil && schema != nil {
-		displaySchemaParameters(schema, serviceID)
+		displaySchemaParameters(schema, deployOpts.ID)
 	}
 
-	// Display component parameters for this service
-	return displayComponentsParameters(ctx, source, service.Dependencies, displayedComponents)
-}
+	// Display parameters for each component provider
+	for _, comp := range deployOpts.Components {
+		for _, provider := range comp.Providers {
+			componentKey := fmt.Sprintf("%s.%s", comp.Type, provider.ID)
 
-// displayComponentsParameters displays parameters for components based on dependencies.
-// If displayedComponents map is provided, it will track and skip duplicates.
-func displayComponentsParameters(ctx context.Context, source catalogClient.CatalogSource, dependencies []catalogTypes.DependencyReference, displayedComponents map[string]bool) error {
-	if len(dependencies) == 0 {
-		return nil
-	}
-
-	components, err := source.ListComponents(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to list components: %w", err)
-	}
-
-	for _, dep := range dependencies {
-		// Find all components of this type
-		for _, comp := range components {
-			if comp.ComponentType == dep.ID {
-				componentKey := fmt.Sprintf("%s.%s", comp.ComponentType, comp.ID)
-
-				// Skip if already displayed (only when tracking duplicates)
-				if displayedComponents != nil {
-					if displayedComponents[componentKey] {
-						continue
-					}
-					displayedComponents[componentKey] = true
+			// Skip if already displayed (only when tracking duplicates)
+			if displayedComponents != nil {
+				if displayedComponents[componentKey] {
+					continue
 				}
+				displayedComponents[componentKey] = true
+			}
 
-				schema, err := source.GetComponentProviderParams(ctx, comp.ComponentType, comp.ID, string(vars.RuntimeFactory.GetRuntimeType()))
-				if err == nil && schema != nil {
-					displaySchemaParameters(schema, componentKey)
-				}
+			schema, err := source.GetComponentProviderParams(ctx, comp.Type, provider.ID, runtimeType())
+			if err == nil && schema != nil {
+				displaySchemaParameters(schema, componentKey)
 			}
 		}
 	}
-
-	return nil
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/catalog/apiserver/services/bundle/service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/bundle/service.go
@@ -26,6 +26,8 @@ type CatalogProvider interface {
 	Reload(ctx context.Context) error
 	ServiceExists(id string) bool
 	ComponentExists(componentType, id string) bool
+	ListServices() ([]catalogtypes.Service, error)
+	ListComponents() ([]catalogtypes.Component, error)
 }
 
 // bundleService implements BundleServiceInterface.
@@ -111,7 +113,7 @@ func (s *bundleService) ValidateBundle(_ context.Context, file io.Reader) (any, 
 }
 
 // checkCatalogCollision returns a ValidationError when the metadata conflicts with a
-// registered catalog entry. Returns nil when catalog is nil (CLI/test paths).
+// registered catalog entry (by id or by name). Returns nil when catalog is nil (CLI/test paths).
 func (s *bundleService) checkCatalogCollision(meta any) error {
 	if s.catalog == nil {
 		return nil
@@ -125,11 +127,59 @@ func (s *bundleService) checkCatalogCollision(meta any) error {
 				Message: fmt.Sprintf("metadata.yaml: service id %q conflicts with an existing catalog service; choose a unique id", m.ID),
 			}
 		}
+		if err := checkNameCollisionServices(s.catalog, m.Name); err != nil {
+			return err
+		}
 	case *bundlemetadata.ComponentMetadataYAML:
 		if s.catalog.ComponentExists(m.ComponentType, m.ID) {
 			return &validators.ValidationError{
 				Code:    http.StatusUnprocessableEntity,
 				Message: fmt.Sprintf("metadata.yaml: component %q (type: %s) conflicts with an existing catalog component; choose a unique id", m.ID, m.ComponentType),
+			}
+		}
+		if err := checkNameCollisionComponents(s.catalog, m.ComponentType, m.Name); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkNameCollisionServices returns a ValidationError when the given name
+// (case-insensitive) matches any existing service's name.
+func checkNameCollisionServices(catalog CatalogProvider, name string) error {
+	services, err := catalog.ListServices()
+	if err != nil {
+		return fmt.Errorf("name collision check failed: %w", err)
+	}
+
+	lower := strings.ToLower(name)
+	for _, svc := range services {
+		if strings.ToLower(svc.Name) == lower {
+			return &validators.ValidationError{
+				Code:    http.StatusUnprocessableEntity,
+				Message: fmt.Sprintf("metadata.yaml: service name %q conflicts with an existing catalog service name; choose a unique name", name),
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkNameCollisionComponents returns a ValidationError when the given name
+// (case-insensitive) matches any existing component's name within the same component_type.
+func checkNameCollisionComponents(catalog CatalogProvider, componentType, name string) error {
+	components, err := catalog.ListComponents()
+	if err != nil {
+		return fmt.Errorf("name collision check failed: %w", err)
+	}
+
+	lower := strings.ToLower(name)
+	for _, comp := range components {
+		if comp.ComponentType == componentType && strings.ToLower(comp.Name) == lower {
+			return &validators.ValidationError{
+				Code:    http.StatusUnprocessableEntity,
+				Message: fmt.Sprintf("metadata.yaml: component name %q conflicts with an existing %s component name; choose a unique name", name, componentType),
 			}
 		}
 	}
@@ -299,6 +349,21 @@ func (s *bundleService) ReplaceBundle(ctx context.Context, existing *BundleRespo
 				"catalog_type mismatch: archive contains %q but existing bundle has %q",
 				catalogType, existing.CatalogType,
 			),
+		}
+	}
+
+	// Step 2b: name collision check — reject if the new name matches another catalog entry.
+	// Skip when the name is unchanged (the bundle keeps its own existing name).
+	if s.catalog != nil && !strings.EqualFold(name, existing.Name) {
+		switch m := meta.(type) {
+		case *bundlemetadata.ServiceMetadataYAML:
+			if err := checkNameCollisionServices(s.catalog, name); err != nil {
+				return nil, err
+			}
+		case *bundlemetadata.ComponentMetadataYAML:
+			if err := checkNameCollisionComponents(s.catalog, m.ComponentType, name); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/ai-services/internal/pkg/catalog/apiserver/services/bundle/service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/bundle/service.go
@@ -308,6 +308,37 @@ func (s *bundleService) insertActivateAndFetch(ctx context.Context, catalogType,
 	return s.GetBundleByID(ctx, row.ID.String())
 }
 
+// checkReplaceIdentity enforces the two pre-validation checks for ReplaceBundle:
+//  1. catalog_id and catalog_type are immutable — archive values must match the existing record.
+//  2. name must not collide with any other catalog entry (skipped when the name is unchanged).
+func (s *bundleService) checkReplaceIdentity(meta any, existing *BundleResponse, catalogType, catalogID, name string) error {
+	if catalogID != existing.CatalogID {
+		return &validators.ValidationError{
+			Code:    http.StatusUnprocessableEntity,
+			Message: fmt.Sprintf("catalog_id mismatch: archive contains %q but existing bundle has %q", catalogID, existing.CatalogID),
+		}
+	}
+	if catalogType != existing.CatalogType {
+		return &validators.ValidationError{
+			Code:    http.StatusUnprocessableEntity,
+			Message: fmt.Sprintf("catalog_type mismatch: archive contains %q but existing bundle has %q", catalogType, existing.CatalogType),
+		}
+	}
+
+	if s.catalog == nil || strings.EqualFold(name, existing.Name) {
+		return nil
+	}
+
+	switch m := meta.(type) {
+	case *bundlemetadata.ServiceMetadataYAML:
+		return checkNameCollisionServices(s.catalog, name)
+	case *bundlemetadata.ComponentMetadataYAML:
+		return checkNameCollisionComponents(s.catalog, m.ComponentType, name)
+	}
+
+	return nil
+}
+
 // ReplaceBundle is the synchronous PUT update path.
 //
 //  1. peekMetadata: read minimal identity fields from the archive.
@@ -332,39 +363,9 @@ func (s *bundleService) ReplaceBundle(ctx context.Context, existing *BundleRespo
 
 	catalogType, catalogID, version, name := metaFields(meta)
 
-	// Step 2: immutability check — catalog_id and catalog_type must not change.
-	if catalogID != existing.CatalogID {
-		return nil, &validators.ValidationError{
-			Code: http.StatusUnprocessableEntity,
-			Message: fmt.Sprintf(
-				"catalog_id mismatch: archive contains %q but existing bundle has %q",
-				catalogID, existing.CatalogID,
-			),
-		}
-	}
-	if catalogType != existing.CatalogType {
-		return nil, &validators.ValidationError{
-			Code: http.StatusUnprocessableEntity,
-			Message: fmt.Sprintf(
-				"catalog_type mismatch: archive contains %q but existing bundle has %q",
-				catalogType, existing.CatalogType,
-			),
-		}
-	}
-
-	// Step 2b: name collision check — reject if the new name matches another catalog entry.
-	// Skip when the name is unchanged (the bundle keeps its own existing name).
-	if s.catalog != nil && !strings.EqualFold(name, existing.Name) {
-		switch m := meta.(type) {
-		case *bundlemetadata.ServiceMetadataYAML:
-			if err := checkNameCollisionServices(s.catalog, name); err != nil {
-				return nil, err
-			}
-		case *bundlemetadata.ComponentMetadataYAML:
-			if err := checkNameCollisionComponents(s.catalog, m.ComponentType, name); err != nil {
-				return nil, err
-			}
-		}
+	// Steps 2–2b: immutability + name collision checks.
+	if err := s.checkReplaceIdentity(meta, existing, catalogType, catalogID, name); err != nil {
+		return nil, err
 	}
 
 	// Step 3: full validation — same rules as POST /validate, no re-read needed.

--- a/ai-services/internal/pkg/catalog/apiserver/services/bundle/service_test.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/bundle/service_test.go
@@ -14,6 +14,7 @@ import (
 	bundlemetadata "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/bundle/validate/metadata"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/models"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
+	catalogtypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/validators"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1352,6 +1353,8 @@ type mockCatalogProvider struct {
 	reload          func(ctx context.Context) error
 	serviceExists   func(id string) bool
 	componentExists func(componentType, id string) bool
+	listServices    func() ([]catalogtypes.Service, error)
+	listComponents  func() ([]catalogtypes.Component, error)
 }
 
 func (m *mockCatalogProvider) Reload(ctx context.Context) error {
@@ -1370,6 +1373,20 @@ func (m *mockCatalogProvider) ComponentExists(componentType, id string) bool {
 		return m.componentExists(componentType, id)
 	}
 	return false
+}
+
+func (m *mockCatalogProvider) ListServices() ([]catalogtypes.Service, error) {
+	if m.listServices != nil {
+		return m.listServices()
+	}
+	return nil, nil
+}
+
+func (m *mockCatalogProvider) ListComponents() ([]catalogtypes.Component, error) {
+	if m.listComponents != nil {
+		return m.listComponents()
+	}
+	return nil, nil
 }
 
 // alwaysReloads returns a reloader that records the number of calls and always succeeds.

--- a/ai-services/internal/pkg/catalog/apiserver/services/bundle/validate/openshift.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/bundle/validate/openshift.go
@@ -272,6 +272,12 @@ func checkOpenShiftTemplateLabels(rendered map[string]string) error {
 			continue
 		}
 
+		// doc is nil when the template rendered to empty output (e.g. a
+		// conditional-only template gated on an optional value). Skip.
+		if doc == nil {
+			continue
+		}
+
 		path := openShiftRuntime + "/templates"
 
 		// Use only the base filename to avoid the "chartname/templates/" prefix.

--- a/ai-services/internal/pkg/catalog/apiserver/services/bundle/validate/podman.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/bundle/validate/podman.go
@@ -189,6 +189,12 @@ func validatePodmanTemplates(templFiles map[string][]byte) error {
 			}
 		}
 
+		// doc is nil when the template rendered to empty output (e.g. a
+		// conditional-only template gated on an optional value). Skip.
+		if doc == nil {
+			continue
+		}
+
 		if err := checkTemplateSpec(doc, podmanRuntime, path); err != nil {
 			return err
 		}

--- a/ai-services/internal/pkg/catalog/client/catalog_source.go
+++ b/ai-services/internal/pkg/catalog/client/catalog_source.go
@@ -33,6 +33,10 @@ type CatalogSource interface {
 	// ListComponents returns all available component templates.
 	// This always reads from the embedded catalog — no API endpoint exists.
 	ListComponents(ctx context.Context) ([]types.Component, error)
+	// GetServiceDeployOptions returns the full deploy options for a service,
+	// including all available component providers (embedded + active bundles).
+	// runtimeType selects the runtime (e.g. "podman" or "openshift").
+	GetServiceDeployOptions(ctx context.Context, serviceID, runtimeType string) (*types.DeployOptionsService, error)
 	// LoadArchitecture returns the full details of a single architecture.
 	LoadArchitecture(ctx context.Context, id string) (*types.Architecture, error)
 	// LoadService returns the full details of a single service.
@@ -127,6 +131,22 @@ func (s *apiSource) ListComponents(_ context.Context) ([]types.Component, error)
 	return listComponentsFromEmbedded(s.embedded)
 }
 
+func (s *apiSource) GetServiceDeployOptions(ctx context.Context, serviceID, runtimeType string) (*types.DeployOptionsService, error) {
+	opts, err := s.api.GetServiceDeployOptions(ctx, serviceID, runtimeType)
+	if err != nil && isConnectivityError(err) {
+		logger.DebugfCtx(ctx, "API GetServiceDeployOptions unreachable, falling back to embedded: %v", err)
+
+		scopedCatalog, scopeErr := s.embedded.WithRuntime(runtimeType)
+		if scopeErr != nil {
+			return nil, scopeErr
+		}
+
+		return scopedCatalog.GetServiceDeployOptions(ctx, serviceID)
+	}
+
+	return opts, err
+}
+
 func (s *apiSource) LoadArchitecture(ctx context.Context, id string) (*types.Architecture, error) {
 	arch, err := s.api.GetArchitectureDetails(ctx, id)
 	if err != nil && isConnectivityError(err) {
@@ -211,6 +231,15 @@ func (s *embeddedOnlySource) ListServices(_ context.Context) ([]types.ServiceSum
 
 func (s *embeddedOnlySource) ListComponents(_ context.Context) ([]types.Component, error) {
 	return listComponentsFromEmbedded(s.embedded)
+}
+
+func (s *embeddedOnlySource) GetServiceDeployOptions(ctx context.Context, serviceID, runtimeType string) (*types.DeployOptionsService, error) {
+	scopedCatalog, err := s.embedded.WithRuntime(runtimeType)
+	if err != nil {
+		return nil, err
+	}
+
+	return scopedCatalog.GetServiceDeployOptions(ctx, serviceID)
 }
 
 func (s *embeddedOnlySource) LoadArchitecture(_ context.Context, id string) (*types.Architecture, error) {


### PR DESCRIPTION
- Call GetDeployOptions for application templates to use print the components along with provider types. Currently reads from embed asset
- Add name collision check so that if 2 components with same provider or 2 services have same name with diff ids, then it becomes easy to distinguish on CLient (UI/CLI)