### PR TITLE
fix: call uninstall worker as part of catalog uninstall

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.349
+TAG?=v0.0.350
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.349
+  image: icr.io/ai-services-cicd/ai-services:v0.0.350
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.349
+  image: icr.io/ai-services-cicd/ai-services:v0.0.350
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.349
+  image: icr.io/ai-services-cicd/ai-services:v0.0.350
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.349
+  image: icr.io/ai-services-cicd/ai-services:v0.0.350
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/internal/pkg/catalog/apiserver/services/deletion/repository/podman/deletion.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deletion/repository/podman/deletion.go
@@ -292,7 +292,7 @@ func (s *PodmanDeletion) deleteVolumesFromPods(ctx context.Context, pods []runti
 
 	// Delete each unique volume using the runtime client
 	for volumeName := range volumesToDelete {
-		if err := s.rt.DeleteVolume(ctx, volumeName); err != nil {
+		if err := s.rt.DeleteVolume(ctx, volumeName, utils.BoolPtr(true)); err != nil {
 			// Ignore "not found" errors - volume already deleted or never existed
 			if utils.IsNotFoundError(err) {
 				logger.InfofCtx(ctx, "Volume %s already deleted or does not exist", volumeName)

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -64,15 +64,7 @@ func UninstallCatalog(ctx context.Context, opts cliutils.UninstallOptions) error
 func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.Pod, skipCleanup bool) error {
 	logger.Infoln("Proceeding with deletion...")
 
-	// Retrieve the BaseDir from the catalog pod configuration
-	var baseDir string
-	config, _, err := catalogUtils.GetCatalogPodConfig(ctx, rt)
-	if err != nil {
-		logger.Warningf("Failed to retrieve BaseDir from catalog pod: %v. Using default BaseDir.\n", err)
-		baseDir = utils.GetBaseDir()
-	} else {
-		baseDir = config.BaseDir
-	}
+	baseDir := resolveBaseDir(ctx, rt)
 	logger.Infof("Using base directory for cleanup: %s\n", baseDir)
 
 	// Check before catalog pods are deleted whether a local worker is co-located.
@@ -81,20 +73,13 @@ func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.P
 		return fmt.Errorf("failed to check local worker: %w", err)
 	}
 
-	secretsToDelete, secretsToSkip := fetchSecretsToDelete(pods)
-	secretsToDelete = append(secretsToDelete, constants.PodmanAuthSecret, catalogConstants.CatalogConnectorSecretName, catalogConstants.CatalogMTLSSecretName)
-
-	// Checking if 'catalog-caddy-cert-secret' is created as part of catalog configure
-	// If secret is created adding it to 'secretsToDelete' list
-	exists, err := rt.SecretExists(ctx, catalogConstants.CatalogCertSecretName)
+	secretsToDelete, err := buildSecretsToDelete(ctx, rt, pods)
 	if err != nil {
 		return err
 	}
-	if exists {
-		secretsToDelete = append(secretsToDelete, catalogConstants.CatalogCertSecretName)
-	}
 
 	volumesToDelete, volumesToSkip := podmanutils.FetchVolumesToDelete(pods)
+	_, secretsToSkip := fetchSecretsToDelete(pods)
 
 	// Delete catalog pods
 	if err := podmanutils.DeletePods(ctx, rt, pods); err != nil {
@@ -122,19 +107,53 @@ func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.P
 		return err
 	}
 
-	// Only uninstall the co-located worker if LOCAL_WORKER is true
 	if isLocalWorker {
-		if err := workeruninstall.Uninstall(ctx, workerutils.UninstallOptions{
-			RuntimeType: types.RuntimeTypePodman,
-			AutoYes:     true,
-			SkipCleanup: skipCleanup,
-		}); err != nil {
-			return fmt.Errorf("worker uninstall failed: %w", err)
+		if err := uninstallLocalWorker(ctx, skipCleanup); err != nil {
+			return err
 		}
 	}
 
 	logger.Infoln("Catalog service removed successfully")
 
+	return nil
+}
+
+// resolveBaseDir returns the base directory from the catalog pod config, falling back to the default.
+func resolveBaseDir(ctx context.Context, rt *podman.PodmanClient) string {
+	config, _, err := catalogUtils.GetCatalogPodConfig(ctx, rt)
+	if err != nil {
+		logger.Warningf("Failed to retrieve BaseDir from catalog pod: %v. Using default BaseDir.\n", err)
+		return utils.GetBaseDir()
+	}
+	return config.BaseDir
+}
+
+// buildSecretsToDelete assembles the full list of secrets that must be deleted unconditionally.
+func buildSecretsToDelete(ctx context.Context, rt *podman.PodmanClient, pods []types.Pod) ([]string, error) {
+	secretsToDelete, _ := fetchSecretsToDelete(pods)
+	secretsToDelete = append(secretsToDelete, constants.PodmanAuthSecret, catalogConstants.CatalogConnectorSecretName, catalogConstants.CatalogMTLSSecretName)
+
+	// Checking if 'catalog-caddy-cert-secret' is created as part of catalog configure
+	// If secret is created adding it to 'secretsToDelete' list
+	exists, err := rt.SecretExists(ctx, catalogConstants.CatalogCertSecretName)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		secretsToDelete = append(secretsToDelete, catalogConstants.CatalogCertSecretName)
+	}
+	return secretsToDelete, nil
+}
+
+// uninstallLocalWorker removes the co-located local worker.
+func uninstallLocalWorker(ctx context.Context, skipCleanup bool) error {
+	if err := workeruninstall.Uninstall(ctx, workerutils.UninstallOptions{
+		RuntimeType: types.RuntimeTypePodman,
+		AutoYes:     true,
+		SkipCleanup: skipCleanup,
+	}); err != nil {
+		return fmt.Errorf("worker uninstall failed: %w", err)
+	}
 	return nil
 }
 

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -4,18 +4,22 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	clicommon "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common"
 	cliutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/uninstall/utils"
 	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
-
 	podmanutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	workercommon "github.com/project-ai-services/ai-services/internal/pkg/worker/common"
+	workerConstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
+	workeruninstall "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall"
+	workerutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 )
 
 // UninstallCatalog removes the catalog service and all associated resources.
@@ -29,6 +33,20 @@ func UninstallCatalog(ctx context.Context, opts cliutils.UninstallOptions) error
 	pods, err := clicommon.GetCatalogPods(ctx, rt)
 	if err != nil || len(pods) == 0 {
 		return err
+	}
+
+	// Filter out any worker pod (ai-services.io/component=worker) — those are
+	// managed by the worker uninstall path and must not be touched here.
+	workerComponentValue := strings.TrimPrefix(workerConstants.WorkerPodLabel, workerConstants.CatalogBackendPodLabel+"=")
+	filtered := pods[:0]
+	for _, pod := range pods {
+		if pod.Labels[workerConstants.CatalogBackendPodLabel] != workerComponentValue {
+			filtered = append(filtered, pod)
+		}
+	}
+	pods = filtered
+	if len(pods) == 0 {
+		return nil
 	}
 
 	// Warn about potential application staleness
@@ -56,6 +74,12 @@ func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.P
 		baseDir = config.BaseDir
 	}
 	logger.Infof("Using base directory for cleanup: %s\n", baseDir)
+
+	// Check before catalog pods are deleted whether a local worker is co-located.
+	isLocalWorker, err := workercommon.IsPodmanLocalWorker(ctx, rt)
+	if err != nil {
+		return fmt.Errorf("failed to check local worker: %w", err)
+	}
 
 	secretsToDelete, secretsToSkip := fetchSecretsToDelete(pods)
 	secretsToDelete = append(secretsToDelete, constants.PodmanAuthSecret, catalogConstants.CatalogConnectorSecretName, catalogConstants.CatalogMTLSSecretName)
@@ -96,6 +120,17 @@ func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.P
 	// Delete skip-cleanup resources (secrets and volumes preserved when --skip-cleanup is set)
 	if err := podmanutils.CleanupSkippedResources(ctx, rt, secretsToSkip, volumesToSkip, skipCleanup); err != nil {
 		return err
+	}
+
+	// Only uninstall the co-located worker if LOCAL_WORKER is true
+	if isLocalWorker {
+		if err := workeruninstall.Uninstall(ctx, workerutils.UninstallOptions{
+			RuntimeType: types.RuntimeTypePodman,
+			AutoYes:     true,
+			SkipCleanup: skipCleanup,
+		}); err != nil {
+			return fmt.Errorf("worker uninstall failed: %w", err)
+		}
 	}
 
 	logger.Infoln("Catalog service removed successfully")

--- a/ai-services/internal/pkg/cli/utils/podman.go
+++ b/ai-services/internal/pkg/cli/utils/podman.go
@@ -53,7 +53,7 @@ func DeleteVolumes(ctx context.Context, rt runtime.Runtime, volumeNames []string
 	for _, volumeName := range volumeNames {
 		logger.Infof("Deleting volume: %s\n", volumeName)
 
-		if err := rt.DeleteVolume(ctx, volumeName); err != nil {
+		if err := rt.DeleteVolume(ctx, volumeName, utils.BoolPtr(true)); err != nil {
 			// Ignore "not found" errors - volume already deleted or never existed
 			if utils.IsNotFoundError(err) {
 				logger.Infof("Volume %s already deleted or does not exist\n", volumeName)

--- a/ai-services/internal/pkg/runtime/interface.go
+++ b/ai-services/internal/pkg/runtime/interface.go
@@ -33,7 +33,7 @@ type Runtime interface {
 	UpdateSecret(ctx context.Context, name, deploymentName string, data map[string][]byte) error
 
 	// Volume operations
-	DeleteVolume(ctx context.Context, name string) error
+	DeleteVolume(ctx context.Context, name string, force *bool) error
 	VolumeExists(ctx context.Context, nameOrID string) (bool, error)
 
 	// Container operations

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -576,7 +576,7 @@ func (kc *OpenshiftClient) UpdateSecret(ctx context.Context, name, deploymentNam
 	return fmt.Errorf("timed out waiting for deployment %q to become ready after secret update", deploymentName)
 }
 
-func (kc *OpenshiftClient) DeleteVolume(_ context.Context, name string) error {
+func (kc *OpenshiftClient) DeleteVolume(_ context.Context, name string, force *bool) error {
 	logger.Warningln("Not implemented")
 
 	return nil

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -567,11 +567,11 @@ func (pc *PodmanClient) DeleteSecret(ctx context.Context, name string) error {
 	return nil
 }
 
-func (pc *PodmanClient) DeleteVolume(ctx context.Context, name string) error {
+func (pc *PodmanClient) DeleteVolume(ctx context.Context, name string, force *bool) error {
 	podCtx, cancel := pc.podmanCtx(ctx)
 	defer cancel()
 
-	err := volumes.Remove(podCtx, name, nil)
+	err := volumes.Remove(podCtx, name, &volumes.RemoveOptions{Force: force})
 	if err != nil {
 		return fmt.Errorf("failed to remove volume: %w", err)
 	}

--- a/ai-services/internal/pkg/runtime/remote/runtime.go
+++ b/ai-services/internal/pkg/runtime/remote/runtime.go
@@ -242,7 +242,7 @@ func (r *RemoteRuntime) UpdateSecret(ctx context.Context, name, deploymentName s
 
 // ─── Volume operations ────────────────────────────────────────────────────────
 
-func (r *RemoteRuntime) DeleteVolume(ctx context.Context, name string) error {
+func (r *RemoteRuntime) DeleteVolume(ctx context.Context, name string, _ *bool) error {
 	_, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_DELETE_VOLUME, payload.Name{Namespace: r.namespace, Name: name})
 
 	return err

--- a/ai-services/internal/pkg/worker/dispatch/dispatch.go
+++ b/ai-services/internal/pkg/worker/dispatch/dispatch.go
@@ -197,7 +197,7 @@ func handle(ctx context.Context, rt runtime.Runtime, pr *workercaddy.ProxyRouter
 		}
 		nrt := rtInNamespace(rt, req.Namespace)
 
-		return nil, nrt.DeleteVolume(ctx, req.Name)
+		return nil, nrt.DeleteVolume(ctx, req.Name, nil)
 
 	case workerpb.CommandType_COMMAND_TYPE_VOLUME_EXISTS:
 		var req payload.NameOrID


### PR DESCRIPTION
Catalog uninstall was uninstalling worker pod since we were filtering via label: `ai-services.io/application: ai-services`. Ideally it should be handled when worker uninstall is called.

1. remove worker pod from the list of pods deleted as part of catalog uninstall.
2. invoking worker uninstall to remove worker pods now.
3. Added force flag in volume deletion. Reason: when catalog uninstall in invoked, it fails to delete podman auth secret as it is used by worker pod. Now force deleting it as there is no use of standalone worker pod now that catalog is uninstalled.