### PR TITLE
update spyre operator csv to v1.3.1

### DIFF
--- a/ai-services/assets/bootstrap/openshift/02-operators/03-spyre-operator.yaml
+++ b/ai-services/assets/bootstrap/openshift/02-operators/03-spyre-operator.yaml
@@ -28,4 +28,4 @@ spec:
   name: spyre-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: spyre-operator.v1.3.0
+  startingCSV: spyre-operator.v1.3.1


### PR DESCRIPTION
currently  we are installing spyre-operator.v1.3.0 and bootstrap is failing with version not found. openshift console mentions that v1.3.1 is available and v1.3.0 is no longer there.

Updating it to available version