### PR TITLE
fix(catalog): reset worker pod on catalog --reset-podman-auth

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.359
+TAG?=v0.0.360
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.359
+  image: icr.io/ai-services-cicd/ai-services:v0.0.360
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
+++ b/ai-services/assets/catalog/podman/templates/catalog.yaml.tmpl
@@ -5,6 +5,7 @@ metadata:
   labels:
     ai-services.io/application: "{{ .AppName }}"
     ai-services.io/template: "{{ .AppTemplateName }}"
+    ai-services.io/component: "catalog"
     ai-services.io/version: "{{ .Version }}"
     ai-services.io/secret: "catalog-secret,catalog-db-encryption-secret,catalog-mtls-encryption-secret,podman-auth-secret"
     ai-services.io/secret-skip-cleanup: "true"

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.359
+  image: icr.io/ai-services-cicd/ai-services:v0.0.360
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.359
+  image: icr.io/ai-services-cicd/ai-services:v0.0.360
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.359
+  image: icr.io/ai-services-cicd/ai-services:v0.0.360
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/cmd/ai-services/cmd/mustgather/podman.go
+++ b/ai-services/cmd/ai-services/cmd/mustgather/podman.go
@@ -9,8 +9,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	cliUtils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	podmanRuntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	pkgutils "github.com/project-ai-services/ai-services/internal/pkg/utils"
@@ -94,7 +96,8 @@ func (g *podmanGatherer) gather(ctx context.Context, opts gatherOptions) (string
 func (g *podmanGatherer) resolveBaseDir(ctx context.Context, rt *podmanRuntime.PodmanClient) {
 	g.baseDir = pkgutils.GetBaseDir() // safe fallback
 
-	config, _, err := catalogUtils.GetCatalogPodConfig(ctx, rt)
+	catalogPodLabel := constants.PodComponentKey + "=" + catalogConstants.CatalogComponentValue
+	config, _, err := catalogUtils.GetCatalogPodConfig(ctx, rt, catalogPodLabel)
 	if err != nil {
 		if errors.Is(err, cliUtils.ErrPodNotFound) {
 			logger.WarninglnCtx(ctx, "Catalog backend pod is stopped — base directory resolved to default.")

--- a/ai-services/cmd/ai-services/cmd/worker/reset.go
+++ b/ai-services/cmd/ai-services/cmd/worker/reset.go
@@ -59,7 +59,8 @@ Note: Supported for podman runtime only.`,
 		ctx := cmd.Context()
 
 		if resetPodmanAuthFlag {
-			return workerpodman.ResetPodmanAuth(ctx)
+			// Delete the secret so the fresh auth.json is picked up on pod recreation.
+			return workerpodman.ResetPodmanAuth(ctx, true)
 		} else if resetCertificateFlag {
 			return workerpodman.ResetWorkerCertificate(ctx,
 				catalogUtils.SanitizeFilePath(sslCertPath),

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/helpers.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/caddy"
 	cliutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/configure/utils"
+	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	commonutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 )
@@ -16,7 +18,8 @@ import (
 // getExistingConfigFromCatalogBackend retrieves the existing configuration from the catalog pod.
 // These values are used to validate that configuration hasn't changed during reconfigure operations.
 func getExistingConfigFromCatalogBackend(ctx context.Context, rt runtime.Runtime) (*catalogUtils.PodmanConfigureOptions, error) {
-	opts, _, err := catalogUtils.GetCatalogPodConfig(ctx, rt)
+	catalogPodLabel := constants.PodComponentKey + "=" + catalogConstants.CatalogComponentValue
+	opts, _, err := catalogUtils.GetCatalogPodConfig(ctx, rt, catalogPodLabel)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get catalog pod details: %w", err)
 	}
@@ -105,7 +108,8 @@ func validateCertificateChanges(ctx context.Context, opts *catalogUtils.PodmanCo
 
 // IsCatalogServiceRunning checks if the catalog service is configured and running.
 func IsCatalogServiceRunning(ctx context.Context, rt runtime.Runtime) (bool, error) {
-	_, _, err := catalogUtils.GetCatalogPodConfig(ctx, rt)
+	catalogPodLabel := constants.PodComponentKey + "=" + catalogConstants.CatalogComponentValue
+	_, _, err := catalogUtils.GetCatalogPodConfig(ctx, rt, catalogPodLabel)
 	if err != nil {
 		if errors.Is(err, commonutils.ErrPodNotFound) {
 			logger.InfolnCtx(ctx, "Catalog service is not configured or running.")

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_certificate.go
@@ -8,6 +8,7 @@ import (
 	catalogConstant "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	podmanutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
@@ -73,7 +74,8 @@ func ResetCatalogCertificate(ctx context.Context, sslCertPath, sslKeyPath string
 // prepareCatalogOpts fetches the current catalog pod config, validates the base dir,
 // and ensures the domain has not changed relative to the new certificates.
 func prepareCatalogOpts(ctx context.Context, deployCtx *deploy.DeployContext, sslCertPath, sslKeyPath string) (*catalogUtils.PodmanConfigureOptions, error) {
-	opts, _, err := catalogUtils.GetCatalogPodConfig(ctx, deployCtx.Runtime)
+	catalogPodLabel := constants.PodComponentKey + "=" + catalogConstant.CatalogComponentValue
+	opts, _, err := catalogUtils.GetCatalogPodConfig(ctx, deployCtx.Runtime, catalogPodLabel)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get catalog pod details: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_password.go
@@ -7,6 +7,7 @@ import (
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
 	catalogConstant "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
 )
@@ -42,7 +43,8 @@ func ResetCatalogPassword(ctx context.Context) error {
 		return fmt.Errorf("failed to delete existing catalog secret: %w", err)
 	}
 
-	opts, podID, err := catalogUtils.GetCatalogPodConfig(ctx, deployCtx.Runtime)
+	catalogPodLabel := constants.PodComponentKey + "=" + catalogConstant.CatalogComponentValue
+	opts, podID, err := catalogUtils.GetCatalogPodConfig(ctx, deployCtx.Runtime, catalogPodLabel)
 	if err != nil {
 		return fmt.Errorf("failed to get existing catalog pod details: %w", err)
 	}

--- a/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
+++ b/ai-services/internal/pkg/catalog/cli/configure/podman/reset_podman_auth.go
@@ -2,13 +2,19 @@ package podman
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common/podman/deploy"
+	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
+	podmanutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
+	workerconstants "github.com/project-ai-services/ai-services/internal/pkg/worker/constants"
+	workerpodman "github.com/project-ai-services/ai-services/internal/pkg/worker/deploy/podman"
 )
 
 func ResetPodmanAuth(ctx context.Context) error {
@@ -35,7 +41,8 @@ func ResetPodmanAuth(ctx context.Context) error {
 		return fmt.Errorf("failed to delete existing catalog podman auth secret: %w", err)
 	}
 
-	opts, podID, err := catalogUtils.GetCatalogPodConfig(ctx, deployCtx.Runtime)
+	catalogPodLabel := constants.PodComponentKey + "=" + catalogConstants.CatalogComponentValue
+	opts, podID, err := catalogUtils.GetCatalogPodConfig(ctx, deployCtx.Runtime, catalogPodLabel)
 	if err != nil {
 		return fmt.Errorf("failed to get existing catalog pod details: %w", err)
 	}
@@ -51,5 +58,29 @@ func ResetPodmanAuth(ctx context.Context) error {
 		return fmt.Errorf("failed to deploy catalog pod: %w", err)
 	}
 
+	// Reset the local worker pod if one is co-located on this machine.
+	if err := resetLocalWorkerIfPresent(ctx, deployCtx.Runtime); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// resetLocalWorkerIfPresent resets the worker pod's podman auth when a local
+// worker pod is detected. If no worker pod exists the call is a no-op.
+func resetLocalWorkerIfPresent(ctx context.Context, rt runtime.Runtime) error {
+	_, _, err := podmanutils.GetPodConfig(ctx, rt, workerconstants.WorkerPodLabel)
+	if err != nil {
+		if errors.Is(err, podmanutils.ErrPodNotFound) {
+			// No local worker pod — nothing to do.
+			return nil
+		}
+
+		return fmt.Errorf("failed to check for local worker pod: %w", err)
+	}
+
+	logger.InfolnCtx(ctx, "Local worker pod detected — resetting worker podman auth...")
+
+	// Secret was already deleted by the catalog reset above; only the pod needs to be recreated.
+	return workerpodman.ResetPodmanAuth(ctx, false)
 }

--- a/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
+++ b/ai-services/internal/pkg/catalog/cli/uninstall/podman/uninstall.go
@@ -7,9 +7,10 @@ import (
 
 	clicommon "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/common"
 	cliutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/cli/uninstall/utils"
+	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	catalogUtils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
-
 	podmanutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/constants"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/podman"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
@@ -46,7 +47,8 @@ func performCleanup(ctx context.Context, rt *podman.PodmanClient, pods []types.P
 
 	// Retrieve the BaseDir from the catalog pod configuration
 	var baseDir string
-	config, _, err := catalogUtils.GetCatalogPodConfig(ctx, rt)
+	catalogPodLabel := constants.PodComponentKey + "=" + catalogConstants.CatalogComponentValue
+	config, _, err := catalogUtils.GetCatalogPodConfig(ctx, rt, catalogPodLabel)
 	if err != nil {
 		logger.Warningf("Failed to retrieve BaseDir from catalog pod: %v. Using default BaseDir.\n", err)
 		baseDir = utils.GetBaseDir()

--- a/ai-services/internal/pkg/catalog/constants/catalog.go
+++ b/ai-services/internal/pkg/catalog/constants/catalog.go
@@ -63,6 +63,10 @@ const (
 	// CatalogAPIRouteKey is the routeURLs map key for the catalog backend API URL,
 	// populated by caddy.RegisterCatalogRoutes during podman configure.
 	CatalogAPIRouteKey = "CATALOG_API_ROUTE"
+
+	// CatalogComponentValue is the ai-services.io/component label value
+	// stamped on the catalog pod.
+	CatalogComponentValue = "catalog"
 )
 
 // Pagination constants.

--- a/ai-services/internal/pkg/catalog/utils/common.go
+++ b/ai-services/internal/pkg/catalog/utils/common.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	catalogConstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	cliutils "github.com/project-ai-services/ai-services/internal/pkg/cli/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/helm"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
@@ -46,10 +45,8 @@ type OpenShiftConfigureOptions struct {
 
 // GetCatalogPodConfig retrieves catalog pod configuration by inspecting the running pod and its containers.
 // It extracts environment variables like AI_SERVICES_BASE_DIR, DOMAIN_SUFFIX, and CADDY_HTTPS_PORT.
-func GetCatalogPodConfig(ctx context.Context, rt runtime.Runtime) (*PodmanConfigureOptions, string, error) {
-	label := fmt.Sprintf("%s=%s", catalogConstants.CatalogSecretLabel, catalogConstants.CatalogSecretName)
-
-	podmanOpts, podID, err := cliutils.GetPodConfig(ctx, rt, label)
+func GetCatalogPodConfig(ctx context.Context, rt runtime.Runtime, podLabel string) (*PodmanConfigureOptions, string, error) {
+	podmanOpts, podID, err := cliutils.GetPodConfig(ctx, rt, podLabel)
 	if err != nil {
 		return nil, "", err
 	}

--- a/ai-services/internal/pkg/cli/utils/podman.go
+++ b/ai-services/internal/pkg/cli/utils/podman.go
@@ -243,6 +243,16 @@ func CleanupSkippedResources(ctx context.Context, rt runtime.Runtime, secretsToS
 	return DeleteVolumes(ctx, rt, volumesToSkip)
 }
 
+// DeletePod force-deletes the named pod.
+func DeletePod(ctx context.Context, rt runtime.Runtime, podName string) error {
+	logger.InfofCtx(ctx, "Deleting existing pod %s", podName)
+	if err := rt.DeletePod(ctx, podName, utils.BoolPtr(true)); err != nil {
+		return fmt.Errorf("failed to delete existing pod %s: %w", podName, err)
+	}
+
+	return nil
+}
+
 // DeleteSecretAndPod deletes the named secret and then force-deletes the named pod.
 // It is used during certificate reset operations to remove the existing secret and
 // pod before redeployment with new credentials.
@@ -252,12 +262,7 @@ func DeleteSecretAndPod(ctx context.Context, rt runtime.Runtime, secretName, pod
 		return fmt.Errorf("failed to delete existing secret %s: %w", secretName, err)
 	}
 
-	logger.InfofCtx(ctx, "Deleting existing pod %s", podName)
-	if err := rt.DeletePod(ctx, podName, utils.BoolPtr(true)); err != nil {
-		return fmt.Errorf("failed to delete existing pod %s: %w", podName, err)
-	}
-
-	return nil
+	return DeletePod(ctx, rt, podName)
 }
 
 // LoadCertificatesToCaddy checks Caddy health and loads SSL certificates.

--- a/ai-services/internal/pkg/constants/annotations.go
+++ b/ai-services/internal/pkg/constants/annotations.go
@@ -10,5 +10,5 @@ const (
 	PrerequisiteLabelKey     = "ai-services.io/prerequisite"
 	ComponentLabelKey        = "ai-services.io/component-type"
 	EndpointTypeLabelKey     = "ai-services.io/endpoint-type"
-	PodComponentKey = "ai-services.io/component"
+	PodComponentKey          = "ai-services.io/component"
 )

--- a/ai-services/internal/pkg/constants/annotations.go
+++ b/ai-services/internal/pkg/constants/annotations.go
@@ -10,4 +10,5 @@ const (
 	PrerequisiteLabelKey     = "ai-services.io/prerequisite"
 	ComponentLabelKey        = "ai-services.io/component-type"
 	EndpointTypeLabelKey     = "ai-services.io/endpoint-type"
+	PodComponentKey = "ai-services.io/component"
 )

--- a/ai-services/internal/pkg/worker/deploy/podman/reset_podman_auth.go
+++ b/ai-services/internal/pkg/worker/deploy/podman/reset_podman_auth.go
@@ -12,7 +12,8 @@ import (
 	workertypes "github.com/project-ai-services/ai-services/internal/pkg/worker/types"
 )
 
-func ResetPodmanAuth(ctx context.Context) error {
+// ResetPodmanAuth resets the worker pod's podman auth.
+func ResetPodmanAuth(ctx context.Context, deleteSecret bool) error {
 	rt, err := runtime.CreateRuntime(types.RuntimeTypePodman, "")
 	if err != nil {
 		return fmt.Errorf("worker reset: init runtime: %w", err)
@@ -26,9 +27,15 @@ func ResetPodmanAuth(ctx context.Context) error {
 		return fmt.Errorf("failed to get existing worker pod details: %w", err)
 	}
 
-	// 2. Delete the podman auth secret and worker pod.
-	if err := podmanutils.DeleteSecretAndPod(ctx, rt, constants.PodmanAuthSecret, podID); err != nil {
-		return err
+	// 2. Optionally delete the podman auth secret, always delete the worker pod.
+	if deleteSecret {
+		if err := podmanutils.DeleteSecretAndPod(ctx, rt, constants.PodmanAuthSecret, podID); err != nil {
+			return err
+		}
+	} else {
+		if err := podmanutils.DeletePod(ctx, rt, podID); err != nil {
+			return err
+		}
 	}
 
 	// 3. Re-deploy the worker pod with the extracted configuration.


### PR DESCRIPTION
When catalog configure --reset-podman-auth is run on a node with a co-located local worker, the worker pod was left stale with the old auth secret. This change detects the local worker pod and recreates it after the catalog pod is back up, mirroring what worker reset --reset-podman-auth already does.

Changes:

1. Add ai-services.io/component=catalog label to the catalog pod template so it can be reliably identified by label selector (the previous ai-services.io/secret label had a multi-value string that never matched)
2. Add PodComponentKey and CatalogComponentValue constants; update GetCatalogPodConfig to accept the label from the caller
3. Add deleteSecret bool param to workerpodman.ResetPodmanAuth: true for standalone worker reset (deletes secret + pod), false for catalog-triggered reset (secret already deleted, pod only)
4. After catalog pod is redeployed, detect local worker via WorkerPodLabel and call ResetPodmanAuth(ctx, false)