### PR TITLE
fix catalog and worker OpenShift RBAC

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.362
+TAG?=v0.0.363
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/templates/catalog-backend.yaml
+++ b/ai-services/assets/catalog/openshift/templates/catalog-backend.yaml
@@ -20,7 +20,7 @@ spec:
         ai-services.io/version: {{ default .Chart.AppVersion | quote }}
         ai-services.io/component: catalog-backend
     spec:
-      serviceAccountName: ai-services-sa
+      serviceAccountName: ai-services-catalog-sa
       automountServiceAccountToken: true
       initContainers:
         - name: db-migration

--- a/ai-services/assets/catalog/openshift/templates/rbac.yaml
+++ b/ai-services/assets/catalog/openshift/templates/rbac.yaml
@@ -1,84 +1,29 @@
-{{- if not (lookup "v1" "ServiceAccount" .Release.Namespace "ai-services-sa") }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ai-services-sa
+  name: ai-services-catalog-sa
   namespace: {{ .Release.Namespace }}
-{{- end }}
 ---
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "ai-services-manager") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ai-services-manager
+  name: ai-services-catalog-reader
 rules:
-  - apiGroups: [""]
-    resources: ["namespaces"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["serving.kserve.io"]
-    resources: ["inferenceservices", "servingruntimes"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: [""]
-    resources: ["services"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["get", "list", "watch"]
-  # Required by execEnvInContainer to read live container env vars (Spyre card PCI addresses)
-  # via the Kubernetes API pod/exec subresource — no oc binary needed.
-  - apiGroups: [""]
-    resources: ["pods/exec"]
-    verbs: ["create"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["apps"]
-    resources: ["deployments", "statefulsets", "replicasets"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["policy"]
-    resources: ["poddisruptionbudgets"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Required by GatewayRouteHost to look up the catalog-worker-gateway Route host
+  # in order to embed the correct DNS SAN in the server certificate and bootstrap token.
   - apiGroups: ["route.openshift.io"]
     resources: ["routes"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # Required by GetSystemInfo / getSpyreCardInfo to read node capacity and allocatable resources.
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["list"]
-{{- end }}
+    verbs: ["get", "list"]
 ---
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRoleBinding" "" "ai-services-manager-binding") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ai-services-manager-binding
+  name: ai-services-catalog-reader-binding
 subjects:
   - kind: ServiceAccount
-    name: ai-services-sa
+    name: ai-services-catalog-sa
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: ai-services-manager
+  name: ai-services-catalog-reader
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
----
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRoleBinding" "" "ai-services-monitoring-view-binding") }}
-# Grants the backend SA access to query the OpenShift Thanos Querier (port 9091).
-# Without this the Thanos HTTP endpoint returns 403 Forbidden (plain text),
-# which causes a JSON parse error in GetSystemInfo.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: ai-services-monitoring-view-binding
-subjects:
-  - kind: ServiceAccount
-    name: ai-services-sa
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: cluster-monitoring-view
-  apiGroup: rbac.authorization.k8s.io
-{{- end }}

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.362
+  image: icr.io/ai-services-cicd/ai-services:v0.0.363
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.362
+  image: icr.io/ai-services-cicd/ai-services:v0.0.363
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/templates/rbac.yaml
+++ b/ai-services/assets/worker/openshift/templates/rbac.yaml
@@ -1,12 +1,9 @@
-{{- if not (lookup "v1" "ServiceAccount" .Release.Namespace "ai-services-sa") }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ai-services-sa
   namespace: {{ .Release.Namespace }}
-{{- end }}
 ---
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "ai-services-manager") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -48,9 +45,7 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["list"]
-{{- end }}
 ---
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRoleBinding" "" "ai-services-manager-binding") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -63,9 +58,7 @@ roleRef:
   kind: ClusterRole
   name: ai-services-manager
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
 ---
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRoleBinding" "" "ai-services-monitoring-view-binding") }}
 # Grants the backend SA access to query the OpenShift Thanos Querier (port 9091).
 # Without this the Thanos HTTP endpoint returns 403 Forbidden (plain text),
 # which causes a JSON parse error in GetSystemInfo.
@@ -81,4 +74,3 @@ roleRef:
   kind: ClusterRole
   name: cluster-monitoring-view
   apiGroup: rbac.authorization.k8s.io
-{{- end }}

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.362
+  image: icr.io/ai-services-cicd/ai-services:v0.0.363
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.362
+  image: icr.io/ai-services-cicd/ai-services:v0.0.363
   runtime: "podman"
   token: ""
   gatewayAddr: ""


### PR DESCRIPTION
Scope **Catalog** OpenShift permissions to a minimal `ClusterRole` (`ai-services-catalog-reader`) with only `get`/`list` on `routes` (`route.openshift.io`), using dedicated ServiceAccount `ai-services-catalog-sa`.
- Update `catalog-backend` Deployment to use `ai-services-catalog-sa`.
- Remove redundant Helm `lookup` conditions across both Catalog and Worker RBAC templates.