### PR TITLE
use registered worker name case instead of lowering

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.356
+TAG?=v0.0.357
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.356
+  image: icr.io/ai-services-cicd/ai-services:v0.0.357
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.356
+  image: icr.io/ai-services-cicd/ai-services:v0.0.357
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.356
+  image: icr.io/ai-services-cicd/ai-services:v0.0.357
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.356
+  image: icr.io/ai-services-cicd/ai-services:v0.0.357
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/cmd/ai-services/cmd/application/create.go
+++ b/ai-services/cmd/ai-services/cmd/application/create.go
@@ -625,7 +625,7 @@ func resolveDeployRuntimeType(ctx context.Context) (runtimeTypes.RuntimeType, er
 	}
 
 	for _, w := range workers {
-		if w.Name == workerName {
+		if strings.EqualFold(w.Name, workerName) {
 			if w.RuntimeType == "" {
 				return "", fmt.Errorf("worker %q has no runtime type", workerName)
 			}

--- a/ai-services/docs/docs.go
+++ b/ai-services/docs/docs.go
@@ -4214,9 +4214,7 @@ const docTemplate = `{
             ],
             "properties": {
                 "worker_name": {
-                    "type": "string",
-                    "maxLength": 100,
-                    "minLength": 1
+                    "type": "string"
                 }
             }
         },

--- a/ai-services/docs/swagger.json
+++ b/ai-services/docs/swagger.json
@@ -4208,9 +4208,7 @@
             ],
             "properties": {
                 "worker_name": {
-                    "type": "string",
-                    "maxLength": 100,
-                    "minLength": 1
+                    "type": "string"
                 }
             }
         },

--- a/ai-services/docs/swagger.yaml
+++ b/ai-services/docs/swagger.yaml
@@ -995,8 +995,6 @@ definitions:
   internal_pkg_catalog_apiserver_handlers.createWorkerReq:
     properties:
       worker_name:
-        maxLength: 100
-        minLength: 1
         type: string
     required:
     - worker_name

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
@@ -34,7 +34,7 @@ func NewWorkerHandler(reg *registry.Registry, repo repository.WorkerRepository, 
 
 // createWorkerReq is the request body for registering a new worker.
 type createWorkerReq struct {
-	WorkerName string `json:"worker_name" binding:"required,min=1,max=100"`
+	WorkerName string `json:"worker_name" binding:"required,max=64"`
 }
 
 // createWorkerResp is the response body for a newly registered worker.
@@ -66,11 +66,15 @@ func (h *WorkerHandler) CreateWorker(c *gin.Context) {
 		return
 	}
 
-	// Normalise: trim surrounding whitespace and lowercase so that
-	// "Worker-A", "worker-a", and " worker-a " all resolve to the same name.
-	req.WorkerName = strings.ToLower(strings.TrimSpace(req.WorkerName))
-	if req.WorkerName == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "worker_name must not be blank"})
+	// Normalise: trim surrounding whitespace only. Case is preserved so that
+	// the DB row and in-memory entry reflect the name as the operator gave it.
+	// All lookups use case-insensitive comparison so "Worker-A" and "worker-a"
+	// resolve to the same entry regardless of how it was registered.
+	req.WorkerName = strings.TrimSpace(req.WorkerName)
+	// Re-check length after trimming: a value like "  ab  " passes the binder
+	// (raw length ≤ 64) but may be too short once whitespace is removed.
+	if len(req.WorkerName) < 3 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "worker_name must be between 3 and 64 characters"})
 
 		return
 	}
@@ -78,7 +82,8 @@ func (h *WorkerHandler) CreateWorker(c *gin.Context) {
 	// "Local" is reserved for the catalog-machine worker registered by the
 	// configure flow. It is only allowed when LOCAL_WORKER=true, meaning this
 	// catalog instance is configured to host a co-located worker.
-	// Preserve the canonical casing so the DB row matches LocalWorkerName exactly.
+	// Normalise to the canonical casing so the DB row and token store always
+	// use "Local" regardless of how the operator typed it.
 	if strings.EqualFold(req.WorkerName, workerconstants.LocalWorkerName) {
 		if utils.GetEnv(workerconstants.LocalWorkerEnvVar, "") != "true" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("worker name %q is reserved", req.WorkerName)})

--- a/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
+++ b/ai-services/internal/pkg/catalog/apiserver/handlers/worker_handler.go
@@ -19,6 +19,13 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/registry"
 )
 
+const (
+	// workerNameMinLen is the minimum allowed length for a worker name after trimming whitespace.
+	workerNameMinLen = 3
+	// workerNameMaxLen is the maximum allowed length for a worker name after trimming whitespace.
+	workerNameMaxLen = 64
+)
+
 // WorkerHandler handles worker management endpoints.
 type WorkerHandler struct {
 	reg         *registry.Registry
@@ -34,7 +41,7 @@ func NewWorkerHandler(reg *registry.Registry, repo repository.WorkerRepository, 
 
 // createWorkerReq is the request body for registering a new worker.
 type createWorkerReq struct {
-	WorkerName string `json:"worker_name" binding:"required,max=64"`
+	WorkerName string `json:"worker_name" binding:"required"`
 }
 
 // createWorkerResp is the response body for a newly registered worker.
@@ -71,10 +78,8 @@ func (h *WorkerHandler) CreateWorker(c *gin.Context) {
 	// All lookups use case-insensitive comparison so "Worker-A" and "worker-a"
 	// resolve to the same entry regardless of how it was registered.
 	req.WorkerName = strings.TrimSpace(req.WorkerName)
-	// Re-check length after trimming: a value like "  ab  " passes the binder
-	// (raw length ≤ 64) but may be too short once whitespace is removed.
-	if len(req.WorkerName) < 3 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "worker_name must be between 3 and 64 characters"})
+	if len(req.WorkerName) < workerNameMinLen || len(req.WorkerName) > workerNameMaxLen {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "worker name must be between 3 and 64 characters"})
 
 		return
 	}

--- a/ai-services/internal/pkg/catalog/client/worker.go
+++ b/ai-services/internal/pkg/catalog/client/worker.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	catalogtypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
@@ -100,7 +101,7 @@ func (c *WorkerClient) DeleteWorkerByName(ctx context.Context, name string) erro
 	}
 
 	for _, w := range workers {
-		if w.Name == name {
+		if strings.EqualFold(w.Name, name) {
 			return c.deleteWorkerByID(ctx, w.ID)
 		}
 	}

--- a/ai-services/internal/pkg/catalog/db/repository/worker_repo.go
+++ b/ai-services/internal/pkg/catalog/db/repository/worker_repo.go
@@ -234,11 +234,13 @@ func (r *workerRepo) GetByID(ctx context.Context, id uuid.UUID) (*models.Worker,
 }
 
 // GetByName returns the worker with the given name, or (nil, nil) if not found.
+// The match is case-insensitive so "Worker-A" and "worker-a" resolve to the
+// same row regardless of how the name was stored.
 func (r *workerRepo) GetByName(ctx context.Context, name string) (*models.Worker, error) {
 	query := `
 		SELECT id, name, runtime_type, status, message, last_heartbeat, metadata, registered_at, updated_at
 		FROM workers
-		WHERE name = $1
+		WHERE LOWER(name) = LOWER($1)
 	`
 
 	var (

--- a/ai-services/internal/pkg/worker/registry/registry.go
+++ b/ai-services/internal/pkg/worker/registry/registry.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -120,8 +121,9 @@ func (r *Registry) Register(ctx context.Context, workerName, runtimeType string,
 		return nil, fmt.Errorf("%w: %q", ErrUnsupportedRuntimeType, runtimeType)
 	}
 
+	k := workerKey(workerName)
 	r.mu.Lock()
-	if _, exists := r.workers[workerName]; exists {
+	if _, exists := r.workers[k]; exists {
 		r.mu.Unlock()
 
 		return nil, fmt.Errorf("%w: %s", ErrWorkerAlreadyActive, workerName)
@@ -134,7 +136,7 @@ func (r *Registry) Register(ctx context.Context, workerName, runtimeType string,
 		CommandCh:   make(chan *workerpb.Command, commandChannelSize),
 		results:     make(map[string]chan *workerpb.CommandResult),
 	}
-	r.workers[workerName] = entry
+	r.workers[k] = entry
 	r.mu.Unlock()
 
 	if r.repo != nil {
@@ -171,9 +173,10 @@ func (r *Registry) Register(ctx context.Context, workerName, runtimeType string,
 //
 // On success the DB status is updated to ready and the new entry is returned.
 func (r *Registry) Restore(ctx context.Context, workerName string) (*WorkerEntry, error) {
+	k := workerKey(workerName)
 	// Fast path: already in memory (e.g. concurrent reconnect races).
 	r.mu.RLock()
-	if entry, ok := r.workers[workerName]; ok {
+	if entry, ok := r.workers[k]; ok {
 		r.mu.RUnlock()
 
 		return entry, nil
@@ -196,7 +199,7 @@ func (r *Registry) Restore(ctx context.Context, workerName string) (*WorkerEntry
 
 	entry := &WorkerEntry{
 		DBID:        w.ID,
-		WorkerName:  workerName,
+		WorkerName:  w.Name, // use the DB-stored casing, not the caller-supplied name
 		RuntimeType: string(w.RuntimeType),
 		Metadata:    metadataToString(w.Metadata),
 		CommandCh:   make(chan *workerpb.Command, commandChannelSize),
@@ -205,12 +208,12 @@ func (r *Registry) Restore(ctx context.Context, workerName string) (*WorkerEntry
 
 	r.mu.Lock()
 	// Re-check under write lock to guard against a concurrent Restore.
-	if existing, ok := r.workers[workerName]; ok {
+	if existing, ok := r.workers[k]; ok {
 		r.mu.Unlock()
 
 		return existing, nil
 	}
-	r.workers[workerName] = entry
+	r.workers[k] = entry
 	r.mu.Unlock()
 
 	if err := r.repo.Update(ctx, w.ID, repository.WorkerUpdate{Status: utils.Ptr(models.WorkerStatusReady), Message: utils.Ptr("")}); err != nil {
@@ -234,7 +237,7 @@ func (r *Registry) Preregister(ctx context.Context, workerName string) (string, 
 	}
 
 	// Evict any live in-memory entry so UpdateHeartbeat stops updating the row
-	// we are about to reset to pending.
+	// we are about to reset to pending. Disconnect normalises the key itself.
 	r.Disconnect(ctx, workerName)
 
 	w := &models.Worker{
@@ -262,7 +265,7 @@ func (r *Registry) List(ctx context.Context) ([]models.Worker, error) {
 func (r *Registry) Get(workerName string) (*WorkerEntry, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	e, ok := r.workers[workerName]
+	e, ok := r.workers[workerKey(workerName)]
 
 	return e, ok
 }
@@ -270,10 +273,11 @@ func (r *Registry) Get(workerName string) (*WorkerEntry, bool) {
 // Disconnect removes the worker from the in-memory map and marks it disconnected in the DB.
 // The DB row is kept so the worker can reconnect and its history is preserved.
 func (r *Registry) Disconnect(ctx context.Context, workerName string) {
+	k := workerKey(workerName)
 	r.mu.Lock()
-	entry, ok := r.workers[workerName]
+	entry, ok := r.workers[k]
 	if ok {
-		delete(r.workers, workerName)
+		delete(r.workers, k)
 	}
 	r.mu.Unlock()
 
@@ -331,7 +335,7 @@ func (r *Registry) UpdateHeartbeat(ctx context.Context, workerName string) {
 	}
 
 	r.mu.RLock()
-	entry, ok := r.workers[workerName]
+	entry, ok := r.workers[workerKey(workerName)]
 	r.mu.RUnlock()
 
 	if !ok || entry.DBID == uuid.Nil {
@@ -373,7 +377,7 @@ func (r *Registry) Deregister(ctx context.Context, id uuid.UUID) (bool, error) {
 // DeliverResult routes an incoming CommandResult to the waiting RemoteRuntime call.
 func (r *Registry) DeliverResult(res *workerpb.CommandResult) {
 	r.mu.RLock()
-	entry, ok := r.workers[res.GetWorkerName()]
+	entry, ok := r.workers[workerKey(res.GetWorkerName())]
 	r.mu.RUnlock()
 	if ok {
 		entry.deliverResult(res)
@@ -383,7 +387,7 @@ func (r *Registry) DeliverResult(res *workerpb.CommandResult) {
 // WaitForResult returns a channel that will receive the result for commandID on workerName.
 func (r *Registry) WaitForResult(workerName, commandID string) (chan *workerpb.CommandResult, error) {
 	r.mu.RLock()
-	entry, ok := r.workers[workerName]
+	entry, ok := r.workers[workerKey(workerName)]
 	r.mu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("worker %s not connected", workerName)
@@ -396,7 +400,7 @@ func (r *Registry) WaitForResult(workerName, commandID string) (chan *workerpb.C
 // It satisfies the stream.WorkerRegistry interface.
 func (r *Registry) WorkerCommandChannel(workerName string) (chan *workerpb.Command, bool) {
 	r.mu.RLock()
-	entry, ok := r.workers[workerName]
+	entry, ok := r.workers[workerKey(workerName)]
 	r.mu.RUnlock()
 	if !ok {
 		return nil, false
@@ -409,7 +413,7 @@ func (r *Registry) WorkerCommandChannel(workerName string) (chan *workerpb.Comma
 // It satisfies the stream.WorkerRegistry interface.
 func (r *Registry) WorkerRuntimeType(workerName string) (string, bool) {
 	r.mu.RLock()
-	entry, ok := r.workers[workerName]
+	entry, ok := r.workers[workerKey(workerName)]
 	r.mu.RUnlock()
 	if !ok {
 		return "", false
@@ -422,7 +426,7 @@ func (r *Registry) WorkerRuntimeType(workerName string) (string, bool) {
 // It satisfies the stream.WorkerRegistry interface.
 func (r *Registry) WorkerMetadata(workerName string) (map[string]string, bool) {
 	r.mu.RLock()
-	entry, ok := r.workers[workerName]
+	entry, ok := r.workers[workerKey(workerName)]
 	r.mu.RUnlock()
 	if !ok {
 		return nil, false
@@ -435,7 +439,7 @@ func (r *Registry) WorkerMetadata(workerName string) (map[string]string, bool) {
 // time. Returns (uuid.Nil, false) if the worker is not currently connected.
 func (r *Registry) WorkerID(workerName string) (uuid.UUID, bool) {
 	r.mu.RLock()
-	entry, ok := r.workers[workerName]
+	entry, ok := r.workers[workerKey(workerName)]
 	r.mu.RUnlock()
 	if !ok {
 		return uuid.Nil, false
@@ -451,9 +455,9 @@ func (r *Registry) WorkerNameByID(id uuid.UUID) (string, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	for name, entry := range r.workers {
+	for _, entry := range r.workers {
 		if entry.DBID == id {
-			return name, true
+			return entry.WorkerName, true
 		}
 	}
 
@@ -468,7 +472,7 @@ func (r *Registry) WorkerNameByID(id uuid.UUID) (string, bool) {
 // It satisfies the stream.WorkerRegistry interface.
 func (r *Registry) IsWorkerConnected(ctx context.Context, workerName string) bool {
 	r.mu.RLock()
-	_, inCache := r.workers[workerName]
+	_, inCache := r.workers[workerKey(workerName)]
 	r.mu.RUnlock()
 
 	if !inCache {
@@ -490,6 +494,12 @@ func (r *Registry) IsWorkerConnected(ctx context.Context, workerName string) boo
 // ──────────────────────────────────────────────────────────────────────────────
 // Internal helpers
 // ──────────────────────────────────────────────────────────────────────────────
+
+// workerKey returns the canonical map key for a worker name: lowercase of name.
+// The WorkerEntry.WorkerName field always stores the original casing.
+func workerKey(name string) string {
+	return strings.ToLower(name)
+}
 
 // metadataToAny converts a map[string]string (from proto) to map[string]any (for the DB model).
 func metadataToAny(m map[string]string) map[string]any {


### PR DESCRIPTION
1. Always use user provided worker name.
2. Validation check for 3-64 chars and trim spaces.