### PR TITLE
Verifying the logs of running worker pod

### DIFF
--- a/ai-services/internal/pkg/worker/deploy/openshift/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/openshift/deploy.go
@@ -53,6 +53,10 @@ func DeployWorker(ctx context.Context, opts workertypes.OpenshiftWorkerOptions) 
 		return fmt.Errorf("failed to init runtime: %w", err)
 	}
 
+	if err := checkAndCleanExistingWorkerPods(ctx, rt, namespace); err != nil {
+		return fmt.Errorf("failed to verify existing worker pods: %w", err)
+	}
+
 	return deployWorkerHelm(ctx, chartData, values, namespace, rt)
 }
 
@@ -97,21 +101,42 @@ func deployWorkerHelm(ctx context.Context, chartData chart.Charter, values map[s
 		s.Fail("failed to deploy worker")
 
 		// Verifying worker pod logs for the error message from 'grpcstream' cmd
-		if workerErr := checkAndUninstallOnWorkerErr(ctx, rt, namespace); workerErr != nil {
-			return workerErr
+		if err := checkAndUninstallOnWorkerErr(ctx, rt, namespace); err != nil {
+			return err
 		}
 
 		return fmt.Errorf("failed to deploy worker: %w", err)
 	}
 
 	// Verifying worker pod logs for the error message from 'grpcstream' cmd
-	if workerErr := checkAndUninstallOnWorkerErr(ctx, rt, namespace); workerErr != nil {
+	if err := checkAndUninstallOnWorkerErr(ctx, rt, namespace); err != nil {
 		s.Fail("worker failed to join")
 
-		return workerErr
+		return err
 	}
 
 	s.Stop("Worker deployed successfully")
+
+	return nil
+}
+
+// checkAndCleanExistingWorkerPods checks if any worker pods are present and inspects
+// their container logs. If an error is detected or logs indicate failure, it uninstalls
+// the Helm release so setup can proceed cleanly.
+func checkAndCleanExistingWorkerPods(ctx context.Context, rt runtime.Runtime, namespace string) error {
+	pods, err := rt.ListPods(ctx, map[string][]string{
+		"label": {workerconstants.WorkerPodLabel},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list pods: %w", err)
+	}
+
+	if len(pods) > 0 {
+		logger.InfolnCtx(ctx, "Existing worker pods found, verifying container logs...")
+		if err := checkAndUninstallOnWorkerErr(ctx, rt, namespace); err != nil {
+			logger.WarningfCtx(ctx, "Existing worker pod was in a failed state (%v); uninstalled release and proceeding with setup", err)
+		}
+	}
 
 	return nil
 }

--- a/ai-services/internal/pkg/worker/deploy/openshift/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/openshift/deploy.go
@@ -53,10 +53,12 @@ func DeployWorker(ctx context.Context, opts workertypes.OpenshiftWorkerOptions) 
 		return fmt.Errorf("failed to init runtime: %w", err)
 	}
 
-	if err := checkAndCleanExistingWorkerPods(ctx, rt, namespace); err != nil {
-		return fmt.Errorf("failed to verify existing worker pods: %w", err)
+	// Step 3: Check existing worker logs; if a failure is detected, uninstall all worker components.
+	if err := deployutils.CheckLogsAndUninstall(ctx, rt); err != nil {
+		return err
 	}
 
+	// Step4: Deploy worker helm chart
 	return deployWorkerHelm(ctx, chartData, values, namespace, rt)
 }
 
@@ -101,7 +103,7 @@ func deployWorkerHelm(ctx context.Context, chartData chart.Charter, values map[s
 		s.Fail("failed to deploy worker")
 
 		// Verifying worker pod logs for the error message from 'grpcstream' cmd
-		if err := checkAndUninstallOnWorkerErr(ctx, rt, namespace); err != nil {
+		if err := deployutils.CheckLogsAndUninstall(ctx, rt); err != nil {
 			return err
 		}
 
@@ -109,50 +111,13 @@ func deployWorkerHelm(ctx context.Context, chartData chart.Charter, values map[s
 	}
 
 	// Verifying worker pod logs for the error message from 'grpcstream' cmd
-	if err := checkAndUninstallOnWorkerErr(ctx, rt, namespace); err != nil {
+	if err := deployutils.CheckLogsAndUninstall(ctx, rt); err != nil {
 		s.Fail("worker failed to join")
 
 		return err
 	}
 
 	s.Stop("Worker deployed successfully")
-
-	return nil
-}
-
-// checkAndCleanExistingWorkerPods checks if any worker pods are present and inspects
-// their container logs. If an error is detected or logs indicate failure, it uninstalls
-// the Helm release so setup can proceed cleanly.
-func checkAndCleanExistingWorkerPods(ctx context.Context, rt runtime.Runtime, namespace string) error {
-	pods, err := rt.ListPods(ctx, map[string][]string{
-		"label": {workerconstants.WorkerPodLabel},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to list pods: %w", err)
-	}
-
-	if len(pods) > 0 {
-		logger.InfolnCtx(ctx, "Existing worker pods found, verifying container logs...")
-		if err := checkAndUninstallOnWorkerErr(ctx, rt, namespace); err != nil {
-			logger.WarningfCtx(ctx, "Existing worker pod was in a failed state (%v); uninstalled release and proceeding with setup", err)
-		}
-	}
-
-	return nil
-}
-
-// checkAndUninstallOnWorkerErr checks the worker container logs for a gRPC join
-// error. If a join error is found, it uninstalls the Helm release before
-// returning the error so the namespace is left clean for a retry.
-func checkAndUninstallOnWorkerErr(ctx context.Context, rt runtime.Runtime, namespace string) error {
-	if workerErr := deployutils.CheckWorkerContainerLogs(ctx, rt); workerErr != nil {
-		uninstallErr := helm.UninstallRelease(ctx, workerconstants.WorkerHelmReleaseName, namespace)
-		if uninstallErr != nil {
-			logger.ErrorfCtx(ctx, "failed to delete '%s' release: %v\n", workerconstants.WorkerHelmReleaseName, uninstallErr)
-		}
-
-		return workerErr
-	}
 
 	return nil
 }

--- a/ai-services/internal/pkg/worker/deploy/podman/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/podman/deploy.go
@@ -193,8 +193,6 @@ func CheckStatus(ctx context.Context, rt runtime.Runtime, tp templates.Template)
 		workerResourceCount--
 	}
 
-	
-
 	return len(existingResources) == workerResourceCount, existingResources, nil
 }
 

--- a/ai-services/internal/pkg/worker/deploy/podman/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/podman/deploy.go
@@ -72,8 +72,9 @@ func DeployWorker(ctx context.Context, opts workertypes.PodmanWorkerOptions) err
 
 	tp := templates.NewEmbedTemplateProvider(&assets.WorkerFS, "")
 
-	if err := checkAndCleanExistingWorkerPods(ctx, rt); err != nil {
-		return fmt.Errorf("failed to verify existing worker pods: %w", err)
+	// Check existing worker logs; if a failure is detected, uninstall all worker components.
+	if err := deployutils.CheckLogsAndUninstall(ctx, rt); err != nil {
+		return err
 	}
 
 	deployed, existingResource, err := CheckStatus(ctx, rt, tp)
@@ -106,9 +107,7 @@ func DeployWorker(ctx context.Context, opts workertypes.PodmanWorkerOptions) err
 		return err
 	}
 
-	if err := deployutils.CheckWorkerContainerLogs(ctx, rt); err != nil {
-		cleanupFailedWorkerPods(ctx, rt)
-
+	if err := deployutils.CheckLogsAndUninstall(ctx, rt); err != nil {
 		return err
 	}
 
@@ -117,44 +116,6 @@ func DeployWorker(ctx context.Context, opts workertypes.PodmanWorkerOptions) err
 	return nil
 }
 
-// checkAndCleanExistingWorkerPods checks if any worker pods are present and inspects
-// their container logs. If an error is detected or logs indicate failure, it cleans up
-// the failed pods so setup can proceed cleanly.
-func checkAndCleanExistingWorkerPods(ctx context.Context, rt runtime.Runtime) error {
-	pods, err := rt.ListPods(ctx, map[string][]string{
-		"label": {workerconstants.WorkerPodLabel},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to list pods: %w", err)
-	}
-
-	if len(pods) > 0 {
-		logger.InfolnCtx(ctx, "Existing worker pods found, verifying container logs...")
-		if err := deployutils.CheckWorkerContainerLogs(ctx, rt); err != nil {
-			logger.WarningfCtx(ctx, "Existing worker pod is in a failed state (%v); deleting pod and proceeding with setup", err)
-			cleanupFailedWorkerPods(ctx, rt)
-		}
-	}
-
-	return nil
-}
-
-// cleanupFailedWorkerPods deletes all worker pods after a failed join attempt.
-func cleanupFailedWorkerPods(ctx context.Context, rt runtime.Runtime) {
-	pods, listErr := rt.ListPods(ctx, map[string][]string{"label": {workerconstants.WorkerPodLabel}})
-	if listErr != nil {
-		logger.ErrorfCtx(ctx, "failed to list worker pods for cleanup: %v\n", listErr)
-
-		return
-	}
-
-	for _, pod := range pods {
-		logger.InfofCtx(ctx, "Deleting '%s' pod, as worker failed to join", pod.Name)
-		if delErr := rt.DeletePod(ctx, pod.ID, utils.BoolPtr(true)); delErr != nil {
-			logger.ErrorfCtx(ctx, "failed to delete worker pod %s: %v\n", pod.Name, delErr)
-		}
-	}
-}
 
 // CheckStatus checks whether the worker node is already deployed by listing
 // pods with the worker proxy and worker pod labels.

--- a/ai-services/internal/pkg/worker/deploy/podman/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/podman/deploy.go
@@ -72,6 +72,10 @@ func DeployWorker(ctx context.Context, opts workertypes.PodmanWorkerOptions) err
 
 	tp := templates.NewEmbedTemplateProvider(&assets.WorkerFS, "")
 
+	if err := checkAndCleanExistingWorkerPods(ctx, rt); err != nil {
+		return fmt.Errorf("failed to verify existing worker pods: %w", err)
+	}
+
 	deployed, existingResource, err := CheckStatus(ctx, rt, tp)
 	if err != nil {
 		return err
@@ -109,6 +113,28 @@ func DeployWorker(ctx context.Context, opts workertypes.PodmanWorkerOptions) err
 	}
 
 	logger.InfolnCtx(ctx, "Worker node setup complete.")
+
+	return nil
+}
+
+// checkAndCleanExistingWorkerPods checks if any worker pods are present and inspects
+// their container logs. If an error is detected or logs indicate failure, it cleans up
+// the failed pods so setup can proceed cleanly.
+func checkAndCleanExistingWorkerPods(ctx context.Context, rt runtime.Runtime) error {
+	pods, err := rt.ListPods(ctx, map[string][]string{
+		"label": {workerconstants.WorkerPodLabel},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list pods: %w", err)
+	}
+
+	if len(pods) > 0 {
+		logger.InfolnCtx(ctx, "Existing worker pods found, verifying container logs...")
+		if err := deployutils.CheckWorkerContainerLogs(ctx, rt); err != nil {
+			logger.WarningfCtx(ctx, "Existing worker pod is in a failed state (%v); deleting pod and proceeding with setup", err)
+			cleanupFailedWorkerPods(ctx, rt)
+		}
+	}
 
 	return nil
 }
@@ -166,6 +192,8 @@ func CheckStatus(ctx context.Context, rt runtime.Runtime, tp templates.Template)
 		// as resource is created based on optional flag (--ssl-cert and --ssl-key)
 		workerResourceCount--
 	}
+
+	
 
 	return len(existingResources) == workerResourceCount, existingResources, nil
 }

--- a/ai-services/internal/pkg/worker/deploy/podman/deploy.go
+++ b/ai-services/internal/pkg/worker/deploy/podman/deploy.go
@@ -116,7 +116,6 @@ func DeployWorker(ctx context.Context, opts workertypes.PodmanWorkerOptions) err
 	return nil
 }
 
-
 // CheckStatus checks whether the worker node is already deployed by listing
 // pods with the worker proxy and worker pod labels.
 // Returns (true, existingResources, nil) when all worker pods are already running.

--- a/ai-services/internal/pkg/worker/deploy/utils/utils.go
+++ b/ai-services/internal/pkg/worker/deploy/utils/utils.go
@@ -7,8 +7,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
+	workeruninstall "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall"
+	workeruninstallutils "github.com/project-ai-services/ai-services/internal/pkg/worker/uninstall/utils"
 )
 
 const (
@@ -36,6 +39,25 @@ func CheckWorkerContainerLogs(ctx context.Context, rt runtime.Runtime) error {
 		if err := pollPodLogs(ctx, rt, pod.Name, deadline); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// CheckLogsAndUninstall checks worker container logs and, on failure, runs Uninstall
+// to clean up all worker components before returning the combined error.
+func CheckLogsAndUninstall(ctx context.Context, rt runtime.Runtime) error {
+	if err := CheckWorkerContainerLogs(ctx, rt); err != nil {
+		logger.WarningfCtx(ctx, "Worker container logs indicate a failure (%v); uninstalling worker components...\n", err)
+
+		if uninstallErr := workeruninstall.Uninstall(ctx, workeruninstallutils.UninstallOptions{
+			RuntimeType: rt.Type(),
+			AutoYes:     true,
+		}); uninstallErr != nil {
+			return fmt.Errorf("%w; worker uninstall: %w", err, uninstallErr)
+		}
+
+		return err
 	}
 
 	return nil

--- a/ai-services/internal/pkg/worker/deploy/utils/utils.go
+++ b/ai-services/internal/pkg/worker/deploy/utils/utils.go
@@ -48,7 +48,7 @@ func CheckWorkerContainerLogs(ctx context.Context, rt runtime.Runtime) error {
 // to clean up all worker components before returning the combined error.
 func CheckLogsAndUninstall(ctx context.Context, rt runtime.Runtime) error {
 	if err := CheckWorkerContainerLogs(ctx, rt); err != nil {
-		logger.WarningfCtx(ctx, "Worker container logs indicate a failure (%v); uninstalling worker components...\n", err)
+		logger.WarningfCtx(ctx, "Worker container logs indicate a failure uninstalling worker components...\n")
 
 		if uninstallErr := workeruninstall.Uninstall(ctx, workeruninstallutils.UninstallOptions{
 			RuntimeType: rt.Type(),

--- a/ai-services/internal/pkg/worker/join/join.go
+++ b/ai-services/internal/pkg/worker/join/join.go
@@ -211,6 +211,12 @@ func runStreamLoop(ctx context.Context, rt runtime.Runtime, pr *workercaddy.Prox
 				"and 'worker join' to reconnect: %w", err)
 		}
 
+		// Non-transient errors will not resolve on their own — retrying would
+		// loop forever without any chance of recovery.
+		if !isTransient(err) {
+			return fmt.Errorf("worker join: permanent stream error, not retrying: %w", err)
+		}
+
 		logger.WarningfCtx(ctx, "CommandStream disconnected (%v) — retrying in %s...\n", err, backoff)
 
 		select {
@@ -391,6 +397,45 @@ func sendHeartbeat(stream grpc.BidiStreamingClient[workerpb.CommandResult, worke
 // isUnauthenticated reports whether err carries gRPC status Unauthenticated.
 func isUnauthenticated(err error) bool {
 	return status.Code(err) == codes.Unauthenticated
+}
+
+// isTransient reports whether a CommandStream error is worth retrying.
+//
+// Transient errors are temporary conditions that can resolve without operator
+// intervention:
+//
+//   - codes.Unavailable       — gateway pod restarting, network blip, or load
+//     balancer dropped the connection.
+//   - codes.DeadlineExceeded  — gateway was slow accepting the stream open.
+//   - codes.ResourceExhausted — gateway is rate-limiting or at max concurrent
+//     streams; backing off and retrying is the correct response.
+//   - codes.Internal          — gateway panicked mid-stream and closed it; a
+//     fresh stream to a healthy replica is likely to succeed.
+//
+// Permanent errors will not resolve without operator action and must not be
+// retried — doing so would loop forever:
+//
+//   - codes.PermissionDenied    — mTLS certificate was revoked or the gateway
+//     explicitly denied this worker identity.
+//   - codes.NotFound            — the CommandStream RPC does not exist at the
+//     given address (wrong gateway version or wrong address entirely).
+//   - codes.Unimplemented       — the WorkerGateway service is not registered
+//     on that server.
+//   - codes.FailedPrecondition  — gateway rejected the stream due to a logic
+//     precondition (e.g. worker not in an expected state).
+//   - codes.Unauthenticated     — handled separately by the caller via
+//     isUnauthenticated; included here for completeness.
+//   - io.EOF on stream open     — gateway accepted the TCP connection but
+//     closed the stream immediately on every attempt; will not self-heal.
+func isTransient(err error) bool {
+	switch status.Code(err) {
+	case codes.Unavailable,
+		codes.DeadlineExceeded,
+		codes.ResourceExhausted,
+		codes.Internal:
+		return true
+	}
+	return false
 }
 
 // Made with Bob

--- a/ai-services/internal/pkg/worker/join/join.go
+++ b/ai-services/internal/pkg/worker/join/join.go
@@ -51,6 +51,10 @@ const (
 
 	// retryBackoffFactor is the exponential multiplier applied to the backoff duration.
 	retryBackoffFactor = 2
+
+	// retryMaxAttempts is the maximum number of reconnect attempts before
+	// giving up, even for transient errors.
+	retryMaxAttempts = 10
 )
 
 // StartGrpcStream dials the catalog gRPC worker-gateway, registers with the
@@ -188,6 +192,7 @@ func connectAndStream(ctx context.Context, rt runtime.Runtime, pr *workercaddy.P
 // reconnecting.
 func runStreamLoop(ctx context.Context, rt runtime.Runtime, pr *workercaddy.ProxyRouter, client workerpb.WorkerGatewayClient, workerName string) error {
 	backoff := retryBase
+	attempts := 0
 
 	for {
 		if ctx.Err() != nil {
@@ -217,7 +222,12 @@ func runStreamLoop(ctx context.Context, rt runtime.Runtime, pr *workercaddy.Prox
 			return fmt.Errorf("worker join: permanent stream error, not retrying: %w", err)
 		}
 
-		logger.WarningfCtx(ctx, "CommandStream disconnected (%v) — retrying in %s...\n", err, backoff)
+		attempts++
+		if attempts >= retryMaxAttempts {
+			return fmt.Errorf("CommandStream failed to connect after %d attempts, giving up: %w", attempts, err)
+		}
+
+		logger.WarningfCtx(ctx, "CommandStream disconnected (%v) — retrying in %s (attempt %d/%d)...\n", err, backoff, attempts, retryMaxAttempts)
 
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
- `Pre-flight Pod Verification`: When re-running worker join, checks whether existing worker pods are present and inspects their container logs.
- **`Automatic Cleanup on Failure`**: If an existing pod is found in an error/failed state, it deletes the pod (or uninstalls the Helm release).
- `Clean Re-deployment`: Allows the setup flow to proceed smoothly with a fresh deployment instead of failing due to stale resources.