### PR TITLE
Cover Connector and Sync logs schema as part of Import/Export APIs

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.358
+TAG?=v0.0.359
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/applications/rag-cpu/podman/values.yaml
+++ b/ai-services/assets/applications/rag-cpu/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.63
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.64
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/openshift/values.yaml
+++ b/ai-services/assets/applications/rag-dev/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.63
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.64
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag-dev/podman/values.yaml
+++ b/ai-services/assets/applications/rag-dev/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.63
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.64
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/openshift/values.yaml
+++ b/ai-services/assets/applications/rag/openshift/values.yaml
@@ -26,7 +26,7 @@ similarity:
 
 digitize:
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.63
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.64
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/applications/rag/podman/values.yaml
+++ b/ai-services/assets/applications/rag/podman/values.yaml
@@ -18,7 +18,7 @@ digitize:
   # @description Host port for the DIGITIZE API. If unspecified, a random available port is assigned. Specify a port number to use a custom value.
   port: ""
   # @hidden
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.63
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.64
   # @hidden
   log_level: "INFO"
   # @description Database name for the DIGITIZE service. Default is "digitize_metadata".

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.358
+  image: icr.io/ai-services-cicd/ai-services:v0.0.359
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.358
+  image: icr.io/ai-services-cicd/ai-services:v0.0.359
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/services/digitize/openshift/values.yaml
+++ b/ai-services/assets/services/digitize/openshift/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.63
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.64
   log_level: "INFO"
   database: "digitize_metadata"
   numShards: 1

--- a/ai-services/assets/services/digitize/podman/values.yaml
+++ b/ai-services/assets/services/digitize/podman/values.yaml
@@ -1,5 +1,5 @@
 digitize:
-  image: icr.io/ai-services-cicd/digitize-service:v0.0.63
+  image: icr.io/ai-services-cicd/digitize-service:v0.0.64
   log_level: "INFO"
   database: "digitize_metadata"
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.358
+  image: icr.io/ai-services-cicd/ai-services:v0.0.359
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.358
+  image: icr.io/ai-services-cicd/ai-services:v0.0.359
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/services/digitize/Makefile
+++ b/services/digitize/Makefile
@@ -1,5 +1,5 @@
 IMAGE=digitize-service
-TAG?=v0.0.63
+TAG?=v0.0.64
 
 run:
 	PORT=$${PORT:-4000} /var/venv/bin/python -m uvicorn app:app --host 0.0.0.0 --port $$PORT

--- a/services/digitize/api/v1/admin.py
+++ b/services/digitize/api/v1/admin.py
@@ -84,7 +84,7 @@ async def import_metadata(payload: models.ImportRequest):
         logger.error(f"Failed to import metadata: {exc}", exc_info=True)
         APIError.raise_error(
             ErrorCode.INTERNAL_SERVER_ERROR,
-            "Database connection failed during import",
+            f"Import failed: {exc}",
         )
 
 

--- a/services/digitize/app.py
+++ b/services/digitize/app.py
@@ -288,10 +288,6 @@ tags_metadata = [
         "name": "documents",
         "description": "Document management operations including retrieval and deletion",
     },
-    {
-        "name": "connectors",
-        "description": "Data-source connector lifecycle management (file_system, object_storage)",
-    },
 ]
 
 app = FastAPI(
@@ -379,7 +375,7 @@ from digitize.api.v1.connectors import router as connectors_router
 app.include_router(jobs_router, prefix="/v1/jobs", tags=["jobs"])
 app.include_router(admin_router, prefix="/v1", tags=["jobs"])
 app.include_router(documents_router, prefix="/v1/documents", tags=["documents"])
-app.include_router(connectors_router, prefix="/v1/connectors", tags=["connectors"])
+app.include_router(connectors_router, prefix="/v1/connectors", tags=["connectors"], include_in_schema=False)
 
 
 if __name__ == "__main__":

--- a/services/digitize/db/manager.py
+++ b/services/digitize/db/manager.py
@@ -1615,6 +1615,136 @@ class DatabaseManager:
             logger.error(f"DB error in get_sync_logs({connector_id}): {e}", exc_info=True)
             return []
 
+    @staticmethod
+    def get_all_sync_logs() -> List[ConnectorSyncLog]:
+        """Return every sync-log row across all connectors, ordered by connector_id, seq asc.
+
+        Used exclusively by export_metadata to snapshot full history.
+        Each object is eagerly loaded and expunged from the session.
+        """
+        try:
+            with get_db_session() as session:
+                stmt = select(ConnectorSyncLog).order_by(
+                    ConnectorSyncLog.connector_id,
+                    ConnectorSyncLog.seq,
+                )
+                rows = list(session.scalars(stmt).all())
+                for row in rows:
+                    _ = (
+                        row.connector_id, row.seq,
+                        row.started_at, row.finished_at,
+                        row.total_files, row.new_files, row.completed_files,
+                        row.removed_files, row.status, row.error,
+                    )
+                    session.expunge(row)
+                logger.debug(f"get_all_sync_logs: returned {len(rows)} row(s)")
+                return rows
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in get_all_sync_logs: {e}", exc_info=True)
+            return []
+
+    @staticmethod
+    def import_connector(
+        connector_id: str,
+        name: str,
+        connector_type: str,
+        allowed_extensions: list,
+        sync_interval_seconds: int,
+        attached_at: datetime,
+        last_sync_at: Optional[datetime],
+        status: str,
+        total_files: int,
+        message: Optional[str],
+    ) -> bool:
+        """Insert a connector row during import (no credentials — shell only).
+
+        Uses ON CONFLICT DO NOTHING so re-importing the same snapshot is safe.
+        Returns True if the row was inserted, False if it already existed.
+        """
+        try:
+            with get_db_session() as session:
+                stmt = (
+                    pg_insert(Connector)
+                    .values(
+                        id=connector_id,
+                        name=name,
+                        type=connector_type,
+                        connection_details={},
+                        allowed_extensions=allowed_extensions,
+                        sync_interval_seconds=sync_interval_seconds,
+                        attached_at=attached_at,
+                        last_sync_at=last_sync_at,
+                        status=status,
+                        total_files=total_files,
+                        message=message,
+                    )
+                    .on_conflict_do_nothing(index_elements=["id"])
+                )
+                result = session.execute(stmt)
+                inserted = result.rowcount == 1
+                if inserted:
+                    logger.info(f"import_connector: inserted connector {connector_id!r} ({name!r})")
+                else:
+                    logger.debug(f"import_connector: connector {connector_id!r} already exists — skipped")
+                return inserted
+        except SQLAlchemyError as e:
+            logger.error(f"DB error in import_connector({connector_id!r}): {e}", exc_info=True)
+            raise
+
+    @staticmethod
+    def import_sync_log(
+        connector_id: str,
+        seq: int,
+        started_at: datetime,
+        finished_at: Optional[datetime],
+        total_files: int,
+        new_files: int,
+        completed_files: int,
+        removed_files: int,
+        status: str,
+        error: str,
+    ) -> bool:
+        """Insert a sync-log row during import.
+
+        Uses ON CONFLICT DO NOTHING so re-importing the same snapshot is safe.
+        Returns True if the row was inserted, False if it already existed.
+        """
+        try:
+            with get_db_session() as session:
+                stmt = (
+                    pg_insert(ConnectorSyncLog)
+                    .values(
+                        connector_id=connector_id,
+                        seq=seq,
+                        started_at=started_at,
+                        finished_at=finished_at,
+                        total_files=total_files,
+                        new_files=new_files,
+                        completed_files=completed_files,
+                        removed_files=removed_files,
+                        status=status,
+                        error=error,
+                    )
+                    .on_conflict_do_nothing(index_elements=["connector_id", "seq"])
+                )
+                result = session.execute(stmt)
+                inserted = result.rowcount == 1
+                if inserted:
+                    logger.debug(
+                        f"import_sync_log: inserted connector={connector_id!r} seq={seq}"
+                    )
+                else:
+                    logger.debug(
+                        f"import_sync_log: connector={connector_id!r} seq={seq} already exists — skipped"
+                    )
+                return inserted
+        except SQLAlchemyError as e:
+            logger.error(
+                f"DB error in import_sync_log(connector={connector_id!r}, seq={seq}): {e}",
+                exc_info=True,
+            )
+            raise
+
     # ========================================================================
     # Document metadata helper
     # ========================================================================

--- a/services/digitize/models.py
+++ b/services/digitize/models.py
@@ -199,8 +199,6 @@ class ImportExportData(BaseModel):
     """Shared payload structure for import/export APIs."""
     jobs: List["ExportJobRecord"] = Field(default_factory=list)
     documents: List["ExportDocumentRecord"] = Field(default_factory=list)
-    connectors: List["ExportConnectorRecord"] = Field(default_factory=list)
-    sync_logs: List["ExportSyncLogRecord"] = Field(default_factory=list)
 
 
 class ExportJobRecord(BaseModel):
@@ -273,14 +271,9 @@ class ImportRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_non_empty_payload(self):
-        if (
-            not self.data.jobs
-            and not self.data.documents
-            and not self.data.connectors
-            and not self.data.sync_logs
-        ):
+        if not self.data.jobs and not self.data.documents:
             raise ValueError(
-                "At least one job, document, connector, or sync_log record must be provided"
+                "At least one job or document record must be provided"
             )
         return self
 
@@ -305,8 +298,6 @@ class ImportSummary(BaseModel):
     """Import summary grouped by entity type."""
     jobs: ImportEntitySummary
     documents: ImportEntitySummary
-    connectors: ImportEntitySummary = Field(default_factory=ImportEntitySummary)
-    sync_logs: ImportEntitySummary = Field(default_factory=ImportEntitySummary)
 
 
 class ImportResponse(BaseModel):
@@ -329,8 +320,6 @@ class ExportSummary(BaseModel):
     """Export summary grouped by entity type."""
     jobs: ExportEntitySummary
     documents: ExportEntitySummary
-    connectors: ExportEntitySummary = Field(default_factory=ExportEntitySummary)
-    sync_logs: ExportEntitySummary = Field(default_factory=ExportEntitySummary)
 
 
 class ExportPagination(BaseModel):

--- a/services/digitize/models.py
+++ b/services/digitize/models.py
@@ -199,6 +199,8 @@ class ImportExportData(BaseModel):
     """Shared payload structure for import/export APIs."""
     jobs: List["ExportJobRecord"] = Field(default_factory=list)
     documents: List["ExportDocumentRecord"] = Field(default_factory=list)
+    connectors: List["ExportConnectorRecord"] = Field(default_factory=list)
+    sync_logs: List["ExportSyncLogRecord"] = Field(default_factory=list)
 
 
 class ExportJobRecord(BaseModel):
@@ -206,6 +208,7 @@ class ExportJobRecord(BaseModel):
     job_id: str
     operation: str
     status: str
+    source: str = "user"
     job_name: Optional[str] = None
     submitted_at: str
     completed_at: Optional[str] = None
@@ -220,11 +223,47 @@ class ExportDocumentRecord(BaseModel):
     name: str
     type: str
     status: str
+    source: str = "user"
     output_format: str
     submitted_at: str
     completed_at: Optional[str] = None
     error: Optional[str] = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ExportConnectorRecord(BaseModel):
+    """Serializable connector record for export/import APIs.
+
+    connection_details is intentionally excluded — encrypted credentials
+    cannot be round-tripped; connectors must be re-registered with fresh
+    credentials after restore. The record carries all other config fields
+    so the connector shell (id, name, type, extensions, interval, state)
+    is preserved.
+    """
+    id: str
+    name: str
+    type: str
+    allowed_extensions: List[str] = Field(default_factory=list)
+    sync_interval_seconds: int = 300
+    attached_at: str
+    last_sync_at: Optional[str] = None
+    status: str = "up to date"
+    total_files: int = 0
+    message: Optional[str] = None
+
+
+class ExportSyncLogRecord(BaseModel):
+    """Serializable connector sync-log record for export/import APIs."""
+    connector_id: str
+    seq: int
+    started_at: str
+    finished_at: Optional[str] = None
+    total_files: int = 0
+    new_files: int = 0
+    completed_files: int = 0
+    removed_files: int = 0
+    status: str
+    error: str = ""
 
 
 class ImportRequest(BaseModel):
@@ -234,8 +273,15 @@ class ImportRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_non_empty_payload(self):
-        if not self.data.jobs and not self.data.documents:
-            raise ValueError("At least one job or document record must be provided")
+        if (
+            not self.data.jobs
+            and not self.data.documents
+            and not self.data.connectors
+            and not self.data.sync_logs
+        ):
+            raise ValueError(
+                "At least one job, document, connector, or sync_log record must be provided"
+            )
         return self
 
 
@@ -256,9 +302,11 @@ class ImportEntitySummary(BaseModel):
 
 
 class ImportSummary(BaseModel):
-    """Import summary grouped by jobs and documents."""
+    """Import summary grouped by entity type."""
     jobs: ImportEntitySummary
     documents: ImportEntitySummary
+    connectors: ImportEntitySummary = Field(default_factory=ImportEntitySummary)
+    sync_logs: ImportEntitySummary = Field(default_factory=ImportEntitySummary)
 
 
 class ImportResponse(BaseModel):
@@ -278,9 +326,11 @@ class ExportEntitySummary(BaseModel):
 
 
 class ExportSummary(BaseModel):
-    """Export summary grouped by jobs and documents."""
+    """Export summary grouped by entity type."""
     jobs: ExportEntitySummary
     documents: ExportEntitySummary
+    connectors: ExportEntitySummary = Field(default_factory=ExportEntitySummary)
+    sync_logs: ExportEntitySummary = Field(default_factory=ExportEntitySummary)
 
 
 class ExportPagination(BaseModel):

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -20,6 +20,8 @@ from digitize.models import (
     JobStats,
     ExportJobRecord,
     ExportDocumentRecord,
+    ExportConnectorRecord,
+    ExportSyncLogRecord,
     ImportRequest,
     ImportResponse,
     ImportSummary,
@@ -704,11 +706,18 @@ def _serialize_datetime(timestamp: Optional[datetime]) -> Optional[str]:
     return timestamp.isoformat().replace("+00:00", "Z")
 
 
-def _build_import_summary(total_jobs: int, total_documents: int) -> ImportSummary:
+def _build_import_summary(
+    total_jobs: int,
+    total_documents: int,
+    total_connectors: int = 0,
+    total_sync_logs: int = 0,
+) -> ImportSummary:
     """Create an initialized import summary object."""
     return ImportSummary(
         jobs=ImportEntitySummary(total_received=total_jobs),
         documents=ImportEntitySummary(total_received=total_documents),
+        connectors=ImportEntitySummary(total_received=total_connectors),
+        sync_logs=ImportEntitySummary(total_received=total_sync_logs),
     )
 
 
@@ -788,6 +797,7 @@ def export_metadata(limit: int = IMPORT_EXPORT_DEFAULT_LIMIT, offset: int = 0) -
             job_id=job.job_id,
             operation=job.operation,
             status=job.status,
+            source=job.source or JobSource.USER.value,
             job_name=job.job_name,
             submitted_at=_serialize_datetime(job.submitted_at) or "",
             completed_at=_serialize_datetime(job.completed_at),
@@ -804,6 +814,7 @@ def export_metadata(limit: int = IMPORT_EXPORT_DEFAULT_LIMIT, offset: int = 0) -
             name=doc.name,
             type=doc.type,
             status=doc.status,
+            source=doc.source or DocumentSource.USER.value,
             output_format=doc.output_format,
             submitted_at=_serialize_datetime(doc.submitted_at) or "",
             completed_at=_serialize_datetime(doc.completed_at),
@@ -813,13 +824,54 @@ def export_metadata(limit: int = IMPORT_EXPORT_DEFAULT_LIMIT, offset: int = 0) -
         for doc in documents
     ]
 
+    # Export connectors (credentials excluded — connection_details stripped)
+    all_connectors = db_manager.get_all_connectors()
+    exported_connectors = [
+        ExportConnectorRecord(
+            id=c.id,
+            name=c.name,
+            type=c.type,
+            allowed_extensions=list(c.allowed_extensions or []),
+            sync_interval_seconds=c.sync_interval_seconds,
+            attached_at=_serialize_datetime(c.attached_at) or "",
+            last_sync_at=_serialize_datetime(c.last_sync_at),
+            status=c.status,
+            total_files=c.total_files,
+            message=c.message,
+        )
+        for c in all_connectors
+    ]
+
+    # Export all sync logs across all connectors
+    all_sync_logs = db_manager.get_all_sync_logs()
+    exported_sync_logs = [
+        ExportSyncLogRecord(
+            connector_id=row.connector_id,
+            seq=row.seq,
+            started_at=_serialize_datetime(row.started_at) or "",
+            finished_at=_serialize_datetime(row.finished_at),
+            total_files=row.total_files,
+            new_files=row.new_files,
+            completed_files=row.completed_files,
+            removed_files=row.removed_files,
+            status=row.status,
+            error=row.error or "",
+        )
+        for row in all_sync_logs
+    ]
+
     returned_records = len(exported_jobs) + len(exported_documents)
     total_records = total_jobs + total_documents
     effective_limit = returned_records if limit == -1 else limit
 
     return ExportResponse(
         status="completed",
-        data=ImportExportData(jobs=exported_jobs, documents=exported_documents),
+        data=ImportExportData(
+            jobs=exported_jobs,
+            documents=exported_documents,
+            connectors=exported_connectors,
+            sync_logs=exported_sync_logs,
+        ),
         summary=ExportSummary(
             jobs=ExportEntitySummary(
                 total_exported=len(exported_jobs),
@@ -836,6 +888,14 @@ def export_metadata(limit: int = IMPORT_EXPORT_DEFAULT_LIMIT, offset: int = 0) -
                     if doc.status in (DocStatus.COMPLETED.value, DocStatus.COMPLETED_WITH_ERRORS.value)
                 ),
                 failed=sum(1 for doc in exported_documents if doc.status == DocStatus.FAILED.value),
+            ),
+            connectors=ExportEntitySummary(
+                total_exported=len(exported_connectors),
+            ),
+            sync_logs=ExportEntitySummary(
+                total_exported=len(exported_sync_logs),
+                completed=sum(1 for s in exported_sync_logs if s.status == "completed"),
+                failed=sum(1 for s in exported_sync_logs if s.status == "failed"),
             ),
         ),
         export_timestamp=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -864,21 +924,28 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
         raise RuntimeError("Database not available. Cannot import metadata without database connection.")
 
     started_at = perf_counter()
-    summary = _build_import_summary(len(payload.data.jobs), len(payload.data.documents))
+    summary = _build_import_summary(
+        len(payload.data.jobs),
+        len(payload.data.documents),
+        len(payload.data.connectors),
+        len(payload.data.sync_logs),
+    )
     warnings: list[ImportRecordIssue] = []
     errors: list[ImportRecordIssue] = []
 
     existing_job_ids = set(get_all_job_ids())
     existing_document_ids = set(get_all_document_ids())
+    existing_connector_ids = {c.id for c in db_manager.get_all_connectors()}
 
     importable_job_ids = set(existing_job_ids)
+    importable_connector_ids = set(existing_connector_ids)
 
+    # ── Jobs ─────────────────────────────────────────────────────────────────
     for job_record in payload.data.jobs:
         if job_record.job_id in existing_job_ids:
             summary.jobs.skipped += 1
             continue
 
-        # Parse and validate timestamps once, then reuse
         try:
             submitted_at = _parse_iso_datetime(job_record.submitted_at)
             completed_at = _parse_iso_datetime(job_record.completed_at)
@@ -899,11 +966,13 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             importable_job_ids.add(job_record.job_id)
             continue
 
+        source = JobSource.CONNECTOR if job_record.source == JobSource.CONNECTOR.value else JobSource.USER
         created_job = db_manager.create_job(
             job_id=job_record.job_id,
             operation=job_record.operation,
             status=JobStatus(job_record.status),
             job_name=job_record.job_name,
+            source=source,
             submitted_at=submitted_at,
             completed_at=completed_at,
             error=job_record.error,
@@ -925,6 +994,7 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
         summary.jobs.imported += 1
         importable_job_ids.add(job_record.job_id)
 
+    # ── Documents ─────────────────────────────────────────────────────────────
     for document_record in payload.data.documents:
         if document_record.id in existing_document_ids:
             summary.documents.skipped += 1
@@ -942,7 +1012,6 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             )
             continue
 
-        # Parse and validate timestamps once, then reuse
         try:
             submitted_at = _parse_iso_datetime(document_record.submitted_at)
             completed_at = _parse_iso_datetime(document_record.completed_at)
@@ -962,6 +1031,11 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             summary.documents.imported += 1
             continue
 
+        doc_source = (
+            DocumentSource.CONNECTOR
+            if document_record.source == DocumentSource.CONNECTOR.value
+            else DocumentSource.USER
+        )
         created_document = db_manager.create_document(
             doc_id=document_record.id,
             name=document_record.name,
@@ -972,6 +1046,7 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             completed_at=completed_at,
             error=document_record.error,
             job_id=document_record.job_id,
+            source=doc_source,
             metadata=document_record.metadata,
         )
 
@@ -988,6 +1063,131 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             continue
 
         summary.documents.imported += 1
+
+    # ── Connectors ────────────────────────────────────────────────────────────
+    for connector_record in payload.data.connectors:
+        if connector_record.id in existing_connector_ids:
+            summary.connectors.skipped += 1
+            continue
+
+        try:
+            attached_at = _parse_iso_datetime(connector_record.attached_at)
+            if attached_at is None:
+                raise ValueError("attached_at is required")
+            last_sync_at = _parse_iso_datetime(connector_record.last_sync_at)
+        except ValueError as exc:
+            summary.connectors.failed += 1
+            errors.append(
+                ImportRecordIssue(
+                    record_type="connector",
+                    record_id=connector_record.id,
+                    type="validation_error",
+                    message=f"Invalid timestamp: {exc}",
+                )
+            )
+            continue
+
+        if payload.validate_only:
+            summary.connectors.imported += 1
+            importable_connector_ids.add(connector_record.id)
+            continue
+
+        try:
+            inserted = db_manager.import_connector(
+                connector_id=connector_record.id,
+                name=connector_record.name,
+                connector_type=connector_record.type,
+                allowed_extensions=connector_record.allowed_extensions,
+                sync_interval_seconds=connector_record.sync_interval_seconds,
+                attached_at=attached_at,
+                last_sync_at=last_sync_at,
+                status=connector_record.status,
+                total_files=connector_record.total_files,
+                message=connector_record.message,
+            )
+            if inserted:
+                summary.connectors.imported += 1
+                importable_connector_ids.add(connector_record.id)
+            else:
+                summary.connectors.skipped += 1
+        except Exception as exc:
+            summary.connectors.failed += 1
+            errors.append(
+                ImportRecordIssue(
+                    record_type="connector",
+                    record_id=connector_record.id,
+                    type="database_error",
+                    message=f"Failed to create connector record: {exc}",
+                )
+            )
+
+    # ── Sync logs ─────────────────────────────────────────────────────────────
+    for sync_log_record in payload.data.sync_logs:
+        record_id = f"{sync_log_record.connector_id}:{sync_log_record.seq}"
+
+        if sync_log_record.connector_id not in importable_connector_ids:
+            summary.sync_logs.failed += 1
+            warnings.append(
+                ImportRecordIssue(
+                    record_type="sync_log",
+                    record_id=record_id,
+                    type="orphaned_sync_log",
+                    message=(
+                        f"sync_log references non-existent connector_id: "
+                        f"{sync_log_record.connector_id}"
+                    ),
+                )
+            )
+            continue
+
+        try:
+            started_at = _parse_iso_datetime(sync_log_record.started_at)
+            if started_at is None:
+                raise ValueError("started_at is required")
+            finished_at = _parse_iso_datetime(sync_log_record.finished_at)
+        except ValueError as exc:
+            summary.sync_logs.failed += 1
+            errors.append(
+                ImportRecordIssue(
+                    record_type="sync_log",
+                    record_id=record_id,
+                    type="validation_error",
+                    message=f"Invalid timestamp: {exc}",
+                )
+            )
+            continue
+
+        if payload.validate_only:
+            summary.sync_logs.imported += 1
+            continue
+
+        try:
+            inserted = db_manager.import_sync_log(
+                connector_id=sync_log_record.connector_id,
+                seq=sync_log_record.seq,
+                started_at=started_at,
+                finished_at=finished_at,
+                total_files=sync_log_record.total_files,
+                new_files=sync_log_record.new_files,
+                completed_files=sync_log_record.completed_files,
+                removed_files=sync_log_record.removed_files,
+                status=sync_log_record.status,
+                error=sync_log_record.error,
+            )
+            if inserted:
+                summary.sync_logs.imported += 1
+            else:
+                summary.sync_logs.skipped += 1
+        except Exception as exc:
+            summary.sync_logs.failed += 1
+            errors.append(
+                ImportRecordIssue(
+                    record_type="sync_log",
+                    record_id=record_id,
+                    type="database_error",
+                    message=f"Failed to create sync_log record: {exc}",
+                )
+            )
 
     return ImportResponse(
         status="completed",

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -20,8 +20,6 @@ from digitize.models import (
     JobStats,
     ExportJobRecord,
     ExportDocumentRecord,
-    ExportConnectorRecord,
-    ExportSyncLogRecord,
     ImportRequest,
     ImportResponse,
     ImportSummary,
@@ -709,15 +707,11 @@ def _serialize_datetime(timestamp: Optional[datetime]) -> Optional[str]:
 def _build_import_summary(
     total_jobs: int,
     total_documents: int,
-    total_connectors: int = 0,
-    total_sync_logs: int = 0,
 ) -> ImportSummary:
     """Create an initialized import summary object."""
     return ImportSummary(
         jobs=ImportEntitySummary(total_received=total_jobs),
         documents=ImportEntitySummary(total_received=total_documents),
-        connectors=ImportEntitySummary(total_received=total_connectors),
-        sync_logs=ImportEntitySummary(total_received=total_sync_logs),
     )
 
 
@@ -824,42 +818,6 @@ def export_metadata(limit: int = IMPORT_EXPORT_DEFAULT_LIMIT, offset: int = 0) -
         for doc in documents
     ]
 
-    # Export connectors (credentials excluded — connection_details stripped)
-    all_connectors = db_manager.get_all_connectors()
-    exported_connectors = [
-        ExportConnectorRecord(
-            id=c.id,
-            name=c.name,
-            type=c.type,
-            allowed_extensions=list(c.allowed_extensions or []),
-            sync_interval_seconds=c.sync_interval_seconds,
-            attached_at=_serialize_datetime(c.attached_at) or "",
-            last_sync_at=_serialize_datetime(c.last_sync_at),
-            status=c.status,
-            total_files=c.total_files,
-            message=c.message,
-        )
-        for c in all_connectors
-    ]
-
-    # Export all sync logs across all connectors
-    all_sync_logs = db_manager.get_all_sync_logs()
-    exported_sync_logs = [
-        ExportSyncLogRecord(
-            connector_id=row.connector_id,
-            seq=row.seq,
-            started_at=_serialize_datetime(row.started_at) or "",
-            finished_at=_serialize_datetime(row.finished_at),
-            total_files=row.total_files,
-            new_files=row.new_files,
-            completed_files=row.completed_files,
-            removed_files=row.removed_files,
-            status=row.status,
-            error=row.error or "",
-        )
-        for row in all_sync_logs
-    ]
-
     returned_records = len(exported_jobs) + len(exported_documents)
     total_records = total_jobs + total_documents
     effective_limit = returned_records if limit == -1 else limit
@@ -869,8 +827,6 @@ def export_metadata(limit: int = IMPORT_EXPORT_DEFAULT_LIMIT, offset: int = 0) -
         data=ImportExportData(
             jobs=exported_jobs,
             documents=exported_documents,
-            connectors=exported_connectors,
-            sync_logs=exported_sync_logs,
         ),
         summary=ExportSummary(
             jobs=ExportEntitySummary(
@@ -888,14 +844,6 @@ def export_metadata(limit: int = IMPORT_EXPORT_DEFAULT_LIMIT, offset: int = 0) -
                     if doc.status in (DocStatus.COMPLETED.value, DocStatus.COMPLETED_WITH_ERRORS.value)
                 ),
                 failed=sum(1 for doc in exported_documents if doc.status == DocStatus.FAILED.value),
-            ),
-            connectors=ExportEntitySummary(
-                total_exported=len(exported_connectors),
-            ),
-            sync_logs=ExportEntitySummary(
-                total_exported=len(exported_sync_logs),
-                completed=sum(1 for s in exported_sync_logs if s.status == "completed"),
-                failed=sum(1 for s in exported_sync_logs if s.status == "failed"),
             ),
         ),
         export_timestamp=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -927,18 +875,14 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
     summary = _build_import_summary(
         len(payload.data.jobs),
         len(payload.data.documents),
-        len(payload.data.connectors),
-        len(payload.data.sync_logs),
     )
     warnings: list[ImportRecordIssue] = []
     errors: list[ImportRecordIssue] = []
 
     existing_job_ids = set(get_all_job_ids())
     existing_document_ids = set(get_all_document_ids())
-    existing_connector_ids = {c.id for c in db_manager.get_all_connectors()}
 
     importable_job_ids = set(existing_job_ids)
-    importable_connector_ids = set(existing_connector_ids)
 
     # ── Jobs ─────────────────────────────────────────────────────────────────
     for job_record in payload.data.jobs:
@@ -1063,131 +1007,6 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
             continue
 
         summary.documents.imported += 1
-
-    # ── Connectors ────────────────────────────────────────────────────────────
-    for connector_record in payload.data.connectors:
-        if connector_record.id in existing_connector_ids:
-            summary.connectors.skipped += 1
-            continue
-
-        try:
-            attached_at = _parse_iso_datetime(connector_record.attached_at)
-            if attached_at is None:
-                raise ValueError("attached_at is required")
-            last_sync_at = _parse_iso_datetime(connector_record.last_sync_at)
-        except ValueError as exc:
-            summary.connectors.failed += 1
-            errors.append(
-                ImportRecordIssue(
-                    record_type="connector",
-                    record_id=connector_record.id,
-                    type="validation_error",
-                    message=f"Invalid timestamp: {exc}",
-                )
-            )
-            continue
-
-        if payload.validate_only:
-            summary.connectors.imported += 1
-            importable_connector_ids.add(connector_record.id)
-            continue
-
-        try:
-            inserted = db_manager.import_connector(
-                connector_id=connector_record.id,
-                name=connector_record.name,
-                connector_type=connector_record.type,
-                allowed_extensions=connector_record.allowed_extensions,
-                sync_interval_seconds=connector_record.sync_interval_seconds,
-                attached_at=attached_at,
-                last_sync_at=last_sync_at,
-                status=connector_record.status,
-                total_files=connector_record.total_files,
-                message=connector_record.message,
-            )
-            if inserted:
-                summary.connectors.imported += 1
-                importable_connector_ids.add(connector_record.id)
-            else:
-                summary.connectors.skipped += 1
-        except Exception as exc:
-            summary.connectors.failed += 1
-            errors.append(
-                ImportRecordIssue(
-                    record_type="connector",
-                    record_id=connector_record.id,
-                    type="database_error",
-                    message=f"Failed to create connector record: {exc}",
-                )
-            )
-
-    # ── Sync logs ─────────────────────────────────────────────────────────────
-    for sync_log_record in payload.data.sync_logs:
-        record_id = f"{sync_log_record.connector_id}:{sync_log_record.seq}"
-
-        if sync_log_record.connector_id not in importable_connector_ids:
-            summary.sync_logs.failed += 1
-            warnings.append(
-                ImportRecordIssue(
-                    record_type="sync_log",
-                    record_id=record_id,
-                    type="orphaned_sync_log",
-                    message=(
-                        f"sync_log references non-existent connector_id: "
-                        f"{sync_log_record.connector_id}"
-                    ),
-                )
-            )
-            continue
-
-        try:
-            started_at = _parse_iso_datetime(sync_log_record.started_at)
-            if started_at is None:
-                raise ValueError("started_at is required")
-            finished_at = _parse_iso_datetime(sync_log_record.finished_at)
-        except ValueError as exc:
-            summary.sync_logs.failed += 1
-            errors.append(
-                ImportRecordIssue(
-                    record_type="sync_log",
-                    record_id=record_id,
-                    type="validation_error",
-                    message=f"Invalid timestamp: {exc}",
-                )
-            )
-            continue
-
-        if payload.validate_only:
-            summary.sync_logs.imported += 1
-            continue
-
-        try:
-            inserted = db_manager.import_sync_log(
-                connector_id=sync_log_record.connector_id,
-                seq=sync_log_record.seq,
-                started_at=started_at,
-                finished_at=finished_at,
-                total_files=sync_log_record.total_files,
-                new_files=sync_log_record.new_files,
-                completed_files=sync_log_record.completed_files,
-                removed_files=sync_log_record.removed_files,
-                status=sync_log_record.status,
-                error=sync_log_record.error,
-            )
-            if inserted:
-                summary.sync_logs.imported += 1
-            else:
-                summary.sync_logs.skipped += 1
-        except Exception as exc:
-            summary.sync_logs.failed += 1
-            errors.append(
-                ImportRecordIssue(
-                    record_type="sync_log",
-                    record_id=record_id,
-                    type="database_error",
-                    message=f"Failed to create sync_log record: {exc}",
-                )
-            )
 
     return ImportResponse(
         status="completed",

--- a/services/digitize/utils/db.py
+++ b/services/digitize/utils/db.py
@@ -923,7 +923,7 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
     if engine is None:
         raise RuntimeError("Database not available. Cannot import metadata without database connection.")
 
-    started_at = perf_counter()
+    _perf_start = perf_counter()
     summary = _build_import_summary(
         len(payload.data.jobs),
         len(payload.data.documents),
@@ -1192,7 +1192,7 @@ def import_metadata(payload: ImportRequest) -> ImportResponse:
     return ImportResponse(
         status="completed",
         summary=summary,
-        duration_seconds=round(perf_counter() - started_at, 4),
+        duration_seconds=round(perf_counter() - _perf_start, 4),
         errors=errors,
         warnings=warnings,
     )


### PR DESCRIPTION
- Contains code changes for including connector and connector sync logs schema as part of Export and Import APIs
- Added only the method definitions for connector schema metadata import and export. 
- Existing definitions of import-export APIs are not modified to call the new methods on connectors as don't support backup and restore functionality for connectors yet. these methods will be called when we have cover it in the later release. 