### PR TITLE
fix: data connect to services via remote worker

### DIFF
--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.364
+TAG?=v0.0.365
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/Makefile
+++ b/ai-services/Makefile
@@ -1,6 +1,6 @@
 REGISTRY?=icr.io/ai-services-private
 IMAGE=ai-services
-TAG?=v0.0.363
+TAG?=v0.0.365
 CONTAINER_BUILDER?=podman
 CREDS_ARG := $(if $(and $(REGISTRY_USER),$(REGISTRY_PASSWORD)),--creds="$(REGISTRY_USER):$(REGISTRY_PASSWORD)")
 

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.363
+  image: icr.io/ai-services-cicd/ai-services:v0.0.365
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/openshift/values.yaml
+++ b/ai-services/assets/catalog/openshift/values.yaml
@@ -9,7 +9,7 @@ ui:
       cpu: "500m"
 
 backend:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.364
+  image: icr.io/ai-services-cicd/ai-services:v0.0.365
   runtime: "openshift"
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.364
+  image: icr.io/ai-services-cicd/ai-services:v0.0.365
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/catalog/podman/values.yaml
+++ b/ai-services/assets/catalog/podman/values.yaml
@@ -4,7 +4,7 @@ ui:
 
 backend:
   port: ""
-  image: icr.io/ai-services-cicd/ai-services:v0.0.363
+  image: icr.io/ai-services-cicd/ai-services:v0.0.365
   runtime: ""
   adminPasswordHash: ""
   # @generate:password length=32, special=false

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.363
+  image: icr.io/ai-services-cicd/ai-services:v0.0.365
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/openshift/values.yaml
+++ b/ai-services/assets/worker/openshift/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.364
+  image: icr.io/ai-services-cicd/ai-services:v0.0.365
   runtime: "openshift"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.364
+  image: icr.io/ai-services-cicd/ai-services:v0.0.365
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/assets/worker/podman/values.yaml
+++ b/ai-services/assets/worker/podman/values.yaml
@@ -1,5 +1,5 @@
 worker:
-  image: icr.io/ai-services-cicd/ai-services:v0.0.363
+  image: icr.io/ai-services-cicd/ai-services:v0.0.365
   runtime: "podman"
   token: ""
   gatewayAddr: ""

--- a/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
+++ b/ai-services/cmd/ai-services/cmd/catalog/apiserver.go
@@ -142,14 +142,14 @@ func buildAPIServerOptions(ctx context.Context, pool *pgxpool.Pool, secretKey, a
 		return apiserver.APIServerOptions{}, nil, fmt.Errorf("failed to initialize catalog provider: %w", err)
 	}
 
-	datasourceSvc, err := apirepository.NewDatasourceService(connectorRepo, appRepo, svcDepRepo, catalogProvider)
-	if err != nil {
-		return apiserver.APIServerOptions{}, nil, fmt.Errorf("failed to initialize datasource service: %w", err)
-	}
-
 	tokenMgr := auth.NewTokenManager(secretKey, accessTTL, refreshTTL)
 	workerRepo := repository.NewWorkerRepository(pool)
 	workerReg := workerregistry.New(workerRepo)
+
+	datasourceSvc, err := apirepository.NewDatasourceService(connectorRepo, appRepo, svcDepRepo, catalogProvider, workerReg)
+	if err != nil {
+		return apiserver.APIServerOptions{}, nil, fmt.Errorf("failed to initialize datasource service: %w", err)
+	}
 
 	stopBackgroundServices, err := startBackgroundServices(ctx, appRepo, svcRepo, compRepo, svcDepRepo, connectorRepo, catalogProvider, workerReg, encryptionKey)
 	if err != nil {

--- a/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/application_service/common.go
@@ -141,28 +141,25 @@ func (s *ApplicationServiceBase) createRuntime(app *models.Application) (runtime
 	return rt, nil
 }
 
-// buildWorkerInfo resolves the worker name and runtime type from the registry and returns
-// an ApplicationWorker for embedding in the application response.
-func (s *ApplicationServiceBase) buildWorkerInfo(workerID uuid.UUID) (*types.ApplicationWorker, error) {
+// buildWorkerInfo resolves the worker name and runtime type for the given worker UUID.
+// Delegates to WorkerRegistry.WorkerInfoByID which tries the live registry first
+// and falls back to the DB for disconnected workers.
+func (s *ApplicationServiceBase) buildWorkerInfo(ctx context.Context, workerID uuid.UUID) (*types.ApplicationWorker, error) {
 	if s.WorkerRegistry == nil {
 		return nil, fmt.Errorf("worker registry not configured")
 	}
 
-	name, ok := s.WorkerRegistry.WorkerNameByID(workerID)
-	if !ok {
-		return nil, fmt.Errorf("worker %s is not connected", workerID)
-	}
+	name, rtStr := s.WorkerRegistry.WorkerInfoByID(ctx, workerID)
 
-	w := &types.ApplicationWorker{ID: workerID.String(), Name: name}
-	if rtStr, ok := s.WorkerRegistry.WorkerRuntimeType(name); ok {
-		w.RuntimeType = rtStr
-	}
-
-	return w, nil
+	return &types.ApplicationWorker{
+		ID:          workerID.String(),
+		Name:        name,
+		RuntimeType: rtStr,
+	}, nil
 }
 
 // buildApplication creates an Application from a models.Application.
-func (s *ApplicationServiceBase) buildApplication(app models.Application) (types.Application, error) {
+func (s *ApplicationServiceBase) buildApplication(ctx context.Context, app models.Application) (types.Application, error) {
 	// Get type (display name) from catalog metadata
 	typeName, err := s.getApplicationType(app.CatalogID, app.DeploymentType)
 	if err != nil {
@@ -186,7 +183,7 @@ func (s *ApplicationServiceBase) buildApplication(app models.Application) (types
 		return types.Application{}, fmt.Errorf("application %s has no worker_id", app.ID)
 	}
 
-	worker, err := s.buildWorkerInfo(*app.WorkerID)
+	worker, err := s.buildWorkerInfo(ctx, *app.WorkerID)
 	if err != nil {
 		return types.Application{}, fmt.Errorf("failed to resolve worker for application %s: %w", app.ID, err)
 	}
@@ -289,7 +286,7 @@ func (s *ApplicationServiceBase) UpdateApplication(ctx context.Context, id uuid.
 		}
 	}
 
-	appData, err := s.buildApplication(*updatedApp)
+	appData, err := s.buildApplication(ctx, *updatedApp)
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +336,7 @@ func (s *ApplicationServiceBase) buildGetApplicationResponse(ctx context.Context
 		return nil, fmt.Errorf("application %s has no worker_id", app.ID)
 	}
 
-	worker, err := s.buildWorkerInfo(*app.WorkerID)
+	worker, err := s.buildWorkerInfo(ctx, *app.WorkerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve worker for application %s: %w", app.ID, err)
 	}
@@ -696,7 +693,7 @@ func (s *ApplicationServiceBase) ListApplications(ctx context.Context, req ListA
 
 	apps := make([]types.Application, 0, len(applications))
 	for _, app := range applications {
-		appData, err := s.buildApplication(app)
+		appData, err := s.buildApplication(ctx, app)
 		if err != nil {
 			return nil, err
 		}
@@ -1182,7 +1179,7 @@ func (s *ApplicationServiceBase) ApplicationsPs(ctx context.Context, appID uuid.
 		return nil, fmt.Errorf("application %s has no worker_id", app.ID)
 	}
 
-	workerInfo, err := s.buildWorkerInfo(*app.WorkerID)
+	workerInfo, err := s.buildWorkerInfo(ctx, *app.WorkerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve worker for application %s: %w", app.ID, err)
 	}

--- a/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog"
 	datasourceservice "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service"
-	catalogclient "github.com/project-ai-services/ai-services/internal/pkg/catalog/client"
 	catalogconstants "github.com/project-ai-services/ai-services/internal/pkg/catalog/constants"
 	dbrepo "github.com/project-ai-services/ai-services/internal/pkg/catalog/db/repository"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/validators"
+	"github.com/project-ai-services/ai-services/internal/pkg/worker/stream"
 )
 
 // NewDatasourceService creates the DatasourceService wired with all known provider testers.
@@ -20,6 +20,7 @@ func NewDatasourceService(
 	appRepo dbrepo.ApplicationRepository,
 	svcDepRepo dbrepo.ServiceDependencyRepository,
 	provider *catalog.CatalogProvider,
+	workerRegistry stream.WorkerRegistry,
 ) (DatasourceServiceInterface, error) {
 	encryptionKey := os.Getenv(catalogconstants.DBEncryptionKeyEnv)
 	if encryptionKey == "" {
@@ -34,7 +35,7 @@ func NewDatasourceService(
 		svcDepRepo,
 		validator,
 		provider,
-		catalogclient.NewServiceClient(""),
+		workerRegistry,
 		encryptionKey,
 	), nil
 }

--- a/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service/datasource_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service/datasource_service.go
@@ -17,10 +17,8 @@ import (
 	catalogtypes "github.com/project-ai-services/ai-services/internal/pkg/catalog/types"
 	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/validators"
+	"github.com/project-ai-services/ai-services/internal/pkg/httpproxy"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
-	remoteruntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/remote"
-	runtimetypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	pkgutils "github.com/project-ai-services/ai-services/internal/pkg/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/worker/stream"
 )
@@ -79,10 +77,9 @@ func NewDatasourceService(
 	}
 }
 
-// runtimeFor returns a RemoteRuntime for the given worker UUID by looking up the
-// worker name and runtime type from the registry. Returns an error if the worker
-// is not connected.
-func (s *DatasourceService) runtimeFor(ctx context.Context, workerID *uuid.UUID) (runtime.Runtime, error) {
+// httpProxierFor returns an HTTPProxier for the given worker UUID by looking up
+// the worker name from the registry. Returns an error if the worker is not connected.
+func (s *DatasourceService) httpProxierFor(workerID *uuid.UUID) (httpproxy.HTTPProxier, error) {
 	if workerID == nil {
 		return nil, fmt.Errorf("application has no worker assigned")
 	}
@@ -92,12 +89,7 @@ func (s *DatasourceService) runtimeFor(ctx context.Context, workerID *uuid.UUID)
 		return nil, fmt.Errorf("worker %s is not connected", *workerID)
 	}
 
-	rtStr, ok := s.workerRegistry.WorkerRuntimeType(workerName)
-	if !ok {
-		return nil, fmt.Errorf("runtime type for worker %s not available", workerName)
-	}
-
-	return remoteruntime.New(workerName, runtimetypes.RuntimeType(rtStr), s.workerRegistry), nil
+	return httpproxy.NewRemoteHTTPProxier(workerName, s.workerRegistry), nil
 }
 
 // CreateDatasource is the single create flow shared by all providers:
@@ -413,13 +405,14 @@ func (s *DatasourceService) buildConnectedApplications(ctx context.Context, conn
 			return nil, fmt.Errorf("failed to load application %s: %w", row.ApplicationID, appErr)
 		}
 
-		rt, rtErr := s.runtimeFor(ctx, app.WorkerID)
-		if rtErr != nil {
-			logger.WarningfCtx(ctx, "worker not reachable for application %s: %v", row.ApplicationID, rtErr)
+		proxy, proxyErr := s.httpProxierFor(app.WorkerID)
+		if proxyErr != nil {
+			logger.WarningfCtx(ctx, "worker not reachable for application %s: %v", row.ApplicationID, proxyErr)
+
 			continue
 		}
 
-		syncDetails := s.fetchServiceSyncDetails(ctx, rt, connectorID, baseURL)
+		syncDetails := s.fetchServiceSyncDetails(ctx, proxy, connectorID, baseURL)
 
 		// Resolve the type name from catalog metadata; fall back to catalog_id.
 		typeName := row.ApplicationCatalogID
@@ -551,18 +544,18 @@ func (s *DatasourceService) connectOneDatasource(ctx context.Context, datasource
 		return uuid.Nil, fmt.Errorf("failed to load application: %w", appErr)
 	}
 
-	rt, rtErr := s.runtimeFor(ctx, app.WorkerID)
-	if rtErr != nil {
+	proxy, proxyErr := s.httpProxierFor(app.WorkerID)
+	if proxyErr != nil {
 		return uuid.Nil, &ValidationError{
 			Code:    http.StatusBadGateway,
-			Message: fmt.Sprintf("worker not reachable: %v", rtErr),
+			Message: fmt.Sprintf("worker not reachable: %v", proxyErr),
 		}
 	}
 
 	var connectedServiceID uuid.UUID
 
 	for _, svc := range linkedServices {
-		if err := s.sendToService(ctx, rt, svc, connector, connectionDetails, datasourceID); err != nil {
+		if err := s.sendToService(ctx, proxy, svc, connector, connectionDetails, datasourceID); err != nil {
 			return uuid.Nil, err
 		}
 
@@ -652,7 +645,7 @@ func (s *DatasourceService) decryptedConnectionDetails(ctx context.Context, conn
 // service_dependency row. Returns a *ValidationError on downstream failure.
 func (s *DatasourceService) sendToService(
 	ctx context.Context,
-	rt runtime.Runtime,
+	proxy httpproxy.HTTPProxier,
 	svc dbrepo.LinkedServiceRow,
 	connector *dbmodels.Connector,
 	connectionDetails map[string]any,
@@ -682,7 +675,7 @@ func (s *DatasourceService) sendToService(
 		ConnectionDetails: connectionDetails,
 	}
 
-	if err := catalogclient.NewServiceClient(rt, svc.URL).Connect(ctx, connectReq); err != nil {
+	if err := catalogclient.NewServiceClient(proxy, svc.URL).Connect(ctx, connectReq); err != nil {
 		return &ValidationError{
 			Code:    http.StatusBadGateway,
 			Message: fmt.Sprintf("failed to connect datasource to service %s: %v", svc.ServiceCatalogID, err),
@@ -837,12 +830,12 @@ func (s *DatasourceService) GetApplicationDatasource(ctx context.Context, applic
 
 	// Step 5: fetch live sync state using the endpoint URL captured in step 3.
 	// Degrades gracefully to sync_status="unknown" when the service is unreachable.
-	rt, rtErr := s.runtimeFor(ctx, app.WorkerID)
-	if rtErr != nil {
-		logger.WarningfCtx(ctx, "worker not reachable for application %s: %v", applicationID, rtErr)
+	proxy, proxyErr := s.httpProxierFor(app.WorkerID)
+	if proxyErr != nil {
+		logger.WarningfCtx(ctx, "worker not reachable for application %s: %v", applicationID, proxyErr)
 	}
 
-	serviceDetails := s.fetchServiceSyncDetails(ctx, rt, datasourceID, baseURL)
+	serviceDetails := s.fetchServiceSyncDetails(ctx, proxy, datasourceID, baseURL)
 
 	return &apimodels.GetApplicationDatasourceResponse{
 		ID:             connector.ID.String(),
@@ -904,13 +897,13 @@ func (s *DatasourceService) DisconnectDatasourcesFromApplication(ctx context.Con
 		}
 	}
 
-	// Resolve runtime once from the already-loaded app.
-	rt, rtErr := s.runtimeFor(ctx, app.WorkerID)
-	if rtErr != nil {
-		logger.WarningfCtx(ctx, "worker not reachable for application %s during disconnect: %v", applicationID, rtErr)
+	// Resolve proxier once from the already-loaded app.
+	proxy, proxyErr := s.httpProxierFor(app.WorkerID)
+	if proxyErr != nil {
+		logger.WarningfCtx(ctx, "worker not reachable for application %s during disconnect: %v", applicationID, proxyErr)
 	}
 
-	return s.disconnectOneDatasource(ctx, rt, datasourceID, appLinked)
+	return s.disconnectOneDatasource(ctx, proxy, datasourceID, appLinked)
 }
 
 // disconnectOneDatasource calls DELETE /v1/connectors/{id} on each linked service and
@@ -918,11 +911,11 @@ func (s *DatasourceService) DisconnectDatasourcesFromApplication(ctx context.Con
 // A 404 from the downstream service is treated as success — the connector was already
 // removed (idempotency for partial-failure retries). DB cleanup failures are logged
 // but do not block the caller.
-func (s *DatasourceService) disconnectOneDatasource(ctx context.Context, rt runtime.Runtime, datasourceID uuid.UUID, linkedServices []dbrepo.LinkedServiceRow) error {
+func (s *DatasourceService) disconnectOneDatasource(ctx context.Context, proxy httpproxy.HTTPProxier, datasourceID uuid.UUID, linkedServices []dbrepo.LinkedServiceRow) error {
 	for _, svc := range linkedServices {
 		url := extractInternalEndpointURL(svc.EndpointsJSON)
 		if url != "" {
-			err := catalogclient.NewServiceClient(rt, url).Disconnect(ctx, datasourceID.String())
+			err := catalogclient.NewServiceClient(proxy, url).Disconnect(ctx, datasourceID.String())
 			if err != nil {
 				var httpErr *catalogclient.ServiceHTTPError
 				if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
@@ -1048,49 +1041,58 @@ func (s *DatasourceService) propagateCredentials(
 	var propErrors []apimodels.PropagationError
 
 	for _, svc := range serviceEndpoints {
-		baseURL := extractInternalEndpointURL(svc.EndpointsJSON)
-		if baseURL == "" {
-			propErrors = append(propErrors, apimodels.PropagationError{
-				ID:    svc.ApplicationID.String(),
-				Name:  svc.ApplicationName,
-				Error: "service has no reachable endpoint",
-			})
-
-			continue
-		}
-
-		app, appErr := s.appRepo.GetByID(ctx, svc.ApplicationID)
-		if appErr != nil {
-			propErrors = append(propErrors, apimodels.PropagationError{
-				ID:    svc.ApplicationID.String(),
-				Name:  svc.ApplicationName,
-				Error: fmt.Sprintf("failed to load application: %v", appErr),
-			})
-
-			continue
-		}
-
-		rt, rtErr := s.runtimeFor(ctx, app.WorkerID)
-		if rtErr != nil {
-			propErrors = append(propErrors, apimodels.PropagationError{
-				ID:    svc.ApplicationID.String(),
-				Name:  svc.ApplicationName,
-				Error: fmt.Sprintf("worker not reachable: %v", rtErr),
-			})
-
-			continue
-		}
-
-		if err := catalogclient.NewServiceClient(rt, baseURL).UpdateConnector(ctx, datasourceID.String(), credPayload); err != nil {
-			propErrors = append(propErrors, apimodels.PropagationError{
-				ID:    svc.ApplicationID.String(),
-				Name:  svc.ApplicationName,
-				Error: err.Error(),
-			})
+		if propErr := s.propagateToService(ctx, datasourceID, credPayload, svc); propErr != nil {
+			propErrors = append(propErrors, *propErr)
 		}
 	}
 
 	return propErrors
+}
+
+// propagateToService pushes updated credentials to a single linked service endpoint.
+// Returns a PropagationError if the service is unreachable or the update fails, nil on success.
+func (s *DatasourceService) propagateToService(
+	ctx context.Context,
+	datasourceID uuid.UUID,
+	credPayload map[string]any,
+	svc dbrepo.LinkedServiceRow,
+) *apimodels.PropagationError {
+	baseURL := extractInternalEndpointURL(svc.EndpointsJSON)
+	if baseURL == "" {
+		return &apimodels.PropagationError{
+			ID:    svc.ApplicationID.String(),
+			Name:  svc.ApplicationName,
+			Error: "service has no reachable endpoint",
+		}
+	}
+
+	app, appErr := s.appRepo.GetByID(ctx, svc.ApplicationID)
+	if appErr != nil {
+		return &apimodels.PropagationError{
+			ID:    svc.ApplicationID.String(),
+			Name:  svc.ApplicationName,
+			Error: fmt.Sprintf("failed to load application: %v", appErr),
+		}
+	}
+
+	proxy, proxyErr := s.httpProxierFor(app.WorkerID)
+	if proxyErr != nil {
+		return &apimodels.PropagationError{
+			ID:    svc.ApplicationID.String(),
+			Name:  svc.ApplicationName,
+			Error: fmt.Sprintf("worker not reachable: %v", proxyErr),
+		}
+	}
+
+	if err := catalogclient.NewServiceClient(proxy, baseURL).UpdateConnector(ctx, datasourceID.String(), credPayload); err != nil {
+		return &apimodels.PropagationError{
+			ID:    svc.ApplicationID.String(),
+			Name:  svc.ApplicationName,
+			Error: err.Error(),
+		}
+	}
+
+	return nil
 }
 
 // filterUpdatableFields returns a new map containing only the keys present in allowed.
@@ -1123,9 +1125,9 @@ func datasourceItemFromConnector(c *dbmodels.Connector) apimodels.DatasourceItem
 	}
 }
 
-// fetchServiceSyncDetails calls GET /v1/connectors/{connectorID} via HTTPProxy and returns a
+// fetchServiceSyncDetails calls GET /v1/connectors/{connectorID} and returns a
 // fully-populated ServiceSyncDetails. Degrades gracefully on failure.
-func (s *DatasourceService) fetchServiceSyncDetails(ctx context.Context, rt runtime.Runtime, connectorID uuid.UUID, baseURL string) apimodels.ServiceSyncDetails {
+func (s *DatasourceService) fetchServiceSyncDetails(ctx context.Context, proxy httpproxy.HTTPProxier, connectorID uuid.UUID, baseURL string) apimodels.ServiceSyncDetails {
 	if baseURL == "" {
 		return apimodels.ServiceSyncDetails{
 			SyncStatus: "unknown",
@@ -1133,7 +1135,7 @@ func (s *DatasourceService) fetchServiceSyncDetails(ctx context.Context, rt runt
 		}
 	}
 
-	state, err := catalogclient.NewServiceClient(rt, baseURL).GetConnectorSync(ctx, connectorID.String())
+	state, err := catalogclient.NewServiceClient(proxy, baseURL).GetConnectorSync(ctx, connectorID.String())
 	if err != nil {
 		logger.WarningfCtx(ctx, "failed to fetch sync state for connector %s from %s: %v", connectorID, baseURL, err)
 
@@ -1211,7 +1213,7 @@ func (s *DatasourceService) ListApplicationDatasources(ctx context.Context, req 
 		return nil, fmt.Errorf("failed to list application connectors: %w", err)
 	}
 
-	rt, err := s.runtimeFor(ctx, app.WorkerID)
+	proxy, err := s.httpProxierFor(app.WorkerID)
 	if err != nil {
 		return nil, &ValidationError{Code: http.StatusBadGateway, Message: fmt.Sprintf("worker not reachable: %v", err)}
 	}
@@ -1220,7 +1222,7 @@ func (s *DatasourceService) ListApplicationDatasources(ctx context.Context, req 
 
 	// Resolve the service base URL and call GET /v1/connectors with the caller's pagination
 	// params. The service response is authoritative for both the page content and total count.
-	baseURL, servicePage := s.fetchServiceConnectors(ctx, rt, appID, allConnectorIDs, req.PageSize, offset)
+	baseURL, servicePage := s.fetchServiceConnectors(ctx, proxy, appID, allConnectorIDs, req.PageSize, offset)
 
 	data, err := s.buildDatasourcePage(ctx, baseURL, servicePage.ByID)
 	if err != nil {
@@ -1251,7 +1253,7 @@ func (s *DatasourceService) ListApplicationDatasources(ctx context.Context, req 
 // Only rows belonging to appID are considered when selecting the base URL, preventing a
 // mismatch when the same connector is linked to multiple applications.
 // Returns an empty-page result when no endpoint is found or the call fails.
-func (s *DatasourceService) fetchServiceConnectors(ctx context.Context, rt runtime.Runtime, appID uuid.UUID, connectorIDs []uuid.UUID, limit, offset int) (string, catalogclient.ServiceConnectorPage) {
+func (s *DatasourceService) fetchServiceConnectors(ctx context.Context, proxy httpproxy.HTTPProxier, appID uuid.UUID, connectorIDs []uuid.UUID, limit, offset int) (string, catalogclient.ServiceConnectorPage) {
 	empty := catalogclient.ServiceConnectorPage{ByID: make(map[string]apimodels.ConnectorItem)}
 
 	if len(connectorIDs) == 0 {
@@ -1282,7 +1284,7 @@ func (s *DatasourceService) fetchServiceConnectors(ctx context.Context, rt runti
 		return "", empty
 	}
 
-	page, err := catalogclient.NewServiceClient(rt, baseURL).ListConnectors(ctx, limit, offset)
+	page, err := catalogclient.NewServiceClient(proxy, baseURL).ListConnectors(ctx, limit, offset)
 	if err != nil {
 		logger.WarningfCtx(ctx, "failed to list connectors from service at %s: %v", baseURL, err)
 

--- a/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service/datasource_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service/datasource_service.go
@@ -18,7 +18,11 @@ import (
 	catalogutils "github.com/project-ai-services/ai-services/internal/pkg/catalog/utils"
 	"github.com/project-ai-services/ai-services/internal/pkg/catalog/validators"
 	"github.com/project-ai-services/ai-services/internal/pkg/logger"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	remoteruntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/remote"
+	runtimetypes "github.com/project-ai-services/ai-services/internal/pkg/runtime/types"
 	pkgutils "github.com/project-ai-services/ai-services/internal/pkg/utils"
+	"github.com/project-ai-services/ai-services/internal/pkg/worker/stream"
 )
 
 const (
@@ -28,14 +32,6 @@ const (
 
 // ValidationError re-exported so callers use the same type as for application errors.
 type ValidationError = validators.ValidationError
-
-// ServiceConnectorClientInterface is the contract for sending connector payloads to downstream
-// services that accept datasource connectors.
-type ServiceConnectorClientInterface interface {
-	Connect(ctx context.Context, baseURL string, req apimodels.ConnectDatasourceRequest) error
-	// Disconnect calls DELETE /v1/connectors/{connectorID} on the service.
-	Disconnect(ctx context.Context, baseURL, connectorID string) error
-}
 
 // DatasourceService is the single implementation of the datasource connector business logic.
 // It is provider-agnostic: provider-specific behaviour (connection testing and
@@ -49,7 +45,7 @@ type DatasourceService struct {
 	svcDepRepo      dbrepo.ServiceDependencyRepository
 	validator       *validators.ConnectorValidator
 	catalogProvider *catalog.CatalogProvider
-	serviceClient   ServiceConnectorClientInterface
+	workerRegistry  stream.WorkerRegistry
 	encryptionKey   string
 	// testers maps providerID → ConnectionTester. Populated by NewDatasourceService.
 	testers map[string]ConnectionTester
@@ -65,7 +61,7 @@ func NewDatasourceService(
 	svcDepRepo dbrepo.ServiceDependencyRepository,
 	validator *validators.ConnectorValidator,
 	catalogProvider *catalog.CatalogProvider,
-	serviceClient ServiceConnectorClientInterface,
+	workerRegistry stream.WorkerRegistry,
 	encryptionKey string,
 ) *DatasourceService {
 	return &DatasourceService{
@@ -74,13 +70,34 @@ func NewDatasourceService(
 		svcDepRepo:      svcDepRepo,
 		validator:       validator,
 		catalogProvider: catalogProvider,
-		serviceClient:   serviceClient,
+		workerRegistry:  workerRegistry,
 		encryptionKey:   encryptionKey,
 		testers: map[string]ConnectionTester{
 			catalogconstants.DatasourceProviderObjectStorage: NewObjectStorageTester(),
 			catalogconstants.DatasourceProviderFileSystem:    NewFileSystemTester(),
 		},
 	}
+}
+
+// runtimeFor returns a RemoteRuntime for the given worker UUID by looking up the
+// worker name and runtime type from the registry. Returns an error if the worker
+// is not connected.
+func (s *DatasourceService) runtimeFor(ctx context.Context, workerID *uuid.UUID) (runtime.Runtime, error) {
+	if workerID == nil {
+		return nil, fmt.Errorf("application has no worker assigned")
+	}
+
+	workerName, ok := s.workerRegistry.WorkerNameByID(*workerID)
+	if !ok {
+		return nil, fmt.Errorf("worker %s is not connected", *workerID)
+	}
+
+	rtStr, ok := s.workerRegistry.WorkerRuntimeType(workerName)
+	if !ok {
+		return nil, fmt.Errorf("runtime type for worker %s not available", workerName)
+	}
+
+	return remoteruntime.New(workerName, runtimetypes.RuntimeType(rtStr), s.workerRegistry), nil
 }
 
 // CreateDatasource is the single create flow shared by all providers:
@@ -390,7 +407,19 @@ func (s *DatasourceService) buildConnectedApplications(ctx context.Context, conn
 	applications := make([]apimodels.ConnectedApplicationItem, 0, len(linkedRows))
 	for _, row := range linkedRows {
 		baseURL := extractInternalEndpointURL(row.EndpointsJSON)
-		syncStatus, lastSyncAt, syncErr := fetchSyncState(ctx, connectorID, baseURL)
+
+		app, appErr := s.appRepo.GetByID(ctx, row.ApplicationID)
+		var workerID *uuid.UUID
+		if appErr == nil && app != nil {
+			workerID = app.WorkerID
+		}
+
+		rt, rtErr := s.runtimeFor(ctx, workerID)
+		if rtErr != nil {
+			logger.WarningfCtx(ctx, "worker not reachable for application %s: %v", row.ApplicationID, rtErr)
+		}
+
+		syncDetails := s.fetchServiceSyncDetails(ctx, rt, connectorID, baseURL)
 
 		// Resolve the type name from catalog metadata; fall back to catalog_id.
 		typeName := row.ApplicationCatalogID
@@ -409,11 +438,9 @@ func (s *DatasourceService) buildConnectedApplications(ctx context.Context, conn
 			Name:       row.ApplicationName,
 			CatalogID:  row.ApplicationCatalogID,
 			Type:       typeName,
-			SyncStatus: syncStatus,
-			LastSyncAt: lastSyncAt,
-		}
-		if syncErr != "" {
-			item.ErrMsg = syncErr
+			SyncStatus: syncDetails.SyncStatus,
+			LastSyncAt: syncDetails.LastSyncAt,
+			ErrMsg:     syncDetails.ErrMsg,
 		}
 		applications = append(applications, item)
 	}
@@ -514,10 +541,28 @@ func (s *DatasourceService) connectOneDatasource(ctx context.Context, datasource
 		return uuid.Nil, err
 	}
 
+	// All eligible services belong to the same application — resolve runtime once.
+	if len(linkedServices) == 0 {
+		return uuid.Nil, nil
+	}
+
+	app, appErr := s.appRepo.GetByID(ctx, linkedServices[0].ApplicationID)
+	if appErr != nil {
+		return uuid.Nil, fmt.Errorf("failed to load application: %w", appErr)
+	}
+
+	rt, rtErr := s.runtimeFor(ctx, app.WorkerID)
+	if rtErr != nil {
+		return uuid.Nil, &ValidationError{
+			Code:    http.StatusBadGateway,
+			Message: fmt.Sprintf("worker not reachable: %v", rtErr),
+		}
+	}
+
 	var connectedServiceID uuid.UUID
 
 	for _, svc := range linkedServices {
-		if err := s.sendToService(ctx, svc, connector, connectionDetails, datasourceID); err != nil {
+		if err := s.sendToService(ctx, rt, svc, connector, connectionDetails, datasourceID); err != nil {
 			return uuid.Nil, err
 		}
 
@@ -607,6 +652,7 @@ func (s *DatasourceService) decryptedConnectionDetails(ctx context.Context, conn
 // service_dependency row. Returns a *ValidationError on downstream failure.
 func (s *DatasourceService) sendToService(
 	ctx context.Context,
+	rt runtime.Runtime,
 	svc dbrepo.LinkedServiceRow,
 	connector *dbmodels.Connector,
 	connectionDetails map[string]any,
@@ -636,7 +682,7 @@ func (s *DatasourceService) sendToService(
 		ConnectionDetails: connectionDetails,
 	}
 
-	if err := s.serviceClient.Connect(ctx, svc.URL, connectReq); err != nil {
+	if err := catalogclient.NewServiceClient(rt, svc.URL).Connect(ctx, connectReq); err != nil {
 		return &ValidationError{
 			Code:    http.StatusBadGateway,
 			Message: fmt.Sprintf("failed to connect datasource to service %s: %v", svc.ServiceCatalogID, err),
@@ -791,7 +837,12 @@ func (s *DatasourceService) GetApplicationDatasource(ctx context.Context, applic
 
 	// Step 5: fetch live sync state using the endpoint URL captured in step 3.
 	// Degrades gracefully to sync_status="unknown" when the service is unreachable.
-	serviceDetails := fetchServiceSyncDetails(ctx, datasourceID, baseURL)
+	rt, rtErr := s.runtimeFor(ctx, app.WorkerID)
+	if rtErr != nil {
+		logger.WarningfCtx(ctx, "worker not reachable for application %s: %v", applicationID, rtErr)
+	}
+
+	serviceDetails := s.fetchServiceSyncDetails(ctx, rt, datasourceID, baseURL)
 
 	return &apimodels.GetApplicationDatasourceResponse{
 		ID:             connector.ID.String(),
@@ -853,25 +904,29 @@ func (s *DatasourceService) DisconnectDatasourcesFromApplication(ctx context.Con
 		}
 	}
 
-	return s.disconnectOneDatasource(ctx, datasourceID, appLinked)
+	// Resolve runtime once from the already-loaded app.
+	rt, rtErr := s.runtimeFor(ctx, app.WorkerID)
+	if rtErr != nil {
+		logger.WarningfCtx(ctx, "worker not reachable for application %s during disconnect: %v", applicationID, rtErr)
+	}
+
+	return s.disconnectOneDatasource(ctx, rt, datasourceID, appLinked)
 }
 
 // disconnectOneDatasource calls DELETE /v1/connectors/{id} on each linked service and
 // removes the service_dependency row.
 // A 404 from the downstream service is treated as success — the connector was already
-// removed (idempotency for partial-failure retries). The 404 handling lives here rather
-// than in the client so that other callers of Disconnect can choose to treat 404 as an
-// error if appropriate. DB cleanup failures are logged but do not block the caller.
-func (s *DatasourceService) disconnectOneDatasource(ctx context.Context, datasourceID uuid.UUID, linkedServices []dbrepo.LinkedServiceRow) error {
+// removed (idempotency for partial-failure retries). DB cleanup failures are logged
+// but do not block the caller.
+func (s *DatasourceService) disconnectOneDatasource(ctx context.Context, rt runtime.Runtime, datasourceID uuid.UUID, linkedServices []dbrepo.LinkedServiceRow) error {
 	for _, svc := range linkedServices {
 		url := extractInternalEndpointURL(svc.EndpointsJSON)
 		if url != "" {
-			if err := s.serviceClient.Disconnect(ctx, url, datasourceID.String()); err != nil {
-				// 404 means the connector is already gone on the downstream side —
-				// treat as success so we still clean up the DB row.
+			err := catalogclient.NewServiceClient(rt, url).Disconnect(ctx, datasourceID.String())
+			if err != nil {
 				var httpErr *catalogclient.ServiceHTTPError
 				if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-					logger.InfofCtx(ctx, "connector %s not found from service %s, continuing cleanup", datasourceID, svc.ServiceCatalogID)
+					logger.InfofCtx(ctx, "connector %s not found on service %s, continuing cleanup", datasourceID, svc.ServiceCatalogID)
 				} else {
 					return &ValidationError{
 						Code:    http.StatusBadGateway,
@@ -1004,7 +1059,29 @@ func (s *DatasourceService) propagateCredentials(
 			continue
 		}
 
-		if err := catalogclient.NewServiceClient(baseURL).UpdateConnector(ctx, datasourceID.String(), credPayload); err != nil {
+		app, appErr := s.appRepo.GetByID(ctx, svc.ApplicationID)
+		var rt runtime.Runtime
+		var rtErr error
+		if appErr == nil {
+			rt, rtErr = s.runtimeFor(ctx, app.WorkerID)
+		}
+
+		if appErr != nil || rtErr != nil {
+			msg := fmt.Sprintf("failed to load application: %v", appErr)
+			if rtErr != nil {
+				msg = fmt.Sprintf("worker not reachable: %v", rtErr)
+			}
+
+			propErrors = append(propErrors, apimodels.PropagationError{
+				ID:    svc.ApplicationID.String(),
+				Name:  svc.ApplicationName,
+				Error: msg,
+			})
+
+			continue
+		}
+
+		if err := catalogclient.NewServiceClient(rt, baseURL).UpdateConnector(ctx, datasourceID.String(), credPayload); err != nil {
 			propErrors = append(propErrors, apimodels.PropagationError{
 				ID:    svc.ApplicationID.String(),
 				Name:  svc.ApplicationName,
@@ -1046,31 +1123,9 @@ func datasourceItemFromConnector(c *dbmodels.Connector) apimodels.DatasourceItem
 	}
 }
 
-// fetchSyncState calls GET /v1/connectors/{connectorID} on the downstream service pod at baseURL
-// using catalogclient.ServiceClient (resty-based) and returns the sync_status, last_sync_at,
-// and a non-empty errMsg when the state could not be fetched (empty baseURL or HTTP failure).
-// The caller embeds errMsg in the response item so users know why sync state is unavailable;
-// the connector record is always returned regardless of sync-state fetch outcome.
-func fetchSyncState(ctx context.Context, connectorID uuid.UUID, baseURL string) (syncStatus string, lastSyncAt *string, errMsg string) {
-	if baseURL == "" {
-		return "unknown", nil, "no api endpoint registered for this service"
-	}
-
-	state, err := catalogclient.NewServiceClient(baseURL).GetConnectorSync(ctx, connectorID.String())
-	if err != nil {
-		logger.WarningfCtx(ctx, "failed to fetch sync state for datasource %s from %s: %v", connectorID, baseURL, err)
-
-		return "unknown", nil, fmt.Sprintf("failed to fetch sync state: %v", err)
-	}
-
-	return state.SyncStatus, state.LastSyncAt, ""
-}
-
-// fetchServiceSyncDetails calls GET /v1/connectors/{connectorID} on the connected service
-// at baseURL and returns a fully-populated ServiceSyncDetails. On failure (empty baseURL
-// or HTTP error) it degrades gracefully: SyncStatus = "unknown", all numeric/timestamp
-// fields = nil, ErrMsg populated.
-func fetchServiceSyncDetails(ctx context.Context, connectorID uuid.UUID, baseURL string) apimodels.ServiceSyncDetails {
+// fetchServiceSyncDetails calls GET /v1/connectors/{connectorID} via HTTPProxy and returns a
+// fully-populated ServiceSyncDetails. Degrades gracefully on failure.
+func (s *DatasourceService) fetchServiceSyncDetails(ctx context.Context, rt runtime.Runtime, connectorID uuid.UUID, baseURL string) apimodels.ServiceSyncDetails {
 	if baseURL == "" {
 		return apimodels.ServiceSyncDetails{
 			SyncStatus: "unknown",
@@ -1078,7 +1133,7 @@ func fetchServiceSyncDetails(ctx context.Context, connectorID uuid.UUID, baseURL
 		}
 	}
 
-	state, err := catalogclient.NewServiceClient(baseURL).GetConnectorSync(ctx, connectorID.String())
+	state, err := catalogclient.NewServiceClient(rt, baseURL).GetConnectorSync(ctx, connectorID.String())
 	if err != nil {
 		logger.WarningfCtx(ctx, "failed to fetch sync state for connector %s from %s: %v", connectorID, baseURL, err)
 
@@ -1156,11 +1211,16 @@ func (s *DatasourceService) ListApplicationDatasources(ctx context.Context, req 
 		return nil, fmt.Errorf("failed to list application connectors: %w", err)
 	}
 
+	rt, err := s.runtimeFor(ctx, app.WorkerID)
+	if err != nil {
+		return nil, &ValidationError{Code: http.StatusBadGateway, Message: fmt.Sprintf("worker not reachable: %v", err)}
+	}
+
 	offset := (req.Page - 1) * req.PageSize
 
 	// Resolve the service base URL and call GET /v1/connectors with the caller's pagination
 	// params. The service response is authoritative for both the page content and total count.
-	baseURL, servicePage := s.fetchServiceConnectors(ctx, allConnectorIDs, req.PageSize, offset)
+	baseURL, servicePage := s.fetchServiceConnectors(ctx, rt, allConnectorIDs, req.PageSize, offset)
 
 	data, err := s.buildDatasourcePage(ctx, baseURL, servicePage.ByID)
 	if err != nil {
@@ -1187,10 +1247,9 @@ func (s *DatasourceService) ListApplicationDatasources(ctx context.Context, req 
 }
 
 // fetchServiceConnectors resolves the service base URL from the first connector ID in the
-// list (via the existing GetLinkedServiceEndpoints + extractInternalEndpointURL path), then calls
-// GET /v1/connectors once with the given limit/offset. Returns an empty-page result when no
-// endpoint is found or the call fails.
-func (s *DatasourceService) fetchServiceConnectors(ctx context.Context, connectorIDs []uuid.UUID, limit, offset int) (string, catalogclient.ServiceConnectorPage) {
+// list via GetLinkedServiceEndpoints, then calls GET /v1/connectors via HTTPProxy.
+// Returns an empty-page result when no endpoint is found or the call fails.
+func (s *DatasourceService) fetchServiceConnectors(ctx context.Context, rt runtime.Runtime, connectorIDs []uuid.UUID, limit, offset int) (string, catalogclient.ServiceConnectorPage) {
 	empty := catalogclient.ServiceConnectorPage{ByID: make(map[string]apimodels.ConnectorItem)}
 
 	if len(connectorIDs) == 0 {
@@ -1217,7 +1276,7 @@ func (s *DatasourceService) fetchServiceConnectors(ctx context.Context, connecto
 		return "", empty
 	}
 
-	page, err := catalogclient.NewServiceClient(baseURL).ListConnectors(ctx, limit, offset)
+	page, err := catalogclient.NewServiceClient(rt, baseURL).ListConnectors(ctx, limit, offset)
 	if err != nil {
 		logger.WarningfCtx(ctx, "failed to list connectors from service at %s: %v", baseURL, err)
 

--- a/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service/datasource_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service/datasource_service.go
@@ -409,14 +409,14 @@ func (s *DatasourceService) buildConnectedApplications(ctx context.Context, conn
 		baseURL := extractInternalEndpointURL(row.EndpointsJSON)
 
 		app, appErr := s.appRepo.GetByID(ctx, row.ApplicationID)
-		var workerID *uuid.UUID
-		if appErr == nil && app != nil {
-			workerID = app.WorkerID
+		if appErr != nil {
+			return nil, fmt.Errorf("failed to load application %s: %w", row.ApplicationID, appErr)
 		}
 
-		rt, rtErr := s.runtimeFor(ctx, workerID)
+		rt, rtErr := s.runtimeFor(ctx, app.WorkerID)
 		if rtErr != nil {
 			logger.WarningfCtx(ctx, "worker not reachable for application %s: %v", row.ApplicationID, rtErr)
+			continue
 		}
 
 		syncDetails := s.fetchServiceSyncDetails(ctx, rt, connectorID, baseURL)
@@ -1060,22 +1060,22 @@ func (s *DatasourceService) propagateCredentials(
 		}
 
 		app, appErr := s.appRepo.GetByID(ctx, svc.ApplicationID)
-		var rt runtime.Runtime
-		var rtErr error
-		if appErr == nil {
-			rt, rtErr = s.runtimeFor(ctx, app.WorkerID)
-		}
-
-		if appErr != nil || rtErr != nil {
-			msg := fmt.Sprintf("failed to load application: %v", appErr)
-			if rtErr != nil {
-				msg = fmt.Sprintf("worker not reachable: %v", rtErr)
-			}
-
+		if appErr != nil {
 			propErrors = append(propErrors, apimodels.PropagationError{
 				ID:    svc.ApplicationID.String(),
 				Name:  svc.ApplicationName,
-				Error: msg,
+				Error: fmt.Sprintf("failed to load application: %v", appErr),
+			})
+
+			continue
+		}
+
+		rt, rtErr := s.runtimeFor(ctx, app.WorkerID)
+		if rtErr != nil {
+			propErrors = append(propErrors, apimodels.PropagationError{
+				ID:    svc.ApplicationID.String(),
+				Name:  svc.ApplicationName,
+				Error: fmt.Sprintf("worker not reachable: %v", rtErr),
 			})
 
 			continue

--- a/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service/datasource_service.go
+++ b/ai-services/internal/pkg/catalog/apiserver/repository/datasource_service/datasource_service.go
@@ -1220,7 +1220,7 @@ func (s *DatasourceService) ListApplicationDatasources(ctx context.Context, req 
 
 	// Resolve the service base URL and call GET /v1/connectors with the caller's pagination
 	// params. The service response is authoritative for both the page content and total count.
-	baseURL, servicePage := s.fetchServiceConnectors(ctx, rt, allConnectorIDs, req.PageSize, offset)
+	baseURL, servicePage := s.fetchServiceConnectors(ctx, rt, appID, allConnectorIDs, req.PageSize, offset)
 
 	data, err := s.buildDatasourcePage(ctx, baseURL, servicePage.ByID)
 	if err != nil {
@@ -1248,8 +1248,10 @@ func (s *DatasourceService) ListApplicationDatasources(ctx context.Context, req 
 
 // fetchServiceConnectors resolves the service base URL from the first connector ID in the
 // list via GetLinkedServiceEndpoints, then calls GET /v1/connectors via HTTPProxy.
+// Only rows belonging to appID are considered when selecting the base URL, preventing a
+// mismatch when the same connector is linked to multiple applications.
 // Returns an empty-page result when no endpoint is found or the call fails.
-func (s *DatasourceService) fetchServiceConnectors(ctx context.Context, rt runtime.Runtime, connectorIDs []uuid.UUID, limit, offset int) (string, catalogclient.ServiceConnectorPage) {
+func (s *DatasourceService) fetchServiceConnectors(ctx context.Context, rt runtime.Runtime, appID uuid.UUID, connectorIDs []uuid.UUID, limit, offset int) (string, catalogclient.ServiceConnectorPage) {
 	empty := catalogclient.ServiceConnectorPage{ByID: make(map[string]apimodels.ConnectorItem)}
 
 	if len(connectorIDs) == 0 {
@@ -1265,6 +1267,10 @@ func (s *DatasourceService) fetchServiceConnectors(ctx context.Context, rt runti
 
 	baseURL := ""
 	for _, row := range linkedRows {
+		if row.ApplicationID != appID {
+			continue
+		}
+
 		if u := extractInternalEndpointURL(row.EndpointsJSON); u != "" {
 			baseURL = u
 

--- a/ai-services/internal/pkg/catalog/client/service.go
+++ b/ai-services/internal/pkg/catalog/client/service.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	apimodels "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
-	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+	"github.com/project-ai-services/ai-services/internal/pkg/httpproxy"
 )
 
 const (
@@ -50,18 +50,18 @@ type serviceUpdatePayload struct {
 }
 
 // ServiceClient calls downstream service pod endpoints (e.g. Digitize) via
-// runtime.HTTPProxy — all HTTP traffic is tunnelled through the worker so that
+// an HTTPProxier — all HTTP traffic is tunnelled through the worker so that
 // internal pod URLs (svc.cluster.local or Podman container names) are reachable
 // from the control plane.
 type ServiceClient struct {
-	rt      runtime.Runtime
+	proxy   httpproxy.HTTPProxier
 	baseURL string
 }
 
-// NewServiceClient creates a ServiceClient that routes all calls through rt.HTTPProxy
+// NewServiceClient creates a ServiceClient that routes all calls through proxy
 // to the given baseURL.
-func NewServiceClient(rt runtime.Runtime, baseURL string) *ServiceClient {
-	return &ServiceClient{rt: rt, baseURL: baseURL}
+func NewServiceClient(proxy httpproxy.HTTPProxier, baseURL string) *ServiceClient {
+	return &ServiceClient{proxy: proxy, baseURL: baseURL}
 }
 
 // do executes a single HTTP request via HTTPProxy and returns the raw response.
@@ -71,7 +71,7 @@ func (c *ServiceClient) do(ctx context.Context, method, path string, body []byte
 		headers = map[string]string{"Content-Type": "application/json"}
 	}
 
-	resp, err := c.rt.HTTPProxy(ctx, method, c.baseURL+path, headers, body)
+	resp, err := c.proxy.HTTPProxy(ctx, method, c.baseURL+path, headers, body)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -93,11 +93,13 @@ func (c *ServiceClient) UpdateConnector(ctx context.Context, connectorID string,
 		status, _, reqErr := c.do(ctx, http.MethodPut, serviceConnectPath+"/"+connectorID, body)
 		if reqErr != nil {
 			lastErr = fmt.Errorf("service PUT request failed: %w", reqErr)
+
 			continue
 		}
 
 		if status < 200 || status >= 300 {
 			lastErr = fmt.Errorf("service returned unexpected status %d", status)
+
 			continue
 		}
 

--- a/ai-services/internal/pkg/catalog/client/service.go
+++ b/ai-services/internal/pkg/catalog/client/service.go
@@ -2,13 +2,19 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
-	"time"
 
-	"github.com/go-resty/resty/v2"
 	apimodels "github.com/project-ai-services/ai-services/internal/pkg/catalog/apiserver/models"
+	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
+)
+
+const (
+	// serviceMaxRetries is the number of retries on failure (one retry = two total attempts).
+	serviceMaxRetries  = 1
+	serviceConnectPath = "/v1/connectors"
 )
 
 // serviceConnectorListResponse is the paginated envelope returned by
@@ -27,14 +33,6 @@ type ServiceConnectorPage struct {
 	Total int
 }
 
-const (
-	// serviceHTTPTimeout is the per-request timeout for calls to a downstream service pod.
-	serviceHTTPTimeout = 15 * time.Second
-	// serviceMaxRetries is the number of retries on failure (one retry = two total attempts).
-	serviceMaxRetries  = 1
-	serviceConnectPath = "/v1/connectors"
-)
-
 // ServiceHTTPError is returned by client methods when the downstream service responds
 // with a non-2xx status code. Callers can type-assert to inspect the status code and
 // decide whether to treat specific codes (e.g. 404) as non-fatal.
@@ -47,108 +45,109 @@ func (e *ServiceHTTPError) Error() string {
 }
 
 // serviceUpdatePayload is the request body for PUT /v1/connectors/<connector_id>.
-// Only the fields being updated are sent; the service performs a partial update.
 type serviceUpdatePayload struct {
-	// ConnectionDetails holds the updated credential fields.
 	ConnectionDetails map[string]any `json:"connection_details"`
 }
 
-// ServiceClient is an HTTP client for downstream service API calls (e.g. Digitize).
+// ServiceClient calls downstream service pod endpoints (e.g. Digitize) via
+// runtime.HTTPProxy — all HTTP traffic is tunnelled through the worker so that
+// internal pod URLs (svc.cluster.local or Podman container names) are reachable
+// from the control plane.
 type ServiceClient struct {
-	http *resty.Client
+	rt      runtime.Runtime
+	baseURL string
 }
 
-// NewServiceClient creates a ServiceClient pointed at baseURL.
-// The resty client is configured with a 15-second timeout. Calls go to the internal
-// pod-to-pod endpoint (plain HTTP), so no TLS configuration is required.
-func NewServiceClient(baseURL string) *ServiceClient {
-	r := resty.New().
-		SetBaseURL(baseURL).
-		SetTimeout(serviceHTTPTimeout)
-
-	return &ServiceClient{http: r}
+// NewServiceClient creates a ServiceClient that routes all calls through rt.HTTPProxy
+// to the given baseURL.
+func NewServiceClient(rt runtime.Runtime, baseURL string) *ServiceClient {
+	return &ServiceClient{rt: rt, baseURL: baseURL}
 }
 
-// UpdateConnector calls PUT /v1/connectors/{connectorID} on the service pod to propagate
-// updated credentials. Retries once on failure. Returns nil on success.
+// do executes a single HTTP request via HTTPProxy and returns the raw response.
+func (c *ServiceClient) do(ctx context.Context, method, path string, body []byte) (statusCode int, respBody []byte, err error) {
+	headers := map[string]string(nil)
+	if len(body) > 0 {
+		headers = map[string]string{"Content-Type": "application/json"}
+	}
+
+	resp, err := c.rt.HTTPProxy(ctx, method, c.baseURL+path, headers, body)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return resp.StatusCode, resp.Body, nil
+}
+
+// UpdateConnector calls PUT /v1/connectors/{connectorID} to propagate updated credentials.
+// Retries once on failure.
 func (c *ServiceClient) UpdateConnector(ctx context.Context, connectorID string, updatedCreds map[string]any) error {
-	payload := serviceUpdatePayload{ConnectionDetails: updatedCreds}
+	body, err := json.Marshal(serviceUpdatePayload{ConnectionDetails: updatedCreds})
+	if err != nil {
+		return fmt.Errorf("marshal update payload: %w", err)
+	}
 
 	var lastErr error
 
 	for attempt := 0; attempt <= serviceMaxRetries; attempt++ {
-		resp, err := c.http.R().
-			SetContext(ctx).
-			SetBody(payload).
-			Put("/v1/connectors/" + connectorID)
-		if err != nil {
-			lastErr = fmt.Errorf("service PUT request failed: %w", err)
-
+		status, _, reqErr := c.do(ctx, http.MethodPut, serviceConnectPath+"/"+connectorID, body)
+		if reqErr != nil {
+			lastErr = fmt.Errorf("service PUT request failed: %w", reqErr)
 			continue
 		}
 
-		if resp.IsError() {
-			lastErr = fmt.Errorf("service returned unexpected status %d", resp.StatusCode())
-
+		if status < 200 || status >= 300 {
+			lastErr = fmt.Errorf("service returned unexpected status %d", status)
 			continue
 		}
 
 		return nil
 	}
 
-	return fmt.Errorf("failed to propagate credentials to service after %d attempt(s): %w", serviceMaxRetries+1, lastErr)
+	return fmt.Errorf("failed to propagate credentials after %d attempt(s): %w", serviceMaxRetries+1, lastErr)
 }
 
-// GetConnectorSync calls GET /v1/connectors/{connectorID} on the service pod and
-// returns the connector's sync_status and last_sync_at values.
-// Returns an error when the HTTP call fails or the pod returns a non-200 status.
+// GetConnectorSync calls GET /v1/connectors/{connectorID} and returns the connector's
+// sync_status and related fields. Returns an error on HTTP failure or non-200 response.
 func (c *ServiceClient) GetConnectorSync(ctx context.Context, connectorID string) (*apimodels.ConnectorSyncState, error) {
-	var result apimodels.ConnectorSyncState
-
-	resp, err := c.http.R().
-		SetContext(ctx).
-		SetResult(&result).
-		Get("/v1/connectors/" + connectorID)
+	status, body, err := c.do(ctx, http.MethodGet, serviceConnectPath+"/"+connectorID, nil)
 	if err != nil {
-		return nil, fmt.Errorf("service request failed: %w", err)
+		return nil, fmt.Errorf("service GET request failed: %w", err)
 	}
 
-	if resp.IsError() {
-		return nil, fmt.Errorf("service returned status %d", resp.StatusCode())
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("service returned status %d", status)
+	}
+
+	var result apimodels.ConnectorSyncState
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode sync state: %w", err)
 	}
 
 	return &result, nil
 }
 
-// ListConnectors calls GET /v1/connectors on the service pod with limit/offset pagination
-// and returns a ServiceConnectorPage containing a map keyed by connector ID for O(1) lookup
-// and the Total count from the service response — used to drive API-level pagination.
-// The ConnectorListItem already includes the message field covering all status phases and
-// error details — no separate sync-log call is required.
-// Pass limit=0 to use the service default (50). offset is zero-based.
-// Returns an error when the HTTP call fails or the pod returns a non-200 status.
+// ListConnectors calls GET /v1/connectors with limit/offset pagination and returns a
+// ServiceConnectorPage keyed by connector ID for O(1) lookup. Pass limit=0 to use the
+// service default. Returns an error on HTTP failure or non-200 response.
 func (c *ServiceClient) ListConnectors(ctx context.Context, limit, offset int) (*ServiceConnectorPage, error) {
-	var result serviceConnectorListResponse
-
-	req := c.http.R().
-		SetContext(ctx).
-		SetResult(&result)
-
-	if limit > 0 {
-		req = req.SetQueryParam("limit", strconv.Itoa(limit))
+	path := serviceConnectPath
+	if limit > 0 || offset > 0 {
+		path += "?limit=" + strconv.Itoa(limit) + "&offset=" + strconv.Itoa(offset)
 	}
 
-	if offset > 0 {
-		req = req.SetQueryParam("offset", strconv.Itoa(offset))
-	}
-
-	resp, err := req.Get(serviceConnectPath)
+	status, body, err := c.do(ctx, http.MethodGet, path, nil)
 	if err != nil {
-		return nil, fmt.Errorf("service request failed: %w", err)
+		return nil, fmt.Errorf("service GET request failed: %w", err)
 	}
 
-	if resp.IsError() {
-		return nil, fmt.Errorf("service returned status %d", resp.StatusCode())
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("service returned status %d", status)
+	}
+
+	var result serviceConnectorListResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode connector list: %w", err)
 	}
 
 	byID := make(map[string]apimodels.ConnectorItem, len(result.Items))
@@ -159,39 +158,40 @@ func (c *ServiceClient) ListConnectors(ctx context.Context, limit, offset int) (
 	return &ServiceConnectorPage{ByID: byID, Total: result.Total}, nil
 }
 
-// Connect calls POST /v1/connectors on the given service base URL.
-// 409 Conflict is treated as success (idempotent — connector already exists).
-func (c *ServiceClient) Connect(ctx context.Context, baseURL string, req apimodels.ConnectDatasourceRequest) error {
-	resp, err := c.http.R().
-		SetContext(ctx).
-		SetBody(req).
-		Post(baseURL + serviceConnectPath)
+// Connect calls POST /v1/connectors on the service pod.
+// 409 Conflict is treated as success — connector already exists (idempotent).
+func (c *ServiceClient) Connect(ctx context.Context, req apimodels.ConnectDatasourceRequest) error {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal connect request: %w", err)
+	}
+
+	status, _, err := c.do(ctx, http.MethodPost, serviceConnectPath, body)
 	if err != nil {
 		return fmt.Errorf("service POST request failed: %w", err)
 	}
 
-	if resp.StatusCode() == http.StatusConflict {
+	if status == http.StatusConflict {
 		return nil
 	}
 
-	if resp.IsError() {
-		return fmt.Errorf("service returned unexpected status %d", resp.StatusCode())
+	if status < 200 || status >= 300 {
+		return fmt.Errorf("service returned unexpected status %d", status)
 	}
 
 	return nil
 }
 
-// Disconnect calls DELETE /v1/connectors/{connectorID} on the given service base URL.
-func (c *ServiceClient) Disconnect(ctx context.Context, baseURL, connectorID string) error {
-	resp, err := c.http.R().
-		SetContext(ctx).
-		Delete(baseURL + serviceConnectPath + "/" + connectorID)
+// Disconnect calls DELETE /v1/connectors/{connectorID} on the service pod.
+// Returns a *ServiceHTTPError so callers can inspect the status code (e.g. treat 404 as success).
+func (c *ServiceClient) Disconnect(ctx context.Context, connectorID string) error {
+	status, _, err := c.do(ctx, http.MethodDelete, serviceConnectPath+"/"+connectorID, nil)
 	if err != nil {
 		return fmt.Errorf("service DELETE request failed: %w", err)
 	}
 
-	if resp.IsError() {
-		return &ServiceHTTPError{StatusCode: resp.StatusCode()}
+	if status < 200 || status >= 300 {
+		return &ServiceHTTPError{StatusCode: status}
 	}
 
 	return nil

--- a/ai-services/internal/pkg/httpproxy/httpproxy.go
+++ b/ai-services/internal/pkg/httpproxy/httpproxy.go
@@ -1,0 +1,101 @@
+// Package httpproxy provides HTTP proxy primitives that are independent of any
+// specific runtime. It mirrors the proxy package pattern:
+//
+//   - Response is the result type for any proxied HTTP call.
+//   - HTTPProxier is the interface used by callers (e.g. ServiceClient).
+//   - Exec makes a direct HTTP call via resty; used by the worker dispatcher
+//     and by local runtimes (OpenShift, Podman) that have direct network access.
+//   - RemoteHTTPProxier sends COMMAND_TYPE_HTTP_PROXY over the gRPC
+//     CommandStream to a worker, which calls Exec locally and returns the result.
+package httpproxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/project-ai-services/ai-services/internal/pkg/worker/payload"
+	workerpb "github.com/project-ai-services/ai-services/internal/pkg/worker/proto"
+	"github.com/project-ai-services/ai-services/internal/pkg/worker/stream"
+)
+
+// Response carries the result of a proxied HTTP request.
+type Response struct {
+	StatusCode int
+	Headers    map[string]string
+	Body       []byte
+}
+
+// HTTPProxier executes an HTTP request and returns the response.
+// Exec implements this interface for direct (local) calls;
+// RemoteHTTPProxier implements it for gRPC-tunnelled calls.
+type HTTPProxier interface {
+	HTTPProxy(ctx context.Context, method, targetURL string, headers map[string]string, body []byte) (*Response, error)
+}
+
+// Exec makes a direct HTTP request using resty and returns the response.
+// Used by the worker dispatcher and by local runtimes that have direct network
+// access to the target URL.
+func Exec(ctx context.Context, method, targetURL string, headers map[string]string, body []byte) (*Response, error) {
+	client := resty.New()
+
+	req := client.R().SetContext(ctx)
+	for k, v := range headers {
+		req.SetHeader(k, v)
+	}
+	if len(body) > 0 {
+		req.SetBody(body)
+	}
+
+	resp, err := req.Execute(method, targetURL)
+	if err != nil {
+		return nil, fmt.Errorf("httpproxy: execute request: %w", err)
+	}
+
+	respHeaders := make(map[string]string, len(resp.Header()))
+	for k := range resp.Header() {
+		respHeaders[k] = resp.Header().Get(k)
+	}
+
+	return &Response{
+		StatusCode: resp.StatusCode(),
+		Headers:    respHeaders,
+		Body:       resp.Body(),
+	}, nil
+}
+
+// RemoteHTTPProxier implements HTTPProxier by forwarding the request as a
+// COMMAND_TYPE_HTTP_PROXY command over the gRPC CommandStream to a worker node,
+// which calls Exec locally and returns the response.
+type RemoteHTTPProxier struct {
+	sender *stream.Sender
+}
+
+// NewRemoteHTTPProxier returns a RemoteHTTPProxier targeting the named worker.
+func NewRemoteHTTPProxier(workerName string, reg stream.WorkerRegistry) *RemoteHTTPProxier {
+	return &RemoteHTTPProxier{sender: stream.New(workerName, reg)}
+}
+
+// HTTPProxy implements HTTPProxier.
+func (r *RemoteHTTPProxier) HTTPProxy(ctx context.Context, method, targetURL string, headers map[string]string, body []byte) (*Response, error) {
+	res, err := r.sender.Send(ctx, workerpb.CommandType_COMMAND_TYPE_HTTP_PROXY,
+		payload.HTTPProxy{
+			Method:    method,
+			TargetURL: targetURL,
+			Headers:   headers,
+			Body:      body,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	var result Response
+	if len(res.GetData()) > 0 {
+		if err := json.Unmarshal(res.GetData(), &result); err != nil {
+			return nil, fmt.Errorf("httpproxy: unmarshal response: %w", err)
+		}
+	}
+
+	return &result, nil
+}

--- a/ai-services/internal/pkg/runtime/interface.go
+++ b/ai-services/internal/pkg/runtime/interface.go
@@ -62,14 +62,6 @@ type Runtime interface {
 	// System information
 	GetSystemInfo(ctx context.Context) (*models.SystemInfo, error)
 
-	// HTTPProxy tunnels an HTTP request through the gRPC stream to a worker
-	// pod endpoint and returns the response.
-	// method is the HTTP verb (GET, POST, …), targetURL is the full URL of the
-	// pod endpoint on the worker, headers are optional extra request headers,
-	// and body is the request body (may be nil). Returns the HTTP status code,
-	// response headers, and body.
-	HTTPProxy(ctx context.Context, method, targetURL string, headers map[string]string, body []byte) (*types.HTTPProxyResponse, error)
-
 	// WaitForInferenceServiceReady polls a KServe InferenceService until its
 	// Ready condition is True or the context deadline is exceeded.
 	// Non-OpenShift runtimes return nil immediately (no-op).

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -16,7 +16,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/go-resty/resty/v2"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/project-ai-services/ai-services/internal/pkg/accelerator/spyre"
@@ -980,35 +979,4 @@ func (kc *OpenshiftClient) DeleteNamespace(ctx context.Context, name string) err
 	}
 
 	return nil
-}
-
-// HTTPProxy executes an HTTP request from within the OpenShift cluster.
-// The control plane runs inside the cluster and can resolve svc.cluster.local
-// DNS natively, so resty makes the call directly — identical to Podman.
-func (kc *OpenshiftClient) HTTPProxy(ctx context.Context, method, targetURL string, headers map[string]string, body []byte) (*types.HTTPProxyResponse, error) {
-	client := resty.New()
-
-	req := client.R().SetContext(ctx)
-	for k, v := range headers {
-		req.SetHeader(k, v)
-	}
-	if len(body) > 0 {
-		req.SetBody(body)
-	}
-
-	resp, err := req.Execute(method, targetURL)
-	if err != nil {
-		return nil, fmt.Errorf("HTTPProxy: execute request: %w", err)
-	}
-
-	respHeaders := make(map[string]string, len(resp.Header()))
-	for k := range resp.Header() {
-		respHeaders[k] = resp.Header().Get(k)
-	}
-
-	return &types.HTTPProxyResponse{
-		StatusCode: resp.StatusCode(),
-		Headers:    respHeaders,
-		Body:       resp.Body(),
-	}, nil
 }

--- a/ai-services/internal/pkg/runtime/openshift/openshift.go
+++ b/ai-services/internal/pkg/runtime/openshift/openshift.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/go-resty/resty/v2"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/project-ai-services/ai-services/internal/pkg/accelerator/spyre"
@@ -981,8 +982,33 @@ func (kc *OpenshiftClient) DeleteNamespace(ctx context.Context, name string) err
 	return nil
 }
 
-// HTTPProxy is not implemented on OpenShift — the control plane manages
-// OpenShift pods directly via the Kubernetes API without needing a tunnel.
-func (kc *OpenshiftClient) HTTPProxy(_ context.Context, _, _ string, _ map[string]string, _ []byte) (*types.HTTPProxyResponse, error) {
-	return nil, fmt.Errorf("HTTPProxy not implemented on OpenShift runtime")
+// HTTPProxy executes an HTTP request from within the OpenShift cluster.
+// The control plane runs inside the cluster and can resolve svc.cluster.local
+// DNS natively, so resty makes the call directly — identical to Podman.
+func (kc *OpenshiftClient) HTTPProxy(ctx context.Context, method, targetURL string, headers map[string]string, body []byte) (*types.HTTPProxyResponse, error) {
+	client := resty.New()
+
+	req := client.R().SetContext(ctx)
+	for k, v := range headers {
+		req.SetHeader(k, v)
+	}
+	if len(body) > 0 {
+		req.SetBody(body)
+	}
+
+	resp, err := req.Execute(method, targetURL)
+	if err != nil {
+		return nil, fmt.Errorf("HTTPProxy: execute request: %w", err)
+	}
+
+	respHeaders := make(map[string]string, len(resp.Header()))
+	for k := range resp.Header() {
+		respHeaders[k] = resp.Header().Get(k)
+	}
+
+	return &types.HTTPProxyResponse{
+		StatusCode: resp.StatusCode(),
+		Headers:    respHeaders,
+		Body:       resp.Body(),
+	}, nil
 }

--- a/ai-services/internal/pkg/runtime/podman/podman.go
+++ b/ai-services/internal/pkg/runtime/podman/podman.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/go-resty/resty/v2"
-
 	"github.com/containers/podman/v5/libpod/define"
 	"github.com/containers/podman/v5/pkg/bindings"
 	"github.com/containers/podman/v5/pkg/bindings/containers"
@@ -953,40 +951,6 @@ func (pc *PodmanClient) ExecInContainerWithCmd(_ context.Context, _, _ string, _
 	logger.Errorf("unsupported method called!")
 
 	return "", fmt.Errorf("unsupported method")
-}
-
-// ─── HTTP proxy tunnel ────────────────────────────────────────────────────────
-
-// HTTPProxy makes an HTTP request to targetURL from the worker node and returns
-// the response to the control plane. The worker pod runs in the same Podman
-// network as the target pods, so pod-name DNS resolution works natively inside
-// the container without any host-side IP lookup.
-func (pc *PodmanClient) HTTPProxy(ctx context.Context, method, targetURL string, headers map[string]string, body []byte) (*types.HTTPProxyResponse, error) {
-	client := resty.New()
-
-	req := client.R().SetContext(ctx)
-	for k, v := range headers {
-		req.SetHeader(k, v)
-	}
-	if len(body) > 0 {
-		req.SetBody(body)
-	}
-
-	resp, err := req.Execute(method, targetURL)
-	if err != nil {
-		return nil, fmt.Errorf("HTTPProxy: execute request: %w", err)
-	}
-
-	respHeaders := make(map[string]string, len(resp.Header()))
-	for k := range resp.Header() {
-		respHeaders[k] = resp.Header().Get(k)
-	}
-
-	return &types.HTTPProxyResponse{
-		StatusCode: resp.StatusCode(),
-		Headers:    respHeaders,
-		Body:       resp.Body(),
-	}, nil
 }
 
 // WaitForInferenceServiceReady is a no-op for Podman — KServe InferenceServices

--- a/ai-services/internal/pkg/runtime/remote/runtime.go
+++ b/ai-services/internal/pkg/runtime/remote/runtime.go
@@ -313,31 +313,6 @@ func (r *RemoteRuntime) ExecInContainerWithCmd(ctx context.Context, podName, con
 	return output, nil
 }
 
-// ─── HTTP proxy tunnel ────────────────────────────────────────────────────────
-
-// HTTPProxy tunnels an HTTP request to the worker via the gRPC stream.
-// The worker executes the request locally (inside the Podman network) and
-// returns the status, headers, and body as a single CommandResult.
-func (r *RemoteRuntime) HTTPProxy(ctx context.Context, method, targetURL string, headers map[string]string, body []byte) (*types.HTTPProxyResponse, error) {
-	res, err := r.send(ctx, workerpb.CommandType_COMMAND_TYPE_HTTP_PROXY,
-		payload.HTTPProxy{
-			Method:    method,
-			TargetURL: targetURL,
-			Headers:   headers,
-			Body:      body,
-		})
-	if err != nil {
-		return nil, err
-	}
-
-	var result types.HTTPProxyResponse
-	if err := unmarshalData(res, &result); err != nil {
-		return nil, err
-	}
-
-	return &result, nil
-}
-
 // ─── Network operations ───────────────────────────────────────────────────────
 
 func (r *RemoteRuntime) ListRoutes(ctx context.Context, labelSelector string) ([]types.Route, error) {

--- a/ai-services/internal/pkg/runtime/types/types.go
+++ b/ai-services/internal/pkg/runtime/types/types.go
@@ -74,11 +74,3 @@ type CRDResource struct {
 	Name   string
 	Labels map[string]string
 }
-
-// HTTPProxyResponse carries the result of an HTTP request executed on the
-// worker node and returned to the control plane via the gRPC stream.
-type HTTPProxyResponse struct {
-	StatusCode int
-	Headers    map[string]string
-	Body       []byte
-}

--- a/ai-services/internal/pkg/worker/dispatch/dispatch.go
+++ b/ai-services/internal/pkg/worker/dispatch/dispatch.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/project-ai-services/ai-services/internal/pkg/cli/helpers"
 	helmutil "github.com/project-ai-services/ai-services/internal/pkg/helm"
+	"github.com/project-ai-services/ai-services/internal/pkg/httpproxy"
 	"github.com/project-ai-services/ai-services/internal/pkg/runtime"
 	openshiftRuntime "github.com/project-ai-services/ai-services/internal/pkg/runtime/openshift"
 	"github.com/project-ai-services/ai-services/internal/pkg/utils"
@@ -366,7 +367,7 @@ func handle(ctx context.Context, rt runtime.Runtime, pr *workercaddy.ProxyRouter
 		if err := json.Unmarshal(p, &req); err != nil {
 			return nil, fmt.Errorf("decode http_proxy payload: %w", err)
 		}
-		result, err := rt.HTTPProxy(ctx, req.Method, req.TargetURL, req.Headers, req.Body)
+		result, err := httpproxy.Exec(ctx, req.Method, req.TargetURL, req.Headers, req.Body)
 		if err != nil {
 			return nil, err
 		}

--- a/ai-services/internal/pkg/worker/payload/payload.go
+++ b/ai-services/internal/pkg/worker/payload/payload.go
@@ -113,7 +113,7 @@ type Route struct {
 
 // HTTPProxy is the request payload for COMMAND_TYPE_HTTP_PROXY.
 // The control plane sends this; the worker executes the HTTP request locally
-// against a pod endpoint and returns a types.HTTPProxyResponse.
+// against a pod endpoint and returns an httpproxy.Response.
 type HTTPProxy struct {
 	Method    string            `json:"method"`
 	TargetURL string            `json:"target_url"`

--- a/ai-services/internal/pkg/worker/registry/registry.go
+++ b/ai-services/internal/pkg/worker/registry/registry.go
@@ -471,6 +471,31 @@ func (r *Registry) WorkerNameByID(id uuid.UUID) (string, bool) {
 	return "", false
 }
 
+// WorkerInfoByID returns the name and runtime-type string for the given worker UUID.
+// It checks the live in-memory cache first; if the worker is disconnected it falls
+// back to the DB (when repo is available) so callers always get a useful name.
+// Returns ("", "") when the worker cannot be found in either source.
+func (r *Registry) WorkerInfoByID(ctx context.Context, id uuid.UUID) (name, runtimeType string) {
+	r.mu.RLock()
+	for _, entry := range r.workers {
+		if entry.DBID == id {
+			r.mu.RUnlock()
+
+			return entry.WorkerName, entry.RuntimeType
+		}
+	}
+	r.mu.RUnlock()
+
+	// Not in the live cache — try the DB for disconnected workers.
+	if r.repo != nil {
+		if w, err := r.repo.GetByID(ctx, id); err == nil && w != nil {
+			return w.Name, string(w.RuntimeType)
+		}
+	}
+
+	return "", ""
+}
+
 // IsWorkerConnected checks the in-memory cache first, then confirms status=ready
 // in the DB. Returns false if the worker is absent from the cache, not found in
 // the DB, or has any status other than ready.

--- a/ai-services/internal/pkg/worker/stream/registry.go
+++ b/ai-services/internal/pkg/worker/stream/registry.go
@@ -34,6 +34,12 @@ type WorkerRegistry interface {
 	// or ("", false) if no connected worker has that ID.
 	WorkerNameByID(id uuid.UUID) (string, bool)
 
+	// WorkerInfoByID returns the name and runtime-type string for the given database
+	// UUID. It checks the live in-memory registry first; if the worker is not currently
+	// connected it falls back to the DB so that the values are still available for
+	// offline workers. Returns ("", "") when the worker cannot be found at all.
+	WorkerInfoByID(ctx context.Context, id uuid.UUID) (name, runtimeType string)
+
 	// IsWorkerConnected reports whether the named worker has status=ready in the DB.
 	IsWorkerConnected(ctx context.Context, workerName string) bool
 }


### PR DESCRIPTION
Route all datasource → Digitize service HTTP calls through runtime.HTTPProxy instead of direct pod-URL calls from the control plane.

Implements HTTPProxy on OpenshiftClient (was a stub). Replaces resty-based ServiceClient with an HTTPProxy-backed one. Drops runtimeFactory; resolves runtime once per operation from app.WorkerID.