### PR TITLE
fix: WaitInferenceService method should only be called if a component is deploying isvc resource

### DIFF
--- a/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/openshift/deployer.go
+++ b/ai-services/internal/pkg/catalog/apiserver/services/deployment/repository/openshift/deployer.go
@@ -184,17 +184,19 @@ func (d *OpenShiftDeployer) deployComponent(ctx context.Context, plan *Deploymen
 
 	// KServe marks an InferenceService "Ready=True" only once the predictor pod is fully up.
 	// Helm considers the InferenceService "Current" as soon as the CRD is accepted,
-	// so we must poll the InferenceService status directly.
-	// Non-OpenShift runtimes return nil immediately (no-op).
-	isvcName := comp.ComponentType
+	// so we must poll the InferenceService status directly — but only when the
+	// chart actually deploys an InferenceService resource.
+	if catalogutils.ChartHasInferenceService(fsys, comp.CatalogPath) {
+		isvcName := comp.ComponentType
 
-	logger.InfofCtx(ctx, "Waiting for InferenceService '%s' to become ready\n", isvcName)
+		logger.InfofCtx(ctx, "Waiting for InferenceService '%s' to become ready\n", isvcName)
 
-	waitCtx, cancel := context.WithTimeout(ctx, constants.PredictorWaitTimeout)
-	defer cancel()
+		waitCtx, cancel := context.WithTimeout(ctx, constants.PredictorWaitTimeout)
+		defer cancel()
 
-	if err := d.runtime.WaitForInferenceServiceReady(waitCtx, isvcName); err != nil {
-		return fmt.Errorf("InferenceService %q is not ready yet: %w", isvcName, err)
+		if err := d.runtime.WaitForInferenceServiceReady(waitCtx, isvcName); err != nil {
+			return fmt.Errorf("InferenceService %q is not ready yet: %w", isvcName, err)
+		}
 	}
 
 	if err := d.updateComponentEndpoint(ctx, plan, comp); err != nil {

--- a/ai-services/internal/pkg/catalog/utils/deployment_utils.go
+++ b/ai-services/internal/pkg/catalog/utils/deployment_utils.go
@@ -1,8 +1,10 @@
 package utils
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io/fs"
 	"sync"
 
 	"github.com/google/uuid"
@@ -76,4 +78,32 @@ func RunConcurrently(
 	}
 
 	return nil
+}
+
+// ChartHasInferenceService reports whether any template file under catalogPath
+// in fsys declares a KServe InferenceService (i.e. contains "kind: InferenceService").
+// It is used to decide whether WaitForInferenceServiceReady must be called after
+// a Helm install — Helm marks an InferenceService "Current" as soon as the CRD is
+// accepted, but KServe only sets Ready=True once the predictor pod is fully up.
+func ChartHasInferenceService(fsys fs.FS, catalogPath string) bool {
+	found := false
+
+	_ = fs.WalkDir(fsys, catalogPath, func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || found {
+			return err
+		}
+
+		data, readErr := fs.ReadFile(fsys, p)
+		if readErr != nil {
+			return nil
+		}
+
+		if bytes.Contains(data, []byte("kind: InferenceService")) {
+			found = true
+		}
+
+		return nil
+	})
+
+	return found
 }


### PR DESCRIPTION
- Currently if a component doesnt deploy isvc it simply checks and fails if overall application deployment doesnt depend on isvc.