### PR TITLE
Remove runtime and use default worker runtime

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.354
+TAG?=v0.0.355
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/aiservices-podman-dev-guide.md
+++ b/ai-services/aiservices-podman-dev-guide.md
@@ -73,7 +73,7 @@ Use `-h` for more configuration options.
 **Step 1: Login to Catalog Backend**
 
 ```bash
-./bin/ai-services catalog login --server <catalog_backend_endpoint> --username admin --runtime podman --insecure
+./bin/ai-services catalog login --server <catalog_backend_endpoint> --username admin --insecure
 ```
 
 Use `-h` for more information.
@@ -132,10 +132,10 @@ Get application details:
 ./bin/ai-services catalog info --runtime podman
 
 # Check current login status
-./bin/ai-services catalog whoami --runtime podman
+./bin/ai-services catalog whoami
 
 # Logout from catalog
-./bin/ai-services catalog logout --runtime podman
+./bin/ai-services catalog logout
 
 # Uninstall catalog service (removes catalog pods and data)
 ./bin/ai-services catalog uninstall --runtime podman

--- a/ai-services/assets/catalog/openshift/templates/catalog-backend.yaml
+++ b/ai-services/assets/catalog/openshift/templates/catalog-backend.yaml
@@ -38,7 +38,6 @@ spec:
                 echo "Migration attempt $attempt of $max_retries..."
 
                 if /usr/bin/ai-services catalog dbmigrate init \
-                  --runtime={{ .Values.backend.runtime }} \
                   --db-host=catalog-db \
                   --db-port=5432 \
                   --db-user={{ .Values.db.user }} \

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.354
+  image: icr.io/ai-services-cicd/ai-services:v0.0.355
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -33,7 +33,6 @@ spec:
             echo "Migration attempt $attempt of $max_retries..."
 
             if /usr/bin/ai-services catalog dbmigrate init \
-              --runtime={{ .Values.backend.runtime }} \
               --db-host={{ .AppName }}--db \
               --db-port=5432 \
               --db-user={{ .Values.db.user }} \

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.354
+  image: icr.io/ai-services-cicd/ai-services:v0.0.355
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.354
+  image: icr.io/ai-services-cicd/ai-services:v0.0.355
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.354
+  image: icr.io/ai-services-cicd/ai-services:v0.0.355
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/cmd/ai-services/cmd/application/application.go
+++ b/ai-services/cmd/ai-services/cmd/application/application.go
@@ -1,21 +1,26 @@
 package application
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
 	"github.com/project-ai-services/ai-services/cmd/ai-services/cmd/application/image"
 	"github.com/project-ai-services/ai-services/cmd/ai-services/cmd/application/model"
+	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
+	cliUtils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
+	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 var (
 	hiddenTemplates bool
-	// Runtime type flag for application command.
+	// Runtime type flag for application command. Optional — commands that operate
+	// on an existing application (start, stop, logs, backup, restore) derive the
+	// runtime from the application's Worker record when this is left empty.
 	runtimeType string
 )
 
@@ -24,10 +29,20 @@ var ApplicationCmd = &cobra.Command{
 	Use:   "application",
 	Short: "Deploy and monitor the applications",
 	Long:  `The application command helps you deploy and monitor the applications`,
+	// PersistentPreRunE initialises vars.RuntimeFactory only when --runtime is supplied.
+	// Sub-commands that need the runtime (templates, create, ps, delete, info) enforce
+	// the flag themselves. Sub-commands that can derive the runtime from the application's
+	// Worker record (start, stop, logs, backup, restore) call resolveRuntimeForApp in RunE.
+	// Platform support (linux/ppc64le) is checked only by sub-commands that actually
+	// launch Podman work (create --legacy, bootstrap), not here.
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		// Initialize runtime factory based on flag
-		rt := types.RuntimeType(runtimeType)
+
+		if runtimeType == "" {
+			return nil
+		}
+
+		rt := runtimeTypes.RuntimeType(runtimeType)
 		if !rt.Valid() {
 			return fmt.Errorf("invalid runtime type: %s (must be 'podman' or 'openshift'). Please specify runtime using --runtime flag", runtimeType)
 		}
@@ -53,12 +68,59 @@ func init() {
 	ApplicationCmd.AddCommand(restoreCmd)
 	ApplicationCmd.AddCommand(backupCmd)
 
-	// Add runtime flag as required
-	ApplicationCmd.PersistentFlags().StringVarP(&runtimeType, "runtime", "r", "", fmt.Sprintf("runtime to use (options: %s, %s) (required)", types.RuntimeTypePodman, types.RuntimeTypeOpenShift))
-	_ = ApplicationCmd.MarkPersistentFlagRequired("runtime")
+	// --runtime is optional: commands that operate on an existing application
+	// (start, stop, logs, backup, restore) can resolve the runtime from the
+	// application's Worker record. Commands that need a runtime up-front
+	// (templates, create, ps, delete, info) enforce it themselves.
+	ApplicationCmd.PersistentFlags().StringVarP(&runtimeType, "runtime", "r", "",
+		fmt.Sprintf("runtime to use (options: %s, %s)", runtimeTypes.RuntimeTypePodman, runtimeTypes.RuntimeTypeOpenShift))
 
 	ApplicationCmd.PersistentFlags().StringVar(&vars.ToolImage, "tool-image", vars.ToolImage, "Tool image to use for downloading the model(only for the development purpose)")
 	ApplicationCmd.PersistentFlags().BoolVar(&hiddenTemplates, "hidden", false, "Show hidden templates")
 	_ = ApplicationCmd.PersistentFlags().MarkHidden("tool-image")
 	_ = ApplicationCmd.PersistentFlags().MarkHidden("hidden")
+}
+
+// resolveRuntimeForApp returns the RuntimeType to use for an operation on an
+// existing application.
+//
+// When --runtime is explicitly provided (existingRuntime != ""), it uses that value
+// (which has already been validated by InitAndValidateOptionalRuntimeFlag in the
+// parent PersistentPreRunE). Otherwise it queries the catalog for the named
+// application and reads the runtime type from its Worker record.
+//
+// If neither source yields a valid runtime type an error is returned that tells
+// the user to supply --runtime explicitly.
+func resolveRuntimeForApp(ctx context.Context, appName, existingRuntime string) (runtimeTypes.RuntimeType, error) {
+	if existingRuntime != "" {
+		// --runtime was given and already validated — vars.RuntimeFactory is set.
+		return vars.RuntimeFactory.GetRuntimeType(), nil
+	}
+
+	// No --runtime flag: ask the catalog for the application's Worker.
+	appClient, err := catalogClient.NewApplicationClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("catalog is unavailable (%w)", err)
+	}
+
+	app, err := cliUtils.GetAppByName(ctx, appClient, appName)
+	if err != nil {
+		return "", fmt.Errorf("application %q not found in catalog (%w)", appName, err)
+	}
+
+	fullApp, err := appClient.GetApplication(ctx, app.ID)
+	if err != nil {
+		return "", fmt.Errorf("could not fetch application details (%w)", err)
+	}
+
+	if fullApp.Worker != nil && fullApp.Worker.RuntimeType != "" {
+		rt := runtimeTypes.RuntimeType(fullApp.Worker.RuntimeType)
+		// Initialise vars.RuntimeFactory so any downstream code that reads it
+		// (e.g. flagvalidator, legacy paths) sees a consistent value.
+		vars.RuntimeFactory = runtime.NewRuntimeFactory(rt)
+
+		return rt, nil
+	}
+
+	return "", fmt.Errorf("could not determine runtime for application %q: Worker record missing or has no runtime_type; please supply --runtime explicitly", appName)
 }

--- a/ai-services/cmd/ai-services/cmd/application/backup.go
+++ b/ai-services/cmd/ai-services/cmd/application/backup.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
-	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 var (
@@ -30,14 +28,14 @@ Arguments:
 Supported targets:
   - opensearch: Backup OpenSearch indices and data (Podman and OpenShift)
   - digitize:   Backup digitize metadata (jobs and documents) (Podman and OpenShift)`,
-	Example: `  # Backup OpenSearch data with Podman (auto-generated filename)
-  ai-services application backup myapp --target opensearch --runtime podman
+	Example: `  # Backup OpenSearch data
+	 ai-services application backup myapp --target opensearch
 
-  # Backup digitize data with OpenShift
-  ai-services application backup myapp --target digitize --runtime openshift
+  # Backup digitize data
+  ai-services application backup myapp --target digitize
 
   # Backup digitize data with custom filename
-  ai-services application backup myapp --target digitize --filename mybackup.tar.gz --runtime podman`,
+  ai-services application backup myapp --target digitize --filename mybackup.tar.gz`,
 	Args: cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		target := backupTarget
@@ -81,13 +79,16 @@ Supported targets:
 		// Once precheck passes, silence usage for any later internal errors
 		cmd.SilenceUsage = true
 
-		rt := vars.RuntimeFactory.GetRuntimeType()
-		logger.Infof("Runtime: %s\n", rt)
+		// Derive the runtime from the application's Worker record in the catalog,
+		// or use --runtime directly if it was supplied.
+		rt, err := resolveRuntimeForApp(ctx, applicationName, runtimeType)
+		if err != nil {
+			return err
+		}
 
 		// Get absolute path to backup file if provided
 		var absFilename string
 		if backupFilename != "" {
-			var err error
 			absFilename, err = filepath.Abs(backupFilename)
 			if err != nil {
 				return fmt.Errorf("failed to get absolute path for backup file: %w", err)

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -71,12 +71,20 @@ Arguments:
 	Example: createExample(),
 	Args:    cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// Check if podman runtime is being used on unsupported platform
-		if err := utils.CheckPodmanPlatformSupport(vars.RuntimeFactory.GetRuntimeType()); err != nil {
-			return err
+		// --runtime is required only for legacy mode; in the default flow the
+		// runtime is resolved from the Worker record registered with the catalog.
+		if legacyCreate && runtimeType == "" {
+			return fmt.Errorf("required flag(s) \"runtime\" not set (required with --legacy)")
 		}
 
-		// Build and run flag validator
+		// Only validate platform support when runtime is explicitly given.
+		if runtimeType != "" {
+			if err := utils.CheckPodmanPlatformSupport(vars.RuntimeFactory.GetRuntimeType()); err != nil {
+				return err
+			}
+		}
+
+		// Build and run flag validator (runtime may be empty for default flow).
 		flagValidator := buildFlagValidator()
 		if err := flagValidator.Validate(cmd); err != nil {
 			return err
@@ -93,9 +101,11 @@ Arguments:
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true
 
-		rt := vars.RuntimeFactory.GetRuntimeType()
-		// When legacyCreate is true, use the older/stable code path
+		// When legacyCreate is true, use the older/stable code path.
+		// This path requires --runtime (enforced in PreRunE above).
 		if legacyCreate {
+			rt := vars.RuntimeFactory.GetRuntimeType()
+
 			if err := cmdcommon.DoBootstrapValidate(ctx, skipChecks); err != nil {
 				return err
 			}
@@ -127,22 +137,20 @@ Arguments:
 }
 
 func createExample() string {
-	return `  For Podman:
-  # Deploy with default mode (5 Spyre cards)
-  ai-services application create rag --template rag --runtime podman
+	return `  # Deploy using the local worker
+  ai-services application create rag --template rag
 
-  # Deploy with default mode (4 Spyre cards - reranker on CPU)
-  ai-services application create rag --template rag --runtime podman --params reranker.vllm-cpu=true
+  # Deploy to a specific remote worker
+  ai-services application create rag --template rag --worker node-1
 
-  # Deploy with default mode (CPU mode)
-  ai-services application create rag --template rag --runtime podman --params reranker.vllm-cpu=true,llm.vllm-cpu=true
+  # Deploy with extra parameters
+  ai-services application create rag --template rag --params reranker.vllm-cpu=true
 
-  # Deploy with legacy mode
-  ai-services application create rag --template rag --runtime podman --legacy
+  # Deploy in CPU mode
+  ai-services application create rag --template rag --params reranker.vllm-cpu=true,llm.vllm-cpu=true
 
-  For Openshift:
-  # Deploy with default mode (5 Spyre cards)
-  ai-services application create rag --template rag --runtime openshift`
+  # Deploy with legacy mode (requires --runtime)
+  ai-services application create rag --template rag --legacy --runtime podman`
 }
 
 func init() {
@@ -158,9 +166,7 @@ func initCreateCommonFlags() {
 	createCmd.Flags().StringVarP(&templateName, appFlags.Create.Template, "t", "", "Application template to use (required)")
 	_ = createCmd.MarkFlagRequired(appFlags.Create.Template)
 
-	// TODO: Once runtime deployment is enabled, use default value as workerconstants.LocalWorkerName
-	// createCmd.Flags().StringVar(&workerName, appFlags.Create.WorkerName, workerconstants.LocalWorkerName,
-	createCmd.Flags().StringVar(&workerName, appFlags.Create.WorkerName, "",
+	createCmd.Flags().StringVar(&workerName, appFlags.Create.WorkerName, workerconstants.LocalWorkerName,
 		"Name of a connected remote worker to deploy to.\n"+
 			fmt.Sprintf("Defaults to %q (local deployment).\n", workerconstants.LocalWorkerName)+
 			"Example: --worker node-1\n")
@@ -255,10 +261,12 @@ func deprecatedPodmanFlags() {
 }
 
 // buildFlagValidator creates and configures the flag validator with all flag definitions.
+// When --runtime is not provided (new default flow), the runtime is resolved from the
+// Worker record by the catalog; all create flags are common-scoped or only validated
+// in the legacy path, so an empty runtime is safe here.
 func buildFlagValidator() *flagvalidator.FlagValidator {
-	runtimeType := vars.RuntimeFactory.GetRuntimeType()
-
-	builder := flagvalidator.NewFlagValidatorBuilder(runtimeType)
+	// Use the package-level runtimeType (may be "" in the default flow).
+	builder := flagvalidator.NewFlagValidatorBuilder(runtimeTypes.RuntimeType(runtimeType))
 
 	// Register common flags with their validation functions
 	builder.
@@ -416,7 +424,10 @@ func buildCatalogPayload(ctx context.Context, appClient *catalogClient.Applicati
 	}
 
 	// Resolve the target runtime once here so all downstream calls use the same value.
-	deployRT := resolveDeployRuntimeType(ctx)
+	deployRT, err := resolveDeployRuntimeType(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	// Try architecture first; fall through to service on not-found.
 	arch, err := source.LoadArchitecture(ctx, templateName)
@@ -518,13 +529,9 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 		return fmt.Errorf("failed to get application pods for next steps: %w", err)
 	}
 
-	rt := vars.RuntimeFactory.GetRuntimeType()
-	// When the application is deployed on a remote worker, use the worker's
-	// runtime type to select the correct service steps (vars_file.yaml, next.md).
-	// TODO: worker will always exist so we do not need to read from cmd
-	if application.Worker != nil && application.Worker.RuntimeType != "" {
-		rt = runtimeTypes.RuntimeType(application.Worker.RuntimeType)
-	}
+	// Every application is always deployed through a worker (WorkerID is NOT NULL).
+	// Read the runtime type directly from the worker record — no CLI fallback needed.
+	rt := runtimeTypes.RuntimeType(application.Worker.RuntimeType)
 
 	// InstanceSlug is derived from the application UUID — same as at deploy time
 	instanceSlug := catalogUtils.GenerateInstanceSlug(app.ID)
@@ -537,7 +544,7 @@ func printNextSteps(ctx context.Context, app *catalogTypes.Application) error {
 	}
 
 	// Print the info command regardless of whether any service has next.md
-	logger.Infof("\n- For detailed endpoint information, use: `ai-services application info %s --runtime %s`\n", application.Name, runtimeType)
+	logger.Infof("\n- For detailed endpoint information, use: `ai-services application info %s --runtime %s`\n", application.Name, rt)
 
 	return nil
 }
@@ -603,34 +610,31 @@ func printNextStepsMD(tmpls map[string]*template.Template, params map[string]str
 	return nil
 }
 
-// resolveDeployRuntimeType returns the RuntimeType to use when fetching deploy
-// options. When a --worker flag is given and the worker is connected, its
-// declared runtime type is returned so that the server serves the correct
-// runtime-specific assets (schemas, resource specs, vars_file).
-// Falls back to the locally configured runtime when the worker is absent or
-// its runtime type cannot be determined.
-func resolveDeployRuntimeType(ctx context.Context) runtimeTypes.RuntimeType {
-	if workerName == "" {
-		return vars.RuntimeFactory.GetRuntimeType()
-	}
-
+// resolveDeployRuntimeType returns the RuntimeType for the target worker by
+// querying the catalog. The worker must be registered and connected; an error
+// is returned otherwise so that the create call fails fast before any API work.
+func resolveDeployRuntimeType(ctx context.Context) (runtimeTypes.RuntimeType, error) {
 	wc, err := catalogClient.NewWorkerClient(ctx)
 	if err != nil {
-		return vars.RuntimeFactory.GetRuntimeType()
+		return "", fmt.Errorf("failed to create worker client: %w", err)
 	}
 
 	workers, err := wc.ListWorkers(ctx)
 	if err != nil {
-		return vars.RuntimeFactory.GetRuntimeType()
+		return "", fmt.Errorf("failed to list workers: %w", err)
 	}
 
 	for _, w := range workers {
 		if w.Name == workerName {
-			return runtimeTypes.RuntimeType(w.RuntimeType)
+			if w.RuntimeType == "" {
+				return "", fmt.Errorf("worker %q has no runtime type", workerName)
+			}
+
+			return runtimeTypes.RuntimeType(w.RuntimeType), nil
 		}
 	}
 
-	return vars.RuntimeFactory.GetRuntimeType()
+	return "", fmt.Errorf("worker %q is not registered or not connected; run 'worker join' first", workerName)
 }
 
 // buildArchitecturePayload builds the payload for an architecture deployment.

--- a/ai-services/cmd/ai-services/cmd/application/delete.go
+++ b/ai-services/cmd/ai-services/cmd/application/delete.go
@@ -16,6 +16,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/flagvalidator"
 	cliUtils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
@@ -33,14 +34,19 @@ var deleteCmd = &cobra.Command{
 
 Arguments:
   [name] : Application name (required)`,
-	Example: `  # Delete an application from podman runtime
-  ai-services application delete rag --runtime podman
-  
-  # Delete an application from openshift runtime
-  ai-services application delete rag --runtime openshift
+	Example: `  # Delete an application
+  ai-services application delete rag
+
+  # Delete an application using the legacy path (requires --runtime)
+  ai-services application delete rag --legacy --runtime podman
   `,
 	Args: cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
+		// --runtime is only required for legacy delete; the catalog path does not need it.
+		if legacyDelete && runtimeType == "" {
+			return fmt.Errorf("required flag(s) \"runtime\" not set (required with --legacy)")
+		}
+
 		// Build and run flag validator
 		flagValidator := buildDeleteFlagValidator()
 		if err := flagValidator.Validate(cmd); err != nil {
@@ -109,9 +115,7 @@ func initDeleteOpenShiftFlags() {
 
 // buildDeleteFlagValidator creates and configures the flag validator for the delete command.
 func buildDeleteFlagValidator() *flagvalidator.FlagValidator {
-	runtimeType := vars.RuntimeFactory.GetRuntimeType()
-
-	builder := flagvalidator.NewFlagValidatorBuilder(runtimeType)
+	builder := flagvalidator.NewFlagValidatorBuilder(runtimeTypes.RuntimeType(runtimeType))
 
 	// Register common flags
 	builder.

--- a/ai-services/cmd/ai-services/cmd/application/info.go
+++ b/ai-services/cmd/ai-services/cmd/application/info.go
@@ -33,13 +33,21 @@ var infoCmd = &cobra.Command{
 Arguments:
   [name] : Application name (required)
 	`,
-	Example: `  # Display application information from podman runtime
-  ai-services application info rag --runtime podman
-  
-  # Display application information from openshift runtime
-  ai-services application info rag --runtime openshift
+	Example: `  # Display application information
+  ai-services application info rag
+
+  # Display application information using the legacy path (requires --runtime)
+  ai-services application info rag --legacy --runtime podman
   `,
 	Args: cobra.ExactArgs(1),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		// --runtime is only required for legacy info; the catalog path derives it from the Worker record.
+		if legacyInfo && runtimeType == "" {
+			return fmt.Errorf("required flag(s) \"runtime\" not set (required with --legacy)")
+		}
+
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// fetch application name
 		applicationName := args[0]
@@ -48,10 +56,10 @@ Arguments:
 		cmd.SilenceUsage = true
 
 		ctx := cmd.Context()
-		rt := vars.RuntimeFactory.GetRuntimeType()
 
 		// When legacyInfo is true, use the older/stable code path
 		if legacyInfo {
+			rt := vars.RuntimeFactory.GetRuntimeType()
 			// Create application instance using factory
 			factory := application.NewFactory(rt)
 			app, err := factory.Create(applicationName)
@@ -67,7 +75,7 @@ Arguments:
 		}
 
 		// Default: use new implementation using catalog
-		return renderApplicationInfo(ctx, applicationName, rt)
+		return renderApplicationInfo(ctx, applicationName)
 	},
 }
 
@@ -75,7 +83,7 @@ func init() {
 	infoCmd.Flags().BoolVar(&legacyInfo, "legacy", false, "Use legacy application info implementation")
 }
 
-func renderApplicationInfo(ctx context.Context, appName string, rt types.RuntimeType) error {
+func renderApplicationInfo(ctx context.Context, appName string) error {
 	appClient, err := catalogClient.NewApplicationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create application client: %w", err)
@@ -97,13 +105,11 @@ func renderApplicationInfo(ctx context.Context, appName string, rt types.Runtime
 		return fmt.Errorf("failed to get application: %w", err)
 	}
 
-	// When the application is deployed on a remote worker, use the worker's
-	// runtime type to select the correct service steps (vars_file.yaml, info.md).
-	// The CLI's own --runtime flag reflects the local machine, not the worker.
-	// TODO: worker will always exist so we do not need to read from cmd
-	if application.Worker != nil && application.Worker.RuntimeType != "" {
-		rt = types.RuntimeType(application.Worker.RuntimeType)
+	if application.Worker == nil || application.Worker.RuntimeType == "" {
+		return fmt.Errorf("application %q has no worker runtime type", appName)
 	}
+
+	rt := types.RuntimeType(application.Worker.RuntimeType)
 
 	appPS, err := appClient.GetApplicationPS(ctx, app.ID)
 	if err != nil {

--- a/ai-services/cmd/ai-services/cmd/application/logs.go
+++ b/ai-services/cmd/ai-services/cmd/application/logs.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
@@ -11,8 +13,8 @@ import (
 	appFlags "github.com/project-ai-services/ai-services/internal/pkg/cli/constants/application"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/flagvalidator"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
+	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -28,26 +30,27 @@ var logsCmd = &cobra.Command{
 
 Arguments:
   [name] : Application name (required)`,
-	Example: `  For Podman:
-  # Display logs from an application pod
+	Example: `  # Display logs
+  ai-services application logs rag --pod mypod
+
+  # Display logs with explicit runtime
   ai-services application logs rag --pod mypod --runtime podman
 
   # Display logs from a specific container in a pod
-  ai-services application logs rag --pod mypod --container mycontainer --runtime podman
+  ai-services application logs rag --pod mypod --container mycontainer
 
-  # Display logs using legacy implementation
+  # Display logs using legacy implementation (requires --runtime)
   ai-services application logs rag --pod mypod --legacy --runtime podman
 
-  For Openshift:
-  # Display logs from an application pod
-  ai-services application logs rag --pod mypod --runtime openshift
-
-  # Display logs from a specific container in a pod
-  ai-services application logs rag --pod mypod --container mycontainer --runtime openshift
-
-  `,
+  # Display logs from an OpenShift application
+  ai-services application logs rag --pod mypod --runtime openshift`,
 	Args: cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
+		// --runtime is required for legacy logs; the catalog path derives it from the Worker record.
+		if legacyLogs && runtimeType == "" {
+			return fmt.Errorf("required flag(s) \"runtime\" not set (required with --legacy)")
+		}
+
 		// Build and run flag validator
 		flagValidator := buildLogsFlagValidator()
 		if err := flagValidator.Validate(cmd); err != nil {
@@ -68,10 +71,18 @@ Arguments:
 		cmd.SilenceUsage = true
 
 		ctx := cmd.Context()
-		rt := vars.RuntimeFactory.GetRuntimeType()
-		namespace := applicationName
+
+		var rt runtimeTypes.RuntimeType
+		var namespace string
 
 		if !legacyLogs {
+			// Default: resolve runtime and namespace from the catalog Worker record.
+			var err error
+			rt, err = resolveRuntimeForApp(ctx, applicationName, runtimeType)
+			if err != nil {
+				return err
+			}
+
 			appClient, err := catalogClient.NewApplicationClient(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to create application client: %w", err)
@@ -85,21 +96,22 @@ Arguments:
 				return fmt.Errorf("invalid application ID %q: %w", app.ID, err)
 			}
 			namespace = catalogutils.AppNamespace(appID)
+		} else {
+			// Legacy path: requires --runtime (enforced in PreRunE).
+			rt = vars.RuntimeFactory.GetRuntimeType()
+			namespace = applicationName
 		}
 
-		// Create application instance using factory
 		factory := application.NewFactory(rt)
-		app, err := factory.Create(namespace)
+		appInst, err := factory.Create(namespace)
 		if err != nil {
 			return fmt.Errorf("failed to create application instance: %w", err)
 		}
 
-		opts := appTypes.LogsOptions{
+		return appInst.Logs(ctx, appTypes.LogsOptions{
 			PodName:           podName,
 			ContainerNameOrID: containerNameOrID,
-		}
-
-		return app.Logs(ctx, opts)
+		})
 	},
 }
 
@@ -116,9 +128,11 @@ func initLogsCommonFlags() {
 
 // buildLogsFlagValidator creates and configures the flag validator for the logs command.
 func buildLogsFlagValidator() *flagvalidator.FlagValidator {
-	runtimeType := vars.RuntimeFactory.GetRuntimeType()
-
-	builder := flagvalidator.NewFlagValidatorBuilder(runtimeType)
+	// Use the package-level runtimeType flag value (may be empty when --runtime is
+	// omitted; runtime will be resolved from the application Worker in RunE).
+	// All logs flags are common-scoped so the validator does not need a specific
+	// runtime type to accept them.
+	builder := flagvalidator.NewFlagValidatorBuilder(runtimeTypes.RuntimeType(runtimeType))
 
 	// Register common flags
 	builder.

--- a/ai-services/cmd/ai-services/cmd/application/ps.go
+++ b/ai-services/cmd/ai-services/cmd/application/ps.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
@@ -12,9 +14,9 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/flagvalidator"
 	cliUtils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -35,33 +37,24 @@ Lists information about a specific application if the name is provided
 Arguments:
   [name] : Application name (required)
 `,
-	Example: `  For Podman:
-  # List all running applications
-  ai-services application ps --runtime podman
+	Example: `  # List all running applications
+  ai-services application ps
 
   # List a specific application
-  ai-services application ps myapp --runtime podman
+  ai-services application ps myapp
 
   # List applications with wide output format
-  ai-services application ps --output wide --runtime podman
+  ai-services application ps --output wide
 
-  # List a specific application with wide output
-  ai-services application ps myapp -o wide --runtime podman
-
-  # Use legacy implementation (Podman only)
-  ai-services application ps --legacy --runtime podman
-
-  For OpenShift:
-  # List all running applications
-  ai-services application ps --runtime openshift
-
-  # List a specific application
-  ai-services application ps myapp --runtime openshift
-
-  # List applications with wide output format
-  ai-services application ps --output wide --runtime openshift`,
+  # Use legacy implementation (requires --runtime)
+  ai-services application ps --legacy --runtime podman`,
 	Args: cobra.MaximumNArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
+		// --runtime is only required for legacy ps; the catalog path does not need it.
+		if legacyPs && runtimeType == "" {
+			return fmt.Errorf("required flag(s) \"runtime\" not set (required with --legacy)")
+		}
+
 		// Build and run flag validator
 		flagValidator := buildPsFlagValidator()
 
@@ -78,14 +71,14 @@ Arguments:
 			applicationName = args[0]
 		}
 
-		rt := vars.RuntimeFactory.GetRuntimeType()
 		opts := appTypes.ListOptions{
 			ApplicationName: applicationName,
 			OutputWide:      isOutputWide(),
 		}
 
-		// When legacyPs is true and runtime is podman, use the older/stable code path
+		// When legacyPs is true, use the older/stable code path
 		if legacyPs {
+			rt := vars.RuntimeFactory.GetRuntimeType()
 			// Create application instance using factory
 			factory := application.NewFactory(rt)
 			app, err := factory.Create(applicationName)
@@ -129,9 +122,7 @@ func initPsCommonFlags() {
 
 // buildPsFlagValidator creates and configures the flag validator for the ps command.
 func buildPsFlagValidator() *flagvalidator.FlagValidator {
-	runtimeType := vars.RuntimeFactory.GetRuntimeType()
-
-	builder := flagvalidator.NewFlagValidatorBuilder(runtimeType)
+	builder := flagvalidator.NewFlagValidatorBuilder(runtimeTypes.RuntimeType(runtimeType))
 
 	// Register common flags
 	builder.

--- a/ai-services/cmd/ai-services/cmd/application/restore.go
+++ b/ai-services/cmd/ai-services/cmd/application/restore.go
@@ -12,7 +12,6 @@ import (
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
-	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 )
 
 var (
@@ -35,19 +34,14 @@ Supported targets:
 
 Note:
   - WARNING: Restore will overwrite existing data`,
-	Example: `  For Podman:
-  # Restore OpenSearch data with Podman
-  ai-services application restore myapp --target opensearch --filename backup.tar.gz --runtime podman
+	Example: `  # Restore OpenSearch data
+  ai-services application restore myapp --target opensearch --filename backup.tar.gz
+
+  # Restore digitize data
+  ai-services application restore myapp --target digitize --filename digitize_backup.tar.gz
 
   # Restore with automatic confirmation
-  ai-services application restore myapp --target digitize --filename backup.tar.gz --runtime podman --yes
-
-  For OpenShift:
-  # Restore OpenSearch data with OpenShift
-  ai-services application restore myapp --target opensearch --filename backup.tar.gz --runtime openshift
-
-  # Restore digitize data with OpenShift
-  ai-services application restore myapp --target digitize --filename digitize_backup.tar.gz --runtime openshift `,
+  ai-services application restore myapp --target digitize --filename backup.tar.gz --yes`,
 	Args: cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		target := restoreTarget
@@ -86,8 +80,12 @@ Note:
 		applicationName := args[0]
 		ctx := cmd.Context()
 
-		rt := vars.RuntimeFactory.GetRuntimeType()
-		logger.Infof("Runtime: %s\n", rt)
+		// Derive the runtime from the application's Worker record in the catalog,
+		// or use --runtime directly if it was supplied.
+		rt, err := resolveRuntimeForApp(ctx, applicationName, runtimeType)
+		if err != nil {
+			return err
+		}
 
 		// Get absolute path to backup file
 		absFilename, err := filepath.Abs(restoreFilename)

--- a/ai-services/cmd/ai-services/cmd/application/start.go
+++ b/ai-services/cmd/ai-services/cmd/application/start.go
@@ -3,13 +3,14 @@ package application
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -31,28 +32,41 @@ Note:
   - Logs are streamed only when a single pod is specified, and only after the pod has started.
   - Supported for podman runtime only.
 `,
-	Example: `  # Start an application
+	Example: `  # Start an application (runtime resolved from worker)
+  ai-services application start rag
+
+  # Start an application with explicit runtime
   ai-services application start rag --runtime podman
 
   # Start an application and skip logs
-  ai-services application start rag --skip-logs --runtime podman
+  ai-services application start rag --skip-logs
 
   # Start specific pods in an application
-  ai-services application start rag --pod pod1 --pod pod2 --runtime podman
+  ai-services application start rag --pod pod1 --pod pod2
 
   # Start specific pods using comma-separated list
-  ai-services application start rag --pod pod1,pod2 --runtime podman
+  ai-services application start rag --pod pod1,pod2
 
   # Start a single pod and view logs
-  ai-services application start rag --pod mypod --runtime podman
+  ai-services application start rag --pod mypod
 
   # Start with auto-accept confirmation prompts
-  ai-services application start rag --yes --runtime podman
+  ai-services application start rag --yes
 
-  # Start using legacy implementation
+  # Start using legacy implementation (requires --runtime)
   ai-services application start rag --legacy --runtime podman`,
 	Args: cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
+		// --runtime is required for legacy start; the catalog path derives it from the Worker record.
+		if legacyStart && runtimeType == "" {
+			return fmt.Errorf("required flag(s) \"runtime\" not set (required with --legacy)")
+		}
+
+		// start is only supported for podman runtime.
+		if runtimeType != "" && runtimeType != string(types.RuntimeTypePodman) {
+			return fmt.Errorf("start is only supported for podman runtime")
+		}
+
 		var err error
 		startPodNames, err = cmd.Flags().GetStringSlice("pod")
 		if err != nil {
@@ -68,10 +82,18 @@ Note:
 		cmd.SilenceUsage = true
 
 		ctx := cmd.Context()
-		rt := vars.RuntimeFactory.GetRuntimeType()
 
-		// For podman runtime with default mode, validate application name using catalog API.
-		if !legacyStart && rt == types.RuntimeTypePodman {
+		var rt types.RuntimeType
+
+		if !legacyStart {
+			// Default: resolve runtime from the application's Worker record in the catalog.
+			var err error
+			rt, err = resolveRuntimeForApp(ctx, applicationName, runtimeType)
+			if err != nil {
+				return err
+			}
+
+			// Validate application name using catalog API.
 			appClient, err := catalogClient.NewApplicationClient(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to create application client: %w", err)
@@ -79,6 +101,8 @@ Note:
 			if _, err := utils.GetAppByName(ctx, appClient, applicationName); err != nil {
 				return err
 			}
+		} else {
+			rt = vars.RuntimeFactory.GetRuntimeType()
 		}
 
 		// Create application instance using factory

--- a/ai-services/cmd/ai-services/cmd/application/stop.go
+++ b/ai-services/cmd/ai-services/cmd/application/stop.go
@@ -3,13 +3,14 @@ package application
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/project-ai-services/ai-services/internal/pkg/application"
 	appTypes "github.com/project-ai-services/ai-services/internal/pkg/application/types"
 	catalogClient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -28,22 +29,35 @@ Arguments:
 Note:
   - Supported for podman runtime only.
 `,
-	Example: `  # Stop an application
+	Example: `  # Stop an application (runtime resolved from worker)
+  ai-services application stop rag
+
+  # Stop an application with explicit runtime
   ai-services application stop rag --runtime podman
 
   # Stop specific pods in an application
-  ai-services application stop rag --pod pod1 --pod pod2 --runtime podman
+  ai-services application stop rag --pod pod1 --pod pod2
 
   # Stop specific pods using comma-separated list
-  ai-services application stop rag --pod pod1,pod2 --runtime podman
+  ai-services application stop rag --pod pod1,pod2
 
   # Stop with auto-accept confirmation prompts
-  ai-services application stop rag --yes --runtime podman
+  ai-services application stop rag --yes
 
-  # Stop using legacy implementation
+  # Stop using legacy implementation (requires --runtime)
   ai-services application stop rag --legacy --runtime podman`,
 	Args: cobra.ExactArgs(1),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
+		// --runtime is required for legacy stop; the catalog path derives it from the Worker record.
+		if legacyStop && runtimeType == "" {
+			return fmt.Errorf("required flag(s) \"runtime\" not set (required with --legacy)")
+		}
+
+		// stop is only supported for podman runtime.
+		if runtimeType != "" && runtimeType != string(types.RuntimeTypePodman) {
+			return fmt.Errorf("stop is only supported for podman runtime")
+		}
+
 		var err error
 		stopPodNames, err = cmd.Flags().GetStringSlice("pod")
 		if err != nil {
@@ -59,10 +73,18 @@ Note:
 		cmd.SilenceUsage = true
 
 		ctx := cmd.Context()
-		rt := vars.RuntimeFactory.GetRuntimeType()
 
-		// For podman runtime with default mode, validate application name using catalog API.
-		if !legacyStop && rt == types.RuntimeTypePodman {
+		var rt types.RuntimeType
+
+		if !legacyStop {
+			// Default: resolve runtime from the application's Worker record in the catalog.
+			var err error
+			rt, err = resolveRuntimeForApp(ctx, applicationName, runtimeType)
+			if err != nil {
+				return err
+			}
+
+			// Validate application name using catalog API.
 			appClient, err := catalogClient.NewApplicationClient(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to create application client: %w", err)
@@ -70,6 +92,8 @@ Note:
 			if _, err := utils.GetAppByName(ctx, appClient, applicationName); err != nil {
 				return err
 			}
+		} else {
+			rt = vars.RuntimeFactory.GetRuntimeType()
 		}
 
 		// Create application instance using factory

--- a/ai-services/cmd/ai-services/cmd/application/templates.go
+++ b/ai-services/cmd/ai-services/cmd/application/templates.go
@@ -25,21 +25,30 @@ var templatesCmd = &cobra.Command{
 	Short: "Lists the offered application templates and their supported parameters",
 	Long:  `Retrieves information about the offered application templates and their supported parameters`,
 	Example: `  For Podman:
-	 # List all available application templates (Podman)
-	 ai-services application templates --runtime podman
+  # List all available application templates (Podman)
+  ai-services application templates --runtime podman
 
-	 # List parameters for a specific template (see subcommand)
-	 ai-services application templates parameters --template digitize --runtime podman
+  # List parameters for a specific template (see subcommand)
+  ai-services application templates parameters --template digitize --runtime podman
 
-	 # List templates using legacy implementation
-	 ai-services application templates --legacy --runtime podman
+  # List templates using legacy implementation
+  ai-services application templates --legacy --runtime podman
 
-	 For OpenShift:
-	 # List all available application templates (OpenShift)
-	 ai-services application templates --runtime openshift
+  For OpenShift:
+  # List all available application templates (OpenShift)
+  ai-services application templates --runtime openshift
 
-	 # List parameters for a specific template (see subcommand)
-	 ai-services application templates parameters --template digitize --runtime openshift `,
+  # List parameters for a specific template (see subcommand)
+  ai-services application templates parameters --template digitize --runtime openshift`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		// --runtime is required for templates: listing templates uses the runtime
+		// to filter supported parameter sets.
+		if runtimeType == "" {
+			return fmt.Errorf("required flag(s) \"runtime\" not set")
+		}
+
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Once precheck passes, silence usage for any *later* internal errors.
 		cmd.SilenceUsage = true

--- a/ai-services/cmd/ai-services/cmd/catalog/dbmigrate.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/dbmigrate.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/project-ai-services/ai-services/cmd/ai-services/cmd/common"
+	"github.com/spf13/cobra"
+
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/db/migrations"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/spf13/cobra"
 )
 
 // NewMigrateCmd returns the cobra command for database migration operations.
@@ -85,16 +85,11 @@ check migration status, and rollback migrations.`,
 
 // createInitCmd creates the init subcommand.
 func createInitCmd(getDBConfig func() db.Config) *cobra.Command {
-	var runtimeType string
-
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "init",
 		Short: "Initialize the database and run all migrations",
 		Long: `Initialize the catalog database by creating it if it doesn't exist
 and running all pending migrations.`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return common.InitAndValidateRuntimeFlag(runtimeType)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := getDBConfig()
 
@@ -127,23 +122,14 @@ and running all pending migrations.`,
 			return nil
 		},
 	}
-
-	common.ConfigureRuntimeFlag(cmd, &runtimeType)
-
-	return cmd
 }
 
 // createUpCmd creates the up subcommand.
 func createUpCmd(getDBConfig func() db.Config) *cobra.Command {
-	var runtimeType string
-
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "up",
 		Short: "Run all pending migrations",
 		Long:  `Run all pending database migrations.`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return common.InitAndValidateRuntimeFlag(runtimeType)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := getDBConfig()
 
@@ -170,23 +156,14 @@ func createUpCmd(getDBConfig func() db.Config) *cobra.Command {
 			return nil
 		},
 	}
-
-	common.ConfigureRuntimeFlag(cmd, &runtimeType)
-
-	return cmd
 }
 
 // createStatusCmd creates the status subcommand.
 func createStatusCmd(getDBConfig func() db.Config) *cobra.Command {
-	var runtimeType string
-
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "status",
 		Short: "Check the status of database migrations",
 		Long:  `Display the current status of all database migrations.`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return common.InitAndValidateRuntimeFlag(runtimeType)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := getDBConfig()
 
@@ -212,23 +189,14 @@ func createStatusCmd(getDBConfig func() db.Config) *cobra.Command {
 			return nil
 		},
 	}
-
-	common.ConfigureRuntimeFlag(cmd, &runtimeType)
-
-	return cmd
 }
 
 // createDownCmd creates the down subcommand.
 func createDownCmd(getDBConfig func() db.Config) *cobra.Command {
-	var runtimeType string
-
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "down",
 		Short: "Rollback the most recent migration",
 		Long:  `Rollback the most recently applied database migration.`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return common.InitAndValidateRuntimeFlag(runtimeType)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := getDBConfig()
 
@@ -255,10 +223,6 @@ func createDownCmd(getDBConfig func() db.Config) *cobra.Command {
 			return nil
 		},
 	}
-
-	common.ConfigureRuntimeFlag(cmd, &runtimeType)
-
-	return cmd
 }
 
 // Made with Bob

--- a/ai-services/cmd/ai-services/cmd/catalog/hashpw.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/hashpw.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/project-ai-services/ai-services/cmd/ai-services/cmd/common"
-	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+
+	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 )
 
 const (
@@ -20,10 +20,9 @@ const (
 
 func NewHashpwCmd() *cobra.Command {
 	var (
-		fromStdin   bool
-		noConfirm   bool
-		iterations  = 100000 // NIST recommended minimum
-		runtimeType string
+		fromStdin  bool
+		noConfirm  bool
+		iterations = 100000 // NIST recommended minimum
 	)
 
 	cmd := &cobra.Command{
@@ -31,15 +30,12 @@ func NewHashpwCmd() *cobra.Command {
 		Short: "Generate a password hash",
 		Long:  `Reads a password securely and prints a PBKDF2 hash to stdout.`,
 		Example: `  # Interactive (hidden input, with confirmation)
-  ai-services catalog hashpw --iterations 150000 --runtime podman
+  ai-services catalog hashpw --iterations 150000
 
   # Non-interactive (CI): read from stdin
   printf '%s\n' 'S3cureP@ss!' | ai-services catalog hashpw --stdin --iterations 150000
 
 Tip: Avoid passing plain passwords as CLI args (they can leak via process list).`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return common.InitAndValidateRuntimeFlag(runtimeType)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pw, err := getPassword(fromStdin, noConfirm, cmd)
 			if err != nil {
@@ -59,14 +55,13 @@ Tip: Avoid passing plain passwords as CLI args (they can leak via process list).
 				return fmt.Errorf("write output: %w", err)
 			}
 
-			return common.InitAndValidateRuntimeFlag(runtimeType)
+			return nil
 		},
 	}
 
 	cmd.Flags().IntVar(&iterations, "iterations", iterations, "PBKDF2 iterations (100000+ recommended)")
 	cmd.Flags().BoolVar(&fromStdin, "stdin", false, "read password from stdin (non-interactive)")
 	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "skip confirmation prompt")
-	common.ConfigureRuntimeFlag(cmd, &runtimeType)
 
 	return cmd
 }

--- a/ai-services/cmd/ai-services/cmd/catalog/login.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/login.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"github.com/project-ai-services/ai-services/cmd/ai-services/cmd/common"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 )
@@ -25,7 +24,6 @@ func NewLoginCmd() *cobra.Command {
 		passwordStdin bool
 		miqToken      string
 		insecure      bool
-		runtimeType   string
 	)
 
 	cmd := &cobra.Command{
@@ -43,16 +41,16 @@ unnecessary round-trips to the server.
 
 To get the Catalog backend endpoint, use: ai-services catalog info`,
 		Example: ` # Interactive login (password is prompted securely)
-  ai-services catalog login --server <catalog_backend_endpoint> --username admin --runtime podman
+  ai-services catalog login --server <catalog_backend_endpoint> --username admin
 
   # Non-interactive login via stdin pipe (password not recorded in shell history)
-  echo "$MY_PASSWORD" | ai-services catalog login --server <catalog_backend_endpoint> --username admin --password-stdin --runtime podman
+  echo "$MY_PASSWORD" | ai-services catalog login --server <catalog_backend_endpoint> --username admin --password-stdin
 
-   # Login with insecure TLS (skip certificate verification)
-  ai-services catalog login --server <catalog_backend_endpoint> --username admin --insecure --runtime podman`,
+  # Login with insecure TLS (skip certificate verification)
+  ai-services catalog login --server <catalog_backend_endpoint> --username admin --insecure`,
 
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return validateLoginFlags(runtimeType, serverURL, username, miqToken, passwordStdin)
+			return validateLoginFlags(serverURL, username, miqToken, passwordStdin)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -70,7 +68,6 @@ To get the Catalog backend endpoint, use: ai-services catalog info`,
 	cmd.Flags().StringVar(&miqToken, "miq-token", "", "ManageIQ token for token passthrough login")
 	_ = cmd.Flags().MarkHidden("miq-token")
 	cmd.Flags().BoolVar(&insecure, "insecure", false, "Skip TLS certificate verification (NOT for production use)")
-	common.ConfigureRuntimeFlag(cmd, &runtimeType)
 
 	_ = cmd.MarkFlagRequired("server")
 
@@ -147,10 +144,7 @@ func promptPassword(passwordStdin bool) (string, error) {
 }
 
 // validateLoginFlags validates all PreRunE checks for the login command.
-func validateLoginFlags(runtimeType, serverURL, username, miqToken string, passwordStdin bool) error {
-	if err := common.InitAndValidateRuntimeFlag(runtimeType); err != nil {
-		return err
-	}
+func validateLoginFlags(serverURL, username, miqToken string, passwordStdin bool) error {
 	if err := validateServerURL(serverURL); err != nil {
 		return err
 	}

--- a/ai-services/cmd/ai-services/cmd/catalog/logout.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/logout.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/project-ai-services/ai-services/cmd/ai-services/cmd/common"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/config"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
@@ -13,19 +12,13 @@ import (
 
 // NewLogoutCmd returns the cobra command for logging out from the catalog API server.
 func NewLogoutCmd() *cobra.Command {
-	var (
-		runtimeType string
-	)
 	cmd := &cobra.Command{
 		Use:   "logout",
 		Short: "Log out from the catalog API server",
 		Long: `Invalidate the current session on the catalog API server and remove
 the locally stored credentials.`,
 		Example: `  # Logout from the api server
-  ai-services catalog logout --runtime podman`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return common.InitAndValidateRuntimeFlag(runtimeType)
-		},
+  ai-services catalog logout`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Once precheck passes, silence usage for any *later* internal errors.
 			cmd.SilenceUsage = true
@@ -60,8 +53,6 @@ the locally stored credentials.`,
 			return nil
 		},
 	}
-
-	common.ConfigureRuntimeFlag(cmd, &runtimeType)
 
 	return cmd
 }

--- a/ai-services/cmd/ai-services/cmd/catalog/whoami.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/whoami.go
@@ -5,29 +5,22 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/project-ai-services/ai-services/cmd/ai-services/cmd/common"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 )
 
 // NewWhoamiCmd returns the cobra command that prints the currently authenticated user.
 func NewWhoamiCmd() *cobra.Command {
-	var (
-		runtimeType string
-	)
 	cmd := &cobra.Command{
 		Use:   "whoami",
 		Short: "Show the currently authenticated user",
 		Long: `Retrieve and display information about the user that is currently
 logged in to the catalog API server.`,
-		Example: `  # Show currently authenticated user for podman runtime
-  ai-services catalog whoami --runtime podman
+		Example: `  # Show currently authenticated user
+  ai-services catalog whoami
 
 Note:
   - Requires prior authentication via 'ai-services catalog login'`,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			return common.InitAndValidateRuntimeFlag(runtimeType)
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Once precheck passes, silence usage for any *later* internal errors.
 			cmd.SilenceUsage = true
@@ -52,8 +45,6 @@ Note:
 			return nil
 		},
 	}
-
-	common.ConfigureRuntimeFlag(cmd, &runtimeType)
 
 	return cmd
 }

--- a/ai-services/cmd/ai-services/cmd/common/common.go
+++ b/ai-services/cmd/ai-services/cmd/common/common.go
@@ -40,7 +40,8 @@ func InitAndValidateRuntimeFlag(runtimeType string) error {
 }
 
 // ConfigureRuntimeFlag registers the --runtime / -r flag on cmd and marks it
-// required. Use this in every command that accepts a runtime type.
+// required. Use this in every command that must know the runtime up-front
+// (bootstrap, catalog configure, catalog apiserver, worker join, worker uninstall).
 func ConfigureRuntimeFlag(cmd *cobra.Command, runtimeType *string) {
 	cmd.Flags().StringVarP(runtimeType, constants.RuntimeFlag, "r", "",
 		fmt.Sprintf("runtime to use (options: %s, %s) (required)", types.RuntimeTypePodman, types.RuntimeTypeOpenShift))

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -2174,7 +2174,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Retrieves system resource information including CPU, memory, and accelerator availability.\nWhen the optional ` + "`" + `worker` + "`" + ` query parameter is provided, the resources are fetched from\nthat remote worker node instead of the local runtime.",
+                "description": "Retrieves system resource information including CPU, memory, and accelerator availability.\nDefaults to the local worker when the ` + "`" + `worker` + "`" + ` query parameter is omitted.",
                 "produces": [
                     "application/json"
                 ],
@@ -2185,7 +2185,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Worker name to query resources from",
+                        "description": "Worker name to query resources from (default: Local)",
                         "name": "worker",
                         "in": "query"
                     }

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -2168,7 +2168,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Retrieves system resource information including CPU, memory, and accelerator availability.\nWhen the optional `worker` query parameter is provided, the resources are fetched from\nthat remote worker node instead of the local runtime.",
+                "description": "Retrieves system resource information including CPU, memory, and accelerator availability.\nDefaults to the local worker when the `worker` query parameter is omitted.",
                 "produces": [
                     "application/json"
                 ],
@@ -2179,7 +2179,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Worker name to query resources from",
+                        "description": "Worker name to query resources from (default: Local)",
                         "name": "worker",
                         "in": "query"
                     }

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -2484,10 +2484,9 @@ paths:
     get:
       description: |-
         Retrieves system resource information including CPU, memory, and accelerator availability.
-        When the optional `worker` query parameter is provided, the resources are fetched from
-        that remote worker node instead of the local runtime.
+        Defaults to the local worker when the `worker` query parameter is omitted.
       parameters:
-      - description: Worker name to query resources from
+      - description: 'Worker name to query resources from (default: Local)'
         in: query
         name: worker
         type: string

--- a/ai-services/internal/pkg/catalog/apiserver/apiserver.go
+++ b/ai-services/internal/pkg/catalog/apiserver/apiserver.go
@@ -41,7 +41,6 @@ import (
 	bundlesvc "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/bundle"
 	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/gateway"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/registry"
@@ -120,11 +119,11 @@ func (a *APIserver) Start(ctx context.Context) error {
 	defer cancel(nil)
 
 	// Start the gRPC worker gateway.
-	runtimeType := types.RuntimeTypePodman
-	if vars.RuntimeFactory != nil {
-		runtimeType = vars.RuntimeFactory.GetRuntimeType()
+	if vars.RuntimeFactory == nil {
+		return fmt.Errorf("runtime factory not initialised: --runtime flag is required")
 	}
-	gw, err := gateway.New(ctx, a.workerRegistry, runtimeType)
+
+	gw, err := gateway.New(ctx, a.workerRegistry, vars.RuntimeFactory.GetRuntimeType())
 	if err != nil {
 		return fmt.Errorf("failed to initialise worker gateway: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/resources.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/resources.go
@@ -11,7 +11,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	remoteRuntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/remote"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
-	"github.com/project-ai-services/ai-services/internal/pkg/vars"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/stream"
 )
 
@@ -37,12 +37,11 @@ type ResourcesResponse struct {
 //
 //	@Summary		Get system resources
 //	@Description	Retrieves system resource information including CPU, memory, and accelerator availability.
-//	@Description	When the optional `worker` query parameter is provided, the resources are fetched from
-//	@Description	that remote worker node instead of the local runtime.
+//	@Description	Defaults to the local worker when the `worker` query parameter is omitted.
 //	@Tags			Catalog
 //	@Produce		json
 //	@Security		BearerAuth
-//	@Param			worker	query		string	false	"Worker name to query resources from"
+//	@Param			worker	query		string	false	"Worker name to query resources from (default: Local)"
 //	@Success		200		{object}	ResourcesResponse
 //	@Failure		400		{object}	ErrorResponse	"Worker not connected"
 //	@Failure		401		{object}	ErrorResponse	"Unauthorized - Invalid or missing access token"
@@ -52,32 +51,28 @@ func (h *ResourcesHandler) GetResources(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	workerName := c.Query("worker")
-
-	var rt runtime.Runtime
-
-	if workerName != "" && h.workerRegistry != nil {
-		rtStr, ok := h.workerRegistry.WorkerRuntimeType(workerName)
-		if !ok {
-			c.JSON(http.StatusBadRequest, ErrorResponse{
-				Error: fmt.Sprintf("worker %q is not connected", workerName),
-			})
-
-			return
-		}
-
-		rt = remoteRuntime.New(workerName, runtimeTypes.RuntimeType(rtStr), h.workerRegistry)
-	} else {
-		var err error
-		rt, err = vars.RuntimeFactory.Create("")
-		if err != nil {
-			logger.ErrorfCtx(ctx, "Could not create runtime client: %v", err)
-			c.JSON(http.StatusInternalServerError, ErrorResponse{
-				Error: fmt.Sprintf("Failed to create runtime client: %v", err),
-			})
-
-			return
-		}
+	if workerName == "" {
+		workerName = workerconstants.LocalWorkerName
 	}
+
+	if h.workerRegistry == nil {
+		c.JSON(http.StatusInternalServerError, ErrorResponse{
+			Error: "worker registry not configured",
+		})
+
+		return
+	}
+
+	rtStr, ok := h.workerRegistry.WorkerRuntimeType(workerName)
+	if !ok {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Error: fmt.Sprintf("worker %q is not connected", workerName),
+		})
+
+		return
+	}
+
+	rt := remoteRuntime.New(workerName, runtimeTypes.RuntimeType(rtStr), h.workerRegistry)
 
 	resp, err := getResourcesResponse(ctx, rt)
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service.go
@@ -73,7 +73,6 @@ func NewApplicationService(
 		DeploymentExecutor:    deployment.NewDeploymentExecutor(provider, appRepo, serviceRepo, componentRepo).WithWorkerRegistry(reg),
 		DeletionExecutor:      deletion.NewDeletionExecutor(appRepo, serviceRepo, componentRepo, serviceDependencyRepo),
 		Validator:             validator,
-		RuntimeType:           runtimeType,
 		DeploymentRegistry:    appservice.NewDeploymentRegistry(),
 		WorkerRegistry:        reg,
 		DatasourceService:     datasourceSvc,

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -24,7 +24,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/common"
 	runtimeTypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
-	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/stream"
 )
@@ -101,13 +100,6 @@ type ApplicationServiceBase struct {
 	DeletionExecutor      *deletion.DeletionExecutor
 	Validator             *validators.ApplicationValidator
 
-	// RuntimeType is the runtime this service instance targets (Podman or OpenShift).
-	// Set once at construction; used by CreateApplication to plan and execute deployments.
-	// TODO: Remove once the existing/legacy flow is retired — in the new flow every
-	// application has a WorkerID and CreateApplication will derive the runtime from the
-	// worker's registered runtime type instead of this field.
-	RuntimeType runtimeTypes.RuntimeType
-
 	// DeploymentRegistry tracks in-flight deployments so they can be cancelled
 	// by a concurrent delete request. Nil means no cancellation (e.g. OpenShift stub).
 	DeploymentRegistry *DeploymentRegistry
@@ -123,52 +115,50 @@ type ApplicationServiceBase struct {
 }
 
 // createRuntime returns the runtime.Runtime appropriate for app.
-// When WorkerID is set (new flow) it resolves the worker name and builds a RemoteRuntime
-// over the gRPC CommandStream — this covers both the "Local" worker and actual remote workers.
-// When WorkerID is nil (existing/legacy flow, pre-worker feature) it falls back to
-// vars.RuntimeFactory directly, deriving the namespace from app.ID when needed (OpenShift).
+// Every application has a WorkerID (NOT NULL column, migration 20260801000003). It
+// resolves the worker name and builds a RemoteRuntime over the gRPC CommandStream —
+// this covers both the "Local" worker and actual remote workers.
 func (s *ApplicationServiceBase) createRuntime(app *models.Application) (runtime.Runtime, error) {
-	if app.WorkerID != nil {
-		if s.WorkerRegistry == nil {
-			return nil, fmt.Errorf("worker deployment not configured on this server")
-		}
-
-		workerName, ok := s.WorkerRegistry.WorkerNameByID(*app.WorkerID)
-		if !ok {
-			return nil, fmt.Errorf("worker %s for application %s is not connected", app.WorkerID, app.ID)
-		}
-
-		rtStr, _ := s.WorkerRegistry.WorkerRuntimeType(workerName)
-		rt, err := runtime.NewRuntimeFactory(runtimeTypes.RuntimeType(rtStr)).CreateRemote(workerName, s.WorkerRegistry, catalogutils.AppNamespace(app.ID))
-		if err != nil {
-			return nil, fmt.Errorf("create remote runtime for worker %q: %w", workerName, err)
-		}
-
-		return rt, nil
+	if app.WorkerID == nil {
+		return nil, fmt.Errorf("application %s has no worker_id: every application must be deployed through a worker", app.ID)
 	}
 
-	return vars.RuntimeFactory.Create(catalogutils.AppNamespace(app.ID))
+	if s.WorkerRegistry == nil {
+		return nil, fmt.Errorf("worker deployment not configured on this server")
+	}
+
+	workerName, ok := s.WorkerRegistry.WorkerNameByID(*app.WorkerID)
+	if !ok {
+		return nil, fmt.Errorf("worker %s for application %s is not connected", app.WorkerID, app.ID)
+	}
+
+	rtStr, _ := s.WorkerRegistry.WorkerRuntimeType(workerName)
+	rt, err := runtime.NewRuntimeFactory(runtimeTypes.RuntimeType(rtStr)).CreateRemote(workerName, s.WorkerRegistry, catalogutils.AppNamespace(app.ID))
+	if err != nil {
+		return nil, fmt.Errorf("create remote runtime for worker %q: %w", workerName, err)
+	}
+
+	return rt, nil
 }
 
 // buildWorkerInfo resolves the worker name and runtime type from the registry and returns
-// an ApplicationWorker for embedding in the application response. The ID is always set;
-// name and runtime_type are set only when the worker is currently connected.
-func (s *ApplicationServiceBase) buildWorkerInfo(workerID uuid.UUID) *types.ApplicationWorker {
-	w := &types.ApplicationWorker{ID: workerID.String()}
+// an ApplicationWorker for embedding in the application response.
+func (s *ApplicationServiceBase) buildWorkerInfo(workerID uuid.UUID) (*types.ApplicationWorker, error) {
 	if s.WorkerRegistry == nil {
-		return w
-	}
-	name, ok := s.WorkerRegistry.WorkerNameByID(workerID)
-	if !ok {
-		return w
+		return nil, fmt.Errorf("worker registry not configured")
 	}
 
-	w.Name = name
+	name, ok := s.WorkerRegistry.WorkerNameByID(workerID)
+	if !ok {
+		return nil, fmt.Errorf("worker %s is not connected", workerID)
+	}
+
+	w := &types.ApplicationWorker{ID: workerID.String(), Name: name}
 	if rtStr, ok := s.WorkerRegistry.WorkerRuntimeType(name); ok {
 		w.RuntimeType = rtStr
 	}
 
-	return w
+	return w, nil
 }
 
 // buildApplication creates an Application from a models.Application.
@@ -192,9 +182,16 @@ func (s *ApplicationServiceBase) buildApplication(app models.Application) (types
 		UpdatedAt:      app.UpdatedAt.Format(constants.RFC3339WithTimezone),
 	}
 
-	if app.WorkerID != nil {
-		appData.Worker = s.buildWorkerInfo(*app.WorkerID)
+	if app.WorkerID == nil {
+		return types.Application{}, fmt.Errorf("application %s has no worker_id", app.ID)
 	}
+
+	worker, err := s.buildWorkerInfo(*app.WorkerID)
+	if err != nil {
+		return types.Application{}, fmt.Errorf("failed to resolve worker for application %s: %w", app.ID, err)
+	}
+
+	appData.Worker = worker
 
 	// Add services array only for architectures (not for individual services)
 	if app.DeploymentType == models.DeploymentTypeArchitectures && len(app.Services) > 0 {
@@ -338,9 +335,16 @@ func (s *ApplicationServiceBase) buildGetApplicationResponse(ctx context.Context
 		UpdatedAt:      app.UpdatedAt.Format(constants.RFC3339WithTimezone),
 	}
 
-	if app.WorkerID != nil {
-		appresponse.Worker = s.buildWorkerInfo(*app.WorkerID)
+	if app.WorkerID == nil {
+		return nil, fmt.Errorf("application %s has no worker_id", app.ID)
 	}
+
+	worker, err := s.buildWorkerInfo(*app.WorkerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve worker for application %s: %w", app.ID, err)
+	}
+
+	appresponse.Worker = worker
 
 	// Load services with their components if present
 	if len(app.Services) > 0 {
@@ -547,15 +551,19 @@ func (s *ApplicationServiceBase) insertApplicationRecord(
 		CreatedBy:      createdBy,
 	}
 
-	// Attach the worker FK. In the new flow WorkerName is always set by PlanDeployment
-	// (including "Local" for same-machine deployments). The nil check handles the
-	// existing flow where WorkerName is empty and there is no worker row to look up.
-	// TODO: Remove the empty-string guard once the existing flow is retired.
-	if plan.WorkerName != "" {
-		if dbID, ok := s.DeploymentPlanner.WorkerDBID(plan.WorkerName); ok {
-			app.WorkerID = &dbID
-		}
+	// Attach the worker FK. Every deployment goes through a worker (the local worker
+	// is used for local deployments). WorkerName is always set by the CLI since the
+	// --worker flag defaults to workerconstants.LocalWorkerName.
+	if plan.WorkerName == "" {
+		return fmt.Errorf("worker name is required for application deployment; use --worker to specify a worker (default: %q)", workerconstants.LocalWorkerName)
 	}
+
+	dbID, ok := s.DeploymentPlanner.WorkerDBID(plan.WorkerName)
+	if !ok {
+		return fmt.Errorf("worker %q is not registered or not connected; run 'worker join' first", plan.WorkerName)
+	}
+
+	app.WorkerID = &dbID
 
 	if err := s.AppRepo.Insert(ctx, app); err != nil {
 		return fmt.Errorf("failed to insert application: %w", err)
@@ -1170,25 +1178,27 @@ func (s *ApplicationServiceBase) ApplicationsPs(ctx context.Context, appID uuid.
 		return nil, fmt.Errorf("failed to collect component pods: %w", err)
 	}
 
+	if app.WorkerID == nil {
+		return nil, fmt.Errorf("application %s has no worker_id", app.ID)
+	}
+
+	workerInfo, err := s.buildWorkerInfo(*app.WorkerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve worker for application %s: %w", app.ID, err)
+	}
+
 	psResp := &types.ApplicationPSResponse{
 		ID:          app.ID.String(),
 		Name:        app.Name,
-		RuntimeType: s.RuntimeType.String(),
+		RuntimeType: workerInfo.RuntimeType,
+		WorkerName:  workerInfo.Name,
 		Services:    servicePods,
 		Components:  componentPods,
 	}
 
-	if app.WorkerID != nil {
-		workerInfo := s.buildWorkerInfo(*app.WorkerID)
-		psResp.WorkerName = workerInfo.Name
-		// Namespace is only meaningful for OpenShift workers
-		if runtimeTypes.RuntimeType(workerInfo.RuntimeType) == runtimeTypes.RuntimeTypeOpenShift {
-			psResp.Namespace = catalogutils.AppNamespace(app.ID)
-		}
-		// Override runtime type with the worker's actual runtime when available
-		if workerInfo.RuntimeType != "" {
-			psResp.RuntimeType = workerInfo.RuntimeType
-		}
+	// Namespace is only meaningful for OpenShift workers
+	if runtimeTypes.RuntimeType(workerInfo.RuntimeType) == runtimeTypes.RuntimeTypeOpenShift {
+		psResp.Namespace = catalogutils.AppNamespace(app.ID)
 	}
 
 	return psResp, nil

--- a/ai-services/internal/pkg/catalog/apiserver/router.go
+++ b/ai-services/internal/pkg/catalog/apiserver/router.go
@@ -13,7 +13,6 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/auth"
 	bundlesvc "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/services/bundle"
 	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/vars"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/registry"
 	swaggerFiles "github.com/swaggo/files"
@@ -42,11 +41,11 @@ func CreateRouter(authSvc auth.Service, tokenMgr *auth.TokenManager, blacklist r
 	datasourceH := handlers.NewDatasourceHandler(datasourceSvc)
 	registerCatalogRoutes(v1, handlers.NewCatalogHandler(catalogProvider), handlers.NewResourcesHandler(workerReg), auth)
 	registerApplicationRoutes(v1, handlers.NewApplicationHandler(appService), datasourceH, auth)
-	runtimeType := types.RuntimeTypePodman
-	if vars.RuntimeFactory != nil {
-		runtimeType = vars.RuntimeFactory.GetRuntimeType()
+	if vars.RuntimeFactory == nil {
+		panic("runtime factory not initialised: --runtime flag is required")
 	}
-	registerWorkerRoutes(v1, handlers.NewWorkerHandler(workerReg, workerRepo, runtimeType, workerGatewayPort), auth)
+
+	registerWorkerRoutes(v1, handlers.NewWorkerHandler(workerReg, workerRepo, vars.RuntimeFactory.GetRuntimeType(), workerGatewayPort), auth)
 	registerDatasourceRoutes(v1, datasourceH, auth)
 	registerBundleRoutes(v1, handlers.NewBundleHandler(bundleService), auth)
 

--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/planner.go
@@ -111,14 +111,8 @@ func (p *DeploymentPlanner) PlanDeployment(
 	ctx context.Context,
 	req apimodels.CreateApplicationRequest,
 ) (*DeploymentPlan, error) {
-	runtimeType := p.runtimeType
-	if runtimeType == "" {
-		// TODO: Remove this fallback once all callers provide a runtime-scoped planner.
-		var err error
-		runtimeType, err = p.ResolveRuntimeType(ctx, req.WorkerName)
-		if err != nil {
-			return nil, err
-		}
+	if p.runtimeType == "" {
+		return nil, fmt.Errorf("planner has no runtime type: call WithRuntime before PlanDeployment")
 	}
 
 	workerName := req.WorkerName
@@ -143,7 +137,7 @@ func (p *DeploymentPlanner) PlanDeployment(
 		Components:      make(map[string]*ComponentPlan),
 		Services:        make(map[string]*ServicePlan),
 		WorkerName:      workerName,
-		RuntimeType:     runtimeType,
+		RuntimeType:     p.runtimeType,
 	}
 
 	// Process each service from request
@@ -155,7 +149,7 @@ func (p *DeploymentPlanner) PlanDeployment(
 
 	// Calculate and allocate Spyre cards only for local Podman deployments.
 	// Remote-worker deployments must not probe local /dev/vfio on the API server.
-	if runtimeType == runtimeTypes.RuntimeTypePodman.String() && isLocalWorkerName(workerName) {
+	if p.runtimeType == runtimeTypes.RuntimeTypePodman.String() && isLocalWorkerName(workerName) {
 		if err := p.calculateAndAllocateSpyreCards(ctx, plan); err != nil {
 			return nil, fmt.Errorf("failed to allocate Spyre cards: %w", err)
 		}
@@ -354,11 +348,6 @@ func (p *DeploymentPlanner) ValidateWorker(ctx context.Context, workerName strin
 
 	if p.workerRegistry == nil {
 		return fmt.Errorf("worker deployment is not configured on this server")
-	}
-
-	// TODO: Remove this when remote deployment is by default
-	if workerName == "" {
-		return nil
 	}
 
 	if !p.workerRegistry.IsWorkerConnected(ctx, workerName) {

--- a/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/sync/sync_service.go
@@ -221,8 +221,7 @@ func (s *SyncService) performSync(ctx context.Context) {
 // 3. Update application status based on collected errors.
 func (s *SyncService) syncApplication(ctx context.Context, app *models.Application) error {
 	// Initialize runtime client.
-	// For remote worker apps resolve a RemoteRuntime via the worker registry;
-	// for local apps use the local runtime factory.
+	// For remote worker apps resolve a RemoteRuntime via the worker registry.
 	rt, err := s.createRuntime(ctx, app)
 	if errors.Is(err, errWorkerDisconnected) {
 		return s.updateApplicationStatus(ctx, app, false, []string{err.Error()})
@@ -304,20 +303,14 @@ func (s *SyncService) collectApplicationSyncState(
 }
 
 // createRuntime returns the appropriate runtime.Runtime for the given application.
-// When the app has a WorkerID and the worker is connected, a RemoteRuntime is
-// returned. Returns errWorkerDisconnected (not a hard error) when the worker is
-// absent from the registry or its status is not ready.
-// TODO: in future, set the application status to Error with message
-// "orphaned: worker was deregistered" when worker_id is NULL — this happens
-// because the ON DELETE SET NULL migration nulls worker_id on all applications
-// assigned to a deregistered worker.
+// Every application has a WorkerID (NOT NULL column, migration 20260801000003).
+// When the worker is connected a RemoteRuntime is returned. Returns
+// errWorkerDisconnected (not a hard error) when the worker is absent from the
+// registry — this happens transiently when the worker pod restarts. Worker
+// deregistration is blocked by ON DELETE RESTRICT while applications exist.
 func (s *SyncService) createRuntime(ctx context.Context, app *models.Application) (runtime.Runtime, error) {
-	// TODO: Once remote runtime is enabled by default this check is not needed
-	// and the last return line must be deleted.
 	if app.WorkerID == nil {
-		logger.DebugfCtx(ctx, "Using local runtime %q for application %s sync", s.runtimeType, app.ID)
-
-		return s.runtimeFactory.Create(catalogutils.AppNamespace(app.ID))
+		return nil, fmt.Errorf("application %s has no worker_id: every application must be deployed through a worker", app.ID)
 	}
 
 	if s.workerRegistry == nil {

--- a/ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/openshift/configure.go
@@ -99,7 +99,7 @@ func handlePostDeployment(ctx context.Context, tp templates.Template, runtime *r
 	// Step 8: Join as local worker
 	if !opts.SkipLocalWorker {
 		if err := JoinAsLocalWorker(ctx, runtime, catalogClient); err != nil {
-			return fmt.Errorf("local worker join failed: %w", err)
+			return fmt.Errorf("worker join failed: %w", err)
 		}
 	}
 

--- a/ai-services/internal/pkg/catalog/cli/configure/openshift/local_worker.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/openshift/local_worker.go
@@ -27,7 +27,7 @@ func JoinAsLocalWorker(ctx context.Context, rt *runtimeOpenshift.OpenshiftClient
 
 	token, gatewayAddr, err := configure.RegisterLocalWorker(ctx, c)
 	if err != nil {
-		return fmt.Errorf("local worker join: %w", err)
+		return fmt.Errorf("worker join: %w", err)
 	}
 
 	opts := workertypes.OpenshiftWorkerOptions{
@@ -38,10 +38,10 @@ func JoinAsLocalWorker(ctx context.Context, rt *runtimeOpenshift.OpenshiftClient
 	}
 
 	if err := workeropenshift.DeployWorker(ctx, opts); err != nil {
-		return fmt.Errorf("local worker join: deploy worker: %w", err)
+		return fmt.Errorf("worker join: deploy worker: %w", err)
 	}
 
-	logger.InfolnCtx(ctx, "Local worker joined successfully.")
+	logger.InfolnCtx(ctx, "worker joined successfully.")
 
 	return nil
 }

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/configure.go
@@ -136,7 +136,7 @@ func handlePostDeployment(ctx context.Context, caddyCtx *caddy.Context, deployCt
 
 	if !opts.SkipLocalWorker {
 		if err := JoinAsLocalWorker(ctx, deployCtx.Runtime, opts, catalogClient); err != nil {
-			return fmt.Errorf("local worker join failed: %v", err)
+			return fmt.Errorf("worker join failed: %v", err)
 		}
 	}
 

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/local_worker.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/local_worker.go
@@ -23,7 +23,7 @@ func JoinAsLocalWorker(ctx context.Context, rt *podmanruntime.PodmanClient, opts
 
 	token, gatewayAddr, err := configure.RegisterLocalWorker(ctx, c)
 	if err != nil {
-		return fmt.Errorf("local worker join: %w", err)
+		return fmt.Errorf("worker join: %w", err)
 	}
 
 	workerOpts := workertypes.PodmanWorkerOptions{
@@ -41,10 +41,10 @@ func JoinAsLocalWorker(ctx context.Context, rt *podmanruntime.PodmanClient, opts
 	}
 
 	if err := workerpodman.DeployWorker(ctx, workerOpts); err != nil {
-		return fmt.Errorf("local worker join: deploy worker pod: %w", err)
+		return fmt.Errorf("worker join: deploy worker pod: %w", err)
 	}
 
-	logger.InfolnCtx(ctx, "Local worker joined successfully.")
+	logger.InfolnCtx(ctx, "worker joined successfully.")
 
 	return nil
 }

--- a/ai-services/internal/pkg/catalog/cli/configure/worker.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/worker.go
@@ -29,11 +29,11 @@ func LoginToCatalog(ctx context.Context, catalogAPIURL, adminPassword string) (*
 // RegisterLocalWorker pre-registers the Local worker using the already-authenticated
 // client and returns the bootstrap token and gateway address.
 func RegisterLocalWorker(ctx context.Context, c *catalogclient.Client) (token, gatewayAddr string, err error) {
-	logger.InfolnCtx(ctx, "Registering local worker via catalog API...")
+	logger.InfolnCtx(ctx, "Registering worker via catalog API...")
 
 	resp, err := catalogclient.NewWorkerClientFromClient(c).CreateWorker(ctx, workerconstants.LocalWorkerName)
 	if err != nil {
-		return "", "", fmt.Errorf("register local worker: %w", err)
+		return "", "", fmt.Errorf("register worker: %w", err)
 	}
 
 	return resp.Token, resp.GatewayAddress, nil

--- a/ai-services/internal/pkg/catalog/cli/uninstall/openshift/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/openshift/uninstall.go
@@ -33,7 +33,7 @@ func UninstallCatalog(ctx context.Context, opts utils.UninstallOptions) error {
 	// Check before catalog pods are deleted whether a local worker is co-located.
 	isLocalWorker, err := workercommon.IsOpenShiftLocalWorker(ctx, rt)
 	if err != nil {
-		return fmt.Errorf("failed to check local worker: %w", err)
+		return fmt.Errorf("failed to check worker: %w", err)
 	}
 
 	// Confirm deletion unless auto-yes is set

--- a/ai-services/internal/pkg/catalog/db/migrations/assets/20260430094502_create_applications_table.sql
+++ b/ai-services/internal/pkg/catalog/db/migrations/assets/20260430094502_create_applications_table.sql
@@ -8,16 +8,16 @@ CREATE TYPE deployment_type AS ENUM (
 
 -- Create applications table
 CREATE TABLE applications (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    name VARCHAR(100),
-    catalog_id VARCHAR(100),
-    deployment_type deployment_type,
-    status status,
-    message TEXT,
-    version VARCHAR(50),
-    created_by VARCHAR(100),
-    created_at TIMESTAMPTZ DEFAULT NOW(),
-    updated_at TIMESTAMPTZ DEFAULT NOW()
+    id              UUID             PRIMARY KEY DEFAULT gen_random_uuid(),
+    name            VARCHAR(100)     NOT NULL,
+    catalog_id      VARCHAR(100)     NOT NULL,
+    deployment_type deployment_type  NOT NULL,
+    status          status           NOT NULL,
+    message         TEXT,
+    version         VARCHAR(50)      NOT NULL,
+    created_by      VARCHAR(100)     NOT NULL,
+    created_at      TIMESTAMPTZ      NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ      NOT NULL DEFAULT NOW()
 );
 
 -- Create trigger to automatically update updated_at timestamp

--- a/ai-services/internal/pkg/catalog/db/migrations/assets/20260801000003_add_worker_fk_to_applications.sql
+++ b/ai-services/internal/pkg/catalog/db/migrations/assets/20260801000003_add_worker_fk_to_applications.sql
@@ -2,10 +2,12 @@
 -- +goose StatementBegin
 
 -- Add worker_id FK to applications, referencing the workers table created in
--- migration 20260801000002. Nullable so existing applications without an
--- assigned worker remain valid.
+-- migration 20260801000002. NOT NULL because every application is deployed
+-- through a worker (the Local worker is used for local deployments).
+-- ON DELETE RESTRICT prevents deregistering a worker that still has
+-- applications assigned to it.
 ALTER TABLE applications
-    ADD COLUMN worker_id UUID REFERENCES workers(id) ON DELETE SET NULL;
+    ADD COLUMN worker_id UUID NOT NULL REFERENCES workers(id) ON DELETE RESTRICT;
 
 CREATE INDEX ON applications(worker_id);
 

--- a/ai-services/internal/pkg/catalog/db/models/application.go
+++ b/ai-services/internal/pkg/catalog/db/models/application.go
@@ -53,7 +53,7 @@ type Application struct {
 	Message        string            `json:"message,omitempty"`
 	Version        string            `json:"version"`
 	CreatedBy      string            `json:"created_by"`
-	WorkerID       *uuid.UUID        `json:"worker_id,omitempty"`
+	WorkerID       *uuid.UUID        `json:"worker_id"`
 	CreatedAt      time.Time         `json:"created_at"`
 	UpdatedAt      time.Time         `json:"updated_at"`
 	Services       []Service         `json:"services,omitempty"`

--- a/ai-services/internal/pkg/catalog/types/application_response.go
+++ b/ai-services/internal/pkg/catalog/types/application_response.go
@@ -26,7 +26,7 @@ type Application struct {
 	Services       []ApplicationService `json:"services,omitempty"`
 	CreatedAt      string               `json:"created_at"`
 	UpdatedAt      string               `json:"updated_at"`
-	Worker         *ApplicationWorker   `json:"worker,omitempty"`
+	Worker         *ApplicationWorker   `json:"worker"`
 }
 
 // ApplicationService represents an application service in the list/get response.

--- a/ai-services/tests/e2e/bootstrap_failure_test.go
+++ b/ai-services/tests/e2e/bootstrap_failure_test.go
@@ -239,7 +239,6 @@ var _ = ginkgo.Describe("Bootstrap Failure Scenarios",
 							serverURL,
 							"admin", // correct username — only the password is wrong
 							invalidCatalogPassword,
-							appRuntime,
 							bootstrap.GetCatalogInsecure(),
 						)
 
@@ -295,7 +294,6 @@ var _ = ginkgo.Describe("Bootstrap Failure Scenarios",
 							unreachableCatalogURL,
 							"admin",
 							invalidCatalogPassword,
-							appRuntime,
 							true, // insecure=true — self-signed / no cert on a fake host
 						)
 

--- a/ai-services/tests/e2e/catalog_failure_test.go
+++ b/ai-services/tests/e2e/catalog_failure_test.go
@@ -117,7 +117,7 @@ var _ = ginkgo.Describe("Catalog Failure Scenarios",
 							"[FAILURE-TEST][Catalog] Invoking catalog login without --server flag",
 						)
 
-						output, err := cli.CatalogLoginMissingServer(ctx, cfg, appRuntime)
+						output, err := cli.CatalogLoginMissingServer(ctx, cfg)
 
 						// ── Assertions ─────────────────────────────────────
 						// 1. The command MUST fail.
@@ -168,7 +168,7 @@ var _ = ginkgo.Describe("Catalog Failure Scenarios",
 							badURL,
 						)
 
-						output, err := cli.CatalogLoginInvalidURL(ctx, cfg, badURL, appRuntime)
+						output, err := cli.CatalogLoginInvalidURL(ctx, cfg, badURL)
 
 						// ── Assertions ─────────────────────────────────────
 						gomega.Expect(err).To(
@@ -231,7 +231,7 @@ var _ = ginkgo.Describe("Catalog Failure Scenarios",
 							emptyHome,
 						)
 
-						output, cmdErr := cli.CatalogWhoamiWithoutLogin(ctx, cfg, emptyHome, appRuntime)
+						output, cmdErr := cli.CatalogWhoamiWithoutLogin(ctx, cfg, emptyHome)
 
 						// ── Assertions ─────────────────────────────────────
 						gomega.Expect(cmdErr).To(

--- a/ai-services/tests/e2e/cli/runner.go
+++ b/ai-services/tests/e2e/cli/runner.go
@@ -954,19 +954,18 @@ func ExtractCatalogBackendURLFromConfigureOutput(configureOutput string) string 
 }
 
 // CatalogLogin runs a non-interactive catalog login, piping the password via stdin.
-func CatalogLogin(ctx context.Context, cfg *config.Config, serverURL, username, password, appRuntime string, insecure bool) (string, error) {
+func CatalogLogin(ctx context.Context, cfg *config.Config, serverURL, username, password string, insecure bool) (string, error) {
 	args := []string{
 		"catalog", "login",
 		"--server", serverURL,
 		"--username", username,
 		"--password-stdin",
-		"--runtime", appRuntime,
 	}
 	if insecure {
 		args = append(args, "--insecure")
 	}
-	logger.Infof("[CLI] Running: %s catalog login --server %s --username %s --password-stdin --runtime %s (insecure=%v)",
-		cfg.AIServiceBin, serverURL, username, appRuntime, insecure)
+	logger.Infof("[CLI] Running: %s catalog login --server %s --username %s --password-stdin (insecure=%v)",
+		cfg.AIServiceBin, serverURL, username, insecure)
 	cmd := exec.CommandContext(ctx, cfg.AIServiceBin, args...)
 	cmd.Stdin = bytes.NewBufferString(password + "\n")
 	out, err := cmd.CombinedOutput()
@@ -1085,8 +1084,8 @@ func CatalogApiServerHelp(ctx context.Context, cfg *config.Config, appRuntime st
 }
 
 // CatalogHashpw runs 'catalog hashpw --stdin' with the provided password piped via stdin.
-func CatalogHashpw(ctx context.Context, cfg *config.Config, password, appRuntime string) (string, error) {
-	args := []string{"catalog", "hashpw", "--stdin", "--runtime", appRuntime}
+func CatalogHashpw(ctx context.Context, cfg *config.Config, password string) (string, error) {
+	args := []string{"catalog", "hashpw", "--stdin"}
 	logger.Infof("[CLI] Running: %s %s", cfg.AIServiceBin, strings.Join(args, " "))
 	cmd := exec.CommandContext(ctx, cfg.AIServiceBin, args...)
 	cmd.Stdin = bytes.NewBufferString(password + "\n")
@@ -1100,13 +1099,13 @@ func CatalogHashpw(ctx context.Context, cfg *config.Config, password, appRuntime
 }
 
 // CatalogWhoami runs 'catalog whoami' and returns the combined output.
-func CatalogWhoami(ctx context.Context, cfg *config.Config, appRuntime string) (string, error) {
-	return runCLI(ctx, cfg, "catalog whoami", "catalog", "whoami", "--runtime", appRuntime)
+func CatalogWhoami(ctx context.Context, cfg *config.Config) (string, error) {
+	return runCLI(ctx, cfg, "catalog whoami", "catalog", "whoami")
 }
 
 // CatalogLogout runs 'catalog logout' and returns the combined output.
-func CatalogLogout(ctx context.Context, cfg *config.Config, appRuntime string) (string, error) {
-	return runCLI(ctx, cfg, "catalog logout", "catalog", "logout", "--runtime", appRuntime)
+func CatalogLogout(ctx context.Context, cfg *config.Config) (string, error) {
+	return runCLI(ctx, cfg, "catalog logout", "catalog", "logout")
 }
 
 // CatalogDbMigrateHelp runs 'catalog dbmigrate --help'; full dbmigrate requires a live DB so only help is tested.
@@ -1130,13 +1129,12 @@ func CatalogDbMigrateHelp(ctx context.Context, cfg *config.Config) (string, erro
 //
 // Returns combined stdout+stderr (always populated for flag errors) and the
 // exec error.
-func CatalogLoginMissingServer(ctx context.Context, cfg *config.Config, appRuntime string) (string, error) {
+func CatalogLoginMissingServer(ctx context.Context, cfg *config.Config) (string, error) {
 	args := []string{
 		"catalog", "login",
 		// --server is intentionally omitted.
 		"--username", "admin",
 		"--password-stdin",
-		"--runtime", appRuntime,
 	}
 
 	logger.Infof(
@@ -1161,13 +1159,12 @@ func CatalogLoginMissingServer(ctx context.Context, cfg *config.Config, appRunti
 // reject it in PreRunE before any network call is made.
 //
 // Returns combined stdout+stderr and the exec error.
-func CatalogLoginInvalidURL(ctx context.Context, cfg *config.Config, badURL, appRuntime string) (string, error) {
+func CatalogLoginInvalidURL(ctx context.Context, cfg *config.Config, badURL string) (string, error) {
 	args := []string{
 		"catalog", "login",
 		"--server", badURL,
 		"--username", "admin",
 		"--password-stdin",
-		"--runtime", appRuntime,
 	}
 
 	logger.Infof(
@@ -1193,10 +1190,9 @@ func CatalogLoginInvalidURL(ctx context.Context, cfg *config.Config, badURL, app
 //
 // homeDir must be an existing, empty directory that the calling test owns.
 // Returns combined stdout+stderr and the exec error.
-func CatalogWhoamiWithoutLogin(ctx context.Context, cfg *config.Config, homeDir, appRuntime string) (string, error) {
+func CatalogWhoamiWithoutLogin(ctx context.Context, cfg *config.Config, homeDir string) (string, error) {
 	args := []string{
 		"catalog", "whoami",
-		"--runtime", appRuntime,
 	}
 
 	logger.Infof(

--- a/ai-services/tests/e2e/e2e_suite_test.go
+++ b/ai-services/tests/e2e/e2e_suite_test.go
@@ -223,7 +223,7 @@ func catalogLoginWithDiscovery(loginCtx context.Context, fatal bool) {
 		return
 	}
 
-	_, loginErr := cli.CatalogLogin(loginCtx, cfg, serverURL, loginUsername, loginPassword, appRuntime, loginInsecure)
+	_, loginErr := cli.CatalogLogin(loginCtx, cfg, serverURL, loginUsername, loginPassword, loginInsecure)
 	if loginErr != nil {
 		if fatal {
 			ginkgo.Fail(fmt.Sprintf("Catalog login failed: %v (server: %s, user: %s)", loginErr, serverURL, loginUsername))
@@ -457,7 +457,7 @@ var _ = ginkgo.Describe("AI Services End-to-End Tests", ginkgo.Ordered, func() {
 			if catalogPassword == "" {
 				ginkgo.Skip("CATALOG_PASSWORD not set — skipping catalog hashpw test")
 			}
-			output, err := cli.CatalogHashpw(ctx, cfg, catalogPassword, appRuntime)
+			output, err := cli.CatalogHashpw(ctx, cfg, catalogPassword)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(cli.ValidateCatalogHashpwOutput(output)).To(gomega.Succeed())
 			logger.Infoln("[TEST] Catalog hashpw output validated successfully!")
@@ -570,7 +570,7 @@ var _ = ginkgo.Describe("AI Services End-to-End Tests", ginkgo.Ordered, func() {
 			}
 			ctx, cancel := withTimeout(1 * time.Minute)
 			defer cancel()
-			output, err := cli.CatalogLogin(ctx, cfg, catalogBackendURL, catalogUsername, catalogPassword, appRuntime, catalogInsecure)
+			output, err := cli.CatalogLogin(ctx, cfg, catalogBackendURL, catalogUsername, catalogPassword, catalogInsecure)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(cli.ValidateCatalogLoginOutput(output)).To(gomega.Succeed())
 			logger.Infoln("[TEST] Catalog login validated successfully!")
@@ -591,7 +591,7 @@ var _ = ginkgo.Describe("AI Services End-to-End Tests", ginkgo.Ordered, func() {
 			}
 			ctx, cancel := withTimeout(1 * time.Minute)
 			defer cancel()
-			output, err := cli.CatalogWhoami(ctx, cfg, appRuntime)
+			output, err := cli.CatalogWhoami(ctx, cfg)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(cli.ValidateCatalogWhoamiOutput(output)).To(gomega.Succeed())
 			logger.Infoln("[TEST] Catalog whoami output validated successfully!")
@@ -615,19 +615,19 @@ var _ = ginkgo.Describe("AI Services End-to-End Tests", ginkgo.Ordered, func() {
 			ctx, cancel := withTimeout(2 * time.Minute)
 			defer cancel()
 
-			_, err := cli.CatalogLogin(ctx, cfg, catalogBackendURL, catalogUsername, catalogPassword, appRuntime, catalogInsecure)
+			_, err := cli.CatalogLogin(ctx, cfg, catalogBackendURL, catalogUsername, catalogPassword, catalogInsecure)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			logoutOutput, err := cli.CatalogLogout(ctx, cfg, appRuntime)
+			logoutOutput, err := cli.CatalogLogout(ctx, cfg)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(cli.ValidateCatalogLogoutOutput(logoutOutput)).To(gomega.Succeed())
 
-			_, whoamiErr := cli.CatalogWhoami(ctx, cfg, appRuntime)
+			_, whoamiErr := cli.CatalogWhoami(ctx, cfg)
 			gomega.Expect(whoamiErr).To(gomega.HaveOccurred(), "whoami should fail after logout but succeeded")
 			logger.Infoln("[TEST] Catalog logout invalidated session — whoami correctly rejected")
 
 			// Re-login so downstream specs retain a valid session.
-			_, err = cli.CatalogLogin(ctx, cfg, catalogBackendURL, catalogUsername, catalogPassword, appRuntime, catalogInsecure)
+			_, err = cli.CatalogLogin(ctx, cfg, catalogBackendURL, catalogUsername, catalogPassword, catalogInsecure)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			logger.Infoln("[TEST] Catalog logout / session-invalidation validated successfully!")
 		})
@@ -3332,7 +3332,7 @@ var _ = ginkgo.Describe("AI Services End-to-End Tests", ginkgo.Ordered, func() {
 			ctx, cancel := withTimeout(1 * time.Minute)
 			defer cancel()
 
-			output, err := cli.CatalogLogout(ctx, cfg, appRuntime)
+			output, err := cli.CatalogLogout(ctx, cfg)
 			if err != nil {
 				// Non-fatal: expired token or catalog already down is acceptable here.
 				logger.Warningf("[TEARDOWN] [WARNING] Catalog logout failed (non-fatal): %v\nOutput: %s", err, output)

--- a/docs/proposals/catalog/custom-service-templates-proposal.md
+++ b/docs/proposals/catalog/custom-service-templates-proposal.md
@@ -2017,7 +2017,7 @@ Custom component templates may adopt the same pattern for any key name. The `.en
 
 ```bash
 # Log in once — credentials are stored for subsequent commands
-ai-services catalog login --server https://catalog-api.<domain> --username admin --runtime podman
+ai-services catalog login --server https://catalog-api.<domain> --username admin
 
 # Package the service directory (top-level dir name is irrelevant)
 COPYFILE_DISABLE=1 tar -czf my-bundle.tar.gz my-service/


### PR DESCRIPTION
Remove --runtime dependency from catalog and application commands

- CLI commands no longer require --runtime for non-legacy paths; runtime is resolved from the application's Worker record
- catalog login/logout/whoami/hashpw/dbmigrate — --runtime removed entirely (no runtime dependency)
- Server-side silent fallbacks to local runtime replaced with hard errors throughout
- Worker field always present in application responses (removed omitempty)
- Tests, templates, and docs updated accordingly